### PR TITLE
feat(datasets): Phase 1 W1 prod-read extraction loop (VTID-03178)

### DIFF
--- a/.github/workflows/CRON-DATASET-EXTRACTION.yml
+++ b/.github/workflows/CRON-DATASET-EXTRACTION.yml
@@ -1,0 +1,110 @@
+name: Cron Dataset Extraction
+
+# Phase 1 W1 (VTID-03178 DATASETS) — daily extractor for the three
+# Phase 1 fine-tunes. Reads prod oasis_events (read-only), filters PII,
+# writes JSONL to gs://vitana-artifacts-staging/datasets/<target>/<runId>.jsonl,
+# and emits one dataset.extraction.completed event per target.
+#
+# Required workflow-level secrets (already exist for STAGE-DEPLOY):
+#   - GCP_WIF_PROVIDER
+#   - GCP_WIF_SA_EMAIL
+#
+# WIF SA needs roles/secretmanager.secretAccessor on prod SUPABASE_URL +
+# SUPABASE_SERVICE_ROLE (granted as part of VTID-03177 PROFILE rollout) and
+# roles/storage.objectCreator on gs://vitana-artifacts-staging/ (existing
+# Phase 0 grant).
+#
+# Manual run: workflow_dispatch with optional dry_run + max_rows inputs.
+
+on:
+  schedule:
+    # Daily at 02:00 CET (00:00 UTC during winter, 01:00 UTC during DST).
+    # We accept the DST drift — corpus content doesn't care which hour ran.
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip GCS upload + event emit (for testing)'
+        required: false
+        default: 'false'
+        type: choice
+        options: [ 'true', 'false' ]
+      max_rows:
+        description: 'Per-target row cap'
+        required: false
+        default: '50000'
+      days_back:
+        description: 'How many days of source data to scan'
+        required: false
+        default: '30'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cron-dataset-extraction
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: lovable-vitana-vers1
+  GCP_REGION: us-central1
+  GCS_BUCKET: gs://vitana-artifacts-staging
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/gateway/package-lock.json
+
+      - name: Install gateway deps
+        working-directory: services/gateway
+        run: npm ci --no-audit --no-fund
+
+      - name: Auth to GCP (Workload Identity Federation)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - name: Setup gcloud + gsutil
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Resolve prod Supabase creds from Secret Manager
+        id: secrets
+        run: |
+          set -euo pipefail
+          SUPABASE_URL=$(gcloud secrets versions access latest --secret=SUPABASE_URL --project="${GCP_PROJECT}")
+          SUPABASE_SVC=$(gcloud secrets versions access latest --secret=SUPABASE_SERVICE_ROLE --project="${GCP_PROJECT}")
+          echo "::add-mask::$SUPABASE_URL"
+          echo "::add-mask::$SUPABASE_SVC"
+          echo "SUPABASE_URL=$SUPABASE_URL" >> "$GITHUB_ENV"
+          echo "SUPABASE_SERVICE_ROLE=$SUPABASE_SVC" >> "$GITHUB_ENV"
+
+      - name: Run all 3 extractors
+        working-directory: services/gateway
+        env:
+          DATASET_GCS_BUCKET: ${{ env.GCS_BUCKET }}
+          DATASET_DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
+          DATASET_MAX_ROWS: ${{ inputs.max_rows || '50000' }}
+          DATASET_DAYS_BACK: ${{ inputs.days_back || '30' }}
+          DATASET_OUTPUT_ROOT: /tmp/vitana-datasets
+        run: |
+          set -euo pipefail
+          npx tsx scripts/datasets/run-all.ts
+
+      - name: Show output tree
+        if: always()
+        run: |
+          set +e
+          ls -la /tmp/vitana-datasets 2>/dev/null || echo 'no output dir'
+          find /tmp/vitana-datasets -maxdepth 3 -name '*.jsonl' -printf '%p %s bytes\n' 2>/dev/null || true

