### PR TITLE
feat(cart): Universal Cart Phase 1 schema foundation (VTID-03165)

### DIFF
--- a/supabase/migrations/20260604000000_VTID_03165_universal_cart_schema.sql
+++ b/supabase/migrations/20260604000000_VTID_03165_universal_cart_schema.sql
@@ -49,22 +49,48 @@ DO $vtid_03165_pre_guard$
 DECLARE
   unexpected TEXT;
 BEGIN
-  SELECT string_agg(table_name || '.' || column_name, ', ' ORDER BY table_name, column_name)
+  -- Per-table column check: any column present in carts / cart_items / cart_events
+  -- whose (table_name, column_name) pair is not in the expected set is treated as
+  -- drift. The earlier UNION form (one column-name set across all three tables)
+  -- would have falsely passed e.g. `cart_items.event_type` because `event_type`
+  -- belongs on cart_events.
+  SELECT string_agg(c.table_name || '.' || c.column_name, ', ' ORDER BY c.table_name, c.column_name)
     INTO unexpected
-    FROM information_schema.columns
-   WHERE table_schema = 'public'
-     AND table_name IN ('carts', 'cart_items', 'cart_events')
-     AND column_name NOT IN (
-       -- carts (shared id/created_at/updated_at + table-specific below)
-       'id', 'user_id', 'tenant_id', 'status', 'source_context', 'metadata',
-       'created_at', 'updated_at',
-       -- cart_items table-specific
-       'cart_id', 'item_type', 'product_id', 'merchant_id', 'quantity',
-       'unit_price_cents_snapshot', 'currency_snapshot',
-       'source_surface', 'source_ref',
-       -- cart_events table-specific
-       'event_type', 'event_payload'
-     );
+    FROM information_schema.columns c
+    LEFT JOIN (VALUES
+      ('carts','id'),
+      ('carts','user_id'),
+      ('carts','tenant_id'),
+      ('carts','status'),
+      ('carts','source_context'),
+      ('carts','metadata'),
+      ('carts','created_at'),
+      ('carts','updated_at'),
+      ('cart_items','id'),
+      ('cart_items','cart_id'),
+      ('cart_items','item_type'),
+      ('cart_items','product_id'),
+      ('cart_items','merchant_id'),
+      ('cart_items','quantity'),
+      ('cart_items','unit_price_cents_snapshot'),
+      ('cart_items','currency_snapshot'),
+      ('cart_items','source_surface'),
+      ('cart_items','source_ref'),
+      ('cart_items','status'),
+      ('cart_items','metadata'),
+      ('cart_items','created_at'),
+      ('cart_items','updated_at'),
+      ('cart_events','id'),
+      ('cart_events','cart_id'),
+      ('cart_events','user_id'),
+      ('cart_events','event_type'),
+      ('cart_events','event_payload'),
+      ('cart_events','created_at')
+    ) AS allowed(tbl, col)
+      ON allowed.tbl = c.table_name AND allowed.col = c.column_name
+   WHERE c.table_schema = 'public'
+     AND c.table_name IN ('carts', 'cart_items', 'cart_events')
+     AND allowed.tbl IS NULL;
 
   IF unexpected IS NOT NULL THEN
     RAISE EXCEPTION
@@ -229,6 +255,21 @@ CREATE INDEX IF NOT EXISTS cart_events_type_idx
   ON public.cart_events (event_type, created_at DESC);
 
 -- ============================================================
+-- Explicit table grants (defense-in-depth alongside RLS).
+-- Supabase configures DEFAULT PRIVILEGES on `public` for these roles, but
+-- declaring them explicitly keeps the migration self-contained and resilient
+-- to schema-level privilege drift (e.g. a future REVOKE ALL on public).
+-- cart_events stays SELECT-only for `authenticated` — gateway writes via
+-- service_role, which bypasses RLS.
+-- ============================================================
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.carts        TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.cart_items   TO authenticated;
+GRANT SELECT                          ON public.cart_events TO authenticated;
+GRANT ALL                             ON public.carts        TO service_role;
+GRANT ALL                             ON public.cart_items   TO service_role;
+GRANT ALL                             ON public.cart_events  TO service_role;
+
+-- ============================================================
 -- updated_at trigger (shared function, two triggers)
 -- ============================================================
 CREATE OR REPLACE FUNCTION public.universal_cart_touch_updated_at()
@@ -307,12 +348,20 @@ CREATE POLICY cart_items_delete_via_cart ON public.cart_items
   USING (EXISTS (SELECT 1 FROM public.carts c
                   WHERE c.id = cart_items.cart_id AND c.user_id = auth.uid()));
 
--- cart_events: read-own only; writes are service_role-only (no INSERT policy for
--- `authenticated` — service_role bypasses RLS, which is the only writer).
-DROP POLICY IF EXISTS cart_events_select_own ON public.cart_events;
-CREATE POLICY cart_events_select_own ON public.cart_events
+-- cart_events: SELECT is gated by parent-cart ownership — we do NOT trust
+-- cart_events.user_id alone (defense-in-depth: if service_role ever wrote the
+-- wrong user_id, the wrong user would be able to read it). The cart_id FK is
+-- the source of truth for ownership, mirroring the cart_items policy pattern.
+-- No INSERT / UPDATE / DELETE policy for `authenticated`; service_role bypasses
+-- RLS and is the only writer.
+-- Idempotent: drop both legacy and current names before recreating, so re-runs
+-- after a partial apply or a name change land cleanly.
+DROP POLICY IF EXISTS cart_events_select_via_cart ON public.cart_events;
+DROP POLICY IF EXISTS cart_events_select_own      ON public.cart_events;
+CREATE POLICY cart_events_select_via_cart ON public.cart_events
   FOR SELECT TO authenticated
-  USING (user_id = auth.uid());
+  USING (EXISTS (SELECT 1 FROM public.carts c
+                  WHERE c.id = cart_events.cart_id AND c.user_id = auth.uid()));
 
 -- ============================================================
 -- Post-condition: required-column guard

