### PR TITLE
fix(self-healing): honor FULL_AUTO autonomy level in auto-approval gate

### DIFF
--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -303,8 +303,13 @@ export async function processFailingService(
     diagnosis.auto_fixable = false;
   }
 
+  // Level 4 (FULL_AUTO): the injector relaxes the auto-approve floor to 0.5 via
+  // autoApproveFloor(), so confidence in [0.5, 0.8) auto-runs instead of waiting
+  // for a human. The <0.5 escalation above still applies. The autonomy level is
+  // passed through so the injector can pick the correct floor.
+
   // Inject into autopilot pipeline
-  const injection = await injectIntoAutopilotPipeline(vtid, diagnosis, spec, spec_hash);
+  const injection = await injectIntoAutopilotPipeline(vtid, diagnosis, spec, spec_hash, autonomyLevel);
   if (!injection.success) {
     console.error(`[self-healing] Failed to inject ${vtid}: ${injection.error}`);
     return { action: 'escalated', vtid, reason: `Injection failed: ${injection.error}` };
@@ -314,10 +319,11 @@ export async function processFailingService(
   // which the autopilot event loop picks up and dispatches through the
   // standard pipeline (enforceSpecRequirement → worker-runner → completion).
 
-  // Gchat notification ONLY when a human decision is required.
-  // Auto-approved tasks run silently — the team sees them in the
-  // Command Hub if they look, but we don't ping for in-progress work.
-  if (diagnosis.confidence < 0.8) {
+  // Gchat notification ONLY when a human decision is required. Use the injector's
+  // actual approval decision (which honours the per-level floor) instead of a
+  // hardcoded 0.8 — otherwise FULL_AUTO would auto-run a 0.6 fix yet still ping
+  // the team to "approve" it.
+  if (!injection.autoApproved) {
     await notifyGChat(
       `⏳ *Self-Healing AWAITING APPROVAL*\n` +
       `Task: ${vtid}\n` +

--- a/services/gateway/src/services/self-healing-injector-service.ts
+++ b/services/gateway/src/services/self-healing-injector-service.ts
@@ -7,7 +7,7 @@
  */
 
 import { createHash } from 'crypto';
-import { Diagnosis } from '../types/self-healing';
+import { Diagnosis, AutonomyLevel } from '../types/self-healing';
 import { emitOasisEvent } from './oasis-event-service';
 import { bridgeActivationToExecution } from './dev-autopilot-execute';
 import { loadSourceFile } from './self-healing-diagnosis-service';
@@ -402,6 +402,30 @@ async function bridgeToAutopilotExecution(
 }
 
 /**
+ * Confidence floor at or above which a diagnosis is auto-approved (no human
+ * gate) for a given autonomy level.
+ *
+ * Historically this gate was a hardcoded `confidence >= 0.8` that ignored the
+ * autonomy level entirely — so selecting "Level 4: FULL AUTO" in the Command
+ * Hub had no effect and every sub-0.8 failure escalated. FULL_AUTO now relaxes
+ * the floor to 0.5 (matching the <0.5 escalation boundary in
+ * processFailingService), so moderately-confident diagnoses actually run.
+ */
+export function autoApproveFloor(level: AutonomyLevel): number {
+  switch (level) {
+    case AutonomyLevel.FULL_AUTO:
+      return 0.5;
+    case AutonomyLevel.AUTO_FIX_SIMPLE:
+      return 0.8;
+    // OBSERVE_ONLY / DIAGNOSE_ONLY never reach injection; SPEC_AND_WAIT always
+    // requires a human. A floor above 1.0 makes confidence-based auto-approval
+    // impossible for those levels.
+    default:
+      return 1.01;
+  }
+}
+
+/**
  * Inject a diagnosed failure into the autopilot pipeline.
  * The VTID already exists in vtid_ledger (created in diagnosis phase).
  * This function transitions it to 'pending' and attaches the spec.
@@ -411,7 +435,8 @@ export async function injectIntoAutopilotPipeline(
   diagnosis: Diagnosis,
   spec: string,
   specHash: string,
-): Promise<{ success: boolean; error?: string }> {
+  autonomyLevel: AutonomyLevel = AutonomyLevel.AUTO_FIX_SIMPLE,
+): Promise<{ success: boolean; error?: string; autoApproved?: boolean }> {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
     console.error('[self-healing-injector] Supabase not configured');
     return { success: false, error: 'supabase_not_configured' };
@@ -424,7 +449,9 @@ export async function injectIntoAutopilotPipeline(
     const isVoiceSyntheticSource =
       typeof diagnosis.endpoint === 'string' &&
       diagnosis.endpoint.startsWith('voice-error://');
-    const autoApproved = isVoiceSyntheticSource || diagnosis.confidence >= 0.8;
+    const autoApproved =
+      isVoiceSyntheticSource ||
+      diagnosis.confidence >= autoApproveFloor(autonomyLevel);
 
     // Step 1: Update the existing VTID entry — transition allocated → pending
     const updateResp = await fetch(
@@ -585,7 +612,7 @@ export async function injectIntoAutopilotPipeline(
       console.warn(`[self-healing-injector] Failed to insert self_healing_log: ${err.message}`);
     });
 
-    return { success: true };
+    return { success: true, autoApproved };
   } catch (error: any) {
     console.error(`[self-healing-injector] Error injecting ${vtid}: ${error.message}`);
     return { success: false, error: error.message };

--- a/services/gateway/test/self-healing-full-auto-floor.test.ts
+++ b/services/gateway/test/self-healing-full-auto-floor.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Self-Healing FULL_AUTO auto-approval floor.
+ *
+ * Bug: AutonomyLevel.FULL_AUTO (Level 4) was defined in the enum but never
+ * wired into the auto-approval decision. The injector hardcoded
+ * `confidence >= 0.8`, so selecting "Level 4: FULL AUTO" in the Command Hub
+ * had no effect — every sub-0.8 diagnosis stayed `spec_status='validated'`
+ * (awaiting approval) and the reconciler later marked it `escalated`. Result:
+ * the Self-Healing History showed 100% escalated / 0 fixed.
+ *
+ * Fix: autoApproveFloor(level) returns a per-level confidence floor —
+ * FULL_AUTO relaxes it to 0.5 (matching the <0.5 escalation boundary), while
+ * AUTO_FIX_SIMPLE keeps the historical 0.8 and the human-gated levels never
+ * auto-approve on confidence alone.
+ */
+
+import { autoApproveFloor } from '../src/services/self-healing-injector-service';
+import { AutonomyLevel } from '../src/types/self-healing';
+
+describe('autoApproveFloor (self-healing auto-approval gate)', () => {
+  it('FULL_AUTO (Level 4) auto-approves at >= 0.5 confidence', () => {
+    expect(autoApproveFloor(AutonomyLevel.FULL_AUTO)).toBe(0.5);
+  });
+
+  it('AUTO_FIX_SIMPLE (Level 3) keeps the historical 0.8 floor', () => {
+    expect(autoApproveFloor(AutonomyLevel.AUTO_FIX_SIMPLE)).toBe(0.8);
+  });
+
+  it('human-gated / observe levels never auto-approve on confidence alone', () => {
+    expect(autoApproveFloor(AutonomyLevel.SPEC_AND_WAIT)).toBeGreaterThan(1.0);
+    expect(autoApproveFloor(AutonomyLevel.DIAGNOSE_ONLY)).toBeGreaterThan(1.0);
+    expect(autoApproveFloor(AutonomyLevel.OBSERVE_ONLY)).toBeGreaterThan(1.0);
+  });
+
+  describe('regression: a 0.6-confidence diagnosis', () => {
+    const confidence = 0.6;
+
+    it('auto-runs under FULL_AUTO (previously escalated)', () => {
+      expect(confidence >= autoApproveFloor(AutonomyLevel.FULL_AUTO)).toBe(true);
+    });
+
+    it('still requires human approval under AUTO_FIX_SIMPLE', () => {
+      expect(confidence >= autoApproveFloor(AutonomyLevel.AUTO_FIX_SIMPLE)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Why self-healing "stopped working"

The Self-Healing dashboard shows **1506 failures detected, but 100% `escalated` / 0 fixed** — even with **Mode: FULL AUTO (Level 4)** selected. Detection works; the **decide-and-act stage never auto-approves**, so everything falls through to escalation.

### Root cause

`AutonomyLevel.FULL_AUTO = 4` is defined in the enum (`types/self-healing.ts`) but was **only used to render a label string** — it was never wired into the decision logic. The actual auto-approval gate in the injector was hardcoded:

```ts
const autoApproved = isVoiceSyntheticSource || diagnosis.confidence >= 0.8; // ignores autonomy level
```

So selecting "Level 4: FULL AUTO" changed nothing — the system still demanded ≥0.8 confidence to act. Since most diagnoses land at 0.3–0.6 (e.g. connection-refused → 0.4, non-HTTP task names → 0%), they were injected as `spec_status='validated'` (awaiting approval), nobody approved them, and the reconciler marked them `escalated` after the stale window. Hence the dashboard pattern.

## Fix

- Add `autoApproveFloor(level)` — a per-level confidence floor:
  - **FULL_AUTO → 0.5** (matches the existing `<0.5` escalation boundary, so moderately-confident fixes actually run)
  - **AUTO_FIX_SIMPLE → 0.8** (unchanged, backward compatible)
  - human-gated / observe levels → never auto-approve on confidence alone
- Pass the autonomy level into `injectIntoAutopilotPipeline(...)` so it picks the correct floor.
- Base the "awaiting approval" GChat notification on the injector's **actual** approval decision instead of a hardcoded 0.8 (otherwise FULL_AUTO would auto-run a 0.6 fix yet still ping the team to approve it).
- Regression test `self-healing-full-auto-floor.test.ts`.

## Verification

- `npm run build` ✅ (TS 5.3.3, 0 errors)
- New test ✅ (5/5)
- Existing `self-healing-injector-autopilot-bridge` suite ✅ (4/4, unchanged — they use confidence 0.9 / default level)

## ⚠️ Follow-up to confirm before declaring victory

Even with approval fixed, worker execution is gated by `isAutopilotExecutionArmed()` (control `autopilot_execution_enabled`, `system-controls-service.ts`). If that control is **DISARMED**, auto-approved fixes still won't run (they'd show approved/in-progress rather than escalated). **Please confirm `autopilot_execution_enabled` is ARMED in the DB.** This is a config flip, not a code change, so it's intentionally out of scope for this PR.

Optional future scope: non-HTTP "endpoints" like `autopilot.plan_gen` / `autopilot.approve_safety` can't be HTTP-probed and produce permanent 0%-confidence escalations — they should probably be routed/excluded from this path.

https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB)_