### PR TITLE
fix(orb-widget): VTID-03185 / DEV-COMHU-03185 ORB Recovery Phase 0 — audio queue closure fix + regression

### DIFF
--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc --noEmit",
     "validate:dev-frontend-spec": "node ./scripts/validate-dev-frontend-spec.mjs",
     "nav:sync": "tsx scripts/sync-nav-catalog-from-manifest.ts",
-    "nav:check": "tsx scripts/sync-nav-catalog-from-manifest.ts --check"
+    "nav:check": "tsx scripts/sync-nav-catalog-from-manifest.ts --check",
+    "smoke:orb-widget": "node ./scripts/orb-widget-stop-regression.mjs && node ./scripts/orb-widget-audio-playback-regression.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",

--- a/services/gateway/scripts/orb-widget-audio-playback-regression.mjs
+++ b/services/gateway/scripts/orb-widget-audio-playback-regression.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Regression: the ORB playback queue must remove the exact AudioBufferSource
+ * that fired `onended`.
+ *
+ * The previous code captured `var src` inside a loop. Every onended callback
+ * then pointed at the final source scheduled by that loop, so earlier chunks
+ * did not remove themselves from `_s.scheduledSources`. The widget could stay
+ * stuck in "Vitana speaking..." after audio had ended, gating the mic and
+ * making the conversation look like TTS had gone silent.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const sourcePath = resolve(repoRoot, 'services/gateway/src/frontend/command-hub/orb-widget.js');
+const source = readFileSync(sourcePath, 'utf8');
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`[orb-widget-audio-playback-regression] FAIL: ${message}`);
+    process.exit(1);
+  }
+}
+
+function extractFunctionBody(signature) {
+  const sigIdx = source.indexOf(signature);
+  assert(sigIdx >= 0, `missing function signature: ${signature}`);
+  const openIdx = source.indexOf('{', sigIdx);
+  assert(openIdx >= 0, `missing function body open brace: ${signature}`);
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    if (c === '}') depth--;
+    if (depth === 0) return source.slice(openIdx + 1, i);
+  }
+  throw new Error(`unclosed function body: ${signature}`);
+}
+
+const processQueueBody = extractFunctionBody('function _processQueue()');
+
+assert(
+  /\(function\s*\(\s*endedSrc\s*\)\s*\{[\s\S]*src\.onended\s*=\s*function\s*\(\s*\)\s*\{[\s\S]*indexOf\(endedSrc\)[\s\S]*\}\s*;[\s\S]*\}\)\(src\);/.test(processQueueBody),
+  '_processQueue must wrap each onended handler in a per-source closure.',
+);
+assert(
+  /indexOf\(endedSrc\)/.test(processQueueBody),
+  'onended must remove endedSrc from _s.scheduledSources.',
+);
+assert(
+  !/indexOf\(src\)/.test(processQueueBody),
+  'onended must not remove the loop-scoped var src.',
+);
+assert(
+  !/var\s+endedSrc\s*=\s*src;/.test(processQueueBody),
+  'endedSrc must not be declared with var inside the loop; var is function-scoped and preserves the bug.',
+);
+
+console.log('[orb-widget-audio-playback-regression] OK: scheduledSources drains per ended source.');

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -29,7 +29,7 @@
   <!-- VTID-01216: Intelligence Panel containers -->
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
-  <script src="/command-hub/orb-widget.js?v=20260519-fix-sessionstart-race"></script>
+  <script src="/command-hub/orb-widget.js?v=20260529-VTID-03185-audio-queue-closure"></script>
   <script src="/command-hub/app.js?v=20260528-orb-voice-health-probe"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -936,24 +936,33 @@
         src.start(_s.lastScheduledEnd);
 
         _s.scheduledSources.push(src);
