### PR TITLE
feat(daily-recompute): add Vitana Index stage + scheduler job (BOOTSTRAP-VITANA-INDEX-DAILY)

### DIFF
--- a/scripts/setup-cloud-scheduler.sh
+++ b/scripts/setup-cloud-scheduler.sh
@@ -120,6 +120,58 @@ DIRECT_JOBS=(
   "reminders-sweeper|*/5 * * * *|UTC|/api/v1/scheduled-notifications/reminders-sweeper"
 )
 
+# ──────────────────────────────────────────────────────────────
+# Tenant-scoped daily recompute (BOOTSTRAP-VITANA-INDEX-DAILY)
+#
+# POSTs to /api/v1/scheduler/daily-recompute once a day so the
+# pipeline writes a fresh `vitana_index_scores` row (plus the
+# longevity / topics / community_recs / matches stages) for each
+# active user. Without this job the Vitana Index only updates on
+# activity events, leaving the Health screen at 0 on inactive days.
+# ──────────────────────────────────────────────────────────────
+
+# Format: NAME|SCHEDULE|TIMEZONE|PATH
+TENANT_DIRECT_JOBS=(
+  "daily-recompute|0 2 * * *|UTC|/api/v1/scheduler/daily-recompute"
+)
+
+for JOB in "${TENANT_DIRECT_JOBS[@]}"; do
+  IFS='|' read -r NAME SCHEDULE TIMEZONE PATH_ <<< "$JOB"
+  JOB_NAME="gateway-${NAME}"
+  TARGET_URL="${GATEWAY_URL}${PATH_}"
+
+  if $DELETE; then
+    echo "Deleting: $JOB_NAME"
+    if ! $DRY_RUN; then
+      gcloud scheduler jobs delete "$JOB_NAME" \
+        --project="$PROJECT" \
+        --location="$REGION" \
+        --quiet 2>/dev/null || echo "  (not found, skipping)"
+    fi
+  else
+    echo "Creating: $JOB_NAME → $PATH_ ($SCHEDULE $TIMEZONE)"
+    if ! $DRY_RUN; then
+      gcloud scheduler jobs delete "$JOB_NAME" \
+        --project="$PROJECT" \
+        --location="$REGION" \
+        --quiet 2>/dev/null || true
+
+      gcloud scheduler jobs create http "$JOB_NAME" \
+        --project="$PROJECT" \
+        --location="$REGION" \
+        --schedule="$SCHEDULE" \
+        --time-zone="$TIMEZONE" \
+        --uri="$TARGET_URL" \
+        --http-method=POST \
+        --headers="Content-Type=application/json" \
+        --message-body="{\"tenant_id\":\"$TENANT_ID\"}" \
+        --attempt-deadline=600s \
+        --max-retry-attempts=2 \
+        --description="Gateway daily cron: $NAME"
+    fi
+  fi
+done
+
 for JOB in "${DIRECT_JOBS[@]}"; do
   IFS='|' read -r NAME SCHEDULE TIMEZONE PATH_ <<< "$JOB"
   JOB_NAME="gateway-${NAME}"

--- a/services/gateway/src/services/daily-recompute-service.ts
+++ b/services/gateway/src/services/daily-recompute-service.ts
@@ -2,10 +2,11 @@
  * VTID-01095: Daily Recompute Service
  *
  * Orchestrates the daily recompute pipeline for each user:
- *   Stage A: Longevity compute
- *   Stage B: Topics recompute
- *   Stage C: Community recommendations
- *   Stage D: Matches recompute
+ *   Stage A: Vitana Index compute (BOOTSTRAP-VITANA-INDEX-DAILY)
+ *   Stage B: Longevity compute
+ *   Stage C: Topics recompute
+ *   Stage D: Community recommendations
+ *   Stage E: Matches recompute
  *
  * Key features:
  *   - Idempotent: Uses daily_recompute_runs table to track progress
@@ -20,8 +21,10 @@ import { emitOasisEvent } from './oasis-event-service';
 
 const VTID = 'VTID-01095';
 
