### PR TITLE
fix(scheduler): make date optional + fix longevity stub tenants column (BOOTSTRAP-VITANA-INDEX-DAILY)

### DIFF
--- a/services/gateway/src/routes/scheduler.ts
+++ b/services/gateway/src/routes/scheduler.ts
@@ -21,7 +21,13 @@ const VTID = 'VTID-01095';
 // Request validation schemas
 const DailyRecomputeRequestSchema = z.object({
   tenant_id: z.string().uuid('tenant_id must be a valid UUID'),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be in YYYY-MM-DD format'),
+  // Optional — Cloud Scheduler's static message-body can't substitute "today",
+  // so the cron POSTs only { tenant_id } and we default to the UTC date here.
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be in YYYY-MM-DD format')
+    .optional()
+    .default(() => new Date().toISOString().slice(0, 10)),
   limit_users: z.number().int().min(1).max(200).optional().default(200),
   cursor: z.string().uuid().nullable().optional(),
 });

--- a/supabase/migrations/20260528130000_BOOTSTRAP_fix_longevity_stub_tenants_column.sql
+++ b/supabase/migrations/20260528130000_BOOTSTRAP_fix_longevity_stub_tenants_column.sql
@@ -1,0 +1,74 @@
+-- =============================================================================
+-- Fix longevity stub: tenants.id → tenants.tenant_id
+-- BOOTSTRAP-VITANA-INDEX-DAILY follow-up
+-- Date: 2026-05-28
+--
+-- The original stub in 20251231000001_vtid_01095_daily_scheduler.sql referenced
+-- `SELECT id FROM public.tenants`, but the column is `tenant_id`. The migration
+-- was never applied in prod, so the bug only surfaced once the orchestrator
+-- finally ran for real — POST /api/v1/scheduler/daily-recompute returned
+-- 5 × "Stage longevity failed: column \"id\" does not exist".
+--
+-- One-character surgical fix: replace `id` with `tenant_id` in the COALESCE
+-- fallback. The Index stage in PIPELINE_STAGES runs before longevity and
+-- writes its vitana_index_scores row successfully on every call — this just
+-- stops the orchestrator from marking the run as failed on the downstream
+-- no-op stub. The stub itself stays a placeholder until VTID-01083 ships
+-- the real longevity compute.
+-- =============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.scheduler_longevity_compute_daily(
+    p_user_id UUID,
+    p_date DATE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_tenant_id UUID;
+    v_start_time TIMESTAMPTZ;
+    v_duration_ms INTEGER;
+BEGIN
+    v_start_time := clock_timestamp();
+
+    -- Resolve tenant: prefer the just-inserted daily_recompute_runs row;
+    -- fall back to the first tenant if (somehow) no run row exists yet.
+    SELECT COALESCE(
+        (SELECT tenant_id FROM public.daily_recompute_runs
+         WHERE user_id = p_user_id AND run_date = p_date LIMIT 1),
+        (SELECT tenant_id FROM public.tenants LIMIT 1)
+    ) INTO v_tenant_id;
+
+    -- STUB: actual longevity computation lives behind VTID-01083.
+    v_duration_ms := EXTRACT(MILLISECOND FROM (clock_timestamp() - v_start_time))::INTEGER;
+
+    RETURN jsonb_build_object(
+        'ok', true,
+        'stage', 'longevity',
+        'user_id', p_user_id,
+        'date', p_date,
+        'duration_ms', v_duration_ms,
+        'signals_computed', 0,
+        'message', 'Longevity compute stub - awaiting VTID-01083 implementation'
+    );
+EXCEPTION WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+        'ok', false,
+        'stage', 'longevity',
+        'user_id', p_user_id,
+        'date', p_date,
+        'error', SQLERRM
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.scheduler_longevity_compute_daily(UUID, DATE) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.scheduler_longevity_compute_daily(UUID, DATE) TO service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Problem

After #2345 landed (Vitana Index stage in the daily-recompute pipeline + Cloud Scheduler job), the first manual `POST /api/v1/scheduler/daily-recompute` against the deployed gateway surfaced **two latent bugs** in the pre-existing pipeline:

### Bug 1 — Required `date` in the orchestrator request schema

The schema in `services/gateway/src/routes/scheduler.ts:24` requires `date` as a non-optional `YYYY-MM-DD` string. The Cloud Scheduler job's `--message-body` is a static `{"tenant_id":"…"}` (gcloud has no template substitution for "today"), so the recurring 02:00 UTC cron would have hit `VALIDATION_FAILED` every night.

```json
{"ok":false,"error":"VALIDATION_FAILED","details":[{"code":"invalid_type","expected":"string","received":"undefined","path":["date"],"message":"Required"}]}
```

### Bug 2 — `scheduler_longevity_compute_daily` references `tenants.id` (column is `tenant_id`)

The longevity stub committed in `20251231000001_vtid_01095_daily_scheduler.sql` 5 months ago used `SELECT id FROM public.tenants` for the tenant fallback. The actual column is `tenant_id`. The migration was never applied to prod, so the bug was latent — and the moment the orchestrator finally ran for real, every user errored:

```json
{"errors":[
  {"user_id":"0012fa12-…","error":"Stage longevity failed: column \"id\" does not exist"},
  {"user_id":"03ed673b-…","error":"Stage longevity failed: column \"id\" does not exist"},
  …5 of 5…
]}
```

The Index stage runs first in `PIPELINE_STAGES` and already wrote `vitana_index_scores` rows for every user before longevity crashed, so the functional goal was met — but the orchestrator marked every run as `failed`, which is misleading.

## Fix

Two scoped changes, both BOOTSTRAP-VITANA-INDEX-DAILY follow-ups:

1. **Route schema**: make `date` optional with a UTC-today default. The handler already passes the validated value through to `processDailyRecomputeBatch` unchanged, so callers that still send an explicit date are unaffected.
   ```ts
   date: z.string().regex(...).optional().default(() => new Date().toISOString().slice(0, 10))
   ```

2. **Longevity stub** (new migration `20260528130000_…`): one-character surgical fix via `CREATE OR REPLACE FUNCTION` — `SELECT id FROM tenants` → `SELECT tenant_id FROM tenants`. The stub stays a no-op placeholder until VTID-01083 ships the real longevity compute; this just stops it from crashing the orchestrator on a downstream stage.

The three other sibling stubs (`scheduler_topics_…`, `scheduler_community_…`, `scheduler_match_…`) were inspected and have no DB reads — they're pure `EXTRACT(MILLISECOND…)` no-ops that return placeholder success. They're not affected by this PR.

## Test plan

- [x] `tsc --noEmit` clean on the changed route file (pre-existing repo-wide TS2742 errors remain on every router file, unrelated).
- [ ] After deploy: `POST /api/v1/scheduler/daily-recompute` with body `{"tenant_id":"<uuid>"}` (no date) → `{"ok":true,"processed":…}`.
- [ ] After migration applied: `POST /api/v1/scheduler/daily-recompute` with a real tenant succeeds for every user and `daily_recompute_runs.status = 'completed'`, `stage_status->'index'->>'status' = 'success'`, `stage_status->'longevity'->>'status' = 'success'`.
- [ ] Cloud Scheduler job `gateway-daily-recompute` fires successfully at 02:00 UTC with no manual intervention.

## Operator steps after merge

1. Apply migration `supabase/migrations/20260528130000_BOOTSTRAP_fix_longevity_stub_tenants_column.sql` to the prod Supabase project (the file is idempotent — `CREATE OR REPLACE FUNCTION`).
2. Wait for EXEC-DEPLOY to ship the route schema change (auto-dispatched on `BOOTSTRAP-VITANA-INDEX-DAILY` prefix).
3. Verify with the curl + SQL from the test plan.