--- a/supabase/migrations/20260604000000_VTID_03165_universal_cart_schema.sql
+++ b/supabase/migrations/20260604000000_VTID_03165_universal_cart_schema.sql
@@ -1,0 +1,350 @@
+-- VTID-03165 — Universal Cart Phase 1, Slice A: schema foundation.
+--
+-- Introduces three tables that back the persistent multi-item Universal Cart
+-- sitting on top of the Discover marketplace (VTID-02000):
+--
+--   * public.carts        — one active cart per user (partial-unique index)
+--   * public.cart_items   — items staged from web / mobile / voice / autopilot
+--   * public.cart_events  — append-only audit ledger of cart mutations
+--
+-- Phase 1 scope (per Universal Cart PRD, Section 2):
+--   - Single active cart per user, item types limited to 'supplement' /
+--     'partner_product' (anything from the existing products catalog).
+--   - No checkout, no quote, no validations, no wallet waterfall, no
+--     autopilot auto-create. Those land in Phases 2-4 on top of this schema.
+--   - Per-item exit uses the existing single-item product_orders flow with
+--     a new cart_item_id callback param (handled in VTID-B, the gateway slice).
+--
+-- Decisions locked (PRD Section 14):
+--   Q1 NO  — /discover/orders does not surface cart items.
+--   Q2 YES — source_surface attributes by intent origin; community group threads
+--            land as source_surface='community' regardless of HTTP transport.
+--   Q3 YES — cart_items.metadata.autopilot_rec_id is populated day 1 (Phase 1)
+--            so the decision-contract `commerce_cart` provider's
+--            has_autopilot_link signal works before Phase 4 auto-create.
+--   Q4 EXPLICIT — completion is signalled via an explicit `cart_item_id`
+--            callback parameter, not webhook archaeology.
+--   Q5 COMMUNITY-ONLY — cart endpoints will return 403 cart_unavailable_for_role
+--            for non-community sessions (enforced in gateway VTID-B).
+--
+-- Schema-drift safeguard:
+--   Per the VTID-03152 / VTID-03159 incident (user_journey table) memory rule,
+--   any CREATE TABLE IF NOT EXISTS that could collide with a pre-existing
+--   ad-hoc table must introspect information_schema first and fail loudly if
+--   drift is present. This migration:
+--     (1) Pre-condition guard at the top that RAISEs if any of the three target
+--         tables exist with columns outside the expected set.
+--     (2) Defensive `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` per column,
+--         ensuring required columns end up present even if a partial same-named
+--         table predates this migration.
+--     (3) Post-condition guard at the bottom that RAISEs if any expected
+--         column is missing after DDL.
+
+BEGIN;
+
+-- ============================================================
+-- Pre-condition: schema-drift guard
+-- ============================================================
+DO $vtid_03165_pre_guard$
+DECLARE
+  unexpected TEXT;
+BEGIN
+  SELECT string_agg(table_name || '.' || column_name, ', ' ORDER BY table_name, column_name)
+    INTO unexpected
+    FROM information_schema.columns
+   WHERE table_schema = 'public'
+     AND table_name IN ('carts', 'cart_items', 'cart_events')
+     AND column_name NOT IN (
+       -- carts (shared id/created_at/updated_at + table-specific below)
+       'id', 'user_id', 'tenant_id', 'status', 'source_context', 'metadata',
+       'created_at', 'updated_at',
+       -- cart_items table-specific
+       'cart_id', 'item_type', 'product_id', 'merchant_id', 'quantity',
+       'unit_price_cents_snapshot', 'currency_snapshot',
+       'source_surface', 'source_ref',
+       -- cart_events table-specific
+       'event_type', 'event_payload'
+     );
+
+  IF unexpected IS NOT NULL THEN
+    RAISE EXCEPTION
+      'VTID-03165 pre-condition: unexpected columns in public.carts / cart_items / cart_events: %. Investigate ad-hoc DB state and migrate intentionally (ALTER TABLE) before re-running.',
+      unexpected;
+  END IF;
+END
+$vtid_03165_pre_guard$;
+
+-- ============================================================
+-- carts
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.carts (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES public.app_users(user_id) ON DELETE CASCADE,
+  tenant_id       UUID,
+  status          TEXT NOT NULL DEFAULT 'active',
+  source_context  TEXT,
+  metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Defensive column additions (idempotent under drift)
+ALTER TABLE public.carts ADD COLUMN IF NOT EXISTS user_id        UUID;
+ALTER TABLE public.carts ADD COLUMN IF NOT EXISTS tenant_id      UUID;
+ALTER TABLE public.carts ADD COLUMN IF NOT EXISTS status         TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE public.carts ADD COLUMN IF NOT EXISTS source_context TEXT;
+ALTER TABLE public.carts ADD COLUMN IF NOT EXISTS metadata       JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE public.carts ADD COLUMN IF NOT EXISTS created_at     TIMESTAMPTZ NOT NULL DEFAULT now();
+ALTER TABLE public.carts ADD COLUMN IF NOT EXISTS updated_at     TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE public.carts
+  DROP CONSTRAINT IF EXISTS carts_status_check;
+ALTER TABLE public.carts
+  ADD  CONSTRAINT carts_status_check CHECK (status IN ('active','archived'));
+
+COMMENT ON TABLE public.carts IS
+  'VTID-03165: persistent Universal Cart. One active cart per user (partial-unique index). Phase 1 — staging area only; checkout lives in Phase 3.';
+COMMENT ON COLUMN public.carts.tenant_id IS
+  'Optional. Cart is user-scoped; tenant_id is read from user_tenants at query time but mirrored here when known for fast filtering.';
+COMMENT ON COLUMN public.carts.source_context IS
+  'Free-form hint about where the cart was first opened (e.g. discover_supplements, voice_session_id, autopilot_rec_id).';
+COMMENT ON COLUMN public.carts.metadata IS
+  'JSONB. Future fields (Phase 5+): cohort hints, group_buy linkage, named-stack label. No PII.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS carts_one_active_per_user
+  ON public.carts (user_id) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS carts_user_status_idx
+  ON public.carts (user_id, status);
+CREATE INDEX IF NOT EXISTS carts_tenant_idx
+  ON public.carts (tenant_id) WHERE tenant_id IS NOT NULL;
+
+-- ============================================================
+-- cart_items
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.cart_items (
+  id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cart_id                    UUID NOT NULL REFERENCES public.carts(id) ON DELETE CASCADE,
+  item_type                  TEXT NOT NULL,
+  product_id                 UUID NOT NULL REFERENCES public.products(id),
+  merchant_id                UUID REFERENCES public.merchants(id),
+  quantity                   NUMERIC NOT NULL DEFAULT 1,
+  unit_price_cents_snapshot  INT,
+  currency_snapshot          CHAR(3),
+  source_surface             TEXT,
+  source_ref                 TEXT,
+  status                     TEXT NOT NULL DEFAULT 'active',
+  metadata                   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS cart_id                   UUID;
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS item_type                 TEXT;
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS product_id                UUID;
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS merchant_id               UUID;
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS quantity                  NUMERIC NOT NULL DEFAULT 1;
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS unit_price_cents_snapshot INT;
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS currency_snapshot         CHAR(3);
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS source_surface            TEXT;
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS source_ref                TEXT;
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS status                    TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS metadata                  JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS created_at                TIMESTAMPTZ NOT NULL DEFAULT now();
+ALTER TABLE public.cart_items ADD COLUMN IF NOT EXISTS updated_at                TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE public.cart_items
+  DROP CONSTRAINT IF EXISTS cart_items_item_type_check;
+ALTER TABLE public.cart_items
+  ADD  CONSTRAINT cart_items_item_type_check
+  CHECK (item_type IN ('supplement','partner_product'));
+
+ALTER TABLE public.cart_items
+  DROP CONSTRAINT IF EXISTS cart_items_status_check;
+ALTER TABLE public.cart_items
+  ADD  CONSTRAINT cart_items_status_check
+  CHECK (status IN ('active','removed','completed','expired'));
+
+ALTER TABLE public.cart_items
+  DROP CONSTRAINT IF EXISTS cart_items_quantity_positive;
+ALTER TABLE public.cart_items
+  ADD  CONSTRAINT cart_items_quantity_positive CHECK (quantity > 0);
+
+ALTER TABLE public.cart_items
+  DROP CONSTRAINT IF EXISTS cart_items_source_surface_check;
+ALTER TABLE public.cart_items
+  ADD  CONSTRAINT cart_items_source_surface_check
+  CHECK (source_surface IS NULL OR source_surface IN ('web','mobile','voice','autopilot','community'));
+
+COMMENT ON TABLE public.cart_items IS
+  'VTID-03165: items staged in a Universal Cart. Phase 1 — supplement / partner_product only; subscriptions, lab_tests, appointments, protocol_bundles arrive in later phases.';
+COMMENT ON COLUMN public.cart_items.unit_price_cents_snapshot IS
+  'Price (cents, matching products.price_cents) at add-time. Stored for future price-watch comparison (Phase 2+) and audit hygiene.';
+COMMENT ON COLUMN public.cart_items.currency_snapshot IS
+  'ISO 4217 currency at add-time (matching products.currency CHAR(3)).';
+COMMENT ON COLUMN public.cart_items.source_surface IS
+  'Origin of the add intent, not the HTTP transport. Adds from a community group chat thread land as ''community'' even if transport is web/mobile (PRD Q2).';
+COMMENT ON COLUMN public.cart_items.source_ref IS
+  'Free-form correlation handle (e.g. voice session_id, autopilot rec_id, group thread id).';
+COMMENT ON COLUMN public.cart_items.metadata IS
+  'JSONB. Phase 1 hint: metadata.autopilot_rec_id populated when add traces to an autopilot_recommendations row, even though auto-create is Phase 4 (PRD Q3). Never store PII or pricing strings here.';
+
+CREATE INDEX IF NOT EXISTS cart_items_cart_active_idx
+  ON public.cart_items (cart_id) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS cart_items_product_idx
+  ON public.cart_items (product_id);
+CREATE INDEX IF NOT EXISTS cart_items_status_idx
+  ON public.cart_items (cart_id, status);
+CREATE INDEX IF NOT EXISTS cart_items_autopilot_rec_idx
+  ON public.cart_items ((metadata->>'autopilot_rec_id'))
+  WHERE metadata ? 'autopilot_rec_id';
+
+-- ============================================================
+-- cart_events  (append-only audit ledger)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.cart_events (
+  id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  cart_id       UUID NOT NULL REFERENCES public.carts(id) ON DELETE CASCADE,
+  user_id       UUID NOT NULL,
+  event_type    TEXT NOT NULL,
+  event_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.cart_events ADD COLUMN IF NOT EXISTS cart_id       UUID;
+ALTER TABLE public.cart_events ADD COLUMN IF NOT EXISTS user_id       UUID;
+ALTER TABLE public.cart_events ADD COLUMN IF NOT EXISTS event_type    TEXT;
+ALTER TABLE public.cart_events ADD COLUMN IF NOT EXISTS event_payload JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE public.cart_events ADD COLUMN IF NOT EXISTS created_at    TIMESTAMPTZ NOT NULL DEFAULT now();
+
+COMMENT ON TABLE public.cart_events IS
+  'VTID-03165: append-only ledger of cart mutations. Event types in Phase 1: cart.created, item.added, item.removed, item.quantity_changed, item.completed, cart.archived. PRIVACY RULE: event_payload MUST NOT contain unit_price_cents_snapshot, full product descriptions, or PII — only ids and minimal structural fields. Writes via service_role only.';
+COMMENT ON COLUMN public.cart_events.event_payload IS
+  'Minimal structural payload. Allowed keys: cart_item_id, product_id, quantity_before, quantity_after, source_surface, source_ref, removal_reason. Disallowed: prices, names, descriptions, user-identifying strings.';
+
+CREATE INDEX IF NOT EXISTS cart_events_cart_recent_idx
+  ON public.cart_events (cart_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS cart_events_user_recent_idx
+  ON public.cart_events (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS cart_events_type_idx
+  ON public.cart_events (event_type, created_at DESC);
+
+-- ============================================================
+-- updated_at trigger (shared function, two triggers)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.universal_cart_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS carts_updated_at_trigger ON public.carts;
+CREATE TRIGGER carts_updated_at_trigger
+  BEFORE UPDATE ON public.carts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.universal_cart_touch_updated_at();
+
+DROP TRIGGER IF EXISTS cart_items_updated_at_trigger ON public.cart_items;
+CREATE TRIGGER cart_items_updated_at_trigger
+  BEFORE UPDATE ON public.cart_items
+  FOR EACH ROW
+  EXECUTE FUNCTION public.universal_cart_touch_updated_at();
+
+-- ============================================================
+-- RLS — owner-only read/write; service_role bypasses for gateway writes.
+-- ============================================================
+ALTER TABLE public.carts        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.cart_items   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.cart_events  ENABLE ROW LEVEL SECURITY;
+
+-- carts: owner full access
+DROP POLICY IF EXISTS carts_select_own ON public.carts;
+CREATE POLICY carts_select_own ON public.carts
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS carts_insert_own ON public.carts;
+CREATE POLICY carts_insert_own ON public.carts
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS carts_update_own ON public.carts;
+CREATE POLICY carts_update_own ON public.carts
+  FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS carts_delete_own ON public.carts;
+CREATE POLICY carts_delete_own ON public.carts
+  FOR DELETE TO authenticated
+  USING (user_id = auth.uid());
+
+-- cart_items: gated by parent cart ownership
+DROP POLICY IF EXISTS cart_items_select_via_cart ON public.cart_items;
+CREATE POLICY cart_items_select_via_cart ON public.cart_items
+  FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.carts c
+                  WHERE c.id = cart_items.cart_id AND c.user_id = auth.uid()));
+
+DROP POLICY IF EXISTS cart_items_insert_via_cart ON public.cart_items;
+CREATE POLICY cart_items_insert_via_cart ON public.cart_items
+  FOR INSERT TO authenticated
+  WITH CHECK (EXISTS (SELECT 1 FROM public.carts c
+                       WHERE c.id = cart_items.cart_id AND c.user_id = auth.uid()));
+
+DROP POLICY IF EXISTS cart_items_update_via_cart ON public.cart_items;
+CREATE POLICY cart_items_update_via_cart ON public.cart_items
+  FOR UPDATE TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.carts c
+                  WHERE c.id = cart_items.cart_id AND c.user_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.carts c
+                       WHERE c.id = cart_items.cart_id AND c.user_id = auth.uid()));
+
+DROP POLICY IF EXISTS cart_items_delete_via_cart ON public.cart_items;
+CREATE POLICY cart_items_delete_via_cart ON public.cart_items
+  FOR DELETE TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.carts c
+                  WHERE c.id = cart_items.cart_id AND c.user_id = auth.uid()));
+
+-- cart_events: read-own only; writes are service_role-only (no INSERT policy for
+-- `authenticated` — service_role bypasses RLS, which is the only writer).
+DROP POLICY IF EXISTS cart_events_select_own ON public.cart_events;
+CREATE POLICY cart_events_select_own ON public.cart_events
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+-- ============================================================
+-- Post-condition: required-column guard
+-- ============================================================
+DO $vtid_03165_post_guard$
+DECLARE
+  expected_columns CONSTANT TEXT[] := ARRAY[
+    'carts.id','carts.user_id','carts.tenant_id','carts.status','carts.source_context',
+    'carts.metadata','carts.created_at','carts.updated_at',
+    'cart_items.id','cart_items.cart_id','cart_items.item_type','cart_items.product_id',
+    'cart_items.merchant_id','cart_items.quantity','cart_items.unit_price_cents_snapshot',
+    'cart_items.currency_snapshot','cart_items.source_surface','cart_items.source_ref',
+    'cart_items.status','cart_items.metadata','cart_items.created_at','cart_items.updated_at',
+    'cart_events.id','cart_events.cart_id','cart_events.user_id','cart_events.event_type',
+    'cart_events.event_payload','cart_events.created_at'
+  ];
+  missing TEXT;
+BEGIN
+  SELECT string_agg(spec, ', ' ORDER BY spec)
+    INTO missing
+    FROM unnest(expected_columns) AS spec
+   WHERE NOT EXISTS (
+     SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND (table_name || '.' || column_name) = spec
+   );
+
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION
+      'VTID-03165 post-condition: required columns missing after migration: %', missing;
+  END IF;
+END
+$vtid_03165_post_guard$;
+
+COMMIT;

