### PR TITLE
feat(decision-contract): seed D39 compatibility matrices (VTID-03169)

### DIFF
--- a/services/gateway/test/services/decision-contract/d39-pr5b-seed-migration.test.ts
+++ b/services/gateway/test/services/decision-contract/d39-pr5b-seed-migration.test.ts
@@ -1,0 +1,333 @@
+// VTID-03169 — D39 PR 5b seed migration shape guard.
+//
+// Asserts the seed migration that populates `decision_compatibility_score`
+// with the 138-cell D39 matrix snapshot from the rev e962dbe7 of
+// services/gateway/src/services/d39-taste-alignment-service.ts:
+//
+//   - All 9 dimensions are present with the exact cell counts from the
+//     PR 5b brief (simplicity 9, premium 12, aesthetic 36, tone 36,
+//     routine 6, social 12, convenience 9, experience 9, novelty 9).
+//   - aesthetic + tone are full-grid 6×6 (no implicit resolver default).
+//   - Every (dimension, profile_value, candidate_value) tuple is unique
+//     within the migration.
+//   - Every score is in [0, 1].
+//   - Every row uses `tenant_id = NULL`, `version = 1`, `source = 'seed'`.
+//   - Idempotency is via ON CONFLICT DO NOTHING (relies on the
+//     NULLS NOT DISTINCT constraint from PR 5a).
+//   - PR 5b also seeds three `decision_policy` JSONB rows
+//     (`taste_alignment.scoring_weights`, `.thresholds`, `.tag_emission`).
+//   - Scope discipline: no D39 service code or resolver imports.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '../../../../../supabase/migrations/' +
+    '20260605000000_VTID_03169_seed_compatibility_matrices.sql',
+);
+
+interface ParsedRow {
+  dimension: string;
+  profile_value: string;
+  candidate_value: string;
+  score: number;
+  tenant_id: string; // 'NULL' literal expected
+  version: number;
+  source: string;
+}
+
+/**
+ * Parse every `('dim', 'profile', 'cand', <score>, '<rationale>',
+ * NULL, <version>, '<source>')` VALUES row from the migration SQL.
+ * Returns one entry per row across all 9 dimension INSERTs.
+ */
+function parseSeedRows(sql: string): ParsedRow[] {
+  // Rows look like:
+  //   ('simplicity', 'minimalist', 'simple', 1.00, 'perfect match', NULL, 1, 'seed'),
+  // We match anything in single quotes for the string fields and the
+  // numeric score / version. The rationale may contain a comma, so we
+  // capture it with `[^']*`. Trailing comma OR closing paren both OK.
+  const re =
+    /\(\s*'([a-z_]+)'\s*,\s*'([a-z_]+)'\s*,\s*'([a-z_]+)'\s*,\s*([0-9]+\.[0-9]+)\s*,\s*'([^']*)'\s*,\s*NULL\s*,\s*([0-9]+)\s*,\s*'([a-z_]+)'\s*\)/g;
+  const out: ParsedRow[] = [];
+  let m;
+  while ((m = re.exec(sql)) !== null) {
+    out.push({
+      dimension: m[1],
+      profile_value: m[2],
+      candidate_value: m[3],
+      score: Number.parseFloat(m[4]),
+      tenant_id: 'NULL',
+      version: Number.parseInt(m[6], 10),
+      source: m[7],
+    });
+  }
+  return out;
+}
+
+describe('VTID-03169 D39 PR 5b — compatibility seed migration', () => {
+  let sql: string;
+  let rows: ParsedRow[];
+  beforeAll(() => {
+    sql = readFileSync(MIGRATION_PATH, 'utf8');
+    rows = parseSeedRows(sql);
+  });
+
+  describe('idempotency posture', () => {
+    it('uses ON CONFLICT DO NOTHING (PR 5a NULLS NOT DISTINCT constraint)', () => {
+      const occurrences = sql.match(/ON\s+CONFLICT\s+DO\s+NOTHING/gi) ?? [];
+      // 9 compatibility-score INSERTs (one per dimension), each gated
+      // with ON CONFLICT DO NOTHING. The three decision_policy seeds
+      // use WHERE NOT EXISTS instead, so they don't add to the count.
+      expect(occurrences.length).toBeGreaterThanOrEqual(9);
+    });
+
+    it('decision_policy seeds use WHERE NOT EXISTS (matches decision_policy unique constraint shape)', () => {
+      // The decision_policy unique constraint pre-dates NULLS NOT DISTINCT;
+      // VTID-03113/03140/03142 used WHERE NOT EXISTS as the idempotency
+      // idiom — keep it for the three taste_alignment rows.
+      const matches = sql.match(/WHERE NOT EXISTS\s*\(\s*SELECT 1 FROM decision_policy/g) ?? [];
+      expect(matches.length).toBe(3);
+    });
+
+    it('migration is re-runnable: no DELETE / TRUNCATE statements', () => {
+      expect(sql).not.toMatch(/\bDELETE\s+FROM\s+decision_compatibility_score/i);
+      expect(sql).not.toMatch(/\bTRUNCATE\s+decision_compatibility_score/i);
+    });
+  });
+
+  describe('cell counts per dimension', () => {
+    const EXPECTED: Record<string, number> = {
+      simplicity:  9,
+      premium:    12,
+      aesthetic:  36,
+      tone:       36,
+      routine:     6,
+      social:     12,
+      convenience: 9,
+      experience:  9,
+      novelty:     9,
+    };
+
+    for (const [dim, expected] of Object.entries(EXPECTED)) {
+      it(`${dim} has exactly ${expected} cells`, () => {
+        const dimRows = rows.filter(r => r.dimension === dim);
+        expect(dimRows.length).toBe(expected);
+      });
+    }
+
+    it('total cell count is exactly 138 across all dimensions', () => {
+      expect(rows.length).toBe(138);
+    });
+  });
+
+  describe('aesthetic and tone are full 6×6 grids', () => {
+    const SIX_VALUES_AESTHETIC = [
+      'modern', 'classic', 'eclectic', 'natural', 'functional', 'neutral',
+    ];
+    const SIX_VALUES_TONE = [
+      'technical', 'expressive', 'casual', 'professional', 'minimalist', 'neutral',
+    ];
+
+    function fullGridCheck(dim: string, values: string[]) {
+      const dimRows = rows.filter(r => r.dimension === dim);
+      const seen = new Set<string>();
+      for (const r of dimRows) {
+        seen.add(`${r.profile_value}|${r.candidate_value}`);
+      }
+      const expected = new Set<string>();
+      for (const p of values) for (const c of values) expected.add(`${p}|${c}`);
+      // Every expected pair is present (full grid)
+      for (const pair of expected) {
+        expect(seen.has(pair)).toBe(true);
+      }
+      // No extras
+      expect(seen.size).toBe(values.length * values.length);
+    }
+
+    it('aesthetic: every (profile, candidate) pair from the 6 values is present (36/36)', () => {
+      fullGridCheck('aesthetic', SIX_VALUES_AESTHETIC);
+    });
+
+    it('tone: every (profile, candidate) pair from the 6 values is present (36/36)', () => {
+      fullGridCheck('tone', SIX_VALUES_TONE);
+    });
+
+    it('aesthetic diagonal cells (excluding neutral) carry score 1.0', () => {
+      const nonNeutralDiag = SIX_VALUES_AESTHETIC.filter(v => v !== 'neutral');
+      for (const v of nonNeutralDiag) {
+        const cell = rows.find(
+          r => r.dimension === 'aesthetic' && r.profile_value === v && r.candidate_value === v,
+        );
+        expect(cell?.score).toBe(1.0);
+      }
+    });
+
+    it('aesthetic neutral row/col cells carry score 0.5', () => {
+      const neutralCells = rows.filter(
+        r => r.dimension === 'aesthetic' &&
+          (r.profile_value === 'neutral' || r.candidate_value === 'neutral'),
+      );
+      // 6 neutral-profile + 5 neutral-candidate (excl. neutral×neutral dup) = 11
+      expect(neutralCells.length).toBe(11);
+      for (const c of neutralCells) expect(c.score).toBe(0.5);
+    });
+
+    it('tone neutral row/col cells carry score 0.5', () => {
+      const neutralCells = rows.filter(
+        r => r.dimension === 'tone' &&
+          (r.profile_value === 'neutral' || r.candidate_value === 'neutral'),
+      );
+      expect(neutralCells.length).toBe(11);
+      for (const c of neutralCells) expect(c.score).toBe(0.5);
+    });
+  });
+
+  describe('row invariants', () => {
+    it('every score is in [0, 1]', () => {
+      for (const r of rows) {
+        expect(r.score).toBeGreaterThanOrEqual(0);
+        expect(r.score).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('every row uses tenant_id = NULL', () => {
+      for (const r of rows) expect(r.tenant_id).toBe('NULL');
+    });
+
+    it('every row uses version = 1', () => {
+      for (const r of rows) expect(r.version).toBe(1);
+    });
+
+    it("every row uses source = 'seed'", () => {
+      for (const r of rows) expect(r.source).toBe('seed');
+    });
+
+    it('no duplicate (dimension, profile_value, candidate_value) tuples within the migration', () => {
+      const seen = new Set<string>();
+      for (const r of rows) {
+        const key = `${r.dimension}|${r.profile_value}|${r.candidate_value}`;
+        expect(seen.has(key)).toBe(false);
+        seen.add(key);
+      }
+    });
+  });
+
+  describe('exact value byte-identity against the d39 service literals', () => {
+    // A few spot-checks to lock the migration to the source literals.
+    // Catches the case where someone edits the migration and drifts
+    // from d39-taste-alignment-service.ts.
+    const SPOT_CHECKS: Array<[string, string, string, number]> = [
+      // simplicity scoreMap
+      ['simplicity', 'minimalist', 'simple', 1.0],
+      ['simplicity', 'minimalist', 'complex', 0.2],
+      ['simplicity', 'comprehensive', 'complex', 1.0],
+      // premium scoreMap
+      ['premium', 'value_focused', 'budget', 1.0],
+      ['premium', 'value_focused', 'luxury', 0.2],
+      ['premium', 'premium_oriented', 'luxury', 0.9],
+      // aesthetic specific cells
+      ['aesthetic', 'modern', 'eclectic', 0.7],       // compat
+      ['aesthetic', 'modern', 'classic', 0.3],        // mismatch
+      ['aesthetic', 'functional', 'natural', 0.7],    // compat
+      // tone specific cells
+      ['tone', 'technical', 'minimalist', 0.7],       // compat
+      ['tone', 'casual', 'professional', 0.3],        // mismatch
+      // routine scoreMap
+      ['routine', 'hybrid', 'fixed', 0.7],
+      // social scoreMap
+      ['social', 'solo_focused', 'large_group', 0.2],
+      ['social', 'social_oriented', 'large_group', 1.0],
+      // convenience scoreMap
+      ['convenience', 'intentional_living', 'low', 0.8],
+      // experience scoreMap
+      ['experience', 'blended', 'hybrid', 1.0],
+      // novelty scoreMap
+      ['novelty', 'conservative', 'novel', 0.2],
+      ['novelty', 'explorer', 'novel', 1.0],
+    ];
+
+    for (const [dim, profile, candidate, expected] of SPOT_CHECKS) {
+      it(`${dim}/${profile}×${candidate} = ${expected}`, () => {
+        const cell = rows.find(
+          r => r.dimension === dim &&
+            r.profile_value === profile &&
+            r.candidate_value === candidate,
+        );
+        expect(cell).toBeDefined();
+        expect(cell!.score).toBeCloseTo(expected, 2);
+      });
+    }
+  });
+
+  describe('decision_policy companion seeds', () => {
+    it('seeds taste_alignment.scoring_weights with 9 dimension weights', () => {
+      expect(sql).toMatch(/'taste_alignment\.scoring_weights'/);
+      // Spot-check the 9 weight keys are present in the JSONB literal
+      for (const dim of [
+        'simplicity', 'premium', 'aesthetic', 'tone',
+        'routine', 'social', 'convenience', 'experience', 'novelty',
+      ]) {
+        // After 'taste_alignment.scoring_weights' policy_key but before
+        // the next INSERT. Loose scan: the substring must appear somewhere.
+        expect(sql).toMatch(new RegExp(`"${dim}"\\s*:`));
+      }
+    });
+
+    it('seeds taste_alignment.thresholds with the 6 named thresholds', () => {
+      expect(sql).toMatch(/'taste_alignment\.thresholds'/);
+      for (const k of [
+        'exclude', 'reframe', 'good_fit', 'confidence_min_scoring',
+        'sparse_data', 'exploration_boost',
+      ]) {
+        expect(sql).toMatch(new RegExp(`"${k}"\\s*:`));
+      }
+    });
+
+    it('seeds taste_alignment.tag_emission with 10 tag rules', () => {
+      expect(sql).toMatch(/'taste_alignment\.tag_emission'/);
+      // 10 tags from generateAlignmentTags
+      const tags = [
+        'minimalist_fit', 'premium_fit', 'classic_style', 'modern_fit',
+        'convenience_first', 'exploratory_ok', 'solo_appropriate',
+        'social_appropriate', 'routine_compatible', 'flexible_fit',
+      ];
+      for (const tag of tags) {
+        expect(sql).toMatch(new RegExp(`"${tag}"`));
+      }
+    });
+  });
+
+  describe('scope discipline — PR 5b is seed-only', () => {
+    it('contains NO actual code references to the D39 service or resolver', () => {
+      // The migration is allowed to NAME its source file inside the
+      // `notes` audit column (single-quoted SQL string literal) — that
+      // is the provenance trail an analyst wants. What's forbidden is
+      // an actual code reference (e.g. an IMPORT-like construct, a
+      // function call, a code-fence reference) in the SQL or comments.
+      // Strip SQL comments AND single-quoted string literals before
+      // scanning so the audit-trail notes don't false-positive.
+      const sqlOnly = sql
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .split('\n')
+        .map(line => line.replace(/--.*$/, ''))
+        .join('\n')
+        .replace(/'(?:[^']|'')*'/g, "''");
+      expect(sqlOnly).not.toMatch(/d39-taste-alignment-service/);
+      expect(sqlOnly).not.toMatch(/compatibility-resolver/);
+    });
+
+    it('does NOT recreate / alter the decision_compatibility_score table', () => {
+      // PR 5a owns the schema. PR 5b is data-only.
+      expect(sql).not.toMatch(/CREATE\s+TABLE\s+(IF\s+NOT\s+EXISTS\s+)?decision_compatibility_score/i);
+      expect(sql).not.toMatch(/ALTER\s+TABLE\s+decision_compatibility_score/i);
+      expect(sql).not.toMatch(/DROP\s+TABLE\s+decision_compatibility_score/i);
+    });
+
+    it('does NOT touch the decision_compatibility_score RLS policy', () => {
+      expect(sql).not.toMatch(/decision_compatibility_score_tenant_read/);
+      expect(sql).not.toMatch(/decision_compatibility_score\s+ENABLE\s+ROW\s+LEVEL\s+SECURITY/i);
+    });
+  });
+});

--- a/supabase/migrations/20260605000000_VTID_03169_seed_compatibility_matrices.sql
+++ b/supabase/migrations/20260605000000_VTID_03169_seed_compatibility_matrices.sql
@@ -1,0 +1,362 @@
+-- Phase D39 PR 5b (decision-contract refactor) — seed
+-- `decision_compatibility_score` with the current D39 matrices.
+--
+-- VTID-03169. Second slice of the D39 taste-alignment externalization.
+-- Inserts the full set of 138 cells across 9 dimensions, byte-identical
+-- to the literals in
+-- services/gateway/src/services/d39-taste-alignment-service.ts (rev
+-- e962dbe7 at the time of writing). No code consumer reads from this
+-- table yet — the resolver lands in PR 5c, the wiring in PR 5d-g.
+--
+-- Full-grid seeding strategy (matches PR 5a brief):
+--   - simplicity / premium / routine / social / convenience /
+--     experience / novelty: 1:1 with the inline scoreMap literals.
+--   - aesthetic + tone: full 6×6 grids. The current service emits
+--     0.3 for "not in compatibility list" and 0.5 for any row/col
+--     touching 'neutral'. We seed all of those cells explicitly so
+--     the PR 5c resolver does pure lookups and no implicit default
+--     branch remains.
+--
+-- Idempotency:
+--   ON CONFLICT DO NOTHING relies on the
+--   UNIQUE NULLS NOT DISTINCT (dimension, profile_value,
+--   candidate_value, tenant_id, version) constraint from PR 5a.
+--   The migration is safe to re-run; existing global rows are
+--   preserved untouched.
+--
+-- Rationale column:
+--   Each row carries a short note keyed to its score band so an
+--   analyst can scan the seed and audit intent without re-reading
+--   the service file.
+--
+-- Cell counts per dimension (assertion target for the test):
+--   simplicity:    9
+--   premium:      12
+--   aesthetic:    36
+--   tone:         36
+--   routine:       6
+--   social:       12
+--   convenience:   9
+--   experience:    9
+--   novelty:       9
+--   ---------------
+--   total:       138
+
+-- =========================================================================
+-- D39 simplicity matrix — 3×3 = 9 cells
+-- d39-taste-alignment-service.ts scoreSimplicityAlignment
+-- =========================================================================
+INSERT INTO decision_compatibility_score
+  (dimension, profile_value, candidate_value, score, rationale, tenant_id, version, source)
+VALUES
+  ('simplicity', 'minimalist',    'simple',   1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('simplicity', 'minimalist',    'moderate', 0.60, 'partial fit',          NULL, 1, 'seed'),
+  ('simplicity', 'minimalist',    'complex',  0.20, 'strong mismatch',      NULL, 1, 'seed'),
+  ('simplicity', 'balanced',      'simple',   0.70, 'compatible',           NULL, 1, 'seed'),
+  ('simplicity', 'balanced',      'moderate', 1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('simplicity', 'balanced',      'complex',  0.70, 'compatible',           NULL, 1, 'seed'),
+  ('simplicity', 'comprehensive', 'simple',   0.40, 'partial mismatch',     NULL, 1, 'seed'),
+  ('simplicity', 'comprehensive', 'moderate', 0.70, 'compatible',           NULL, 1, 'seed'),
+  ('simplicity', 'comprehensive', 'complex',  1.00, 'perfect match',        NULL, 1, 'seed')
+ON CONFLICT DO NOTHING;
+
+-- =========================================================================
+-- D39 premium matrix — 3×4 = 12 cells
+-- d39-taste-alignment-service.ts scorePremiumAlignment
+-- =========================================================================
+INSERT INTO decision_compatibility_score
+  (dimension, profile_value, candidate_value, score, rationale, tenant_id, version, source)
+VALUES
+  ('premium', 'value_focused',     'budget',  1.00, 'perfect match',     NULL, 1, 'seed'),
+  ('premium', 'value_focused',     'mid',     0.80, 'compatible',        NULL, 1, 'seed'),
+  ('premium', 'value_focused',     'premium', 0.40, 'partial mismatch',  NULL, 1, 'seed'),
+  ('premium', 'value_focused',     'luxury',  0.20, 'strong mismatch',   NULL, 1, 'seed'),
+  ('premium', 'quality_balanced',  'budget',  0.60, 'partial fit',       NULL, 1, 'seed'),
+  ('premium', 'quality_balanced',  'mid',     1.00, 'perfect match',     NULL, 1, 'seed'),
+  ('premium', 'quality_balanced',  'premium', 0.80, 'compatible',        NULL, 1, 'seed'),
+  ('premium', 'quality_balanced',  'luxury',  0.50, 'neutral',           NULL, 1, 'seed'),
+  ('premium', 'premium_oriented',  'budget',  0.20, 'strong mismatch',   NULL, 1, 'seed'),
+  ('premium', 'premium_oriented',  'mid',     0.50, 'neutral',           NULL, 1, 'seed'),
+  ('premium', 'premium_oriented',  'premium', 1.00, 'perfect match',     NULL, 1, 'seed'),
+  ('premium', 'premium_oriented',  'luxury',  0.90, 'compatible',        NULL, 1, 'seed')
+ON CONFLICT DO NOTHING;
+
+-- =========================================================================
+-- D39 aesthetic matrix — full 6×6 = 36 cells
+-- d39-taste-alignment-service.ts scoreAestheticAlignment
+-- Diagonals = 1.0 (perfect match); compatibilityMap = 0.7; anything
+-- with 'neutral' on either side = 0.5; remaining cells = 0.3.
+-- =========================================================================
+INSERT INTO decision_compatibility_score
+  (dimension, profile_value, candidate_value, score, rationale, tenant_id, version, source)
+VALUES
+  -- modern row
+  ('aesthetic', 'modern',     'modern',     1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('aesthetic', 'modern',     'classic',    0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('aesthetic', 'modern',     'eclectic',   0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'modern',     'natural',    0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('aesthetic', 'modern',     'functional', 0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'modern',     'neutral',    0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- classic row
+  ('aesthetic', 'classic',    'modern',     0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('aesthetic', 'classic',    'classic',    1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('aesthetic', 'classic',    'eclectic',   0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('aesthetic', 'classic',    'natural',    0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'classic',    'functional', 0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'classic',    'neutral',    0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- eclectic row
+  ('aesthetic', 'eclectic',   'modern',     0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'eclectic',   'classic',    0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('aesthetic', 'eclectic',   'eclectic',   1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('aesthetic', 'eclectic',   'natural',    0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'eclectic',   'functional', 0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('aesthetic', 'eclectic',   'neutral',    0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- natural row
+  ('aesthetic', 'natural',    'modern',     0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('aesthetic', 'natural',    'classic',    0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'natural',    'eclectic',   0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('aesthetic', 'natural',    'natural',    1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('aesthetic', 'natural',    'functional', 0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'natural',    'neutral',    0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- functional row
+  ('aesthetic', 'functional', 'modern',     0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'functional', 'classic',    0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'functional', 'eclectic',   0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('aesthetic', 'functional', 'natural',    0.70, 'compatible',           NULL, 1, 'seed'),
+  ('aesthetic', 'functional', 'functional', 1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('aesthetic', 'functional', 'neutral',    0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- neutral row (profile=neutral → 0.5 across all candidates)
+  ('aesthetic', 'neutral',    'modern',     0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('aesthetic', 'neutral',    'classic',    0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('aesthetic', 'neutral',    'eclectic',   0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('aesthetic', 'neutral',    'natural',    0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('aesthetic', 'neutral',    'functional', 0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('aesthetic', 'neutral',    'neutral',    0.50, 'neutral both sides',   NULL, 1, 'seed')
+ON CONFLICT DO NOTHING;
+
+-- =========================================================================
+-- D39 tone matrix — full 6×6 = 36 cells
+-- d39-taste-alignment-service.ts scoreToneAlignment
+-- Same semantics as aesthetic: diagonals=1.0; compatibilityMap=0.7;
+-- neutral row/col = 0.5; remaining cells = 0.3.
+-- =========================================================================
+INSERT INTO decision_compatibility_score
+  (dimension, profile_value, candidate_value, score, rationale, tenant_id, version, source)
+VALUES
+  -- technical row
+  ('tone', 'technical',    'technical',    1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('tone', 'technical',    'expressive',   0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'technical',    'casual',       0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'technical',    'professional', 0.70, 'compatible',           NULL, 1, 'seed'),
+  ('tone', 'technical',    'minimalist',   0.70, 'compatible',           NULL, 1, 'seed'),
+  ('tone', 'technical',    'neutral',      0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- expressive row
+  ('tone', 'expressive',   'technical',    0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'expressive',   'expressive',   1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('tone', 'expressive',   'casual',       0.70, 'compatible',           NULL, 1, 'seed'),
+  ('tone', 'expressive',   'professional', 0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'expressive',   'minimalist',   0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'expressive',   'neutral',      0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- casual row
+  ('tone', 'casual',       'technical',    0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'casual',       'expressive',   0.70, 'compatible',           NULL, 1, 'seed'),
+  ('tone', 'casual',       'casual',       1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('tone', 'casual',       'professional', 0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'casual',       'minimalist',   0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'casual',       'neutral',      0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- professional row
+  ('tone', 'professional', 'technical',    0.70, 'compatible',           NULL, 1, 'seed'),
+  ('tone', 'professional', 'expressive',   0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'professional', 'casual',       0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'professional', 'professional', 1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('tone', 'professional', 'minimalist',   0.70, 'compatible',           NULL, 1, 'seed'),
+  ('tone', 'professional', 'neutral',      0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- minimalist row
+  ('tone', 'minimalist',   'technical',    0.70, 'compatible',           NULL, 1, 'seed'),
+  ('tone', 'minimalist',   'expressive',   0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'minimalist',   'casual',       0.30, 'mismatch',             NULL, 1, 'seed'),
+  ('tone', 'minimalist',   'professional', 0.70, 'compatible',           NULL, 1, 'seed'),
+  ('tone', 'minimalist',   'minimalist',   1.00, 'perfect match',        NULL, 1, 'seed'),
+  ('tone', 'minimalist',   'neutral',      0.50, 'neutral candidate',    NULL, 1, 'seed'),
+  -- neutral row (profile=neutral → 0.5 across all candidates)
+  ('tone', 'neutral',      'technical',    0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('tone', 'neutral',      'expressive',   0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('tone', 'neutral',      'casual',       0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('tone', 'neutral',      'professional', 0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('tone', 'neutral',      'minimalist',   0.50, 'neutral profile',      NULL, 1, 'seed'),
+  ('tone', 'neutral',      'neutral',      0.50, 'neutral both sides',   NULL, 1, 'seed')
+ON CONFLICT DO NOTHING;
+
+-- =========================================================================
+-- D39 routine matrix — 3×2 = 6 cells
+-- d39-taste-alignment-service.ts scoreRoutineAlignment
+-- =========================================================================
+INSERT INTO decision_compatibility_score
+  (dimension, profile_value, candidate_value, score, rationale, tenant_id, version, source)
+VALUES
+  ('routine', 'structured', 'fixed',    1.00, 'perfect match',     NULL, 1, 'seed'),
+  ('routine', 'structured', 'flexible', 0.40, 'partial mismatch',  NULL, 1, 'seed'),
+  ('routine', 'flexible',   'fixed',    0.40, 'partial mismatch',  NULL, 1, 'seed'),
+  ('routine', 'flexible',   'flexible', 1.00, 'perfect match',     NULL, 1, 'seed'),
+  ('routine', 'hybrid',     'fixed',    0.70, 'compatible',        NULL, 1, 'seed'),
+  ('routine', 'hybrid',     'flexible', 0.70, 'compatible',        NULL, 1, 'seed')
+ON CONFLICT DO NOTHING;
+
+-- =========================================================================
+-- D39 social matrix — 4×3 = 12 cells
+-- d39-taste-alignment-service.ts scoreSocialAlignment
+-- =========================================================================
+INSERT INTO decision_compatibility_score
+  (dimension, profile_value, candidate_value, score, rationale, tenant_id, version, source)
+VALUES
+  ('social', 'solo_focused',    'solo',        1.00, 'perfect match',  NULL, 1, 'seed'),
+  ('social', 'solo_focused',    'small_group', 0.50, 'neutral',        NULL, 1, 'seed'),
+  ('social', 'solo_focused',    'large_group', 0.20, 'strong mismatch', NULL, 1, 'seed'),
+  ('social', 'small_groups',    'solo',        0.50, 'neutral',        NULL, 1, 'seed'),
+  ('social', 'small_groups',    'small_group', 1.00, 'perfect match',  NULL, 1, 'seed'),
+  ('social', 'small_groups',    'large_group', 0.50, 'neutral',        NULL, 1, 'seed'),
+  ('social', 'social_oriented', 'solo',        0.30, 'mismatch',       NULL, 1, 'seed'),
+  ('social', 'social_oriented', 'small_group', 0.70, 'compatible',     NULL, 1, 'seed'),
+  ('social', 'social_oriented', 'large_group', 1.00, 'perfect match',  NULL, 1, 'seed'),
+  ('social', 'adaptive',        'solo',        0.50, 'neutral profile', NULL, 1, 'seed'),
+  ('social', 'adaptive',        'small_group', 0.50, 'neutral profile', NULL, 1, 'seed'),
+  ('social', 'adaptive',        'large_group', 0.50, 'neutral profile', NULL, 1, 'seed')
+ON CONFLICT DO NOTHING;
+
+-- =========================================================================
+-- D39 convenience matrix — 3×3 = 9 cells
+-- d39-taste-alignment-service.ts scoreConvenienceAlignment
+-- =========================================================================
+INSERT INTO decision_compatibility_score
+  (dimension, profile_value, candidate_value, score, rationale, tenant_id, version, source)
+VALUES
+  ('convenience', 'convenience_first',  'low',    0.20, 'strong mismatch',  NULL, 1, 'seed'),
+  ('convenience', 'convenience_first',  'medium', 0.60, 'partial fit',      NULL, 1, 'seed'),
+  ('convenience', 'convenience_first',  'high',   1.00, 'perfect match',    NULL, 1, 'seed'),
+  ('convenience', 'balanced',           'low',    0.50, 'neutral',          NULL, 1, 'seed'),
+  ('convenience', 'balanced',           'medium', 1.00, 'perfect match',    NULL, 1, 'seed'),
+  ('convenience', 'balanced',           'high',   0.70, 'compatible',       NULL, 1, 'seed'),
+  ('convenience', 'intentional_living', 'low',    0.80, 'compatible',       NULL, 1, 'seed'),
+  ('convenience', 'intentional_living', 'medium', 0.70, 'compatible',       NULL, 1, 'seed'),
+  ('convenience', 'intentional_living', 'high',   0.40, 'partial mismatch', NULL, 1, 'seed')
+ON CONFLICT DO NOTHING;
+
+-- =========================================================================
+-- D39 experience matrix — 3×3 = 9 cells
+-- d39-taste-alignment-service.ts scoreExperienceAlignment
+-- =========================================================================
+INSERT INTO decision_compatibility_score
+  (dimension, profile_value, candidate_value, score, rationale, tenant_id, version, source)
+VALUES
+  ('experience', 'digital_native',   'digital',  1.00, 'perfect match',    NULL, 1, 'seed'),
+  ('experience', 'digital_native',   'hybrid',   0.70, 'compatible',       NULL, 1, 'seed'),
+  ('experience', 'digital_native',   'physical', 0.30, 'mismatch',         NULL, 1, 'seed'),
+  ('experience', 'physical_focused', 'digital',  0.30, 'mismatch',         NULL, 1, 'seed'),
+  ('experience', 'physical_focused', 'hybrid',   0.60, 'partial fit',      NULL, 1, 'seed'),
+  ('experience', 'physical_focused', 'physical', 1.00, 'perfect match',    NULL, 1, 'seed'),
+  ('experience', 'blended',          'digital',  0.60, 'neutral profile',  NULL, 1, 'seed'),
+  ('experience', 'blended',          'hybrid',   1.00, 'perfect match',    NULL, 1, 'seed'),
+  ('experience', 'blended',          'physical', 0.60, 'neutral profile',  NULL, 1, 'seed')
+ON CONFLICT DO NOTHING;
+
+-- =========================================================================
+-- D39 novelty matrix — 3×3 = 9 cells
+-- d39-taste-alignment-service.ts scoreNoveltyAlignment
+-- =========================================================================
+INSERT INTO decision_compatibility_score
+  (dimension, profile_value, candidate_value, score, rationale, tenant_id, version, source)
+VALUES
+  ('novelty', 'conservative', 'familiar', 1.00, 'perfect match',     NULL, 1, 'seed'),
+  ('novelty', 'conservative', 'moderate', 0.60, 'partial fit',       NULL, 1, 'seed'),
+  ('novelty', 'conservative', 'novel',    0.20, 'strong mismatch',   NULL, 1, 'seed'),
+  ('novelty', 'moderate',     'familiar', 0.60, 'partial fit',       NULL, 1, 'seed'),
+  ('novelty', 'moderate',     'moderate', 1.00, 'perfect match',     NULL, 1, 'seed'),
+  ('novelty', 'moderate',     'novel',    0.60, 'partial fit',       NULL, 1, 'seed'),
+  ('novelty', 'explorer',     'familiar', 0.40, 'partial mismatch',  NULL, 1, 'seed'),
+  ('novelty', 'explorer',     'moderate', 0.70, 'compatible',        NULL, 1, 'seed'),
+  ('novelty', 'explorer',     'novel',    1.00, 'perfect match',     NULL, 1, 'seed')
+ON CONFLICT DO NOTHING;
+
+-- =========================================================================
+-- D39 PR 5b also-seeds — three decision_policy JSONB rows the PR 5f
+-- consumer wiring will eventually read. Data only; no code reads them
+-- yet. Uses the canonical `WHERE NOT EXISTS` idempotency idiom that
+-- the decision_policy table has used since VTID-03113 (its UNIQUE
+-- constraint pre-dates NULLS NOT DISTINCT — see decision_conflict_pair
+-- + VTID-03140 / VTID-03142 prior seed migrations for the same shape).
+-- =========================================================================
+
+-- A. scoring weights — 9 dimension weights (taste 4 × 0.25; lifestyle
+-- 0.20/0.25/0.20/0.15/0.20). Mirrors the SCORING_WEIGHTS constant.
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'taste_alignment.scoring_weights', NULL, 1,
+       '{
+         "version": 1,
+         "weights": {
+           "simplicity":  0.25,
+           "premium":     0.25,
+           "aesthetic":   0.25,
+           "tone":        0.25,
+           "routine":     0.20,
+           "social":      0.25,
+           "convenience": 0.20,
+           "experience":  0.15,
+           "novelty":     0.20
+         }
+       }'::jsonb,
+       'seed', 'd39-taste-alignment-service.ts SCORING_WEIGHTS'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'taste_alignment.scoring_weights'
+    AND tenant_id IS NULL AND version = 1
+);
+
+-- B. tuning thresholds — 6 scalars (exclude/reframe/good_fit/
+-- confidence_min_scoring/sparse_data/exploration_boost). Mirrors the
+-- ALIGNMENT_THRESHOLDS constant.
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'taste_alignment.thresholds', NULL, 1,
+       '{
+         "version": 1,
+         "thresholds": {
+           "exclude":                0.3,
+           "reframe":                0.5,
+           "good_fit":               0.7,
+           "confidence_min_scoring": 20,
+           "sparse_data":            30,
+           "exploration_boost":      0.1
+         }
+       }'::jsonb,
+       'seed', 'd39-taste-alignment-service.ts ALIGNMENT_THRESHOLDS'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'taste_alignment.thresholds'
+    AND tenant_id IS NULL AND version = 1
+);
+
+-- C. tag emission rules — 10 (profile_dim, profile_value) → tag
+-- mappings. Mirrors generateAlignmentTags. The PR 5f resolver will
+-- iterate this list to emit AlignmentTag values for good-fit actions.
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'taste_alignment.tag_emission', NULL, 1,
+       '{
+         "version": 1,
+         "rules": [
+           { "dimension": "simplicity_preference", "value": "minimalist",        "tag": "minimalist_fit"     },
+           { "dimension": "premium_orientation",   "value": "premium_oriented",  "tag": "premium_fit"        },
+           { "dimension": "aesthetic_style",       "value": "classic",           "tag": "classic_style"      },
+           { "dimension": "aesthetic_style",       "value": "modern",            "tag": "modern_fit"         },
+           { "dimension": "convenience_bias",      "value": "convenience_first", "tag": "convenience_first"  },
+           { "dimension": "novelty_tolerance",     "value": "explorer",          "tag": "exploratory_ok"     },
+           { "dimension": "social_orientation",    "value": "solo_focused",      "tag": "solo_appropriate"   },
+           { "dimension": "social_orientation",    "value": "social_oriented",   "tag": "social_appropriate" },
+           { "dimension": "routine_style",         "value": "structured",        "tag": "routine_compatible" },
+           { "dimension": "routine_style",         "value": "flexible",          "tag": "flexible_fit"       }
+         ]
+       }'::jsonb,
+       'seed', 'd39-taste-alignment-service.ts generateAlignmentTags'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'taste_alignment.tag_emission'
+    AND tenant_id IS NULL AND version = 1
+);


### PR DESCRIPTION
## Summary

**D39 PR 5b — seed migration only.** Populates the `decision_compatibility_score` table created in PR 5a with the full **138-cell snapshot** of the D39 alignment matrices from rev `e962dbe7` of `services/gateway/src/services/d39-taste-alignment-service.ts`. Also lands the three companion `decision_policy` JSONB rows the PR 5f consumer wiring will eventually read.

**No resolver. No D39 service code touched. Behaviour unchanged at rollout — nothing reads these rows yet.**

## Cell counts (matches the PR 5b brief)

| Dimension | Cells | Shape |
|---|---:|---|
| simplicity | 9 | 3×3 |
| premium | 12 | 3×4 |
| aesthetic | **36** | full 6×6 (incl. 0.30 mismatch + 0.50 neutral cells) |
| tone | **36** | full 6×6 (same shape) |
| routine | 6 | 3×2 |
| social | 12 | 4×3 |
| convenience | 9 | 3×3 |
| experience | 9 | 3×3 |
| novelty | 9 | 3×3 |
| **total** | **138** | |

For aesthetic + tone, the migration seeds all 36 cells explicitly — including the `0.30` mismatch cells and the `0.50` neutral row/column cells. The PR 5c resolver will then do pure lookups and the inline `if`-cascade in `scoreAestheticAlignment` / `scoreToneAlignment` can collapse to a single accessor call in PR 5e.

## Idempotency

- **compatibility-score INSERTs**: `ON CONFLICT DO NOTHING` relies on the `UNIQUE NULLS NOT DISTINCT (dimension, profile_value, candidate_value, tenant_id, version)` constraint introduced in PR 5a. Re-running the migration is a no-op.
- **decision_policy INSERTs**: `WHERE NOT EXISTS` idiom, matching the pre-existing `decision_policy` unique constraint shape (VTID-03113 / 03140 / 03142 used the same pattern).

## decision_policy companion rows

- `taste_alignment.scoring_weights` — 9 dimension weights (taste 4×0.25; lifestyle 0.20/0.25/0.20/0.15/0.20). Mirrors `SCORING_WEIGHTS`.
- `taste_alignment.thresholds` — 6 scalars (`exclude` / `reframe` / `good_fit` / `confidence_min_scoring` / `sparse_data` / `exploration_boost`). Mirrors `ALIGNMENT_THRESHOLDS`.
- `taste_alignment.tag_emission` — 10 (dimension, value) → tag mappings. Mirrors `generateAlignmentTags`.

## Tests

`test/services/decision-contract/d39-pr5b-seed-migration.test.ts` — **47 shape-guard assertions**:
- Parses every VALUES row into a typed list and asserts the 9 per-dimension cell counts + total of 138
- aesthetic + tone **full-grid coverage** (every pair of the 6 values is present) + diagonal=1.0 + neutral row/col = 0.5
- **Row invariants**: score ∈ [0, 1], tenant_id=NULL, version=1, source='seed', no duplicate (dim, profile, candidate) tuples
- **18 exact-value spot-checks** against the d39-taste-alignment-service literals (catches drift if someone edits the migration)
- **Idempotency posture**: 9 `ON CONFLICT DO NOTHING` + 3 `WHERE NOT EXISTS` clauses, no `DELETE` / `TRUNCATE`
- `decision_policy` seeds present + carry the 9/6/10 keys
- **Scope discipline**: no actual code references (test strips both SQL comments AND single-quoted string literals before scanning, so the audit-trail provenance notes inside the `notes` column don't false-positive)
- PR 5b does **NOT** recreate / alter / drop the table and does NOT touch RLS

**237/237** decision-contract suite green.

## Scope discipline

Per the PR 5b brief: **seed migration only**. NO compatibility resolver added. NO `d39-taste-alignment-service.ts` changes. NO consumer wiring. NO D28/D38/D47/D48 touched. NO onboarding templates. NO LiveKit / Vertex / Teacher.

## Test plan

- [x] `npm run build` clean
- [x] `npx jest test/services/decision-contract/d39-pr5b-seed-migration.test.ts` — 47/47 pass
- [x] `npx jest test/services/decision-contract/` — 237/237 pass (regression check)
- [ ] RUN-MIGRATION applies `20260605000000_VTID_03169` idempotently
- [ ] Post-migration: `SELECT count(*) FROM decision_compatibility_score` returns **138** (39 per dimension where applicable, summed)
- [ ] Post-migration: `SELECT count(*) FROM decision_policy WHERE policy_key LIKE 'taste_alignment.%'` returns **3**
- [ ] Re-applying the migration is a no-op (counts unchanged)
- [ ] Auto-deploy + `/alive` 200 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)