### PR TITLE
fix: VTID-03157 journey greeting owns turn 1 + Teacher check-in + morning previews coming days

### DIFF
--- a/services/gateway/src/orb/live/instruction/journey-greeting.ts
+++ b/services/gateway/src/orb/live/instruction/journey-greeting.ts
@@ -170,17 +170,18 @@ same opening on two consecutive days.
   return {
     block: `
 
-=== DAILY MORNING GREETING (VTID-03154 Slice D — first session of a new day) ===
+=== DAILY MORNING GREETING (VTID-03154 / VTID-03157 Slice D — first session of a new day) ===
 
 This is the user's FIRST session of a new calendar day. Compose a fresh
-2–3 sentence greeting that satisfies this contract. Speak in ${langUpper}.
+2–4 sentence greeting that satisfies this contract. Speak in ${langUpper}.
 
 REQUIRED — your greeting MUST:
 - Use a time-appropriate salutation per the user's LOCAL TIME (good morning / good afternoon / good evening — pick the one that matches the local hour from the environment context block above).
 - ${nameClause}
 - State **"day ${dayInJourney}"** of the journey explicitly (DE: "Tag ${dayInJourney}"). The journey is ${totalDays} days total.
 - ${purposeClause}
-- End with ONE concrete pointer to today — either name the next planned action (if you know one) OR reference the user's last meaningful step (whichever is more useful given context). NOT a menu of options.
+- Give the user a clear status of WHERE they are right now (day count + phase placement) AND a one-sentence preview of WHAT TO EXPECT in the COMING DAYS of this phase — not just today. The user explicitly asked for both "where I am" AND "where I'm going next". Example: "today is about X, and over the next few days we'll move toward Y" / DE "heute geht es um X, und in den kommenden Tagen kommen wir zu Y". Use the phase description to ground what comes next.
+- End with ONE concrete pointer to today — either name the next planned action (if you know one) OR reference the user's last meaningful step. NOT a menu of options.
 
 CONTEXT:
 - ${phaseClause}

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1073,13 +1073,38 @@ export async function handleLiveSessionStart(
             (session as any).journeyGreetingMeta = result.meta;
             // Suppress the wake-brief Say-exactly override when a journey
             // greeting fires — the journey greeting becomes the turn-1
-            // owner. Teacher Mode (turn 2+) is unaffected. Otherwise the
-            // model gets two conflicting "first turn" instructions.
+            // owner. Otherwise the model gets two conflicting "first turn"
+            // instructions.
             if (session.wakeBriefOverrideBlock) {
               console.log(
                 `[VTID-03154] Suppressing wake-brief override block for ${sessionId} — journey greeting (${result.meta.kind}) takes turn 1.`,
               );
               session.wakeBriefOverrideBlock = '';
+            }
+            // VTID-03157: also suppress the Teacher Mode block. Its
+            // system_instruction contains the literal sentence "Your
+            // FIRST spoken line of this session was a permission-asking
+            // offer for X", which directly contradicts the journey
+            // greeting. Because Teacher Mode is concatenated AFTER the
+            // journey greeting in orb-live.ts, Gemini's recency primacy
+            // gives Teacher Mode the upper hand — so the user hears the
+            // curriculum-march pattern instead of the new journey
+            // framing. The user's runtime test surfaced this: they
+            // experienced "no change" after VTID-03154 because Teacher
+            // Mode was still winning turn 1.
+            // Clearing teacherModeContent here means: on a new-day
+            // session (or a brand-new user's first session), the journey
+            // greeting cleanly owns turn 1 and Vitana responds normally
+            // to whatever the user says from turn 2+. If the user wants
+            // to keep learning a specific capability, they can ask, and
+            // Vitana will discover/answer via search_knowledge — same
+            // pathway as any other "what is X?" question.
+            if ((session as any).teacherModeContent) {
+              console.log(
+                `[VTID-03157] Suppressing Teacher Mode block for ${sessionId} — journey greeting (${result.meta.kind}) takes turn 1 and dominates the session.`,
+              );
+              (session as any).teacherModeContent = null;
+              (session as any).teacherModeFirstName = null;
             }
             console.log(
               `[VTID-03154] Journey greeting prepared for ${sessionId}: kind=${result.meta.kind} day=${journey.day_in_journey}/${journey.total_days} phase=${journey.current_wave?.id ?? 'none'} life_compass=${lifeCompass ? 'set' : 'unset'}`,

--- a/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
+++ b/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
@@ -121,30 +121,63 @@ ${remainingList}
      Vitanaland. Two sentences is NOT enough; explain it properly.
 `}
 
