### PR TITLE
feat(my-journey): goal-centric North Star data block (VTID-03152)

### DIFF
--- a/services/gateway/src/routes/my-journey.ts
+++ b/services/gateway/src/routes/my-journey.ts
@@ -10,7 +10,11 @@
  *     day_in_journey, total_days, days_left, plan_type, plan_summary,
  *     status, is_first_session, last_session_date,
  *     current_phase: { id, name, day_range, day_in_phase, days_to_next_milestone },
- *     life_compass: { active_goal_text, pillar_focus, set_at } | null,
+ *     life_compass: {
+ *       active_goal_text, pillar_focus, set_at,
+ *       target_date, target_value, target_unit,        // goal-centric North Star
+ *       has_deadline, days_to_deadline, goal_total_days, goal_day, goal_progress_pct,
+ *     } | null,
  *     vitana_index: { today, tier, trend_7d } | null,
  *   }
  *
@@ -23,12 +27,75 @@
 import { Router, Response } from 'express';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
-import { fetchVitanaIndexForProfiler, fetchLifeCompass } from '../services/user-context-profiler';
+import { fetchVitanaIndexForProfiler, fetchLifeCompass, LifeCompassSnapshot } from '../services/user-context-profiler';
 import { getJourneyState } from '../services/journey/user-journey-service';
 
 const router = Router();
 
 const VTID = 'VTID-03152';