-        src.onended = function () {
-          var idx = _s.scheduledSources.indexOf(src);
-          if (idx !== -1) _s.scheduledSources.splice(idx, 1);
-          if (_s.scheduledSources.length === 0) {
-            // Grace period before clearing audioPlaying. Covers inter-chunk
-            // scheduling gaps (~50-100ms). Previously 1000ms to prevent
-            // greeting flicker, but mic is now off during greeting so 400ms
-            // is enough. _waitForAudioEnd also checks scheduledSources +
-            // audioQueue directly, so LISTENING only shows when truly done.
-            clearTimeout(_s.audioEndGraceTimer);
-            _s.audioEndGraceTimer = setTimeout(function () {
-              if (_s.scheduledSources.length === 0 && _s.audioQueue.length === 0) {
-                _s.audioPlaying = false;
-                _s.lastAudioEndTime = Date.now();
-              }
-            }, 400);
-          }
-        };
+        // VTID-03185 — Phase 0 of ORB Recovery: wrap onended in an IIFE that
+        // captures the *specific* AudioBufferSource for this iteration. The
+        // bug was that `src` is `var`-scoped (function-scoped, not block-
+        // scoped), so every onended closure pointed at the LAST `src` the
+        // loop assigned. Earlier chunks could not remove themselves from
+        // _s.scheduledSources, leaving stale entries → the widget stayed in
+        // "Vitana speaking..." after audio had ended, gating the mic.
+        (function (endedSrc) {
+          src.onended = function () {
+            var idx = _s.scheduledSources.indexOf(endedSrc);
+            if (idx !== -1) _s.scheduledSources.splice(idx, 1);
+            if (_s.scheduledSources.length === 0) {
+              // Grace period before clearing audioPlaying. Covers inter-chunk
+              // scheduling gaps (~50-100ms). Previously 1000ms to prevent
+              // greeting flicker, but mic is now off during greeting so 400ms
+              // is enough. _waitForAudioEnd also checks scheduledSources +
+              // audioQueue directly, so LISTENING only shows when truly done.
+              clearTimeout(_s.audioEndGraceTimer);
+              _s.audioEndGraceTimer = setTimeout(function () {
+                if (_s.scheduledSources.length === 0 && _s.audioQueue.length === 0) {
+                  _s.audioPlaying = false;
+                  _s.lastAudioEndTime = Date.now();
+                }
+              }, 400);
+            }
+          };
+        })(src);
 
         _s.lastScheduledEnd += buf.duration;
         _s.audioPlaying = true;

--- a/services/gateway/test/frontend/orb-widget-audio-playback.test.ts
+++ b/services/gateway/test/frontend/orb-widget-audio-playback.test.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const WIDGET_PATH = path.resolve(
+  __dirname,
+  '../../src/frontend/command-hub/orb-widget.js',
+);
+
+function extractFunctionBody(source: string, signature: string): string {
+  const sigIdx = source.indexOf(signature);
+  expect(sigIdx).toBeGreaterThanOrEqual(0);
+  const openIdx = source.indexOf('{', sigIdx);
+  expect(openIdx).toBeGreaterThanOrEqual(0);
+
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    if (c === '}') depth--;
+    if (depth === 0) return source.slice(openIdx + 1, i);
+  }
+  throw new Error(`unclosed function body: ${signature}`);
+}
+
+describe('orb-widget audio playback queue', () => {
+  it('removes the actual ended AudioBufferSource from scheduledSources', () => {
+    const source = fs.readFileSync(WIDGET_PATH, 'utf8');
+    const processQueueBody = extractFunctionBody(source, 'function _processQueue()');
+
+    expect(processQueueBody).toMatch(
+      /\(function\s*\(\s*endedSrc\s*\)\s*\{[\s\S]*src\.onended\s*=\s*function\s*\(\s*\)\s*\{[\s\S]*indexOf\(endedSrc\)[\s\S]*\}\s*;[\s\S]*\}\)\(src\);/,
+    );
+    expect(processQueueBody).toMatch(/indexOf\(endedSrc\)/);
+    expect(processQueueBody).not.toMatch(/indexOf\(src\)/);
+    expect(processQueueBody).not.toMatch(/var\s+endedSrc\s*=\s*src;/);
+  });
+});


