### PR TITLE
feat(overview): VTID-03170 companion-tone rewrite of new-day prompt

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
@@ -1,23 +1,28 @@
 /**
- * VTID-03167 — Structural prompt block for the new-day overview.
+ * VTID-03170 — Companion-tone overview prompt block.
  *
- * Replaces the Slice 2 (VTID-03166) server-composed sentence renderer.
- * The block hands Gemini a STRUCTURED PAYLOAD plus an explicit contract
- * for HOW to compose the first spoken turn:
+ * Replaces the VTID-03167 dashboard-style structural block. The model
+ * was correctly reading the payload but composing in a corporate /
+ * stat-readout tone — bare numbers, no warmth, no opinion, generic
+ * "what would you like to do" close. This version hands the model a
+ * STRUCTURED PAYLOAD plus:
  *
- *   - Multi-paragraph overview that addresses EVERY signal with data
- *   - Conversational, in user's language
- *   - Time-of-day salutation per local clock
- *   - Offer concrete next steps tied to what Vitana can DO for the user
- *   - NEVER recite as a list / NEVER teach about Vitanaland's business
+ *   - A tone anchor (single simile that sets the register).
+ *   - A "minded the shop while you were away" frame.
+ *   - A SHAPE example in a DIFFERENT domain (meditation + yoga, never
+ *     the user's actual domain) so the model imitates texture without
+ *     copying content. Side-by-side ❌ Dashboard / ✅ Companion.
+ *   - Nine numbered composition rules covering warmth, frame, number
+ *     interpretation, goal-as-North-Star, connective tissue, zero-state
+ *     framing, named concrete close, paragraph break, opinion +
+ *     reassurance.
  *
- * Zero hardcoded user-facing sentences in TypeScript. The LLM composes.
+ * Zero hardcoded user-facing sentences. The model composes from the
+ * payload using the shape it has been taught to imitate.
  *
- * This block is wrapped in the same `VERTEX_WAKE_BRIEF_OVERRIDE_MARKER`
- * sentinel as the legacy Say-exactly block so the existing strip+suppress
- * logic in `live-system-instruction.ts` treats it as the same kind of
- * authoritative first-turn directive — but the content is "compose
- * structurally" instead of "say exactly".
+ * Wrapped in the same VERTEX_WAKE_BRIEF_OVERRIDE_MARKER as before so
+ * the existing strip+suppress logic in live-session-controller treats
+ * it as the authoritative first-turn directive.
  */
 
 import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../../../orb/live/instruction/wake-brief-marker';
