### PR TITLE
fix+feat(goal-plan): unblock generation + clarify broad goals

### DIFF
--- a/services/gateway/src/routes/goal-planner.ts
+++ b/services/gateway/src/routes/goal-planner.ts
@@ -12,7 +12,13 @@
 import { Router, Response } from 'express';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
-import { generateGoalPlan, getGoalPlan, setStepStatus } from '../services/journey/goal-planner-service';
+import {
+  generateGoalPlan,
+  getGoalPlan,
+  setStepStatus,
+  clarifyGoalIfNeeded,
+  type ClarificationAnswer,
+} from '../services/journey/goal-planner-service';
 
 const router = Router();
 const VTID = 'VTID-03152';
@@ -30,8 +36,23 @@ router.post('/generate', requireAuth, async (req: AuthenticatedRequest, res: Res
   const client = getServiceClient();
   if (!client) return res.status(503).json({ ok: false, error: 'supabase_unavailable', vtid: VTID });
 
+  // Optional clarifying answers from a prior clarification round.
+  const rawAnswers = Array.isArray(req.body?.answers) ? req.body.answers : [];
+  const answers: ClarificationAnswer[] = rawAnswers
+    .filter((a: any) => a && typeof a.question === 'string')
+    .map((a: any) => ({ question: String(a.question), answer: typeof a.answer === 'string' ? a.answer : '' }));
+
   try {
-    const result = await generateGoalPlan(client, userId);
+    // First pass (no answers yet): if the goal is too broad, ask Vitana's
+    // clarifying questions instead of building a generic plan.
+    if (answers.length === 0) {
+      const clar = await clarifyGoalIfNeeded(client, userId);
+      if (clar.hasGoal && !clar.specific && clar.questions.length > 0) {
+        return res.status(200).json({ ok: true, vtid: VTID, needs_clarification: true, questions: clar.questions, plan: null });
+      }
+    }
+
+    const result = await generateGoalPlan(client, userId, answers);
     if (!result) {
       // No goal/deadline yet, or generation failed — let the client fall back gracefully.
       return res.status(200).json({ ok: false, error: 'no_plan_generated', vtid: VTID, plan: null });

--- a/services/gateway/src/services/journey/goal-planner-service.ts
+++ b/services/gateway/src/services/journey/goal-planner-service.ts
@@ -216,11 +216,14 @@ export async function generateGoalPlan(
   // Ask for plain JSON instead of forcing a tool call: Vertex/Gemini returns an
   // empty response under forced function-calling here, so we parse JSON from text.
   // High token budget — the planner model is a "thinking" model whose reasoning
-  // consumes the budget, so a low cap truncates the JSON output mid-object.
+  // tokens count against the output budget, so a low cap can be fully consumed
+  // by reasoning and leave nothing for the JSON (empty text, finishReason
+  // MAX_TOKENS). Some goal phrasings reason longer than others, so give ample
+  // headroom for thinking + the full JSON object.
   const result = await callViaRouter('planner', user, {
     service: 'goal-planner',
     systemPrompt: system,
-    maxTokens: 8000,
+    maxTokens: 16000,
   });
   console.log(
     `${LOG} llm result ok=${result.ok} provider=${result.provider} model=${result.model} ` +

--- a/services/gateway/src/services/journey/goal-planner-service.ts
+++ b/services/gateway/src/services/journey/goal-planner-service.ts
@@ -25,6 +25,25 @@ const LANGUAGE_NAMES: Record<string, string> = {
   sr: 'Serbian',
 };
 
+// Intent gloss for the canonical Life Compass preset categories. The presets
+// store only a short title + category (the rich description lives in the
+// frontend), so we restate each domain's intent here to ground the planner and
+// clarifying questions across all suggested goals.
+const CATEGORY_INTENT: Record<string, string> = {
+  relationship: 'building meaningful romantic relationships and finding a life partner',
+  health: 'achieving optimal physical and mental wellness',
+  career: 'building a fulfilling and successful career',
+  learning: 'learning and growing through new skills and knowledge',
+  spiritual: 'deepening purpose, presence, and inner peace',
+  longevity: 'healthspan, energy, and longevity',
+  wealth: 'building financial freedom and security',
+};
+
+function goalDomain(goal: ActiveGoal): string | null {
+  if (!goal.category) return null;
+  return CATEGORY_INTENT[goal.category.trim().toLowerCase()] ?? goal.category;
+}
+
 export interface ClarificationAnswer {
   question: string;
   answer: string;
@@ -183,6 +202,7 @@ function buildPrompt(
       : '';
   const user =
     `Goal: "${goal.primary_goal}"\n` +
+    (goalDomain(goal) ? `Life domain: ${goalDomain(goal)}\n` : '') +
     `Quantified target: ${target}\n` +
     `Start day offset: 0 (${startDateIso})\n` +
     `Final day offset: ${totalDays} (deadline ${goal.target_date})\n` +
@@ -231,8 +251,11 @@ export async function clarifyGoalIfNeeded(client: SupabaseClient, userId: string
     'enough to design a concrete, personalized day-by-day plan. A goal is NOT specific enough when ' +
     'key details are missing — e.g. which skill, what kind of career move, what target, or important ' +
     'constraints (time, budget, starting point). Ask only what genuinely changes the plan.';
+  const domain = goalDomain(goal);
   const user =
-    `Goal: "${goal.primary_goal}"\nQuantified target: ${target}\nCategory: ${goal.category ?? 'none'}\n\n` +
+    `Goal: "${goal.primary_goal}"\nQuantified target: ${target}\n` +
+    (domain ? `Life domain: ${domain}\n` : `Category: ${goal.category ?? 'none'}\n`) +
+    '\n' +
     'If the goal is specific enough, respond {"specific": true, "questions": []}. ' +
     'If not, respond {"specific": false, "questions": [...]} with 2-3 short, friendly questions — ' +
     `each one sentence, easy to answer — that would make the plan concrete. Write the questions in ${language}. ` +

--- a/services/gateway/src/services/journey/goal-planner-service.ts
+++ b/services/gateway/src/services/journey/goal-planner-service.ts
@@ -11,9 +11,30 @@
 import { SupabaseClient } from '@supabase/supabase-js';
 import { callViaRouter } from '../llm-router';
 import { bulkCreateCalendarEvents } from '../calendar-service';
+import { getUserLocale } from '../../i18n/server-locale';
 import type { CreateCalendarEventInput } from '../../types/calendar';
 
 const LOG = '[VTID-03152 goal-planner]';
+
+// Localized question generation — broad goals ask the user to clarify in their
+// own language so a German user never sees English questions.
+const LANGUAGE_NAMES: Record<string, string> = {
+  de: 'German',
+  en: 'English',
+  es: 'Spanish',
+  sr: 'Serbian',
+};
+
+export interface ClarificationAnswer {
+  question: string;
+  answer: string;
+}
+
+export interface ClarifyResult {
+  hasGoal: boolean;
+  specific: boolean;
+  questions: string[];
+}
 
 export type GoalStepKind = 'milestone' | 'checkpoint' | 'habit';
 
@@ -135,7 +156,12 @@ async function fetchActiveGoal(client: SupabaseClient, userId: string): Promise<
   };
 }
 
-function buildPrompt(goal: ActiveGoal, startDateIso: string, totalDays: number): { system: string; user: string } {
+function buildPrompt(
+  goal: ActiveGoal,
+  startDateIso: string,
+  totalDays: number,
+  answers?: ClarificationAnswer[],
+): { system: string; user: string } {
   const target =
     goal.target_value != null && goal.target_unit
       ? `${goal.target_value} ${goal.target_unit}`
@@ -147,13 +173,22 @@ function buildPrompt(goal: ActiveGoal, startDateIso: string, totalDays: number):
     'never a rote action for every single day. Keep titles short and motivating; keep ' +
     'descriptions to one sentence. day_offset is the number of days after the start (0 = today). ' +
     'Spread milestones and checkpoints across the whole timeframe up to the final day.';
+  const clarifications =
+    answers && answers.length
+      ? '\nThe user answered these clarifying questions — use them to make the plan concrete and personal:\n' +
+        answers
+          .map((a) => `Q: ${a.question}\nA: ${a.answer?.trim() ? a.answer.trim() : '(no answer — make a sensible assumption)'}`)
+          .join('\n') +
+        '\n'
+      : '';
   const user =
     `Goal: "${goal.primary_goal}"\n` +
     `Quantified target: ${target}\n` +
     `Start day offset: 0 (${startDateIso})\n` +
     `Final day offset: ${totalDays} (deadline ${goal.target_date})\n` +
-    `Total days: ${totalDays}\n\n` +
-    'Respond with ONLY a JSON object — no markdown fences, no commentary — of exactly this shape:\n' +
+    `Total days: ${totalDays}\n` +
+    clarifications +
+    '\nRespond with ONLY a JSON object — no markdown fences, no commentary — of exactly this shape:\n' +
     '{"plan_summary": string, ' +
     '"milestones": [{"day_offset": number, "title": string, "description": string}], ' +
     '"weekly_checkpoints": [{"day_offset": number, "title": string, "description": string}], ' +
@@ -161,6 +196,65 @@ function buildPrompt(goal: ActiveGoal, startDateIso: string, totalDays: number):
     `Include 5-8 milestones spread from day 0 to day ${totalDays} (the last on or near day ${totalDays}), ` +
     'a roughly weekly checkpoint cadence, and 3-5 sustainable daily habits.';
   return { system, user };
+}
+
+function parseQuestions(raw: unknown): ClarifyResult['questions'] | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as any;
+  if (typeof r.specific !== 'boolean') return null;
+  if (r.specific) return [];
+  if (!Array.isArray(r.questions)) return [];
+  return r.questions
+    .filter((q: unknown) => typeof q === 'string' && q.trim())
+    .map((q: string) => q.trim())
+    .slice(0, 3);
+}
+
+/**
+ * Ask the planner whether the goal is specific enough to build a concrete plan.
+ * Broad goals (e.g. "Master new skills", "Advance career") return 2-3 short
+ * clarifying questions, written in the user's language, so the plan can be
+ * personalized. Fails open (treats the goal as specific) on any LLM error so a
+ * hiccup never blocks plan generation.
+ */
+export async function clarifyGoalIfNeeded(client: SupabaseClient, userId: string): Promise<ClarifyResult> {
+  const goal = await fetchActiveGoal(client, userId);
+  if (!goal) return { hasGoal: false, specific: true, questions: [] };
+
+  const locale = await getUserLocale(client, userId).catch(() => 'en');
+  const language = LANGUAGE_NAMES[locale] ?? 'English';
+  const target =
+    goal.target_value != null && goal.target_unit ? `${goal.target_value} ${goal.target_unit}` : 'unspecified';
+
+  const system =
+    'You are Vitana, a warm longevity and wellness coach. Decide whether a user goal is specific ' +
+    'enough to design a concrete, personalized day-by-day plan. A goal is NOT specific enough when ' +
+    'key details are missing — e.g. which skill, what kind of career move, what target, or important ' +
+    'constraints (time, budget, starting point). Ask only what genuinely changes the plan.';
+  const user =
+    `Goal: "${goal.primary_goal}"\nQuantified target: ${target}\nCategory: ${goal.category ?? 'none'}\n\n` +
+    'If the goal is specific enough, respond {"specific": true, "questions": []}. ' +
+    'If not, respond {"specific": false, "questions": [...]} with 2-3 short, friendly questions — ' +
+    `each one sentence, easy to answer — that would make the plan concrete. Write the questions in ${language}. ` +
+    'Respond with ONLY the JSON object, no markdown fences, no commentary.';
+
+  const result = await callViaRouter('planner', user, {
+    service: 'goal-planner-clarify',
+    systemPrompt: system,
+    maxTokens: 6000,
+  });
+  if (!result.ok) {
+    console.warn(`${LOG} clarify check failed (${result.error ?? 'unknown'}) — treating goal as specific`);
+    return { hasGoal: true, specific: true, questions: [] };
+  }
+  const parsed = result.text ? parseQuestions(parseLooseJson(result.text)) : null;
+  if (parsed === null) {
+    console.warn(`${LOG} clarify check unparseable — treating goal as specific`);
+    return { hasGoal: true, specific: true, questions: [] };
+  }
+  const specific = parsed.length === 0;
+  console.log(`${LOG} clarify user=${userId} specific=${specific} questions=${parsed.length}`);
+  return { hasGoal: true, specific, questions: parsed };
 }
 
 function parseLooseJson(text: string): unknown {
@@ -199,6 +293,7 @@ function validatePlan(raw: unknown): LLMPlan | null {
 export async function generateGoalPlan(
   client: SupabaseClient,
   userId: string,
+  answers?: ClarificationAnswer[],
 ): Promise<{ plan_id: string; step_count: number } | null> {
   const goal = await fetchActiveGoal(client, userId);
   if (!goal) {
@@ -206,13 +301,15 @@ export async function generateGoalPlan(
     return null;
   }
 
-  console.log(`${LOG} generate requested user=${userId} goal="${goal.primary_goal}" deadline=${goal.target_date}`);
+  console.log(
+    `${LOG} generate requested user=${userId} goal="${goal.primary_goal}" deadline=${goal.target_date} answers=${answers?.length ?? 0}`,
+  );
 
   const startIso = goal.set_at;
   const startDate = startIso.slice(0, 10);
   const totalDays = Math.max(1, calendarDaysBetween(startIso, goal.target_date));
 
-  const { system, user } = buildPrompt(goal, startDate, totalDays);
+  const { system, user } = buildPrompt(goal, startDate, totalDays, answers);
   // Ask for plain JSON instead of forcing a tool call: Vertex/Gemini returns an
   // empty response under forced function-calling here, so we parse JSON from text.
   // High token budget — the planner model is a "thinking" model whose reasoning

--- a/services/gateway/src/services/llm-router.ts
+++ b/services/gateway/src/services/llm-router.ts
@@ -350,6 +350,18 @@ const openaiAdapter: ProviderAdapter = {
  * back to GOOGLE_GEMINI_API_KEY for local dev. Supports text, multi-image,
  * and function calling.
  */
+// Permissive safety thresholds for Gemini. The default filters block benign
+// wellness/coaching topics (relationships, weight, mental health, substance
+// recovery) — e.g. a goal of "Find a life partner" came back empty and the
+// planner surfaced no_plan_generated. BLOCK_ONLY_HIGH still blocks
+// high-confidence harmful content while letting legitimate coaching through.
+const GEMINI_SAFETY_SETTINGS = [
+  { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
+];
+
 const vertexAdapter: ProviderAdapter = {
   isAvailable: () =>
     Boolean(process.env.GOOGLE_CLOUD_PROJECT) || Boolean(process.env.GOOGLE_GEMINI_API_KEY),
@@ -384,6 +396,7 @@ const vertexAdapter: ProviderAdapter = {
         const modelInit: Record<string, unknown> = {
           model,
           generationConfig: { maxOutputTokens: maxTokens ?? 8000 },
+          safetySettings: GEMINI_SAFETY_SETTINGS,
         };
         if (systemPrompt) {
           modelInit.systemInstruction = { role: 'system', parts: [{ text: systemPrompt }] };
@@ -418,6 +431,11 @@ const vertexAdapter: ProviderAdapter = {
           ? { name: fnPart.functionCall.name, arguments: fnPart.functionCall.args }
           : undefined;
         const usageMeta = result.response?.usageMetadata;
+        if (!text && !toolCall) {
+          const finishReason = (candidate as any)?.finishReason;
+          const blockReason = (result.response as any)?.promptFeedback?.blockReason;
+          return { ok: false, error: `gemini_no_output finishReason=${finishReason ?? 'none'} blockReason=${blockReason ?? 'none'}` };
+        }
         return {
           ok: true,
           text,
@@ -464,6 +482,7 @@ const vertexAdapter: ProviderAdapter = {
       const body: Record<string, unknown> = {
         contents: [{ role: 'user', parts }],
         generationConfig: { maxOutputTokens: maxTokens ?? 8000 },
+        safetySettings: GEMINI_SAFETY_SETTINGS,
       };
       if (systemPrompt) body.systemInstruction = { role: 'system', parts: [{ text: systemPrompt }] };
       if (fnDecls) {
@@ -487,15 +506,23 @@ const vertexAdapter: ProviderAdapter = {
         return { ok: false, error: `Google AI ${resp.status}: ${errText.slice(0, 300)}` };
       }
       const json = await resp.json() as {
-        candidates?: Array<{ content?: { parts?: Array<{ text?: string; functionCall?: { name?: string; args?: Record<string, unknown> } }> } }>;
+        candidates?: Array<{ finishReason?: string; content?: { parts?: Array<{ text?: string; functionCall?: { name?: string; args?: Record<string, unknown> } }> } }>;
+        promptFeedback?: { blockReason?: string };
         usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
       };
-      const candidateParts = json.candidates?.[0]?.content?.parts || [];
+      const candidate0 = json.candidates?.[0];
+      const candidateParts = candidate0?.content?.parts || [];
       const text = candidateParts.map(p => p.text || '').join('');
       const fnPart = candidateParts.find(p => !!p.functionCall);
       const toolCall = fnPart?.functionCall?.name && fnPart.functionCall.args
         ? { name: fnPart.functionCall.name, arguments: fnPart.functionCall.args }
         : undefined;
+      if (!text && !toolCall) {
+        return {
+          ok: false,
+          error: `gemini_no_output finishReason=${candidate0?.finishReason ?? 'none'} blockReason=${json.promptFeedback?.blockReason ?? 'none'}`,
+        };
+      }
       return {
         ok: true,
         text,


### PR DESCRIPTION
Improves goal-plan generation in three ways, all shipping in one gateway deploy.

**1. Unblock failing goals.** Plan generation returned `no_plan_generated` for some goals ("Find a life partner", "Advance Career", "Master New Skills") while others worked. Two content-dependent causes:
- Default Gemini safety filters blocked benign wellness/coaching topics → added permissive `BLOCK_ONLY_HIGH` `safetySettings` to both the Vertex and AI Studio paths.
- The thinking model's reasoning tokens count against the output budget, so verbose goals exhausted 8000 tokens before emitting JSON → raised the planner budget to 16000.
- Empty/blocked Gemini responses now return a loud error with `finishReason`/`blockReason` instead of a silent `ok`.

**2. Clarify broad goals before planning (NEW).** Broad goals produce generic plans. On the first generate pass, Vitana judges whether the goal is specific enough; if not, it returns **2–3 LLM-generated clarifying questions** (written in the user's language) instead of a plan. The client collects answers and re-calls generate; the answers are folded into the planner prompt for a concrete, personalized plan. Fails open (treats the goal as specific) on any clarify-LLM error so it never blocks generation.

API: `POST /api/v1/goal-plan/generate` now accepts `{ answers: [{question, answer}] }` and may respond `{ ok: true, needs_clarification: true, questions: [...] }`.

Gateway `npm run build` clean. Paired with the frontend clarify UI in vitana-v1 (separate PR).

⚠️ **Needs a gateway redeploy** to take effect (vitana-platform is private — not auto-deployed with the frontend).

https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU)_