### PR TITLE
fix(autopilot): capture real failure reason on allocated→failed (Phase 1)

### DIFF
--- a/services/gateway/src/services/autopilot-controller.ts
+++ b/services/gateway/src/services/autopilot-controller.ts
@@ -148,6 +148,81 @@ interface StateTransition {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * Structured failure context (Session 4 / autopilot-error-capture).
+ *
+ * Previously the `allocated → failed` transition emitted a hardcoded
+ * `unknown_error` trigger whenever no errorCode was threaded through,
+ * which swallowed the real reason. This carries the actual error name,
+ * message, and a stack prefix onto the OASIS event payload so the feed
+ * surfaces *why* a run failed instead of "unknown_error".
+ */
+export interface FailureContext {
+  error_name?: string;
+  error_message?: string;
+  stack_prefix?: string;
+  source_event_type?: string;
+}
+
+/**
+ * Normalize an arbitrary thrown value (or structured metadata) into a
+ * FailureContext. Captures err.name, err.message, and the first few lines
+ * of the stack so the OASIS payload is diagnosable without a redeploy.
+ */
+export function extractErrorContext(
+  err: unknown,
+  fallbackMessage?: string
+): FailureContext {
+  if (err instanceof Error) {
+    return {
+      error_name: err.name || 'Error',
+      error_message: err.message || fallbackMessage,
+      stack_prefix: err.stack
+        ? err.stack.split('\n').slice(0, 4).join('\n')
+        : undefined,
+    };
+  }
+  if (err && typeof err === 'object') {
+    const o = err as Record<string, unknown>;
+    const stack = typeof o.stack === 'string' ? o.stack : undefined;
+    return {
+      error_name: (o.error_name || o.errorName || o.name) as string | undefined,
+      error_message: (o.error_message ||
+        o.message ||
+        o.error ||
+        fallbackMessage) as string | undefined,
+      stack_prefix: stack ? stack.split('\n').slice(0, 4).join('\n') : undefined,
+    };
+  }
+  if (typeof err === 'string' && err.length > 0) {
+    return { error_message: err };
+  }
+  return fallbackMessage ? { error_message: fallbackMessage } : {};
+}
+
+/**
+ * Derive a non-empty, human-meaningful trigger slug for a failure event.
+ * Order: explicit errorCode → error name → sanitized message → source event
+ * type. Deliberately avoids the literal "unknown_error" unless we genuinely
+ * have nothing — and even then prefers "unspecified_failure" so the feed is
+ * never silently masked by the old hardcoded default.
+ */
+export function deriveFailureTrigger(
+  errorCode: string | undefined,
+  ctx: FailureContext | undefined
+): string {
+  if (errorCode && errorCode.trim()) return errorCode.trim();
+  if (ctx?.error_name && ctx.error_name.trim()) return ctx.error_name.trim();
+  if (ctx?.error_message && ctx.error_message.trim()) {
+    // Compact the message into a slug-ish trigger (first ~60 chars, no newlines).
+    return ctx.error_message.trim().replace(/\s+/g, ' ').slice(0, 60);
+  }
+  if (ctx?.source_event_type && ctx.source_event_type.trim()) {
+    return ctx.source_event_type.trim();
+  }
+  return 'unspecified_failure';
+}
+
 // =============================================================================
 // In-Memory State
 // =============================================================================
@@ -728,12 +803,26 @@ export async function markCompleted(
 
 /**
  * Mark as failed (terminal failure)
+ *
+ * Session 4 (autopilot-error-capture): `context` carries the structured
+ * err.name / err.message / stack-prefix from the originating failure so the
+ * OASIS `autopilot.state.failed` payload surfaces the real reason instead of
+ * the old hardcoded `unknown_error` trigger.
  */
 export async function markFailed(
   vtid: string,
   error: string,
-  errorCode?: string
+  errorCode?: string,
+  context?: FailureContext
 ): Promise<boolean> {
+  // Backfill structured context from the error string when the caller did
+  // not supply one, so the payload always carries at least a message.
+  const ctx: FailureContext = {
+    ...extractErrorContext(error, error),
+    ...(context || {}),
+  };
+  const trigger = deriveFailureTrigger(errorCode, ctx);
+
   const run = activeRuns.get(vtid);
   if (!run) {
     // Create a minimal run record for tracking
@@ -759,8 +848,19 @@ export async function markFailed(
       run_id: failedRun.id,
       from_state: 'allocated',
       to_state: 'failed',
-      trigger: errorCode || 'unknown_error',
-      metadata: { error },
+      trigger,
+      metadata: {
+        error,
+        error_code: errorCode,
+        error_name: ctx.error_name,
+        error_message: ctx.error_message,
+        stack_prefix: ctx.stack_prefix,
+        source_event_type: ctx.source_event_type,
+        // Flag the legacy no-run path so we can tell (in the feed/Phase 2
+        // backlog analysis) that this VTID failed without an in-memory run —
+        // typically a gateway restart wiping activeRuns.
+        no_active_run: true,
+      },
     });
 
     return true;
@@ -772,7 +872,14 @@ export async function markFailed(
   // Update ledger to terminal state
   await updateLedgerTerminal(vtid, 'failed');
 
-  return transitionState(run, 'failed', errorCode || 'error', { error });
+  return transitionState(run, 'failed', trigger, {
+    error,
+    error_code: errorCode,
+    error_name: ctx.error_name,
+    error_message: ctx.error_message,
+    stack_prefix: ctx.stack_prefix,
+    source_event_type: ctx.source_event_type,
+  });
 }
 
 // =============================================================================

--- a/services/gateway/src/services/autopilot-event-loop.ts
+++ b/services/gateway/src/services/autopilot-event-loop.ts
@@ -367,10 +367,32 @@ async function performTransition(
       await markCompleted(vtid);
       await markRunCompleted(vtid); // Update persistent run state
       break;
-    case 'failed':
-      const errorMsg = (event.message || event.metadata?.error || 'Unknown error') as string;
-      await markFailed(vtid, errorMsg);
+    case 'failed': {
+      // Session 4 (autopilot-error-capture): the originating failure event
+      // (worker.execution.failed, cicd.ci.failed, verification.failed, …)
+      // carries the real reason in its message/metadata. Thread it through to
+      // markFailed so the autopilot.state.failed payload no longer collapses
+      // to a hardcoded `unknown_error` trigger.
+      const meta = (event.metadata || event.meta || {}) as Record<string, unknown>;
+      const errorMsg = (event.message ||
+        meta.error_message ||
+        meta.error ||
+        'Unknown error') as string;
+      const errorCode = (meta.error_code || meta.errorCode) as string | undefined;
+      const rawStack = (meta.stack || meta.stack_prefix) as string | undefined;
+      await markFailed(vtid, errorMsg, errorCode, {
+        error_name: (meta.error_name || meta.errorName || meta.name) as
+          | string
+          | undefined,
+        error_message: (meta.error_message || meta.error) as string | undefined,
+        stack_prefix:
+          typeof rawStack === 'string'
+            ? rawStack.split('\n').slice(0, 4).join('\n')
+            : undefined,
+        source_event_type: normalizeEventType(event),
+      });
       break;
+    }
   }
 
   // Emit transition event

--- a/services/gateway/test/autopilot-error-capture.test.ts
+++ b/services/gateway/test/autopilot-error-capture.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Session 4 (autopilot-error-capture) — Phase 1 visibility regression test.
+ *
+ * The OASIS `autopilot.state.failed` event was emitted with a hardcoded
+ * `unknown_error` trigger whenever `markFailed` ran without an errorCode and
+ * without an in-memory run (the common case after a gateway restart wipes the
+ * in-process `activeRuns` map). The real reason — carried on the originating
+ * failure event's message/metadata — was swallowed and never reached the feed
+ * or the event payload.
+ *
+ * This locks in:
+ *   1. `deriveFailureTrigger` never collapses to the literal "unknown_error".
+ *   2. `extractErrorContext` lifts err.name / err.message / stack-prefix from
+ *      Error objects, structured metadata, and bare strings.
+ *   3. `markFailed`'s no-run branch emits a meaningful trigger AND structured
+ *      error fields (error_name / error_message / stack_prefix) on the payload.
+ */
+
+// Mock the OASIS emitter so we can capture the payload without a network call.
+const emitted: any[] = [];
+jest.mock('../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn(async (event: any) => {
+    emitted.push(event);
+    return { ok: true, event_id: 'test-event' };
+  }),
+}));
+
+import {
+  extractErrorContext,
+  deriveFailureTrigger,
+  markFailed,
+} from '../src/services/autopilot-controller';
+
+beforeEach(() => {
+  emitted.length = 0;
+  // Ensure updateLedgerTerminal short-circuits (no Supabase writes in unit test).
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE;
+});
+
+describe('extractErrorContext', () => {
+  it('lifts name, message and a stack prefix from an Error', () => {
+    const err = new TypeError('boom while routing');
+    const ctx = extractErrorContext(err);
+    expect(ctx.error_name).toBe('TypeError');
+    expect(ctx.error_message).toBe('boom while routing');
+    expect(ctx.stack_prefix).toContain('TypeError: boom while routing');
+    // Stack prefix must be bounded (we keep the first few lines only).
+    expect((ctx.stack_prefix || '').split('\n').length).toBeLessThanOrEqual(4);
+  });
+
+  it('reads structured metadata objects', () => {
+    const ctx = extractErrorContext({
+      error_name: 'WorkerDispatchError',
+      error_message: 'no worker available',
+      stack: 'a\nb\nc\nd\ne\nf',
+    });
+    expect(ctx.error_name).toBe('WorkerDispatchError');
+    expect(ctx.error_message).toBe('no worker available');
+    expect((ctx.stack_prefix || '').split('\n').length).toBeLessThanOrEqual(4);
+  });
+
+  it('falls back to the raw string', () => {
+    expect(extractErrorContext('plain failure').error_message).toBe('plain failure');
+  });
+});
+
+describe('deriveFailureTrigger', () => {
+  it('prefers an explicit error code', () => {
+    expect(deriveFailureTrigger('CI_TIMEOUT', { error_name: 'X' })).toBe('CI_TIMEOUT');
+  });
+
+  it('uses the error name when no code is present', () => {
+    expect(deriveFailureTrigger(undefined, { error_name: 'WorkerDispatchError' })).toBe(
+      'WorkerDispatchError'
+    );
+  });
+
+  it('compacts a message into a trigger slug when only a message exists', () => {
+    const t = deriveFailureTrigger(undefined, {
+      error_message: 'no worker available\nfor target role DEV',
+    });
+    expect(t).toBe('no worker available for target role DEV');
+    expect(t).not.toContain('\n');
+  });
+
+  it('never returns the legacy hardcoded "unknown_error"', () => {
+    expect(deriveFailureTrigger(undefined, {})).toBe('unspecified_failure');
+    expect(deriveFailureTrigger('', { source_event_type: 'worker.execution.failed' })).toBe(
+      'worker.execution.failed'
+    );
+  });
+});
+
+describe('markFailed (no active run / allocated → failed)', () => {
+  it('emits a meaningful trigger and structured error fields instead of unknown_error', async () => {
+    await markFailed(
+      'VTID-90001',
+      'no worker available for target role DEV',
+      undefined,
+      {
+        error_name: 'WorkerDispatchError',
+        error_message: 'no worker available for target role DEV',
+        stack_prefix: 'WorkerDispatchError: no worker available\n    at dispatch (x.ts:1:1)',
+        source_event_type: 'worker.execution.failed',
+      }
+    );
+
+    const failedEvent = emitted.find((e) => e.type === 'autopilot.state.failed');
+    expect(failedEvent).toBeDefined();
+    // Feed line is built from the trigger — it must not be the legacy default.
+    expect(failedEvent.message).toContain('allocated → failed');
+    expect(failedEvent.message).not.toContain('unknown_error');
+    expect(failedEvent.payload.trigger).toBe('WorkerDispatchError');
+    expect(failedEvent.payload.error_name).toBe('WorkerDispatchError');
+    expect(failedEvent.payload.error_message).toContain('no worker available');
+    expect(failedEvent.payload.stack_prefix).toContain('WorkerDispatchError');
+    expect(failedEvent.payload.source_event_type).toBe('worker.execution.failed');
+    expect(failedEvent.payload.no_active_run).toBe(true);
+  });
+
+  it('still surfaces a reason when only a bare error string is supplied', async () => {
+    await markFailed('VTID-90002', 'spec checksum mismatch');
+    const failedEvent = emitted.find(
+      (e) => e.type === 'autopilot.state.failed' && e.vtid === 'VTID-90002'
+    );
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent.payload.trigger).not.toBe('unknown_error');
+    expect(failedEvent.payload.error_message).toBe('spec checksum mismatch');
+  });
+});