-// Pipeline stages in execution order
-export const PIPELINE_STAGES = ['longevity', 'topics', 'community_recs', 'matches'] as const;
+// Pipeline stages in execution order. `index` runs first so the freshly
+// computed Vitana Index row is available to any downstream stage that
+// reads from `vitana_index_scores` (matches, recommendations).
+export const PIPELINE_STAGES = ['index', 'longevity', 'topics', 'community_recs', 'matches'] as const;
 export type PipelineStage = (typeof PIPELINE_STAGES)[number];
 
 export interface StageStatus {
@@ -143,6 +146,7 @@ async function getOrCreateRun(
   const now = new Date().toISOString();
 
   const initialStageStatus: Record<PipelineStage, StageStatus> = {
+    index: { status: 'pending' },
     longevity: { status: 'pending' },
     topics: { status: 'pending' },
     community_recs: { status: 'pending' },
@@ -164,7 +168,7 @@ async function getOrCreateRun(
       run_date: runDate,
       status: 'in_progress',
       stage_status: initialStageStatus,
-      current_stage: 'longevity',
+      current_stage: 'index',
       started_at: now,
     }),
   });
@@ -221,6 +225,7 @@ async function executeStage(
   const startTime = Date.now();
 
   const rpcNames: Record<PipelineStage, string> = {
+    index: 'scheduler_vitana_index_compute_daily',
     longevity: 'scheduler_longevity_compute_daily',
     topics: 'scheduler_topics_recompute_user_profile',
     community_recs: 'scheduler_community_recompute_recommendations',

--- a/supabase/migrations/20260528120000_BOOTSTRAP_vitana_index_daily_stage.sql
+++ b/supabase/migrations/20260528120000_BOOTSTRAP_vitana_index_daily_stage.sql
@@ -1,0 +1,91 @@
+-- =============================================================================
+-- Daily Recompute Pipeline — Vitana Index stage (BOOTSTRAP-VITANA-INDEX-DAILY)
+-- Date: 2026-05-28
+--
+-- The Vitana Index `vitana_index_scores` table is only written when activity
+-- events fire (calendar completion, health log, integration, voice tool).
+-- The existing daily recompute pipeline (VTID-01095) has stages for
+-- longevity / topics / community_recs / matches but no stage that writes a
+-- fresh per-user Index row, so an inactive day leaves the trailing window
+-- empty and downstream surfaces (native app, voice, profile cards) show 0.
+--
+-- This migration adds the missing pipeline stage. It wraps the existing
+-- `health_compute_vitana_index_for_user(user, date, model_version)` RPC and
+-- reshapes its return into the `{ ok, stage, user_id, date, ... }` envelope
+-- the orchestrator expects (see executeStage() in
+-- services/gateway/src/services/daily-recompute-service.ts).
+--
+-- Grants follow the existing pattern: service_role only (this RPC is invoked
+-- from the gateway with the service-role key).
+-- =============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.scheduler_vitana_index_compute_daily(
+    p_user_id UUID,
+    p_date DATE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_start_time TIMESTAMPTZ;
+    v_duration_ms INTEGER;
+    v_result JSONB;
+    v_ok BOOLEAN;
+BEGIN
+    v_start_time := clock_timestamp();
+
+    v_result := public.health_compute_vitana_index_for_user(
+        p_user_id,
+        p_date,
+        'v3-5pillar'
+    );
+
+    v_duration_ms := EXTRACT(MILLISECOND FROM (clock_timestamp() - v_start_time))::INTEGER;
+    v_ok := COALESCE((v_result->>'ok')::BOOLEAN, FALSE);
+
+    IF v_ok THEN
+        RETURN jsonb_build_object(
+            'ok', true,
+            'stage', 'index',
+            'user_id', p_user_id,
+            'date', p_date,
+            'duration_ms', v_duration_ms,
+            'score_total', v_result->'score_total',
+            'model_version', v_result->'model_version'
+        );
+    ELSE
+        RETURN jsonb_build_object(
+            'ok', false,
+            'stage', 'index',
+            'user_id', p_user_id,
+            'date', p_date,
+            'duration_ms', v_duration_ms,
+            'error', COALESCE(v_result->>'error', 'INDEX_COMPUTE_FAILED')
+        );
+    END IF;
+EXCEPTION WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+        'ok', false,
+        'stage', 'index',
+        'user_id', p_user_id,
+        'date', p_date,
+        'error', SQLERRM
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.scheduler_vitana_index_compute_daily(UUID, DATE) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.scheduler_vitana_index_compute_daily(UUID, DATE) FROM authenticated;
+REVOKE ALL ON FUNCTION public.scheduler_vitana_index_compute_daily(UUID, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.scheduler_vitana_index_compute_daily(UUID, DATE) TO service_role;
+
+COMMENT ON FUNCTION public.scheduler_vitana_index_compute_daily(UUID, DATE) IS
+  'Daily-recompute pipeline stage that writes a fresh vitana_index_scores row for the given user/date by delegating to health_compute_vitana_index_for_user. Returns the standard stage envelope { ok, stage, user_id, date, duration_ms, ... }.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Problem

The Vitana Index `vitana_index_scores` table is only written when **activity events** fire — calendar completion, health log, integration ping, voice tool. The daily recompute pipeline (`services/gateway/src/services/daily-recompute-service.ts`) had four stages — `longevity`, `topics`, `community_recs`, `matches` — and **none of them called the Index compute RPC**. There was also no Cloud Scheduler job pointing at `/api/v1/scheduler/daily-recompute`, so the pipeline itself only ran when invoked manually.

End result: an inactive user (or any user, on the first read of a new day) has no row for "today" and every surface that reads `vitana_index_scores` — native Health screen, voice/ORB, public profile cards, push notification body — falls back to 0. This is the recurring "VITANA Index shows 0 each new day" complaint that surfaced in `vitana-v1` PR #556.

## Fix

Three scoped changes that close the daily-write gap:

1. **New migration** `20260528120000_BOOTSTRAP_vitana_index_daily_stage.sql` — adds `public.scheduler_vitana_index_compute_daily(p_user_id UUID, p_date DATE) RETURNS JSONB`. It wraps the existing `health_compute_vitana_index_for_user` and reshapes its return into the standard stage envelope `{ ok, stage, user_id, date, duration_ms, ... }` that the orchestrator's `executeStage()` expects. `service_role`-only grants, matching the four existing stage RPCs.

2. **Pipeline orchestrator** (`daily-recompute-service.ts`) — `'index'` added **first** to `PIPELINE_STAGES` so the freshly computed Index row is available to any downstream stage that reads from `vitana_index_scores` (matches, recommendations). `initialStageStatus`, `rpcNames`, and `current_stage` extended consistently. Already-in-progress runs from before this commit terminate cleanly — the executor checks `stageStatus[stage]?.status === 'success'` and runs `index` because that key is undefined on legacy rows.

3. **Cloud Scheduler entry** (`scripts/setup-cloud-scheduler.sh`) — adds a daily `0 2 * * *` UTC job named `gateway-daily-recompute` that `POST`s `{"tenant_id":"$TENANT_ID"}` to `/api/v1/scheduler/daily-recompute`. Uses the same `gcloud scheduler jobs create http` pattern as the existing `reminders-tick` / `reminders-sweeper` entries.

The complementary frontend self-heal in `vitana-v1` PR #556 stays as the user-visible safety net; this PR closes the gap for non-app surfaces (voice/ORB, push notifications, public profile cards) that read the table directly and have no self-heal of their own.

## Test plan

- [ ] Apply the migration → `public.scheduler_vitana_index_compute_daily` exists with `EXECUTE` granted to `service_role` only.
- [ ] Invoke it manually (`SELECT public.scheduler_vitana_index_compute_daily('<user>', CURRENT_DATE);`) → returns `{ok: true, stage: 'index', score_total: ..., ...}` and the row appears in `vitana_index_scores`.
- [ ] `POST /api/v1/scheduler/daily-recompute` with a `tenant_id` → run is created with all five stages and `index` runs first.
- [ ] Re-running the same date is idempotent (Index RPC upserts on `(tenant_id, user_id, date)`, executor skips `success` stages).
- [ ] After running `scripts/setup-cloud-scheduler.sh` with `DEFAULT_TENANT_ID` set → `gcloud scheduler jobs list` shows `gateway-daily-recompute` scheduled at `0 2 * * *` UTC.
- [ ] Gateway `tsc --noEmit` is clean for the changed file (verified locally; only pre-existing repo-wide TS2742 errors from pnpm-nested types remain, unrelated to this change).

## Out of scope

- **Pagination of the daily-recompute endpoint**: the route processes batches of up to 200 users with a `next_cursor` that no caller currently follows. The new scheduler job calls it once per day, which matches the existing pattern but caps coverage at 200 users. If the active-user count exceeds that, a follow-up should either raise the batch ceiling, have the scheduler loop through cursors, or migrate to a Cloud Run job. Not addressed here.
- **Migration/deploy execution**: this PR ships the code and the scheduler-script entry; running `setup-cloud-scheduler.sh` in `lovable-vitana-vers1` to actually create the job is an infra step left to the operator (no `gcloud` access in this environment, and per `CLAUDE.md` § Infrastructure that step belongs to the deploy operator).

## Governance

VTID prefix in the commit message is `BOOTSTRAP-VITANA-INDEX-DAILY` per the `CLAUDE.md` § CI/CD pattern for non-ledger-VTID changes, so Auto Deploy will pick this up when merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUbXZ3NeNCCz5Vr5FFvcuj)_