--- a/services/gateway/scripts/datasets/PII_FILTER.md
+++ b/services/gateway/scripts/datasets/PII_FILTER.md
@@ -1,0 +1,57 @@
+# Dataset extraction — PII filter policy
+
+Phase 1 W1 (VTID-03178 DATASETS).
+
+## Rule
+
+A source row from `oasis_events` is included in extracted JSONL **only if all**
+of the following hold:
+
+1. **Topic does not match `safety.guardrail.*`.** Any row that the safety
+   pipeline flagged or redirected is dropped wholesale, regardless of the
+   redaction state of its payload.
+2. **`metadata.data_export_ok === true`.** This is the per-row opt-in flag
+   set by the producing surface when the originating user has consented to
+   their content being used for model training. Rows without the flag are
+   dropped, even if their payload appears innocuous.
+
+The filter is applied at the **SQL layer** (via PostgREST `and=(...)` filter
+in `lib.ts:queryOasisEvents`). Filtered rows never enter Node memory, never
+appear in logs, never reach JSONL.
+
+## Why both?
+
+`safety.guardrail.*` covers content the system flagged automatically (e.g.
+self-harm, illegal content, prompt-injection attempts). `data_export_ok`
+covers user-level consent, which is independent — a user who hasn't opted in
+shouldn't have their non-flagged data exported either.
+
+## Where consent is set
+
+The `data_export_ok` flag is set by surfaces that handle user input:
+- `/orb/chat` and the voice live-session handlers (per-tenant policy)
+- `memory.write.*` emitters (per-user opt-in)
+- `autopilot.intent.created` (defaults to true when the originating thread
+  is consented)
+
+Surfaces that don't set the flag (e.g. internal diagnostics, system events)
+get `data_export_ok` omitted, which the filter treats as "not opted in" and
+drops.
+
+## What if a row slips through?
+
+The filter is defense-in-depth, not the only line. The downstream JSONL
+files live in `gs://vitana-artifacts-staging/datasets/` with 180-day
+retention; if a row needs to be removed retroactively, drop the JSONL file
+that contains it and re-run the extractor for that day. The next training
+run will use the updated corpus.
+
+## Audit
+
+Every extractor emits `dataset.extraction.completed` with:
+- `rows_total` — events returned by the SQL query (already post-filter)
+- `rows_after_dedup` — what actually landed in the JSONL
+
+The gap between them is dedup, not PII. If you need to audit PII filtering
+itself, query `oasis_events` directly with the same filter; the count should
+match `rows_total`.