--- a/supabase/ops/2026-05-28_VTID_03165_universal_cart_rls_verification.sql
+++ b/supabase/ops/2026-05-28_VTID_03165_universal_cart_rls_verification.sql
@@ -8,7 +8,12 @@
 --   §1  Structural checks  — tables, columns, constraints, indexes, triggers, policies all present.
 --   §2  Cascade & constraint behavior — INSERT, partial-unique, CHECK, ON DELETE CASCADE.
 --   §3  RLS — authenticated user A sees own cart, cannot see user B's cart, cannot insert into user B's cart.
---   §4  RLS — authenticated user cannot INSERT into cart_events (service_role only).
+--   §4  RLS — authenticated user cannot INSERT into cart_events; can only SELECT events for carts they own.
+--
+-- Test fixtures: a synthetic merchant + product are inserted at the head of §2
+-- so the script tests every assertion regardless of whether the target DB has
+-- any real products. All fixture rows (merchants, products, app_users, carts,
+-- cart_items, cart_events) are rolled back at the end.
 --
 -- Invocation (psql, with a service-role connection string):
 --   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/ops/2026-05-28_VTID_03165_universal_cart_rls_verification.sql
@@ -68,7 +73,7 @@ BEGIN
       ('cart_items','cart_items_insert_via_cart'),
       ('cart_items','cart_items_update_via_cart'),
       ('cart_items','cart_items_delete_via_cart'),
