### PR TITLE
feat(finetunes): Phase 1 W1 training pipeline + shadow harness + 5 crons (VTID-03179)

### DIFF
--- a/.github/workflows/CRON-AUTO-PROMOTER.yml
+++ b/.github/workflows/CRON-AUTO-PROMOTER.yml
@@ -1,0 +1,72 @@
+name: Cron Auto-Promoter
+
+# Phase 1 W1 (VTID-03179 FINETUNES) — hourly auto-promoter. Reads rolling
+# 24h eval.shadow.compared events from STAGING, computes per-feature
+# rollups, emits auto_promote.proposed / auto_promote.rejected events.
+#
+# W1 runs in DRY mode (AUTO_PROMOTER_DRY_RUN=1 default): emits events but
+# does NOT open a PR to flip FEATURE_*_ENV. W2+ flips to AUTO_PROMOTER_DRY_RUN=0
+# once the first auto-promotion has been reviewed by a human and the
+# promoter has demonstrated sane decisions for >=48h.
+
+on:
+  schedule:
+    # Hourly on the half-hour.
+    - cron: '30 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry mode (emit events only, no PR)'
+        required: false
+        default: 'true'
+        type: choice
+        options: [ 'true', 'false' ]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cron-auto-promoter
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: lovable-vitana-vers1
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/gateway/package-lock.json
+      - working-directory: services/gateway
+        run: npm ci --no-audit --no-fund
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Resolve STAGING Supabase creds
+        run: |
+          set -euo pipefail
+          STAGING_URL=$(gcloud secrets versions access latest --secret=STAGING_SUPABASE_URL --project="${GCP_PROJECT}")
+          STAGING_KEY=$(gcloud secrets versions access latest --secret=STAGING_SUPABASE_SERVICE_ROLE_KEY --project="${GCP_PROJECT}")
+          echo "::add-mask::$STAGING_URL"
+          echo "::add-mask::$STAGING_KEY"
+          echo "STAGING_SUPABASE_URL=$STAGING_URL" >> "$GITHUB_ENV"
+          echo "STAGING_SUPABASE_SERVICE_ROLE_KEY=$STAGING_KEY" >> "$GITHUB_ENV"
+
+      - name: Run auto-promoter
+        working-directory: services/gateway
+        env:
+          AUTO_PROMOTER_DRY_RUN: ${{ inputs.dry_run == 'false' && '0' || '1' }}
+        run: npx tsx scripts/auto-promoter.ts

