### PR TITLE
fix(ci): RUN-MIGRATION.yml fails loudly on psql errors (VTID-03174)

### DIFF
--- a/.github/workflows/RUN-MIGRATION.yml
+++ b/.github/workflows/RUN-MIGRATION.yml
@@ -7,6 +7,16 @@ on:
         required: true
         default: 'supabase/migrations/20260321000000_community_user_analyzer.sql'
 
+# VTID-03174: hardened so a psql ERROR fails the step.
+# Prior to this commit, the workflow ran `psql ... -f file.sql` without
+# `-v ON_ERROR_STOP=1`, so psql exited 0 after any SQL error and the shell
+# unconditionally echoed "Migration applied successfully" — producing a
+# green workflow even when the entire transaction had rolled back. See the
+# VTID-03165 incident on 2026-05-28 where the in-migration drift guard
+# RAISEd, the BEGIN..COMMIT rolled back, no DDL applied, and the workflow
+# reported success. A green migration workflow that rolled back is worse
+# than a red one.
+
 jobs:
   migrate:
     runs-on: ubuntu-latest
@@ -16,16 +26,23 @@ jobs:
       - name: Apply migration
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+          MIGRATION_FILE: ${{ inputs.migration_file }}
         run: |
+          set -euo pipefail
           sudo apt-get install -y postgresql-client > /dev/null 2>&1
-          echo "Applying migration: ${{ inputs.migration_file }}"
-          psql "$SUPABASE_DB_URL" -f "${{ inputs.migration_file }}"
+          echo "Applying migration: ${MIGRATION_FILE}"
+          # `-v ON_ERROR_STOP=1` makes psql abort + exit nonzero on the first
+          # SQL error. `set -euo pipefail` makes the bash step abort + fail
+          # the GitHub Actions step on that nonzero exit. The "successfully"
+          # marker is only emitted if both psql and bash returned 0.
+          psql -v ON_ERROR_STOP=1 -f "${MIGRATION_FILE}" "${SUPABASE_DB_URL}"
           echo "Migration applied successfully"
 
       - name: Reload PostgREST schema cache
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
+          set -euo pipefail
           echo "Reloading PostgREST schema cache..."
-          psql "$SUPABASE_DB_URL" -c "NOTIFY pgrst, 'reload schema';"
+          psql -v ON_ERROR_STOP=1 -c "NOTIFY pgrst, 'reload schema';" "${SUPABASE_DB_URL}"
           echo "Schema cache reload signal sent"


### PR DESCRIPTION
## Why

`RUN-MIGRATION.yml` was reporting **success** on workflow runs where the SQL migration had actually **rolled back**. A green migration workflow that rolled back is worse than a red one.

### Concrete incident (2026-05-28)

VTID-03165 fired the in-migration drift guard, which `RAISE EXCEPTION`'d. Postgres rolled back the entire `BEGIN..COMMIT` transaction, no DDL applied. Workflow reported `completed: success` for several minutes before someone read the logs and realized the migration had failed. That delay is the kind of cliff this prevents.

### Root cause

```yaml
# old:
psql "$SUPABASE_DB_URL" -f "${{ inputs.migration_file }}"
echo "Migration applied successfully"
```

1. `psql` without `-v ON_ERROR_STOP=1` continues after errors and **exits 0** when its input ends.
2. `bash` step has implicit `-e` from GitHub Actions but `psql` returned 0, so nothing fails.
3. The trailing `echo` runs unconditionally → workflow green.

## What this changes

```yaml
# new:
set -euo pipefail
...
psql -v ON_ERROR_STOP=1 -f "${MIGRATION_FILE}" "${SUPABASE_DB_URL}"
echo "Migration applied successfully"
```

- `set -euo pipefail` — bash step aborts on any nonzero command, undefined var, or pipeline failure.
- `psql -v ON_ERROR_STOP=1` — psql aborts + exits nonzero on the first SQL error.
- The success echo only emits if both psql and bash returned 0.
- Migration file path moved to a `MIGRATION_FILE` env var instead of bash-interpolating the workflow input, so quoting is consistent and there's a single substitution point.
- Same treatment applied to the PostgREST schema cache reload step.

## Test plan

- [ ] CI: validate check passes.
- [ ] Operator-side smoke: dispatch this workflow against a SQL file that intentionally `RAISE EXCEPTION`s on line 1 (e.g. `SELECT 1/0;`) — workflow must now report `failure`, not `success`.
- [ ] Operator-side smoke: dispatch against a known-good migration — workflow still reports `success`.

(I'm not dispatching either smoke from this PR — that goes through `RUN-MIGRATION.yml` which is exactly what we're hardening. Operator runs both confirmations after merge.)

## Scope

Workflow file only. No DDL, no service code, no Cloud Run deploy. `AUTO-DEPLOY.yml` doesn't trigger on `.github/workflows/**` changes.

## Related

- Surfaced during VTID-03165 incident (#2347, reverted in #2361).
- Hard prerequisite for the next migration attempt — gated per operator instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)