### PR TITLE
feat(cache): Phase 1 W1 Cloudflare KV cache + 3 materialized views (VTID-03180)

### DIFF
--- a/cloudflare/community-cache/worker.js
+++ b/cloudflare/community-cache/worker.js
@@ -1,0 +1,217 @@
+/**
+ * Community cache worker (staging) — Phase 1 W1 (VTID-03180 CACHE).
+ *
+ * Sits in front of gateway-staging and serves cacheable GET responses from
+ * Cloudflare KV with stale-while-revalidate semantics.
+ *
+ * Cache decision:
+ *   1. Method must be GET.
+ *   2. Path must be in CACHEABLE_PATHS or match CATALOG_PATTERNS.
+ *   3. Request must not carry user-specific headers that would taint the
+ *      cached object (Authorization, Cookie, X-Tenant-Override, etc.).
+ *
+ * Cache key:  `${pathname}?${sortedSearchString}` — query-order normalized.
+ * Cache TTL:  per-route family (env vars SWR_DEFAULT_S / SWR_CATALOG_S).
+ * Cache miss: fetch from gateway, store the response if eligible, return it.
+ * Cache hit:  return cached body immediately; if stale, schedule a
+ *             background refresh via ctx.waitUntil.
+ *
+ * Personalized mutation purge: the worker watches POST/PUT/PATCH/DELETE
+ * requests and purges any cached object whose path-prefix matches the
+ * mutated resource's path. This is intentionally aggressive — better to
+ * over-purge than serve stale personalized data.
+ */
+
+const CACHEABLE_PATHS = new Set([
+  '/api/v1/autopilot/recommendations',
+  '/api/v1/vitana-index/detail',
+  '/api/v1/vitana-index/overview',
+  '/api/v1/intents/board',
+  '/api/v1/community/feed',
+  '/api/v1/community/discover',
+  '/api/v1/marketplace/feed',
+  '/api/v1/marketplace/categories',
+  '/api/v1/knowledge/topics',
+  '/api/v1/diary/templates',
+]);
+
+const CATALOG_PATTERNS = [
+  /^\/api\/v1\/catalog\//,
+  /^\/api\/v1\/marketplace\/products\//,
+];
+
+const PURGE_TRIGGERS = [
+  '/api/v1/memory',
+  '/api/v1/intents',
+  '/api/v1/calendar',
+  '/api/v1/autopilot/intent',
+];
+
+const PERSONAL_HEADERS = ['authorization', 'cookie', 'x-tenant-override', 'x-user-override'];
+
+function isCacheableGet(request, url) {
+  if (request.method !== 'GET') return false;
+  if (CACHEABLE_PATHS.has(url.pathname)) return true;
+  return CATALOG_PATTERNS.some((re) => re.test(url.pathname));
+}
+
+function isCatalogPath(pathname) {
+  if (CATALOG_PATTERNS.some((re) => re.test(pathname))) return true;
+  return pathname === '/api/v1/knowledge/topics' || pathname === '/api/v1/diary/templates';
+}
+
+function hasPersonalHeaders(request) {
+  return PERSONAL_HEADERS.some((h) => request.headers.has(h));
+}
+
+function normalizeKey(url) {
+  const params = [...url.searchParams.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const qs = params.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
+  return qs ? `${url.pathname}?${qs}` : url.pathname;
+}
+
+async function fromKv(env, key) {
+  const raw = await env.COMMUNITY_CACHE_KV.getWithMetadata(key, { type: 'json' });
+  if (!raw || !raw.value) return null;
+  return { value: raw.value, metadata: raw.metadata || {} };
+}
+
+async function toKv(env, key, body, init, ttlSeconds) {
+  try {
+    await env.COMMUNITY_CACHE_KV.put(
+      key,
+      JSON.stringify({ body, init }),
+      {
+        expirationTtl: Math.max(60, ttlSeconds * 4), // hold past SWR window so background refresh works
+        metadata: { stored_at: Date.now(), ttl_s: ttlSeconds },
+      },
+    );
+  } catch (err) {
+    console.error('[community-cache] KV put failed:', err);
+  }
+}
+
+async function purgePrefix(env, prefix) {
+  // Soft purge — KV has no batch delete by prefix on free tier; track in a
+  // small marker so subsequent reads treat anything from before this
+  // timestamp as instantly stale.
+  try {
+    await env.COMMUNITY_CACHE_KV.put(`__purge_marker__:${prefix}`, String(Date.now()), {
+      expirationTtl: 60 * 60 * 24,
+    });
+  } catch (err) {
+    console.error('[community-cache] purge marker failed:', err);
+  }
+}
+
+async function getPurgeMarker(env, pathname) {
+  for (const prefix of PURGE_TRIGGERS) {
+    if (pathname.startsWith(prefix)) {
+      const raw = await env.COMMUNITY_CACHE_KV.get(`__purge_marker__:${prefix}`);
+      if (raw) return Number(raw);
+    }
+  }
+  return 0;
+}
+
+function buildResponse(body, init) {
+  const headers = new Headers(init.headers || {});
+  headers.set('x-cache-source', 'community-cache');
+  return new Response(body, { status: init.status, statusText: init.statusText, headers });
+}
+
+async function fetchAndCache(request, env, url, key, ttlSeconds, source) {
+  const upstreamUrl = new URL(url.pathname + url.search, env.GATEWAY_ORIGIN);
+  const upstreamReq = new Request(upstreamUrl.toString(), {
+    method: 'GET',
+    headers: filterHeaders(request.headers),
+  });
+  const upstream = await fetch(upstreamReq);
+  if (!upstream.ok) return upstream;
+  const body = await upstream.text();
+  const maxBytes = Number(env.MAX_CACHEABLE_BYTES || 65536);
+  if (body.length <= maxBytes) {
+    const init = {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: Object.fromEntries([...upstream.headers.entries()]),
+    };
+    init.headers['x-cache-status'] = source;
+    await toKv(env, key, body, init, ttlSeconds);
+    return buildResponse(body, init);
+  }
+  // Too large to cache; pass through.
+  return new Response(body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: upstream.headers,
+  });
+}
+
+function filterHeaders(headers) {
+  const out = new Headers();
+  for (const [k, v] of headers.entries()) {
+    if (k.toLowerCase() === 'host') continue;
+    out.set(k, v);
+  }
+  out.set('x-forwarded-by', 'community-cache');
+  return out;
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    // Mutations: forward + schedule a purge marker.
+    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method)) {
+      ctx.waitUntil((async () => {
+        for (const prefix of PURGE_TRIGGERS) {
+          if (url.pathname.startsWith(prefix)) {
+            await purgePrefix(env, prefix);
+            break;
+          }
+        }
+      })());
+      const upstreamUrl = new URL(url.pathname + url.search, env.GATEWAY_ORIGIN);
+      return fetch(new Request(upstreamUrl.toString(), {
+        method: request.method,
+        headers: filterHeaders(request.headers),
+        body: request.body,
+      }));
+    }
+
+    if (!isCacheableGet(request, url) || hasPersonalHeaders(request)) {
+      const upstreamUrl = new URL(url.pathname + url.search, env.GATEWAY_ORIGIN);
+      const upstream = await fetch(new Request(upstreamUrl.toString(), {
+        method: 'GET',
+        headers: filterHeaders(request.headers),
+      }));
+      const headers = new Headers(upstream.headers);
+      headers.set('x-cache-source', 'community-cache');
+      headers.set('x-cache-status', 'BYPASS');
+      return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers });
+    }
+
+    const ttlSeconds = isCatalogPath(url.pathname)
+      ? Number(env.SWR_CATALOG_S || 300)
+      : Number(env.SWR_DEFAULT_S || 30);
+    const key = normalizeKey(url);
+    const purgeAfter = await getPurgeMarker(env, url.pathname);
+    const cached = await fromKv(env, key);
+
+    if (cached) {
+      const storedAt = Number(cached.metadata.stored_at || 0);
+      const age = (Date.now() - storedAt) / 1000;
+      const stale = age > ttlSeconds || storedAt < purgeAfter;
+      cached.value.init.headers['x-cache-status'] = stale ? 'STALE' : 'HIT';
+      cached.value.init.headers['age'] = String(Math.floor(age));
+
+      if (stale) {
+        ctx.waitUntil(fetchAndCache(request, env, url, key, ttlSeconds, 'REVALIDATE'));
+      }
+      return buildResponse(cached.value.body, cached.value.init);
+    }
+
+    return fetchAndCache(request, env, url, key, ttlSeconds, 'MISS');
+  },
+};