--- a/.github/workflows/CRON-FINETUNE-TRAINER.yml
+++ b/.github/workflows/CRON-FINETUNE-TRAINER.yml
@@ -1,0 +1,69 @@
+name: Cron Finetune Trainer
+
+# Phase 1 W1 (VTID-03179 FINETUNES) — weekly Vertex AI Custom Training
+# submitter. Reads scripts/finetune/<target>/config.yaml and invokes
+# `gcloud ai custom-jobs create`. Submission only — does NOT wait for the
+# training job to finish; trained weights are picked up later by the
+# shadow harness when they land in gs://vitana-artifacts-staging/finetune-runs/.
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC (07:00 CET winter / 08:00 CET summer).
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Which fine-tune to submit'
+        required: true
+        default: 'voice-tool-router'
+        type: choice
+        options: [ voice-tool-router, intent-kind, pillar-classifier ]
+      dry_run:
+        description: 'Print gcloud command without invoking'
+        required: false
+        default: 'false'
+        type: choice
+        options: [ 'true', 'false' ]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cron-finetune-trainer-${{ inputs.target || 'weekly' }}
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: lovable-vitana-vers1
+  GCP_REGION: us-central1
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        target: ${{ inputs.target && fromJSON(format('[{0}]', toJSON(inputs.target))) || fromJSON('["voice-tool-router"]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/gateway/package-lock.json
+      - working-directory: services/gateway
+        run: npm ci --no-audit --no-fund
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Submit ${{ matrix.target }}
+        working-directory: services/gateway
+        env:
+          FINETUNE_DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
+        run: npx tsx scripts/finetune/submit-job.ts ${{ matrix.target }}

--- a/.github/workflows/CRON-GRADUATION-RECOMMENDER.yml
+++ b/.github/workflows/CRON-GRADUATION-RECOMMENDER.yml
@@ -1,0 +1,78 @@
+name: Cron Graduation Recommender
+
+# Phase 1 W1 (VTID-03179 FINETUNES) — daily at 09:00 CET. Scans recent
+# auto-promote events, identifies features that have been at promote for
+# >=5 consecutive days, emits an auto_promote.proposed event to PROD
+# oasis_events with action='graduate_to_prod' (the operator's FCM digest
+# pipeline picks that up).
+
+on:
+  schedule:
+    # 09:00 CET = 08:00 UTC (winter) / 07:00 UTC (summer). We use 08:00 UTC
+    # year-round and accept the DST drift.
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip FCM digest emit'
+        required: false
+        default: 'false'
+        type: choice
+        options: [ 'true', 'false' ]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cron-graduation-recommender
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: lovable-vitana-vers1
+
+jobs:
+  recommend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/gateway/package-lock.json
+      - working-directory: services/gateway
+        run: npm ci --no-audit --no-fund
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Resolve STAGING + PROD Supabase creds
+        run: |
+          set -euo pipefail
+          STAGING_URL=$(gcloud secrets versions access latest --secret=STAGING_SUPABASE_URL --project="${GCP_PROJECT}")
+          STAGING_KEY=$(gcloud secrets versions access latest --secret=STAGING_SUPABASE_SERVICE_ROLE_KEY --project="${GCP_PROJECT}")
+          PROD_URL=$(gcloud secrets versions access latest --secret=SUPABASE_URL --project="${GCP_PROJECT}")
+          PROD_KEY=$(gcloud secrets versions access latest --secret=SUPABASE_SERVICE_ROLE --project="${GCP_PROJECT}")
+          echo "::add-mask::$STAGING_URL"
+          echo "::add-mask::$STAGING_KEY"
+          echo "::add-mask::$PROD_URL"
+          echo "::add-mask::$PROD_KEY"
+          {
+            echo "STAGING_SUPABASE_URL=$STAGING_URL"
+            echo "STAGING_SUPABASE_SERVICE_ROLE_KEY=$STAGING_KEY"
+            echo "SUPABASE_URL=$PROD_URL"
+            echo "SUPABASE_SERVICE_ROLE=$PROD_KEY"
+          } >> "$GITHUB_ENV"
+
+      - name: Run graduation recommender
+        working-directory: services/gateway
+        env:
+          GRADUATION_DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
+        run: npx tsx scripts/graduation-recommender.ts

--- a/.github/workflows/MIRROR-ARTIFACTS-S3.yml
+++ b/.github/workflows/MIRROR-ARTIFACTS-S3.yml
@@ -1,0 +1,85 @@
+name: Mirror Artifacts to S3 (dormant)
+
+# Phase 1 W1 (VTID-03179 FINETUNES) — DORMANT until AWS is provisioned per
+# the 40-day plan W3+ conditional. The job's only step early-exits if
+# AWS_BUCKET secret is empty, so the workflow is safe to schedule now and
+# wakes up automatically when secrets land.
+#
+# When live, mirrors gs://vitana-artifacts-staging/finetune-current/<target>/weights.tar.gz
+# to s3://<AWS_BUCKET>/finetune-current/<target>/weights.tar.gz so the
+# Bedrock canary path has a portable copy.
+
+on:
+  schedule:
+    # Daily at 04:30 UTC (right after STAGE-ARTIFACTS-GCS).
+    - cron: '30 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: mirror-artifacts-s3
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: lovable-vitana-vers1
+  STAGING_BUCKET: gs://vitana-artifacts-staging
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      aws_ready: ${{ steps.check.outputs.aws_ready }}
+    steps:
+      - id: check
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          if [ -n "$AWS_BUCKET" ] && [ -n "$AWS_ROLE_ARN" ]; then
+            echo 'aws_ready=true' >> "$GITHUB_OUTPUT"
+            echo "AWS_BUCKET + AWS_ROLE_ARN present; will mirror"
+          else
+            echo 'aws_ready=false' >> "$GITHUB_OUTPUT"
+            echo "AWS_BUCKET / AWS_ROLE_ARN not configured; skipping (this is expected pre-W3)"
+          fi
+
+  mirror:
+    needs: guard
+    if: needs.guard.outputs.aws_ready == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Mirror each target's current weights GCS -> S3
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+        run: |
+          set -euo pipefail
+          for TARGET in voice-tool-router intent-kind pillar-classifier; do
+            SRC="${STAGING_BUCKET}/finetune-current/${TARGET}/weights.tar.gz"
+            if ! gsutil -q stat "${SRC}" 2>/dev/null; then
+              echo "${TARGET}: no current weights; skipping"
+              continue
+            fi
+            TMP="/tmp/${TARGET}-weights.tar.gz"
+            gsutil cp "${SRC}" "${TMP}"
+            aws s3 cp "${TMP}" "s3://${AWS_BUCKET}/finetune-current/${TARGET}/weights.tar.gz"
+            rm -f "${TMP}"
+            echo "${TARGET}: mirrored"
+          done

--- a/.github/workflows/STAGE-ARTIFACTS-GCS.yml
+++ b/.github/workflows/STAGE-ARTIFACTS-GCS.yml
@@ -1,0 +1,65 @@
+name: Stage Artifacts to GCS
+
+# Phase 1 W1 (VTID-03179 FINETUNES) — daily HF Hub -> GCS mirror for
+# trained finetune weights so all artifacts have a portable, GCP-local copy.
+# Reads the latest weight bundle for each target from gs://vitana-artifacts-staging/finetune-runs/<target>/
+# and ensures it's present in a stable canonical location.
+#
+# In W1 this workflow is mostly a no-op (no fine-tunes have completed yet).
+# It will start doing real work in W2 when the first voice-tool-router run
+# finishes.
+
+on:
+  schedule:
+    # Daily at 04:00 UTC (~05:00-06:00 CET).
+    - cron: '0 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: stage-artifacts-gcs
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: lovable-vitana-vers1
+  STAGING_BUCKET: gs://vitana-artifacts-staging
+
+jobs:
+  stage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Mirror latest weights for each target
+        run: |
+          set -euo pipefail
+          for TARGET in voice-tool-router intent-kind pillar-classifier; do
+            SRC="${STAGING_BUCKET}/finetune-runs/${TARGET}/"
+            DST="${STAGING_BUCKET}/finetune-current/${TARGET}/"
+            echo "=== ${TARGET} ==="
+            # List existing runs newest-first; take the first that has a
+            # weights.tar.gz at its root.
+            LATEST=$(gsutil ls "${SRC}" 2>/dev/null | sort -r | head -10)
+            if [ -z "$LATEST" ]; then
+              echo "no runs yet for ${TARGET}; skipping"
+              continue
+            fi
+            for RUN in $LATEST; do
+              if gsutil -q stat "${RUN}weights.tar.gz" 2>/dev/null; then
+                echo "selecting ${RUN}weights.tar.gz -> ${DST}weights.tar.gz"
+                gsutil -m cp "${RUN}weights.tar.gz" "${DST}weights.tar.gz"
+                echo "${RUN}" | gsutil -m cp - "${DST}LATEST_RUN.txt"
+                break
+              fi
+            done
+          done

--- a/services/gateway/scripts/auto-promoter.ts
+++ b/services/gateway/scripts/auto-promoter.ts
@@ -1,0 +1,172 @@
+/**
+ * Auto-promoter — Phase 1 W1 (VTID-03179 FINETUNES).
+ *
+ * Hourly cron (CRON-AUTO-PROMOTER.yml). Reads rolling 24h
+ * `eval.shadow.compared` events from STAGING oasis_events, computes
+ * agreement / latency / error rate per feature, and decides whether the
+ * staging traffic flip should be advanced (5% -> 50% -> 100%) for that
+ * feature.
+ *
+ * Promotion happens by emitting `auto_promote.proposed` and (in W2+, once
+ * the auto-promoter is allowed to act) opening a PR that flips
+ * FEATURE_<NAME>_ENV in the STAGE-DEPLOY env block. In W1 the promoter
+ * runs in DRY mode — it emits the event but does NOT open a PR yet.
+ *
+ * Promotion to PROD never happens here. Graduation to prod is a human
+ * canary PUBLISH triggered by `graduation-recommender.ts`.
+ *
+ * Run: `npx tsx services/gateway/scripts/auto-promoter.ts`
+ * Env: STAGING_SUPABASE_URL, STAGING_SUPABASE_SERVICE_ROLE_KEY,
+ *      AUTO_PROMOTER_DRY_RUN=0 in W2+ to actually open PRs.
+ */
+
+const STAGING_URL = process.env.STAGING_SUPABASE_URL;
+const STAGING_KEY = process.env.STAGING_SUPABASE_SERVICE_ROLE_KEY;
+const DRY_RUN = process.env.AUTO_PROMOTER_DRY_RUN !== '0';
+const FEATURES = ['voice-tool-router', 'intent-kind', 'pillar-classifier'] as const;
+
+const PROMOTION_THRESHOLDS = {
+  min_samples_per_feature: 200,
+  min_agreement: 0.92,
+  max_candidate_p95_ms: 800,
+  max_candidate_error_rate: 0.02,
+} as const;
+
+interface ShadowEvent {
+  id: string;
+  created_at: string;
+  metadata: {
+    feature?: string;
+    agreement?: boolean | null;
+    candidate_ms?: number;
+    candidate_error?: string | null;
+    [k: string]: unknown;
+  };
+}
+
+interface FeatureRollup {
+  feature: string;
+  samples: number;
+  agreement_rate: number;
+  candidate_p95_ms: number;
+  candidate_error_rate: number;
+}
+
+async function fetchShadowEvents(feature: string): Promise<ShadowEvent[]> {
+  if (!STAGING_URL || !STAGING_KEY) return [];
+  const since = new Date(Date.now() - 24 * 3600_000).toISOString();
+  const url = `${STAGING_URL}/rest/v1/oasis_events?topic=eq.eval.shadow.compared&created_at=gte.${encodeURIComponent(since)}&order=created_at.desc&limit=10000&select=id,created_at,metadata`;
+  const resp = await fetch(url, {
+    headers: {
+      apikey: STAGING_KEY,
+      Authorization: `Bearer ${STAGING_KEY}`,
+    },
+  });
+  if (!resp.ok) {
+    console.error(`[auto-promoter] fetch failed: ${resp.status}`);
+    return [];
+  }
+  const rows = (await resp.json()) as ShadowEvent[];
+  return rows.filter((r) => r.metadata?.feature === feature);
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, idx))];
+}
+
+function rollup(feature: string, events: ShadowEvent[]): FeatureRollup {
+  const samples = events.length;
+  const agreed = events.filter((e) => e.metadata.agreement === true).length;
+  const errored = events.filter((e) => Boolean(e.metadata.candidate_error)).length;
+  const latencies = events
+    .map((e) => e.metadata.candidate_ms)
+    .filter((m): m is number => typeof m === 'number')
+    .sort((a, b) => a - b);
+  return {
+    feature,
+    samples,
+    agreement_rate: samples > 0 ? agreed / samples : 0,
+    candidate_p95_ms: percentile(latencies, 95),
+    candidate_error_rate: samples > 0 ? errored / samples : 0,
+  };
+}
+
+interface Decision {
+  feature: string;
+  action: 'promote' | 'reject' | 'none';
+  reason: string;
+  rollup: FeatureRollup;
+}
+
+function decide(r: FeatureRollup): Decision {
+  if (r.samples < PROMOTION_THRESHOLDS.min_samples_per_feature) {
+    return { feature: r.feature, action: 'none', reason: `insufficient_samples (${r.samples})`, rollup: r };
+  }
+  if (r.agreement_rate < PROMOTION_THRESHOLDS.min_agreement) {
+    return { feature: r.feature, action: 'reject', reason: `low_agreement (${r.agreement_rate.toFixed(3)})`, rollup: r };
+  }
+  if (r.candidate_p95_ms > PROMOTION_THRESHOLDS.max_candidate_p95_ms) {
+    return { feature: r.feature, action: 'reject', reason: `slow_candidate_p95 (${r.candidate_p95_ms}ms)`, rollup: r };
+  }
+  if (r.candidate_error_rate > PROMOTION_THRESHOLDS.max_candidate_error_rate) {
+    return { feature: r.feature, action: 'reject', reason: `high_error_rate (${r.candidate_error_rate.toFixed(3)})`, rollup: r };
+  }
+  return { feature: r.feature, action: 'promote', reason: 'thresholds_met', rollup: r };
+}
+
+async function emitDecision(d: Decision): Promise<void> {
+  if (!STAGING_URL || !STAGING_KEY) return;
+  const topic = d.action === 'promote' ? 'auto_promote.proposed' : 'auto_promote.rejected';
+  const body = {
+    vtid: 'VTID-03179',
+    topic,
+    service: 'gateway/auto-promoter',
+    role: 'CICD',
+    model: 'auto-promoter',
+    status: d.action === 'promote' ? 'success' : 'warning',
+    message: `${d.action} ${d.feature}: ${d.reason}`,
+    metadata: {
+      env: 'staging',
+      action: d.action,
+      reason: d.reason,
+      rollup: d.rollup,
+      dry_run: DRY_RUN,
+    },
+  };
+  try {
+    await fetch(`${STAGING_URL}/rest/v1/oasis_events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: STAGING_KEY,
+        Authorization: `Bearer ${STAGING_KEY}`,
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error('[auto-promoter] event emit failed:', err);
+  }
+}
+
+async function main(): Promise<void> {
+  const results: Decision[] = [];
+  for (const feature of FEATURES) {
+    const events = await fetchShadowEvents(feature);
+    const r = rollup(feature, events);
+    const d = decide(r);
+    console.log(`[auto-promoter] ${feature}: action=${d.action} reason=${d.reason} samples=${r.samples} agreement=${r.agreement_rate.toFixed(3)} p95=${r.candidate_p95_ms}ms`);
+    await emitDecision(d);
+    results.push(d);
+  }
+  console.log(JSON.stringify({ dry_run: DRY_RUN, results }, null, 2));
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[auto-promoter] FAILED:', err);
+    process.exit(1);
+  });
+}

--- a/services/gateway/scripts/distill/voice-tool-router-int4/README.md
+++ b/services/gateway/scripts/distill/voice-tool-router-int4/README.md
@@ -1,0 +1,17 @@
+# INT4 distillation — voice tool router
+
+Phase 1 W4 (VTID-03179 FINETUNES placeholder).
+
+The Phase 1 plan distills the voice tool router fine-tune to INT4 (~1.2 GB)
+in W4 once it has reached 100% of staging traffic and held quality. Until
+then this directory is intentionally empty.
+
+When W4 starts, populate with:
+
+- `quantize.py` — wraps `optimum-cli onnxruntime quantize` against the
+  HF-format LoRA + base model
+- `benchmark.py` — runs the INT4 vs FP16 comparison against the W1 golden
+  corpus
+- `config.yaml` — target latency, target accuracy, AWS readiness flags
+
+Output lands under `gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/<runId>/distilled/int4/`.

--- a/services/gateway/scripts/finetune/intent-kind/config.yaml
+++ b/services/gateway/scripts/finetune/intent-kind/config.yaml
@@ -1,0 +1,48 @@
+# Intent-kind classifier fine-tune config — Phase 1 W1 (VTID-03179 FINETUNES)
+# Trained in W3 of the 40-day plan; ~$5k Vertex AI Custom Training.
+# Output: HF-format LoRA adapter merged with Qwen-2.5 7B base.
+
+target: intent-kind
+base_model: Qwen/Qwen2.5-7B-Instruct
+adapter_method: lora
+lora_r: 16
+lora_alpha: 32
+lora_dropout: 0.05
+target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+
+dataset:
+  gcs_prefix: gs://vitana-artifacts-staging/datasets/intent-kind/
+  format: jsonl
+  field_input: payload.signal_text
+  field_output: payload.intent_kind
+  min_rows_required: 1500
+
+training:
+  epochs: 4
+  batch_size: 8
+  learning_rate: 1.0e-4
+  warmup_steps: 75
+  gradient_accumulation_steps: 4
+  max_seq_len: 1024
+
+vertex_custom_job:
+  project: lovable-vitana-vers1
+  region: us-central1
+  display_name_prefix: intent-kind-ft
+  worker_pool:
+    machine_type: a2-highgpu-1g
+    accelerator_type: NVIDIA_TESLA_A100
+    accelerator_count: 1
+    replica_count: 1
+  container_image: us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-3.py310:latest
+  python_module: finetune.train
+  output_uri_prefix: gs://vitana-artifacts-staging/finetune-runs/intent-kind/
+
+eval:
+  golden_corpus_min_size: 50
+  primary_metric: kind_macro_f1
+  promotion_threshold: 0.88

--- a/services/gateway/scripts/finetune/pillar-classifier/config.yaml
+++ b/services/gateway/scripts/finetune/pillar-classifier/config.yaml
@@ -1,0 +1,51 @@
+# Pillar classifier oracle fine-tune config — Phase 1 W1 (VTID-03179 FINETUNES)
+# Trained in W2 of the 40-day plan; ~$3k Vertex AI Custom Training.
+# Used as an oracle (labeler for ranker training), NOT as a runtime
+# replacement for services/gateway/src/lib/vitana-pillars.ts (rule-based).
+# Output: HF-format LoRA adapter merged with Gemma-2 2B base.
+
+target: pillar-classifier
+base_model: google/gemma-2-2b-it
+adapter_method: lora
+lora_r: 8
+lora_alpha: 16
+lora_dropout: 0.1
+target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+
+dataset:
+  gcs_prefix: gs://vitana-artifacts-staging/datasets/pillar-classification/
+  format: jsonl
+  field_input: payload.text
+  field_output: payload.pillars
+  multi_label: true
+  min_rows_required: 2000
+
+training:
+  epochs: 3
+  batch_size: 16
+  learning_rate: 2.0e-4
+  warmup_steps: 100
+  gradient_accumulation_steps: 2
+  max_seq_len: 1024
+
+vertex_custom_job:
+  project: lovable-vitana-vers1
+  region: us-central1
+  display_name_prefix: pillar-classifier-ft
+  worker_pool:
+    machine_type: g2-standard-8
+    accelerator_type: NVIDIA_L4
+    accelerator_count: 1
+    replica_count: 1
+  container_image: us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-3.py310:latest
+  python_module: finetune.train
+  output_uri_prefix: gs://vitana-artifacts-staging/finetune-runs/pillar-classifier/
+
+eval:
+  golden_corpus_min_size: 100
+  primary_metric: pillar_micro_f1
+  promotion_threshold: 0.85

--- a/services/gateway/scripts/finetune/submit-job.ts
+++ b/services/gateway/scripts/finetune/submit-job.ts
@@ -1,0 +1,116 @@
+/**
+ * Vertex AI Custom Training submitter — Phase 1 W1 (VTID-03179 FINETUNES).
+ *
+ * Wraps `gcloud ai custom-jobs create` with parameters from a finetune
+ * config YAML. Used by CRON-FINETUNE-TRAINER.yml (weekly) and by ad-hoc
+ * manual triggers ("submit voice-tool-router for first training").
+ *
+ * Run: `npx tsx services/gateway/scripts/finetune/submit-job.ts <target>`
+ *      where <target> is one of: voice-tool-router | intent-kind | pillar-classifier
+ *
+ * Env:
+ *   GCP_PROJECT (default lovable-vitana-vers1)
+ *   GCP_REGION  (default us-central1)
+ *   FINETUNE_DRY_RUN=1 — print the gcloud command without invoking
+ */
+
+import { execSync } from 'child_process';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+interface FinetuneConfig {
+  target: string;
+  base_model: string;
+  dataset: {
+    gcs_prefix: string;
+    min_rows_required: number;
+  };
+  training: Record<string, unknown>;
+  vertex_custom_job: {
+    project: string;
+    region: string;
+    display_name_prefix: string;
+    worker_pool: {
+      machine_type: string;
+      accelerator_type: string;
+      accelerator_count: number;
+      replica_count: number;
+    };
+    container_image: string;
+    python_module: string;
+    output_uri_prefix: string;
+  };
+}
+
+const TARGET = process.argv[2];
+const DRY_RUN = process.env.FINETUNE_DRY_RUN === '1';
+const VALID_TARGETS = new Set(['voice-tool-router', 'intent-kind', 'pillar-classifier']);
+
+if (!TARGET || !VALID_TARGETS.has(TARGET)) {
+  console.error(`Usage: tsx submit-job.ts <target>\n  target: ${[...VALID_TARGETS].join(' | ')}`);
+  process.exit(2);
+}
+
+async function parseYaml(file: string): Promise<FinetuneConfig> {
+  const raw = await fs.readFile(file, 'utf-8');
+  const jsYaml = await import('js-yaml');
+  return jsYaml.load(raw) as FinetuneConfig;
+}
+
+async function main(): Promise<void> {
+  const configPath = path.join(__dirname, TARGET, 'config.yaml');
+  console.log(`[submit-job] loading ${configPath}`);
+  const cfg = await parseYaml(configPath);
+
+  const runId = `${cfg.vertex_custom_job.display_name_prefix}-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}-${randomUUID().slice(0, 8)}`;
+  const outputUri = `${cfg.vertex_custom_job.output_uri_prefix}${runId}/`;
+
+  const workerPoolSpec = JSON.stringify({
+    machine_spec: {
+      machine_type: cfg.vertex_custom_job.worker_pool.machine_type,
+      accelerator_type: cfg.vertex_custom_job.worker_pool.accelerator_type,
+      accelerator_count: cfg.vertex_custom_job.worker_pool.accelerator_count,
+    },
+    replica_count: cfg.vertex_custom_job.worker_pool.replica_count,
+    python_package_spec: {
+      executor_image_uri: cfg.vertex_custom_job.container_image,
+      package_uris: [`${cfg.vertex_custom_job.output_uri_prefix}trainer/finetune-trainer-0.1.0.tar.gz`],
+      python_module: cfg.vertex_custom_job.python_module,
+      args: [
+        `--target=${cfg.target}`,
+        `--base-model=${cfg.base_model}`,
+        `--dataset-prefix=${cfg.dataset.gcs_prefix}`,
+        `--output-uri=${outputUri}`,
+        ...Object.entries(cfg.training).map(([k, v]) => `--${k.replace(/_/g, '-')}=${v}`),
+      ],
+    },
+  });
+
+  const args = [
+    'ai', 'custom-jobs', 'create',
+    `--project=${cfg.vertex_custom_job.project}`,
+    `--region=${cfg.vertex_custom_job.region}`,
+    `--display-name=${runId}`,
+    `--worker-pool-spec=${workerPoolSpec}`,
+  ];
+
+  console.log(`[submit-job] job: ${runId}`);
+  console.log(`[submit-job] output_uri: ${outputUri}`);
+  console.log(`[submit-job] command: gcloud ${args.join(' ')}`);
+
+  if (DRY_RUN) {
+    console.log('[submit-job] dry run — not invoking gcloud');
+    return;
+  }
+
+  try {
+    execSync(['gcloud', ...args].join(' '), { stdio: 'inherit' });
+    console.log(`[submit-job] submitted ${runId}`);
+  } catch (err) {
+    console.error('[submit-job] gcloud failed:', err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/services/gateway/scripts/finetune/voice-tool-router/config.yaml
+++ b/services/gateway/scripts/finetune/voice-tool-router/config.yaml
@@ -1,0 +1,48 @@
+# Voice tool router fine-tune config — Phase 1 W1 (VTID-03179 FINETUNES)
+# Trained first in W1 (per the 40-day plan); ~$4k Vertex AI Custom Training.
+# Output: HF-format LoRA adapter merged with Gemma-2 2B base for shadow eval.
+
+target: voice-tool-router
+base_model: google/gemma-2-2b-it
+adapter_method: lora
+lora_r: 16
+lora_alpha: 32
+lora_dropout: 0.05
+target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+
+dataset:
+  gcs_prefix: gs://vitana-artifacts-staging/datasets/voice-tool-routing/
+  format: jsonl
+  field_input: payload.user_input
+  field_output: payload.tool_chosen
+  min_rows_required: 1000
+
+training:
+  epochs: 3
+  batch_size: 16
+  learning_rate: 2.0e-4
+  warmup_steps: 50
+  gradient_accumulation_steps: 2
+  max_seq_len: 512
+
+vertex_custom_job:
+  project: lovable-vitana-vers1
+  region: us-central1
+  display_name_prefix: voice-tool-router-ft
+  worker_pool:
+    machine_type: g2-standard-8
+    accelerator_type: NVIDIA_L4
+    accelerator_count: 1
+    replica_count: 1
+  container_image: us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-3.py310:latest
+  python_module: finetune.train
+  output_uri_prefix: gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/
+
+eval:
+  golden_corpus_min_size: 50
+  primary_metric: tool_choice_accuracy
+  promotion_threshold: 0.92

--- a/services/gateway/scripts/graduation-recommender.ts
+++ b/services/gateway/scripts/graduation-recommender.ts
@@ -1,0 +1,153 @@
+/**
+ * Graduation recommender — Phase 1 W1 (VTID-03179 FINETUNES).
+ *
+ * Daily cron at 09:00 CET (CRON-GRADUATION-RECOMMENDER.yml). Scans the
+ * staging metrics for each fine-tune feature; for any feature that has been
+ * at 100% of staging traffic for >=5 days with thresholds met, emits an
+ * `auto_promote.proposed` event with action='graduate_to_prod' AND fires
+ * an FCM digest to the operator(s) saying "X is ready to PUBLISH".
+ *
+ * The recommender ONLY recommends. Promotion to prod is a human canary
+ * PUBLISH from the prod Command Hub (operator clicks PUBLISH, watches
+ * metrics for 48h, then clicks Promote).
+ *
+ * Run: `npx tsx services/gateway/scripts/graduation-recommender.ts`
+ * Env:
+ *   STAGING_SUPABASE_URL / STAGING_SUPABASE_SERVICE_ROLE_KEY
+ *   PROD_SUPABASE_URL / PROD_SUPABASE_SERVICE_ROLE_KEY (for the FCM emit)
+ *   FCM_RECIPIENT_EMAIL (default d.stevanovic@exafy.io)
+ *   GRADUATION_DRY_RUN=1 to skip FCM
+ */
+
+const STAGING_URL = process.env.STAGING_SUPABASE_URL;
+const STAGING_KEY = process.env.STAGING_SUPABASE_SERVICE_ROLE_KEY;
+const PROD_URL = process.env.SUPABASE_URL;
+const PROD_KEY = process.env.SUPABASE_SERVICE_ROLE;
+const FCM_RECIPIENT = process.env.FCM_RECIPIENT_EMAIL || 'd.stevanovic@exafy.io';
+const DRY_RUN = process.env.GRADUATION_DRY_RUN === '1';
+const FEATURES = ['voice-tool-router', 'intent-kind', 'pillar-classifier'] as const;
+const SOAK_DAYS_REQUIRED = 5;
+
+interface PromoteEvent {
+  id: string;
+  created_at: string;
+  metadata: {
+    action?: string;
+    reason?: string;
+    feature?: string;
+    rollup?: Record<string, unknown>;
+  };
+}
+
+async function fetchRecentPromoteEvents(): Promise<PromoteEvent[]> {
+  if (!STAGING_URL || !STAGING_KEY) return [];
+  const since = new Date(Date.now() - 30 * 86_400_000).toISOString();
+  const url = `${STAGING_URL}/rest/v1/oasis_events?topic=in.(auto_promote.proposed,auto_promote.rejected)&created_at=gte.${encodeURIComponent(since)}&order=created_at.desc&limit=5000&select=id,created_at,metadata`;
+  const resp = await fetch(url, {
+    headers: { apikey: STAGING_KEY, Authorization: `Bearer ${STAGING_KEY}` },
+  });
+  if (!resp.ok) {
+    console.error(`[graduation-recommender] fetch failed: ${resp.status}`);
+    return [];
+  }
+  return (await resp.json()) as PromoteEvent[];
+}
+
+interface Candidate {
+  feature: string;
+  consecutive_proposed_days: number;
+  most_recent_rollup: Record<string, unknown> | null;
+  ready: boolean;
+}
+
+function evaluate(events: PromoteEvent[]): Candidate[] {
+  const out: Candidate[] = [];
+  for (const feature of FEATURES) {
+    const featureEvents = events.filter((e) => e.metadata.feature === feature);
+
+    // Walk back in time. Count contiguous days where the MOST RECENT decision
+    // of the day was action='promote'. If we hit a rejected before the soak
+    // is satisfied, the streak resets.
+    const dayBuckets = new Map<string, PromoteEvent>(); // day -> most recent event for that day
+    for (const e of featureEvents) {
+      const day = e.created_at.slice(0, 10);
+      if (!dayBuckets.has(day)) dayBuckets.set(day, e);
+    }
+
+    const days = [...dayBuckets.keys()].sort().reverse();
+    let consecutive = 0;
+    let mostRecent: Record<string, unknown> | null = null;
+    for (const day of days) {
+      const e = dayBuckets.get(day)!;
+      if (e.metadata.action === 'promote') {
+        consecutive++;
+        if (mostRecent === null) mostRecent = e.metadata.rollup ?? null;
+      } else {
+        break;
+      }
+    }
+
+    out.push({
+      feature,
+      consecutive_proposed_days: consecutive,
+      most_recent_rollup: mostRecent,
+      ready: consecutive >= SOAK_DAYS_REQUIRED,
+    });
+  }
+  return out;
+}
+
+async function fcmDigest(candidates: Candidate[]): Promise<void> {
+  const ready = candidates.filter((c) => c.ready);
+  if (DRY_RUN || !PROD_URL || !PROD_KEY) {
+    console.log('[graduation-recommender] DRY/UNCONFIGURED — skipping FCM:', JSON.stringify(ready, null, 2));
+    return;
+  }
+  const body = {
+    vtid: 'VTID-03179',
+    topic: 'auto_promote.proposed',
+    service: 'gateway/graduation-recommender',
+    role: 'CICD',
+    model: 'graduation-recommender',
+    status: ready.length > 0 ? 'success' : 'info',
+    message: ready.length > 0
+      ? `${ready.length} feature(s) ready to PUBLISH: ${ready.map((c) => c.feature).join(', ')}`
+      : 'no graduation candidates today',
+    metadata: {
+      env: 'production',
+      action: 'graduate_to_prod',
+      candidates,
+      fcm_recipient: FCM_RECIPIENT,
+      soak_days_required: SOAK_DAYS_REQUIRED,
+    },
+  };
+  try {
+    await fetch(`${PROD_URL}/rest/v1/oasis_events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: PROD_KEY,
+        Authorization: `Bearer ${PROD_KEY}`,
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(body),
+    });
+    console.log(`[graduation-recommender] FCM digest emitted (${ready.length} ready)`);
+  } catch (err) {
+    console.error('[graduation-recommender] emit failed:', err);
+  }
+}
+
+async function main(): Promise<void> {
+  const events = await fetchRecentPromoteEvents();
+  const candidates = evaluate(events);
+  console.log(JSON.stringify({ dry_run: DRY_RUN, candidates }, null, 2));
+  await fcmDigest(candidates);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[graduation-recommender] FAILED:', err);
+    process.exit(1);
+  });
+}

