### PR TITLE
feat(orb): per-surface persona — Command Hub voice swaps to engineering co-pilot (VTID-03163)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -562,6 +562,13 @@ export function buildLiveSystemInstruction(
   // comment for the full rationale. Only LiveKit callers pass true —
   // Vertex still needs it because Gemini Live generates the greeting.
   omitGreetingPolicy?: boolean,
+  // Per-surface persona switch. Derived from session.surface in orb-live.ts
+  // session bootstrap (see deriveSurfaceFromRoute). When 'command-hub', the
+  // dev_orb voice_* fields overlay voice_live so the Command Hub voice
+  // assistant speaks as the engineering co-pilot instead of the community
+  // wellness companion. Default (undefined or 'vitanaland') is unchanged
+  // behavior — the existing community persona.
+  surface?: string | null,
 ): string {
   const languageNames: Record<string, string> = {
     'en': 'English',
@@ -574,8 +581,45 @@ export function buildLiveSystemInstruction(
     'sr': 'Serbian'
   };
 
-  // Load personality config from service (uses cached values or hardcoded defaults)
-  const voiceLiveConfig = getPersonalityConfigSync('voice_live') as Record<string, any>;
+  // Load personality config from service (uses cached values or hardcoded defaults).
+  // Shallow-clone so the dev_orb overlay below does not mutate the cached
+  // defaults object — that would leak the developer persona into subsequent
+  // community sessions.
+  const voiceLiveConfig: Record<string, any> = { ...(getPersonalityConfigSync('voice_live') as Record<string, any>) };
+
+  // Per-surface persona overlay. When the session is on the Command Hub
+  // (developer surface), pull voice_* fields from dev_orb so the assistant
+  // speaks as the engineering co-pilot instead of the community wellness
+  // companion. Missing fields fall back to voice_live defaults — a partial
+  // dev_orb override (e.g. only voice_tools_section set in the DB) is safe.
+  //
+  // Resolution mirrors the role-override logic in orb-live.ts session
+  // bootstrap (~14327): mobile is always community, /command-hub/* is the
+  // developer surface, /admin/* is the admin surface (no overlay yet —
+  // behaves as community). An explicit `surface` param wins over the
+  // heuristic so voice-lab eval and tests can force a surface.
+  const resolveSurface = (): string => {
+    if (typeof surface === 'string' && surface.trim()) return surface.trim();
+    if (clientContext?.isMobile) return 'vitanaland';
+    const route = (currentRoute || '').toLowerCase();
+    if (route.startsWith('/command-hub')) return 'command-hub';
+    if (route.startsWith('/admin')) return 'admin';
+    return 'vitanaland';
+  };
+  const resolvedSurface = resolveSurface();
+  const isCommandHubSurface = resolvedSurface === 'command-hub';
+  let identityLockRoleLine = "the user's life companion and instruction manual";
+  if (isCommandHubSurface) {
+    const devOrbConfig = getPersonalityConfigSync('dev_orb') as Record<string, any>;
+    if (devOrbConfig.voice_base_identity) voiceLiveConfig.base_identity = devOrbConfig.voice_base_identity;
+    if (devOrbConfig.voice_general_behavior) voiceLiveConfig.general_behavior = devOrbConfig.voice_general_behavior;
+    if (devOrbConfig.voice_greeting_rules) voiceLiveConfig.greeting_rules = devOrbConfig.voice_greeting_rules;
+    if (devOrbConfig.voice_tools_section) voiceLiveConfig.tools_section = devOrbConfig.voice_tools_section;
+    if (devOrbConfig.voice_important_section) voiceLiveConfig.important_section = devOrbConfig.voice_important_section;
+    if (typeof devOrbConfig.voice_identity_lock_role === 'string' && devOrbConfig.voice_identity_lock_role.trim()) {
+      identityLockRoleLine = devOrbConfig.voice_identity_lock_role;
+    }
+  }
 
   // VTID-01225-ROLE + BOOTSTRAP-ORB-ROLE-CLARITY: Build role-aware context
   // section. The authoritative role declaration is also prepended to the very
@@ -643,7 +687,7 @@ Do NOT substitute an internal UUID under any circumstance.
   // utterances ("Hi I'm Devon") and continue speaking as them in her voice.
   const VITANA_IDENTITY_LOCK = `=== IDENTITY LOCK ===
 YOU ARE Vitana.
-Your role is the user's life companion and instruction manual.
+Your role is ${identityLockRoleLine}.
 
 You speak EXCLUSIVELY as Vitana. You NEVER:
   - introduce yourself as another persona ("Hi, this is Devon" — only Devon ever says that)

--- a/services/gateway/src/services/ai-personality-service.ts
+++ b/services/gateway/src/services/ai-personality-service.ts
@@ -229,6 +229,25 @@ export const PERSONALITY_DEFAULTS: Record<PersonalitySurfaceKey, Record<string, 
       '1. Be concise and helpful - developers appreciate direct answers\n2. Focus on explanations and guidance - do NOT execute actions or create tasks\n3. You are read-only in this context - no side effects\n4. When discussing code or technical concepts, be precise\n5. If you don\'t know something, say so honestly\n6. Reference specific VTIDs, modules, or features when relevant',
     important_section:
       '- This is the Dev ORB assistant, NOT the Operator Chat\n- You cannot create tasks, trigger deployments, or modify system state\n- Your role is purely informational and educational',
+    // --------------------------------------------------------------------------
+    // Voice fields (read by orb/live/instruction/live-system-instruction.ts when
+    // session.surface === 'command-hub'). These overlay the corresponding
+    // voice_live defaults so the Command Hub voice surface speaks as the
+    // engineering co-pilot, not the community wellness companion. Text-channel
+    // consumers (assistant-service.ts) ignore these fields.
+    // --------------------------------------------------------------------------
+    voice_base_identity:
+      'You are Vitana — the engineering co-pilot for the Vitana platform team. The user is talking to you from the Command Hub, the developer surface for building, shipping, and operating Vitanaland.com, the Maxina Community experience, the gateway service, the orb agent, and supporting infrastructure. In THIS surface you help the developer with VTIDs, deploys, code, CI/CD, OASIS events, architecture, debugging, and platform operations. You do NOT play the role of a health, wellness, or community companion here — that is a different surface (vitanaland.com). PRONUNCIATION (CRITICAL): "Vitana" = vee-TAH-nah (3 syllables, your name). "Vitanaland" = vee-TAH-nah-land (4 syllables, the platform). "Maxina" = mah-KSEE-nah (3 syllables, the community).',
+    voice_general_behavior:
+      '- Be direct and technical — the user is a platform engineer\n- Keep voice responses concise (1-3 sentences for simple acks; up to 5-6 sentences for substantive technical answers)\n- Skip wellness/empathy framing — this is a work surface\n- Use precise terminology: VTID-XXXXX, branch names, service names, route paths, file paths\n- Speak in complete thoughts; avoid one-liners that force the user to ask follow-ups',
+    voice_greeting_rules:
+      '- When the conversation starts, greet briefly with one short work-focused sentence — e.g. "Ready when you are — what are we working on?" or "What platform task can I help with?"\n- Do NOT recite remembered information\n- Do NOT mention health, community, events, meetups, or wellness in the greeting\n- NEVER use a community-surface greeting ("How are you feeling today?", "Ready to join an event?", etc.)',
+    voice_tools_section:
+      '- Use search_knowledge to look up VTID status, architecture docs, deployment history, OASIS event types, and platform documentation\n- Use search_memory to recall past technical discussions with this developer\n- Use search_web for external technical references when needed (library docs, error messages, RFCs)\n- DO NOT use search_events, search_community, get_recommendations, find_reminders, set_reminder, send_chat_message in this surface — those are community-surface tools and do NOT belong in Command Hub voice\n- If the user asks about events, groups, the Maxina Community, or wellness topics, tell them honestly: "The Command Hub Vitana is the engineering assistant. For community and wellness, switch to vitanaland.com."',
+    voice_important_section:
+      '- This is the COMMAND HUB voice surface — you are an engineering co-pilot, NOT the community wellness companion\n- The user is building Vitanaland; you are helping them build it\n- Stay in this lane: code, deploys, VTIDs, architecture, platform operations, debugging\n- The community/health/social Vitana lives at vitanaland.com — a different surface, a different conversation',
+    voice_identity_lock_role:
+      "the developer's engineering co-pilot for the Vitana platform team",
   },
 
   developer_assistant: {

--- a/services/gateway/test/orb/live/characterization/system-instruction.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/system-instruction.characterization.test.ts
@@ -65,4 +65,51 @@ describe('A0.1 characterization: buildLiveSystemInstruction', () => {
     const de = buildLiveSystemInstruction('de', 'conversational', '', 'community', '', '', false, null, '/', [], undefined, '@x');
     expect(en).not.toEqual(de);
   });
+
+  // Per-surface persona switch. Inside the Command Hub the assistant must
+  // speak as the engineering co-pilot, NOT the community wellness companion.
+  // The signal is derived from currentRoute (mirrors orb-live.ts session
+  // bootstrap). These tests assert the divergence at the byte level so a
+  // future "simplification" cannot collapse the two surfaces back into one.
+  describe('per-surface persona switch', () => {
+    const baseArgs = ['en', 'conversational', '', 'developer', '', '', false, null] as const;
+
+    it('Command Hub route swaps the identity-lock role line', () => {
+      const community = buildLiveSystemInstruction(...baseArgs, '/', [], undefined, '@x');
+      const cmdhub = buildLiveSystemInstruction(...baseArgs, '/command-hub/tasks', [], undefined, '@x');
+      expect(community).toContain("Your role is the user's life companion and instruction manual.");
+      expect(cmdhub).toContain("Your role is the developer's engineering co-pilot for the Vitana platform team.");
+      expect(cmdhub).not.toContain("Your role is the user's life companion and instruction manual.");
+    });
+
+    it('Command Hub route swaps base_identity to the engineering co-pilot framing', () => {
+      const cmdhub = buildLiveSystemInstruction(...baseArgs, '/command-hub', [], undefined, '@x');
+      expect(cmdhub).toContain('engineering co-pilot for the Vitana platform team');
+      expect(cmdhub).not.toContain('AI health and wellbeing companion of the Maxina Community');
+    });
+
+    it('Command Hub route swaps tools_section to drop community-surface tools', () => {
+      const cmdhub = buildLiveSystemInstruction(...baseArgs, '/command-hub/cockpit', [], undefined, '@x');
+      // The community voice_live tools_section advertises search_events /
+      // search_community / get_recommendations as primary tools. On the
+      // developer surface, those must NOT be advertised as primary tools.
+      expect(cmdhub).not.toContain('Use search_events to find upcoming events, meetups, and live rooms');
+      expect(cmdhub).not.toContain('Use search_community to find groups and community activities');
+      expect(cmdhub).not.toContain('Use get_recommendations to get personalized event, group, and match suggestions');
+      // And the dev_orb tools_section must explicitly call out platform topics.
+      expect(cmdhub).toContain('VTID status');
+      expect(cmdhub).toContain('Command Hub Vitana is the engineering assistant');
+    });
+
+    it('mobile + Command Hub route still resolves to community (mobile override wins)', () => {
+      const mobileCmdhub = buildLiveSystemInstruction(
+        ...baseArgs,
+        '/command-hub',
+        [],
+        { ip: '0.0.0.0', isMobile: true },
+        '@x',
+      );
+      expect(mobileCmdhub).toContain("Your role is the user's life companion and instruction manual.");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- The voice/orb-live pipeline was surface-blind: every session loaded the `voice_live` personality config regardless of whether the user opened it from the Command Hub (developer surface) or from vitanaland (community surface), so a developer on `/command-hub` heard the same "AI health and wellbeing companion of the Maxina Community" identity, `search_events` / `search_community` / `get_recommendations` tool guidance, and life-companion identity lock as a community user.
- This slice threads the surface signal into `buildLiveSystemInstruction` without touching any caller. The builder derives surface from `currentRoute` + `clientContext.isMobile` (mirroring the role-override logic at orb-live.ts:14327): mobile → community, `/command-hub/*` → command-hub, `/admin/*` → admin, else community.
- When `surface === 'command-hub'`, six `voice_*` fields on the existing `dev_orb` config overlay `voice_live` for `base_identity`, `general_behavior`, `greeting_rules`, `tools_section`, `important_section`, and the identity-lock role line. Missing `dev_orb` fields fall back to `voice_live` defaults so a partial DB override is safe. `voice_live` is shallow-cloned before the overlay so the cached defaults object cannot leak the developer persona into a subsequent community session.

## Behavior change (scope-bound)

- `/command-hub/*` voice now opens as **"engineering co-pilot for the Vitana platform team"**, advertises `search_knowledge` / `search_memory` / `search_web` for VTIDs + architecture + deploys, and explicitly refuses the community-surface tools.
- **Every other route** (community URLs, `/admin/*`, mobile of any kind) renders **byte-identical** to today — confirmed by the 3 existing characterization snapshots still passing unchanged.

## Not in this slice (follow-ups)

- `/admin/*` persona overlay (heuristic wired, no admin `voice_*` fields yet — admins still get the community persona with the briefing block prepended, same as today)
- Gating the trailing `EVENT LINK SHARING` / `report_to_specialist` / `switch_persona to Devon` blocks behind `!isCommandHubSurface`
- Re-pointing the brain path's inner "intelligent voice assistant" line in `vitana-brain.ts buildBrainSystemInstruction`

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] All 18 characterization suites green (`241 tests passed, 9 snapshots`)
- [x] 3 existing community-persona snapshots match **byte-for-byte** unchanged
- [x] 4 new per-surface tests lock the developer-surface divergence:
  - Identity-lock role line swaps on `/command-hub`
  - `base_identity` swaps to "engineering co-pilot" framing
  - `tools_section` drops `search_events` / `search_community` / `get_recommendations`
  - Mobile + `/command-hub` still resolves to community (mobile override wins)
- [ ] **Human in-browser smoke**: open Command Hub voice chat → greeting must NOT mention health/wellness/community/events; should open with a brief work-focused line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)