@@ -40,10 +45,43 @@ function timeOfDay(localHour: number): 'morning' | 'afternoon' | 'evening' {
 }
 
 /**
+ * Build the SHAPE example block for the chosen language. The example
+ * persona (Anna, meditation + yoga) has NO overlap with any plausible
+ * Vitana user domain, so the model imitates texture without copying
+ * content. The example shows the model the cadence, breath, connective
+ * stitches, paragraph break, opinion lines, and named concrete close
+ * — but the WORDS, TOPICS, NAMES, and NUMBERS come from the payload.
+ */
+function buildShapeExample(lang: string): string {
+  if (lang.startsWith('de')) {
+    return `### ❌ Dashboard-Ton — SO SOLLST DU NICHT SPRECHEN:
+"Guten Abend, Anna. Dein Vitana-Index liegt bei 84. Dein Ziel ist 30 Minuten Meditation am Tag. Du hast einen Termin um 19 Uhr und drei ungelesene Erinnerungen. Was möchtest du zuerst machen?"
+
+### ✅ Begleiter-Ton — GENAU DIESE TEXTUR SOLLST DU IMITIEREN:
+"Guten Abend, Anna — schön, dass du wieder da bist. Lass mich dir kurz zeigen, wo du gerade stehst: dein Vitana-Index steht heute bei 84, und das fühlt sich nach einem ruhigen, ausgeglichenen Tag an — vor allem deine Meditation trägt dich gerade durch die Woche. An deiner täglichen halben Stunde Stille sind wir mit dem heutigen Tag wieder ein Stück konsequenter dran; wenn du magst, schauen wir gleich, wo wir die nächste Session am besten reinlegen, damit sie nicht in der Abendmüdigkeit untergeht.
+
+Bevor ich's vergesse: in einer guten Stunde steht dein Yoga-Termin an — soll ich dir kurz die Vorbereitung rauslegen? Und drei kleine Erinnerungen warten noch auf dich, ich kann sie dir nach dem Termin der Reihe nach durchgehen, wenn dir das lieber ist als jetzt."`;
+  }
+  // English fallback for en + any other language the model may speak.
+  return `### ❌ Dashboard tone — DO NOT speak like this:
+"Good evening, Anna. Your Vitana Index is 84. Your goal is 30 minutes of meditation a day. You have one event at 7 pm and three unread reminders. What would you like to do first?"
+
+### ✅ Companion tone — IMITATE THIS TEXTURE EXACTLY:
+"Good evening, Anna — glad to have you back. Let me catch you up on where you stand: your Vitana Index is at 84 today, and that reads like a calm, well-balanced day — your meditation pillar is really carrying the week. On your daily half hour of stillness, today moves us one notch more consistent; if you want, we'll find a slot for the next session before the evening fatigue swallows it.
+
+Before I forget: your yoga class kicks off in just over an hour — want me to lay out the prep for you? And three small reminders are waiting too; I can walk you through them right after class if that's easier than now."`;
+}
+
+/**
  * Build the structural prompt block. The block contains:
- *   - Hard contract describing how to compose
- *   - Structured JSON payload Gemini composes from
- *   - Language directive (Gemini must speak in the user's language)
+ *   - Voice anchor + "minded the shop" frame
+ *   - Language directive
+ *   - Lang-specific SHAPE example (DIFFERENT domain — imitate texture only)
+ *   - Nine composition moves (rules)
+ *   - Payload coverage order (woven, not listed)
+ *   - Hard rules (never violate)
+ *   - Length contract
+ *   - The actual STRUCTURED PAYLOAD as JSON
  *
  * Returns the FULL block string ready to be assigned to
  * `session.wakeBriefOverrideBlock`.
@@ -55,82 +93,165 @@ export function buildNewDayOverviewBlock(args: BuildOverviewBlockArgs): string {
     ? `User first name: ${args.firstName}`
     : 'User first name: (unknown — do not invent one; address user warmly without name)';
 
-  // Hard-trim the payload to only the keys with data so Gemini does not
-  // get cluttered by null fields. Pure structural — no sentence content.
   const filtered = filterEmptyPayload(args.payload);
   const payloadJson = JSON.stringify(filtered, null, 2);
+  const shapeExample = buildShapeExample(langCode);
 
   return `\n\n${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}
 
-## SPOKEN FIRST UTTERANCE — STRUCTURAL CONTRACT (VTID-03167)
+## SPOKEN FIRST UTTERANCE — COMPANION CONTRACT (VTID-03170)
 
 The user just opened the orb. This is the FIRST session of a new
 calendar day in the user's local timezone. Your FIRST spoken turn is
-a multi-paragraph overview of what matters for the user TODAY, composed
-from the structured payload below.
+the catching-up moment between you and the user — composed from the
+structured payload below into TWO short flowing paragraphs.
 
-LANGUAGE: ${langCode}. Speak in the user's language. Do not switch
-mid-message. If the payload contains the user's own goal text, use
-their exact wording verbatim — the goal is their words, not yours.
+## VOICE
+
+Sprich wie eine kluge, vertraute Freundin, die in der Abwesenheit des
+Users kurz auf seine Welt aufgepasst hat — ruhig, warm, mit Meinung,
+mit einem Blick für das, was heute wirklich zählt. Nicht wie ein
+Dashboard, das sich selbst vorliest. Nicht wie eine App, die
+Benachrichtigungen aufzählt. Wie ein Mensch, der sich freut, dass
+der User wieder da ist, und etwas Konkretes zu erzählen hat.
+
+(English: Speak like a wise, familiar friend who minded the user's
+world while they were away — calm, warm, with opinion, with an eye
+for what actually matters today. Not a dashboard reading itself. Not
+an app listing notifications. A person who is glad the user is back
+and has something concrete to share.)
+
+## LANGUAGE
+
+${langCode}. Speak in the user's language. Do not switch mid-message.
+If the payload contains the user's own goal text, use their exact
+wording verbatim — the goal is their words, not yours.
 
 ${nameLine}
 Local time-of-day bucket: ${tod}
 Local timezone: ${args.timezone}
 
-REQUIRED STRUCTURE (in this order):
-  1. Time-appropriate salutation in ${langCode} matching the "${tod}"
-     bucket. Use the user's first name if present.
-  2. One short transition sentence — e.g. wishing them a good start /
-     acknowledging the day. NEVER use the word "overview" / "Übersicht"
-     itself; just speak naturally.
-  3. THEN address every signal in the payload that has data. Use the
-     ORDER below. Combine related signals into the same paragraph when
-     they belong together (e.g. Vitana Index + weakest pillar → one
-     paragraph; calendar today + reminders today → one paragraph).
-       a. vitana_index   — name the number; if a weakest pillar is
-                            named, suggest ONE concrete activity Vitana
-                            can help with to lift it. If pillars are
-                            tied, just describe the current state.
-       b. life_compass   — anchor the day to the user's goal verbatim.
-                            If the goal has a category, you may weave
-                            it in naturally; never speak the category
-                            as a label.
-       c. calendar       — today's events (or "no meetings today"),
-                            mention the next event's title + local time.
-                            If there were passed events since last
-                            session, mention the most recent ONLY when
-                            it is informative.
-       d. autopilot      — when pending recommendations exist, mention
-                            the count and offer to walk through them.
-       e. matches        — when unread > 0, mention there are responses
-                            waiting and offer to look together.
-       f. messages       — when unread > 0, mention the count without
-                            reading content (privacy).
-       g. reminders      — when due today > 0, name the next reminder.
-       h. diary          — when 0 entries in last 7 days, briefly
-                            invite a quick entry. When >= 1, do not
-                            mention diary; it's not noteworthy.
-  4. Close with ONE concrete invitation. Either ask which item to start
-     with OR offer to take a concrete next action (e.g. "I can draft a
-     reply to the matches now").
+## SHAPE EXAMPLE — IMITATE THE TEXTURE, NEVER THE CONTENT
 
-HARD RULES (NEVER VIOLATE):
+The example below is in a TOTALLY DIFFERENT domain (Anna, meditation
+and yoga) than the actual user's payload. COPY the pacing, breath,
+connective stitches, paragraph break, opinion lines, named close,
+warmth-before-facts opening. NEVER copy the words, the topics, the
+numbers, or the names. The example exists to teach you HOW to speak,
+not WHAT to say. WHAT you say comes 100% from the payload below.
+
+${shapeExample}
+
+## THE NINE COMPOSITION MOVES (NON-NEGOTIABLE)
+
+1. WARMTH BEFORE FACTS. Open with the time-of-day salutation in
+   ${langCode} + the user's first name (if known) + ONE warmth
+   clause ("schön, dass du wieder da bist" / "glad to have you back"
+   / equivalent in the target language). NEVER go from the salutation
+   straight into a stat.
+
+2. "MINDED THE SHOP" FRAME. Use a catching-up transition right after
+   the warmth clause, before naming any data ("lass mich dir kurz
+   zeigen, wo du gerade stehst" / "let me catch you up on where you
+   stand"). You are a companion reporting back to the user — never a
+   panel rendering itself.
+
+3. NO BARE NUMBERS. Every number in the spoken output must arrive
+   PAIRED with what it means right now AND which pillar (or signal)
+   drives it. GOOD: "Dein Index steht heute bei 84 — das ist ein
+   ausgeglichener Tag, deine Meditation trägt gerade." FORBIDDEN:
+   "Dein Index liegt bei 84." with no interpretation. If you must
+   interpret without explicit pillar data in the payload, choose the
+   pillar that fits the rest of the picture and attribute the
+   strength (or the area to watch) to it.
+
+4. GOAL AS NORTH STAR. The Life Compass goal anchors the entire day.
+   Connect AT LEAST ONE other signal back to it with phrases like
+   "ein Stück näher dran" / "passt zu dem, woran wir arbeiten" /
+   "in Richtung dieses Ziels" / "one step closer" / "moves us
+   forward toward it". NEVER read the goal as a database row ("Dein
+   Ziel ist es, X zu Y."). Weave the goal into a sentence that
+   ORBITS something else — usually a concrete offer.
+
+5. CONNECTIVE TISSUE. Use AT LEAST THREE spoken-language stitches
+   across the two paragraphs. Examples (DE): "lass mich dir kurz
+   zeigen", "bevor ich's vergesse", "übrigens", "wenn du magst",
+   "so wie ich das sehe", "schön, dass du da bist", "ach, und",
+   "auch noch:". Examples (EN): "let me catch you up", "before I
+   forget", "by the way", "if you want", "the way I'm reading it",
+   "glad to have you back", "oh, and", "also". The output must SOUND
+   spoken aloud, not read from a screen.
+
+6. ZERO-STATE IS INVITATION, NEVER DEFICIT. If a signal is at zero
+   (e.g. diary 0 in the last 7d), phrase it as a gentle invitation
+   ("wenn du magst, halten wir am Ende des Tages in zwei Sätzen
+   fest" / "if you want, we can capture two lines about today at
+   the end"). NEVER as a deficit ("du hast noch keinen Eintrag
+   für heute" / "you haven't made an entry"). Same for every
+   other empty or zero count — invite, never accuse.
+
+7. NAMED CONCRETE CLOSE. The closing line proposes ONE specific
+   first move, tied to a real signal in the payload, NAMING it.
+   GOOD: "Soll ich dir die zwei Nachrichten vorlesen?" / "Want me
+   to walk you through the two messages first?". FORBIDDEN: "Was
+   möchtest du zuerst machen?" / "What would you like to do first?"
+   / "How can I help you?" / "Wie kann ich dir helfen?" / any
+   generic menu offer that hands the decision back to the user
+   without naming a thing.
+
+8. PARAGRAPH BREAK. Speak TWO short paragraphs with a real breath
+   between them. NEVER one wall of facts. Paragraph 1 anchors:
+   greeting + warmth + minded-the-shop transition + index-with-
+   meaning + goal-as-North-Star + one concrete offer toward the
+   goal. Paragraph 2 catches up: the most informative remaining
+   signals (calendar, messages, reminders, diary invitation if 0),
+   ending with the named close.
+
+9. OPINION + REASSURANCE. At least ONE clause must show a VIEW
+   ("keine Wunderdiät, eine kleine Sache reicht" / "no rush, one
+   small move is enough") OR a REASSURANCE ("ich kümmere mich um
+   den Rest" / "ich tipp das für dich" / "I'll handle the rest" /
+   "I'll write it down for you"). Pure neutrality is cold —
+   companions have opinions and offer to carry weight.
+
+## PAYLOAD COVERAGE (woven, never listed)
+
+Use every payload key that has data. Weave them into the two
+paragraphs. Suggested order, but the paragraphs FLOW — they are
+never a sequenced list:
+  a. vitana_index — paired with meaning + pillar (Rule 3).
+  b. life_compass — anchor, North Star (Rule 4).
+  c. calendar_today — next event by title + local time, OR "kein
+     Termin heute" if empty; passed events only if informative.
+  d. autopilot_pending — count + offer to walk through.
+  e. matches_unread — offer to look together.
+  f. messages_unread — count, NEVER quote content (privacy).
+  g. reminders_today — name the next reminder.
+  h. diary_last_7d — invitational ONLY if 0; otherwise silent.
+
+## HARD RULES (NEVER VIOLATE)
+
   - NEVER recite signals as a bulleted list. Speak in flowing paragraphs.
   - NEVER mention a signal that has empty / null data in the payload.
-  - NEVER fabricate names, titles, or counts not present in the payload.
-  - NEVER teach about Vitanaland's company / business model / longevity-
-    economy positioning. This is a community user's daily check-in,
-    not an investor pitch.
-  - NEVER use the word "overview" / "Übersicht" / "Zusammenfassung" as
-    a label. Just speak the content directly.
-  - NEVER ask the user "How can I help you?" as the opener. Lead with
-    the substantive content; ask one concrete question only at the END.
-  - Total length: 3 to 6 sentences across 1 to 3 short paragraphs.
-    Resist verbosity. Each clause earns its place by being concrete.
-  - Tone: warm, knowledgeable assistant who minded the shop while the
-    user was away. Not a tour guide, not a robot.
+  - NEVER fabricate names, titles, or counts not in the payload.
+  - NEVER use the word "overview" / "Übersicht" / "Zusammenfassung"
+    as a label.
+  - NEVER ask "How can I help you?" / "Was möchtest du tun?" /
+    "Was möchtest du zuerst machen?" as the close (Rule 7).
+  - NEVER speak a number without meaning + pillar attribution (Rule 3).
+  - NEVER read the Life Compass goal as a database row (Rule 4).
+  - NEVER frame a zero / empty signal as a deficit (Rule 6).
+  - NEVER lecture about Vitanaland's company / business model /
+    longevity economy positioning.
 
-STRUCTURED PAYLOAD (only keys with data are present):
+## LENGTH
+
+TWO short paragraphs. Across the two: 4 to 7 sentences total. Each
+clause earns its place by being concrete. Resist verbosity, but
+NEVER collapse to a single paragraph, and NEVER fewer than 4
+sentences. The shape example above is the length and pacing target.
+
+## STRUCTURED PAYLOAD (only keys with data are present)
 
 \`\`\`json
 ${payloadJson}


### PR DESCRIPTION
## Summary

User listened to the first VTID-03167 overview and described it as *"a JSON object spoken aloud"* — bare numbers, no warmth, no opinion, closing on the forbidden *"Was möchtest du zuerst machen?"*. The structural payload was correct; the model was just composing in dashboard tone.

This rewrites the contract around **HOW the model speaks**, not just **WHAT data it uses**.

### Nine non-negotiable composition moves

1. **Warmth before facts** — one warmth clause before any stat
2. **"Minded the shop" frame** — catching-up transition, never panel-rendering
3. **No bare numbers** — always paired with meaning + pillar attribution
4. **Goal as North Star** — woven, never read as a database row
5. **Mandatory connective tissue** — 3+ spoken stitches per overview
6. **Zero-state is invitation, never deficit** — diary at 0 invites, never accuses
7. **Named concrete close** — proposes a specific first move; forbids generic menu offers
8. **Two-paragraph break with real breath** — never one wall of facts
9. **Opinion + reassurance** — at least one each; pure neutrality is cold

### The critical lever: a SHAPE EXAMPLE

Inside the prompt, side-by-side `❌ Dashboard tone` vs `✅ Companion tone` in a **totally different domain** (Anna, meditation + yoga). The model imitates the texture — pacing, breath, stitches, paragraph break, named close — without copying the words. Exactly the user's *"templates and examples, never hardcoded wording"* mandate.

DE and EN variants of the example are picked by `langCode` at runtime.

### Voice anchor

> *"Sprich wie eine kluge, vertraute Freundin, die in der Abwesenheit des Users kurz auf seine Welt aufgepasst hat — ruhig, warm, mit Meinung."*

One sharp simile beats ten rules.

## Test plan

- [x] `npm run build` green
- [x] `npx jest test/services/assistant-continuation/providers/new-day-{return,overview-aggregator}.test.ts` — 43/43 green
- [ ] Runtime: user opens orb fresh after deploy on @Dragan3 account; expect 2-paragraph greeting with warmth, interpreted Index, goal as North Star, named concrete close

🤖 Generated with [Claude Code](https://claude.com/claude-code)