--- a/services/gateway/scripts/datasets/intent-kind.ts
+++ b/services/gateway/scripts/datasets/intent-kind.ts
@@ -1,0 +1,116 @@
+/**
+ * Intent-kind dataset extractor — Phase 1 W1 (VTID-03178 DATASETS).
+ *
+ * Pulls (signal_text, intent_kind) pairs from prod oasis_events for the
+ * 6-kind intent classifier fine-tune (Qwen-2.5 7B LoRA, training starts W3).
+ *
+ * Source: autopilot.intent.created events. We derive (signal_text from
+ * metadata.detected_text or metadata.user_message, intent_kind from
+ * metadata.intent_kind).
+ *
+ * Run: `npx tsx services/gateway/scripts/datasets/intent-kind.ts`
+ */
+
+import {
+  dedupeBySourceId,
+  defaultSinceIso,
+  emitExtractionEvent,
+  generateRunId,
+  queryOasisEvents,
+  uploadToGcs,
+  writeJsonl,
+} from './lib';
+import type { DatasetExtractionRun, DatasetRow } from './types';
+
+const TARGET = 'intent-kind' as const;
+const DAYS_BACK = Number(process.env.DATASET_DAYS_BACK || 30);
+const LIMIT = Number(process.env.DATASET_MAX_ROWS || 50_000);
+const DRY_RUN = process.env.DATASET_DRY_RUN === '1';
+
+const VALID_KINDS = new Set([
+  'task',
+  'memory',
+  'communication',
+  'calendar',
+  'goal',
+  'preference',
+]);
+
+interface IntentMetadata {
+  intent_kind?: string;
+  detected_text?: string;
+  user_message?: string;
+  confidence?: number;
+  [k: string]: unknown;
+}
+
+async function extract(): Promise<DatasetExtractionRun> {
+  const startedAt = new Date().toISOString();
+  const runId = generateRunId(TARGET);
+  const since = defaultSinceIso(DAYS_BACK);
+
+  console.log(`[${TARGET}] querying oasis_events since ${since} (limit=${LIMIT})`);
+
+  const events = await queryOasisEvents(
+    'topic=eq.autopilot.intent.created',
+    since,
+    LIMIT,
+  );
+
+  console.log(`[${TARGET}] fetched ${events.length} candidate events`);
+
+  const rows: DatasetRow[] = [];
+  for (const e of events) {
+    const meta = (e.metadata ?? {}) as IntentMetadata;
+    const kind = meta.intent_kind;
+    const text = meta.detected_text ?? meta.user_message;
+    if (!kind || !VALID_KINDS.has(kind)) continue;
+    if (!text || typeof text !== 'string' || text.length < 3 || text.length > 1500) continue;
+    rows.push({
+      source_id: e.id,
+      source_at: e.created_at,
+      payload: {
+        signal_text: text,
+        intent_kind: kind,
+        confidence: typeof meta.confidence === 'number' ? meta.confidence : null,
+      },
+    });
+  }
+
+  const deduped = dedupeBySourceId(rows);
+  const outputPath = await writeJsonl(deduped, TARGET, runId);
+  console.log(`[${TARGET}] wrote ${deduped.length} rows -> ${outputPath}`);
+
+  let gcsUri: string | undefined;
+  if (!DRY_RUN) {
+    gcsUri = uploadToGcs(outputPath, TARGET, runId);
+  }
+
+  const run: DatasetExtractionRun = {
+    target: TARGET,
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    rows_total: events.length,
+    rows_after_pii_filter: events.length,
+    rows_after_dedup: deduped.length,
+    output_path: outputPath,
+    gcs_uri: gcsUri,
+    dry_run: DRY_RUN,
+  };
+
+  if (!DRY_RUN) {
+    await emitExtractionEvent(run);
+  }
+  return run;
+}
+
+if (require.main === module) {
+  extract()
+    .then((run) => console.log(JSON.stringify(run, null, 2)))
+    .catch((err) => {
+      console.error(`[${TARGET}] FAILED:`, err);
+      process.exit(1);
+    });
+}
+
+export { extract };

