### PR TITLE
fix(gateway): drift-proof get_user_matches tool query (VTID-01270)

### DIFF
--- a/services/gateway/src/services/match-tool-handler.ts
+++ b/services/gateway/src/services/match-tool-handler.ts
@@ -83,47 +83,46 @@ export async function executeGetUserMatches(
   }
 
   try {
-    // Build query: matches_daily for this user + date + state=suggested
+    // Build query: matches_daily for this user + date + state=suggested.
+    // NOTE: We deliberately avoid a PostgREST embed (match_targets!inner) here.
+    // The embed depends on PostgREST discovering the matches_daily ->
+    // match_targets FK in its schema cache; under production schema drift
+    // (FK absent on the deployed table) that fails with PGRST200
+    // "Could not find a relationship ... in the schema cache" and threw.
+    // Instead we fetch match_targets in a second query (no relationship
+    // discovery required) and join in memory.
     let query = supabase
       .from('matches_daily')
-      .select(`
-        id,
-        match_type,
-        target_id,
-        score,
-        reasons,
-        state,
-        match_targets!inner (
-          display_name,
-          topic_keys,
-          tags,
-          metadata,
-          target_type
-        )
-      `)
+      .select('id, match_type, target_id, score, reasons, state')
       .eq('user_id', userId)
       .eq('match_date', date)
       .eq('state', 'suggested')
       .gte('score', minScore)
       .order('score', { ascending: false });
 
-    // Apply match_type filter
+    // Apply match_type filter (real column on matches_daily)
     if (args.match_type) {
       query = query.eq('match_type', args.match_type);
     }
 
-    // Apply topic filter via match_targets.topic_keys array contains
-    if (args.topic_filter) {
-      query = query.contains('match_targets.topic_keys', [args.topic_filter]);
-    }
-
-    const { data: matches, error, count } = await query.limit(limit);
+    // The topic filter lives on match_targets (Step 2). When present we must
+    // over-fetch and filter in memory after the join, since we can't apply it
+    // on matches_daily. Daily matches per user are small, so the cap is safe.
+    const fetchLimit = args.topic_filter ? 200 : limit;
+    const { data: matches, error } = await query.limit(fetchLimit);
 
     if (error) {
       console.error(`[${VTID}] get_user_matches query error:`, error.message);
 
-      // If table doesn't exist yet (migration not deployed), return gracefully
-      if (error.message.includes('does not exist') || error.message.includes('relation')) {
+      // Graceful fallback for table/schema availability (migration not deployed
+      // or schema drift) — return empty rather than surfacing an error.
+      const em = error.message || '';
+      if (
+        em.includes('does not exist') ||
+        em.includes('relation') ||
+        em.includes('Could not find') ||
+        em.includes('schema cache')
+      ) {
         return {
           ok: true,
           matches: [],
@@ -142,6 +141,42 @@ export async function executeGetUserMatches(
         error: error.message,
       };
     }
+
+    // Step 2: Fetch match target details separately (no embed). Applying the
+    // topic filter here also enforces the original inner-join semantics: only
+    // matches whose target survives the lookup (and topic filter) are kept.
+    const matchRows = (matches || []) as any[];
+    const targetIds = [...new Set(matchRows.map((m) => m.target_id).filter(Boolean))];
+    const targetMap = new Map<string, any>();
+    if (targetIds.length > 0) {
+      let tq = supabase
+        .from('match_targets')
+        .select('id, display_name, topic_keys, tags, metadata, target_type')
+        .in('id', targetIds);
+      if (args.topic_filter) {
+        tq = tq.contains('topic_keys', [args.topic_filter]);
+      }
+      const { data: targets, error: targetErr } = await tq;
+      if (targetErr) {
+        const tm = targetErr.message || '';
+        if (
+          !tm.includes('does not exist') &&
+          !tm.includes('relation') &&
+          !tm.includes('Could not find') &&
+          !tm.includes('schema cache')
+        ) {
+          console.warn(`[${VTID}] match_targets lookup failed: ${tm}`);
+        }
+      }
+      for (const t of (targets || []) as any[]) {
+        targetMap.set(t.id, t);
+      }
+    }
+
+    // Enforce inner-join + topic-filter semantics, then apply the result limit.
+    const filteredMatches = matchRows
+      .filter((m) => targetMap.has(m.target_id))
+      .slice(0, limit);
 
     // Get total count of suggested matches for context
     const { count: totalCount } = await supabase
@@ -164,8 +199,8 @@ export async function executeGetUserMatches(
     }
 
     // Build privacy-safe previews
-    const previews: MatchPreview[] = (matches || []).map((m: any) => {
-      const target = m.match_targets;
+    const previews: MatchPreview[] = filteredMatches.map((m: any) => {
+      const target = targetMap.get(m.target_id);
       let displayName = target?.display_name || 'Unknown';
 
       // Privacy gate for person matches

--- a/services/gateway/src/services/proactive-match-messenger.ts
+++ b/services/gateway/src/services/proactive-match-messenger.ts
@@ -49,13 +49,15 @@ interface MatchRow {
   target_id: string;
   score: number;
   reasons: any;
-  match_targets: {
-    display_name: string;
-    topic_keys: string[];
-    tags: string[];
-    metadata: any;
-    target_type: string;
-  };
+}
+
+interface MatchTargetRow {
+  id: string;
+  display_name: string | null;
+  topic_keys: string[] | null;
+  tags: string[] | null;
+  metadata: any;
+  target_type: string | null;
 }
 
 // =============================================================================
@@ -174,23 +176,19 @@ export async function sendProactiveMatchMessages(
       };
     }
 
-    // Step 2: Fetch top matches
+    // Step 2: Fetch top matches.
+    // NOTE: We deliberately do NOT use a PostgREST embed (match_targets!inner)
+    // here. The embed relies on PostgREST discovering the matches_daily ->
+    // match_targets FK in its schema cache. Production schema drift (FK absent
+    // on the deployed table) made that lookup fail with a PGRST200
+    // "Could not find a relationship ... in the schema cache" error, which
+    // bypassed the table-not-deployed fallback below and threw, spamming
+    // match.proactive.error. Fetching match_targets in a separate query (Step
+    // 2b) removes that dependency entirely and matches how matches_daily is
+    // read elsewhere in the gateway.
     const { data: matches, error: matchError } = await supabase
       .from('matches_daily')
-      .select(`
-        id,
-        match_type,
-        target_id,
-        score,
-        reasons,
-        match_targets!inner (
-          display_name,
-          topic_keys,
-          tags,
-          metadata,
-          target_type
-        )
-      `)
+      .select('id, match_type, target_id, score, reasons')
       .eq('user_id', user_id)
       .eq('match_date', date)
       .eq('state', 'suggested')
@@ -199,9 +197,18 @@ export async function sendProactiveMatchMessages(
       .limit(max_matches);
 
     if (matchError) {
-      // Graceful fallback if migration not deployed
-      if (matchError.message.includes('does not exist') || matchError.message.includes('relation')) {
-        console.warn(`[${VTID}] matches_daily table not available, skipping`);
+      // Graceful fallback if migration not deployed or schema drift on the
+      // matches_daily table (missing table/column/relationship). These are
+      // operational/data issues, not code faults — skip quietly instead of
+      // emitting a P0 error event.
+      const m = matchError.message || '';
+      if (
+        m.includes('does not exist') ||
+        m.includes('relation') ||
+        m.includes('Could not find') ||
+        m.includes('schema cache')
+      ) {
+        console.warn(`[${VTID}] matches_daily unavailable (schema drift?), skipping: ${m}`);
         return {
           ok: true,
           user_id,
@@ -211,7 +218,7 @@ export async function sendProactiveMatchMessages(
         };
       }
 
-      throw new Error(`Match query failed: ${matchError.message}`);
+      throw new Error(`Match query failed: ${m}`);
     }
 
     if (!matches || matches.length === 0) {
@@ -235,6 +242,37 @@ export async function sendProactiveMatchMessages(
       };
     }
 
+    // Step 2b: Fetch match target details in a separate query (no embed).
+    // Resilient to a missing/drifted matches_daily -> match_targets FK.
+    const typedMatches = matches as unknown as MatchRow[];
+    const targetIds = [...new Set(typedMatches.map((m) => m.target_id).filter(Boolean))];
+    const targetMap = new Map<string, MatchTargetRow>();
+    if (targetIds.length > 0) {
+      const { data: targets, error: targetError } = await supabase
+        .from('match_targets')
+        .select('id, display_name, topic_keys, tags, metadata, target_type')
+        .in('id', targetIds);
+
+      if (targetError) {
+        // Non-fatal: degrade to display_name fallbacks rather than dropping
+        // the whole proactive message. Only surface as an error if it is not a
+        // known schema-availability issue.
+        const tm = targetError.message || '';
+        if (
+          !tm.includes('does not exist') &&
+          !tm.includes('relation') &&
+          !tm.includes('Could not find') &&
+          !tm.includes('schema cache')
+        ) {
+          console.warn(`[${VTID}] match_targets lookup failed, using fallbacks: ${tm}`);
+        }
+      }
+
+      for (const t of (targets || []) as MatchTargetRow[]) {
+        targetMap.set(t.id, t);
+      }
+    }
+
     // Step 3: Get total count for context
     const { count: totalCount } = await supabase
       .from('matches_daily')
@@ -256,8 +294,8 @@ export async function sendProactiveMatchMessages(
     }
 
     // Step 5: Build match previews
-    const matchPreviews = (matches as unknown as MatchRow[]).map((m) => {
-      const target = m.match_targets;
+    const matchPreviews = typedMatches.map((m) => {
+      const target = targetMap.get(m.target_id);
       let displayName = target?.display_name || 'Unknown';
 
       if (m.match_type === 'person' && revealMode === 'anonymous') {


### PR DESCRIPTION
## Follow-up: same embed drift in the `get_user_matches` LLM tool

Sibling fix to #2373. `services/gateway/src/services/match-tool-handler.ts` (the `get_user_matches` tool the Gemini operator invokes) used the **identical** PostgREST embed pattern:

```ts
.from('matches_daily').select(`... match_targets!inner ( ... )`)
```

So it's vulnerable to the same production schema-cache drift: a missing `matches_daily → match_targets` FK → `PGRST200: Could not find a relationship … in the schema cache`, which bypassed the table-not-deployed guard and surfaced as a tool error to the LLM.

### Fix (same drift-proof pattern as #2373)
- **Drop the embed** — fetch `matches_daily` and `match_targets` in two queries, join in memory. No dependence on PostgREST relationship discovery.
- **Move `topic_filter`** off the embedded resource onto the `match_targets` query; over-fetch (cap 200, daily matches per user are small) then slice to `limit` so topic-filtered results stay correct under the limit.
- **Preserve inner-join + topic-filter semantics** — filtering to the resolved target set means only matches with a surviving (and topic-matching) target are returned, exactly as `!inner` + embedded filter did.
- **Broaden the graceful guard** to treat `Could not find` / `schema cache` as an availability issue (return empty, no error).

### Verification
- `tsc --noEmit` passes under the project-pinned TypeScript. ✅
- Same live-observability caveat as #2373: this sandbox has no `gcloud`/Supabase creds and the gateway is auth-gated, so the deploy is verified by pipeline wiring (VTID in commit + `services/gateway/**` path → AUTO-DEPLOY → EXEC-DEPLOY), not by curling the live endpoint.

This closes out the last known instance of the `match_targets!inner` drift bug in the gateway.

https://claude.ai/code/session_01NY8wvSKrRodntSwLYvMELY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY8wvSKrRodntSwLYvMELY)_