### PR TITLE
fix(i18n): gateway LLM callers respect user locale (BOOTSTRAP-i18n-llm-locale)

### DIFF
--- a/services/gateway/src/i18n/llm-locale.ts
+++ b/services/gateway/src/i18n/llm-locale.ts
@@ -1,0 +1,86 @@
+// LLM locale-injection utility for the gateway.
+//
+// When a gateway service calls an LLM on behalf of a user, the LLM defaults
+// to English unless the system prompt explicitly directs otherwise. This
+// module enforces that every AI-generation path through gateway services
+// injects a language directive at the top of the system prompt.
+//
+// Companion to:
+//   - services/gateway/src/i18n/server-locale.ts (getUserLocale + bulk)
+//   - services/gateway/src/i18n/catalog.ts       (static-string catalog)
+//   - supabase/functions/_shared/llm-locale.ts   (edge-function mirror)
+//
+// Usage:
+//
+//   import { buildLocalizedSystemPrompt } from '../i18n/llm-locale';
+//   import { getUserLocale } from '../i18n/server-locale';
+//
+//   const locale = await getUserLocale(supa, userId);
+//   const systemPrompt = buildLocalizedSystemPrompt(
+//     `You are an expert health coach...`,
+//     locale,
+//   );
+
+import type { GatewayLocale } from './catalog';
+
+// Mirrors the edge-function names + adds the languages the catalog supports.
+const LANGUAGE_NAMES: Record<GatewayLocale, string> = {
+  de: 'German (Deutsch)',
+  en: 'English',
+  sr: 'Serbian (Srpski)',
+  es: 'Spanish (Español)',
+};
+
+// Per-language register hints. Friendly informal tone, mirrors the brand voice.
+const REGISTER_HINTS: Partial<Record<GatewayLocale, string>> = {
+  de: 'Use du-form (informal "du"), NOT Sie-form. The brand voice is informal and friendly.',
+  sr: 'Use ti-form (informal), NOT Vi-form. Friendly, casual register.',
+  es: 'Use tú-form (informal), NOT usted. Friendly tone.',
+};
+
+// Per-language compound-word rules (German is the only language with this
+// problem at the platform scale we see, but the hook is here for others).
+const COMPOUND_RULE: Partial<Record<GatewayLocale, string>> = {
+  de: 'Avoid single words longer than 22 characters. For compounds that would exceed that, insert a hyphen at the natural compound boundary (e.g. "Benachrichtigungs-Einstellungen" not "Benachrichtigungseinstellungen") so they fit narrow mobile layouts.',
+};
+
+/**
+ * Prepend a language directive to a system prompt.
+ *
+ * If `locale` is provided, returns a prompt that forces the LLM to respond
+ * in the user's language with the right register and compound-word rules.
+ * If `locale` is omitted, returns the prompt unchanged (use for paths that
+ * are intentionally English, e.g. admin or developer tooling).
+ */
+export function buildLocalizedSystemPrompt(
+  basePrompt: string,
+  locale: GatewayLocale | null | undefined,
+): string {
+  if (!locale) return basePrompt;
+  const languageName = LANGUAGE_NAMES[locale] ?? 'German (Deutsch)';
+  const registerLine = REGISTER_HINTS[locale] ? `\n- ${REGISTER_HINTS[locale]}` : '';
+  const compoundLine = COMPOUND_RULE[locale] ? `\n- ${COMPOUND_RULE[locale]}` : '';
+  return `LANGUAGE: Respond ONLY in ${languageName}.
+- Every word, label, heading, list item, and example in your response must be in ${languageName}.
+- Do NOT mix languages. Do NOT switch to English for technical terms unless they are universally-untranslated brand names (Vitana, MAXINA, OASIS).${registerLine}${compoundLine}
+
+${basePrompt}`;
+}
+
+/**
+ * Convenience helper for callers that pass an explicit `lang` short code
+ * (the orb voice path style: 'de', 'en', 'sr', etc.) instead of a
+ * GatewayLocale. Normalizes to the supported set and delegates.
+ */
+export function buildLocalizedSystemPromptForLang(
+  basePrompt: string,
+  lang: string | null | undefined,
+): string {
+  if (!lang) return basePrompt;
+  const lower = lang.toLowerCase();
+  if (lower.startsWith('de')) return buildLocalizedSystemPrompt(basePrompt, 'de');
+  if (lower.startsWith('en')) return buildLocalizedSystemPrompt(basePrompt, 'en');
+  if (lower.startsWith('sr')) return buildLocalizedSystemPrompt(basePrompt, 'sr');
+  if (lower.startsWith('es')) return buildLocalizedSystemPrompt(basePrompt, 'es');
+  return basePrompt; // unsupported locale → don't constrain
+}

