### PR TITLE
feat(teacher): VTID-03168 enforce 4-5 sentence intro depth

### DIFF
--- a/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
+++ b/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
@@ -96,29 +96,38 @@ ${remainingList}
        ? `
 
      ===== INTRO SCRIPT — SPEAK VERBATIM =====
-     This is the locked 3-4 sentence intro hand-written for
+     This is the locked 4-to-5 sentence intro hand-written for
      "${args.content.active_display_name}". Speak it WORD FOR WORD —
-     do NOT shorten it, do NOT paraphrase it, do NOT collapse it into
-     a 2-sentence summary. Two sentences is NOT enough for a first-time
-     learner. The script:
+     do NOT shorten it, do NOT paraphrase it, do NOT compress it
+     into a summary, do NOT drop sentences "to save time". Two,
+     three, or even four condensed sentences is NOT enough for a
+     first-time learner. Read EVERY sentence in the script, in the
+     order it appears. The script:
 
      "${args.content.active_teacher_intro_script.replace(/"/g, '\\"')}"
 
-     Read every sentence. Pause briefly at the end of the script for
-     the user to react. Treat the script as the FIRST DELIVERY of this
-     capability — the user is hearing about it for the first time.
+     Count the sentences in the script before you speak — make sure
+     you deliver every single one. Pause briefly at the end of the
+     script for the user to react. Treat the script as the FIRST
+     DELIVERY of this capability — the user is hearing about it for
+     the first time and needs the full picture.
      ===== END INTRO SCRIPT =====
 `
        : `
 
      The active capability has no locked intro script seeded in the
-     catalog. Use your judgment to compose a THREE-to-FOUR sentence
-     intro from the MANUAL CONTENT above. The user is a first-time
-     learner — they don't know the system yet. Three sentences for a
-     simple concept (e.g. "Your Vitana ID"), four for a nuanced one.
-     Make sure the user walks away with a clear mental picture of
-     WHAT the capability is, WHY it exists, and HOW it shows up in
-     Vitanaland. Two sentences is NOT enough; explain it properly.
+     catalog. Compose a FOUR-to-FIVE sentence intro from the MANUAL
+     CONTENT above — FIVE sentences is the target, four is the
+     absolute minimum. The user is a first-time learner; they don't
+     know the system yet and need a real understanding, not a
+     headline. Cover at least: (1) WHAT the capability is in one
+     plain-language line, (2) WHY it exists / what problem it solves
+     for the user, (3) HOW it concretely shows up in Vitanaland
+     (which screen, which moment), (4) one concrete example or
+     reassurance (privacy, control, format flexibility), and (5) the
+     question that invites the user in. Two or three sentences is
+     NEVER enough — that is a headline, not an explanation. Speak
+     warmly and with depth, like a knowledgeable friend over coffee.
 `}
 
      After the intro, end with a question that NAMES the next thing
@@ -267,12 +276,17 @@ Examples of REQUIRED phrasings:
   - "Möchtest du, dass ich dir als Nächstes ${args.content.remaining_capabilities[0]?.display_name ?? '<the named capability>'} vorstelle?"
   - "Shall I introduce you to ${args.content.remaining_capabilities[0]?.display_name ?? '<the named capability>'} now?"
 
-NEVER deliver an intro shorter than 3 full sentences. Two sentences
-is not enough for a first-time learner. If you genuinely cannot find
-3 sentences of substance in the manual content for the active
-capability, expand by explaining HOW the user will encounter the
-capability in Vitanaland (e.g. "you'll see this on the home screen
-when you check in each morning").
+NEVER deliver an intro shorter than 4 full sentences — TARGET FIVE.
+Two or three sentences is not enough for a first-time learner; that
+is a headline, not an explanation. The user must walk away with a
+real mental picture of the capability, not a teaser. If a seeded
+script has 4 sentences, speak ALL 4 verbatim. If a seeded script
+has 5 sentences, speak ALL 5 verbatim. If you are composing without
+a script, target 5 sentences and never go below 4 — expand depth by
+explaining HOW the user will concretely encounter the capability in
+Vitanaland (e.g. "you'll see this on the home screen when you check
+in each morning"), adding a brief privacy or control reassurance, or
+giving a concrete one-line example of using it.
 
 === END TEACHER MODE ===
 


### PR DESCRIPTION
## Summary

The Teacher kept collapsing intros into two sentences despite the existing "min 3" floor in the prompt. User said: *"explaining a feature should be done longer — two sentences is not enough, three sentences is not enough, sometimes four could be, but five would be best."*

This PR raises the floor and the target:

- **Prompt (`teacher-mode-prompt.ts`)**: min 4, target 5. Renames "3-to-4 sentence" → "4-to-5 sentence". Tells the model to count sentences before speaking. Enumerates the 5 coverage dimensions for the no-script path (WHAT / WHY / HOW / example / question).
- **DB scripts** (applied directly via Supabase Management API, no migration): expanded `teacher_intro_de` + `teacher_intro_en` on the 5 active curriculum capabilities — `life_compass`, `vitana_index`, `autopilot`, `diary_entry`, `activity_match` — from 4 sentences (~500 chars) to 5 sentences (~650-780 chars). Voice preserved; added one concrete dimension per script (WHERE the user encounters it / WHEN it refreshes / format flexibility / concrete example / safety reassurance).

## Test plan

- [x] `npm run build` green
- [x] `npx jest test/orb/teacher` — 11/11 green
- [ ] Runtime: user opens orb fresh after deploy; Teacher delivers 5-sentence intro after user says "ja"

🤖 Generated with [Claude Code](https://claude.com/claude-code)