### PR TITLE
feat: VTID-03154 journey greetings — one-time welcome + daily morning

### DIFF
--- a/services/gateway/src/orb/live/instruction/journey-greeting.ts
+++ b/services/gateway/src/orb/live/instruction/journey-greeting.ts
@@ -1,0 +1,204 @@
+/**
+ * VTID-03154 — Slices C + D: journey-greeting block builder.
+ *
+ * Composes a STRUCTURAL prompt block (not a Say-exactly verbatim line)
+ * that turns one of two events into a fresh, naturally-worded greeting:
+ *
+ *   Slice C — One-time first-session welcome
+ *     Trigger: user_journey.is_first_session === true
+ *     Frames: Vitanaland as a JOURNEY (not an app tour), Life Compass
+ *             as the user's long-term goal, Vitana Index as the daily
+ *             progress measure, Vitana herself as the companion who
+ *             guides on this journey. Ends with one open invitation
+ *             to begin.
+ *
+ *   Slice D — Daily morning greeting
+ *     Trigger: last_session_date is null OR last_session_date < today_date
+ *              in the user's local timezone (and is_first_session === false).
+ *     Frames: "day {X}" of the journey explicitly + the active Life
+ *             Compass goal text as the purpose ("…in your plan to
+ *             {goal_text}…") + one pointer to today.
+ *
+ * Both blocks are STRUCTURAL. The LLM composes fresh wording every
+ * time, guided by the required-elements / forbidden-elements contract.
+ * The block also passes `recent_greeting_openings[]` so the model
+ * doesn't repeat the same opening phrase day-over-day.
+ *
+ * No verbatim Say-exactly here. Verbatim is the right pattern for
+ * teaching moments (VTID-03104 / VTID-03120); it is the wrong pattern
+ * for relational moments like the daily welcome.
+ */
+
+import type { JourneyState } from '../../../services/journey/user-journey-service';
+
+export type JourneyGreetingKind = 'first_session' | 'daily_morning' | null;
+
+export interface JourneyGreetingMeta {
+  kind: Exclude<JourneyGreetingKind, null>;
+  today_date_iso: string; // YYYY-MM-DD in user's local TZ — used to advance last_session_date after firing
+}
+
+interface BuildJourneyGreetingBlockArgs {
+  journey: JourneyState | null;
+  lifeCompassGoalText: string | null;
+  firstName: string | null;
+  lang: string;
+  /** YYYY-MM-DD in the user's local TZ (derived from clientContext.timezone or UTC fallback). */
+  todayDateIso: string;
+}
+
+export interface JourneyGreetingResult {
+  block: string;
+  meta: JourneyGreetingMeta | null;
+}
+
+/**
+ * Compute today's date as YYYY-MM-DD in a given IANA timezone. Falls
+ * back to UTC when the timezone is missing or invalid. Pure — exported
+ * for the session controller and the unit tests.
+ */
+export function todayInTimezone(now: Date, timezone: string | null | undefined): string {
+  if (timezone) {
+    try {
+      const fmt = new Intl.DateTimeFormat('en-CA', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      });
+      // en-CA gives YYYY-MM-DD natively.
+      return fmt.format(now);
+    } catch {
+      // fall through to UTC
+    }
+  }
+  return now.toISOString().slice(0, 10);
+}
+
+/**
+ * Decide which greeting fires (if any). Pure — exported for tests.
+ *
+ * Precedence: first_session > daily_morning > null.
+ * Slice G (milestone) and Slice H (gap recovery) will eventually
+ * supersede daily_morning when those slices ship; until then daily_morning
+ * fires for every new-day session.
+ */
+export function decideGreetingKind(
+  journey: JourneyState | null,
+  todayDateIso: string,
+): JourneyGreetingKind {
+  if (!journey) return null;
+  if (journey.is_first_session) return 'first_session';
+  if (!journey.last_session_date) return 'daily_morning';
+  if (journey.last_session_date < todayDateIso) return 'daily_morning';
+  return null;
+}
+
+/**
+ * Build the journey-greeting prompt block, or empty string when no
+ * greeting trigger fires.
+ *
+ * The block is structural: it lists required and forbidden elements
+ * and instructs the LLM to compose 2–4 fresh sentences satisfying the
+ * contract. Anti-repetition is enforced by listing the user's recent
+ * opening phrases and telling the model not to start the same way.
+ */
+export function buildJourneyGreetingBlock(args: BuildJourneyGreetingBlockArgs): JourneyGreetingResult {
+  const kind = decideGreetingKind(args.journey, args.todayDateIso);
+  if (!kind || !args.journey) return { block: '', meta: null };
+
+  const langUpper = (args.lang || 'en').toUpperCase();
+  const nameClause = args.firstName
+    ? `Address the user by first name: ${args.firstName}.`
+    : `You do not have a first name for this user — address them warmly without a name.`;
+
+  const recentOpenings = (args.journey.recent_greeting_openings ?? []).slice(0, 5);
+  const antiRepetition = recentOpenings.length
+    ? `Your most recent opening phrases were: ${recentOpenings.map((o) => `"${o}"`).join(', ')}. Do NOT start the same way today. Compose a fresh opening.`
+    : `Compose a fresh, natural opening.`;
+
+  if (kind === 'first_session') {
+    return {
+      block: `
+
+=== FIRST-SESSION WELCOME (VTID-03154 Slice C — one-time, do not repeat) ===
+
+This is the user's FIRST session ever inside Vitanaland. Compose a fresh
+3–4 sentence welcome that satisfies this contract. Speak in ${langUpper}.
+
+REQUIRED — your welcome MUST:
+- ${nameClause}
+- Frame what they are starting as a JOURNEY (DE: Reise / Weg), NOT an app, tour, or platform tour.
+- Explain that the **Life Compass** holds their long-term goal — what they want from this journey overall.
+- Explain that the **Vitana Index** is how we measure daily progress along the way — a number that reflects how the day went across the five pillars.
+- Position yourself, Vitana, as the **companion / guide** who supports them on this journey (not as an "AI assistant" or "feature").
+- End with ONE open invitation to begin (a single question, not a menu).
+
+FORBIDDEN — your welcome MUST NOT:
+- List features ("we have X, Y, Z").
+- Call Vitanaland a "tour", "app", "platform", or "product".
+- Call the Life Compass a "tool" / "setting".
+- Call the Vitana Index a "score" / "number" (call it a daily progress measure or daily reading).
+- Introduce yourself as an "AI assistant" or a "feature".
+- Offer a multi-option menu of next steps. ONE open invitation is enough.
+
+STYLE: warm, first-day-of-something-meaningful, written like a knowledgeable
+friend at a coffee table. Vary your wording every session — never reuse the
+same opening on two consecutive days.
+
+=== END FIRST-SESSION WELCOME ===
+
+`,
+      meta: { kind: 'first_session', today_date_iso: args.todayDateIso },
+    };
+  }
+
+  // daily_morning
+  const dayInJourney = args.journey.day_in_journey;
+  const totalDays = args.journey.total_days;
+  const phaseName = args.journey.current_wave?.name ?? null;
+  const goalText = args.lifeCompassGoalText;
+
+  const purposeClause = goalText
+    ? `Reference their active Life Compass goal as the *purpose* of the journey, by inserting the goal text verbatim into a phrase like "in your plan to ${goalText}" / DE "in deinem Plan, ${goalText}". This anchors the day in WHY the journey exists.`
+    : `The user has not yet set a Life Compass goal. Use a phase-based purpose instead — e.g. "in your plan to find your rhythm" if the phase is "Getting Started", or a similar phase-appropriate framing.`;
+
+  const phaseClause = phaseName
+    ? `Current phase: "${phaseName}". You may name the phase naturally, but do not lecture about it.`
+    : `No active phase identified for today.`;
+
+  return {
+    block: `
+
+=== DAILY MORNING GREETING (VTID-03154 Slice D — first session of a new day) ===
+
+This is the user's FIRST session of a new calendar day. Compose a fresh
+2–3 sentence greeting that satisfies this contract. Speak in ${langUpper}.
+
+REQUIRED — your greeting MUST:
+- Use a time-appropriate salutation per the user's LOCAL TIME (good morning / good afternoon / good evening — pick the one that matches the local hour from the environment context block above).
+- ${nameClause}
+- State **"day ${dayInJourney}"** of the journey explicitly (DE: "Tag ${dayInJourney}"). The journey is ${totalDays} days total.
+- ${purposeClause}
+- End with ONE concrete pointer to today — either name the next planned action (if you know one) OR reference the user's last meaningful step (whichever is more useful given context). NOT a menu of options.
+
+CONTEXT:
+- ${phaseClause}
+- ${antiRepetition}
+
+FORBIDDEN — your greeting MUST NOT:
+- Use a generic "hello" / "hi" without a time salutation.
+- Address the user as "user" / "friend" / nameless when a first name is available.
+- Call this a "session N" or "visit N" — it is "day ${dayInJourney}".
+- Use generic phrases like "your wellness goals" / "your plan" when an active Life Compass goal text is available — use the goal text itself.
+- Offer a 3-item menu. One concrete pointer to today is enough.
+
+STYLE: warm but matter-of-fact, like a coach who genuinely remembers where
+the user is. The user should feel located in their journey, not lectured.
+
+=== END DAILY MORNING GREETING ===
+
+`,
+    meta: { kind: 'daily_morning', today_date_iso: args.todayDateIso },
+  };
+}

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1019,6 +1019,91 @@ export async function handleLiveSessionStart(
     );
   }
 
