### PR TITLE
feat(decision-contract): add compatibility score schema (VTID-03161)

### DIFF
--- a/services/gateway/test/services/decision-contract/d39-pr5a-migration.test.ts
+++ b/services/gateway/test/services/decision-contract/d39-pr5a-migration.test.ts
@@ -1,0 +1,169 @@
+// VTID-03161 — D39 PR 5a schema migration shape guard.
+//
+// Asserts the migration that introduces `decision_compatibility_score`:
+//   - Creates the table with the documented columns + check constraints.
+//   - Uses NULLS NOT DISTINCT on the unique constraint so global-tenant
+//     (tenant_id IS NULL) rows collide on the constraint instead of
+//     admitting duplicates.
+//   - Indexes the hot-path lookup (dimension, tenant_id, profile_value,
+//     effective_from DESC).
+//   - Enables RLS with the same tenant-isolation policy decision_policy
+//     and decision_conflict_pair use.
+//   - Does NOT contain seeds, a resolver, or any code wiring — those
+//     ship in PR 5b / 5c / 5d-g.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '../../../../../supabase/migrations/' +
+    '20260604000000_VTID_03161_decision_compatibility_score.sql',
+);
+
+describe('VTID-03161 D39 PR 5a — decision_compatibility_score schema migration', () => {
+  let sql: string;
+  beforeAll(() => {
+    sql = readFileSync(MIGRATION_PATH, 'utf8');
+  });
+
+  describe('table creation', () => {
+    it('creates the table idempotently', () => {
+      expect(sql).toMatch(
+        /CREATE TABLE IF NOT EXISTS decision_compatibility_score/,
+      );
+    });
+
+    it('keys on id UUID PRIMARY KEY with gen_random_uuid default', () => {
+      expect(sql).toMatch(
+        /id\s+UUID\s+PRIMARY KEY\s+DEFAULT\s+gen_random_uuid\(\)/,
+      );
+    });
+
+    it('declares the four scoring columns: dimension, profile_value, candidate_value, score', () => {
+      expect(sql).toMatch(/dimension\s+TEXT\s+NOT NULL/);
+      expect(sql).toMatch(/profile_value\s+TEXT\s+NOT NULL/);
+      expect(sql).toMatch(/candidate_value\s+TEXT\s+NOT NULL/);
+      expect(sql).toMatch(/score\s+NUMERIC\(3,2\)\s+NOT NULL/);
+    });
+
+    it('constrains score to [0, 1]', () => {
+      expect(sql).toMatch(/CHECK\s*\(\s*score\s*>=\s*0\s+AND\s+score\s*<=\s*1\s*\)/);
+    });
+
+    it('has the versioned / tenant-aware / time-bounded columns', () => {
+      expect(sql).toMatch(/tenant_id\s+UUID(?!\s+NOT NULL)/);
+      expect(sql).toMatch(/version\s+INTEGER\s+NOT NULL\s+DEFAULT\s+1/);
+      expect(sql).toMatch(/effective_from\s+TIMESTAMPTZ\s+NOT NULL\s+DEFAULT\s+now\(\)/);
+      expect(sql).toMatch(/effective_until\s+TIMESTAMPTZ(?!\s+NOT NULL)/);
+    });
+
+    it('locks the source CHECK to the canonical four values', () => {
+      expect(sql).toMatch(
+        /source\s+TEXT\s+NOT NULL\s+DEFAULT\s+'seed'[\s\S]*?CHECK\s*\(\s*source\s+IN\s*\(\s*'seed'\s*,\s*'admin_ui'\s*,\s*'autopilot'\s*,\s*'experiment'\s*\)\s*\)/,
+      );
+    });
+
+    it('carries the audit columns: rationale, notes, created_at, created_by', () => {
+      expect(sql).toMatch(/rationale\s+TEXT/);
+      expect(sql).toMatch(/notes\s+TEXT/);
+      expect(sql).toMatch(/created_at\s+TIMESTAMPTZ\s+NOT NULL\s+DEFAULT\s+now\(\)/);
+      expect(sql).toMatch(/created_by\s+TEXT/);
+    });
+  });
+
+  describe('uniqueness — Postgres-safe global-tenant handling', () => {
+    it('uses NULLS NOT DISTINCT so global (tenant_id IS NULL) rows collide on the constraint', () => {
+      // The whole point of PR 5a's correction over decision_conflict_pair:
+      // plain UNIQUE(...tenant_id...) would let two rows with NULL
+      // tenant_id coexist for the same (dimension, profile, candidate, version).
+      expect(sql).toMatch(/UNIQUE\s+NULLS\s+NOT\s+DISTINCT/);
+    });
+
+    it('uniqueness covers (dimension, profile_value, candidate_value, tenant_id, version)', () => {
+      expect(sql).toMatch(
+        /UNIQUE\s+NULLS\s+NOT\s+DISTINCT[\s\S]*?\(\s*dimension\s*,\s*profile_value\s*,\s*candidate_value\s*,\s*tenant_id\s*,\s*version\s*\)/,
+      );
+    });
+
+    it('does not declare a plain nullable-tenant UNIQUE that admits duplicate global rows', () => {
+      // Defensive: catch a future "fix" that drops NULLS NOT DISTINCT.
+      // A plain UNIQUE(..., tenant_id, version) without the NULLS NOT
+      // DISTINCT clause is forbidden by the audit. Scan only SQL lines
+      // (strip `--` line comments and `/* … */` block comments first)
+      // so the test doesn't false-positive on its own prose.
+      const sqlOnly = sql
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .split('\n')
+        .map(line => line.replace(/--.*$/, ''))
+        .join('\n');
+      const matches = sqlOnly.match(/UNIQUE[^\(]*\([^)]*tenant_id[^)]*\)/g) ?? [];
+      for (const m of matches) {
+        expect(m).toMatch(/NULLS\s+NOT\s+DISTINCT/);
+      }
+    });
+  });
+
+  describe('hot-path lookup index', () => {
+    it('indexes (dimension, tenant_id, profile_value, effective_from DESC)', () => {
+      expect(sql).toMatch(
+        /CREATE INDEX IF NOT EXISTS decision_compatibility_score_lookup_idx\s+ON\s+decision_compatibility_score\s*\(\s*dimension\s*,\s*tenant_id\s*,\s*profile_value\s*,\s*effective_from\s+DESC\s*\)/,
+      );
+    });
+  });
+
+  describe('row-level security', () => {
+    it('enables RLS on the table', () => {
+      expect(sql).toMatch(
+        /ALTER TABLE decision_compatibility_score ENABLE ROW LEVEL SECURITY/,
+      );
+    });
+
+    it('drops any pre-existing policy before recreating it (idempotent re-apply)', () => {
+      expect(sql).toMatch(
+        /DROP POLICY IF EXISTS decision_compatibility_score_tenant_read/,
+      );
+    });
+
+    it('creates the tenant-read policy mirroring decision_policy / decision_conflict_pair', () => {
+      expect(sql).toMatch(
+        /CREATE POLICY decision_compatibility_score_tenant_read[\s\S]*?ON decision_compatibility_score[\s\S]*?FOR SELECT[\s\S]*?TO authenticated/,
+      );
+    });
+
+    it('USING clause admits global defaults (tenant_id IS NULL) + caller tenant via user_tenants', () => {
+      expect(sql).toMatch(/tenant_id\s+IS\s+NULL/);
+      expect(sql).toMatch(/user_tenants\s+WHERE\s+user_id\s*=\s*auth\.uid\(\)/);
+    });
+
+    it('does NOT grant authenticated INSERT/UPDATE/DELETE policies (service-role writes only)', () => {
+      // Mirrors decision_policy/decision_conflict_pair: SELECT-only for
+      // authenticated; service-role bypasses RLS for the seed pass +
+      // future admin-UI writes.
+      expect(sql).not.toMatch(/FOR\s+INSERT[\s\S]*?TO\s+authenticated/);
+      expect(sql).not.toMatch(/FOR\s+UPDATE[\s\S]*?TO\s+authenticated/);
+      expect(sql).not.toMatch(/FOR\s+DELETE[\s\S]*?TO\s+authenticated/);
+    });
+  });
+
+  describe('scope discipline — PR 5a is schema only', () => {
+    it('contains NO INSERT statements (seeds ship in PR 5b)', () => {
+      // The migration must NOT carry any seed rows — those land in a
+      // dedicated 5b migration so the schema can be reviewed in
+      // isolation and a future seed bump doesn't reshape the table.
+      expect(sql).not.toMatch(/INSERT\s+INTO\s+decision_compatibility_score/i);
+    });
+
+    it('contains NO references to D39 service code or resolver imports', () => {
+      // PR 5a is pure SQL — no application code wiring. Catches a
+      // future migration that tries to combine schema + code
+      // touchpoints into one PR.
+      expect(sql).not.toMatch(/d39-taste-alignment-service/);
+      expect(sql).not.toMatch(/compatibility-resolver/);
+    });
+
+    it('contains a COMMENT ON TABLE documenting the boundary intent', () => {
+      expect(sql).toMatch(/COMMENT ON TABLE decision_compatibility_score IS/);
+    });
+  });
+});