-     After the intro, end with a question that NAMES the next thing
-     explicitly. NEVER say a generic "Möchtest du das Nächste sehen?"
-     or "Want to move to next?" — the word "next" is meaningless to
-     a first-week onboarding user, they don't know what comes next.
-     ALWAYS name the next capability by its display name from the
-     Remaining list. The next capability for this session is:
-     "${args.content.remaining_capabilities[0]?.display_name ?? '(none — the curriculum is exhausted; end the session warmly)'}".
-     So the right wording is e.g. "Magst du, dass ich dir noch mehr
-     dazu erzähle, oder soll ich dir als Nächstes
-     ${args.content.remaining_capabilities[0]?.display_name ?? 'eine weitere Vitanaland-Funktion'}
-     vorstellen?" — vary the wording each turn, but the named next
-     capability is non-negotiable.
+     After the intro, you MUST run a COMPREHENSION CHECK-IN — a single
+     short sentence that gives the user a clear three-way choice. 3-4
+     sentences of intro is not enough for a first-30-days learner to
+     fully internalize a feature. Some will need more detail; others
+     understood enough and want to move on; others have lost interest
+     and want a different topic. NEVER jump straight from intro to
+     "want the next thing?" — that is exactly the rushed pattern the
+     user complained about. The check-in offers ALL THREE options:
 
