### PR TITLE
feat(ops): CI smoke + daily health alert for welcome-greeting trigger (VTID-03089)

### DIFF
--- a/.github/workflows/ALERT-WELCOME-GREETING-HEALTH.yml
+++ b/.github/workflows/ALERT-WELCOME-GREETING-HEALTH.yml
@@ -1,0 +1,81 @@
+name: Alert — Welcome Greeting Production Health
+
+# VTID-03089: independent daily heartbeat. Compares actual signups vs actual
+# welcome greetings fired in the last 24 hours. If signups happened but the
+# trigger produced zero greetings, fail the run so the alarm lights up.
+#
+# This is the second layer on top of SMOKE-WELCOME-GREETING.yml: smoke test
+# proves the trigger CODE works on synthetic data; this alert proves the
+# trigger is firing on REAL traffic.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # 09:00 CET daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install psql
+        run: sudo apt-get install -y postgresql-client > /dev/null 2>&1
+
+      - name: Compare last-24h signups vs greetings
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          OUTPUT=$(psql "$SUPABASE_DB_URL" -t -A -F '|' <<'EOF'
+          WITH window AS (SELECT now() - interval '24 hours' AS since),
+          stats AS (
+            SELECT
+              (SELECT COUNT(*) FROM public.app_users u
+                WHERE u.created_at >= (SELECT since FROM window)
+                  AND u.user_id <> '00000000-0000-0000-0000-000000000001'::uuid
+              ) AS signups_24h,
+              (SELECT COUNT(DISTINCT sender_id) FROM public.chat_messages
+                WHERE created_at >= (SELECT since FROM window)
+                  AND metadata->>'source' = 'welcome_chat'
+                  AND metadata->>'trigger' = 'db_trigger_on_membership'
+              ) AS unique_senders_24h,
+              (SELECT COUNT(*) FROM public.app_users u
+                WHERE u.created_at >= (SELECT since FROM window)
+                  AND COALESCE(u.welcome_chat_sent, false) = false
+                  AND u.user_id <> '00000000-0000-0000-0000-000000000001'::uuid
+              ) AS unflagged_recent_users
+          )
+          SELECT signups_24h, unique_senders_24h, unflagged_recent_users FROM stats;
+          EOF
+          )
+
+          # Parse "signups|senders|unflagged".
+          LINE=$(echo "$OUTPUT" | grep -v '^$' | tail -1)
+          SIGNUPS=$(echo "$LINE" | cut -d'|' -f1 | tr -d ' \r')
+          SENDERS=$(echo "$LINE" | cut -d'|' -f2 | tr -d ' \r')
+          UNFLAGGED=$(echo "$LINE" | cut -d'|' -f3 | tr -d ' \r')
+
+          echo "Last 24h: $SIGNUPS signups, $SENDERS distinct trigger-fired senders, $UNFLAGGED unflagged recent users"
+
+          if ! [[ "$SIGNUPS" =~ ^[0-9]+$ ]] || ! [[ "$SENDERS" =~ ^[0-9]+$ ]] || ! [[ "$UNFLAGGED" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not parse health output. Raw: $OUTPUT"
+            exit 1
+          fi
+
+          # Two failure modes worth alarming:
+          #   * Signups happened, but the trigger emitted zero greetings.
+          #   * Any user from the last 24h still has welcome_chat_sent=false.
+          # Either signals a broken trigger or someone reintroducing the
+          # endpoint-attachment regression.
+          if [ "$SIGNUPS" -gt "0" ] && [ "$SENDERS" -eq "0" ]; then
+            echo "::error::$SIGNUPS new signups in last 24h but ZERO trigger-fired greetings. Trigger likely broken or disabled."
+            exit 1
+          fi
+          if [ "$UNFLAGGED" -gt "0" ]; then
+            echo "::error::$UNFLAGGED users registered in the last 24h still have welcome_chat_sent=false. Greeting fan-out is silently failing for them."
+            exit 1
+          fi
+
+          echo "✓ Healthy: every recent signup got greeted by the trigger."

--- a/.github/workflows/SMOKE-WELCOME-GREETING.yml
+++ b/.github/workflows/SMOKE-WELCOME-GREETING.yml
@@ -1,0 +1,83 @@
+name: Smoke — Welcome Greeting Trigger
+
+# VTID-03089: regression guard for the welcome-chat DB trigger.
+# Mints a synthetic user inside a transaction, asserts the trigger fires
+# at least one chat_messages row, then ROLLBACKs so no real DB state changes.
+#
+# Triggered:
+#   * After every successful EXEC-DEPLOY (workflow_run)
+#   * Daily at 07:00 UTC (cron) as an independent heartbeat
+#   * On demand (workflow_dispatch)
+#
+# Failure semantics: a 0-row count = the trigger is broken or missing → exit 1
+# so the deploy lights up red. This is the alarm I should have had on May 18.
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Exec Deploy (VTID Bridge)"]
+    types: [completed]
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    # Skip when EXEC-DEPLOY itself failed — only check on green deploys.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install psql
+        run: sudo apt-get install -y postgresql-client > /dev/null 2>&1
+
+      - name: Smoke — trigger fires inside transaction
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          TEST_UUID=$(uuidgen)
+          TENANT_ID='2e7528b8-472a-4356-88da-0280d4639cce'
+          echo "Synthetic user: $TEST_UUID"
+          echo "Tenant:         $TENANT_ID"
+
+          # Run setup + assertion + ROLLBACK in a single psql session so the
+          # trigger sees the user_tenants insert and our SELECT runs in the
+          # same transaction. ROLLBACK at the end removes every row the
+          # trigger created so production is untouched.
+          OUTPUT=$(psql "$SUPABASE_DB_URL" -t -A <<EOF
+          BEGIN;
+          INSERT INTO public.app_users (user_id, display_name, welcome_chat_sent)
+          VALUES ('$TEST_UUID', 'CI Smoke Test User', false);
+          INSERT INTO public.user_tenants (user_id, tenant_id, is_primary)
+          VALUES ('$TEST_UUID', '$TENANT_ID', true);
+          SELECT COUNT(*) AS smoke_msgs
+            FROM public.chat_messages
+           WHERE sender_id = '$TEST_UUID'
+             AND metadata->>'source' = 'welcome_chat'
+             AND metadata->>'trigger' = 'db_trigger_on_membership';
+          ROLLBACK;
+          EOF
+          )
+
+          # psql -t -A prints the count on its own line (no headers, no
+          # alignment). Take the LAST non-empty line as the result so any
+          # stray NOTICE noise from the trigger doesn't break parsing.
+          COUNT=$(echo "$OUTPUT" | grep -v '^$' | tail -1 | tr -d ' \r')
+          echo "Smoke result: $COUNT chat_messages would have been inserted by the trigger"
+
+          if ! [[ "$COUNT" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not parse trigger smoke output. Raw: $OUTPUT"
+            exit 1
+          fi
+          if [ "$COUNT" -lt "1" ]; then
+            echo "::error::Welcome-chat trigger did NOT fire — regression detected. Expected >=1 chat_messages row."
+            echo "::error::Either the trigger welcome_chat_on_primary_membership is missing, disabled, or its function body is broken."
+            exit 1
+          fi
+
+          echo "✓ Trigger fired $COUNT messages (rolled back, no production state changed)"


### PR DESCRIPTION
Two regression guards on top of the trigger from PR #2355. Smoke runs after every EXEC-DEPLOY and on a daily cron; the production health alert compares signups vs greetings every morning at 09:00 CET. Both fail the run if the trigger doesn't fire — so the next time anyone breaks the greeting, it's the deploy that turns red, not a community of confused users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)