### PR TITLE
fix(gateway): drift-proof proactive match query — stop match.proactive.error P0 (VTID-01270)

### DIFF
--- a/services/gateway/src/services/proactive-match-messenger.ts
+++ b/services/gateway/src/services/proactive-match-messenger.ts
@@ -49,13 +49,15 @@ interface MatchRow {
   target_id: string;
   score: number;
   reasons: any;
-  match_targets: {
-    display_name: string;
-    topic_keys: string[];
-    tags: string[];
-    metadata: any;
-    target_type: string;
-  };
+}
+
+interface MatchTargetRow {
+  id: string;
+  display_name: string | null;
+  topic_keys: string[] | null;
+  tags: string[] | null;
+  metadata: any;
+  target_type: string | null;
 }
 
 // =============================================================================
@@ -174,23 +176,19 @@ export async function sendProactiveMatchMessages(
       };
     }
 
-    // Step 2: Fetch top matches
+    // Step 2: Fetch top matches.
+    // NOTE: We deliberately do NOT use a PostgREST embed (match_targets!inner)
+    // here. The embed relies on PostgREST discovering the matches_daily ->
+    // match_targets FK in its schema cache. Production schema drift (FK absent
+    // on the deployed table) made that lookup fail with a PGRST200
+    // "Could not find a relationship ... in the schema cache" error, which
+    // bypassed the table-not-deployed fallback below and threw, spamming
+    // match.proactive.error. Fetching match_targets in a separate query (Step
+    // 2b) removes that dependency entirely and matches how matches_daily is
+    // read elsewhere in the gateway.
     const { data: matches, error: matchError } = await supabase
       .from('matches_daily')
-      .select(`
-        id,
-        match_type,
-        target_id,
-        score,
-        reasons,
-        match_targets!inner (
-          display_name,
-          topic_keys,
-          tags,
-          metadata,
-          target_type
-        )
-      `)
+      .select('id, match_type, target_id, score, reasons')
       .eq('user_id', user_id)
       .eq('match_date', date)
       .eq('state', 'suggested')
