### PR TITLE
feat(profile): Phase 1 W1 telemetry foundation (VTID-03177)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -210,16 +210,21 @@ jobs:
 
           echo "Recording $NEXT_SWV_ID for gateway-staging@${REVISION}"
 
-          curl -fsS -X POST "$SUPABASE_URL/rest/v1/software_versions" \
+          # VTID-03177 (PROFILE): upsert on swv_id so two concurrent STAGE-DEPLOY
+          # runs that race to claim the same NEXT_SWV_ID don't 409. The "max+1"
+          # increment is inherently racy; merge-duplicates makes the second
+          # writer idempotent rather than failing. Body is identical on collision
+          # so the merge is a no-op in practice.
+          curl -fsS -X POST "$SUPABASE_URL/rest/v1/software_versions?on_conflict=swv_id" \
             -H "Content-Type: application/json" \
             -H "apikey: $SUPABASE_SVC" \
             -H "Authorization: Bearer $SUPABASE_SVC" \
-            -H "Prefer: return=minimal" \
+            -H "Prefer: resolution=merge-duplicates,return=minimal" \
             -d "$(jq -nc \
               --arg swv "$NEXT_SWV_ID" \
               --arg sha "$SHA" \
               '{swv_id:$swv, service:"gateway-staging", git_commit:$sha, deploy_type:"normal", initiator:"agent", status:"success", environment:"staging"}')" || \
-            echo "::warning::software_versions INSERT failed (likely IAM or schema); continuing."
+            echo "::warning::software_versions UPSERT failed (likely IAM or schema); continuing."
 
           EVENT_BODY=$(jq -nc \
             --arg sha "$SHA" \

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -66,6 +66,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const boardAdapter = require('./routes/board-adapter').default;
   const { commandhub } = require('./routes/commandhub');
   const { vtidRouter } = require('./routes/vtid');
+  // VTID-03177 (PROFILE): RUM beacon receiver from vitana-v1 frontend
+  const { rumBeaconRouter } = require('./routes/rum-beacon');
   const { router: tasksRouter } = require('./routes/tasks');
   const { router: eventsRouter } = require('./routes/events');
   const eventsApiRouter = require('./routes/gateway-events-api').default;
@@ -592,6 +594,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
     owner: 'presence-did-you-know',
   });
   mountRouterSync(app, '/api/v1/vtid', vtidRouter, { owner: 'vtid' });
+  // VTID-03177 (PROFILE): RUM beacon — POST /api/v1/rum/beacon
+  mountRouterSync(app, '/api/v1/rum', rumBeaconRouter, { owner: 'rum-beacon' });
 
   // VTID-0516: Autonomous Safe-Merge Layer - CICD routes
   // Note: Same router mounted at multiple paths is allowed (different effective routes)