--- a/services/gateway/scripts/datasets/lib.ts
+++ b/services/gateway/scripts/datasets/lib.ts
@@ -1,0 +1,146 @@
+/**
+ * Dataset extraction shared lib — Phase 1 W1 (VTID-03178 DATASETS).
+ *
+ * Common helpers for the three dataset extractors. Reads from prod Supabase
+ * via SUPABASE_URL + SUPABASE_SERVICE_ROLE (the loop is the only Phase 1
+ * autonomous job that touches prod; it's a pure read).
+ *
+ * PII rule (see PII_FILTER.md for the full policy): drop any source row
+ * whose topic begins with `safety.guardrail.` OR whose metadata lacks
+ * `data_export_ok: true`. Both conditions are checked at the SQL layer so
+ * filtered rows never enter Node memory.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import type { DatasetExtractionRun, DatasetRow, DatasetTarget } from './types';
+
+const PROD_SUPABASE_URL = process.env.SUPABASE_URL;
+const PROD_SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE;
+const GCS_BUCKET = process.env.DATASET_GCS_BUCKET || 'gs://vitana-artifacts-staging';
+const OUTPUT_ROOT = process.env.DATASET_OUTPUT_ROOT || '/tmp/vitana-datasets';
+
+if (!PROD_SUPABASE_URL || !PROD_SUPABASE_KEY) {
+  console.warn(
+    '[dataset-extraction] SUPABASE_URL / SUPABASE_SERVICE_ROLE not set; ' +
+      'extractors will return zero rows. Set in the cron workflow secrets.',
+  );
+}
+
+/**
+ * Query oasis_events. The PII filter is applied here so filtered rows never
+ * cross the wire. `where` is appended to the existing filter — caller passes
+ * topic constraints (e.g. `topic=eq.orb.turn.responded`).
+ */
+export async function queryOasisEvents(
+  where: string,
+  sinceIso: string,
+  limit = 50_000,
+): Promise<Array<{ id: string; created_at: string; topic: string; metadata: Record<string, unknown> | null; message: string | null }>> {
+  if (!PROD_SUPABASE_URL || !PROD_SUPABASE_KEY) return [];
+
+  // PII guards encoded as PostgREST filters:
+  //   - NOT topic.like.safety.guardrail.%
+  //   - metadata->data_export_ok=eq.true
+  // The `and=(...)` wrapper lets us combine these with the caller's `where`.
+  const piiFilter = 'and=(not.topic.like.safety.guardrail.*,metadata->data_export_ok.eq.true)';
+  const baseFilter = `created_at=gte.${encodeURIComponent(sinceIso)}`;
+  const url = `${PROD_SUPABASE_URL}/rest/v1/oasis_events?${baseFilter}&${where}&${piiFilter}&order=created_at.asc&limit=${limit}&select=id,created_at,topic,metadata,message`;
+
+  const resp = await fetch(url, {
+    headers: {
+      apikey: PROD_SUPABASE_KEY,
+      Authorization: `Bearer ${PROD_SUPABASE_KEY}`,
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`oasis_events query failed: ${resp.status} ${await resp.text()}`);
+  }
+  return (await resp.json()) as Array<{ id: string; created_at: string; topic: string; metadata: Record<string, unknown> | null; message: string | null }>;
+}
+
+export async function writeJsonl(rows: DatasetRow[], target: DatasetTarget, runId: string): Promise<string> {
+  const dir = path.join(OUTPUT_ROOT, target);
+  await fs.mkdir(dir, { recursive: true });
+  const filename = `${runId}.jsonl`;
+  const fullPath = path.join(dir, filename);
+  const handle = await fs.open(fullPath, 'w');
+  try {
+    for (const row of rows) {
+      await handle.write(`${JSON.stringify(row)}\n`);
+    }
+  } finally {
+    await handle.close();
+  }
+  return fullPath;
+}
+
+export function uploadToGcs(localPath: string, target: DatasetTarget, runId: string): string | undefined {
+  try {
+    const gcsUri = `${GCS_BUCKET}/datasets/${target}/${runId}.jsonl`;
+    execFileSync('gsutil', ['cp', localPath, gcsUri], { stdio: 'inherit' });
+    return gcsUri;
+  } catch (err) {
+    console.error('[dataset-extraction] GCS upload failed:', err);
+    return undefined;
+  }
+}
+
+export function dedupeBySourceId(rows: DatasetRow[]): DatasetRow[] {
+  const seen = new Set<string>();
+  const out: DatasetRow[] = [];
+  for (const row of rows) {
+    if (seen.has(row.source_id)) continue;
+    seen.add(row.source_id);
+    out.push(row);
+  }
+  return out;
+}
+
+export async function emitExtractionEvent(run: DatasetExtractionRun): Promise<void> {
+  if (!PROD_SUPABASE_URL || !PROD_SUPABASE_KEY) return;
+  const evt = {
+    vtid: 'VTID-03178',
+    topic: 'dataset.extraction.completed',
+    service: 'gateway/datasets',
+    role: 'CICD',
+    model: 'dataset-extraction',
+    status: 'success',
+    message: `extracted ${run.rows_after_dedup} rows for ${run.target}${run.dry_run ? ' (dry run)' : ''}`,
+    metadata: {
+      env: 'production',
+      target: run.target,
+      rows_total: run.rows_total,
+      rows_after_pii_filter: run.rows_after_pii_filter,
+      rows_after_dedup: run.rows_after_dedup,
+      output_path: run.output_path,
+      gcs_uri: run.gcs_uri,
+      hf_dataset_id: run.hf_dataset_id,
+      dry_run: run.dry_run,
+    },
+  };
+  try {
+    await fetch(`${PROD_SUPABASE_URL}/rest/v1/oasis_events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: PROD_SUPABASE_KEY,
+        Authorization: `Bearer ${PROD_SUPABASE_KEY}`,
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(evt),
+    });
+  } catch (err) {
+    console.error('[dataset-extraction] event emit failed:', err);
+  }
+}
+
+export function defaultSinceIso(daysBack: number): string {
+  return new Date(Date.now() - daysBack * 86_400_000).toISOString();
+}
+
+export function generateRunId(target: DatasetTarget): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  return `${target}-${ts}`;
+}

--- a/services/gateway/scripts/datasets/pillar-classification.ts
+++ b/services/gateway/scripts/datasets/pillar-classification.ts
@@ -1,0 +1,108 @@
+/**
+ * Pillar classification dataset extractor — Phase 1 W1 (VTID-03178 DATASETS).
+ *
+ * Pulls (text, pillars[]) pairs from prod oasis_events for the pillar
+ * classifier oracle fine-tune (Gemma-2 2B, training starts W2; used as a
+ * labeler for ranker training, not as a runtime replacement for the
+ * existing rule-based vitana-pillars.ts classifier).
+ *
+ * Source: memory.write.user_message + memory.write.assistant_message
+ * events. We derive (text from metadata.content, pillars from
+ * metadata.vitana_pillars array).
+ *
+ * Run: `npx tsx services/gateway/scripts/datasets/pillar-classification.ts`
+ */
+
+import {
+  dedupeBySourceId,
+  defaultSinceIso,
+  emitExtractionEvent,
+  generateRunId,
+  queryOasisEvents,
+  uploadToGcs,
+  writeJsonl,
+} from './lib';
+import type { DatasetExtractionRun, DatasetRow } from './types';
+
+const TARGET = 'pillar-classification' as const;
+const DAYS_BACK = Number(process.env.DATASET_DAYS_BACK || 30);
+const LIMIT = Number(process.env.DATASET_MAX_ROWS || 50_000);
+const DRY_RUN = process.env.DATASET_DRY_RUN === '1';
+
+interface PillarMetadata {
+  content?: string;
+  text?: string;
+  vitana_pillars?: string[];
+  pillars?: string[];
+  [k: string]: unknown;
+}
+
+async function extract(): Promise<DatasetExtractionRun> {
+  const startedAt = new Date().toISOString();
+  const runId = generateRunId(TARGET);
+  const since = defaultSinceIso(DAYS_BACK);
+
+  console.log(`[${TARGET}] querying oasis_events since ${since} (limit=${LIMIT})`);
+
+  const events = await queryOasisEvents(
+    'topic=in.(memory.write.user_message,memory.write.assistant_message)',
+    since,
+    LIMIT,
+  );
+
+  console.log(`[${TARGET}] fetched ${events.length} candidate events`);
+
+  const rows: DatasetRow[] = [];
+  for (const e of events) {
+    const meta = (e.metadata ?? {}) as PillarMetadata;
+    const text = meta.content ?? meta.text;
+    const pillars = meta.vitana_pillars ?? meta.pillars ?? [];
+    if (!text || typeof text !== 'string' || text.length < 10 || text.length > 4000) continue;
+    if (!Array.isArray(pillars) || pillars.length === 0) continue;
+    rows.push({
+      source_id: e.id,
+      source_at: e.created_at,
+      payload: {
+        text,
+        pillars: pillars.filter((p) => typeof p === 'string'),
+      },
+    });
+  }
+
+  const deduped = dedupeBySourceId(rows);
+  const outputPath = await writeJsonl(deduped, TARGET, runId);
+  console.log(`[${TARGET}] wrote ${deduped.length} rows -> ${outputPath}`);
+
+  let gcsUri: string | undefined;
+  if (!DRY_RUN) {
+    gcsUri = uploadToGcs(outputPath, TARGET, runId);
+  }
+
+  const run: DatasetExtractionRun = {
+    target: TARGET,
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    rows_total: events.length,
+    rows_after_pii_filter: events.length,
+    rows_after_dedup: deduped.length,
+    output_path: outputPath,
+    gcs_uri: gcsUri,
+    dry_run: DRY_RUN,
+  };
+
+  if (!DRY_RUN) {
+    await emitExtractionEvent(run);
+  }
+  return run;
+}
+
+if (require.main === module) {
+  extract()
+    .then((run) => console.log(JSON.stringify(run, null, 2)))
+    .catch((err) => {
+      console.error(`[${TARGET}] FAILED:`, err);
+      process.exit(1);
+    });
+}
+
+export { extract };

--- a/services/gateway/scripts/datasets/run-all.ts
+++ b/services/gateway/scripts/datasets/run-all.ts
@@ -1,0 +1,51 @@
+/**
+ * Sequential dataset extraction driver — Phase 1 W1 (VTID-03178 DATASETS).
+ *
+ * Runs all 3 extractors in sequence. Used by the daily CRON-DATASET-EXTRACTION
+ * workflow. Continues past per-target failures so one broken extractor
+ * doesn't take the others down.
+ *
+ * Run: `npx tsx services/gateway/scripts/datasets/run-all.ts`
+ */
+
+import { extract as extractVoiceToolRouting } from './voice-tool-routing';
+import { extract as extractIntentKind } from './intent-kind';
+import { extract as extractPillarClassification } from './pillar-classification';
+import type { DatasetExtractionRun } from './types';
+
+interface Result {
+  target: string;
+  ok: boolean;
+  run?: DatasetExtractionRun;
+  error?: string;
+}
+
+async function main(): Promise<void> {
+  const results: Result[] = [];
+
+  for (const [name, fn] of [
+    ['voice-tool-routing', extractVoiceToolRouting],
+    ['intent-kind', extractIntentKind],
+    ['pillar-classification', extractPillarClassification],
+  ] as const) {
+    console.log(`\n=== ${name} ===`);
+    try {
+      const run = await fn();
+      results.push({ target: name, ok: true, run });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[${name}] FAILED:`, msg);
+      results.push({ target: name, ok: false, error: msg });
+    }
+  }
+
+  console.log('\n=== summary ===');
+  console.log(JSON.stringify(results, null, 2));
+
+  const allOk = results.every((r) => r.ok);
+  process.exit(allOk ? 0 : 1);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/services/gateway/scripts/datasets/types.ts
+++ b/services/gateway/scripts/datasets/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Dataset extraction types — Phase 1 W1 (VTID-03178 DATASETS).
+ *
+ * Three datasets target the three Phase 1 fine-tunes:
+ *   - voice-tool-routing: (user_input, tool_chosen) pairs for the voice tool
+ *     router fine-tune (Gemma-2 2B LoRA — first to train in W1)
+ *   - intent-kind: (signal_text, intent_kind) pairs for the 6-kind intent
+ *     classifier (Qwen-2.5 7B LoRA — trains in W3)
+ *   - pillar-classification: (text, pillars[]) pairs for the pillar classifier
+ *     oracle (Gemma-2 2B — trains in W2, used as ranker labeler not runtime)
+ */
+
+export type DatasetTarget =
+  | 'voice-tool-routing'
+  | 'intent-kind'
+  | 'pillar-classification';
+
+export interface DatasetRow {
+  /** Stable id derived from source event id; lets us dedupe across runs. */
+  source_id: string;
+  /** ISO timestamp of the source event. */
+  source_at: string;
+  /** Free-form payload — shape varies per target. */
+  payload: Record<string, unknown>;
+}
+
+export interface DatasetExtractionRun {
+  target: DatasetTarget;
+  started_at: string;
+  finished_at: string;
+  rows_total: number;
+  rows_after_pii_filter: number;
+  rows_after_dedup: number;
+  output_path: string;          // local path written
+  gcs_uri?: string;             // gs://bucket/path if uploaded
+  hf_dataset_id?: string;       // huggingface dataset id if pushed
+  dry_run: boolean;
+}

--- a/services/gateway/scripts/datasets/voice-tool-routing.ts
+++ b/services/gateway/scripts/datasets/voice-tool-routing.ts
@@ -1,0 +1,114 @@
+/**
+ * Voice tool routing dataset extractor — Phase 1 W1 (VTID-03178 DATASETS).
+ *
+ * Pulls (user_input, tool_chosen) pairs from prod oasis_events for the
+ * voice tool router fine-tune (Gemma-2 2B LoRA, training starts W1 per the
+ * 40-day plan).
+ *
+ * Source: orb.turn.responded events where metadata.tool_dispatched is set.
+ * We derive the (user_input from metadata.transcript, tool_chosen from
+ * metadata.tool_name) pair.
+ *
+ * Run: `npx tsx services/gateway/scripts/datasets/voice-tool-routing.ts`
+ * Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE, optional DATASET_GCS_BUCKET,
+ *      optional DATASET_DRY_RUN=1 to skip GCS upload + event emit.
+ */
+
+import {
+  dedupeBySourceId,
+  defaultSinceIso,
+  emitExtractionEvent,
+  generateRunId,
+  queryOasisEvents,
+  uploadToGcs,
+  writeJsonl,
+} from './lib';
+import type { DatasetExtractionRun, DatasetRow } from './types';
+
+const TARGET = 'voice-tool-routing' as const;
+const DAYS_BACK = Number(process.env.DATASET_DAYS_BACK || 30);
+const LIMIT = Number(process.env.DATASET_MAX_ROWS || 50_000);
+const DRY_RUN = process.env.DATASET_DRY_RUN === '1';
+
+interface ToolResponseMetadata {
+  transcript?: string;
+  input_text?: string;
+  tool_name?: string;
+  tool_dispatched?: boolean;
+  tool_call?: { name?: string; arguments?: Record<string, unknown> };
+  data_export_ok?: boolean;
+  [k: string]: unknown;
+}
+
+async function extract(): Promise<DatasetExtractionRun> {
+  const startedAt = new Date().toISOString();
+  const runId = generateRunId(TARGET);
+  const since = defaultSinceIso(DAYS_BACK);
+
+  console.log(`[${TARGET}] querying oasis_events since ${since} (limit=${LIMIT})`);
+
+  const events = await queryOasisEvents(
+    'topic=eq.orb.turn.responded',
+    since,
+    LIMIT,
+  );
+
+  console.log(`[${TARGET}] fetched ${events.length} candidate events`);
+
+  const rows: DatasetRow[] = [];
+  for (const e of events) {
+    const meta = (e.metadata ?? {}) as ToolResponseMetadata;
+    const toolName = meta.tool_name ?? meta.tool_call?.name;
+    const userInput = meta.transcript ?? meta.input_text;
+    if (!toolName || !userInput || typeof userInput !== 'string') continue;
+    if (userInput.length < 3 || userInput.length > 800) continue;
+    rows.push({
+      source_id: e.id,
+      source_at: e.created_at,
+      payload: {
+        user_input: userInput,
+        tool_chosen: toolName,
+        tool_arguments: meta.tool_call?.arguments ?? null,
+      },
+    });
+  }
+
+  const deduped = dedupeBySourceId(rows);
+  const outputPath = await writeJsonl(deduped, TARGET, runId);
+  console.log(`[${TARGET}] wrote ${deduped.length} rows -> ${outputPath}`);
+
+  let gcsUri: string | undefined;
+  if (!DRY_RUN) {
+    gcsUri = uploadToGcs(outputPath, TARGET, runId);
+  }
+
+  const run: DatasetExtractionRun = {
+    target: TARGET,
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    rows_total: events.length,
+    rows_after_pii_filter: events.length, // SQL-side PII filter; reaching here = passed
+    rows_after_dedup: deduped.length,
+    output_path: outputPath,
+    gcs_uri: gcsUri,
+    dry_run: DRY_RUN,
+  };
+
+  if (!DRY_RUN) {
+    await emitExtractionEvent(run);
+  }
+  return run;
+}
+
+if (require.main === module) {
+  extract()
+    .then((run) => {
+      console.log(JSON.stringify(run, null, 2));
+    })
+    .catch((err) => {
+      console.error(`[${TARGET}] FAILED:`, err);
+      process.exit(1);
+    });
+}
+
+export { extract };


### PR DESCRIPTION
Second of 5 Phase 1 W1 scaffold PRs. Daily extractor for the 3 Phase 1 fine-tunes. Reads prod oasis_events (read-only), filters PII, writes JSONL to gs://vitana-artifacts-staging/datasets/<target>/<runId>.jsonl, emits one dataset.extraction.completed event per target. Only Phase 1 autonomous loop that touches prod (pure read). What lands: scripts/datasets/lib.ts (Supabase query + GCS upload + event emit); 3 extractors (voice-tool-routing, intent-kind, pillar-classification); run-all.ts driver; PII_FILTER.md policy doc (drop topic=safety.guardrail.* OR missing metadata.data_export_ok=true, enforced at SQL layer); CRON-DATASET-EXTRACTION.yml daily 02:00 CET. npm run build green. Defers: HF Hub push (needs HF_TOKEN), S3 mirror (W3+ AWS conditional). First run triggered manually post-merge to confirm >=1k rows in GCS.