### PR DESCRIPTION
## Session 4 — Autopilot error capture + backlog drain

**Scope:** autopilot service + its OASIS emitters only. Does not touch voice, longevity, match, or frontend.

> ⚠️ VTID note: this container has no allocator/DB access to allocate a real VTID against the live ledger, and fabricating one would violate the "verify VTID existence" rule. Using the documented `BOOTSTRAP-AUTOPILOT-ERROR-CAPTURE` fallback (CLAUDE.md §16) so Auto Deploy can still dispatch EXEC-DEPLOY. Re-tag with a real VTID if one is allocated.

### Phase 1 — visibility (this PR) ✅

**Bug:** The OASIS event `autopilot.state.failed: allocated → failed (unknown_error)` is emitted only by `markFailed`'s no-run branch (`autopilot-controller.ts`). The feed line is built from the `trigger` field, which was **hardcoded to `'unknown_error'`** whenever no `errorCode` was threaded through — the common case after a gateway restart wipes the in-memory `activeRuns` map. The real reason lived on the originating failure event's `message`/`metadata` but never reached the `trigger` or any structured `err.name`/`err.message`/`stack` field. It was swallowed.

**Fix:**
- `extractErrorContext()` — lifts `err.name` / `err.message` / a bounded stack-prefix from `Error` objects, structured metadata, and bare strings.
- `deriveFailureTrigger()` — trigger is never the legacy `'unknown_error'`; falls back to error name → compacted message slug → source event type → `'unspecified_failure'`.
- `markFailed()` now threads a `FailureContext` and emits `error_name` / `error_message` / `stack_prefix` / `source_event_type` onto the payload, and flags the legacy no-run path with `no_active_run: true` (a signal for the Phase 2 backlog analysis — it tells us a VTID failed without an in-memory run, typically a restart).
- The event-loop `'failed'` handler extracts the error context from the originating event (`worker.execution.failed`, `cicd.ci.failed`, `verification.failed`, …) and threads it through instead of dropping the code and reason.

**Tests:** new `test/autopilot-error-capture.test.ts` (9 cases) + existing autopilot suites green (68 total).

Per the plan, Phase 1 deploys **alone** — then we wait for the next failure to emit a real reason.

### Phase 2 — backlog (pending live data)

`AUTOPILOT 99+` badge = unbounded backlog of rows in `allocated` state. Needs live observation post-deploy to:
- count `allocated` rows (`vtid_ledger` / autopilot run state),
- determine whether the consumer is **dead, rate-limited, or starved**,
- document the actual drain rate.

The new `no_active_run` flag on failed events will help distinguish restart-induced failures from genuine consumer death while draining.

### Phase 3 — root cause (pending Phase 1 signal)

Fix based on what the real (no-longer-`unknown_error`) failure reasons surface.

**Done when:** no more `unknown_error` in the feed **and** backlog is decreasing or documented as expected steady state.

https://claude.ai/code/session_01ApVSfZ6m9YdPbCAkpdSs4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApVSfZ6m9YdPbCAkpdSs4k)_