### PR TITLE
fix(ops): smoke greeting INSERT must include app_users.tenant_id (VTID-03089)

### DIFF
--- a/.github/workflows/SMOKE-WELCOME-GREETING.yml
+++ b/.github/workflows/SMOKE-WELCOME-GREETING.yml
@@ -51,8 +51,8 @@ jobs:
           # trigger created so production is untouched.
           OUTPUT=$(psql "$SUPABASE_DB_URL" -t -A <<EOF
           BEGIN;
-          INSERT INTO public.app_users (user_id, display_name, welcome_chat_sent)
-          VALUES ('$TEST_UUID', 'CI Smoke Test User', false);
+          INSERT INTO public.app_users (user_id, tenant_id, display_name, welcome_chat_sent)
+          VALUES ('$TEST_UUID', '$TENANT_ID', 'CI Smoke Test User', false);
           INSERT INTO public.user_tenants (user_id, tenant_id, is_primary)
           VALUES ('$TEST_UUID', '$TENANT_ID', true);
           SELECT COUNT(*) AS smoke_msgs


### PR DESCRIPTION
First smoke run hit `null value in column tenant_id of relation app_users violates not-null constraint`. Add tenant_id to the synthetic INSERT.