--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -506,7 +506,8 @@ function computeRelevanceScore(
  */
 async function fetchKnowledgeHits(
   query: string,
-  limit: number
+  limit: number,
+  userId?: string,
 ): Promise<{ hits: KnowledgeHit[]; latency_ms: number }> {
   const startTime = Date.now();
 
@@ -514,6 +515,9 @@ async function fetchKnowledgeHits(
     const request: KnowledgeSearchRequest = {
       query,
       maxResults: limit,
+      // Pass userId so the answer is generated in the user's preferred
+      // language (German by default — community is German-first).
+      userId,
     };
 
     const result = await searchKnowledge(request);
@@ -797,7 +801,7 @@ export async function buildContextPack(
   // Knowledge Hub retrieval
   if (input.router_decision.sources_to_query.includes('knowledge_hub')) {
     retrievalPromises.push(
-      fetchKnowledgeHits(input.query, input.router_decision.limits.knowledge_hub)
+      fetchKnowledgeHits(input.query, input.router_decision.limits.knowledge_hub, input.lens.user_id ?? undefined)
         .then(result => {
           knowledgeHits = result.hits;
           hitCounts.knowledge_hub = result.hits.length;

--- a/services/gateway/src/services/guide/session-summaries.ts
+++ b/services/gateway/src/services/guide/session-summaries.ts
@@ -115,7 +115,9 @@ export async function recordSessionSummary(
   }
 
   // VTID-01990: prefer Gemini Flash summary, fall back to heuristic on any failure
-  let summary = await summarizeWithGeminiFlash(input.transcript_turns);
+  // Pass user id so the summarizer can resolve preferred locale and respond
+  // in the user's language (German by default — community is German-first).
+  let summary = await summarizeWithGeminiFlash(input.transcript_turns, input.user_id, supabase);
   let summarySource: 'llm' | 'heuristic' = 'llm';
   if (!summary || summary.length === 0) {
     summary = buildSummary(input.transcript_turns);
@@ -170,6 +172,8 @@ export async function recordSessionSummary(
  */
 export async function summarizeWithGeminiFlash(
   turns: Array<{ role: 'user' | 'assistant'; text: string }>,
+  userId?: string,
+  supabase?: any,
 ): Promise<string | null> {
   if (!turns || turns.length === 0) return null;
 
@@ -178,12 +182,26 @@ export async function summarizeWithGeminiFlash(
     .map((t) => `${t.role === 'user' ? 'User' : 'Assistant'}: ${truncate(t.text.trim(), 400)}`)
     .join('\n');
 
+  // Resolve user locale so the summary is in the user's language. Falls
+  // back gracefully if userId or supabase isn't provided (older callers).
+  let localizedPrompt = SUMMARY_SYSTEM_PROMPT;
+  if (userId && supabase) {
+    try {
+      const { getUserLocale } = await import('../../i18n/server-locale');
+      const { buildLocalizedSystemPrompt } = await import('../../i18n/llm-locale');
+      const locale = await getUserLocale(supabase, userId);
+      localizedPrompt = buildLocalizedSystemPrompt(SUMMARY_SYSTEM_PROMPT, locale);
+    } catch (e) {
+      console.warn(`${LOG_PREFIX} locale resolution failed, using base prompt:`, (e as Error).message);
+    }
+  }
+
   if (summaryVertexAI) {
     try {
       const model = summaryVertexAI.getGenerativeModel({
         model: SUMMARY_MODEL,
         generationConfig: { temperature: 0.2, maxOutputTokens: 200, topP: 0.8 },
-        systemInstruction: { role: 'system', parts: [{ text: SUMMARY_SYSTEM_PROMPT }] },
+        systemInstruction: { role: 'system', parts: [{ text: localizedPrompt }] },
       });
       const response = await model.generateContent({
         contents: [{ role: 'user', parts: [{ text: transcript }] }],
@@ -206,7 +224,7 @@ export async function summarizeWithGeminiFlash(
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             contents: [{ parts: [{ text: transcript }] }],
-            systemInstruction: { parts: [{ text: SUMMARY_SYSTEM_PROMPT }] },
+            systemInstruction: { parts: [{ text: localizedPrompt }] },
             generationConfig: { temperature: 0.2, maxOutputTokens: 200 },
           }),
         },

--- a/services/gateway/src/services/knowledge-hub.ts
+++ b/services/gateway/src/services/knowledge-hub.ts
@@ -25,6 +25,12 @@ export interface KnowledgeSearchRequest {
   role?: string;
   tenant?: string;
   maxResults?: number;
+  /**
+   * User ID — when present, the generated answer respects the user's
+   * preferred language (German by default). Without it, the LLM falls
+   * back to whatever language it chooses, which is usually English.
+   */
+  userId?: string;
 }
 
 export interface KnowledgeDoc {
@@ -112,7 +118,8 @@ export async function searchKnowledgeDocs(
  */
 async function generateAnswer(
   query: string,
-  docs: KnowledgeDoc[]
+  docs: KnowledgeDoc[],
+  userId?: string,
 ): Promise<string> {
   if (docs.length === 0) {
     return `I couldn't find any documentation matching your query "${query}". Try rephrasing your question or check the Vitana documentation directly.`;
@@ -129,7 +136,9 @@ async function generateAnswer(
       .map((doc, i) => `[Doc ${i + 1}: ${doc.title}]\n${doc.snippet}`)
       .join('\n\n');
 
-    const prompt = `You are a Vitana documentation assistant. Answer the user's question based ONLY on the documentation excerpts provided below. Be concise and accurate. If the documentation doesn't contain enough information to fully answer, say so.
+    // Resolve user locale so the generated answer is in the user's language.
+    // Falls back to base prompt if userId/supabase not available.
+    let basePrompt = `You are a Vitana documentation assistant. Answer the user's question based ONLY on the documentation excerpts provided below. Be concise and accurate. If the documentation doesn't contain enough information to fully answer, say so.
 
 Documentation excerpts:
 ${context}
@@ -137,6 +146,21 @@ ${context}
 User question: ${query}
 
 Answer (be specific and reference the documentation):`;
+
+    if (userId && SUPABASE_URL && SUPABASE_SERVICE_ROLE) {
+      try {
+        const { createClient } = await import('@supabase/supabase-js');
+        const { getUserLocale } = await import('../i18n/server-locale');
+        const { buildLocalizedSystemPrompt } = await import('../i18n/llm-locale');
+        const supa = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+        const locale = await getUserLocale(supa, userId);
+        basePrompt = buildLocalizedSystemPrompt(basePrompt, locale);
+      } catch (e) {
+        console.warn(`[VTID-0538] locale resolution failed:`, (e as Error).message);
+      }
+    }
+
+    const prompt = basePrompt;
 
     const response = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
@@ -199,7 +223,7 @@ function formatSimpleAnswer(query: string, docs: KnowledgeDoc[]): string {
 export async function searchKnowledge(
   request: KnowledgeSearchRequest
 ): Promise<KnowledgeSearchResponse> {
-  const { query, role = 'operator', tenant, maxResults = 5 } = request;
+  const { query, role = 'operator', tenant, maxResults = 5, userId } = request;
 
   console.log(`[VTID-0538] Knowledge search: "${query}" (role=${role}, tenant=${tenant || 'default'})`);
 
@@ -222,8 +246,8 @@ export async function searchKnowledge(
     // Search for documents
     const docs = await searchKnowledgeDocs(query, maxResults);
 
-    // Generate answer from docs
-    const answer = await generateAnswer(query, docs);
+    // Generate answer from docs (in user's preferred language if userId given)
+    const answer = await generateAnswer(query, docs, userId);
 
     // Log success event
     await emitOasisEvent({

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -1524,7 +1524,7 @@ export async function tool_ask_pillar_agent(
   }
 }
 
-export async function tool_explain_feature(args: OrbToolArgs): Promise<OrbToolResult> {
+export async function tool_explain_feature(args: OrbToolArgs, id?: OrbToolIdentity): Promise<OrbToolResult> {
   // Accept either `topic` (Vertex's canonical key) or legacy `feature`.
   // Both pipelines must work — the LiveKit Python tool sends `feature`, the
   // Vertex-side function-tool schema declares `topic`.
@@ -1560,7 +1560,9 @@ export async function tool_explain_feature(args: OrbToolArgs): Promise<OrbToolRe
     let knowledgeDocs: Array<Record<string, unknown>> = [];
     try {
       const { searchKnowledge } = await import('./knowledge-hub');
-      const kb = await searchKnowledge({ query: topic, maxResults: 5 });
+      // Pass userId so the generated answer respects the user's preferred
+      // language (German by default — community is German-first).
+      const kb = await searchKnowledge({ query: topic, maxResults: 5, userId: id?.user_id });
       if (kb.ok && Array.isArray(kb.docs) && kb.docs.length > 0) {
         knowledgeAnswer = (kb.answer ?? '').trim();
         knowledgeDocs = (kb.docs as unknown) as Array<Record<string, unknown>>;
@@ -3830,7 +3832,7 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   consult_external_ai: tool_consult_external_ai,
   create_index_improvement_plan: tool_create_index_improvement_plan,
   ask_pillar_agent: tool_ask_pillar_agent,
-  explain_feature: (args) => tool_explain_feature(args),
+  explain_feature: (args, id) => tool_explain_feature(args, id),
   resolve_recipient: tool_resolve_recipient,
   send_chat_message: tool_send_chat_message,
   share_link: tool_share_link,


### PR DESCRIPTION
## Summary

Companion to vitana-v1 PR #578 (edge functions). Closes the gap where gateway-side LLM-generated text shipped in English for German users — the root cause behind the "why every new feature ships in English?" complaint about journey plans and Life Compass questionnaires.

## What lands

- `services/gateway/src/i18n/llm-locale.ts` (new): mirror of the edge-function helper, building on existing `i18n/server-locale.getUserLocale()` and `i18n/catalog.GatewayLocale`. Prepends `LANGUAGE: Respond ONLY in {Deutsch}` + register hint (du-form for DE, ti/tú for SR/ES) + German compound-word rule.
- `services/gateway/src/services/knowledge-hub.ts`: `searchKnowledge()` takes optional `userId`. When present, `generateAnswer()` resolves locale and wraps the Gemini system prompt.
- `services/gateway/src/services/guide/session-summaries.ts`: `summarizeWithGeminiFlash()` accepts `userId + supabase`; threads through `recordSessionSummary()`. Both Vertex and Gemini API fallback paths use the localized prompt.
- `services/gateway/src/services/context-pack-builder.ts`: `fetchKnowledgeHits()` threads `userId` so KB answers land in the right language.
- `services/gateway/src/services/orb-tools-shared.ts`: `tool_explain_feature` forwards `user_id` to the knowledge-hub fallback chain.

## Skipped (intentionally)

- **Structured extractors** (intent-extractor, inline-fact-extractor): emit JSON, not prose — no locale needed.
- **Admin/dev paths** (gemini-operator, dev-autopilot-*, embedding-service, intent-classifier, llm-router, self-healing-triage): English by design per CLAUDE.md section 13b.
- **Voice paths** (orb-live, orb-livekit): already enforce language via `buildLiveSystemInstruction`'s explicit `lang` parameter.

## Test plan

- [x] `npx tsc` clean on services/gateway
- [ ] Post-merge: confirm EXEC-DEPLOY succeeds for `gateway` (BOOTSTRAP-i18n-llm-locale)
- [ ] Smoke: German user triggers journey-plan generation → German output
- [ ] Smoke: German user triggers Life Compass questionnaire → German output
- [ ] Smoke: German user asks ORB voice "explain Vitana Index" → German KB answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)