@@ -199,9 +197,18 @@ export async function sendProactiveMatchMessages(
       .limit(max_matches);
 
     if (matchError) {
-      // Graceful fallback if migration not deployed
-      if (matchError.message.includes('does not exist') || matchError.message.includes('relation')) {
-        console.warn(`[${VTID}] matches_daily table not available, skipping`);
+      // Graceful fallback if migration not deployed or schema drift on the
+      // matches_daily table (missing table/column/relationship). These are
+      // operational/data issues, not code faults — skip quietly instead of
+      // emitting a P0 error event.
+      const m = matchError.message || '';
+      if (
+        m.includes('does not exist') ||
+        m.includes('relation') ||
+        m.includes('Could not find') ||
+        m.includes('schema cache')
+      ) {
+        console.warn(`[${VTID}] matches_daily unavailable (schema drift?), skipping: ${m}`);
         return {
           ok: true,
           user_id,
@@ -211,7 +218,7 @@ export async function sendProactiveMatchMessages(
         };
       }
 
-      throw new Error(`Match query failed: ${matchError.message}`);
+      throw new Error(`Match query failed: ${m}`);
     }
 
     if (!matches || matches.length === 0) {
@@ -235,6 +242,37 @@ export async function sendProactiveMatchMessages(
       };
     }
 
+    // Step 2b: Fetch match target details in a separate query (no embed).
+    // Resilient to a missing/drifted matches_daily -> match_targets FK.
+    const typedMatches = matches as unknown as MatchRow[];
+    const targetIds = [...new Set(typedMatches.map((m) => m.target_id).filter(Boolean))];
+    const targetMap = new Map<string, MatchTargetRow>();
+    if (targetIds.length > 0) {
+      const { data: targets, error: targetError } = await supabase
+        .from('match_targets')
+        .select('id, display_name, topic_keys, tags, metadata, target_type')
+        .in('id', targetIds);
+
+      if (targetError) {
+        // Non-fatal: degrade to display_name fallbacks rather than dropping
+        // the whole proactive message. Only surface as an error if it is not a
+        // known schema-availability issue.
+        const tm = targetError.message || '';
+        if (
+          !tm.includes('does not exist') &&
+          !tm.includes('relation') &&
+          !tm.includes('Could not find') &&
+          !tm.includes('schema cache')
+        ) {
+          console.warn(`[${VTID}] match_targets lookup failed, using fallbacks: ${tm}`);
+        }
+      }
+
+      for (const t of (targets || []) as MatchTargetRow[]) {
+        targetMap.set(t.id, t);
+      }
+    }
+
     // Step 3: Get total count for context
     const { count: totalCount } = await supabase
       .from('matches_daily')
@@ -256,8 +294,8 @@ export async function sendProactiveMatchMessages(
     }
 
     // Step 5: Build match previews
-    const matchPreviews = (matches as unknown as MatchRow[]).map((m) => {
-      const target = m.match_targets;
+    const matchPreviews = typedMatches.map((m) => {
+      const target = targetMap.get(m.target_id);
       let displayName = target?.display_name || 'Unknown';
 
       if (m.match_type === 'person' && revealMode === 'anonymous') {


### PR DESCRIPTION
## P0: `match.proactive.error: Match query failed: Could not f…`

### Root cause
`services/gateway/src/services/proactive-match-messenger.ts` fetched matches with a PostgREST **embed**:

```ts
.from('matches_daily').select(`... match_targets!inner ( ... )`)
```

The embed depends on PostgREST discovering the `matches_daily → match_targets` foreign key in its **schema cache**. The repo defines exactly one clean FK for this relationship, so a production failure means **schema drift** — the FK is absent on the deployed table (ghost/hotfix-created table). PostgREST then returns:

```
PGRST200: Could not find a relationship between 'matches_daily' and 'match_targets' in the schema cache
```

That string (`Could not f…` in the truncated UI) matched **neither** graceful-fallback condition (`does not exist` / `relation`), so the code threw `Match query failed: …` and fired `match.proactive.error` repeatedly (5× in the visible window).

This is the same **drift family** flagged in Session 1: the embed pattern is the only `matches_daily` read in the gateway that depends on FK discovery; every other read (`gemini-operator`, `orb-live`, `connect-people`) uses plain selects and is unaffected.

### Fix (drift-proof)
- **Drop the embed.** Fetch `matches_daily` and `match_targets` in two queries and join in memory — removes all dependence on PostgREST relationship discovery.
- **Broaden the graceful-skip guard** to also treat `Could not find` / `schema cache` as an availability issue → skip quietly, no P0 event.
- **`match_targets` lookup failures degrade** to `display_name` fallbacks rather than dropping the whole proactive message.

Healthy-schema behavior is unchanged: the FK guarantees every match has a target, so no `"Unknown"` placeholders appear.

### Scope
Touches only the proactive match service (`proactive-match-messenger.ts`). `match-tool-handler.ts` uses the same embed and is likely vulnerable to the same drift, but is **out of scope** for this session — flagging for follow-up.

### Verification
- `tsc --noEmit` passes under the project-pinned TypeScript (5.9.3 / `^5.3.3`). ✅
- ⚠️ Could **not** pull the live OASIS payload to read the full error string verbatim: this sandbox has no Supabase creds, no `gcloud`, and the gateway is auth-gated (403). Diagnosis is from the migration schema (single FK), PostgREST semantics, and the fact that `Match query failed:` is uniquely the throw site at line 214 — the embed is the only failure mode that produces a `Could not f…` error firing as an error rather than a graceful skip.

**Done when:** 1 hour with zero `match.proactive.error` after deploy.

https://claude.ai/code/session_01NY8wvSKrRodntSwLYvMELY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY8wvSKrRodntSwLYvMELY)_