### PR DESCRIPTION
## Phase 0 of [ORB Communication Recovery Plan](https://github.com/exafyltd/vitana-platform/blob/main/docs/superpowers/plans/2026-05-29-orb-communication-recovery.md)

Port the audio queue closure fix from the `VOICE-LAT` worktree (where it was uncommitted) to `main`. This is the lowest-blast-radius, highest-immediate-UX-gain step in the recovery plan — and it lands in isolation so subsequent phases can be verified against a known-good audio path.

## The bug

In `_processQueue()` inside `orb-widget.js`, every scheduled `AudioBufferSourceNode`'s `onended` handler closed over `var src`, which is **function-scoped**. The loop reassigned `src` each iteration, so by the time `onended` fired for an earlier chunk, `src` already pointed at the **last** chunk the loop had scheduled. The lookup `_s.scheduledSources.indexOf(src)` then either matched the wrong entry or returned `-1`, so earlier chunks could not remove themselves from the queue.

**Effect**: after multi-chunk TTS playback (any Vitana turn longer than ~2 seconds — i.e. every real greeting), stale entries persisted in `_s.scheduledSources`. The widget therefore stayed in *"Vitana speaking..."* state after audio had actually ended, the mic stayed gated, and the conversation looked frozen.

## The fix

Wrap `onended` assignment in an IIFE that captures `endedSrc` per iteration:

```js
(function (endedSrc) {
  src.onended = function () {
    var idx = _s.scheduledSources.indexOf(endedSrc);  // captures THIS source, not the loop var
    ...
  };
})(src);
```

## What ships in this PR

| Change | Why |
|---|---|
| `src/frontend/command-hub/orb-widget.js` — IIFE wrapper around `onended` | The actual fix |
| `src/frontend/command-hub/index.html` — cache-bust bumped to `20260529-VTID-03185-audio-queue-closure` | CLAUDE.md rule 25: defeat stale CDN-cached widget JS |
| `scripts/orb-widget-audio-playback-regression.mjs` (new) | Node-AST-level regex check; ensures IIFE + `endedSrc` lookup present and buggy `indexOf(src)` cannot reappear |
| `test/frontend/orb-widget-audio-playback.test.ts` (new) | Same assertions in Jest form; runs in `npm test` |
| `package.json` — new `smoke:orb-widget` alias | Runs existing X-close stop regression + new audio-playback regression together; one command for the gateway smoke suite |

The `dist/` copy is `.gitignored` and regenerated by `npm run build` (`copy-frontend` step), so the deployed file inherits the fix automatically.

## Local verification

```
$ npm run smoke:orb-widget
[orb-widget-stop-regression] OK: user X-close cannot spawn a background session.
[orb-widget-audio-playback-regression] OK: scheduledSources drains per ended source.

$ npx jest test/frontend/orb-widget-audio-playback.test.ts
PASS test/frontend/orb-widget-audio-playback.test.ts
  orb-widget audio playback queue
    ✓ removes the actual ended AudioBufferSource from scheduledSources
```

## Provider parity ✓ / LiveKit parity — separate audit

- **Vertex path** ✓ — the bug is here, fix applies, regression covers it.
- **LiveKit path** — uses WebRTC tracks directly (not `_s.scheduledSources`), so this closure bug does not apply there. A cross-provider speaking-state audit is the explicit follow-up before Phase 1 starts.

## Verification after deploy

- Hard-refresh the command-hub once and confirm `orb-widget.js?v=20260529-VTID-03185-audio-queue-closure` loads.
- Voice session with a multi-sentence Vitana turn → `_s.scheduledSources` drains to zero → "Vitana speaking..." indicator clears → mic recovers to listening state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)