-      ('cart_events','cart_events_select_own')
+      ('cart_events','cart_events_select_via_cart')
     ) AS expected(tbl, pol),
     LATERAL (SELECT tbl || '.' || pol AS spec) s
     WHERE NOT EXISTS (
@@ -136,7 +141,7 @@ $check_triggers$;
 -- §2  Cascade & constraint behavior  (operating as service_role / superuser)
 -- ============================================================
 
--- Seed two synthetic test users in app_users (rolled back at COMMIT step)
+-- Seed two synthetic test users in app_users (rolled back at end)
 DO $seed_users$
 DECLARE
   user_a CONSTANT UUID := '00000000-0000-4000-a000-000000000a01';
@@ -146,6 +151,29 @@ BEGIN
   INSERT INTO public.app_users (user_id) VALUES (user_b) ON CONFLICT DO NOTHING;
 END
 $seed_users$;
+
+-- Seed a synthetic merchant + product so §2.3 / §2.4 / §3.2 always have a
+-- valid FK target. Without this, an empty-products staging DB would either
+-- silently skip those assertions (false-pass) or fail loudly on the FK to
+-- products(id). Fixture rows persist only inside this transaction (rolled
+-- back at end).
+DO $seed_marketplace_fixture$
+DECLARE
+  fx_merchant_id CONSTANT UUID := '00000000-0000-4000-c000-000000000c01';
+  fx_product_id  CONSTANT UUID := '00000000-0000-4000-c000-000000000c02';
+BEGIN
+  INSERT INTO public.merchants (id, name, source_network)
+    VALUES (fx_merchant_id, '__vtid_03165_test_merchant', 'manual')
+    ON CONFLICT (id) DO NOTHING;
+  INSERT INTO public.products (
+    id, merchant_id, source_network, source_product_id, title, affiliate_url
+  ) VALUES (
+    fx_product_id, fx_merchant_id, 'manual', '__vtid_03165_test_product',
+    'VTID-03165 Test Product', 'https://example.test/vtid-03165'
+  )
+  ON CONFLICT (id) DO NOTHING;
+END
+$seed_marketplace_fixture$;
 
 -- §2.1 partial-unique index: two active carts for same user must fail
 DO $partial_unique$
@@ -189,19 +217,14 @@ $status_check$;
 DO $source_surface_check$
 DECLARE
   cart_id_a UUID;
-  prod_id   UUID;
+  fx_product_id CONSTANT UUID := '00000000-0000-4000-c000-000000000c02';
   caught    BOOLEAN := FALSE;
 BEGIN
   SELECT id INTO cart_id_a FROM public.carts
    WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
-  SELECT id INTO prod_id FROM public.products LIMIT 1;
-  IF prod_id IS NULL THEN
-    RAISE NOTICE '§2.3 skipped: no products in DB to test against';
-    RETURN;
-  END IF;
   BEGIN
     INSERT INTO public.cart_items (cart_id, item_type, product_id, source_surface)
-      VALUES (cart_id_a, 'supplement', prod_id, 'sms');
+      VALUES (cart_id_a, 'supplement', fx_product_id, 'sms');
   EXCEPTION WHEN check_violation THEN
     caught := TRUE;
   END;
@@ -215,18 +238,13 @@ $source_surface_check$;
 DO $cascade_check$
 DECLARE
   cart_id_a UUID;
-  prod_id   UUID;
+  fx_product_id CONSTANT UUID := '00000000-0000-4000-c000-000000000c02';
   remaining INT;
 BEGIN
   SELECT id INTO cart_id_a FROM public.carts
    WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
-  SELECT id INTO prod_id FROM public.products LIMIT 1;
-  IF prod_id IS NULL THEN
-    RAISE NOTICE '§2.4 skipped: no products in DB to test against';
-    RETURN;
-  END IF;
   INSERT INTO public.cart_items (cart_id, item_type, product_id, source_surface)
-    VALUES (cart_id_a, 'supplement', prod_id, 'web');
+    VALUES (cart_id_a, 'supplement', fx_product_id, 'web');
   DELETE FROM public.carts WHERE id = cart_id_a;
   SELECT count(*) INTO remaining FROM public.cart_items WHERE cart_id = cart_id_a;
   IF remaining <> 0 THEN
@@ -284,16 +302,12 @@ $rls_select$;
 DO $rls_cross_insert$
 DECLARE
   cart_b UUID;
-  prod_id UUID;
+  fx_product_id CONSTANT UUID := '00000000-0000-4000-c000-000000000c02';
   caught BOOLEAN := FALSE;
 BEGIN
+  -- Resolve cart_b while still service_role (RLS would hide it from user A)
   SELECT id INTO cart_b FROM public.carts
    WHERE user_id = '00000000-0000-4000-a000-000000000b01' AND status = 'active' LIMIT 1;
-  SELECT id INTO prod_id FROM public.products LIMIT 1;
-  IF prod_id IS NULL THEN
-    RAISE NOTICE '§3.2 skipped: no products in DB';
-    RETURN;
-  END IF;
 
   PERFORM set_config('request.jwt.claims',
     json_build_object('sub','00000000-0000-4000-a000-000000000a01','role','authenticated')::text,
@@ -302,7 +316,7 @@ BEGIN
 
   BEGIN
     INSERT INTO public.cart_items (cart_id, item_type, product_id, source_surface)
-      VALUES (cart_b, 'supplement', prod_id, 'web');
+      VALUES (cart_b, 'supplement', fx_product_id, 'web');
   EXCEPTION WHEN insufficient_privilege OR check_violation THEN
     caught := TRUE;
   END;
@@ -316,7 +330,7 @@ END
 $rls_cross_insert$;
 
 -- ============================================================
--- §4  cart_events  — authenticated cannot INSERT, only SELECT own.
+-- §4  cart_events — authenticated cannot INSERT; SELECT gated by parent cart.
 -- ============================================================
 DO $events_no_insert$
 DECLARE
@@ -345,6 +359,57 @@ BEGIN
   END IF;
 END
 $events_no_insert$;
+
+-- §4.2 cart_events SELECT uses parent-cart ownership, not self user_id.
+-- We seed two events as service_role: one on user A's cart, one on user B's
+-- cart. Switching to authenticated user A, the policy must allow only the
+-- event whose parent cart belongs to user A. We also seed a spoofed row
+-- (user_id = A) on user B's cart to prove the policy ignores cart_events.user_id
+-- and trusts cart_id only.
+DO $events_select_via_parent_cart$
+DECLARE
+  cart_a UUID;
+  cart_b UUID;
+  visible_via_a INT;
+  visible_via_b INT;
+BEGIN
+  SELECT id INTO cart_a FROM public.carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
+  SELECT id INTO cart_b FROM public.carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000b01' AND status = 'active' LIMIT 1;
+
+  -- still service_role: write three rows
+  INSERT INTO public.cart_events (cart_id, user_id, event_type, event_payload)
+    VALUES (cart_a, '00000000-0000-4000-a000-000000000a01', 'cart.created', '{}'::jsonb);
+  INSERT INTO public.cart_events (cart_id, user_id, event_type, event_payload)
+    VALUES (cart_b, '00000000-0000-4000-a000-000000000b01', 'cart.created', '{}'::jsonb);
+  -- Spoof: row on user B's cart with user_id falsely set to user A.
+  -- The OLD policy (USING user_id = auth.uid()) would have leaked this row to A.
+  -- The NEW policy (parent-cart ownership) must NOT.
+  INSERT INTO public.cart_events (cart_id, user_id, event_type, event_payload)
+    VALUES (cart_b, '00000000-0000-4000-a000-000000000a01', 'cart.spoofed', '{}'::jsonb);
+
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub','00000000-0000-4000-a000-000000000a01','role','authenticated')::text,
+    true);
+  SET LOCAL ROLE authenticated;
+
+  SELECT count(*) INTO visible_via_a FROM public.cart_events WHERE cart_id = cart_a;
+  SELECT count(*) INTO visible_via_b FROM public.cart_events WHERE cart_id = cart_b;
+
+  RESET ROLE;
+
+  IF visible_via_a <> 1 THEN
+    RAISE EXCEPTION
+      '§4.2 user A should see exactly 1 cart_event on own cart, saw %', visible_via_a;
+  END IF;
+  IF visible_via_b <> 0 THEN
+    RAISE EXCEPTION
+      '§4.2 RLS LEAK: user A saw % cart_events on user B''s cart (one was spoofed with user_id=A — the new parent-cart policy must reject it)',
+      visible_via_b;
+  END IF;
+END
+$events_select_via_parent_cart$;
 
 -- ============================================================
 -- All checks passed. Roll back synthetic data so the DB is unchanged.

--- a/supabase/ops/2026-05-28_VTID_03165_universal_cart_rls_verification.sql
+++ b/supabase/ops/2026-05-28_VTID_03165_universal_cart_rls_verification.sql
@@ -1,0 +1,354 @@
+-- VTID-03165 — Universal Cart Phase 1, Slice A — RLS + schema verification.
+--
+-- Run AFTER applying 20260604000000_VTID_03165_universal_cart_schema.sql.
+-- Runs entirely inside a transaction that is ROLLED BACK at the end, so it
+-- leaves no rows behind. RAISEs on first failure with a descriptive message.
+--
+-- Coverage:
+--   §1  Structural checks  — tables, columns, constraints, indexes, triggers, policies all present.
+--   §2  Cascade & constraint behavior — INSERT, partial-unique, CHECK, ON DELETE CASCADE.
+--   §3  RLS — authenticated user A sees own cart, cannot see user B's cart, cannot insert into user B's cart.
+--   §4  RLS — authenticated user cannot INSERT into cart_events (service_role only).
+--
+-- Invocation (psql, with a service-role connection string):
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/ops/2026-05-28_VTID_03165_universal_cart_rls_verification.sql
+
+BEGIN;
+
+-- ============================================================
+-- §1  Structural checks
+-- ============================================================
+
+DO $check_tables$
+DECLARE
+  missing TEXT;
+BEGIN
+  SELECT string_agg(t, ', ' ORDER BY t)
+    INTO missing
+    FROM unnest(ARRAY['carts','cart_items','cart_events']) AS t
+   WHERE NOT EXISTS (
+     SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = t
+   );
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION '§1 missing tables: %', missing;
+  END IF;
+END
+$check_tables$;
+
+DO $check_rls_enabled$
+DECLARE
+  unprotected TEXT;
+BEGIN
+  SELECT string_agg(c.relname::text, ', ' ORDER BY c.relname)
+    INTO unprotected
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relname IN ('carts','cart_items','cart_events')
+     AND NOT c.relrowsecurity;
+  IF unprotected IS NOT NULL THEN
+    RAISE EXCEPTION '§1 RLS not enabled on: %', unprotected;
+  END IF;
+END
+$check_rls_enabled$;
+
+DO $check_policies$
+DECLARE
+  missing TEXT;
+BEGIN
+  SELECT string_agg(spec, ', ' ORDER BY spec)
+    INTO missing
+    FROM (VALUES
+      ('carts','carts_select_own'),
+      ('carts','carts_insert_own'),
+      ('carts','carts_update_own'),
+      ('carts','carts_delete_own'),
+      ('cart_items','cart_items_select_via_cart'),
+      ('cart_items','cart_items_insert_via_cart'),
+      ('cart_items','cart_items_update_via_cart'),
+      ('cart_items','cart_items_delete_via_cart'),
+      ('cart_events','cart_events_select_own')
+    ) AS expected(tbl, pol),
+    LATERAL (SELECT tbl || '.' || pol AS spec) s
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_policies
+       WHERE schemaname = 'public'
+         AND tablename = expected.tbl
+         AND policyname = expected.pol
+    );
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION '§1 missing policies: %', missing;
+  END IF;
+END
+$check_policies$;
+
+DO $check_indexes$
+DECLARE
+  missing TEXT;
+BEGIN
+  SELECT string_agg(idx, ', ' ORDER BY idx)
+    INTO missing
+    FROM unnest(ARRAY[
+      'carts_one_active_per_user',
+      'carts_user_status_idx',
+      'cart_items_cart_active_idx',
+      'cart_items_product_idx',
+      'cart_events_cart_recent_idx',
+      'cart_events_user_recent_idx'
+    ]) AS idx
+   WHERE NOT EXISTS (
+     SELECT 1 FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = idx
+   );
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION '§1 missing indexes: %', missing;
+  END IF;
+END
+$check_indexes$;
+
+DO $check_triggers$
+DECLARE
+  missing TEXT;
+BEGIN
+  SELECT string_agg(spec, ', ' ORDER BY spec)
+    INTO missing
+    FROM (VALUES
+      ('carts','carts_updated_at_trigger'),
+      ('cart_items','cart_items_updated_at_trigger')
+    ) AS expected(tbl, trg),
+    LATERAL (SELECT tbl || '.' || trg AS spec) s
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_trigger t
+        JOIN pg_class c ON c.oid = t.tgrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public'
+         AND c.relname = expected.tbl
+         AND t.tgname = expected.trg
+    );
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION '§1 missing triggers: %', missing;
+  END IF;
+END
+$check_triggers$;
+
+-- ============================================================
+-- §2  Cascade & constraint behavior  (operating as service_role / superuser)
+-- ============================================================
+
+-- Seed two synthetic test users in app_users (rolled back at COMMIT step)
+DO $seed_users$
+DECLARE
+  user_a CONSTANT UUID := '00000000-0000-4000-a000-000000000a01';
+  user_b CONSTANT UUID := '00000000-0000-4000-a000-000000000b01';
+BEGIN
+  INSERT INTO public.app_users (user_id) VALUES (user_a) ON CONFLICT DO NOTHING;
+  INSERT INTO public.app_users (user_id) VALUES (user_b) ON CONFLICT DO NOTHING;
+END
+$seed_users$;
+
+-- §2.1 partial-unique index: two active carts for same user must fail
+DO $partial_unique$
+DECLARE
+  cart_a UUID;
+  caught BOOLEAN := FALSE;
+BEGIN
+  INSERT INTO public.carts (user_id, status)
+    VALUES ('00000000-0000-4000-a000-000000000a01', 'active')
+    RETURNING id INTO cart_a;
+  BEGIN
+    INSERT INTO public.carts (user_id, status)
+      VALUES ('00000000-0000-4000-a000-000000000a01', 'active');
+  EXCEPTION WHEN unique_violation THEN
+    caught := TRUE;
+  END;
+  IF NOT caught THEN
+    RAISE EXCEPTION '§2.1 partial-unique index DID NOT block second active cart for same user';
+  END IF;
+END
+$partial_unique$;
+
+-- §2.2 status CHECK constraint rejects unknown value
+DO $status_check$
+DECLARE
+  caught BOOLEAN := FALSE;
+BEGIN
+  BEGIN
+    INSERT INTO public.carts (user_id, status)
+      VALUES ('00000000-0000-4000-a000-000000000b01', 'banana');
+  EXCEPTION WHEN check_violation THEN
+    caught := TRUE;
+  END;
+  IF NOT caught THEN
+    RAISE EXCEPTION '§2.2 carts.status CHECK constraint did NOT reject "banana"';
+  END IF;
+END
+$status_check$;
+
+-- §2.3 cart_items source_surface CHECK rejects unknown value
+DO $source_surface_check$
+DECLARE
+  cart_id_a UUID;
+  prod_id   UUID;
+  caught    BOOLEAN := FALSE;
+BEGIN
+  SELECT id INTO cart_id_a FROM public.carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
+  SELECT id INTO prod_id FROM public.products LIMIT 1;
+  IF prod_id IS NULL THEN
+    RAISE NOTICE '§2.3 skipped: no products in DB to test against';
+    RETURN;
+  END IF;
+  BEGIN
+    INSERT INTO public.cart_items (cart_id, item_type, product_id, source_surface)
+      VALUES (cart_id_a, 'supplement', prod_id, 'sms');
+  EXCEPTION WHEN check_violation THEN
+    caught := TRUE;
+  END;
+  IF NOT caught THEN
+    RAISE EXCEPTION '§2.3 cart_items.source_surface CHECK did NOT reject "sms"';
+  END IF;
+END
+$source_surface_check$;
+
+-- §2.4 ON DELETE CASCADE: deleting cart removes its items
+DO $cascade_check$
+DECLARE
+  cart_id_a UUID;
+  prod_id   UUID;
+  remaining INT;
+BEGIN
+  SELECT id INTO cart_id_a FROM public.carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
+  SELECT id INTO prod_id FROM public.products LIMIT 1;
+  IF prod_id IS NULL THEN
+    RAISE NOTICE '§2.4 skipped: no products in DB to test against';
+    RETURN;
+  END IF;
+  INSERT INTO public.cart_items (cart_id, item_type, product_id, source_surface)
+    VALUES (cart_id_a, 'supplement', prod_id, 'web');
+  DELETE FROM public.carts WHERE id = cart_id_a;
+  SELECT count(*) INTO remaining FROM public.cart_items WHERE cart_id = cart_id_a;
+  IF remaining <> 0 THEN
+    RAISE EXCEPTION '§2.4 ON DELETE CASCADE failed: % cart_items survived parent delete', remaining;
+  END IF;
+END
+$cascade_check$;
+
+-- ============================================================
+-- §3  RLS  — authenticated user A sees only own cart
+-- ============================================================
+-- Restore data for RLS phase (parent was deleted in §2.4)
+DO $rebuild_carts$
+DECLARE
+  cart_a UUID;
+  cart_b UUID;
+BEGIN
+  INSERT INTO public.carts (user_id, status)
+    VALUES ('00000000-0000-4000-a000-000000000a01', 'active') RETURNING id INTO cart_a;
+  INSERT INTO public.carts (user_id, status)
+    VALUES ('00000000-0000-4000-a000-000000000b01', 'active') RETURNING id INTO cart_b;
+END
+$rebuild_carts$;
+
+-- §3.1 user A sees only their own cart
+DO $rls_select$
+DECLARE
+  visible_a INT;
+  visible_b INT;
+BEGIN
+  PERFORM set_config('role', 'authenticated', true);
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub','00000000-0000-4000-a000-000000000a01','role','authenticated')::text,
+    true);
+
+  SET LOCAL ROLE authenticated;
+
+  SELECT count(*) INTO visible_a
+    FROM public.carts WHERE user_id = '00000000-0000-4000-a000-000000000a01';
+  SELECT count(*) INTO visible_b
+    FROM public.carts WHERE user_id = '00000000-0000-4000-a000-000000000b01';
+
+  IF visible_a <> 1 THEN
+    RAISE EXCEPTION '§3.1 user A should see own cart (1), saw %', visible_a;
+  END IF;
+  IF visible_b <> 0 THEN
+    RAISE EXCEPTION '§3.1 RLS LEAK: user A saw % rows of user B''s cart', visible_b;
+  END IF;
+
+  RESET ROLE;
+END
+$rls_select$;
+
+-- §3.2 user A cannot INSERT a cart_item into user B's cart
+DO $rls_cross_insert$
+DECLARE
+  cart_b UUID;
+  prod_id UUID;
+  caught BOOLEAN := FALSE;
+BEGIN
+  SELECT id INTO cart_b FROM public.carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000b01' AND status = 'active' LIMIT 1;
+  SELECT id INTO prod_id FROM public.products LIMIT 1;
+  IF prod_id IS NULL THEN
+    RAISE NOTICE '§3.2 skipped: no products in DB';
+    RETURN;
+  END IF;
+
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub','00000000-0000-4000-a000-000000000a01','role','authenticated')::text,
+    true);
+  SET LOCAL ROLE authenticated;
+
+  BEGIN
+    INSERT INTO public.cart_items (cart_id, item_type, product_id, source_surface)
+      VALUES (cart_b, 'supplement', prod_id, 'web');
+  EXCEPTION WHEN insufficient_privilege OR check_violation THEN
+    caught := TRUE;
+  END;
+
+  RESET ROLE;
+
+  IF NOT caught THEN
+    RAISE EXCEPTION '§3.2 RLS LEAK: user A inserted a cart_item into user B''s cart';
+  END IF;
+END
+$rls_cross_insert$;
+
+-- ============================================================
+-- §4  cart_events  — authenticated cannot INSERT, only SELECT own.
+-- ============================================================
+DO $events_no_insert$
+DECLARE
+  cart_a UUID;
+  caught BOOLEAN := FALSE;
+BEGIN
+  SELECT id INTO cart_a FROM public.carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
+
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub','00000000-0000-4000-a000-000000000a01','role','authenticated')::text,
+    true);
+  SET LOCAL ROLE authenticated;
+
+  BEGIN
+    INSERT INTO public.cart_events (cart_id, user_id, event_type, event_payload)
+      VALUES (cart_a, '00000000-0000-4000-a000-000000000a01', 'cart.created', '{}'::jsonb);
+  EXCEPTION WHEN insufficient_privilege THEN
+    caught := TRUE;
+  END;
+
+  RESET ROLE;
+
+  IF NOT caught THEN
+    RAISE EXCEPTION '§4 RLS LEAK: authenticated user inserted into cart_events (must be service_role only)';
+  END IF;
+END
+$events_no_insert$;
+
+-- ============================================================
+-- All checks passed. Roll back synthetic data so the DB is unchanged.
+-- ============================================================
+ROLLBACK;
+
+DO $ok$ BEGIN RAISE NOTICE 'VTID-03165 RLS + schema verification: ALL CHECKS PASSED'; END $ok$;