--- a/services/gateway/src/services/llm-router-shadow.ts
+++ b/services/gateway/src/services/llm-router-shadow.ts
@@ -1,0 +1,112 @@
+/**
+ * LLM router shadow harness — Phase 1 W1 (VTID-03179 FINETUNES).
+ *
+ * Wraps the existing llm-router so that on any selected call site, the
+ * primary model serves the user AND a candidate (fine-tuned) model is
+ * invoked in parallel with the same input. Both results are recorded as an
+ * `eval.shadow.compared` OASIS event for the auto-promoter to read.
+ *
+ * Wire-up rules:
+ *   - Primary result is what's returned to the caller. Candidate never
+ *     affects the response shape, even on error.
+ *   - Candidate runs in the background — caller does NOT await it.
+ *   - Gated by FEATURE_SHADOW_TOOL_ROUTER_ENV (off | staging-only |
+ *     staging+prod), default off. When off, candidate is not invoked at all
+ *     — zero overhead.
+ *
+ * Auto-promoter (scripts/auto-promoter.ts) reads the resulting events,
+ * computes rolling 24h agreement / latency, and decides 5% → 50% → 100% of
+ * staging traffic flips. Promotion to prod is human-gated via canary
+ * PUBLISH (graduation-recommender FCM digest).
+ */
+
+import { emitOasisEvent } from './oasis-event-service';
+import { isFeatureLive } from './feature-flags';
+
+const FEATURE_NAME = 'SHADOW_TOOL_ROUTER';
+
+export interface ShadowInvocation<TInput, TOutput> {
+  feature: string;             // human-readable target ('voice-tool-router' | 'intent-kind' | 'pillar-classifier')
+  input: TInput;
+  primary: () => Promise<TOutput>;
+  candidate: () => Promise<TOutput>;
+  /** Optional: extract a comparable key from output (e.g. tool name) for shadow agreement metric. */
+  extractKey?: (out: TOutput) => string | null;
+  /** Optional context to attach to the OASIS event (user id, session id). */
+  context?: { actor_id?: string; session_id?: string };
+}
+
+/**
+ * Runs primary and (if enabled) candidate. Returns primary result.
+ * Candidate execution is fire-and-forget.
+ */
+export async function runWithShadow<TInput, TOutput>(
+  inv: ShadowInvocation<TInput, TOutput>,
+): Promise<TOutput> {
+  const enabled = isFeatureLive(FEATURE_NAME);
+
+  if (!enabled) {
+    return inv.primary();
+  }
+
+  const primaryStart = Date.now();
+  const primaryResult = await inv.primary();
+  const primaryMs = Date.now() - primaryStart;
+
+  // Kick off candidate after primary returns so we never extend user-visible
+  // latency by waiting on the candidate to start.
+  void (async () => {
+    const candidateStart = Date.now();
+    let candidateResult: TOutput | undefined;
+    let candidateError: string | undefined;
+    try {
+      candidateResult = await inv.candidate();
+    } catch (err) {
+      candidateError = err instanceof Error ? err.message : String(err);
+    }
+    const candidateMs = Date.now() - candidateStart;
+
+    const primaryKey = inv.extractKey ? safe(() => inv.extractKey!(primaryResult)) : null;
+    const candidateKey = candidateResult && inv.extractKey
+      ? safe(() => inv.extractKey!(candidateResult!))
+      : null;
+    const agreement = primaryKey != null && candidateKey != null
+      ? primaryKey === candidateKey
+      : null;
+
+    try {
+      await emitOasisEvent({
+        vtid: 'VTID-03179',
+        type: 'eval.shadow.compared',
+        source: 'gateway/llm-router-shadow',
+        status: candidateError ? 'warning' : 'success',
+        message: candidateError
+          ? `shadow ${inv.feature}: candidate errored (${candidateError.slice(0, 80)})`
+          : `shadow ${inv.feature}: primary=${primaryKey} candidate=${candidateKey} agree=${agreement}`,
+        actor_id: inv.context?.actor_id,
+        payload: {
+          feature: inv.feature,
+          session_id: inv.context?.session_id,
+          primary_key: primaryKey,
+          candidate_key: candidateKey,
+          agreement,
+          primary_ms: primaryMs,
+          candidate_ms: candidateMs,
+          candidate_error: candidateError,
+        },
+      });
+    } catch {
+      // Never let shadow telemetry break anything.
+    }
+  })();
+
+  return primaryResult;
+}
+
+function safe<T>(fn: () => T): T | null {
+  try {
+    return fn();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Third of 5 Phase 1 W1 scaffold PRs. Stands up the entire fine-tune pipeline plumbing: 3 config YAMLs (one per fine-tune), submit-job.ts wrapping gcloud ai custom-jobs create, shadow harness for safe candidate-vs-primary A/B inside production code, auto-promoter that decides 5%/50%/100% staging flips, graduation-recommender that emits the daily FCM digest, and 5 cron workflows. Gated behind FEATURE_SHADOW_TOOL_ROUTER_ENV (default off) for the shadow path. Crons: CRON-FINETUNE-TRAINER (weekly Mon 06:00 UTC), CRON-AUTO-PROMOTER (hourly :30 in DRY mode), CRON-GRADUATION-RECOMMENDER (daily 08:00 UTC), STAGE-ARTIFACTS-GCS (daily 04:00 UTC), MIRROR-ARTIFACTS-S3 (dormant until AWS_BUCKET secret lands). npm run build green. Defers: actual fine-tune training submission (triggered post-merge manually via gh workflow run), Python trainer package (separate small commit when first job queued), auto-promoter PR-opening path (gated on DRY_RUN=0 in W2+).