### PR TITLE
feat: VTID-03164 new-day-return continuation provider (Slice 1) — Teacher no longer hijacks the morning

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1054,6 +1054,11 @@ export async function handleLiveSessionStart(
       // name-aware greeting pool. LiveKit always passed this; Vertex never
       // did — that's why `firstname_len=0` showed on every Teacher pick.
       firstName,
+      // VTID-03164: forward timezone from the client envelope so the
+      // new-day-return provider can detect "first session of new calendar
+      // day in user TZ". Missing → provider suppresses with reason
+      // 'no_timezone' and falls through to wake-brief, same as before.
+      timezone: session.clientContext?.timezone ?? null,
       // wake_origin is not yet plumbed from the client envelope on
       // Vertex; default 'unknown' so the B1 policy doesn't fire the
       // push_tap nudge. When the envelope ships this field through

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -1604,6 +1604,13 @@ router.get(
           wakeOrigin:
             (envContext as { wakeOrigin?: 'orb_tap' | 'wake_word' | 'push_tap' | 'proactive_opener' | 'deep_link' | 'unknown' } | undefined)
               ?.wakeOrigin ?? 'unknown',
+          // VTID-03164: forward timezone for the new-day-return provider.
+          // LiveKit envelope carries it under clientContext.timezone OR
+          // (legacy) envelope.timezone — try both.
+          timezone:
+            (envContext as { timezone?: string } | undefined)?.timezone
+              ?? (envContext as { clientContext?: { timezone?: string } } | undefined)?.clientContext?.timezone
+              ?? null,
           recordEmission: true,
         });
         // VTID-03081: bump sessions_today_count. Fire-and-forget; never

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-return.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-return.ts
@@ -1,0 +1,406 @@
+/**
+ * VTID-03164 — New-day-return continuation provider (Slice 1).
+ *
+ * Fires the FIRST orb session of a new calendar day in the user's local
+ * timezone. Wins priority 90 — above Teacher (85) and voice-wake-brief
+ * (80). When this provider returns a candidate, Teacher and wake-brief
+ * lose the ranker and Vitana opens with a warm "good {morning/afternoon/
+ * evening}" greeting rather than a Teacher capability-introduction jump.
+ *
+ * Trigger contract:
+ *   user_journey.last_session_date < today_in_user_tz
+ *   OR user_journey.last_session_date IS NULL (and is_first_session=false)
+ *
+ * NOT triggered:
+ *   - Same-day repeat sessions (last_session_date === today)
+ *   - User's very first session ever (is_first_session=true → that's the
+ *     one-time-welcome territory, deferred to a future slice)
+ *   - Anonymous sessions (no user_id)
+ *   - Sessions with no timezone information
+ *
+ * Slice 1 content: salutation per local hour + name (when known) + ONE
+ * open question. No overnight overview yet — that's Slice 2 (calendar
+ * events / reminders / Index delta / today's plan).
+ *
+ * Architecture note: this provider returns a server-composed
+ * `userFacingLine` for the wake-brief Say-exactly pattern. Same path
+ * the Teacher / voice-wake-brief use. No new block, no system-instruction
+ * concat tricks, no post-hoc clearing of other blocks. The ranker picks
+ * this at 90 > 85 (Teacher) and Vitana speaks the line. Clean.
+ */
+
+import { randomUUID } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  ContinuationDecisionContext,
+  ContinuationProvider,
+  ProviderResult,
+  AssistantContinuation,
+} from '../types';
+
+export const NEW_DAY_RETURN_PROVIDER_KEY = 'new_day_return';
+export const NEW_DAY_RETURN_EXTRA_KEY = 'newDayReturn' as const;
+
+/** Priority above Teacher (85) and voice-wake-brief (80). Below the
+ *  urgent next-action bands (95+ reminder) so a time-sensitive reminder
+ *  still pre-empts the new-day greeting. */
+const DEFAULT_PRIORITY = 90;
+
+export interface NewDayReturnInputs {
+  supabase: SupabaseClient;
+  userId: string;
+  tenantId: string;
+  lang: string;
+  firstName: string | null;
+  /** IANA timezone from clientContext.timezone. Provider suppresses when missing. */
+  timezone: string | null;
+}
+
+export interface NewDayReturnProviderOptions {
+  newId?: () => string;
+  now?: () => number;
+  priority?: number;
+  rng?: () => number;
+}
+
+interface UserJourneyRow {
+  last_session_date: string | null; // YYYY-MM-DD in user TZ
+  is_first_session: boolean;
+}
+
+/** Compute YYYY-MM-DD in a given IANA TZ. Falls back to UTC on invalid TZ. */
+export function todayInTimezone(now: Date, timezone: string | null): string {
+  if (timezone) {
+    try {
+      const fmt = new Intl.DateTimeFormat('en-CA', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      });
+      return fmt.format(now);
+    } catch {
+      // fall through
+    }
+  }
+  return now.toISOString().slice(0, 10);
+}
+
+/** Local hour [0-23] in a given IANA TZ. Falls back to UTC on invalid TZ. */
+export function localHourInTimezone(now: Date, timezone: string | null): number {
+  if (timezone) {
+    try {
+      const fmt = new Intl.DateTimeFormat('en-GB', {
+        timeZone: timezone,
+        hour: '2-digit',
+        hourCycle: 'h23',
+      });
+      const parts = fmt.formatToParts(now);
+      const hourStr = parts.find((p) => p.type === 'hour')?.value ?? '0';
+      const hour = parseInt(hourStr, 10);
+      if (Number.isFinite(hour) && hour >= 0 && hour <= 23) return hour;
+    } catch {
+      // fall through
+    }
+  }
+  return now.getUTCHours();
+}
+
+export type SalutationKind = 'morning' | 'afternoon' | 'evening';
+
+/** Map a local hour to one of three salutation buckets. Pure. */
+export function pickSalutationKind(localHour: number): SalutationKind {
+  if (localHour < 5) return 'evening'; // very early hours read as "evening of yesterday"
+  if (localHour < 12) return 'morning';
+  if (localHour < 18) return 'afternoon';
+  return 'evening';
+}
+
+// Pools intentionally vary phrasing per call so the daily greeting does
+// not repeat the same opening word-for-word every day. Each entry is a
+// complete sentence; the provider picks one at random via the injected rng.
+// Naming a single pool per (lang × salutation × name-present) keeps the
+// branching explicit and avoids surprise interpolation bugs.
+
+const GREETING_POOLS: Record<
+  string,
+  Record<SalutationKind, { withName: string[]; withoutName: string[] }>
+> = {
+  de: {
+    morning: {
+      withName: [
+        'Guten Morgen, {name}! Schön, dass du wieder da bist. Womit darf ich dir heute helfen?',
+        'Guten Morgen, {name} — schön, dich zu hören. Was steht heute bei dir an?',
+        'Hallo {name}, einen schönen guten Morgen. Womit kann ich dich heute begleiten?',
+      ],
+      withoutName: [
+        'Guten Morgen! Schön, dass du wieder da bist. Womit darf ich dir heute helfen?',
+        'Guten Morgen — schön, dich zu hören. Was steht heute bei dir an?',
+      ],
+    },
+    afternoon: {
+      withName: [
+        'Guten Tag, {name}! Schön, dass du wieder vorbeischaust. Womit darf ich dir helfen?',
+        'Hallo {name} — schön, dich zu hören. Was steht heute noch bei dir an?',
+        'Schönen Nachmittag, {name}. Womit kann ich dich heute unterstützen?',
+      ],
+      withoutName: [
+        'Guten Tag! Schön, dass du wieder vorbeischaust. Womit darf ich dir helfen?',
+        'Schönen Nachmittag — was steht bei dir an?',
+      ],
+    },
+    evening: {
+      withName: [
+        'Guten Abend, {name}! Schön, dich am Abend zu hören. Womit darf ich dir helfen?',
+        'Hallo {name}, einen schönen Abend. Was beschäftigt dich heute noch?',
+        'Schönen Abend, {name}. Womit kann ich dich heute unterstützen?',
+      ],
+      withoutName: [
+        'Guten Abend! Schön, dich zu hören. Womit darf ich dir helfen?',
+        'Schönen Abend — was beschäftigt dich heute noch?',
+      ],
+    },
+  },
+  en: {
+    morning: {
+      withName: [
+        'Good morning, {name}! Lovely to hear from you. How can I help you today?',
+        'Morning, {name} — good to have you back. What is on your plate today?',
+        'Good morning, {name}. Where would you like to start today?',
+      ],
+      withoutName: [
+        'Good morning! Lovely to hear from you. How can I help you today?',
+        'Morning — good to have you back. What is on your plate today?',
+      ],
+    },
+    afternoon: {
+      withName: [
+        'Good afternoon, {name}! Glad you stopped by. How can I help you?',
+        'Hello {name} — good to hear from you. What is on your mind this afternoon?',
+        'Afternoon, {name}. Where would you like to pick up?',
+      ],
+      withoutName: [
+        'Good afternoon! Glad you stopped by. How can I help you?',
+        'Afternoon — what is on your mind?',
+      ],
+    },
+    evening: {
+      withName: [
+        'Good evening, {name}! Nice to hear from you this evening. How can I help?',
+        'Hello {name}, hope your day was kind. What is still on your mind?',
+        'Evening, {name}. Where would you like to land today?',
+      ],
+      withoutName: [
+        'Good evening! Nice to hear from you this evening. How can I help?',
+        'Evening — what is still on your mind?',
+      ],
+    },
+  },
+};
+
+function pickFromPool(pool: string[], rng: () => number): string {
+  if (pool.length === 0) return '';
+  const idx = Math.min(pool.length - 1, Math.max(0, Math.floor(rng() * pool.length)));
+  return pool[idx];
+}
+
+/**
+ * Pure renderer for the spoken line. Exported for tests.
+ * Lang fallback chain: requested lang → 'en' → empty string.
+ */
+export function renderNewDayReturnLine(
+  args: { lang: string; salutation: SalutationKind; firstName: string | null },
+  rng: () => number = Math.random,
+): string {
+  const langPool = GREETING_POOLS[args.lang] ?? GREETING_POOLS.en;
+  const slot = args.firstName ? langPool[args.salutation].withName : langPool[args.salutation].withoutName;
+  const template = pickFromPool(slot, rng);
+  if (!template) return '';
+  return args.firstName ? template.replace('{name}', args.firstName) : template;
+}
+
+function readInputs(ctx: ContinuationDecisionContext): NewDayReturnInputs | null {
+  const extra = ctx.extra;
+  if (!extra || typeof extra !== 'object') return null;
+  const raw = (extra as Record<string, unknown>)[NEW_DAY_RETURN_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.userId !== 'string' || o.userId.length === 0) return null;
+  if (typeof o.tenantId !== 'string' || o.tenantId.length === 0) return null;
+  if (!o.supabase) return null;
+  return {
+    supabase: o.supabase as SupabaseClient,
+    userId: o.userId,
+    tenantId: o.tenantId,
+    lang: typeof o.lang === 'string' && o.lang.length > 0 ? o.lang : 'en',
+    firstName: typeof o.firstName === 'string' && o.firstName.length > 0 ? o.firstName : null,
+    timezone: typeof o.timezone === 'string' && o.timezone.length > 0 ? o.timezone : null,
+  };
+}
+
+/**
+ * Fire-and-forget DB write: stamp the user_journey row's last_session_date
+ * so same-day repeat sessions don't re-fire the new-day greeting. Never
+ * throws. Logs on failure.
+ */
+async function stampLastSessionDate(
+  supabase: SupabaseClient,
+  userId: string,
+  todayIso: string,
+): Promise<void> {
+  try {
+    const { error } = await supabase
+      .from('user_journey')
+      .update({ last_session_date: todayIso })
+      .eq('user_id', userId);
+    if (error) {
+      console.warn(
+        `[VTID-03164] stampLastSessionDate failed for ${userId.slice(0, 8)}: ${error.message}`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[VTID-03164] stampLastSessionDate threw for ${userId.slice(0, 8)}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+export function makeNewDayReturnProvider(
+  opts: NewDayReturnProviderOptions = {},
+): ContinuationProvider {
+  const newId = opts.newId ?? randomUUID;
+  const now = opts.now ?? (() => Date.now());
+  const priority = opts.priority ?? DEFAULT_PRIORITY;
+  const rng = opts.rng ?? Math.random;
+
+  return {
+    key: NEW_DAY_RETURN_PROVIDER_KEY,
+    surfaces: ['orb_wake'],
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const t0 = now();
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return {
+          providerKey: NEW_DAY_RETURN_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'no_new_day_return_inputs',
+        };
+      }
+
+      // Timezone is required — without it we'd risk firing the wrong day
+      // for users near midnight. Better to suppress and let wake-brief
+      // win than emit "Good morning" at 9pm local.
+      if (!inputs.timezone) {
+        return {
+          providerKey: NEW_DAY_RETURN_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'no_timezone',
+        };
+      }
+
+      // ---- DB fetch: user_journey row ----
+      let row: UserJourneyRow | null = null;
+      try {
+        const { data, error } = await inputs.supabase
+          .from('user_journey')
+          .select('last_session_date, is_first_session')
+          .eq('user_id', inputs.userId)
+          .maybeSingle();
+        if (error) {
+          return {
+            providerKey: NEW_DAY_RETURN_PROVIDER_KEY,
+            status: 'errored',
+            latencyMs: Math.max(0, now() - t0),
+            reason: `user_journey_fetch_failed: ${error.message}`,
+          };
+        }
+        row = (data ?? null) as UserJourneyRow | null;
+      } catch (err) {
+        return {
+          providerKey: NEW_DAY_RETURN_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      // Suppress when this user is brand-new (first session ever). A
+      // future slice owns the one-time welcome; we should not jump in
+      // with a returning-day greeting on day 0.
+      if (row && row.is_first_session === true) {
+        return {
+          providerKey: NEW_DAY_RETURN_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'is_first_session_true',
+        };
+      }
+
+      const nowDate = new Date(now());
+      const todayIso = todayInTimezone(nowDate, inputs.timezone);
+
+      // Same-day repeat: suppress. Lets voice-wake-brief / Teacher take
+      // over with their normal cadence-aware logic for a returning user
+      // who already spoke today.
+      if (row && row.last_session_date && row.last_session_date >= todayIso) {
+        return {
+          providerKey: NEW_DAY_RETURN_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: `same_day_${row.last_session_date}`,
+        };
+      }
+
+      // ---- Compose the spoken line ----
+      const localHour = localHourInTimezone(nowDate, inputs.timezone);
+      const salutation = pickSalutationKind(localHour);
+      const line = renderNewDayReturnLine(
+        { lang: inputs.lang, salutation, firstName: inputs.firstName },
+        rng,
+      );
+      if (line.length === 0) {
+        return {
+          providerKey: NEW_DAY_RETURN_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'renderer_produced_empty_line',
+        };
+      }
+
+      // Fire-and-forget stamp so same-day repeats don't re-fire. Safe to
+      // do before the candidate is selected — if another provider wins
+      // the ranker, we've still correctly recorded that the user opened
+      // the orb today.
+      void stampLastSessionDate(inputs.supabase, inputs.userId, todayIso);
+
+      const candidate: AssistantContinuation = {
+        id: `new-day-return-${newId()}`,
+        surface: 'orb_wake',
+        kind: 'wake_brief',
+        priority,
+        userFacingLine: line,
+        cta: { type: 'explain' },
+        evidence: [
+          { kind: 'new_day_return', detail: `${todayIso}_${salutation}` },
+          { kind: 'last_session_date', detail: row?.last_session_date ?? 'null' },
+        ],
+        // Dedupe key: one new-day greeting per (user × calendar day).
+        // Wake-brief's 60-min wake-brief-emitted cache prevents same-style
+        // emission within an hour; this stamps the row directly so even
+        // a cold cache won't re-fire.
+        dedupeKey: `new-day-return:${todayIso}`,
+        privacyMode: 'safe_to_speak',
+      };
+
+      return {
+        providerKey: NEW_DAY_RETURN_PROVIDER_KEY,
+        status: 'returned',
+        latencyMs: Math.max(0, now() - t0),
+        candidate,
+      };
+    },
+  };
+}

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -52,6 +52,17 @@ import {
   TEACHER_EXTRA_KEY,
   TEACHER_PROVIDER_KEY,
 } from './assistant-continuation/providers/teacher/feature-discovery-teacher';
+// VTID-03164: new-day-return provider — fires first session of a new
+// calendar day in user's local TZ. Priority 90 so it beats Teacher (85)
+// and wake-brief (80). Suppresses cleanly when same-day repeat or when
+// the user is brand-new (is_first_session=true). Owns the rude-jump-to-
+// Teacher bug fix: a returning user's morning is no longer a capability
+// pitch.
+import {
+  makeNewDayReturnProvider,
+  NEW_DAY_RETURN_EXTRA_KEY,
+  NEW_DAY_RETURN_PROVIDER_KEY,
+} from './assistant-continuation/providers/new-day-return';
 // VTID-03061 (B0d-real Xf.1): auto-emit OASIS next_action.suggested/
 // .suppressed events when a wake-brief decision lands. Fire-and-forget;
 // never blocks the voice path.
@@ -98,6 +109,12 @@ export function ensureWakeBriefProviderRegistered(): void {
   // tables; degrades to `suppressed:empty_catalog` when missing.
   if (!defaultProviderRegistry.get(TEACHER_PROVIDER_KEY)) {
     defaultProviderRegistry.register(makeFeatureDiscoveryTeacherProvider());
+  }
+  // VTID-03164: new-day-return at priority 90. Suppresses cleanly when
+  // same-day repeat OR is_first_session=true OR no timezone, so it
+  // never blocks the other providers when the trigger does not apply.
+  if (!defaultProviderRegistry.get(NEW_DAY_RETURN_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeNewDayReturnProvider());
   }
   _registered = true;
 }
@@ -190,6 +207,15 @@ export interface DecideWakeBriefArgs {
    * absent and the Teacher's pool falls back to no-name phrases.
    */
   firstName?: string | null;
+  /**
+   * VTID-03164: IANA timezone string (e.g. 'Europe/Berlin') from the
+   * session's clientContext.timezone. Required for the new-day-return
+   * provider to detect "first session of a new calendar day in user TZ"
+   * — without it the provider suppresses. Missing for anonymous /
+   * legacy sessions; those just lose the new-day-return greeting and
+   * fall back to wake-brief, same as before this slice.
+   */
+  timezone?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -300,6 +326,18 @@ export async function decideWakeBriefForSession(
         // (suppress) from cadence-class skips (still fire — different
         // capability via per-capability dedupe).
         skipReason: greetingDecision.reason,
+      };
+      // VTID-03164: forward new-day-return inputs. Provider suppresses
+      // unless trigger conditions hold (new calendar day in user TZ AND
+      // is_first_session=false AND timezone present), so passing the
+      // extra always is safe.
+      extra[NEW_DAY_RETURN_EXTRA_KEY] = {
+        supabase: args.supabase,
+        tenantId: args.tenantId,
+        userId: args.userId,
+        lang: args.lang,
+        firstName: args.firstName ?? null,
+        timezone: args.timezone ?? null,
       };
     }
   }

--- a/services/gateway/test/services/assistant-continuation/providers/new-day-return.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/new-day-return.test.ts
@@ -1,0 +1,260 @@
+/**
+ * VTID-03164 — new-day-return provider tests.
+ *
+ * Locks the contract:
+ *   - Suppresses on missing inputs / no timezone / is_first_session=true / same-day repeat
+ *   - Fires with priority 90 when last_session_date < today_in_user_tz
+ *   - Picks salutation by local hour bucket
+ *   - Composes line from pool with named/unnamed variants
+ *   - Stamps last_session_date fire-and-forget (no throw)
+ *   - Suppresses Teacher path by winning the ranker via priority 90 > 85
+ */
+
+import {
+  makeNewDayReturnProvider,
+  NEW_DAY_RETURN_PROVIDER_KEY,
+  NEW_DAY_RETURN_EXTRA_KEY,
+  todayInTimezone,
+  localHourInTimezone,
+  pickSalutationKind,
+  renderNewDayReturnLine,
+} from '../../../../src/services/assistant-continuation/providers/new-day-return';
+
+function makeFakeSupabase(row: { last_session_date: string | null; is_first_session: boolean } | null, errorMsg?: string) {
+  const captured: any = {};
+  const sb = {
+    from(table: string) {
+      const builder: any = {
+        select() { return builder; },
+        eq() { return builder; },
+        async maybeSingle() {
+          captured.queriedTable = table;
+          if (errorMsg) return { data: null, error: { message: errorMsg } };
+          return { data: row, error: null };
+        },
+        update(patch: any) {
+          captured.updatePatch = patch;
+          return { eq: () => Promise.resolve({ error: null }) };
+        },
+      };
+      return builder;
+    },
+  } as any;
+  return { sb, captured };
+}
+
+function makeCtx(extraOverride: any = {}) {
+  return {
+    surface: 'orb_wake',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    extra: {
+      [NEW_DAY_RETURN_EXTRA_KEY]: {
+        supabase: extraOverride.supabase ?? makeFakeSupabase({ last_session_date: '2026-06-14', is_first_session: false }).sb,
+        userId: 'u1',
+        tenantId: 't1',
+        lang: 'en',
+        firstName: 'Dragan',
+        timezone: 'Europe/Berlin',
+        ...extraOverride,
+      },
+    },
+  } as any;
+}
+
+const FIXED_NOW = new Date('2026-06-15T10:30:00.000Z'); // ~12:30 in Berlin
+
+describe('VTID-03164 helpers', () => {
+  describe('todayInTimezone', () => {
+    it('returns YYYY-MM-DD in IANA TZ', () => {
+      expect(todayInTimezone(FIXED_NOW, 'Europe/Berlin')).toBe('2026-06-15');
+    });
+    it('handles TZ flipping to next-day vs UTC', () => {
+      // UTC 22:00 → Sydney 08:00 next day
+      const utcEvening = new Date('2026-06-14T22:00:00.000Z');
+      expect(todayInTimezone(utcEvening, 'Australia/Sydney')).toBe('2026-06-15');
+    });
+    it('handles TZ flipping to previous-day vs UTC', () => {
+      // UTC 02:00 → LA 19:00 prev day
+      const utcEarly = new Date('2026-06-15T02:00:00.000Z');
+      expect(todayInTimezone(utcEarly, 'America/Los_Angeles')).toBe('2026-06-14');
+    });
+    it('falls back to UTC on null TZ', () => {
+      expect(todayInTimezone(FIXED_NOW, null)).toBe('2026-06-15');
+    });
+    it('falls back to UTC on invalid TZ', () => {
+      expect(todayInTimezone(FIXED_NOW, 'Not/A_Real_Timezone')).toBe('2026-06-15');
+    });
+  });
+
+  describe('localHourInTimezone', () => {
+    it('returns local hour in IANA TZ', () => {
+      expect(localHourInTimezone(FIXED_NOW, 'Europe/Berlin')).toBe(12);
+    });
+    it('falls back to UTC hour on null TZ', () => {
+      expect(localHourInTimezone(FIXED_NOW, null)).toBe(10);
+    });
+  });
+
+  describe('pickSalutationKind', () => {
+    it('maps very early hours to evening (avoids "good morning" at 3am)', () => {
+      expect(pickSalutationKind(2)).toBe('evening');
+      expect(pickSalutationKind(4)).toBe('evening');
+    });
+    it('maps 5-11 to morning', () => {
+      expect(pickSalutationKind(5)).toBe('morning');
+      expect(pickSalutationKind(11)).toBe('morning');
+    });
+    it('maps 12-17 to afternoon', () => {
+      expect(pickSalutationKind(12)).toBe('afternoon');
+      expect(pickSalutationKind(17)).toBe('afternoon');
+    });
+    it('maps 18-23 to evening', () => {
+      expect(pickSalutationKind(18)).toBe('evening');
+      expect(pickSalutationKind(23)).toBe('evening');
+    });
+  });
+
+  describe('renderNewDayReturnLine', () => {
+    it('substitutes firstName when present', () => {
+      const line = renderNewDayReturnLine(
+        { lang: 'de', salutation: 'morning', firstName: 'Dragan' },
+        () => 0,
+      );
+      expect(line).toMatch(/Dragan/);
+      expect(line).toMatch(/Guten Morgen/);
+    });
+    it('uses no-name pool when firstName is null', () => {
+      const line = renderNewDayReturnLine(
+        { lang: 'de', salutation: 'morning', firstName: null },
+        () => 0,
+      );
+      expect(line).not.toMatch(/Dragan/);
+      expect(line).not.toMatch(/{name}/);
+    });
+    it('falls back to en when lang pool missing', () => {
+      const line = renderNewDayReturnLine(
+        { lang: 'ja', salutation: 'morning', firstName: 'Dragan' },
+        () => 0,
+      );
+      expect(line).toMatch(/Dragan/);
+      expect(line).toMatch(/Good morning|Morning/);
+    });
+    it('English afternoon variant', () => {
+      const line = renderNewDayReturnLine(
+        { lang: 'en', salutation: 'afternoon', firstName: 'Dragan' },
+        () => 0,
+      );
+      expect(line).toMatch(/afternoon/i);
+    });
+    it('English evening variant', () => {
+      const line = renderNewDayReturnLine(
+        { lang: 'en', salutation: 'evening', firstName: null },
+        () => 0,
+      );
+      expect(line).toMatch(/evening|Evening/);
+    });
+    it('rng index out of range clamps to first entry', () => {
+      const line = renderNewDayReturnLine(
+        { lang: 'en', salutation: 'morning', firstName: 'Dragan' },
+        () => 999, // clamps to last
+      );
+      expect(line).toMatch(/Dragan/);
+    });
+  });
+});
+
+describe('VTID-03164 makeNewDayReturnProvider', () => {
+  it('exposes the correct surface + key', () => {
+    const p = makeNewDayReturnProvider();
+    expect(p.key).toBe(NEW_DAY_RETURN_PROVIDER_KEY);
+    expect(p.surfaces).toEqual(['orb_wake']);
+  });
+
+  it('skips when inputs are missing', async () => {
+    const p = makeNewDayReturnProvider();
+    const r = await p.produce({ surface: 'orb_wake', extra: {} } as any);
+    expect(r.status).toBe('skipped');
+    expect((r as any).reason).toBe('no_new_day_return_inputs');
+  });
+
+  it('suppresses when timezone is missing', async () => {
+    const p = makeNewDayReturnProvider();
+    const r = await p.produce(makeCtx({ timezone: null }));
+    expect(r.status).toBe('suppressed');
+    expect((r as any).reason).toBe('no_timezone');
+  });
+
+  it('errors gracefully on DB fetch failure', async () => {
+    const p = makeNewDayReturnProvider();
+    const { sb } = makeFakeSupabase(null, 'boom');
+    const r = await p.produce(makeCtx({ supabase: sb }));
+    expect(r.status).toBe('errored');
+    expect((r as any).reason).toMatch(/user_journey_fetch_failed/);
+  });
+
+  it('suppresses when is_first_session=true (first-time welcome territory)', async () => {
+    const p = makeNewDayReturnProvider();
+    const { sb } = makeFakeSupabase({ last_session_date: null, is_first_session: true });
+    const r = await p.produce(makeCtx({ supabase: sb }));
+    expect(r.status).toBe('suppressed');
+    expect((r as any).reason).toBe('is_first_session_true');
+  });
+
+  it('suppresses when same-day repeat (last_session_date === today)', async () => {
+    jest.useFakeTimers().setSystemTime(FIXED_NOW);
+    const p = makeNewDayReturnProvider({ now: () => FIXED_NOW.getTime() });
+    const { sb } = makeFakeSupabase({ last_session_date: '2026-06-15', is_first_session: false });
+    const r = await p.produce(makeCtx({ supabase: sb }));
+    expect(r.status).toBe('suppressed');
+    expect((r as any).reason).toMatch(/^same_day_/);
+    jest.useRealTimers();
+  });
+
+  it('fires with priority 90 on new-day return', async () => {
+    jest.useFakeTimers().setSystemTime(FIXED_NOW);
+    const p = makeNewDayReturnProvider({ now: () => FIXED_NOW.getTime(), rng: () => 0 });
+    const { sb } = makeFakeSupabase({ last_session_date: '2026-06-14', is_first_session: false });
+    const r = await p.produce(makeCtx({ supabase: sb }));
+    expect(r.status).toBe('returned');
+    const c = (r as any).candidate;
+    expect(c.priority).toBe(90);
+    expect(c.surface).toBe('orb_wake');
+    expect(c.kind).toBe('wake_brief');
+    expect(c.dedupeKey).toBe('new-day-return:2026-06-15');
+    expect(c.userFacingLine).toMatch(/Dragan/);
+    expect(c.userFacingLine).toMatch(/afternoon|Afternoon/); // afternoon Berlin, lang=en in ctx
+    jest.useRealTimers();
+  });
+
+  it('fires when last_session_date is null (returning user whose row never had a stamp)', async () => {
+    jest.useFakeTimers().setSystemTime(FIXED_NOW);
+    const p = makeNewDayReturnProvider({ now: () => FIXED_NOW.getTime() });
+    const { sb } = makeFakeSupabase({ last_session_date: null, is_first_session: false });
+    const r = await p.produce(makeCtx({ supabase: sb }));
+    expect(r.status).toBe('returned');
+    jest.useRealTimers();
+  });
+
+  it('uses no-name pool when firstName is null', async () => {
+    jest.useFakeTimers().setSystemTime(FIXED_NOW);
+    const p = makeNewDayReturnProvider({ now: () => FIXED_NOW.getTime() });
+    const { sb } = makeFakeSupabase({ last_session_date: '2026-06-14', is_first_session: false });
+    const r = await p.produce(makeCtx({ supabase: sb, firstName: null }));
+    expect(r.status).toBe('returned');
+    expect((r as any).candidate.userFacingLine).not.toMatch(/Dragan/);
+    expect((r as any).candidate.userFacingLine).not.toMatch(/{name}/);
+    jest.useRealTimers();
+  });
+
+  it('priority 90 wins against a synthetic Teacher candidate at 85', async () => {
+    // Verifies the architectural contract: this provider's priority beats Teacher's.
+    jest.useFakeTimers().setSystemTime(FIXED_NOW);
+    const p = makeNewDayReturnProvider({ now: () => FIXED_NOW.getTime() });
+    const { sb } = makeFakeSupabase({ last_session_date: '2026-06-14', is_first_session: false });
+    const r = await p.produce(makeCtx({ supabase: sb }));
+    expect((r as any).candidate.priority).toBeGreaterThan(85);
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary

Founder report: first orb session of the day at 9am got hit with Teacher's *"Hast du eine Minute, ich möchte dir etwas zeigen?"* instead of a polite greeting. Audit traced to VTID-03096 hardcoding Teacher's priority to 85 with zero ranker awareness of "first session of new calendar day".

This PR fixes that with a new continuation provider at **priority 90** that fires when the session is the first of a new calendar day in the user's local TZ. Teacher (85) loses the ranker, Vitana opens with a warm greeting.

## Slice 1 scope

- New provider at `services/gateway/src/services/assistant-continuation/providers/new-day-return.ts`
- Wired into wake-brief-wiring.ts (registered at priority 90, extras forwarded)
- Timezone threaded from session.clientContext into the wake-brief args (Vertex + LiveKit)
- Content: time-appropriate salutation + name (when known) + ONE open question, picked from a small per-language × per-salutation pool so wording rotates day-to-day
- Fire-and-forget stamp of `user_journey.last_session_date` so same-day repeats suppress correctly

### Trigger truth table

| Condition | Result |
|---|---|
| Anonymous session OR no userId | skipped (no_new_day_return_inputs) |
| No timezone | suppressed (no_timezone) |
| `is_first_session === true` | suppressed (is_first_session_true) — one-time-welcome territory |
| `last_session_date === today_in_tz` | suppressed (same_day_YYYY-MM-DD) |
| `last_session_date < today_in_tz` OR NULL, with timezone | **returned** — priority 90, wins ranker over Teacher (85) |

## What this does NOT do (Slice 2 — follow-up)

- Aggregate overnight overview content (calendar events since last session, reminders due today, Vitana Index delta, today's plan items) — that's the depth layer the founder also asked for. Slice 2 will extend the renderer with a structured payload from the existing morning-brief-generator sources.

## Architectural notes

This is a clean upstream signal-driven selection. Unlike VTID-03154/-03157 (which I broke and reverted today), this version does NOT clear other blocks post-hoc, does NOT fight Teacher's prompt — Teacher simply doesn't win the ranker on new-day sessions. Suppresses gracefully when trigger conditions are not met so Teacher / voice-wake-brief operate normally on same-day repeats.

## Test plan

- [x] `npm run build` clean
- [x] 27 new unit tests in `new-day-return.test.ts` — all green
- [x] 455 regression tests across `test/services/assistant-continuation` + wake-brief-wiring — all green
- [ ] EXEC-DEPLOY green
- [ ] User runtime test: reset Dragan's `last_session_date` to yesterday via SQL, open the orb, expect a greeting (not Teacher's permission-asking line); same-day reopen expects normal cadence opener (no day-N restatement)

Generated with [Claude Code](https://claude.com/claude-code)