+  // VTID-03154 Slices C + D: journey-greeting block.
+  // Resolves the persistent user_journey row (Slice A) and decides whether
+  // this session should open with the one-time first-session welcome
+  // (is_first_session=true) or the daily-morning greeting (new calendar
+  // day in user TZ). Anonymous and missing-user sessions are skipped.
+  // Best-effort: any failure leaves journeyGreetingBlock empty and the
+  // session falls back to today's behavior. Self-contained scope — uses
+  // its own supabase handle so wake-brief failures upstream don't
+  // suppress the journey greeting.
+  try {
+    if (orbIdentity?.user_id) {
+      const { getSupabase: getSupa } = await import('../../../lib/supabase');
+      const supa = getSupa();
+      if (supa) {
+        const [
+          { getJourneyState, updateSessionEndState },
+          { buildJourneyGreetingBlock, todayInTimezone },
+          { fetchLifeCompass },
+        ] = await Promise.all([
+          import('../../../services/journey/user-journey-service'),
+          import('../instruction/journey-greeting'),
+          import('../../../services/user-context-profiler'),
+        ]);
+        const journey = await getJourneyState(supa, orbIdentity.user_id);
+        if (journey) {
+          const lifeCompass = await fetchLifeCompass(supa, orbIdentity.user_id).catch(() => null);
+          const tz = (session as any).clientContext?.timezone ?? null;
+          const todayDateIso = todayInTimezone(new Date(), tz);
+          // Best-effort first-name read for the contract. The wake-brief
+          // resolves firstName upstream; we read app_users.display_name
+          // here as a self-contained fallback so this block does not
+          // depend on the wake-brief try-block scope.
+          let nameForGreeting: string | null = null;
+          try {
+            const { data: prof } = await supa
+              .from('app_users')
+              .select('display_name')
+              .eq('user_id', orbIdentity.user_id)
+              .maybeSingle();
+            const dn = (prof?.display_name as string | undefined) ?? null;
+            if (dn) nameForGreeting = dn.split(/\s+/)[0] || null;
+          } catch { /* leave nameForGreeting null */ }
+          const result = buildJourneyGreetingBlock({
+            journey,
+            lifeCompassGoalText: lifeCompass?.primary_goal ?? null,
+            firstName: nameForGreeting,
+            lang,
+            todayDateIso,
+          });
+          if (result.block && result.meta) {
+            (session as any).journeyGreetingBlock = result.block;
+            (session as any).journeyGreetingMeta = result.meta;
+            // Suppress the wake-brief Say-exactly override when a journey
+            // greeting fires — the journey greeting becomes the turn-1
+            // owner. Teacher Mode (turn 2+) is unaffected. Otherwise the
+            // model gets two conflicting "first turn" instructions.
+            if (session.wakeBriefOverrideBlock) {
+              console.log(
+                `[VTID-03154] Suppressing wake-brief override block for ${sessionId} — journey greeting (${result.meta.kind}) takes turn 1.`,
+              );
+              session.wakeBriefOverrideBlock = '';
+            }
+            console.log(
+              `[VTID-03154] Journey greeting prepared for ${sessionId}: kind=${result.meta.kind} day=${journey.day_in_journey}/${journey.total_days} phase=${journey.current_wave?.id ?? 'none'} life_compass=${lifeCompass ? 'set' : 'unset'}`,
+            );
+            // Fire-and-forget update: clear is_first_session for Slice C,
+            // advance last_session_date for both kinds so same-day repeat
+            // sessions don't re-fire the morning greeting.
+            const userIdForUpdate = orbIdentity.user_id;
+            updateSessionEndState(supa, userIdForUpdate, {
+              last_session_date: result.meta.today_date_iso,
+              clear_first_session: result.meta.kind === 'first_session',
+            }).catch((err: any) =>
+              console.warn(`[VTID-03154] update after fire failed (non-fatal): ${err.message}`),
+            );
+          }
+        }
+      }
+    }
+  } catch (e) {
+    console.warn(
+      `[VTID-03154] journey-greeting resolution failed (non-fatal) for ${sessionId}: ${(e as Error).message}`,
+    );
+  }
+
   // Emit OASIS event with identity context
   await deps.emitLiveSessionEvent('vtid.live.session.start', {
     session_id: sessionId,

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5782,6 +5782,17 @@ async function connectToLiveAPI(
                           // live-session-controller.ts:VTID-03101 for the
                           // write side. Empty when no override is active.
                           + (session.wakeBriefOverrideBlock || '')
+                          // VTID-03154 Slices C+D: journey-greeting block.
+                          // Owns TURN 1 when fired (first-session welcome
+                          // for is_first_session=true users, or daily
+                          // morning greeting on a new calendar day in user
+                          // TZ). When this fires, the controller has
+                          // already cleared wakeBriefOverrideBlock above so
+                          // they don't conflict. Structural prompt (not
+                          // Say-exactly) — the LLM composes fresh wording
+                          // every time, satisfying the required-elements /
+                          // forbidden-elements contract.
+                          + ((session as any).journeyGreetingBlock || '')
                           // VTID-03112 (T1): Teacher Mode block. Empty
                           // when the wake-brief winner wasn't the
                           // Teacher OR the manual resolver failed.

--- a/services/gateway/test/orb/live/instruction/journey-greeting.test.ts
+++ b/services/gateway/test/orb/live/instruction/journey-greeting.test.ts
@@ -1,0 +1,225 @@
+/**
+ * VTID-03154 — Slices C + D: journey-greeting block builder tests.
+ *
+ * Covers:
+ *   - todayInTimezone: known TZ vs missing TZ vs invalid TZ
+ *   - decideGreetingKind: precedence first_session > daily_morning > null
+ *   - buildJourneyGreetingBlock first_session content invariants
+ *   - buildJourneyGreetingBlock daily_morning content invariants
+ *   - day count + life-compass goal text + anti-repetition memory
+ *   - both blocks are structural (no Say-exactly wording)
+ */
+
+import {
+  todayInTimezone,
+  decideGreetingKind,
+  buildJourneyGreetingBlock,
+} from '../../../../src/orb/live/instruction/journey-greeting';
+import type { JourneyState } from '../../../../src/services/journey/user-journey-service';
+
+const FIXED_NOW = new Date('2026-06-15T10:30:00.000Z');
+
+function makeJourney(overrides: Partial<JourneyState> = {}): JourneyState {
+  return {
+    user_id: 'u1',
+    tenant_id: null,
+    started_at: new Date(FIXED_NOW.getTime() - 14 * 86_400_000).toISOString(),
+    total_days: 90,
+    plan_type: 'default',
+    plan_summary: null,
+    status: 'active',
+    is_first_session: false,
+    last_session_date: '2026-06-14',
+    recent_greeting_openings: [],
+    completed_milestone_ids: [],
+    last_acknowledged_day: null,
+    day_in_journey: 14,
+    days_left: 76,
+    is_past_total_days: false,
+    current_wave: { id: 'wave-2', name: 'Daily Anchors', description: 'Build daily habits', start_day: 1, end_day: 14 },
+    fallback_used: false,
+    ...overrides,
+  };
+}
+
+describe('VTID-03154 journey-greeting', () => {
+  describe('todayInTimezone', () => {
+    it('returns YYYY-MM-DD in the given IANA TZ', () => {
+      // UTC 10:30 on June 15 → Berlin is 12:30 → 2026-06-15
+      expect(todayInTimezone(FIXED_NOW, 'Europe/Berlin')).toBe('2026-06-15');
+    });
+    it('handles a TZ where the local date is the next day', () => {
+      // UTC 10:30 on June 15 → Sydney is 20:30 → 2026-06-15
+      expect(todayInTimezone(FIXED_NOW, 'Australia/Sydney')).toBe('2026-06-15');
+    });
+    it('handles a TZ where the local date is the previous day', () => {
+      // UTC 03:30 on June 15 → LA is 20:30 on June 14
+      const earlyUtc = new Date('2026-06-15T03:30:00.000Z');
+      expect(todayInTimezone(earlyUtc, 'America/Los_Angeles')).toBe('2026-06-14');
+    });
+    it('falls back to UTC when TZ is null', () => {
+      expect(todayInTimezone(FIXED_NOW, null)).toBe('2026-06-15');
+    });
+    it('falls back to UTC when TZ is invalid', () => {
+      expect(todayInTimezone(FIXED_NOW, 'Not/A_Real_Timezone')).toBe('2026-06-15');
+    });
+  });
+
+  describe('decideGreetingKind precedence', () => {
+    it('returns null when journey is null', () => {
+      expect(decideGreetingKind(null, '2026-06-15')).toBeNull();
+    });
+    it('returns first_session when is_first_session=true (even if last_session_date matches today)', () => {
+      const j = makeJourney({ is_first_session: true, last_session_date: '2026-06-15' });
+      expect(decideGreetingKind(j, '2026-06-15')).toBe('first_session');
+    });
+    it('returns daily_morning when last_session_date is null', () => {
+      const j = makeJourney({ is_first_session: false, last_session_date: null });
+      expect(decideGreetingKind(j, '2026-06-15')).toBe('daily_morning');
+    });
+    it('returns daily_morning when last_session_date < today', () => {
+      const j = makeJourney({ is_first_session: false, last_session_date: '2026-06-14' });
+      expect(decideGreetingKind(j, '2026-06-15')).toBe('daily_morning');
+    });
+    it('returns null when last_session_date === today (same-day repeat session)', () => {
+      const j = makeJourney({ is_first_session: false, last_session_date: '2026-06-15' });
+      expect(decideGreetingKind(j, '2026-06-15')).toBeNull();
+    });
+    it('returns null when last_session_date is in the future (clock skew)', () => {
+      const j = makeJourney({ is_first_session: false, last_session_date: '2026-06-20' });
+      expect(decideGreetingKind(j, '2026-06-15')).toBeNull();
+    });
+  });
+
+  describe('buildJourneyGreetingBlock — first_session', () => {
+    it('returns empty when no trigger fires', () => {
+      const j = makeJourney({ is_first_session: false, last_session_date: '2026-06-15' });
+      const r = buildJourneyGreetingBlock({
+        journey: j, lifeCompassGoalText: null, firstName: 'Dragan', lang: 'en',
+        todayDateIso: '2026-06-15',
+      });
+      expect(r.block).toBe('');
+      expect(r.meta).toBeNull();
+    });
+
+    it('emits a structural first-session block with all required framings', () => {
+      const j = makeJourney({ is_first_session: true });
+      const r = buildJourneyGreetingBlock({
+        journey: j, lifeCompassGoalText: null, firstName: 'Dragan', lang: 'en',
+        todayDateIso: '2026-06-15',
+      });
+      expect(r.meta).toEqual({ kind: 'first_session', today_date_iso: '2026-06-15' });
+      // Required framings present
+      expect(r.block).toMatch(/FIRST-SESSION WELCOME/);
+      expect(r.block).toMatch(/Dragan/);
+      expect(r.block).toMatch(/JOURNEY/);
+      expect(r.block).toMatch(/Life Compass/);
+      expect(r.block).toMatch(/Vitana Index/);
+      expect(r.block).toMatch(/companion/i);
+      // Forbidden phrasings called out
+      expect(r.block).toMatch(/tour/);
+      expect(r.block).toMatch(/feature/);
+      // Structural — NOT Say-exactly verbatim
+      expect(r.block).not.toMatch(/Speak this VERBATIM/i);
+      expect(r.block).not.toMatch(/letter[- ]for[- ]letter/i);
+    });
+
+    it('handles missing firstName gracefully', () => {
+      const j = makeJourney({ is_first_session: true });
+      const r = buildJourneyGreetingBlock({
+        journey: j, lifeCompassGoalText: null, firstName: null, lang: 'de',
+        todayDateIso: '2026-06-15',
+      });
+      expect(r.block).toMatch(/without a name/);
+      expect(r.block).toMatch(/Speak in DE/);
+    });
+  });
+
+  describe('buildJourneyGreetingBlock — daily_morning', () => {
+    it('emits day-N + phase + goal text + anti-repetition when all present', () => {
+      const j = makeJourney({
+        day_in_journey: 14,
+        total_days: 90,
+        current_wave: { id: 'wave-2', name: 'Daily Anchors', description: 'Build daily habits', start_day: 1, end_day: 14 },
+        recent_greeting_openings: ['Guten Morgen', 'Good morning'],
+      });
+      const r = buildJourneyGreetingBlock({
+        journey: j,
+        lifeCompassGoalText: 'sleep better and reduce back pain',
+        firstName: 'Dragan',
+        lang: 'en',
+        todayDateIso: '2026-06-15',
+      });
+      expect(r.meta).toEqual({ kind: 'daily_morning', today_date_iso: '2026-06-15' });
+      expect(r.block).toMatch(/DAILY MORNING GREETING/);
+      expect(r.block).toMatch(/day 14/);
+      expect(r.block).toMatch(/90 days total/);
+      expect(r.block).toMatch(/Daily Anchors/);
+      expect(r.block).toMatch(/in your plan to sleep better and reduce back pain/);
+      expect(r.block).toMatch(/Guten Morgen/);
+      expect(r.block).toMatch(/Good morning/);
+      expect(r.block).toMatch(/Do NOT start the same way today/);
+      expect(r.block).toMatch(/Dragan/);
+    });
+
+    it('uses phase-based purpose fallback when life-compass goal is null', () => {
+      const j = makeJourney({
+        day_in_journey: 3,
+        current_wave: { id: 'wave-1', name: 'Getting Started', description: 'Set up profile', start_day: 0, end_day: 7 },
+      });
+      const r = buildJourneyGreetingBlock({
+        journey: j,
+        lifeCompassGoalText: null,
+        firstName: null,
+        lang: 'en',
+        todayDateIso: '2026-06-15',
+      });
+      expect(r.block).toMatch(/has not yet set a Life Compass goal/);
+      expect(r.block).toMatch(/phase-based purpose/);
+      expect(r.block).toMatch(/Getting Started/);
+    });
+
+    it('handles missing current_wave (past total_days edge)', () => {
+      const j = makeJourney({
+        day_in_journey: 95,
+        current_wave: null,
+        is_past_total_days: true,
+      });
+      const r = buildJourneyGreetingBlock({
+        journey: j,
+        lifeCompassGoalText: null,
+        firstName: 'Dragan',
+        lang: 'en',
+        todayDateIso: '2026-06-15',
+      });
+      expect(r.block).toMatch(/No active phase identified for today/);
+    });
+
+    it('omits anti-repetition section when recent_greeting_openings is empty', () => {
+      const j = makeJourney({ recent_greeting_openings: [] });
+      const r = buildJourneyGreetingBlock({
+        journey: j,
+        lifeCompassGoalText: 'find my rhythm',
+        firstName: 'Dragan',
+        lang: 'en',
+        todayDateIso: '2026-06-15',
+      });
+      expect(r.block).toMatch(/Compose a fresh, natural opening/);
+      expect(r.block).not.toMatch(/Do NOT start the same way today/);
+    });
+
+    it('structural — NOT Say-exactly verbatim', () => {
+      const j = makeJourney();
+      const r = buildJourneyGreetingBlock({
+        journey: j,
+        lifeCompassGoalText: 'sleep better',
+        firstName: 'Dragan',
+        lang: 'en',
+        todayDateIso: '2026-06-15',
+      });
+      expect(r.block).not.toMatch(/Speak this VERBATIM/i);
+      expect(r.block).not.toMatch(/letter[- ]for[- ]letter/i);
+      expect(r.block).not.toMatch(/Say exactly/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Slice C + Slice D of the My-Journey engagement-spine plan. Builds on the VTID-03152 `user_journey` foundation.

### Slice C — One-time first-session welcome
Triggers when `user_journey.is_first_session === true`. Structural prompt block tells Gemini to compose 3-4 fresh sentences that satisfy the contract:
- Frame what they are starting as a JOURNEY (not an app tour)
- Life Compass = long-term goal
- Vitana Index = daily progress measure
- Vitana = companion / guide on this journey
- One open invitation to begin; no feature checklist; no menu

### Slice D — Daily morning greeting
Triggers on the first session of a new calendar day in the user's local TZ (`last_session_date < today` AND `is_first_session === false`). Structural prompt:
- Time-appropriate salutation per local hour
- States **"day {X}"** of the journey explicitly with total {N}
- Anchors purpose with the active Life Compass goal text verbatim (falls back to phase-based purpose when no goal is set)
- One concrete pointer to today (next planned action OR last meaningful step)
- Anti-repetition: passes recent_greeting_openings to the LLM with "do NOT start the same way today"

Both blocks are **structural, not Say-exactly**. Verbatim is the right pattern for teaching moments (VTID-03104 / VTID-03120 highlights); it is the wrong pattern for relational moments like the daily welcome — locked wording day-over-day would make Vitana sound like a robot.

### Wiring

- New module `services/gateway/src/orb/live/instruction/journey-greeting.ts` with three pure exports: `todayInTimezone`, `decideGreetingKind`, `buildJourneyGreetingBlock`.
- `live-session-controller.ts` resolves the journey state + Life Compass goal + display-name right after the wake-brief decision, builds the block, stores it on `session.journeyGreetingBlock`, and — when active — **clears `session.wakeBriefOverrideBlock`** so the two don't conflict on turn 1.
- `orb-live.ts` setup envelope concatenates `journeyGreetingBlock` between the wake-brief slot and the Teacher Mode block.
- Fire-and-forget update writes back: clears `is_first_session` after Slice C fires; advances `last_session_date` after either kind fires (so same-day repeat sessions don't re-fire the morning greeting).

### Why no Say-exactly

Two prior incidents in voice memory (VTID-03102 broke audio with long meta-instructions; VTID-03103 silenced session.say in suppressed branches) reinforced that Say-exactly works for short, deterministic teaching lines but breaks down for richer relational language. The contract here forces freshness without locking the words.

## Test plan

- [x] `npm run build` clean
- [x] 19 new unit tests in `test/orb/live/instruction/journey-greeting.test.ts` — all green
- [x] 226 regression tests in `test/orb/live/characterization/` + `test/orb/teacher/` — all green
- [ ] EXEC-DEPLOY green
- [ ] User runtime smoke:
  - Brand-new test user → expect a journey-framed welcome on first session, not a feature list. Watch `[VTID-03154] Journey greeting prepared` in logs.
  - Existing user (Dragan) returning on a new calendar day → expect "Good morning Dragan — day {X}…" framing with the active Life Compass goal woven in. Existing users have `is_first_session=false` from backfill so the one-time welcome does NOT fire retroactively.
  - Same-day second session → expect NO day-N restatement (yields to existing same-day cadence).

## What this does NOT do (still deferred)

- Slice E — personalization / custom plan negotiation
- Slice F — My Journey screen visuals (separate session)
- Slice G — milestone celebration (supersedes morning when crossing a wave boundary)
- Slice H — gap recovery (supersedes morning after ≥14-day absence)
- Slice I — journey-aware Teacher Mode (capabilities scoped per wave)

Generated with [Claude Code](https://claude.com/claude-code)