### PR TITLE
fix(goal-plan): drop over-strict user FK + robust plan parsing

### DIFF
--- a/services/gateway/src/services/journey/goal-planner-service.ts
+++ b/services/gateway/src/services/journey/goal-planner-service.ts
@@ -280,17 +280,44 @@ export async function clarifyGoalIfNeeded(client: SupabaseClient, userId: string
   return { hasGoal: true, specific, questions: parsed };
 }
 
+// Extract the first balanced JSON object, anchored on the plan_summary key when
+// present. Robust to a thinking model wrapping the JSON in prose (or stray
+// braces in that prose), which the naive first-{/last-} slice mishandled.
+function extractJsonObject(text: string): string | null {
+  const keyAt = text.indexOf('"plan_summary"');
+  let start = keyAt >= 0 ? text.lastIndexOf('{', keyAt) : text.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = start; i < text.length; i++) {
+    const c = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null; // unbalanced → truncated output
+}
+
 function parseLooseJson(text: string): unknown {
   if (!text) return null;
   let t = text.trim();
   const fence = t.match(/```(?:json)?\s*([\s\S]*?)```/i);
   if (fence) t = fence[1].trim();
-  const first = t.indexOf('{');
-  const last = t.lastIndexOf('}');
-  if (first >= 0 && last > first) t = t.slice(first, last + 1);
-  t = t.replace(/,\s*([}\]])/g, '$1'); // tolerate trailing commas
+  const obj = extractJsonObject(t);
+  if (!obj) return null;
+  const cleaned = obj.replace(/,\s*([}\]])/g, '$1'); // tolerate trailing commas
   try {
-    return JSON.parse(t);
+    return JSON.parse(cleaned);
   } catch {
     return null;
   }

--- a/services/gateway/src/services/llm-router.ts
+++ b/services/gateway/src/services/llm-router.ts
@@ -424,8 +424,10 @@ const vertexAdapter: ProviderAdapter = {
           contents: [{ role: 'user', parts: parts as any }],
         });
         const candidate = result.response?.candidates?.[0];
-        const candidateParts = (candidate?.content?.parts || []) as Array<{ text?: string; functionCall?: { name?: string; args?: Record<string, unknown> } }>;
-        const text = candidateParts.map(p => p.text || '').join('');
+        const candidateParts = (candidate?.content?.parts || []) as Array<{ text?: string; thought?: boolean; functionCall?: { name?: string; args?: Record<string, unknown> } }>;
+        // Drop the model's "thinking" parts — gemini thinking models emit reasoning
+        // as parts flagged thought=true; only the non-thought parts hold the answer.
+        const text = candidateParts.filter(p => !p.thought).map(p => p.text || '').join('');
         const fnPart = candidateParts.find(p => !!p.functionCall);
         const toolCall = fnPart?.functionCall?.name && fnPart.functionCall.args
           ? { name: fnPart.functionCall.name, arguments: fnPart.functionCall.args }
@@ -506,13 +508,14 @@ const vertexAdapter: ProviderAdapter = {
         return { ok: false, error: `Google AI ${resp.status}: ${errText.slice(0, 300)}` };
       }
       const json = await resp.json() as {
-        candidates?: Array<{ finishReason?: string; content?: { parts?: Array<{ text?: string; functionCall?: { name?: string; args?: Record<string, unknown> } }> } }>;
+        candidates?: Array<{ finishReason?: string; content?: { parts?: Array<{ text?: string; thought?: boolean; functionCall?: { name?: string; args?: Record<string, unknown> } }> } }>;
         promptFeedback?: { blockReason?: string };
         usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
       };
       const candidate0 = json.candidates?.[0];
       const candidateParts = candidate0?.content?.parts || [];
-      const text = candidateParts.map(p => p.text || '').join('');
+      // Drop "thinking" parts (thought=true) — only non-thought parts hold the answer.
+      const text = candidateParts.filter(p => !p.thought).map(p => p.text || '').join('');
       const fnPart = candidateParts.find(p => !!p.functionCall);
       const toolCall = fnPart?.functionCall?.name && fnPart.functionCall.args
         ? { name: fnPart.functionCall.name, arguments: fnPart.functionCall.args }

--- a/supabase/migrations/20260527130000_VTID_03152_goal_plans_drop_user_fk.sql
+++ b/supabase/migrations/20260527130000_VTID_03152_goal_plans_drop_user_fk.sql
@@ -1,0 +1,14 @@
+-- VTID-03152 — Drop the goal_plans.user_id → app_users(user_id) foreign key.
+--
+-- Plan generation failed for real users who have a life_compass goal but no
+-- app_users row: the LLM produced a valid plan, but the INSERT was rejected by
+-- goal_plans_user_id_fkey ("violates foreign key constraint"). life_compass (the
+-- goal source) does not gate on app_users, so requiring it here blocks valid
+-- users. goal_plans is already scoped per-user by RLS (user_id = auth.uid()),
+-- so the FK adds no protection the app relies on — drop it.
+
+BEGIN;
+
+ALTER TABLE public.goal_plans DROP CONSTRAINT IF EXISTS goal_plans_user_id_fkey;
+
+COMMIT;


### PR DESCRIPTION
Follow-up to #2342, from real gateway logs.

**Confirmed working after #2342:** Master New Skills and Advance Career now build plans (safety + token fixes did it).

**Remaining issue — Find Life Partner:** the logs showed the plan generated and parsed fine (`parsed plan from text`, `textLen=19262`) but the **insert was rejected**: `goal_plans_user_id_fkey` — `goal_plans.user_id` references `app_users(user_id)`, and this user has a `life_compass` goal but no `app_users` row. So a valid plan couldn't be saved.

Changes:
1. **Drop the `goal_plans.user_id → app_users` FK** (migration). The table is already RLS-scoped by `auth.uid()`, so the FK only blocked valid users. *(Needs to be applied to the DB — see below.)*
2. **Filter the model's thinking parts** (`thought=true`) from the Gemini response text in both code paths — the planner runs on Vertex and reasoning leaked into the text, which broke the JSON parse on some goals (`no usable plan parsed=false` with a huge `textLen`).
3. **Harden the plan JSON extractor** — anchor on the `plan_summary` object with a balanced-brace scan so prose around the JSON no longer defeats parsing.

Gateway `npm run build` clean.

⚠️ **Two deploy steps for this one:**
- Apply the migration (drop the FK) — one statement, can run in the Supabase SQL editor:
  ```sql
  ALTER TABLE public.goal_plans DROP CONSTRAINT IF EXISTS goal_plans_user_id_fkey;
  ```
- Redeploy the gateway (auto-deploy should fire on merge, as before).

https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU)_