--- a/cloudflare/community-cache/wrangler.toml
+++ b/cloudflare/community-cache/wrangler.toml
@@ -1,0 +1,43 @@
+# Community cache (staging) — Phase 1 W1 (VTID-03180 CACHE)
+#
+# Sits in front of community-app-staging.vitanaland.com / preview.vitanaland.com
+# and the gateway-staging origin. Uses Cloudflare KV (free tier) with
+# stale-while-revalidate to serve cacheable read endpoints.
+#
+# Staging-only in W1; production variant ships via canary PUBLISH after a
+# 48h soak (W3+ per the 40-day plan). DNS for preview-cache.vitanaland.com
+# is managed in the Cloudflare zone via the existing DNS API; until that's
+# set up, the worker is reachable directly at
+# vitana-community-cache-staging.workers.dev.
+
+name = "vitana-community-cache-staging"
+main = "worker.js"
+compatibility_date = "2026-05-26"
+
+# Routes attach the Worker to the staging preview hostname. Production
+# variant (community-cache, no -staging suffix) attaches to
+# community.vitanaland.com via a separate wrangler.toml shipped when the
+# W3 canary PUBLISH fires.
+routes = [
+  { pattern = "preview-cache.vitanaland.com/*", zone_name = "vitanaland.com" },
+]
+
+# KV namespace for cached responses. The first deploy creates the namespace
+# via `wrangler kv:namespace create COMMUNITY_CACHE_KV --env staging`; the
+# resulting id is pasted in here.
+[[kv_namespaces]]
+binding = "COMMUNITY_CACHE_KV"
+id = "REPLACE_WITH_KV_ID_AFTER_FIRST_DEPLOY"
+
+[vars]
+GATEWAY_ORIGIN = "https://gateway-staging-q74ibpv6ia-uc.a.run.app"
+ENVIRONMENT = "staging"
+# Stale-while-revalidate window (seconds) per route family. Personalized
+# routes get a short window; pure catalog reads get longer.
+SWR_DEFAULT_S = "30"
+SWR_CATALOG_S = "300"
+# Hard cap on cached response size; larger responses bypass cache.
+MAX_CACHEABLE_BYTES = "65536"
+
+[observability]
+enabled = true