--- a/supabase/migrations/20260604000000_VTID_03161_decision_compatibility_score.sql
+++ b/supabase/migrations/20260604000000_VTID_03161_decision_compatibility_score.sql
@@ -1,0 +1,110 @@
+-- Phase D39 PR 5a (decision-contract refactor) — decision_compatibility_score
+-- schema.
+--
+-- VTID-03161. First slice of the D39 taste-alignment externalization.
+-- This migration creates the storage table only. Seeds (138 cells across
+-- 9 dimensions) land in PR 5b. No code consumer reads from this table
+-- until PR 5c (resolver). PR 5d-g migrate the D39 service to read here.
+--
+-- Why a dedicated relational table (not JSONB on decision_policy):
+--   D39's 9 alignment dimensions are per-(profile_value, candidate_value)
+--   compatibility grids — 138 cells total. JSONB would compress the
+--   audit trail; a row per cell lets an analyst:
+--     SELECT * FROM decision_compatibility_score WHERE dimension='aesthetic'
+--   and see exactly which 36 cells the engine uses. A future admin UI
+--   can also tune one cell without rewriting a JSONB blob.
+--
+-- Mirrors the decision_policy / decision_conflict_pair pattern:
+--   - versioned, tenant-aware, time-bounded
+--   - service-role writes, authenticated SELECT
+--   - tenant_id IS NULL = global default; tenant rows override per
+--     (dimension, profile_value, candidate_value) when the resolver
+--     lands in PR 5c
+--
+-- Uniqueness — Postgres-safe global-tenant handling:
+--   A plain `UNIQUE (..., tenant_id, version)` would treat each NULL
+--   tenant_id as distinct in the index, allowing duplicate global
+--   default rows. PR 5a uses `NULLS NOT DISTINCT` so two rows with
+--   tenant_id IS NULL collide on the unique constraint just like
+--   two rows with the same UUID would. Requires Postgres 15+, which
+--   Supabase has been on since 2023.
+
+CREATE TABLE IF NOT EXISTS decision_compatibility_score (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Dimension id matching the D39 axis names: 'simplicity', 'premium',
+  -- 'aesthetic', 'tone', 'routine', 'social', 'convenience',
+  -- 'experience', 'novelty'. Free-text (no enum) so future axes can
+  -- be added without DDL — the resolver will reject unknown dims at
+  -- runtime via the typed accessor signature.
+  dimension       TEXT NOT NULL,
+  -- The user's profile value on this dimension (e.g. 'minimalist',
+  -- 'value_focused', 'modern'). Free-text; the resolver maps these
+  -- to TasteProfile / LifestyleProfile zod enums.
+  profile_value   TEXT NOT NULL,
+  -- The candidate action's value on this dimension (e.g. 'simple',
+  -- 'budget', 'classic'). Free-text; the resolver maps these to
+  -- ActionToScore attribute enums.
+  candidate_value TEXT NOT NULL,
+  -- The compatibility score: 1.0 perfect match, 0.7 compatible,
+  -- 0.5 neutral, 0.3 mismatch, 0.2 strong-mismatch (per the
+  -- pre-D39 inline maps). NUMERIC(3,2) gives two-decimal precision
+  -- in [0, 1] which is the only range the engine emits.
+  score           NUMERIC(3,2) NOT NULL CHECK (score >= 0 AND score <= 1),
+  -- Optional human-readable note on why this cell carries this
+  -- score. Surfaced to analysts in the audit UI.
+  rationale       TEXT,
+  -- NULL = global default. Non-NULL = tenant-specific override.
+  tenant_id       UUID,
+  -- Monotonic per (dimension, profile_value, candidate_value,
+  -- tenant_id). Older versions never delete — they supersede via
+  -- effective_from / effective_until.
+  version         INTEGER NOT NULL DEFAULT 1,
+  effective_from  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  effective_until TIMESTAMPTZ,
+  source          TEXT NOT NULL DEFAULT 'seed'
+    CHECK (source IN ('seed', 'admin_ui', 'autopilot', 'experiment')),
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by      TEXT,
+  -- NULLS NOT DISTINCT (PG15+) so the global default rows
+  -- (tenant_id IS NULL) collide on the unique constraint like
+  -- any tenant-specific rows would. Without this, the index treats
+  -- each NULL tenant as distinct and admits duplicate global rows.
+  UNIQUE NULLS NOT DISTINCT
+    (dimension, profile_value, candidate_value, tenant_id, version)
+);
+
+-- Hot-path: the resolver looks up by (dimension, tenant_id,
+-- profile_value) and picks the most recently effective candidate
+-- list. Ordering effective_from DESC puts candidates first.
+CREATE INDEX IF NOT EXISTS decision_compatibility_score_lookup_idx
+  ON decision_compatibility_score (
+    dimension, tenant_id, profile_value, effective_from DESC
+  );
+
+ALTER TABLE decision_compatibility_score ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated app role: SELECT only, scoped to global defaults
+-- (tenant_id IS NULL) plus rows for the caller's tenants. Service-
+-- role bypasses RLS so seeds + admin writes work without an explicit
+-- INSERT/UPDATE/DELETE policy here. Same posture as decision_policy
+-- and decision_conflict_pair.
+DROP POLICY IF EXISTS decision_compatibility_score_tenant_read
+  ON decision_compatibility_score;
+CREATE POLICY decision_compatibility_score_tenant_read
+  ON decision_compatibility_score
+  FOR SELECT
+  TO authenticated
+  USING (
+    tenant_id IS NULL
+    OR tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  );
+
+COMMENT ON TABLE decision_compatibility_score IS
+  'Phase D39 (decision-contract refactor): per-(dimension, profile, '
+  'candidate) compatibility scores for taste / lifestyle alignment. '
+  'One row per cell; the resolver in PR 5c will look up scores by '
+  '(dimension, profile_value, candidate_value, tenant_id). '
+  'Service-role writes; authenticated reads only.';