### PR DESCRIPTION
## Summary

Slice **A** of the Universal Cart PRD — schema-only foundation that subsequent slices (gateway routes, drawer UI, ORB `post_intent` extension, decision-contract provider) build on.

Introduces three tables on top of the existing Discover marketplace (VTID-02000):

- `public.carts` — one active cart per user (enforced via partial-unique index)
- `public.cart_items` — items staged from web / mobile / voice / autopilot / community
- `public.cart_events` — append-only audit ledger of cart mutations (service_role writes only)

## Scope (Phase 1, Slice A)

**In:** tables, RLS, indexes, `updated_at` triggers, schema-drift guards, RLS verification ops script.

**Explicitly out** (later slices / phases):
- No gateway routes — VTID-B
- No drawer / frontend — VTID-C
- No ORB `post_intent` extension — VTID-D
- No `commerce_cart` decision-contract provider — VTID-E
- No checkout / Stripe / wallet waterfall — Phase 3
- No Health Rules Engine — Phase 2
- No autopilot auto-create — Phase 4
- No cohort / group-buy signals — Phase 5

## PRD Q1-Q5 decisions encoded in the schema

| # | Decision | How it's reflected here |
|---|---|---|
| Q1 | `/discover/orders` does NOT surface cart items | No new columns or indexes added for that surface; drawer remains the sole cart UI |
| Q2 | `source_surface` attributes by intent origin, not transport | `cart_items.source_surface` CHECK includes `'community'`; documented on COMMENT |
| Q3 | Autopilot linkage in Phase 1 | `cart_items.metadata.autopilot_rec_id` supported day 1 via partial JSONB index `cart_items_autopilot_rec_idx` |
| Q4 | Explicit `cart_item_id` callback for completion | `status='completed'` state in `cart_items_status_check`; gateway slice (VTID-B) accepts the callback param |
| Q5 | Community-role-only feature | Gateway slice (VTID-B) returns 403 `cart_unavailable_for_role`; schema neutral |

