### PR TITLE
fix(verification): wire verification engine into execution as non-blocking advisory (VTID-01175)

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -301,6 +301,11 @@ jobs:
             EXTRA_ENV_ARGS+=(--update-env-vars=COMMIT_SHA=${{ github.sha }})
             # VTID-01225: Cognee Extractor URL for entity extraction
             EXTRA_ENV_ARGS+=(--update-env-vars=COGNEE_EXTRACTOR_URL=https://cognee-extractor-86804897789.us-central1.run.app)
+            # VTID-01175: Worker verification mode. 'advisory' (default) runs the
+            # verification engine on every completion and emits a developer-review
+            # report of fixes needed, but NEVER blocks the task. Set to 'blocking'
+            # to restore the legacy hard gate (failed verification fails/retries).
+            EXTRA_ENV_ARGS+=(--update-env-vars=VERIFICATION_MODE=advisory)
             # VTID-01155: Bind Gemini API key for TTS and chat
             SECRETS_ARGS+=(--update-secrets=GOOGLE_GEMINI_API_KEY=GOOGLE_GEMINI_API_KEY:latest)
             # VTID-01184 + BOOTSTRAP-LLM-ROUTER: OpenAI API key — used for

--- a/services/gateway/src/routes/worker-orchestrator.ts
+++ b/services/gateway/src/routes/worker-orchestrator.ts
@@ -23,6 +23,9 @@ import {
   emitSubagentFailed,
   completeSubagentWithVerification,
   completeOrchestratorWithVerification,
+  completeSubagentAdvisory,
+  completeOrchestratorAdvisory,
+  VERIFICATION_MODE,
   TaskDomain,
   WorkOrderPayload,
   SubagentResult
@@ -408,7 +411,31 @@ workerOrchestratorRouter.post('/api/v1/worker/subagent/complete', async (req: Re
         });
       }
 
-      // Run verification
+      // VERIFICATION_MODE=advisory (default): verify but NEVER block.
+      // The task always passes; a failed verification yields a developer-review
+      // report describing what needs to be fixed.
+      if (VERIFICATION_MODE === 'advisory') {
+        const advisory = await completeSubagentAdvisory(
+          vtid,
+          domain as TaskDomain,
+          run_id,
+          result as SubagentResult,
+          startedAtDate
+        );
+        console.log(`[VTID-01175] Subagent ${domain} advisory-verified for ${vtid} (passed=${advisory.report.verification_passed}, non-blocking)`);
+        return res.status(200).json({
+          ok: true,
+          vtid,
+          domain,
+          run_id,
+          advisory: true,
+          verified: advisory.report.verification_passed,
+          verification: advisory.report,
+          event: `vtid.stage.worker_${domain}.success`
+        });
+      }
+
+      // VERIFICATION_MODE=blocking (opt-in): legacy hard gate.
       const verificationResult = await completeSubagentWithVerification(
         vtid,
         domain as TaskDomain,
@@ -504,6 +531,56 @@ workerOrchestratorRouter.post('/api/v1/worker/orchestrator/complete', async (req
     const startedAtDate = started_at ? new Date(started_at) : undefined;
 
     if (success) {
+      // VERIFICATION_MODE=advisory (default): verify but NEVER block.
+      // The task always passes; a failed verification yields a developer-review
+      // report describing what needs to be fixed. The governance skip-gate below
+      // is bypassed entirely in advisory mode since nothing is being skipped to
+      // avoid verification — verification always runs (or no-ops when there is
+      // nothing to verify).
+      if (VERIFICATION_MODE === 'advisory') {
+        if (domain && result) {
+          const subagentResult: SubagentResult = {
+            ok: true,
+            files_changed: result.files_changed,
+            files_created: result.files_created,
+            summary: summary
+          };
+          const advisory = await completeOrchestratorAdvisory(
+            vtid,
+            run_id,
+            domain as TaskDomain,
+            subagentResult,
+            startedAtDate
+          );
+          syncSelfHealingLog(vtid, true).catch(() => {});
+          console.log(`[VTID-01175] Orchestrator advisory-verified for ${vtid} (passed=${advisory.report.verification_passed}, non-blocking)`);
+          return res.status(200).json({
+            ok: true,
+            vtid,
+            run_id,
+            advisory: true,
+            verified: advisory.report.verification_passed,
+            verification: advisory.report,
+            event: 'vtid.stage.worker_orchestrator.success'
+          });
+        }
+
+        // Nothing to verify (missing domain or result): pass through with success.
+        await markOrchestratorSuccess(vtid, run_id, summary || 'Orchestrator completed successfully');
+        syncSelfHealingLog(vtid, true).catch(() => {});
+        console.log(`[VTID-01175] Orchestrator succeeded for ${vtid} (advisory: nothing to verify — ${!domain ? 'missing_domain' : 'missing_result'})`);
+        return res.status(200).json({
+          ok: true,
+          vtid,
+          run_id,
+          advisory: true,
+          verified: false,
+          verification_skipped: true,
+          skip_reason: !domain ? 'missing_domain' : 'missing_result',
+          event: 'vtid.stage.worker_orchestrator.success'
+        });
+      }
+
       // VTID-01175: Run verification before marking success (unless skipped with governance approval)
       const needsSkip = skip_verification || !domain || !result;
       if (needsSkip) {
@@ -553,7 +630,7 @@ workerOrchestratorRouter.post('/api/v1/worker/orchestrator/complete', async (req
         summary: summary
       };
 
-      // Run verification
+      // VERIFICATION_MODE=blocking (opt-in): legacy hard gate.
       const verificationResult = await completeOrchestratorWithVerification(
         vtid,
         run_id,

--- a/services/gateway/src/services/worker-orchestrator-service.ts
+++ b/services/gateway/src/services/worker-orchestrator-service.ts
@@ -26,6 +26,17 @@ const VERIFICATION_ENGINE_URL = process.env.VERIFICATION_ENGINE_URL ||
 const VERIFICATION_TIMEOUT_MS = parseInt(process.env.VERIFICATION_TIMEOUT_MS || '30000', 10);
 const MAX_VERIFICATION_RETRIES = parseInt(process.env.MAX_VERIFICATION_RETRIES || '2', 10);
 
+// Verification mode (default: advisory).
+//  - 'advisory'  : verification ALWAYS runs and produces a report, but NEVER blocks
+//                  completion. A failed verification yields a developer-review event
+//                  describing what needs to be fixed; the task still passes so a
+//                  human can decide to accept the result or follow up.
+//  - 'blocking'  : legacy hard-gate behaviour — a non-retriable verification failure
+//                  fails the task (opt-in via VERIFICATION_MODE=blocking).
+export const VERIFICATION_MODE = (process.env.VERIFICATION_MODE || 'advisory').toLowerCase() === 'blocking'
+  ? 'blocking'
+  : 'advisory';
+
 // =============================================================================
 // VTID-01167 + VTID-01170: Identity Defaults (Canonical Identity Enforcement)
 // =============================================================================
@@ -173,6 +184,26 @@ export interface VerificationOutcome {
   should_retry: boolean;
   reason: string;
   verification_response?: VerifyResponse;
+}
+
+/**
+ * Developer-facing verification report (advisory mode).
+ *
+ * Summarises what the verification engine checked, what passed, what failed,
+ * and a human-readable list of fixes needed — so a developer can decide whether
+ * to accept the delivered work or follow up. Never used to block completion.
+ */
+export interface VerificationReport {
+  verification_passed: boolean;
+  verification_result: string;
+  reason: string;
+  recommended_action: string;
+  checks_run: string[];
+  checks_passed: string[];
+  checks_failed: string[];
+  fixes_needed: string[];
+  details: Record<string, unknown>;
+  developer_decision_required: boolean;
 }
 
 // =============================================================================
@@ -1106,7 +1137,7 @@ export async function emitSubagentFailed(
  */
 async function emitVerificationEvent(
   vtid: string,
-  stage: 'start' | 'passed' | 'failed' | 'error',
+  stage: 'start' | 'passed' | 'failed' | 'error' | 'advisory',
   status: 'info' | 'success' | 'warning' | 'error',
   message: string,
   payload: Record<string, unknown> = {}
@@ -1289,6 +1320,118 @@ export async function verifyWorkerOutput(
  * 3. If failed + retriable: return should_retry=true
  * 4. If failed + not retriable: emit failure event, return failure
  */
+/**
+ * Build a developer-facing verification report from a verification outcome.
+ *
+ * Translates raw engine output (checks_failed, recommended_action, details) into
+ * a concrete "fixes needed" list a human can act on.
+ */
+export function buildVerificationReport(outcome: VerificationOutcome): VerificationReport {
+  const vr = outcome.verification_response;
+  const fixes: string[] = [];
+
+  if (vr) {
+    for (const check of vr.checks_failed || []) {
+      fixes.push(`Failed check: ${check}`);
+    }
+    // Surface any structured hints the engine put in `details`.
+    const det = vr.details || {};
+    for (const key of ['missing_files', 'missingFiles', 'unmodified_files', 'violations']) {
+      const val = (det as Record<string, unknown>)[key];
+      if (Array.isArray(val)) {
+        for (const item of val) fixes.push(`${key}: ${String(item)}`);
+      }
+    }
+    if (vr.recommended_action && vr.recommended_action !== 'complete') {
+      fixes.push(`Engine recommendation: ${vr.recommended_action}`);
+    }
+  }
+
+  if (fixes.length === 0 && !outcome.passed) {
+    fixes.push(outcome.reason);
+  }
+
+  return {
+    verification_passed: outcome.passed,
+    verification_result: vr?.verification_result || (outcome.passed ? 'passed' : 'failed'),
+    reason: outcome.reason,
+    recommended_action: vr?.recommended_action || (outcome.passed ? 'complete' : 'manual_review'),
+    checks_run: vr?.checks_run || [],
+    checks_passed: vr?.checks_passed || [],
+    checks_failed: vr?.checks_failed || [],
+    fixes_needed: fixes,
+    details: vr?.details || {},
+    developer_decision_required: !outcome.passed,
+  };
+}
+
+/**
+ * Advisory subagent completion (VERIFICATION_MODE=advisory).
+ *
+ * Runs verification to produce a report, then ALWAYS marks the subagent
+ * successful — verification never blocks. If issues are found, emits a
+ * `vtid.stage.verification.advisory` event describing the fixes needed so a
+ * developer can review and accept (or reject) the delivered work.
+ */
+export async function completeSubagentAdvisory(
+  vtid: string,
+  domain: TaskDomain,
+  run_id: string,
+  result: SubagentResult,
+  startedAt?: Date
+): Promise<{ ok: true; advisory: true; report: VerificationReport }> {
+  console.log(`[VTID-01175] Advisory verification for ${domain} ${vtid} (non-blocking)`);
+
+  // Run verification — emits start + passed/failed detail events with full report.
+  const verification = await verifyWorkerOutput(vtid, domain, result, run_id, startedAt);
+  const report = buildVerificationReport(verification);
+
+  // ADVISORY: the task always passes regardless of verification outcome.
+  await emitSubagentSuccess(vtid, domain, run_id, result);
+
+  if (!verification.passed) {
+    await emitVerificationEvent(
+      vtid,
+      'advisory',
+      'warning',
+      `Advisory verification flagged ${report.fixes_needed.length} issue(s) for ${vtid} — task passed, developer review required`,
+      {
+        run_id,
+        domain,
+        advisory: true,
+        blocking: false,
+        recommended_action: report.recommended_action,
+        checks_failed: report.checks_failed,
+        fixes_needed: report.fixes_needed,
+        details: report.details,
+      }
+    );
+    console.log(`[VTID-01175] Advisory: ${domain} ${vtid} flagged ${report.fixes_needed.length} fix(es), passed anyway`);
+  }
+
+  return { ok: true, advisory: true, report };
+}
+
+/**
+ * Advisory orchestrator completion (VERIFICATION_MODE=advisory).
+ *
+ * Verifies (non-blocking) then always marks the orchestrator successful.
+ */
+export async function completeOrchestratorAdvisory(
+  vtid: string,
+  run_id: string,
+  domain: TaskDomain,
+  result: SubagentResult,
+  startedAt?: Date
+): Promise<{ ok: true; advisory: true; report: VerificationReport }> {
+  const sub = await completeSubagentAdvisory(vtid, domain, run_id, result, startedAt);
+  const note = sub.report.verification_passed
+    ? `Task completed and verified: ${sub.report.reason}`
+    : `Task completed — advisory verification flagged issues (developer review required): ${sub.report.reason}`;
+  await markOrchestratorSuccess(vtid, run_id, note);
+  return sub;
+}
+
 export async function completeSubagentWithVerification(
   vtid: string,
   domain: TaskDomain,

--- a/services/worker-runner/.gitignore
+++ b/services/worker-runner/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.env
+.env.*
+!.env.example
+*.log
+coverage/

--- a/services/worker-runner/src/services/gateway-client.ts
+++ b/services/worker-runner/src/services/gateway-client.ts
@@ -262,7 +262,10 @@ export async function reportSubagentComplete(
         vtid,
         domain,
         run_id: runId,
-        skip_verification: true, // For worker-runner, we trust the LLM result
+        // Let the gateway run verification (advisory mode: never blocks, emits a
+        // developer-review report of fixes needed). Previously this was hardcoded
+        // to skip_verification:true, which bypassed the verification engine for
+        // every autonomous execution.
         result: {
           ok: result.ok,
           files_changed: result.files_changed || [],
@@ -309,7 +312,9 @@ export async function reportOrchestratorComplete(
         success,
         summary: summary || (success ? 'Task completed successfully' : 'Task failed'),
         error,
-        skip_verification: true, // For worker-runner, we trust the LLM result
+        // Let the gateway run verification (advisory mode: never blocks, emits a
+        // developer-review report of fixes needed). Previously hardcoded to
+        // skip_verification:true, bypassing the verification engine entirely.
         result: result
           ? {
               files_changed: result.files_changed || [],


### PR DESCRIPTION
## Problem

The verification engine (`vitana-verification-engine`) is fully implemented but was **operationally bypassed** — no execution ever flowed through it:

1. **`worker-runner` hardcoded `skip_verification: true`** on both completion paths (`reportSubagentComplete`, `reportOrchestratorComplete`) with the comment *"we trust the LLM result"*. Every autonomous execution skipped the verifier.
2. Even without that, the gateway's skip-gate (`isSkipVerificationAllowed`, VTID-01204) would have **403'd** that skip in production — so completions either silently skipped verification or risked being rejected.
3. The deploy pipeline (AUTO-DEPLOY / EXEC-DEPLOY) never calls the engine either (separate gap, not addressed here).

## What this does

Per the requested behaviour: **verification should never block the process — it should always let work pass, but produce a detailed report of what needs to be fixed so a developer can decide to accept or not.**

- **`worker-runner/gateway-client.ts`** — removed the hardcoded `skip_verification: true` so the gateway actually runs verification.
- **`gateway/worker-orchestrator-service.ts`** — added:
  - `VERIFICATION_MODE` env flag, **default `advisory`** (set `VERIFICATION_MODE=blocking` to restore the legacy hard gate).
  - `buildVerificationReport()` — turns raw engine output into a developer-facing report: `checks_run`, `checks_passed`, `checks_failed`, and a concrete `fixes_needed` list + `recommended_action`.
  - `completeSubagentAdvisory()` / `completeOrchestratorAdvisory()` — run verification, **always mark success**, and on failure emit a `vtid.stage.verification.advisory` OASIS event with the fixes needed.
- **`gateway/worker-orchestrator.ts`** — both completion routes default to advisory mode and return the report in the response (`verification`, `verified`, `advisory: true`). Legacy blocking path preserved under `VERIFICATION_MODE=blocking`.

## Behaviour

| Outcome | Advisory (default) | Blocking (opt-in) |
|---|---|---|
| Verification passes | Task completes, `verified: true` | Task completes |
| Verification fails | **Task still completes**, `verified: false`, advisory event + `fixes_needed` report for developer review | Task fails / retries (legacy) |

## Verification

- `services/gateway`: `npm run build` ✅
- `services/worker-runner`: `npm run build` ✅ + `npm test` (42 passed) ✅

## Notes / follow-ups

- The CI deploy pipeline still does not invoke the verification engine — that is a separate gap discussed but intentionally not included in this change.
- No automated tests existed for these gateway routes; consider adding coverage for advisory vs blocking modes.

https://claude.ai/code/session_017u7iZen4y3SApXTd7J3hSF

---
_Generated by [Claude Code](https://claude.ai/code/session_017u7iZen4y3SApXTd7J3hSF)_