### PR DESCRIPTION
## Summary

**D39 PR 5a — schema migration only** for the new `decision_compatibility_score` table. Seeds (138 cells across the 9 D39 alignment dimensions) land in PR 5b. No code consumer reads from this table until PR 5c (resolver).

## Why a dedicated relational table (not JSONB)

D39's 9 alignment dimensions are per-`(profile_value, candidate_value)` compatibility grids — 138 cells once `aesthetic` + `tone` are seeded full-grid. JSONB would compress the audit trail; a row per cell lets an analyst grep the table to see exactly which cells the engine uses, and lets a future admin UI tune individual cells without rewriting a blob.

## Schema posture

Mirrors `decision_policy` / `decision_conflict_pair`:
- versioned, tenant-aware, time-bounded
- service-role writes, authenticated SELECT
- `tenant_id IS NULL` = global default; the PR 5c resolver will merge tenant rows over global per `(dimension, profile_value, candidate_value)`

## Postgres-safe global-tenant uniqueness

Plain `UNIQUE (..., tenant_id, version)` treats each NULL `tenant_id` as distinct in the index, admitting duplicate global rows. PR 5a uses `NULLS NOT DISTINCT` so two rows with `tenant_id IS NULL` collide on the constraint just like two rows with the same UUID would. Requires Postgres 15+, which Supabase has been on since 2023.

