### PR TITLE
feat(overview): VTID-03172 unify voice greeting with My Journey screen + coverage/fallbacks/autopilot-close

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
@@ -1,89 +1,139 @@
 /**
- * VTID-03167 — Broad new-day overview payload aggregator.
+ * VTID-03172 — Unified new-day overview payload aggregator.
  *
- * REPLACES the Slice 2 (VTID-03166) renderer that pre-composed German /
- * English sentences server-side. The founder's contract:
+ * Replaces the VTID-03167 standalone aggregator with one that READS THE
+ * SAME DATA the My Journey screen renders. Voice + screen now share the
+ * exact same per-signal source functions:
  *
- *   1. The aggregator pulls EVERY available signal in parallel.
- *   2. The structured payload is handed to Gemini via a STRUCTURAL
- *      prompt block — NOT a Say-exactly line, NOT pre-composed sentences.
- *   3. Gemini composes the multi-paragraph overview in the user's
- *      language, conversationally, addressing every signal that has data.
- *   4. Zero hardcoded sentences in TypeScript. Zero sentence templates.
- *      This file ONLY produces the structured payload.
+ *   - Journey state        →  getJourneyState (services/journey/user-journey-service)
+ *                             [same path used by GET /api/v1/my-journey]
+ *   - Life Compass         →  fetchLifeCompass (services/user-context-profiler)
+ *                             [same path used by GET /api/v1/my-journey]
+ *   - Vitana Index         →  fetchVitanaIndexForProfiler (snapshot)
+ *                             [same path used by GET /api/v1/my-journey + the
+ *                              trajectory card on AutopilotDashboard]
+ *   - Autopilot recs       →  direct query on autopilot_recommendations
+ *                             [same table the screen renders, bucketed for voice]
  *
- * Sources pulled (all best-effort, per-source try/catch):
- *   - Vitana Index (today total + per-pillar + weakest pillar)
- *   - Life Compass (active goal + category)
- *   - Calendar today (count + next event)
- *   - Calendar passed since last session (count + most recent)
- *   - Autopilot pending recommendations (count + top title)
- *   - Match notifications unread (count)
- *   - Messages unread (count + sender hint when possible)
- *   - Reminders due today (count + next reminder)
- *   - Diary entries last 7 days (streak proxy)
+ * Voice keeps its time-sensitive signals that the screen doesn't render:
+ * calendar today + passed, messages unread, matches unread, reminders
+ * today, diary 7-day streak.
+ *
+ * Per-signal SETUP STATE is exposed (`state: 'set'|'not_set'` style) so
+ * the prompt can switch between three branches for each signal:
+ *   1. has data            → speak it (Rule 3: numbers + meaning + pillar)
+ *   2. empty for today     → silent (it's not a gap, just nothing scheduled)
+ *   3. user hasn't set up  → invitation ("magst du, dass wir das gleich
+ *                            gemeinsam machen?")
+ *
+ * The prompt layer renders. This aggregator only assembles.
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { getJourneyState, type JourneyState } from '../../journey/user-journey-service';
+import { fetchLifeCompass, fetchVitanaIndexForProfiler } from '../../user-context-profiler';
+
+// ---------------------------------------------------------------------------
+// Type definitions
+// ---------------------------------------------------------------------------
+
+export type SignalSetupState = 'set' | 'not_set';
 
 export interface OverviewPayload {
-  // -- VITANA INDEX --
+  // -- JOURNEY (same source as /api/v1/my-journey) --
+  journey: {
+    day_in_journey: number;
+    total_days: number;
+    days_left: number;
+    is_first_session: boolean;
+    plan_type: 'default' | 'personalized';
+    current_wave: {
+      name: string;
+      description: string;
+      day_in_wave: number;
+      days_to_next_wave: number | null;
+    } | null;
+  } | null;
+
+  // -- VITANA INDEX (same source as /api/v1/my-journey + AutopilotDashboard NowCard) --
   vitana_index: {
-    total: number;             // 0-999 (server-computed from score_total)
-    pillars: { sleep: number; nutrition: number; exercise: number; hydration: number; mental: number };
-    weakest_pillar: 'sleep' | 'nutrition' | 'exercise' | 'hydration' | 'mental' | null;
-  } | null;
+    state: 'ok' | 'not_set_up' | 'baseline_no_score';
+    today: number | null;
+    tier: string | null;
+    tier_framing: string | null;
+    trend_7d: number | null;            // delta over last 7 days; can be < 0
+    weakest_pillar: { name: string; score: number } | null;
+    strongest_pillar: { name: string; score: number } | null;
+    balance_label: string | null;
+    pillars: { sleep: number; nutrition: number; exercise: number; hydration: number; mental: number } | null;
+    projected_day_90: number | null;
+    projected_day_90_tier: string | null;
+  };
 
-  // -- LIFE COMPASS --
+  // -- LIFE COMPASS (same source as /api/v1/my-journey + CompassCard) --
   life_compass: {
-    primary_goal: string;        // free text (user's words, language as stored)
-    category: string;            // e.g. 'wealth', 'health', 'relationships'
-  } | null;
-
-  // -- CALENDAR --
-  calendar_today: {
-    count: number;               // events scheduled today (in user TZ today)
-    next: { title: string; start_iso: string } | null;  // chronologically first today
-  };
-  calendar_passed: {
-    count: number;               // events in (lookback, now)
-    most_recent: { title: string; start_iso: string } | null;
+    state: SignalSetupState;
+    primary_goal: string | null;
+    category: string | null;
+    target_date: string | null;
+    target_value: number | null;
+    target_unit: string | null;
+    starting_value: number | null;
+    set_at: string | null;
+    days_to_deadline: number | null;
+    goal_progress_pct: number | null;   // time-based progress, 0-100
   };
 
-  // -- AUTOPILOT --
-  autopilot_pending: {
-    count: number;
-    top: { title: string; domain: string | null } | null;
+  // -- CALENDAR (voice-only signal, time-sensitive) --
+  calendar_today: { count: number; next: { title: string; start_iso: string } | null };
+  calendar_passed: { count: number; most_recent: { title: string; start_iso: string } | null };
+
+  // -- AUTOPILOT (same table as AutopilotDashboard, bucketed for voice) --
+  autopilot: {
+    state: 'has_actions' | 'none_yet';
+    today_checkpoint: {
+      recommendation_id: string;
+      title: string;
+      summary: string | null;
+      domain: string | null;
+      impact_score: number | null;
+    } | null;
+    this_week: Array<{
+      recommendation_id: string;
+      title: string;
+      summary: string | null;
+    }>;
+    pending_total: number;
   };
 
-  // -- MATCHES --
-  matches_unread: number;       // open match_notifications
+  // -- MATCHES (voice-only) --
+  matches_unread: number;
 
-  // -- MESSAGES --
-  messages_unread: number;      // unread messages in inbox
+  // -- MESSAGES (voice-only) --
+  messages_unread: number;
 
-  // -- REMINDERS --
-  reminders_today: {
-    count: number;
-    next: { action_text: string; next_fire_at: string } | null;
-  };
+  // -- REMINDERS (voice-only) --
+  reminders_today: { count: number; next: { action_text: string; next_fire_at: string } | null };
 
-  // -- DIARY (streak proxy) --
+  // -- DIARY (voice-only, streak proxy) --
   diary_last_7d: number;
 
-  // -- META (for the renderer's context) --
-  last_session_date_user_tz: string | null;     // YYYY-MM-DD or null
+  // -- META --
+  last_session_date_user_tz: string | null;
 }
 
 export interface AggregateArgs {
   supabase: SupabaseClient;
   userId: string;
-  timezone: string;             // IANA TZ e.g. 'Europe/Berlin'
+  timezone: string;
   now: Date;
-  lastSessionDateUserTz: string | null;  // YYYY-MM-DD or null (from user_journey)
+  lastSessionDateUserTz: string | null;
 }
 
-/** UTC day-window matching local day in `timezone`. */
+// ---------------------------------------------------------------------------
+// TZ helpers (unchanged)
+// ---------------------------------------------------------------------------
+
 function dayWindowUtcIso(now: Date, timezone: string): { startUtc: string; endUtc: string } {
   try {
     const fmt = new Intl.DateTimeFormat('en-CA', {
@@ -116,7 +166,6 @@ function dayWindowUtcIso(now: Date, timezone: string): { startUtc: string; endUt
   }
 }
 
-/** Local hour [0-23] in IANA TZ. */
 export function localHourInTz(now: Date, timezone: string): number {
   try {
     const fmt = new Intl.DateTimeFormat('en-GB', { timeZone: timezone, hour: '2-digit', hourCycle: 'h23' });
@@ -127,7 +176,6 @@ export function localHourInTz(now: Date, timezone: string): number {
   }
 }
 
-/** Local time HH:MM in IANA TZ for use in payload. */
 export function localHhmmInTz(iso: string, timezone: string): string {
   try {
     const fmt = new Intl.DateTimeFormat('en-GB', { timeZone: timezone, hour: '2-digit', minute: '2-digit', hourCycle: 'h23' });
@@ -140,27 +188,12 @@ export function localHhmmInTz(iso: string, timezone: string): string {
   }
 }
 
-const EMPTY_VITANA_INDEX: OverviewPayload['vitana_index'] = null;
+export { dayWindowUtcIso };
 
-function pickWeakest(p: { sleep: number; nutrition: number; exercise: number; hydration: number; mental: number }): OverviewPayload['vitana_index'] extends infer T ? T extends { weakest_pillar: infer W } ? W : never : never {
-  const entries: Array<[keyof typeof p, number]> = [
-    ['sleep', p.sleep],
-    ['nutrition', p.nutrition],
-    ['exercise', p.exercise],
-    ['hydration', p.hydration],
-    ['mental', p.mental],
-  ];
-  entries.sort((a, b) => a[1] - b[1]);
-  const lowest = entries[0][1];
-  // If all five pillars are tied (e.g., baseline survey state), return null —
-  // the LLM should be told "all pillars need attention" via the absence of a
-  // single weakest, not pick one arbitrarily.
-  const tiedCount = entries.filter(([, v]) => v === lowest).length;
-  if (tiedCount >= 4) return null as any;
-  return entries[0][0] as any;
-}
+// ---------------------------------------------------------------------------
+// Aggregator
+// ---------------------------------------------------------------------------
 
-/** Aggregate the full overview payload. Never throws. Per-source failures degrade fields to null/0. */
 export async function gatherOverviewPayload(args: AggregateArgs): Promise<OverviewPayload> {
   const { startUtc, endUtc } = dayWindowUtcIso(args.now, args.timezone);
   const nowIso = args.now.toISOString();
@@ -169,21 +202,23 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     : new Date(args.now.getTime() - 24 * 3600 * 1000).toISOString();
 
   const [
-    vIdx,
-    lc,
+    journeyState,
+    indexSnapshot,
+    lcSnapshot,
     calToday,
     calPassed,
-    autoP,
+    autopilot,
     matchesUnread,
     msgsUnread,
     remindersToday,
     diary7d,
   ] = await Promise.all([
-    fetchVitanaIndexLatest(args.supabase, args.userId),
-    fetchLifeCompass(args.supabase, args.userId),
+    getJourneyState(args.supabase, args.userId).catch(() => null),
+    fetchVitanaIndexForProfiler(args.supabase, args.userId).catch(() => null),
+    fetchLifeCompass(args.supabase, args.userId).catch(() => null),
     fetchCalendarToday(args.supabase, args.userId, nowIso, endUtc),
     fetchCalendarPassed(args.supabase, args.userId, lookbackIso, nowIso),
-    fetchAutopilotPending(args.supabase, args.userId),
+    fetchAutopilotForVoice(args.supabase, args.userId),
     fetchMatchesUnread(args.supabase, args.userId),
     fetchMessagesUnread(args.supabase, args.userId),
     fetchRemindersToday(args.supabase, args.userId, startUtc, endUtc),
@@ -191,11 +226,12 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
   ]);
 
   return {
-    vitana_index: vIdx,
-    life_compass: lc,
+    journey: projectJourney(journeyState),
+    vitana_index: projectIndex(indexSnapshot),
+    life_compass: projectLifeCompass(lcSnapshot),
     calendar_today: calToday,
     calendar_passed: calPassed,
-    autopilot_pending: autoP,
+    autopilot,
     matches_unread: matchesUnread,
     messages_unread: msgsUnread,
     reminders_today: remindersToday,
@@ -204,56 +240,101 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
   };
 }
 
-// -------------------- per-source fetchers (defensive) --------------------
+// ---------------------------------------------------------------------------
+// Projections — narrow the shared-service shapes into the voice contract
+// ---------------------------------------------------------------------------
 
-async function fetchVitanaIndexLatest(sb: SupabaseClient, userId: string): Promise<OverviewPayload['vitana_index']> {
-  try {
-    const { data, error } = await sb
-      .from('vitana_index_scores')
-      .select('score_total, score_sleep, score_nutrition, score_exercise, score_hydration, score_mental')
-      .eq('user_id', userId)
-      .order('date', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    if (error || !data) return EMPTY_VITANA_INDEX;
-    const pillars = {
-      sleep: Number(data.score_sleep) || 0,
-      nutrition: Number(data.score_nutrition) || 0,
-      exercise: Number(data.score_exercise) || 0,
-      hydration: Number(data.score_hydration) || 0,
-      mental: Number(data.score_mental) || 0,
-    };
-    return {
-      total: Number(data.score_total) || 0,
-      pillars,
-      weakest_pillar: pickWeakest(pillars),
-    };
-  } catch {
-    return EMPTY_VITANA_INDEX;
-  }
+function projectJourney(s: JourneyState | null): OverviewPayload['journey'] {
+  if (!s) return null;
+  const wave = s.current_wave
+    ? {
+        name: s.current_wave.name,
+        description: s.current_wave.description,
+        day_in_wave: Math.max(0, s.day_in_journey - s.current_wave.start_day + 1),
+        days_to_next_wave: Math.max(0, s.current_wave.end_day - s.day_in_journey),
+      }
+    : null;
+  return {
+    day_in_journey: s.day_in_journey,
+    total_days: s.total_days,
+    days_left: s.days_left,
+    is_first_session: s.is_first_session,
+    plan_type: s.plan_type,
+    current_wave: wave,
+  };
 }
 
-async function fetchLifeCompass(sb: SupabaseClient, userId: string): Promise<OverviewPayload['life_compass']> {
-  try {
-    const { data, error } = await sb
-      .from('life_compass')
-      .select('primary_goal, category')
-      .eq('user_id', userId)
-      .eq('is_active', true)
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    if (error || !data || !data.primary_goal) return null;
+function projectIndex(snap: any | null): OverviewPayload['vitana_index'] {
+  // `snap` may be null OR a VitanaIndexSnapshot when the profiler returned state=='ok'.
+  // The profiler hides the state envelope; null means either not_set_up or
+  // baseline_no_score. We collapse both into 'not_set_up' here — the prompt
+  // treats them identically (invite the user to set up the Index).
+  if (!snap) {
     return {
-      primary_goal: String(data.primary_goal),
-      category: String(data.category ?? ''),
+      state: 'not_set_up',
+      today: null, tier: null, tier_framing: null, trend_7d: null,
+      weakest_pillar: null, strongest_pillar: null, balance_label: null,
+      pillars: null, projected_day_90: null, projected_day_90_tier: null,
     };
-  } catch {
-    return null;
   }
+  return {
+    state: 'ok',
+    today: typeof snap.total === 'number' ? snap.total : null,
+    tier: snap.tier ?? null,
+    tier_framing: snap.tier_framing ?? null,
+    trend_7d: typeof snap.trend_7d === 'number' ? snap.trend_7d : null,
+    weakest_pillar: snap.weakest_pillar ?? null,
+    strongest_pillar: snap.strongest_pillar ?? null,
+    balance_label: snap.balance_label ?? null,
+    pillars: snap.pillars ?? null,
+    projected_day_90: typeof snap.projected_day_90 === 'number' ? snap.projected_day_90 : null,
+    projected_day_90_tier: snap.projected_day_90_tier ?? null,
+  };
 }
 
-async function fetchCalendarToday(sb: SupabaseClient, userId: string, nowIso: string, endOfTodayIso: string): Promise<OverviewPayload['calendar_today']> {
+function projectLifeCompass(lc: any | null): OverviewPayload['life_compass'] {
+  if (!lc || !lc.primary_goal) {
+    return {
+      state: 'not_set',
+      primary_goal: null, category: null, target_date: null,
+      target_value: null, target_unit: null, starting_value: null,
+      set_at: null, days_to_deadline: null, goal_progress_pct: null,
+    };
+  }
+  const now = Date.now();
+  const setAtMs = lc.set_at ? Date.parse(lc.set_at) : null;
+  const deadlineMs = lc.target_date ? Date.parse(`${lc.target_date}T23:59:59Z`) : null;
+  let days_to_deadline: number | null = null;
+  let goal_progress_pct: number | null = null;
+  if (deadlineMs && Number.isFinite(deadlineMs)) {
+    days_to_deadline = Math.max(0, Math.ceil((deadlineMs - now) / 86_400_000));
+    if (setAtMs && Number.isFinite(setAtMs) && deadlineMs > setAtMs) {
+      const elapsed = now - setAtMs;
+      const total = deadlineMs - setAtMs;
+      goal_progress_pct = Math.max(0, Math.min(100, Math.round((elapsed / total) * 100)));
+    }
+  }
+  return {
+    state: 'set',
+    primary_goal: String(lc.primary_goal),
+    category: lc.category ?? null,
+    target_date: lc.target_date ?? null,
+    target_value: typeof lc.target_value === 'number' ? lc.target_value : null,
+    target_unit: lc.target_unit ?? null,
+    starting_value: typeof lc.starting_value === 'number' ? lc.starting_value : null,
+    set_at: lc.set_at ?? null,
+    days_to_deadline,
+    goal_progress_pct,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Voice-only fetchers (calendar, messages, matches, reminders, diary)
+// ---------------------------------------------------------------------------
+
+async function fetchCalendarToday(
+  sb: SupabaseClient, userId: string, nowIso: string, endOfTodayIso: string,
+): Promise<OverviewPayload['calendar_today']> {
   try {
     const { data, error } = await sb
       .from('calendar_events')
@@ -274,7 +355,9 @@ async function fetchCalendarToday(sb: SupabaseClient, userId: string, nowIso: st
   }
 }
 
-async function fetchCalendarPassed(sb: SupabaseClient, userId: string, lookbackIso: string, nowIso: string): Promise<OverviewPayload['calendar_passed']> {
+async function fetchCalendarPassed(
+  sb: SupabaseClient, userId: string, lookbackIso: string, nowIso: string,
+): Promise<OverviewPayload['calendar_passed']> {
   try {
     const { data, error } = await sb
       .from('calendar_events')
@@ -295,23 +378,65 @@ async function fetchCalendarPassed(sb: SupabaseClient, userId: string, lookbackI
   }
 }
 
-async function fetchAutopilotPending(sb: SupabaseClient, userId: string): Promise<OverviewPayload['autopilot_pending']> {
+/**
+ * Fetch active autopilot recommendations the same way the screen does:
+ * status='new' (the real default — VTID-03167's `status='pending'` query
+ * was dead code, the column never carries that value). Top-1 by
+ * impact_score is the TODAY checkpoint; top-3 are this_week's actions.
+ *
+ * setup_state distinguishes "user has actions waiting" from "user has
+ * never generated any recommendations" — the prompt invites generation
+ * in the second case.
+ */
+async function fetchAutopilotForVoice(
+  sb: SupabaseClient, userId: string,
+): Promise<OverviewPayload['autopilot']> {
   try {
-    const { data, error } = await sb
+    const { data: activeRows, error: activeErr } = await sb
       .from('autopilot_recommendations')
-      .select('title, domain')
+      .select('id, title, summary, domain, impact_score')
       .eq('user_id', userId)
-      .eq('status', 'pending')
+      .eq('status', 'new')
+      .order('impact_score', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false })
-      .limit(5);
-    if (error) return { count: 0, top: null };
-    const rows = (data ?? []) as Array<{ title: string; domain: string | null }>;
+      .limit(10);
+    if (activeErr) return { state: 'has_actions', today_checkpoint: null, this_week: [], pending_total: 0 };
+    const rows = (activeRows ?? []) as Array<{ id: string; title: string; summary: string | null; domain: string | null; impact_score: number | null }>;
+
+    if (rows.length === 0) {
+      // No active recs. Decide between "none_yet" (user never had any) and
+      // "has_actions" with empty array (user worked through them all).
+      const { count } = await sb
+        .from('autopilot_recommendations')
+        .select('id', { head: true, count: 'exact' })
+        .eq('user_id', userId);
+      return {
+        state: (count ?? 0) > 0 ? 'has_actions' : 'none_yet',
+        today_checkpoint: null,
+        this_week: [],
+        pending_total: 0,
+      };
+    }
+
+    const top = rows[0];
     return {
-      count: rows.length,
-      top: rows[0] ? { title: String(rows[0].title ?? '').trim() || 'recommendation', domain: rows[0].domain ?? null } : null,
+      state: 'has_actions',
+      today_checkpoint: {
+        recommendation_id: top.id,
+        title: String(top.title ?? '').trim() || 'next step',
+        summary: top.summary ?? null,
+        domain: top.domain ?? null,
+        impact_score: top.impact_score ?? null,
+      },
+      this_week: rows.slice(0, 3).map((r) => ({
+        recommendation_id: r.id,
+        title: String(r.title ?? '').trim() || 'next step',
+        summary: r.summary ?? null,
+      })),
+      pending_total: rows.length,
     };
   } catch {
-    return { count: 0, top: null };
+    return { state: 'has_actions', today_checkpoint: null, this_week: [], pending_total: 0 };
   }
 }
 
@@ -343,7 +468,9 @@ async function fetchMessagesUnread(sb: SupabaseClient, userId: string): Promise<
   }
 }
 
-async function fetchRemindersToday(sb: SupabaseClient, userId: string, startUtc: string, endUtc: string): Promise<OverviewPayload['reminders_today']> {
+async function fetchRemindersToday(
+  sb: SupabaseClient, userId: string, startUtc: string, endUtc: string,
+): Promise<OverviewPayload['reminders_today']> {
   try {
     const { data, error } = await sb
       .from('reminders')
@@ -379,6 +506,3 @@ async function fetchDiaryLast7Days(sb: SupabaseClient, userId: string, now: Date
     return 0;
   }
 }
-
-// dayWindowUtcIso exported for tests + the new-day-return provider integration.
-export { dayWindowUtcIso };

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
@@ -1,28 +1,34 @@
 /**
- * VTID-03170 — Companion-tone overview prompt block.
+ * VTID-03172 — Unified journey-greeting prompt block.
  *
- * Replaces the VTID-03167 dashboard-style structural block. The model
- * was correctly reading the payload but composing in a corporate /
- * stat-readout tone — bare numbers, no warmth, no opinion, generic
- * "what would you like to do" close. This version hands the model a
- * STRUCTURED PAYLOAD plus:
+ * Built on the VTID-03170 companion-tone foundation. Two big additions:
  *
- *   - A tone anchor (single simile that sets the register).
- *   - A "minded the shop while you were away" frame.
- *   - A SHAPE example in a DIFFERENT domain (meditation + yoga, never
- *     the user's actual domain) so the model imitates texture without
- *     copying content. Side-by-side ❌ Dashboard / ✅ Companion.
- *   - Nine numbered composition rules covering warmth, frame, number
- *     interpretation, goal-as-North-Star, connective tissue, zero-state
- *     framing, named concrete close, paragraph break, opinion +
- *     reassurance.
+ *   1. COVERAGE AS HARD RULE (not style). The VTID-03170 contract was
+ *      style-heavy and let the model stop after executing the warmth +
+ *      interpreted-Index moves. This block now ships an explicit
+ *      "COVERAGE CHECKLIST" the model must walk before stopping, and
+ *      a length-floor with teeth ("if you have produced fewer than 4
+ *      sentences you have failed the contract").
  *
- * Zero hardcoded user-facing sentences. The model composes from the
- * payload using the shape it has been taught to imitate.
+ *   2. MISSING-SIGNAL FALLBACK split. Empty signals fork into two
+ *      branches:
+ *        - "Empty for today" (no events scheduled, 0 reminders): stay
+ *          silent — that's not a gap.
+ *        - "User hasn't set it up" (Life Compass not_set, Index not_set_up,
+ *          Autopilot none_yet, 0 diary entries in 7d): INVITE the user
+ *          to set it up together — *"magst du, dass wir das gleich
+ *          gemeinsam machen?"*. The voice greeting becomes a coaching
+ *          moment, not a status report.
  *
- * Wrapped in the same VERTEX_WAKE_BRIEF_OVERRIDE_MARKER as before so
- * the existing strip+suppress logic in live-session-controller treats
- * it as the authoritative first-turn directive.
+ *   3. AUTOPILOT-WAITING CLOSE. When autopilot.today_checkpoint exists,
+ *      the closing line names that checkpoint and offers to start it —
+ *      "ich hab den nächsten Schritt für dich vorbereitet: [title].
+ *      Soll ich's starten?". Replaces the generic menu offer with a
+ *      concrete activation offer.
+ *
+ * Same VERTEX_WAKE_BRIEF_OVERRIDE_MARKER sentinel as VTID-03167 +
+ * VTID-03170 so the existing live-session-controller strip+suppress
+ * logic still treats it as the authoritative first-turn directive.
  */
 
 import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../../../orb/live/instruction/wake-brief-marker';
@@ -30,13 +36,12 @@ import type { OverviewPayload } from './new-day-overview-payload';
 
 export interface BuildOverviewBlockArgs {
   payload: OverviewPayload;
-  lang: string;            // e.g. 'de', 'en'
+  lang: string;
   firstName: string | null;
-  localHour: number;       // 0-23 in user TZ
+  localHour: number;
   timezone: string;
 }
 
-/** Map local hour to a coarse time-of-day bucket. */
 function timeOfDay(localHour: number): 'morning' | 'afternoon' | 'evening' {
   if (localHour < 5) return 'evening';
   if (localHour < 12) return 'morning';
@@ -48,43 +53,33 @@ function timeOfDay(localHour: number): 'morning' | 'afternoon' | 'evening' {
  * Build the SHAPE example block for the chosen language. The example
  * persona (Anna, meditation + yoga) has NO overlap with any plausible
  * Vitana user domain, so the model imitates texture without copying
- * content. The example shows the model the cadence, breath, connective
- * stitches, paragraph break, opinion lines, and named concrete close
- * — but the WORDS, TOPICS, NAMES, and NUMBERS come from the payload.
+ * content. The example now demonstrates covering FIVE signals across
+ * the two paragraphs (journey day + index + goal + calendar + autopilot
+ * close) — the model needs to see what full coverage looks like, not
+ * just a thin warmth + one stat.
  */
 function buildShapeExample(lang: string): string {
   if (lang.startsWith('de')) {
     return `### ❌ Dashboard-Ton — SO SOLLST DU NICHT SPRECHEN:
 "Guten Abend, Anna. Dein Vitana-Index liegt bei 84. Dein Ziel ist 30 Minuten Meditation am Tag. Du hast einen Termin um 19 Uhr und drei ungelesene Erinnerungen. Was möchtest du zuerst machen?"
 
-### ✅ Begleiter-Ton — GENAU DIESE TEXTUR SOLLST DU IMITIEREN:
-"Guten Abend, Anna — schön, dass du wieder da bist. Lass mich dir kurz zeigen, wo du gerade stehst: dein Vitana-Index steht heute bei 84, und das fühlt sich nach einem ruhigen, ausgeglichenen Tag an — vor allem deine Meditation trägt dich gerade durch die Woche. An deiner täglichen halben Stunde Stille sind wir mit dem heutigen Tag wieder ein Stück konsequenter dran; wenn du magst, schauen wir gleich, wo wir die nächste Session am besten reinlegen, damit sie nicht in der Abendmüdigkeit untergeht.
+### ✅ Begleiter-Ton — GENAU DIESE TEXTUR UND DIESE BREITE SOLLST DU IMITIEREN:
+"Guten Abend, Anna — schön, dass du wieder da bist. Heute ist Tag 23 von 90 in deiner Reise, du bist mitten in der Erkundungs-Phase. Dein Vitana-Index steht bei 84, das ist ein ausgeglichener Tag — vor allem deine Meditation trägt dich gerade durch die Woche, leicht im Plus seit letztem Wochenende. An deinem Ziel, jeden Tag eine halbe Stunde Stille zu finden, sind wir mit dem heutigen Tag wieder ein Stück konsequenter dran.
 
-Bevor ich's vergesse: in einer guten Stunde steht dein Yoga-Termin an — soll ich dir kurz die Vorbereitung rauslegen? Und drei kleine Erinnerungen warten noch auf dich, ich kann sie dir nach dem Termin der Reihe nach durchgehen, wenn dir das lieber ist als jetzt."`;
+Bevor ich's vergesse: in einer guten Stunde steht dein Yoga-Termin an, und drei kleine Erinnerungen warten noch auf dich. Ich hab heute auch den nächsten Schritt für dich vorbereitet — eine kurze Atem-Sequenz vor dem Schlafengehen. Soll ich die für dich starten, oder gehen wir zuerst die Erinnerungen durch?"`;
   }
   // English fallback for en + any other language the model may speak.
   return `### ❌ Dashboard tone — DO NOT speak like this:
 "Good evening, Anna. Your Vitana Index is 84. Your goal is 30 minutes of meditation a day. You have one event at 7 pm and three unread reminders. What would you like to do first?"
 
-### ✅ Companion tone — IMITATE THIS TEXTURE EXACTLY:
-"Good evening, Anna — glad to have you back. Let me catch you up on where you stand: your Vitana Index is at 84 today, and that reads like a calm, well-balanced day — your meditation pillar is really carrying the week. On your daily half hour of stillness, today moves us one notch more consistent; if you want, we'll find a slot for the next session before the evening fatigue swallows it.
+### ✅ Companion tone — IMITATE THIS TEXTURE AND THIS BREADTH:
+"Good evening, Anna — glad to have you back. Today is day 23 of 90 on your journey, right in the middle of the exploration phase. Your Vitana Index is at 84, that reads like a balanced day — your meditation pillar is really carrying the week, slightly up since last weekend. On your goal of half an hour of stillness every day, today moves us one notch more consistent.
 
-Before I forget: your yoga class kicks off in just over an hour — want me to lay out the prep for you? And three small reminders are waiting too; I can walk you through them right after class if that's easier than now."`;
+Before I forget: your yoga class kicks off in just over an hour, and three small reminders are waiting too. I've also prepared the next step for you — a short breath sequence before bed. Want me to start that for you, or shall we walk through the reminders first?"`;
 }
 
 /**
- * Build the structural prompt block. The block contains:
- *   - Voice anchor + "minded the shop" frame
- *   - Language directive
- *   - Lang-specific SHAPE example (DIFFERENT domain — imitate texture only)
- *   - Nine composition moves (rules)
- *   - Payload coverage order (woven, not listed)
- *   - Hard rules (never violate)
- *   - Length contract
- *   - The actual STRUCTURED PAYLOAD as JSON
- *
- * Returns the FULL block string ready to be assigned to
- * `session.wakeBriefOverrideBlock`.
+ * Build the structural prompt block.
  */
 export function buildNewDayOverviewBlock(args: BuildOverviewBlockArgs): string {
   const langCode = (args.lang || 'en').toLowerCase();
@@ -93,18 +88,24 @@ export function buildNewDayOverviewBlock(args: BuildOverviewBlockArgs): string {
     ? `User first name: ${args.firstName}`
     : 'User first name: (unknown — do not invent one; address user warmly without name)';
 
-  const filtered = filterEmptyPayload(args.payload);
-  const payloadJson = JSON.stringify(filtered, null, 2);
+  const compact = compactPayloadForPrompt(args.payload);
+  const payloadJson = JSON.stringify(compact, null, 2);
   const shapeExample = buildShapeExample(langCode);
+  const coverageChecklist = buildCoverageChecklist(args.payload);
 
   return `\n\n${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}
 
-## SPOKEN FIRST UTTERANCE — COMPANION CONTRACT (VTID-03170)
+## SPOKEN FIRST UTTERANCE — JOURNEY GREETING (VTID-03172)
 
 The user just opened the orb. This is the FIRST session of a new
-calendar day in the user's local timezone. Your FIRST spoken turn is
-the catching-up moment between you and the user — composed from the
+calendar day in their local timezone. Your FIRST spoken turn is the
+catching-up moment between you and the user — composed from the
 structured payload below into TWO short flowing paragraphs.
+
+The payload mirrors what the user sees on their visual "My Journey"
+screen, plus time-sensitive signals only voice can surface. Voice and
+screen draw from the SAME data sources — they are two renderings of
+the same truth.
 
 ## VOICE
 
@@ -131,47 +132,55 @@ ${nameLine}
 Local time-of-day bucket: ${tod}
 Local timezone: ${args.timezone}
 
-## SHAPE EXAMPLE — IMITATE THE TEXTURE, NEVER THE CONTENT
+## SHAPE EXAMPLE — IMITATE THE TEXTURE AND BREADTH, NEVER THE CONTENT
 
 The example below is in a TOTALLY DIFFERENT domain (Anna, meditation
 and yoga) than the actual user's payload. COPY the pacing, breath,
 connective stitches, paragraph break, opinion lines, named close,
-warmth-before-facts opening. NEVER copy the words, the topics, the
-numbers, or the names. The example exists to teach you HOW to speak,
-not WHAT to say. WHAT you say comes 100% from the payload below.
+warmth-before-facts opening, AND the breadth — Anna's example
+addresses five signals across two paragraphs. The example exists to
+teach you HOW to speak and HOW MUCH to cover, not WHAT to say. WHAT
+you say comes 100% from the payload below.
 
 ${shapeExample}
 
-## THE NINE COMPOSITION MOVES (NON-NEGOTIABLE)
+## COVERAGE CHECKLIST — YOU ARE NOT FINISHED UNTIL EVERY APPLICABLE ITEM IS ADDRESSED
+
+This checklist is computed from the payload below. Walk through it
+BEFORE you stop speaking. If any item is unanswered, KEEP GOING.
+
+${coverageChecklist}
+
+If you've produced fewer than 4 sentences when you reach the end of
+the checklist, you have failed the contract — expand. Two-sentence
+greetings are forbidden.
+
+## THE TEN COMPOSITION MOVES (NON-NEGOTIABLE)
 
 1. WARMTH BEFORE FACTS. Open with the time-of-day salutation in
    ${langCode} + the user's first name (if known) + ONE warmth
    clause ("schön, dass du wieder da bist" / "glad to have you back"
-   / equivalent in the target language). NEVER go from the salutation
-   straight into a stat.
+   / equivalent). NEVER go from the salutation straight into a stat.
 
-2. "MINDED THE SHOP" FRAME. Use a catching-up transition right after
-   the warmth clause, before naming any data ("lass mich dir kurz
-   zeigen, wo du gerade stehst" / "let me catch you up on where you
-   stand"). You are a companion reporting back to the user — never a
-   panel rendering itself.
+2. JOURNEY CONTEXT FIRST. If \`journey\` is present, name the day in
+   the journey + the current wave/phase right after the warmth
+   clause. "Heute ist Tag X von Y, du bist mitten in der [phase]" /
+   "Today is day X of Y, you're in [phase]". This anchors the entire
+   greeting in the user's longer arc.
 
 3. NO BARE NUMBERS. Every number in the spoken output must arrive
-   PAIRED with what it means right now AND which pillar (or signal)
-   drives it. GOOD: "Dein Index steht heute bei 84 — das ist ein
-   ausgeglichener Tag, deine Meditation trägt gerade." FORBIDDEN:
-   "Dein Index liegt bei 84." with no interpretation. If you must
-   interpret without explicit pillar data in the payload, choose the
-   pillar that fits the rest of the picture and attribute the
-   strength (or the area to watch) to it.
+   PAIRED with what it means AND which pillar (or trend) drives it.
+   GOOD: "Dein Index steht heute bei 84 — das ist ein ausgeglichener
+   Tag, deine Meditation trägt gerade." FORBIDDEN: "Dein Index liegt
+   bei 84." with no interpretation. Use \`vitana_index.weakest_pillar\`,
+   \`strongest_pillar\`, \`trend_7d\`, \`balance_label\` to interpret.
 
-4. GOAL AS NORTH STAR. The Life Compass goal anchors the entire day.
-   Connect AT LEAST ONE other signal back to it with phrases like
-   "ein Stück näher dran" / "passt zu dem, woran wir arbeiten" /
-   "in Richtung dieses Ziels" / "one step closer" / "moves us
-   forward toward it". NEVER read the goal as a database row ("Dein
-   Ziel ist es, X zu Y."). Weave the goal into a sentence that
-   ORBITS something else — usually a concrete offer.
+4. GOAL AS NORTH STAR. The Life Compass goal anchors the entire day
+   WHEN IT IS SET. Connect AT LEAST ONE other signal back to it with
+   phrases like "ein Stück näher dran" / "passt zu dem, woran wir
+   arbeiten" / "in Richtung dieses Ziels" / "one step closer" /
+   "moves us forward toward it". NEVER read the goal as a database
+   row. Weave it into a sentence that orbits something else.
 
 5. CONNECTIVE TISSUE. Use AT LEAST THREE spoken-language stitches
    across the two paragraphs. Examples (DE): "lass mich dir kurz
@@ -179,33 +188,46 @@ ${shapeExample}
    "so wie ich das sehe", "schön, dass du da bist", "ach, und",
    "auch noch:". Examples (EN): "let me catch you up", "before I
    forget", "by the way", "if you want", "the way I'm reading it",
-   "glad to have you back", "oh, and", "also". The output must SOUND
-   spoken aloud, not read from a screen.
+   "glad to have you back", "oh, and", "also". The output must
+   SOUND spoken aloud, not read from a screen.
 
-6. ZERO-STATE IS INVITATION, NEVER DEFICIT. If a signal is at zero
-   (e.g. diary 0 in the last 7d), phrase it as a gentle invitation
-   ("wenn du magst, halten wir am Ende des Tages in zwei Sätzen
-   fest" / "if you want, we can capture two lines about today at
-   the end"). NEVER as a deficit ("du hast noch keinen Eintrag
-   für heute" / "you haven't made an entry"). Same for every
-   other empty or zero count — invite, never accuse.
+6. SETUP-GAP IS INVITATION, NEVER DEFICIT. Each signal has a SETUP
+   STATE. When a signal is NOT SET UP (life_compass.state='not_set',
+   vitana_index.state='not_set_up', autopilot.state='none_yet',
+   diary_last_7d=0), phrase as a gentle invitation: "mir ist
+   aufgefallen, dass dein Life Compass noch nicht eingerichtet ist —
+   magst du, dass wir das gleich gemeinsam machen?" / "your Life
+   Compass isn't set up yet — want us to do that together right now?".
+   NEVER as a deficit ("du hast keinen Index" / "you don't have an
+   Index"). Each setup invitation must explicitly OFFER PARTNERSHIP
+   ("gemeinsam" / "zusammen" / "together") and propose taking the
+   next step now or naming a moment to come back to it. This is the
+   coaching move — every gap is an opportunity for Vitana to guide.
 
-7. NAMED CONCRETE CLOSE. The closing line proposes ONE specific
-   first move, tied to a real signal in the payload, NAMING it.
-   GOOD: "Soll ich dir die zwei Nachrichten vorlesen?" / "Want me
-   to walk you through the two messages first?". FORBIDDEN: "Was
-   möchtest du zuerst machen?" / "What would you like to do first?"
-   / "How can I help you?" / "Wie kann ich dir helfen?" / any
-   generic menu offer that hands the decision back to the user
-   without naming a thing.
+7. NAMED CONCRETE CLOSE WITH AUTOPILOT PRIORITY. The closing line
+   proposes ONE specific first move, tied to a real signal, NAMING
+   it. PRIORITY ORDER:
+     a. If \`autopilot.today_checkpoint\` exists → name its title and
+        offer to start: "ich hab den nächsten Schritt für dich
+        vorbereitet: [title]. Soll ich's starten?" / "I've prepared
+        the next step for you: [title]. Want me to start it?".
+     b. Else if any setup gap is open → close on the setup invitation
+        from Rule 6.
+     c. Else if calendar_today.next exists → offer prep: "soll ich
+        dir kurz die Vorbereitung für [title] rauslegen?".
+     d. Else if messages_unread > 0 → offer to walk through.
+     e. Else open question: "womit darf ich dir zuerst zur Hand
+        gehen, [first specific named option] oder [second named
+        option]?". NEVER a bare "Was möchtest du tun?".
+   FORBIDDEN: generic "Was möchtest du zuerst machen?" / "What would
+   you like to do first?" / "How can I help you?".
 
 8. PARAGRAPH BREAK. Speak TWO short paragraphs with a real breath
    between them. NEVER one wall of facts. Paragraph 1 anchors:
-   greeting + warmth + minded-the-shop transition + index-with-
-   meaning + goal-as-North-Star + one concrete offer toward the
-   goal. Paragraph 2 catches up: the most informative remaining
-   signals (calendar, messages, reminders, diary invitation if 0),
-   ending with the named close.
+   greeting + warmth + journey context + index-with-meaning + goal-
+   as-North-Star. Paragraph 2 catches up: time-sensitive signals
+   (calendar, messages, reminders) and the autopilot-or-setup-gap
+   close.
 
 9. OPINION + REASSURANCE. At least ONE clause must show a VIEW
    ("keine Wunderdiät, eine kleine Sache reicht" / "no rush, one
@@ -214,25 +236,32 @@ ${shapeExample}
    "I'll write it down for you"). Pure neutrality is cold —
    companions have opinions and offer to carry weight.
 
-## PAYLOAD COVERAGE (woven, never listed)
+10. COVERAGE ENFORCEMENT. Before you stop speaking, walk the
+    COVERAGE CHECKLIST above. If any "ADDRESS" item is unanswered,
+    keep going. Below 4 sentences = contract failure. The shape
+    example covers FIVE signals; aim for similar breadth.
 
-Use every payload key that has data. Weave them into the two
-paragraphs. Suggested order, but the paragraphs FLOW — they are
-never a sequenced list:
-  a. vitana_index — paired with meaning + pillar (Rule 3).
-  b. life_compass — anchor, North Star (Rule 4).
-  c. calendar_today — next event by title + local time, OR "kein
-     Termin heute" if empty; passed events only if informative.
-  d. autopilot_pending — count + offer to walk through.
-  e. matches_unread — offer to look together.
-  f. messages_unread — count, NEVER quote content (privacy).
-  g. reminders_today — name the next reminder.
-  h. diary_last_7d — invitational ONLY if 0; otherwise silent.
+## PAYLOAD COVERAGE — ORDER (woven, never listed)
+
+Use every payload key that has data OR has a setup gap. Weave them
+into the two paragraphs:
+  a. journey                    → P1: day + wave name (Rule 2)
+  b. vitana_index (state=ok)    → P1: number + meaning + pillar (Rule 3)
+  c. vitana_index (not_set_up)  → P2: invitation to set up (Rule 6)
+  d. life_compass (state=set)   → P1: woven anchor (Rule 4)
+  e. life_compass (not_set)     → P2: invitation to set up (Rule 6)
+  f. calendar_today             → P2: next event by title + local time
+  g. autopilot.today_checkpoint → P2: NAMED CLOSE (Rule 7a)
+  h. autopilot (none_yet)       → P2: invitation to generate first one
+  i. matches_unread > 0         → P2: offer to look together
+  j. messages_unread > 0        → P2: count only, never quote content
+  k. reminders_today.count > 0  → P2: name next reminder
+  l. diary_last_7d === 0        → P2: invitation to capture today
+  m. diary_last_7d >= 1         → silent (not noteworthy)
 
 ## HARD RULES (NEVER VIOLATE)
 
   - NEVER recite signals as a bulleted list. Speak in flowing paragraphs.
-  - NEVER mention a signal that has empty / null data in the payload.
   - NEVER fabricate names, titles, or counts not in the payload.
   - NEVER use the word "overview" / "Übersicht" / "Zusammenfassung"
     as a label.
@@ -240,18 +269,20 @@ never a sequenced list:
     "Was möchtest du zuerst machen?" as the close (Rule 7).
   - NEVER speak a number without meaning + pillar attribution (Rule 3).
   - NEVER read the Life Compass goal as a database row (Rule 4).
-  - NEVER frame a zero / empty signal as a deficit (Rule 6).
+  - NEVER frame a setup gap as a deficit (Rule 6).
+  - NEVER stop after one signal — walk the COVERAGE CHECKLIST (Rule 10).
   - NEVER lecture about Vitanaland's company / business model /
     longevity economy positioning.
 
 ## LENGTH
 
-TWO short paragraphs. Across the two: 4 to 7 sentences total. Each
+TWO short paragraphs. Across the two: 5 to 8 sentences total. Each
 clause earns its place by being concrete. Resist verbosity, but
-NEVER collapse to a single paragraph, and NEVER fewer than 4
-sentences. The shape example above is the length and pacing target.
+NEVER collapse to a single paragraph and NEVER fewer than 4
+sentences total. The shape example above is the length and pacing
+target.
 
-## STRUCTURED PAYLOAD (only keys with data are present)
+## STRUCTURED PAYLOAD
 
 \`\`\`json
 ${payloadJson}
@@ -261,17 +292,136 @@ This block OVERRIDES every other greeting rule for the first turn.
 Subsequent turns follow the normal conversation flow.`;
 }
 
-function filterEmptyPayload(p: OverviewPayload): Record<string, unknown> {
+// ---------------------------------------------------------------------------
+// Coverage checklist — computed per-payload, fed to the model as the
+// inventory of things it must address before stopping.
+// ---------------------------------------------------------------------------
+
+function buildCoverageChecklist(p: OverviewPayload): string {
+  const items: string[] = [];
+
+  if (p.journey) {
+    items.push(`- [ ] ADDRESS: journey day ${p.journey.day_in_journey} of ${p.journey.total_days}` +
+      (p.journey.current_wave ? `, currently in "${p.journey.current_wave.name}" phase` : '') +
+      ` (Rule 2 — name the day + phase in paragraph 1).`);
+  }
+
+  if (p.vitana_index.state === 'ok' && p.vitana_index.today !== null) {
+    const pillarHint = p.vitana_index.weakest_pillar
+      ? ` Weakest pillar: ${p.vitana_index.weakest_pillar.name} (${p.vitana_index.weakest_pillar.score}). Strongest: ${p.vitana_index.strongest_pillar?.name ?? 'n/a'}.`
+      : '';
+    const trendHint = p.vitana_index.trend_7d !== null
+      ? ` 7-day trend: ${p.vitana_index.trend_7d >= 0 ? '+' : ''}${p.vitana_index.trend_7d}.`
+      : '';
+    items.push(`- [ ] ADDRESS: Vitana Index ${p.vitana_index.today} (${p.vitana_index.tier ?? 'tier unknown'}, ${p.vitana_index.balance_label ?? 'balance unknown'}).${pillarHint}${trendHint} (Rule 3 — pair number with meaning + pillar attribution.)`);
+  } else {
+    items.push(`- [ ] ADDRESS: Vitana Index is NOT SET UP — invite the user to set it up together (Rule 6, P2).`);
+  }
+
+  if (p.life_compass.state === 'set' && p.life_compass.primary_goal) {
+    const progressHint = p.life_compass.goal_progress_pct !== null
+      ? ` Time progress: ${p.life_compass.goal_progress_pct}%.`
+      : '';
+    const deadlineHint = p.life_compass.days_to_deadline !== null
+      ? ` Days to deadline: ${p.life_compass.days_to_deadline}.`
+      : '';
+    items.push(`- [ ] ADDRESS: Life Compass goal "${p.life_compass.primary_goal}" verbatim.${progressHint}${deadlineHint} (Rule 4 — North Star, woven not listed.)`);
+  } else {
+    items.push(`- [ ] ADDRESS: Life Compass is NOT SET — invite the user to set it up together (Rule 6, P2).`);
+  }
+
+  if (p.calendar_today.count > 0 && p.calendar_today.next) {
+    items.push(`- [ ] ADDRESS: ${p.calendar_today.count} event(s) today. Next: "${p.calendar_today.next.title}" at ${p.calendar_today.next.start_iso}. (P2 — name title + local time.)`);
+  }
+
+  if (p.calendar_passed.count > 0 && p.calendar_passed.most_recent) {
+    items.push(`- [ ] MAY ADDRESS: ${p.calendar_passed.count} event(s) since last session — most recent "${p.calendar_passed.most_recent.title}". (Only mention if it's informative.)`);
+  }
+
+  if (p.autopilot.state === 'has_actions' && p.autopilot.today_checkpoint) {
+    items.push(`- [ ] ADDRESS (CLOSE): Autopilot has prepared "${p.autopilot.today_checkpoint.title}" for the user — name it and offer to start it (Rule 7a — this becomes the NAMED CLOSE).`);
+  } else if (p.autopilot.state === 'none_yet') {
+    items.push(`- [ ] ADDRESS: Autopilot has not generated any recommendations yet — invite the user to set up their first one (Rule 6, P2).`);
+  }
+
+  if (p.matches_unread > 0) {
+    items.push(`- [ ] ADDRESS: ${p.matches_unread} unread match notification(s) — offer to look together. (P2.)`);
+  }
+
+  if (p.messages_unread > 0) {
+    items.push(`- [ ] ADDRESS: ${p.messages_unread} unread message(s) — count only, NEVER quote content. (P2.)`);
+  }
+
+  if (p.reminders_today.count > 0 && p.reminders_today.next) {
+    items.push(`- [ ] ADDRESS: ${p.reminders_today.count} reminder(s) due today. Next: "${p.reminders_today.next.action_text}" at ${p.reminders_today.next.next_fire_at}. (P2.)`);
+  }
+
+  if (p.diary_last_7d === 0) {
+    items.push(`- [ ] ADDRESS: 0 diary entries in the last 7 days — invite a brief entry, gently (Rule 6, P2).`);
+  }
+
+  if (items.length === 0) {
+    return '- [ ] (No applicable items — speak a warm short greeting and ask the user what they want to focus on.)';
+  }
+
+  return items.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Compact payload — what we hand to the model as the structured data
+// block. Strips truly-empty fields, keeps setup-state markers intact.
+// ---------------------------------------------------------------------------
+
+function compactPayloadForPrompt(p: OverviewPayload): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  if (p.vitana_index) out.vitana_index = p.vitana_index;
-  if (p.life_compass) out.life_compass = p.life_compass;
+  if (p.journey) out.journey = p.journey;
+  if (p.vitana_index.state === 'ok') {
+    out.vitana_index = {
+      today: p.vitana_index.today,
+      tier: p.vitana_index.tier,
+      tier_framing: p.vitana_index.tier_framing,
+      trend_7d: p.vitana_index.trend_7d,
+      weakest_pillar: p.vitana_index.weakest_pillar,
+      strongest_pillar: p.vitana_index.strongest_pillar,
+      balance_label: p.vitana_index.balance_label,
+      pillars: p.vitana_index.pillars,
+      projected_day_90: p.vitana_index.projected_day_90,
+      projected_day_90_tier: p.vitana_index.projected_day_90_tier,
+    };
+  } else {
+    out.vitana_index = { state: p.vitana_index.state };  // signals setup gap
+  }
+  if (p.life_compass.state === 'set') {
+    out.life_compass = {
+      primary_goal: p.life_compass.primary_goal,
+      category: p.life_compass.category,
+      target_date: p.life_compass.target_date,
+      target_value: p.life_compass.target_value,
+      target_unit: p.life_compass.target_unit,
+      starting_value: p.life_compass.starting_value,
+      days_to_deadline: p.life_compass.days_to_deadline,
+      goal_progress_pct: p.life_compass.goal_progress_pct,
+    };
+  } else {
+    out.life_compass = { state: 'not_set' };  // signals setup gap
+  }
   if (p.calendar_today.count > 0 || p.calendar_today.next) out.calendar_today = p.calendar_today;
   if (p.calendar_passed.count > 0 || p.calendar_passed.most_recent) out.calendar_passed = p.calendar_passed;
-  if (p.autopilot_pending.count > 0 || p.autopilot_pending.top) out.autopilot_pending = p.autopilot_pending;
+  if (p.autopilot.state === 'has_actions') {
+    if (p.autopilot.today_checkpoint || p.autopilot.pending_total > 0) {
+      out.autopilot = {
+        today_checkpoint: p.autopilot.today_checkpoint,
+        this_week: p.autopilot.this_week,
+        pending_total: p.autopilot.pending_total,
+      };
+    }
+  } else {
+    out.autopilot = { state: 'none_yet' };  // signals setup gap
+  }
   if (p.matches_unread > 0) out.matches_unread = p.matches_unread;
   if (p.messages_unread > 0) out.messages_unread = p.messages_unread;
   if (p.reminders_today.count > 0 || p.reminders_today.next) out.reminders_today = p.reminders_today;
-  out.diary_last_7d = p.diary_last_7d; // include for the "invite an entry" case
+  out.diary_last_7d = p.diary_last_7d;
   if (p.last_session_date_user_tz) out.last_session_date_user_tz = p.last_session_date_user_tz;
   return out;
 }

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-return.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-return.ts
@@ -541,10 +541,22 @@ export function makeNewDayReturnProvider(
         // salutation directive — it composes a polite warm greeting from
         // empty payload. Better than dropping the candidate entirely.
         broadPayload = {
-          vitana_index: null, life_compass: null,
+          journey: null,
+          vitana_index: {
+            state: 'not_set_up' as const, today: null, tier: null, tier_framing: null,
+            trend_7d: null, weakest_pillar: null, strongest_pillar: null,
+            balance_label: null, pillars: null,
+            projected_day_90: null, projected_day_90_tier: null,
+          },
+          life_compass: {
+            state: 'not_set' as const, primary_goal: null, category: null,
+            target_date: null, target_value: null, target_unit: null,
+            starting_value: null, set_at: null,
+            days_to_deadline: null, goal_progress_pct: null,
+          },
           calendar_today: { count: 0, next: null },
           calendar_passed: { count: 0, most_recent: null },
-          autopilot_pending: { count: 0, top: null },
+          autopilot: { state: 'none_yet' as const, today_checkpoint: null, this_week: [], pending_total: 0 },
           matches_unread: 0, messages_unread: 0,
           reminders_today: { count: 0, next: null },
           diary_last_7d: 0,


### PR DESCRIPTION
## Summary

Two independent fixes that share one focused file rewrite.

### 1. Alignment with the My Journey screen

The voice payload was running its own SQL against `life_compass`, `vitana_index_scores`, and `autopilot_recommendations` — so voice and the visual `/autopilot` screen could disagree on the same signal. Replaced with the **same data services** the screen uses:

- `getJourneyState` (services/journey/user-journey-service)
- `fetchLifeCompass` (services/user-context-profiler)
- `fetchVitanaIndexForProfiler` (services/user-context-profiler)

Plus mirrored the screen's autopilot query (top-by-impact_score, status='new') — bucketed for voice into `today_checkpoint` + `this_week`.

**Bonus bug fix:** the old aggregator queried `autopilot_recommendations.status='pending'` — that string never exists in the column (real default is `'new'`). Dead code path, confirmed via `SELECT status, COUNT(*)`.

Voice is now a **superset** of the screen: speaks everything the screen renders, plus the time-sensitive things only voice has time to surface (calendar, messages, reminders, diary).

### 2. Early-stop + missing-data fallback

On the @Dragan3 runtime test, the VTID-03170 contract correctly fixed tone but the model stopped after warmth + interpreted-Index — coverage of remaining signals was style guidance, not a hard rule. Three prompt fixes:

- **COVERAGE CHECKLIST** computed per-payload and fed to the model as the inventory of items it must address before stopping. Each `[ ]` item rendered with the actual data the model needs. *"If any item is unanswered, KEEP GOING."* Floor: 4 sentences minimum.
- **SETUP-GAP IS INVITATION** (the user's feature #1). Every signal carries a setup-state. When `life_compass.state='not_set'` / `vitana_index.state='not_set_up'` / `autopilot.state='none_yet'` / `diary_last_7d=0`, the prompt requires a partnership invitation — *"magst du, dass wir das gleich gemeinsam machen?"* — never a deficit framing.
- **AUTOPILOT-WAITING CLOSE** (the user's feature #3). When `autopilot.today_checkpoint` exists, the closing line names that checkpoint and offers to start it: *"ich hab den nächsten Schritt für dich vorbereitet: [title]. Soll ich's starten?"*. Replaces the generic menu offer as the priority close.

The shape example now demonstrates covering FIVE signals across two paragraphs (journey day + index + goal + calendar + autopilot close) — teaches the model the breadth, not just the tone.

## Files

- `new-day-overview-payload.ts` — full rewrite around shared services
- `new-day-overview-prompt.ts` — adds COVERAGE CHECKLIST + ten composition moves + setup-gap rule + autopilot-close priority
- `new-day-return.ts` — minor: fallback payload shape updated

## Test plan

- [x] `npm run build` green
- [x] `npx jest test/services/assistant-continuation/providers/{new-day-return,new-day-overview-aggregator}.test.ts` — 43/43 green
- [ ] Runtime on @Dragan3: expect 2 paragraphs covering journey day, Index with interpretation, goal as North Star, calendar/messages, and a NAMED autopilot close (or partnership invitation when setup is missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)