+
+const MS_PER_DAY = 86_400_000;
+
+/** UTC-midnight epoch for the calendar date of an ISO date/datetime string. */
+function utcMidnight(iso: string): number | null {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+/**
+ * Whole CALENDAR days between two ISO date/datetime strings (b - a). Both are
+ * normalized to UTC midnight first, so a noon "now" against a midnight deadline
+ * date yields a stable calendar-day count (no time-of-day off-by-one). Can be
+ * negative (deadline already passed). Null when either input is missing/unparseable.
+ */
+function daysBetween(aIso: string | null | undefined, bIso: string | null | undefined): number | null {
+  if (!aIso || !bIso) return null;
+  const a = utcMidnight(aIso);
+  const b = utcMidnight(bIso);
+  if (a === null || b === null) return null;
+  return Math.round((b - a) / MS_PER_DAY);
+}
+
+/**
+ * Goal-centric block for the My Journey North Star. Progress is time-based
+ * (days elapsed since the goal was set vs. days until its deadline) so it is
+ * always computable from dates alone — no quantified measurements required.
+ * All goal-target fields fall back to null when the goal has no deadline yet.
+ */
+export function buildGoalBlock(lc: LifeCompassSnapshot, now: Date = new Date()) {
+  const nowIso = now.toISOString();
+  const hasDeadline = !!lc.target_date;
+
+  const daysToDeadline = hasDeadline
+    ? Math.max(0, daysBetween(nowIso, lc.target_date) ?? 0)
+    : null;
+  const goalTotalDays = hasDeadline
+    ? Math.max(0, daysBetween(lc.set_at, lc.target_date) ?? 0)
+    : null;
+  const goalDay = hasDeadline
+    ? Math.max(0, daysBetween(lc.set_at, nowIso) ?? 0)
+    : null;
+  const goalProgressPct =
+    goalTotalDays && goalTotalDays > 0 && goalDay !== null
+      ? Math.min(100, Math.round((goalDay / goalTotalDays) * 100))
+      : null;
+
+  return {
+    active_goal_text: lc.primary_goal,
+    pillar_focus: lc.category,
+    confidence_score: lc.confidence_score ?? null,
+    target_date: lc.target_date ?? null,
+    target_value: lc.target_value ?? null,
+    target_unit: lc.target_unit ?? null,
+    set_at: lc.set_at ?? null,
+    has_deadline: hasDeadline,
+    days_to_deadline: daysToDeadline,
+    goal_total_days: goalTotalDays,
+    goal_day: goalDay,
+    goal_progress_pct: goalProgressPct,
+  };
+}
 
 function getServiceClient(): SupabaseClient | null {
   const url = process.env.SUPABASE_URL;
@@ -103,13 +170,7 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
         current_phase: phase,
         fallback_used: journey.fallback_used,
       },
-      life_compass: lifeCompass
-        ? {
-            active_goal_text: lifeCompass.primary_goal,
-            pillar_focus: lifeCompass.category,
-            confidence_score: lifeCompass.confidence_score ?? null,
-          }
-        : null,
+      life_compass: lifeCompass ? buildGoalBlock(lifeCompass) : null,
       vitana_index: indexSnapshot
         ? {
             today: indexSnapshot.total,

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -390,21 +390,20 @@ export async function fetchLifeCompass(
     // back to the base columns rather than dropping the compass entirely.
     const extendedCols =
       'primary_goal, category, confidence_score, target_date, target_value, target_unit, starting_value, created_at';
-    let { data, error } = await client
-      .from('life_compass')
-      .select(extendedCols)
-      .eq('user_id', userId)
-      .eq('is_active', true)
-      .order('created_at', { ascending: false })
-      .limit(1);
-    if (error) {
-      ({ data, error } = await client
+    const queryCols = async (cols: string) =>
+      client
         .from('life_compass')
-        .select('primary_goal, category, confidence_score, created_at')
+        .select(cols)
         .eq('user_id', userId)
         .eq('is_active', true)
         .order('created_at', { ascending: false })
-        .limit(1));
+        .limit(1);
+
+    let data: any[] | null;
+    let error: any;
+    ({ data, error } = await queryCols(extendedCols));
+    if (error) {
+      ({ data, error } = await queryCols('primary_goal, category, confidence_score, created_at'));
     }
     if (error || !data || data.length === 0) return null;
     const row = data[0] as {

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -325,6 +325,16 @@ export interface LifeCompassSnapshot {
   primary_goal: string;
   category: string;
   confidence_score?: number | null;
+  /** Goal deadline (ISO date) — drives the My Journey days-to-deadline North Star. */
+  target_date?: string | null;
+  /** Optional quantified target, e.g. 10 for "lose 10 kg". */
+  target_value?: number | null;
+  /** Optional unit for the target, e.g. "kg". */
+  target_unit?: string | null;
+  /** Optional baseline measurement, reserved for later metric-progress. */
+  starting_value?: number | null;
+  /** When the goal was set (life_compass.created_at). */
+  set_at?: string | null;
 }
 
 /**
@@ -375,19 +385,47 @@ export async function fetchLifeCompass(
   userId: string,
 ): Promise<LifeCompassSnapshot | null> {
   try {
-    const { data, error } = await client
+    // Try the goal-target columns first. They land in a separate migration that
+    // may lag this gateway deploy, so on a "column does not exist" error we fall
+    // back to the base columns rather than dropping the compass entirely.
+    const extendedCols =
+      'primary_goal, category, confidence_score, target_date, target_value, target_unit, starting_value, created_at';
+    let { data, error } = await client
       .from('life_compass')
-      .select('primary_goal, category, confidence_score')
+      .select(extendedCols)
       .eq('user_id', userId)
       .eq('is_active', true)
       .order('created_at', { ascending: false })
       .limit(1);
+    if (error) {
+      ({ data, error } = await client
+        .from('life_compass')
+        .select('primary_goal, category, confidence_score, created_at')
+        .eq('user_id', userId)
+        .eq('is_active', true)
+        .order('created_at', { ascending: false })
+        .limit(1));
+    }
     if (error || !data || data.length === 0) return null;
-    const row = data[0] as { primary_goal: string; category: string; confidence_score?: number | null };
+    const row = data[0] as {
+      primary_goal: string;
+      category: string;
+      confidence_score?: number | null;
+      target_date?: string | null;
+      target_value?: number | null;
+      target_unit?: string | null;
+      starting_value?: number | null;
+      created_at?: string | null;
+    };
     return {
       primary_goal: row.primary_goal,
       category: row.category,
       confidence_score: row.confidence_score ?? null,
+      target_date: row.target_date ?? null,
+      target_value: row.target_value ?? null,
+      target_unit: row.target_unit ?? null,
+      starting_value: row.starting_value ?? null,
+      set_at: row.created_at ?? null,
     };
   } catch {
     return null;

--- a/services/gateway/test/routes/my-journey-goal-block.test.ts
+++ b/services/gateway/test/routes/my-journey-goal-block.test.ts
@@ -1,0 +1,88 @@
+/**
+ * VTID-03152 — Slice F: My Journey goal-centric North Star.
+ *
+ * Covers the time-based goal-progress math in buildGoalBlock():
+ *   - goal with a deadline computes days_to_deadline / goal_total_days /
+ *     goal_day / goal_progress_pct
+ *   - goal without a deadline yields null goal-progress fields (has_deadline false)
+ *   - deadline today clamps days_to_deadline to 0 and progress to 100
+ *   - goal-target passthrough (value/unit/text/pillar) is preserved
+ */
+
+import { buildGoalBlock } from '../../src/routes/my-journey';
+import type { LifeCompassSnapshot } from '../../src/services/user-context-profiler';
+
+const FIXED_NOW = new Date('2026-06-01T12:00:00.000Z');
+
+function compass(overrides: Partial<LifeCompassSnapshot> = {}): LifeCompassSnapshot {
+  return {
+    primary_goal: 'Lose 10 kg',
+    category: 'health',
+    confidence_score: 80,
+    target_date: null,
+    target_value: null,
+    target_unit: null,
+    starting_value: null,
+    set_at: null,
+    ...overrides,
+  };
+}
+
+describe('VTID-03152 my-journey buildGoalBlock', () => {
+  it('computes time-based progress for a goal with a deadline', () => {
+    // Set 30 days ago, deadline 60 days from now -> total 90, day 30, 33%.
+    const block = buildGoalBlock(
+      compass({
+        set_at: '2026-05-02T12:00:00.000Z', // 30 days before FIXED_NOW
+        target_date: '2026-07-31', // 60 days after FIXED_NOW
+        target_value: 10,
+        target_unit: 'kg',
+      }),
+      FIXED_NOW,
+    );
+    expect(block.has_deadline).toBe(true);
+    expect(block.days_to_deadline).toBe(60);
+    expect(block.goal_total_days).toBe(90);
+    expect(block.goal_day).toBe(30);
+    expect(block.goal_progress_pct).toBe(33);
+    expect(block.target_value).toBe(10);
+    expect(block.target_unit).toBe('kg');
+    expect(block.active_goal_text).toBe('Lose 10 kg');
+    expect(block.pillar_focus).toBe('health');
+  });
+
+  it('returns null goal-progress fields when no deadline is set', () => {
+    const block = buildGoalBlock(compass({ set_at: '2026-05-02T12:00:00.000Z' }), FIXED_NOW);
+    expect(block.has_deadline).toBe(false);
+    expect(block.days_to_deadline).toBeNull();
+    expect(block.goal_total_days).toBeNull();
+    expect(block.goal_day).toBeNull();
+    expect(block.goal_progress_pct).toBeNull();
+    // Goal text/pillar still pass through.
+    expect(block.active_goal_text).toBe('Lose 10 kg');
+  });
+
+  it('clamps a deadline that is today to 0 days left and 100% progress', () => {
+    const block = buildGoalBlock(
+      compass({
+        set_at: '2026-05-02T12:00:00.000Z', // 30 days before
+        target_date: '2026-06-01', // same calendar day as FIXED_NOW
+      }),
+      FIXED_NOW,
+    );
+    expect(block.days_to_deadline).toBe(0);
+    expect(block.goal_progress_pct).toBe(100);
+  });
+
+  it('clamps a past deadline to 0 days left without going negative', () => {
+    const block = buildGoalBlock(
+      compass({
+        set_at: '2026-04-01T12:00:00.000Z',
+        target_date: '2026-05-15', // already passed
+      }),
+      FIXED_NOW,
+    );
+    expect(block.days_to_deadline).toBe(0);
+    expect(block.goal_progress_pct).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
Backend half of the "My Journey as North Star" rebuild. Enriches the unified `/api/v1/my-journey` endpoint so the screen can render the user's **own goal** with a time-to-deadline countdown — not just the 90-day onboarding arc.

- `fetchLifeCompass` / `LifeCompassSnapshot` now carry `target_date`, `target_value`, `target_unit`, `starting_value`, `set_at`. The select tries the new columns and **falls back** to the base columns on error, so it won't regress the existing compass display if the gateway deploys before the column migration lands.
- `/api/v1/my-journey` `life_compass` block adds a goal-progress section computed purely from dates (`has_deadline`, `days_to_deadline`, `goal_total_days`, `goal_day`, `goal_progress_pct`) via a new `buildGoalBlock()`. Calendar-day (UTC-midnight) math avoids time-of-day off-by-one in the user-facing "days left" counter.
- Unit test covers the with-deadline math, the no-deadline (null) case, deadline-today, and past-deadline clamping.

The matching `life_compass` column migration ships in the **vitana-v1** PR on the same branch (that repo owns the table). The AI-prescribed multi-step plan ("Slice E") remains deferred.

> Note: this branch predates the session, so the diff vs `main` includes earlier branch commits. The commit specific to this work is `feat(my-journey): enrich endpoint with goal-centric North Star block`.

## Test plan
- [ ] `cd services/gateway && npm test -- my-journey-goal-block` (date math)
- [ ] Apply the `life_compass` migration, then `curl` `/api/v1/my-journey` for a user with a `target_date` and confirm `days_to_deadline` / `goal_progress_pct`
- [ ] Confirm a user with no goal returns `life_compass: null` and a goal with no deadline returns null goal-progress fields (no regression)

https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU)_