This is the fix on top of the `decision_conflict_pair` pattern shipped in D42.

## Indexes

Hot-path lookup index covers `(dimension, tenant_id, profile_value, effective_from DESC)` — matches the PR 5c resolver's grouping shape (load all rows for a dimension into a per-`profile_value` → score map).

## RLS

Same posture as `decision_policy` and `decision_conflict_pair`: authenticated SELECT scoped to `tenant_id IS NULL OR caller's user_tenants`; no INSERT/UPDATE/DELETE policy for authenticated (service-role bypasses RLS for seeds + future admin-UI writes).

## Tests

`test/services/decision-contract/d39-pr5a-migration.test.ts` — **19 shape-guard assertions** on the migration SQL:
- table creation + idempotency
- all required columns + `score` CHECK constraint
- `source` CHECK locks to `{seed, admin_ui, autopilot, experiment}`
- `NULLS NOT DISTINCT` uniqueness with defensive scan for plain nullable-tenant `UNIQUE` clauses (strips SQL comments before scanning so the test doesn't false-positive on its own prose)
- hot-path lookup index shape
- RLS enabled with the canonical tenant-isolation policy
- no `INSERT` statements (seeds belong in PR 5b)
- no D39 service-code or resolver imports (scope discipline)

**190/190** decision-contract suite green (was 171; +19 from this PR).

## Scope discipline

Per the PR 5a brief: **schema migration only**. NO seed rows. NO resolver. NO D39 service code touched. NO D28/D38/D47/D48 touched. NO onboarding templates. NO LiveKit / Vertex / Teacher.

## Test plan

- [x] `npm run build` clean
- [x] `npx jest test/services/decision-contract/d39-pr5a-migration.test.ts` — 19/19 pass
- [x] `npx jest test/services/decision-contract/` — 190/190 pass (regression check)
- [ ] RUN-MIGRATION applies `20260604000000_VTID_03161_decision_compatibility_score.sql` idempotently
- [ ] Post-migration: `SELECT count(*) FROM decision_compatibility_score` returns 0 (no seeds yet — confirms PR 5b is needed for data)
- [ ] Auto-deploy + `/alive` 200 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)