--- a/supabase/migrations/20260528220000_VTID_03180_community_cache_materialized_views.sql
+++ b/supabase/migrations/20260528220000_VTID_03180_community_cache_materialized_views.sql
@@ -1,0 +1,90 @@
+-- Phase 1 W1 (VTID-03180 CACHE): three materialized views for the
+-- heaviest aggregation reads the Cloudflare community-cache worker fronts.
+--
+-- W1 scope: ship the views to STAGING ONLY via RUN-MIGRATION.yml. Routes
+-- continue reading from base tables; W2 swaps reads to the MVs once the
+-- worker is observed serving stale-cache hits cleanly.
+--
+-- Refresh strategy in W1: hourly CONCURRENTLY refresh via a small cron
+-- script (added in PR #3 FINETUNES' STAGE-ARTIFACTS-GCS proximity layer
+-- if needed; for W1 we leave them populate-once and verify the schema
+-- shape works under the worker's cache TTL).
+--
+-- Hard rule (per CLAUDE.md): introspect information_schema.columns BEFORE
+-- writing CREATE TABLE IF NOT EXISTS to avoid the user_journey-style silent
+-- no-op hazard. Materialized views are namespaced separately; no collision
+-- expected, but CREATE MATERIALIZED VIEW IF NOT EXISTS is still defensive.
+
+-- ===========================================================================
+-- mv_autopilot_recs_summary
+-- ===========================================================================
+-- Pre-aggregates the autopilot recommendations endpoint payload per tenant
+-- so the cache can serve a JSON-stable shape. Columns chosen to match the
+-- shape services/gateway/src/routes/autopilot.ts currently builds at read
+-- time (kind, priority, source_type, count).
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_autopilot_recs_summary AS
+SELECT
+  tenant_id,
+  kind,
+  COALESCE(priority, 'normal') AS priority,
+  COALESCE(source_type, 'unknown') AS source_type,
+  COUNT(*) AS rec_count,
+  MAX(created_at) AS latest_created_at
+FROM autopilot_recs
+WHERE created_at > now() - INTERVAL '30 days'
+GROUP BY tenant_id, kind, priority, source_type
+WITH DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_autopilot_recs_summary_unique_idx
+  ON mv_autopilot_recs_summary (tenant_id, kind, priority, source_type);
+
+-- ===========================================================================
+-- mv_vitana_index_overview
+-- ===========================================================================
+-- Latest value per (user_id, axis) for the index overview endpoint. The
+-- detail endpoint still reads raw rows; overview is the heavier aggregation
+-- that benefits most from caching.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_vitana_index_overview AS
+SELECT DISTINCT ON (user_id, axis)
+  user_id,
+  axis,
+  value,
+  computed_at,
+  metadata
+FROM vitana_index_values
+ORDER BY user_id, axis, computed_at DESC
+WITH DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_vitana_index_overview_unique_idx
+  ON mv_vitana_index_overview (user_id, axis);
+
+-- ===========================================================================
+-- mv_intent_kind_30d
+-- ===========================================================================
+-- 30-day intent-kind counts per user for the /intents/board endpoint sidebar.
+-- Sourced from oasis_events rather than a base intents table because the
+-- intent-creation surface emits the event and the table snapshots latest
+-- state only.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_intent_kind_30d AS
+SELECT
+  actor_id AS user_id,
+  COALESCE(metadata->>'intent_kind', 'unknown') AS intent_kind,
+  COUNT(*) AS event_count,
+  MAX(created_at) AS latest_at
+FROM oasis_events
+WHERE topic = 'autopilot.intent.created'
+  AND created_at > now() - INTERVAL '30 days'
+  AND actor_id IS NOT NULL
+GROUP BY actor_id, COALESCE(metadata->>'intent_kind', 'unknown')
+WITH DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_intent_kind_30d_unique_idx
+  ON mv_intent_kind_30d (user_id, intent_kind);
+
+-- Operator note: refresh via
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_<name>;
+-- Schedule TBD in a small refresh cron added in W2 once endpoint cutover
+-- begins. Until then, the worker SWR window absorbs staleness.


### PR DESCRIPTION
Fourth of 5 Phase 1 W1 scaffold PRs. Stands up the staging community-cache worker in front of gateway-staging plus the 3 materialized views that back the heaviest aggregation reads. cloudflare/community-cache/worker.js: KV-backed cache with stale-while-revalidate; 30s SWR for personalized routes, 300s for catalog; 64 KiB cap; mutations to /memory/ /intents/ /calendar/ /autopilot/intent/ trigger soft purge markers; bypasses cache on Authorization/Cookie/X-Tenant-Override headers (never serves cross-user data). cloudflare/community-cache/wrangler.toml: staging-only; KV namespace id placeholder filled in after first wrangler kv:namespace create. supabase/migrations/...VTID_03180_community_cache_materialized_views.sql: mv_autopilot_recs_summary + mv_vitana_index_overview + mv_intent_kind_30d, each with a unique-key index so CONCURRENT refresh works. Existing DEPLOY-CLOUDFLARE-WORKERS.yml auto-picks up the new worker dir. Defers: apply migration via RUN-MIGRATION.yml post-merge, backfill KV namespace id, route handler ETag annotation (W2), prod-tier wrangler (W3 via canary), MV refresh cron (W2).