-   - User signals satisfaction or curiosity ("nice", "okay", "verstanden",
-     "tell me more", "wie funktioniert das?"): if they want more detail,
-     answer from the manual. If they sound ready to move on, chain to
-     the NEXT capability from the Remaining list — name it explicitly,
-     e.g. "Lass mich dir als Nächstes ${args.content.remaining_capabilities[0]?.display_name ?? 'eine weitere Funktion'}
+       (a) deepen this one (more detail / examples / how it works)
+       (b) move on to the named next capability
+       (c) not interested in this — pick a different topic
+
+     Example check-in phrasings (vary the wording each turn — never
+     reuse the same construction back-to-back):
+       • DE: "Konntest du das so verstehen? Wenn du dazu mehr erfahren
+         möchtest, erkläre ich es dir gerne im Detail. Wenn das für
+         dich klar ist, kann ich dir als Nächstes
+         ${args.content.remaining_capabilities[0]?.display_name ?? 'eine weitere Funktion'}
+         vorstellen. Oder wenn dich das gerade nicht interessiert,
+         sag's mir und ich zeige dir etwas Anderes."
+       • EN: "Did that land okay? Happy to go deeper on it if you want
+         more detail. Otherwise I can introduce you to
+         ${args.content.remaining_capabilities[0]?.display_name ?? 'another Vitanaland feature'}
+         next — or, if this just isn't grabbing you, tell me and I'll
+         pick something else."
+
+     The check-in is NON-NEGOTIABLE. After every intro you deliver, the
+     check-in sentence MUST follow. The check-in NAMES the next
+     capability explicitly. The bare word "next" / "das Nächste" is
+     STILL forbidden.
+
+   - User responds to the check-in by asking for more depth ("mehr",
+     "detail", "wie funktioniert das genau?", "explain more", "tell me
+     more", "go deeper"): answer from the MANUAL CONTENT above, using
+     2-4 sentences. Then re-offer a SHORTER check-in: "Klar so weit?
+     Magst du noch tiefer, oder zu ${args.content.remaining_capabilities[0]?.display_name ?? 'der nächsten Funktion'}?"
+     Loop until the user signals they've had enough.
+
+   - User signals satisfaction or readiness ("okay", "verstanden",
+     "got it", "klar", "passt"): chain to the next capability — name
+     it explicitly, e.g. "Lass mich dir als Nächstes
+     ${args.content.remaining_capabilities[0]?.display_name ?? 'eine weitere Funktion'}
      vorstellen — das ist ${args.content.remaining_capabilities[0]?.description ?? 'eine weitere Funktion in Vitanaland'}.
      Magst du?" and treat the new capability as the active one. NEVER
      use the bare word "Nächstes" / "next" without immediately naming
      what it is. When chaining, FIRST call \`teacher_event\` with
-     eventName='tried' and capability_key='${args.content.active_capability_key}'
+     eventName='introduced' (or 'seen' if the user actively asked
+     follow-ups during the check-in) and capability_key='${args.content.active_capability_key}'
      to mark the current one done in the ledger.
+
+   - User signals lack of interest in the current capability but wants
+     to keep learning ("not really", "skip", "nicht so spannend",
+     "something else", "anders"): acknowledge briefly (one sentence),
+     call \`teacher_event\` with eventName='dismissed' and
+     capability_key='${args.content.active_capability_key}', then offer
+     the next capability the same way as above.
 
    - User asks an unrelated question: answer it naturally with your
      other tools (search_knowledge, search_memory, etc). After

--- a/services/gateway/test/orb/live/instruction/journey-greeting.test.ts
+++ b/services/gateway/test/orb/live/instruction/journey-greeting.test.ts
@@ -208,6 +208,22 @@ describe('VTID-03154 journey-greeting', () => {
       expect(r.block).not.toMatch(/Do NOT start the same way today/);
     });
 
+    it('VTID-03157: requires a preview of what to expect in the COMING DAYS, not just today', () => {
+      const j = makeJourney({
+        day_in_journey: 5,
+        current_wave: { id: 'wave-1', name: 'Getting Started', description: 'Set up profile', start_day: 0, end_day: 7 },
+      });
+      const r = buildJourneyGreetingBlock({
+        journey: j,
+        lifeCompassGoalText: 'sleep better',
+        firstName: 'Dragan',
+        lang: 'en',
+        todayDateIso: '2026-06-15',
+      });
+      expect(r.block).toMatch(/preview of WHAT TO EXPECT in the COMING DAYS/);
+      expect(r.block).toMatch(/over the next few days/);
+    });
+
     it('structural — NOT Say-exactly verbatim', () => {
       const j = makeJourney();
       const r = buildJourneyGreetingBlock({

--- a/services/gateway/test/orb/teacher/teacher-mode-prompt-checkin.test.ts
+++ b/services/gateway/test/orb/teacher/teacher-mode-prompt-checkin.test.ts
@@ -1,0 +1,80 @@
+/**
+ * VTID-03157 — Teacher Mode comprehension check-in contract.
+ *
+ * Founder feedback after VTID-03154 runtime test: the Teacher Mode
+ * pattern was rushed — 2-4 sentences explaining a feature then
+ * immediately "want me to introduce another?". A first-30-days user
+ * can't internalize a feature in 2-4 sentences; some need more depth,
+ * others didn't connect and want a different topic, others are ready
+ * to move on. The contract NOW requires a mandatory check-in sentence
+ * after every intro with a clear three-way choice.
+ *
+ * This test locks the contract structurally so a future refactor can't
+ * silently remove the check-in.
+ */
+
+import { buildTeacherModeBlock } from '../../../src/orb/teacher/teacher-mode-prompt';
+import type { TeacherModeContent } from '../../../src/orb/teacher/teacher-content-resolver';
+
+function makeContent(overrides: Partial<TeacherModeContent> = {}): TeacherModeContent {
+  return {
+    active_capability_key: 'life_compass',
+    active_display_name: 'Life Compass',
+    active_description: 'Your active longevity goal',
+    active_manual_path: 'kb/life-compass.md',
+    active_manual_content: 'Life Compass is your single active longevity goal.',
+    active_teacher_intro_script: null,
+    remaining_capabilities: [
+      { capability_key: 'vitana_index', display_name: 'Vitana Index', description: 'Your daily progress measure' },
+      { capability_key: 'autopilot', display_name: 'Autopilot', description: 'Agentic execution' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('VTID-03157 Teacher Mode comprehension check-in', () => {
+  it('emits a non-empty block when content is present', () => {
+    const block = buildTeacherModeBlock({ content: makeContent(), lang: 'en', firstName: 'Dragan' });
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).toMatch(/TEACHER MODE/);
+  });
+
+  it('contract REQUIRES a comprehension check-in after every intro', () => {
+    const block = buildTeacherModeBlock({ content: makeContent(), lang: 'en', firstName: 'Dragan' });
+    expect(block).toMatch(/COMPREHENSION CHECK-IN/);
+    expect(block).toMatch(/NON-NEGOTIABLE/);
+  });
+
+  it('contract spells out the THREE-way choice (deepen / move on / different topic)', () => {
+    const block = buildTeacherModeBlock({ content: makeContent(), lang: 'en', firstName: 'Dragan' });
+    expect(block).toMatch(/deepen this one/);
+    expect(block).toMatch(/move on to the named next capability/);
+    expect(block).toMatch(/not interested in this/);
+  });
+
+  it('contract forbids the rushed pattern that triggered the founder complaint', () => {
+    const block = buildTeacherModeBlock({ content: makeContent(), lang: 'en', firstName: 'Dragan' });
+    expect(block).toMatch(/NEVER jump straight from intro to\s+"want the next thing\?"/);
+    expect(block).toMatch(/rushed pattern the\s+user complained about/);
+  });
+
+  it('check-in NAMES the next capability explicitly (no bare "next")', () => {
+    const block = buildTeacherModeBlock({ content: makeContent(), lang: 'en', firstName: 'Dragan' });
+    // Both example phrasings (DE + EN) interpolate the next display name.
+    expect(block).toMatch(/Vitana Index/);
+    // The "bare next is forbidden" rule survives.
+    expect(block).toMatch(/bare word "next" \/ "das N.chste" is\s+STILL forbidden/);
+  });
+
+  it('lack-of-interest branch routes to dismissed event with the current capability key', () => {
+    const block = buildTeacherModeBlock({ content: makeContent(), lang: 'en', firstName: 'Dragan' });
+    expect(block).toMatch(/eventName='dismissed'/);
+    expect(block).toMatch(/capability_key='life_compass'/);
+  });
+
+  it('user-wants-more-depth branch loops with a shorter follow-up check-in', () => {
+    const block = buildTeacherModeBlock({ content: makeContent(), lang: 'en', firstName: 'Dragan' });
+    expect(block).toMatch(/SHORTER check-in/);
+    expect(block).toMatch(/Loop until the user signals they've had enough/);
+  });
+});


### PR DESCRIPTION
## Summary

Three corrections to VTID-03154 based on the founder's runtime test.

### Fix 1 — Root cause of \"nothing has changed\"

The journey greeting block IS being injected, but Teacher Mode block — concatenated AFTER it in orb-live.ts — contains the literal instruction *\"Your FIRST spoken line of this session was a permission-asking offer for X\"*. Gemini's recency primacy gave Teacher Mode the win, so the user heard the old curriculum-march pattern instead of the new journey framing.

`live-session-controller.ts` now clears `(session as any).teacherModeContent` + `teacherModeFirstName` whenever a journey greeting fires (same spot it already clears `session.wakeBriefOverrideBlock`). Turn 1 is now unambiguously owned by the journey greeting; turns 2+ behave normally and the user can ask anything without the curriculum-march pattern.

### Fix 2 — Teacher Mode comprehension check-in

> *\"2-3-4 sentences are too short for a first-time user during their first 30 days to understand. Before saying 'introduce something new', there should be a sentence in between: 'Could you understand what I described?' This way the user has a choice to deepen, move on, or pick a different topic.\"*

After every intro, Teacher Mode MUST now run a 3-way check-in:
- (a) deepen this one (more detail / examples / how it works)
- (b) move on to the **named** next capability
- (c) not interested in this — pick a different topic

Lack-of-interest routes to `teacher_event(eventName='dismissed')`; deepening loops with a shorter follow-up check-in until the user is ready. Locked structurally by 6 new tests in `teacher-mode-prompt-checkin.test.ts`.

### Fix 3 — Morning greeting previews coming days

> *\"Where am I + how much do I have to go\"* — the founder wants both \"today\" AND \"what to expect in the coming days\".

Daily-morning contract in `journey-greeting.ts` now requires the LLM to pair the day-count with a one-sentence preview of WHAT TO EXPECT in the coming days of the current phase. Sentence budget bumped from 2-3 to 2-4 to fit the preview.

## Test plan

- [x] `npm run build` clean
- [x] 6 new tests in `teacher-mode-prompt-checkin.test.ts` lock the new contract structurally
- [x] 1 new test in `journey-greeting.test.ts` locks the coming-days-preview requirement
- [x] 54 total green across journey + teacher suites
- [x] 215 char regression green
- [ ] EXEC-DEPLOY green
- [ ] User runtime re-test:
  - **Test A** — Dragan opens orb after midnight (or after server-side reset of last_session_date): expect *journey* greeting that owns turn 1, no Teacher Mode curriculum march. Watch for `[VTID-03157] Suppressing Teacher Mode block` log.
  - **Test B** — Same session continues: Vitana should respond to whatever the user asks (no automated capability intro).
  - **Test C** — If the user asks Vitana to introduce a feature, Teacher Mode-style intro should be followed by the 3-way check-in (\"Did that land? Want to go deeper, move on to NAME, or pick something else?\"), NOT a rushed jump to the next feature.

Generated with [Claude Code](https://claude.com/claude-code)