## Schema-drift safeguard

Per the VTID-03152 / VTID-03159 `user_journey` precedent (CREATE TABLE IF NOT EXISTS silently no-op'd against an ad-hoc table), this migration:

1. **Pre-condition guard** — `DO` block at the top RAISEs if `carts` / `cart_items` / `cart_events` already exist with columns outside the expected set.
2. **Defensive ALTER TABLE ADD COLUMN IF NOT EXISTS** per column — ensures required columns end up present even under partial pre-existence.
3. **Post-condition guard** — `DO` block at the bottom RAISEs if any expected column is missing after DDL.

In-repo grep on `origin/main` for `\b(carts|cart_items|cart_events)\b` returned no matches, so in-repo drift is not expected. The guards protect against out-of-band DB state.

## Privacy rule baked into the schema

`cart_events.event_payload` is documented (table COMMENT) as carrying ids + minimal structural fields only — no prices, no product names, no PII. Future analytics / OASIS emits read from this table; the constraint is policy-by-COMMENT plus code review on writers.

## RLS posture

- `carts` — owner: SELECT, INSERT, UPDATE, DELETE
- `cart_items` — owner via parent cart: SELECT, INSERT, UPDATE, DELETE
- `cart_events` — owner: SELECT only (no INSERT policy for `authenticated`; service_role bypasses RLS)
- service_role bypasses on all three — the gateway is the only writer

## Test plan

- [ ] CI: schema applies cleanly on a fresh Postgres (CI migration runner).
- [ ] After merge: run `RUN-MIGRATION.yml` against **Staging** (Phase 0 staging Supabase branch).
- [ ] Operator runs `supabase/ops/2026-05-28_VTID_03165_universal_cart_rls_verification.sql` against Staging (service_role connection); expects `RAISE NOTICE 'ALL CHECKS PASSED'` with rollback at end.
- [ ] Confirm tables visible in Supabase studio: `carts`, `cart_items`, `cart_events`.
- [ ] Confirm partial-unique index `carts_one_active_per_user` rejects a 2nd active cart for the same user.
- [ ] Confirm RLS leak attempts in §3 of the ops script all hit `insufficient_privilege` (no rows returned for other users).
- [ ] Only after Staging green: re-run `RUN-MIGRATION.yml` against **production**.

## Follow-up VTIDs (separate PRs)

- **VTID-B** — gateway CRUD routes (`/api/v1/cart/*`) + 403 community-role gate + `cart_item_id` completion callback wiring
- **VTID-C** — vitana-v1 drawer + Add-to-Cart on Discover cards + nav badge
- **VTID-D** — ORB `post_intent(commercial_buy, stage='staged')` extension
- **VTID-E** — `commerce_cart` decision-contract provider + OASIS `marketplace.cart.*` emits + KPI dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)