### PR TITLE
feat(d39): route simplicity scoring through compatibility resolver (VTID-03182)

### DIFF
--- a/services/gateway/src/services/d39-taste-alignment-service.ts
+++ b/services/gateway/src/services/d39-taste-alignment-service.ts
@@ -22,6 +22,13 @@
 
 import { emitOasisEvent } from './oasis-event-service';
 import { CicdEventType } from '../types/cicd';
+// VTID-03182 (D39 PR 5d — vertical proof): simplicity scoring now
+// reads through the compatibility-resolver boundary. The cold
+// fallback in the resolver is byte-identical to the inline scoreMap
+// this function used to carry, so behaviour is unchanged at rollout.
+// Other 8 D39 scoring functions still use inline literals; PR 5e
+// sweeps them.
+import { getCompatibilityResolver } from './decision-contract';
 import {
   TasteProfile,
   LifestyleProfile,
@@ -141,15 +148,22 @@ function scoreSimplicityAlignment(
   userPref: SimplicityPreference,
   actionComplexity: 'simple' | 'moderate' | 'complex' | undefined
 ): number {
-  if (!actionComplexity) return 0.5; // Neutral if unknown
-
-  const scoreMap: Record<SimplicityPreference, Record<string, number>> = {
-    minimalist: { simple: 1.0, moderate: 0.6, complex: 0.2 },
-    balanced: { simple: 0.7, moderate: 1.0, complex: 0.7 },
-    comprehensive: { simple: 0.4, moderate: 0.7, complex: 1.0 }
-  };
-
-  return scoreMap[userPref][actionComplexity] ?? 0.5;
+  // Neutral if the candidate carries no complexity attribute.
+  // Preserved at the call-site so we don't push `undefined` through
+  // the resolver's typed string-key API.
+  if (!actionComplexity) return 0.5;
+  // VTID-03182 (D39 PR 5d): score lookup now lives behind the
+  // compatibility-resolver boundary. The resolver's cold-cache
+  // fallback is byte-identical to the inline scoreMap this function
+  // used to carry, and its final `?? 0.5` tail matches the old
+  // unknown-key behaviour. No tenant context is threaded here; the
+  // scoring function signature does not (yet) carry tenant scope —
+  // that widening lands when a caller actually wants per-tenant D39.
+  return getCompatibilityResolver().getCompatibilityScore(
+    'simplicity',
+    userPref,
+    actionComplexity,
+  );
 }
 
 /**

--- a/services/gateway/test/services/decision-contract/compatibility-resolver-boundary.test.ts
+++ b/services/gateway/test/services/decision-contract/compatibility-resolver-boundary.test.ts
@@ -68,19 +68,19 @@ describe('VTID-03171 D39 PR 5c — compatibility resolver boundary', () => {
     });
   });
 
-  describe('no D39 consumer reads the resolver yet (PR 5d/5e territory)', () => {
-    it('d39-taste-alignment-service.ts does not import the resolver', () => {
-      const src = readFileSync(D39_SERVICE_PATH, 'utf8');
-      // Forbidden: any import-like reference to the new resolver
-      // module or its public surface.
-      expect(src).not.toMatch(/from\s+['"][^'"]*compatibility-resolver['"]/);
-      expect(src).not.toMatch(/getCompatibilityResolver\s*\(/);
-      expect(src).not.toMatch(/getCompatibilityScore\s*\(/);
-      expect(src).not.toMatch(/getCompatibilityMatrix\s*\(/);
-      expect(src).not.toMatch(/warmCompatibilityCache\s*\(/);
-    });
+  describe('D39 consumer surface (per-PR contract)', () => {
+    // Originally written for PR 5c ("no D39 consumer reads the
+    // resolver yet"). Updated for PR 5d (VTID-03182) which migrated
+    // ONLY scoreSimplicityAlignment behind the resolver. The
+    // per-function vertical-proof assertions live in
+    // `d39-pr5d-simplicity-vertical-proof.test.ts`; this file keeps
+    // only the wider boundary guards that apply across the PR 5d-g
+    // sweep.
 
     it('taste-alignment routes do not import the resolver', () => {
+      // No route handler should reach the resolver directly — the
+      // service layer is the only consumer. This stays true for
+      // every PR in the 5d-g sweep.
       const src = readFileSync(D39_ROUTE_PATH, 'utf8');
       expect(src).not.toMatch(/from\s+['"][^'"]*compatibility-resolver['"]/);
       expect(src).not.toMatch(/getCompatibilityResolver\s*\(/);
@@ -88,10 +88,13 @@ describe('VTID-03171 D39 PR 5c — compatibility resolver boundary', () => {
       expect(src).not.toMatch(/getCompatibilityMatrix\s*\(/);
     });
 
-    it("d39-taste-alignment-service.ts still uses inline scoreMap literals (proves PR 5d hasn't shipped)", () => {
-      // Sanity-check the wiring hasn't drifted in some other PR while
-      // PR 5c is in flight. The vertical proof in PR 5d will flip
-      // these to resolver calls.
+    it("d39-taste-alignment-service.ts still carries inline scoreMap literals for the un-migrated dimensions (proves PR 5e hasn't shipped)", () => {
+      // PR 5d migrated only simplicity. The remaining 8 functions
+      // still own their inline literals; PR 5e will sweep them.
+      // The per-function "still has inline literal" assertions live
+      // in d39-pr5d-simplicity-vertical-proof.test.ts. This is a
+      // cross-cut sanity check that *some* inline scoreMap remains
+      // in the file.
       const src = readFileSync(D39_SERVICE_PATH, 'utf8');
       expect(src).toMatch(/const\s+scoreMap\s*:\s*Record</);
     });

--- a/services/gateway/test/services/decision-contract/d39-pr5d-simplicity-vertical-proof.test.ts
+++ b/services/gateway/test/services/decision-contract/d39-pr5d-simplicity-vertical-proof.test.ts
@@ -1,0 +1,173 @@
+// VTID-03182 — D39 PR 5d vertical proof.
+//
+// PR 5d migrates ONLY `scoreSimplicityAlignment` to read through
+// `getCompatibilityResolver().getCompatibilityScore('simplicity', …)`.
+// All other 8 D39 scoring functions still use their inline scoreMap
+// literals; PR 5e sweeps them next.
+//
+// This test locks the vertical-proof contract:
+//   - `scoreSimplicityAlignment` no longer carries an inline numeric
+//     matrix / scoreMap literal in its body.
+//   - The service imports `getCompatibilityResolver` from the
+//     decision-contract barrel.
+//   - The other 8 scoring functions STILL carry their inline
+//     scoreMap / compatibilityMap literals (proves PR 5e hasn't
+//     drifted in by accident).
+//   - The early-return `if (!actionComplexity) return 0.5;` short-
+//     circuit is preserved at the call-site (so we don't push
+//     `undefined` through the resolver's typed string-key API).
+//
+// Behavioural parity is locked by the existing 52-test
+// `test/d39-taste-alignment.test.ts` suite — those tests exercise
+// every simplicity combination via the public `calculateAlignmentScore`
+// / `scoreActions` entry-points and stay green after this refactor.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const D39_SERVICE_PATH = join(
+  __dirname,
+  '../../../src/services/d39-taste-alignment-service.ts',
+);
+
+/** Extract a top-level `function NAME(...): ReturnType { ... }` body
+ *  from the source. After the parameter list closes, the very next
+ *  `{` at brace-depth 0 is the body opener — TS scoring functions
+ *  here all use simple primitive return types (`number`) so we don't
+ *  need to defend against return-type object literals. */
+function extractFunctionBody(src: string, name: string): string {
+  const sigRegex = new RegExp(
+    `(?:export\\s+)?(?:async\\s+)?function ${name}\\s*\\(`,
+  );
+  const sigMatch = sigRegex.exec(src);
+  if (!sigMatch) throw new Error(`function ${name} not found in source`);
+  // Step 1: walk parens to skip the parameter list.
+  let i = sigMatch.index + sigMatch[0].length - 1;
+  let parens = 0;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '(') parens++;
+    else if (c === ')') {
+      parens--;
+      if (parens === 0) { i++; break; }
+    }
+    i++;
+  }
+  // Step 2: skip forward to the next `{` — that's the body brace.
+  while (i < src.length && src[i] !== '{') i++;
+  if (i === src.length) {
+    throw new Error(`body brace not found for ${name}`);
+  }
+  const bodyStart = i + 1;
+  // Step 3: walk braces to find the matching `}`.
+  let braceDepth = 1;
+  i = bodyStart;
+  while (i < src.length && braceDepth > 0) {
+    const c = src[i];
+    if (c === '{') braceDepth++;
+    else if (c === '}') braceDepth--;
+    i++;
+  }
+  return src.slice(bodyStart, i - 1);
+}
+
+describe('VTID-03182 D39 PR 5d — simplicity vertical proof', () => {
+  let src: string;
+  let simplicityBody: string;
+  beforeAll(() => {
+    src = readFileSync(D39_SERVICE_PATH, 'utf8');
+    simplicityBody = extractFunctionBody(src, 'scoreSimplicityAlignment');
+  });
+
+  describe('positive contract — simplicity now reads through the resolver', () => {
+    it('imports getCompatibilityResolver from the decision-contract barrel', () => {
+      expect(src).toMatch(
+        /from\s+['"]\.\/decision-contract['"]/,
+      );
+      expect(src).toMatch(/getCompatibilityResolver/);
+    });
+
+    it('scoreSimplicityAlignment body calls getCompatibilityScore with the simplicity dimension', () => {
+      // Allow either single-line or multi-line argument lists for
+      // resilience against formatter changes.
+      expect(simplicityBody).toMatch(
+        /getCompatibilityResolver\s*\(\)\s*\.\s*getCompatibilityScore\s*\(\s*['"]simplicity['"]/s,
+      );
+    });
+
+    it('scoreSimplicityAlignment forwards userPref + actionComplexity (in that order)', () => {
+      expect(simplicityBody).toMatch(
+        /getCompatibilityScore\s*\(\s*['"]simplicity['"]\s*,\s*userPref\s*,\s*actionComplexity/s,
+      );
+    });
+
+    it("preserves the early-return short-circuit on undefined actionComplexity", () => {
+      // Without this, undefined would flow into the resolver's typed
+      // string-key API. The behaviour (0.5 neutral for unknown
+      // complexity) must be preserved at the call-site.
+      expect(simplicityBody).toMatch(
+        /if\s*\(\s*!\s*actionComplexity\s*\)\s*return\s+0\.5/,
+      );
+    });
+  });
+
+  describe('negative contract — no inline simplicity scoreMap in the function body', () => {
+    it("scoreSimplicityAlignment body does NOT declare a `scoreMap: Record<…>` literal", () => {
+      // The whole point of the vertical proof: the body must not
+      // carry the inline matrix anymore.
+      expect(simplicityBody).not.toMatch(/scoreMap\s*:\s*Record</);
+      // Defensive: also catches a plain `const scoreMap = { … }`
+      expect(simplicityBody).not.toMatch(/const\s+scoreMap/);
+    });
+
+    it('does NOT carry any of the simplicity cell values inline anymore', () => {
+      // Pre-PR-5d this function literally contained `simple: 1.0`,
+      // `moderate: 0.6`, `complex: 0.2`, etc. After PR 5d, all the
+      // numeric matrix data lives in the resolver / table.
+      for (const lit of ['simple:', 'moderate:', 'complex:']) {
+        expect(simplicityBody).not.toContain(lit);
+      }
+    });
+  });
+
+  describe('scope discipline — only simplicity migrated', () => {
+    // Each tuple: [scoring-function-name, profile-type the inline
+    // literal is keyed on]. The vertical proof asserts each of the
+    // 8 untouched scoring functions still owns its inline literal
+    // and does NOT yet call the resolver.
+    const OTHER_FUNCTIONS: Array<[string, string]> = [
+      ['scorePremiumAlignment',     'PremiumOrientation'],
+      ['scoreAestheticAlignment',   'AestheticStyle'],
+      ['scoreToneAlignment',        'ToneAffinity'],
+      ['scoreRoutineAlignment',     'RoutineStyle'],
+      ['scoreSocialAlignment',      'SocialOrientation'],
+      ['scoreConvenienceAlignment', 'ConvenienceBias'],
+      ['scoreExperienceAlignment',  'ExperienceType'],
+      ['scoreNoveltyAlignment',     'NoveltyTolerance'],
+    ];
+
+    function escapeRegex(s: string): string {
+      return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    for (const [fnName, profileType] of OTHER_FUNCTIONS) {
+      it(`${fnName} STILL carries its inline scoreMap / compatibilityMap literal (PR 5e territory)`, () => {
+        const body = extractFunctionBody(src, fnName);
+        // The function should still own its inline literal — PR 5e
+        // hasn't shipped yet. We look for either `scoreMap:
+        // Record<<profile-type>` or `compatibilityMap:
+        // Record<<profile-type>` (aesthetic + tone use the latter).
+        const pattern = new RegExp(
+          '(scoreMap|compatibilityMap)\\s*:\\s*Record<\\s*' +
+            escapeRegex(profileType),
+        );
+        expect(body).toMatch(pattern);
+      });
+
+      it(`${fnName} does NOT call getCompatibilityScore (proves PR 5e hasn't drifted in)`, () => {
+        const body = extractFunctionBody(src, fnName);
+        expect(body).not.toMatch(/getCompatibilityScore\s*\(/);
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**D39 PR 5d — vertical proof.** Migrates ONLY `scoreSimplicityAlignment` to read through `getCompatibilityResolver().getCompatibilityScore`. All other 8 D39 scoring functions still use inline `scoreMap` literals; PR 5e sweeps them.

## Behaviour preserved byte-identically

- The resolver's cold-cache fallback for the `simplicity` dimension is **byte-identical** to the inline `scoreMap` this function used to carry (shipped in PR 5c, asserted by parity tests there)
- The resolver's final `?? 0.5` neutral default matches the old `scoreMap[userPref][actionComplexity] ?? 0.5` tail
- The `if (!actionComplexity) return 0.5;` short-circuit is preserved at the call-site so `undefined` never reaches the resolver's typed string-key API
- No tenant context is threaded — the scoring function signature does not (yet) carry tenant scope. Widening the D39 surface for per-tenant scoring lands when a caller actually asks for it.
- **52/52** existing D39 behavioural tests still green (`test/d39-taste-alignment.test.ts`)

## Wiring

`d39-taste-alignment-service.ts` now imports `getCompatibilityResolver` from `./decision-contract` (the barrel). The simplicity function body shrinks from 14 lines of inline matrix + lookup to 4 lines (early-return + resolver call).

## Tests

**New `test/services/decision-contract/d39-pr5d-simplicity-vertical-proof.test.ts`** — 22 structural assertions:

- **Positive contract**: imports `getCompatibilityResolver` from the barrel; body calls `getCompatibilityScore` with the `simplicity` dimension; forwards `(userPref, actionComplexity)` in that order; preserves the early-return short-circuit on `undefined`
- **Negative contract**: `scoreSimplicityAlignment` body no longer contains a `scoreMap: Record<...>` literal or any of the `simple:` / `moderate:` / `complex:` cell values inline
- **Scope discipline**: each of the remaining 8 scoring functions (premium / aesthetic / tone / routine / social / convenience / experience / novelty) STILL carries its inline `scoreMap` / `compatibilityMap` literal AND does NOT call `getCompatibilityScore` (catches a drift where PR 5e accidentally lands in this PR)

**Updated `test/services/decision-contract/compatibility-resolver-boundary.test.ts`** — the original PR 5c-era guards that asserted "no D39 consumer reads the resolver yet" are superseded by the new vertical-proof test. The cross-cut guards that survive every PR in the 5d-g sweep (no route reads the resolver; some inline `scoreMap` still in the file) are kept.

**334/334** D39 + decision-contract suites green (excluding the pre-existing policy-resolver cross-suite flake unrelated to this PR).

## Scope discipline

Per the PR 5d brief: vertical proof only. NO other dimension migrated. NO PR 5f policy rows touched. NO D28/D38/D47/D48 touched. NO onboarding templates. NO LiveKit / Vertex / Teacher.

## Test plan

- [x] `npm run build` clean
- [x] `npx jest test/d39-taste-alignment.test.ts` — 52/52 pass (byte-identical behaviour)
- [x] `npx jest test/services/decision-contract/d39-pr5d-simplicity-vertical-proof.test.ts` — 22/22 pass
- [x] Full D39 + decision-contract suite (excluding pre-existing policy-resolver flake) — 334/334 pass
- [ ] Auto-deploy + `/alive` 200 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)