--- a/services/gateway/src/middleware/server-timing.ts
+++ b/services/gateway/src/middleware/server-timing.ts
@@ -1,0 +1,93 @@
+/**
+ * Server-Timing middleware — Phase 1 W1 (VTID-03177 PROFILE).
+ *
+ * Adds `Server-Timing` headers on responses so RUM (vitana-v1) and the eval
+ * harness can break down per-route latency without instrumenting each handler.
+ *
+ * Gated by `FEATURE_LATENCY_TELEMETRY_ENV` (off | staging-only | staging+prod).
+ * When off, this middleware is a no-op — zero overhead, no header emitted.
+ *
+ * Usage on a route file:
+ *   import { withServerTiming } from '../middleware/server-timing';
+ *   router.use(withServerTiming());
+ *
+ * Per-handler marks (optional):
+ *   res.locals.serverTimingMarks?.push({ name: 'db', dur: 42 });
+ *   res.locals.serverTimingMarks?.push({ name: 'render', dur: 8 });
+ *
+ * The middleware always records `total` from request-in to response-finish.
+ * Marks are emitted in insertion order before `total`. Names must match
+ * /^[A-Za-z0-9_-]+$/ — any non-conforming mark is dropped to keep the header
+ * valid (RFC 8941).
+ */
+
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import { isFeatureLive } from '../services/feature-flags';
+
+const FEATURE_NAME = 'LATENCY_TELEMETRY';
+const NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+export interface ServerTimingMark {
+  name: string;
+  dur?: number;       // milliseconds
+  desc?: string;      // RFC 8941 description (optional, must be ASCII-safe)
+}
+
+declare module 'express-serve-static-core' {
+  interface Locals {
+    serverTimingMarks?: ServerTimingMark[];
+  }
+}
+
+function formatHeader(marks: ServerTimingMark[]): string {
+  return marks
+    .filter((m) => NAME_RE.test(m.name))
+    .map((m) => {
+      const parts: string[] = [m.name];
+      if (typeof m.dur === 'number' && Number.isFinite(m.dur)) {
+        parts.push(`dur=${m.dur.toFixed(1)}`);
+      }
+      if (m.desc && NAME_RE.test(m.desc)) {
+        parts.push(`desc="${m.desc}"`);
+      }
+      return parts.join(';');
+    })
+    .join(', ');
+}
+
+export function withServerTiming(): RequestHandler {
+  return function serverTimingMiddleware(_req: Request, res: Response, next: NextFunction) {
+    if (!isFeatureLive(FEATURE_NAME)) {
+      return next();
+    }
+
+    const start = process.hrtime.bigint();
+    res.locals.serverTimingMarks = [];
+
+    res.on('finish', () => {
+      // Headers are already flushed by the time `finish` fires for streaming
+      // responses; this is fine — we only attach when headers are still mutable.
+    });
+
+    const originalEnd = res.end.bind(res);
+    res.end = function patchedEnd(this: Response, ...args: unknown[]) {
+      try {
+        if (!res.headersSent) {
+          const totalMs = Number(process.hrtime.bigint() - start) / 1_000_000;
+          const marks = (res.locals.serverTimingMarks ?? []).slice();
+          marks.push({ name: 'total', dur: totalMs });
+          const header = formatHeader(marks);
+          if (header) {
+            res.setHeader('Server-Timing', header);
+          }
+        }
+      } catch {
+        // Never let telemetry break a response.
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return originalEnd(...(args as [any, any?, any?]));
+    };
+
+    next();
+  };
+}

--- a/services/gateway/src/orb/live/latency-tracker.ts
+++ b/services/gateway/src/orb/live/latency-tracker.ts
@@ -1,0 +1,165 @@
+/**
+ * Voice/chat latency tracker — Phase 1 W1 (VTID-03177 PROFILE).
+ *
+ * One tracker per logical "turn" (chat request OR voice user-turn). Callers
+ * mark phase boundaries; on `.finalize()` the tracker emits a single
+ * `voice.latency.measured` OASIS event with the full timeline.
+ *
+ * Phase ids are canonical so dashboards can chart them:
+ *   - audio_in_first_byte    — first audio chunk received from client
+ *   - transcript_ready       — STT result available
+ *   - tool_dispatch          — tool execution started
+ *   - tool_response          — tool execution finished
+ *   - audio_out_first_chunk  — first TTS chunk sent back to client
+ *
+ * For text turns (`/orb/chat`), only `text_request_in` and
+ * `text_response_out` are recorded — the other 5 are voice-only.
+ *
+ * Gated by `FEATURE_LATENCY_TELEMETRY_ENV`. When off, every method is a
+ * no-op and `finalize()` does NOT emit. Cheap enough to leave wired in.
+ */
+
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import { emitOasisEvent } from '../../services/oasis-event-service';
+import { isFeatureLive } from '../../services/feature-flags';
+
+const FEATURE_NAME = 'LATENCY_TELEMETRY';
+
+export type LatencyPhase =
+  | 'text_request_in'
+  | 'text_response_out'
+  | 'audio_in_first_byte'
+  | 'transcript_ready'
+  | 'tool_dispatch'
+  | 'tool_response'
+  | 'audio_out_first_chunk';
+
+export interface LatencyMark {
+  phase: LatencyPhase;
+  /** Wall-clock epoch ms when the mark was recorded. */
+  at_ms: number;
+  /** Optional context (tool name, transcript length, etc.). */
+  detail?: Record<string, unknown>;
+}
+
+export interface LatencyContext {
+  /** Caller-stable id (orb_session_id, conversation_id, or chat req id). */
+  session_id: string;
+  /** 'voice' | 'text' — drives which phases are expected. */
+  surface: 'voice' | 'text';
+  /** Optional user id. */
+  actor_id?: string;
+  /** Optional turn index within the session (1-based). */
+  turn?: number;
+  /** Optional provider/model hint (e.g. 'vertex/gemini-2.5-flash'). */
+  provider?: string;
+}
+
+export class LatencyTracker {
+  private readonly start_ms: number;
+  private readonly marks: LatencyMark[] = [];
+  private readonly enabled: boolean;
+  private finalized = false;
+
+  constructor(private readonly ctx: LatencyContext) {
+    this.enabled = isFeatureLive(FEATURE_NAME);
+    this.start_ms = Date.now();
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  mark(phase: LatencyPhase, detail?: Record<string, unknown>): void {
+    if (!this.enabled || this.finalized) return;
+    this.marks.push({ phase, at_ms: Date.now(), detail });
+  }
+
+  async finalize(status: 'success' | 'error' = 'success', error?: string): Promise<void> {
+    if (!this.enabled || this.finalized) return;
+    this.finalized = true;
+    const end_ms = Date.now();
+    const total_ms = end_ms - this.start_ms;
+
+    // Deltas from start, in mark order. Cheaper to compute once here than at
+    // dashboard read time.
+    const phases = this.marks.map((m) => ({
+      phase: m.phase,
+      offset_ms: m.at_ms - this.start_ms,
+      detail: m.detail,
+    }));
+
+    try {
+      await emitOasisEvent({
+        vtid: 'VTID-03177',
+        type: 'voice.latency.measured',
+        source: 'gateway/latency-tracker',
+        status,
+        message: status === 'success'
+          ? `latency ${total_ms}ms (${this.ctx.surface}/${phases.length} phases)`
+          : `latency ${total_ms}ms (${this.ctx.surface}, errored)`,
+        actor_id: this.ctx.actor_id,
+        payload: {
+          session_id: this.ctx.session_id,
+          surface: this.ctx.surface,
+          turn: this.ctx.turn,
+          provider: this.ctx.provider,
+          total_ms,
+          phases,
+          error,
+        },
+      });
+    } catch {
+      // Never let telemetry break a request.
+    }
+  }
+}
+
+declare module 'express-serve-static-core' {
+  interface Locals {
+    latencyTracker?: LatencyTracker;
+  }
+}
+
+/**
+ * Express middleware factory — attaches a LatencyTracker to res.locals and
+ * finalizes it when the response ends. Use on routes where the request →
+ * response boundary is the right turn boundary (i.e. `/orb/chat`, not the
+ * voice WebSocket which spans many turns).
+ *
+ * The tracker still no-ops at zero cost when FEATURE_LATENCY_TELEMETRY_ENV
+ * is off.
+ */
+export function withLatencyTracker(surface: 'voice' | 'text'): RequestHandler {
+  return function latencyTrackerMiddleware(req: Request, res: Response, next: NextFunction) {
+    const tracker = new LatencyTracker({
+      session_id: (req.body?.orb_session_id as string)
+        || (req.body?.conversation_id as string)
+        || (req.headers['x-request-id'] as string)
+        || 'unknown',
+      surface,
+    });
+    if (tracker.isEnabled()) {
+      tracker.mark(surface === 'text' ? 'text_request_in' : 'audio_in_first_byte');
+    }
+    res.locals.latencyTracker = tracker;
+
+    const originalEnd = res.end.bind(res);
+    res.end = function patchedEnd(this: Response, ...args: unknown[]) {
+      try {
+        const t = res.locals.latencyTracker;
+        if (t?.isEnabled()) {
+          t.mark(surface === 'text' ? 'text_response_out' : 'audio_out_first_chunk');
+          // fire-and-forget; never block response close on the OASIS write
+          void t.finalize(res.statusCode >= 400 ? 'error' : 'success');
+        }
+      } catch {
+        // Never let telemetry break a response.
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return originalEnd(...(args as [any, any?, any?]));
+    };
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -46,6 +46,9 @@ import { randomUUID } from 'crypto';
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
+// VTID-03177 (PROFILE): per-turn latency telemetry. The middleware is a no-op
+// when FEATURE_LATENCY_TELEMETRY_ENV is off; safe to wire on every route.
+import { withLatencyTracker } from '../orb/live/latency-tracker';
 // VTID-02917 (B0d.3): wake reliability timeline — emit + record only,
 // never block the wake path. The recorder is best-effort by design.
 import { defaultWakeTimelineRecorder } from '../services/wake-timeline/wake-timeline-recorder';
@@ -8402,7 +8405,7 @@ router.post('/stop', (req: Request, res: Response) => {
  *   "meta": { "provider": "vertex", "model": "gemini-*", "mode": "orb_voice" }
  * }
  */
-router.post('/chat', optionalAuth, async (req: AuthenticatedRequest, res: Response) => {
+router.post('/chat', withLatencyTracker('text'), optionalAuth, async (req: AuthenticatedRequest, res: Response) => {
   const body = req.body as OrbChatRequest;
 
   // VTID-01186: Extract identity from authenticated request or fallback to DEV_IDENTITY

--- a/services/gateway/src/routes/rum-beacon.ts
+++ b/services/gateway/src/routes/rum-beacon.ts
@@ -1,0 +1,96 @@
+/**
+ * RUM beacon receiver — Phase 1 W1 (VTID-03177 PROFILE).
+ *
+ * Accepts small JSON beacons from the vitana-v1 frontend (see
+ * `vitana-v1/src/lib/rum.ts`) and translates each into a
+ * `screen.latency.measured` OASIS event. The beacon is intentionally a thin
+ * pipe — no per-metric business logic, no aggregation. Dashboards do that
+ * downstream.
+ *
+ * Gated by `FEATURE_LATENCY_TELEMETRY_ENV` so flipping the flag off drops
+ * traffic at the edge.
+ *
+ * Beacon shape (matches `RumBeacon` in vitana-v1):
+ *   {
+ *     "screen": "/community/feed",
+ *     "metric": "LCP" | "TTFB" | "CLS" | "FCP" | "INP",
+ *     "value":   1234.5,           // number, units defined per metric (ms or unitless)
+ *     "rating":  "good" | "needs-improvement" | "poor",
+ *     "session": "anonymous-uuid",
+ *     "captured_at": "2026-05-28T12:34:56.789Z",
+ *     "user_agent": "Mozilla/...",
+ *     "ts_origin_ms": 1748434496789
+ *   }
+ *
+ * Hard limits: body size <= 4 KiB, single event per beacon (no batching in
+ * W1 — keep the receiver dumb; batching is a W2 enhancement if volume needs
+ * it).
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import { isFeatureLive } from '../services/feature-flags';
+
+const FEATURE_NAME = 'LATENCY_TELEMETRY';
+const MAX_BODY_BYTES = 4 * 1024;
+
+const BeaconSchema = z.object({
+  screen: z.string().min(1).max(256),
+  metric: z.enum(['LCP', 'TTFB', 'CLS', 'FCP', 'INP']),
+  value: z.number().finite(),
+  rating: z.enum(['good', 'needs-improvement', 'poor']).optional(),
+  session: z.string().min(1).max(128),
+  captured_at: z.string().min(20).max(40),
+  user_agent: z.string().max(512).optional(),
+  ts_origin_ms: z.number().int().nonnegative().optional(),
+});
+
+export type RumBeacon = z.infer<typeof BeaconSchema>;
+
+const router = Router();
+
+router.post('/beacon', async (req: Request, res: Response) => {
+  if (!isFeatureLive(FEATURE_NAME)) {
+    // Silently 204 when telemetry is off — frontends don't need to know.
+    return res.status(204).end();
+  }
+
+  const raw = req.body;
+  if (raw && typeof raw === 'object' && JSON.stringify(raw).length > MAX_BODY_BYTES) {
+    return res.status(413).json({ ok: false, error: 'beacon_too_large' });
+  }
+
+  const parse = BeaconSchema.safeParse(raw);
+  if (!parse.success) {
+    return res.status(400).json({ ok: false, error: 'invalid_beacon', issues: parse.error.issues });
+  }
+  const beacon = parse.data;
+
+  try {
+    await emitOasisEvent({
+      vtid: 'VTID-03177',
+      type: 'screen.latency.measured',
+      source: 'gateway/rum-beacon',
+      status: 'success',
+      message: `${beacon.metric} ${beacon.value.toFixed(1)} on ${beacon.screen}`,
+      payload: {
+        screen: beacon.screen,
+        metric: beacon.metric,
+        value: beacon.value,
+        rating: beacon.rating,
+        session: beacon.session,
+        captured_at: beacon.captured_at,
+        user_agent: beacon.user_agent,
+        ts_origin_ms: beacon.ts_origin_ms,
+      },
+    });
+    return res.status(204).end();
+  } catch (err) {
+    // Beacon failures must never block the frontend; return 204 and log.
+    console.error('[rum-beacon] emit failed:', err);
+    return res.status(204).end();
+  }
+});
+
+export { router as rumBeaconRouter };

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -879,7 +879,18 @@ export type CicdEventType =
   | 'production.canary.requested'
   | 'production.canary.started'
   | 'production.canary.promoted'
-  | 'production.canary.aborted';
+  | 'production.canary.aborted'
+  // Phase 1 W1 (VTID-03177 PROFILE): latency + eval + dataset + fine-tune telemetry.
+  // All emitted with env=staging|production via env-tagging in emitOasisEvent().
+  // Inert in prod until FEATURE_LATENCY_TELEMETRY_ENV is flipped on.
+  | 'voice.latency.measured'        // per-turn phased latency: audio_in_first_byte..audio_out_first_chunk
+  | 'screen.latency.measured'       // per-route TTFB / Server-Timing breakdown from gateway
+  | 'eval.shadow.compared'          // shadow harness compared primary vs candidate model on one eval input
+  | 'eval.coverage.report'          // periodic golden-corpus coverage report (replay-runner output)
+  | 'dataset.extraction.completed'  // dataset-extraction cron finished one slice; metadata.rows / .target
+  | 'finetune.training.completed'   // Vertex Custom Training job ended; metadata.job_id / .status / .target
+  | 'auto_promote.proposed'         // auto-promoter chose to bump a staging tier; metadata.from / .to
+  | 'auto_promote.rejected';        // auto-promoter declined to bump; metadata.reason
 
 export interface CicdOasisEvent {
   vtid: string;

--- a/services/gateway/test/eval/README.md
+++ b/services/gateway/test/eval/README.md
@@ -1,0 +1,54 @@
+# Eval harness — Phase 1 W1 (VTID-03177 PROFILE)
+
+Replays a golden corpus of recorded sessions against a configurable gateway
+URL and produces a per-fixture latency roll-up. The runner is intentionally
+small in W1; substantive checks (tool-routing accuracy, transcript quality,
+shadow-comparator integration) land in W2+ alongside the fine-tune pipeline.
+
+## Run it
+
+```bash
+# Against staging (default)
+npx tsx services/gateway/test/eval/replay-runner.ts
+
+# Against a custom gateway
+EVAL_GATEWAY_URL=https://gateway.vitanaland.com \
+  npx tsx services/gateway/test/eval/replay-runner.ts
+```
+
+Output is JSON to stdout. The `totals.p95_ms` line is the W1 baseline that
+W2–W5 compare against.
+
+## Corpus expansion
+
+W1 ships 3 synthetic fixtures as a smoke seed. The plan calls for **50
+fixtures by end of W1** (expanding to 400 by end of W5).
+
+The W2 expansion uses the dataset extraction loop (PR #2 DATASETS): the
+extractor pulls anonymized prod conversation_messages and writes each
+qualifying session out as a fixture under this directory. Until that lands,
+add fixtures manually in the same shape — see [types.ts](./types.ts) for the
+canonical schema.
+
+PII rule: prod-extracted fixtures must pass the same filter as datasets —
+skip any session tagged `safety.guardrail.*` or where the source row lacks
+`data_export_ok=true`.
+
+## Schema
+
+A fixture is one JSON file under `golden-corpus/`, matching
+`GoldenCorpusFixture` in [types.ts](./types.ts).
+
+## What the runner measures today
+
+Per turn: total wall-clock round-trip to `/api/v1/admin/health`, plus any
+`Server-Timing` phases the response carries. Per fixture: p50/p95/p99 across
+its turns. Per run: roll-up across all fixtures.
+
+## What it will measure once PR #1 follow-ups land
+
+Once `orb-live.ts` emits the 5 phased latency events
+(`audio_in_first_byte` → `audio_out_first_chunk`) and the eval harness is
+allowed to exercise real chat turns instead of the health probe, the runner
+will read those events back via Supabase and turn them into the same
+`ReplayPhaseTiming[]` shape.

--- a/services/gateway/test/eval/golden-corpus/synthetic-001-greeting.json
+++ b/services/gateway/test/eval/golden-corpus/synthetic-001-greeting.json
@@ -1,0 +1,22 @@
+{
+  "fixture_id": "synthetic-001-greeting",
+  "source": "synthetic",
+  "captured_at": "2026-05-28T00:00:00Z",
+  "turn_count": 2,
+  "notes": "Baseline single-turn greeting then wake-brief. Cheapest possible session — used for latency floor.",
+  "turns": [
+    {
+      "turn": 1,
+      "kind": "voice",
+      "user_input": "Hello Vitana",
+      "expected_intent": "greeting"
+    },
+    {
+      "turn": 2,
+      "kind": "text",
+      "user_input": "What's on my plan today?",
+      "expected_tool": "get_today_plan",
+      "expected_intent": "plan.read"
+    }
+  ]
+}

--- a/services/gateway/test/eval/golden-corpus/synthetic-002-tool-routing.json
+++ b/services/gateway/test/eval/golden-corpus/synthetic-002-tool-routing.json
@@ -1,0 +1,30 @@
+{
+  "fixture_id": "synthetic-002-tool-routing",
+  "source": "synthetic",
+  "captured_at": "2026-05-28T00:00:00Z",
+  "turn_count": 3,
+  "notes": "Three-turn session that exercises the top voice-tool-routing surfaces (memory write, send message, schedule).",
+  "turns": [
+    {
+      "turn": 1,
+      "kind": "voice",
+      "user_input": "Remember that I had a great walk this morning",
+      "expected_tool": "remember",
+      "expected_intent": "memory.write"
+    },
+    {
+      "turn": 2,
+      "kind": "voice",
+      "user_input": "Send a message to Maria saying I'll be late",
+      "expected_tool": "send_chat_message",
+      "expected_intent": "communication.send_message"
+    },
+    {
+      "turn": 3,
+      "kind": "voice",
+      "user_input": "Book a 30 minute focus block tomorrow at 10",
+      "expected_tool": "create_calendar_event",
+      "expected_intent": "calendar.create"
+    }
+  ]
+}

--- a/services/gateway/test/eval/golden-corpus/synthetic-003-screen-load.json
+++ b/services/gateway/test/eval/golden-corpus/synthetic-003-screen-load.json
@@ -1,0 +1,33 @@
+{
+  "fixture_id": "synthetic-003-screen-load",
+  "source": "synthetic",
+  "captured_at": "2026-05-28T00:00:00Z",
+  "turn_count": 4,
+  "notes": "Screen-navigation session that exercises the top-10 community routes targeted by the Cloudflare KV cache PR (#4).",
+  "turns": [
+    {
+      "turn": 1,
+      "kind": "text",
+      "user_input": "open autopilot recommendations",
+      "expected_intent": "screen.autopilot.recommendations"
+    },
+    {
+      "turn": 2,
+      "kind": "text",
+      "user_input": "show me my vitana index",
+      "expected_intent": "screen.vitana_index.detail"
+    },
+    {
+      "turn": 3,
+      "kind": "text",
+      "user_input": "what intents do I have on the board",
+      "expected_intent": "screen.intents.board"
+    },
+    {
+      "turn": 4,
+      "kind": "text",
+      "user_input": "go back to community feed",
+      "expected_intent": "screen.community.feed"
+    }
+  ]
+}

--- a/services/gateway/test/eval/replay-runner.ts
+++ b/services/gateway/test/eval/replay-runner.ts
@@ -1,0 +1,176 @@
+/**
+ * Golden-corpus replay runner — Phase 1 W1 (VTID-03177 PROFILE).
+ *
+ * Reads every `*.json` fixture under `golden-corpus/`, replays each turn
+ * against a configurable gateway URL, and produces a per-fixture latency
+ * roll-up. In W1 the "replay" is a thin probe against `/api/v1/admin/health`
+ * — enough to establish a baseline that downstream PRs can compare against
+ * once orb-live emits phased `voice.latency.measured` events (PR #1
+ * follow-up commit) and the eval harness graduates to driving real chat
+ * turns (W2+).
+ *
+ * Output is JSON to stdout when run via `npm run eval:replay`. The same
+ * function is also exported so a future cron workflow can emit the result
+ * as an `eval.coverage.report` OASIS event.
+ *
+ * Acceptance for W1: baseline runs once on staging without throwing.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import type {
+  GoldenCorpusFixture,
+  ReplayFixtureResult,
+  ReplayPhaseTiming,
+  ReplayRunOutput,
+  ReplayTurnResult,
+} from './types';
+
+const DEFAULT_GATEWAY = process.env.EVAL_GATEWAY_URL
+  || 'https://gateway-staging-q74ibpv6ia-uc.a.run.app';
+const CORPUS_DIR = path.join(__dirname, 'golden-corpus');
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, idx))];
+}
+
+function parseServerTiming(header: string | null | undefined): ReplayPhaseTiming[] {
+  if (!header) return [];
+  const phases: ReplayPhaseTiming[] = [];
+  let cursor = 0;
+  for (const entry of header.split(',').map((s) => s.trim()).filter(Boolean)) {
+    const [rawName, ...rest] = entry.split(';').map((s) => s.trim());
+    const name = rawName;
+    let durMs: number | undefined;
+    for (const part of rest) {
+      const [k, v] = part.split('=');
+      if (k === 'dur' && v) {
+        const n = Number(v);
+        if (Number.isFinite(n)) durMs = n;
+      }
+    }
+    const start = cursor;
+    const end = durMs != null ? cursor + durMs : undefined;
+    if (durMs != null) cursor = end!;
+    phases.push({ phase: name, start_ms: start, end_ms: end, duration_ms: durMs });
+  }
+  return phases;
+}
+
+async function loadFixtures(): Promise<GoldenCorpusFixture[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(CORPUS_DIR);
+  } catch {
+    return [];
+  }
+  const out: GoldenCorpusFixture[] = [];
+  for (const entry of entries.filter((e) => e.endsWith('.json'))) {
+    try {
+      const raw = await fs.readFile(path.join(CORPUS_DIR, entry), 'utf-8');
+      const parsed = JSON.parse(raw) as GoldenCorpusFixture;
+      out.push(parsed);
+    } catch (err) {
+      console.error(`[eval] skip ${entry}: ${(err as Error).message}`);
+    }
+  }
+  return out;
+}
+
+async function replayTurn(
+  gatewayUrl: string,
+  fixture: GoldenCorpusFixture,
+  turnIdx: number,
+): Promise<ReplayTurnResult> {
+  const turn = fixture.turns[turnIdx];
+  const start = Date.now();
+  try {
+    // W1 baseline probe — hits admin health to measure round-trip latency.
+    // W2+ swaps to a chat-turn endpoint once the eval harness is allowed to
+    // exercise real conversational paths against staging.
+    const resp = await fetch(`${gatewayUrl}/api/v1/admin/health`, {
+      method: 'GET',
+      headers: { 'x-eval-fixture': fixture.fixture_id, 'x-eval-turn': String(turn.turn) },
+    });
+    const totalMs = Date.now() - start;
+    const phases = parseServerTiming(resp.headers.get('server-timing'));
+    return {
+      turn: turn.turn,
+      ok: resp.ok,
+      total_ms: totalMs,
+      phases,
+      http_status: resp.status,
+    };
+  } catch (err) {
+    return {
+      turn: turn.turn,
+      ok: false,
+      total_ms: Date.now() - start,
+      phases: [],
+      error: (err as Error).message,
+    };
+  }
+}
+
+async function replayFixture(
+  gatewayUrl: string,
+  fixture: GoldenCorpusFixture,
+): Promise<ReplayFixtureResult> {
+  const turnResults: ReplayTurnResult[] = [];
+  for (let i = 0; i < fixture.turns.length; i++) {
+    turnResults.push(await replayTurn(gatewayUrl, fixture, i));
+  }
+  const okTurns = turnResults.filter((t) => t.ok).map((t) => t.total_ms).sort((a, b) => a - b);
+  return {
+    fixture_id: fixture.fixture_id,
+    ok: turnResults.every((t) => t.ok),
+    turn_results: turnResults,
+    p50_ms: percentile(okTurns, 50),
+    p95_ms: percentile(okTurns, 95),
+    p99_ms: percentile(okTurns, 99),
+  };
+}
+
+export async function runReplay(
+  gatewayUrl: string = DEFAULT_GATEWAY,
+): Promise<ReplayRunOutput> {
+  const startedAt = new Date().toISOString();
+  const fixtures = await loadFixtures();
+  const fixtureResults: ReplayFixtureResult[] = [];
+  for (const fixture of fixtures) {
+    fixtureResults.push(await replayFixture(gatewayUrl, fixture));
+  }
+  const allOkMs = fixtureResults.flatMap((f) => f.turn_results.filter((t) => t.ok).map((t) => t.total_ms))
+    .sort((a, b) => a - b);
+  return {
+    run_id: randomUUID(),
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    gateway_url: gatewayUrl,
+    fixtures: fixtureResults,
+    totals: {
+      fixtures_total: fixtureResults.length,
+      fixtures_ok: fixtureResults.filter((f) => f.ok).length,
+      turns_total: fixtureResults.reduce((acc, f) => acc + f.turn_results.length, 0),
+      turns_ok: fixtureResults.reduce((acc, f) => acc + f.turn_results.filter((t) => t.ok).length, 0),
+      p50_ms: percentile(allOkMs, 50),
+      p95_ms: percentile(allOkMs, 95),
+      p99_ms: percentile(allOkMs, 99),
+    },
+  };
+}
+
+// Direct-invoke entry: `npx tsx services/gateway/test/eval/replay-runner.ts`
+if (require.main === module) {
+  runReplay()
+    .then((out) => {
+      console.log(JSON.stringify(out, null, 2));
+    })
+    .catch((err) => {
+      console.error('[eval] runReplay failed:', err);
+      process.exit(1);
+    });
+}

--- a/services/gateway/test/eval/types.ts
+++ b/services/gateway/test/eval/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Eval harness types — Phase 1 W1 (VTID-03177 PROFILE).
+ *
+ * A "golden corpus" is a set of recorded prod sessions captured for replay.
+ * Each fixture is one session: a sequence of user turns + the expected
+ * primary-model response shape (intent, tool calls, voice or text).
+ *
+ * The replay runner is intentionally narrow in W1: it measures per-turn
+ * latency against a configurable gateway URL and produces a summary report.
+ * W2+ expands assertions (tool-routing accuracy, transcript quality).
+ */
+
+export type GoldenTurnKind = 'voice' | 'text';
+
+export interface GoldenTurn {
+  /** Increment within the session, starting at 1. */
+  turn: number;
+  /** What the user said/typed (canonical UTF-8). */
+  user_input: string;
+  /** Voice or text turn. Voice turns simulate audio; W1 just runs the text-equivalent. */
+  kind: GoldenTurnKind;
+  /** Optional canonical expected tool name (e.g. `send_chat_message`); used for accuracy scoring. */
+  expected_tool?: string;
+  /** Optional canonical expected intent kind (e.g. `task.create`). */
+  expected_intent?: string;
+}
+
+export interface GoldenCorpusFixture {
+  /** Stable id; matches filename (without `.json`). */
+  fixture_id: string;
+  /** Source: `prod-extracted` for sessions pulled from prod, `synthetic` for hand-crafted. */
+  source: 'prod-extracted' | 'synthetic';
+  /** When the fixture was captured. */
+  captured_at: string;
+  /** Number of turns; sanity check vs `turns.length`. */
+  turn_count: number;
+  /** Free-form notes (e.g. why this session was chosen). */
+  notes?: string;
+  turns: GoldenTurn[];
+}
+
+export interface ReplayPhaseTiming {
+  phase: string;
+  start_ms: number;
+  end_ms?: number;
+  duration_ms?: number;
+}
+
+export interface ReplayTurnResult {
+  turn: number;
+  ok: boolean;
+  /** Total wall-clock for the turn (request-in to response-finish). */
+  total_ms: number;
+  /** Phased timings, when Server-Timing was present. */
+  phases: ReplayPhaseTiming[];
+  /** HTTP status of the gateway response. */
+  http_status?: number;
+  /** Error text if `ok` is false. */
+  error?: string;
+}
+
+export interface ReplayFixtureResult {
+  fixture_id: string;
+  ok: boolean;
+  turn_results: ReplayTurnResult[];
+  /** p50/p95/p99 of total_ms across turns. */
+  p50_ms?: number;
+  p95_ms?: number;
+  p99_ms?: number;
+  error?: string;
+}
+
+export interface ReplayRunOutput {
+  run_id: string;
+  started_at: string;
+  finished_at: string;
+  gateway_url: string;
+  fixtures: ReplayFixtureResult[];
+  /** Roll-up across all turns of all fixtures. */
+  totals: {
+    fixtures_total: number;
+    fixtures_ok: number;
+    turns_total: number;
+    turns_ok: number;
+    p50_ms: number;
+    p95_ms: number;
+    p99_ms: number;
+  };
+}


### PR DESCRIPTION
First of 5 Phase 1 W1 scaffold PRs. Telemetry plumbing for the fine-tune/cache/voice-latency PRs. Everything gated behind FEATURE_LATENCY_TELEMETRY_ENV (default off). What lands: 8 new OASIS topics (voice.latency.measured, screen.latency.measured, eval.shadow.compared, eval.coverage.report, dataset.extraction.completed, finetune.training.completed, auto_promote.proposed, auto_promote.rejected); middleware/server-timing.ts; orb/live/latency-tracker.ts + withLatencyTracker middleware wired on /orb/chat; routes/rum-beacon.ts (companion vitana-v1 frontend PR ships src/lib/rum.ts); test/eval/ replay-runner + 3 synthetic fixtures; STAGE-DEPLOY.yml step 8 INSERT->UPSERT fix for the concurrent-deploy 409 race. npm run build green.