### PR TITLE
feat(ops): RUN-STAGING-MIGRATION + BOOTSTRAP-CLOUDFLARE-KV workflows (VTID-03177 follow-up)

### DIFF
--- a/.github/workflows/BOOTSTRAP-CLOUDFLARE-KV.yml
+++ b/.github/workflows/BOOTSTRAP-CLOUDFLARE-KV.yml
@@ -1,0 +1,176 @@
+name: Bootstrap Cloudflare KV Namespace
+
+# One-shot bootstrap: creates a Cloudflare KV namespace for a worker that ships
+# with REPLACE_WITH_KV_ID_AFTER_FIRST_DEPLOY as the kv_namespaces[].id placeholder
+# in its wrangler.toml. Prints the new namespace id; the operator pastes it into
+# wrangler.toml and commits. We do NOT auto-commit — keeping bootstrap separate
+# from deploy avoids tangling a one-time setup action with the auto-deploy path
+# in DEPLOY-CLOUDFLARE-WORKERS.yml.
+#
+# Typical usage:
+#   1. Add cloudflare/<worker>/wrangler.toml with a kv_namespaces entry whose
+#      id = "REPLACE_WITH_KV_ID_AFTER_FIRST_DEPLOY".
+#   2. Run this workflow via the Actions UI with worker_dir + binding_name + env.
+#   3. Copy the printed namespace id from the run summary into wrangler.toml.
+#   4. Commit + push; DEPLOY-CLOUDFLARE-WORKERS.yml will pick it up.
+
+on:
+  workflow_dispatch:
+    inputs:
+      worker_dir:
+        description: 'Worker directory (e.g. cloudflare/community-cache)'
+        required: true
+        type: string
+      binding_name:
+        description: 'KV binding name (must match wrangler.toml kv_namespaces[].binding)'
+        required: true
+        default: 'COMMUNITY_CACHE_KV'
+        type: string
+      env:
+        description: 'Wrangler env (staging|production)'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-kv-bootstrap-${{ inputs.worker_dir }}-${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      PLACEHOLDER: 'REPLACE_WITH_KV_ID_AFTER_FIRST_DEPLOY'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate inputs
+        id: validate
+        run: |
+          set -euo pipefail
+          WORKER_DIR='${{ inputs.worker_dir }}'
+          BINDING='${{ inputs.binding_name }}'
+          ENV_NAME='${{ inputs.env }}'
+
+          # Path-traversal & shape guard
+          case "$WORKER_DIR" in
+            cloudflare/*) : ;;
+            *) echo "::error::worker_dir must start with 'cloudflare/' (got '$WORKER_DIR')"; exit 1 ;;
+          esac
+          case "$WORKER_DIR" in
+            *..*) echo "::error::worker_dir must not contain '..'"; exit 1 ;;
+          esac
+          case "$BINDING" in
+            ''|*[^A-Za-z0-9_]*) echo "::error::binding_name must be [A-Za-z0-9_]+ (got '$BINDING')"; exit 1 ;;
+          esac
+
+          TOML="$WORKER_DIR/wrangler.toml"
+          if [ ! -f "$TOML" ]; then
+            echo "::error::$TOML not found"
+            exit 1
+          fi
+          echo "toml=$TOML"          >> "$GITHUB_OUTPUT"
+          echo "binding=$BINDING"    >> "$GITHUB_OUTPUT"
+          echo "env_name=$ENV_NAME"  >> "$GITHUB_OUTPUT"
+          echo "::notice::Validated $TOML (binding=$BINDING, env=$ENV_NAME)"
+
+      - name: Refuse if namespace id already set
+        run: |
+          set -euo pipefail
+          TOML='${{ steps.validate.outputs.toml }}'
+          BINDING='${{ steps.validate.outputs.binding }}'
+
+          # Sanity: binding must appear in the toml.
+          if ! grep -q "binding *= *\"$BINDING\"" "$TOML"; then
+            echo "::error::binding=\"$BINDING\" not found in $TOML"
+            echo '::error::Add a [[kv_namespaces]] (or [env.<env>.kv_namespaces]) entry with id="'"$PLACEHOLDER"'" first.'
+            exit 1
+          fi
+
+          # If the placeholder is gone, this worker has already been bootstrapped — bail out.
+          if ! grep -q "$PLACEHOLDER" "$TOML"; then
+            echo "::error::No '$PLACEHOLDER' marker in $TOML — namespace appears to already be set."
+            echo '::error::Refusing to create a duplicate namespace. Remove this check manually if you really want a new one.'
+            exit 1
+          fi
+
+          echo "::notice::Placeholder present — proceeding to create namespace for binding=$BINDING"
+
+      - name: Create KV namespace
+        id: create
+        working-directory: ${{ inputs.worker_dir }}
+        run: |
+          set -euo pipefail
+          BINDING='${{ steps.validate.outputs.binding }}'
+          ENV_NAME='${{ steps.validate.outputs.env_name }}'
+
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID secrets must be set on the repo."
+            exit 1
+          fi
+
+          # Wrangler 3 syntax. Capture both streams; the id appears in stdout as
+          # either `id = "<hex>"` (toml suggestion) or `"id": "<hex>"` (json-ish).
+          set +e
+          OUTPUT=$(npx --yes wrangler@3 kv:namespace create "$BINDING" --env "$ENV_NAME" 2>&1)
+          RC=$?
+          set -e
+          echo "----- wrangler output -----"
+          echo "$OUTPUT"
+          echo "---------------------------"
+          if [ $RC -ne 0 ]; then
+            echo "::error::wrangler kv:namespace create failed (exit $RC)"
+            exit $RC
+          fi
+
+          # Parse: try toml-form first, then json-form. Namespace ids are 32 hex chars.
+          NS_ID=$(echo "$OUTPUT" | grep -oE 'id *= *"[a-f0-9]{32}"'   | head -n1 | grep -oE '[a-f0-9]{32}' || true)
+          if [ -z "$NS_ID" ]; then
+            NS_ID=$(echo "$OUTPUT" | grep -oE '"id" *: *"[a-f0-9]{32}"' | head -n1 | grep -oE '[a-f0-9]{32}' || true)
+          fi
+          if [ -z "$NS_ID" ]; then
+            echo "::error::Could not parse a 32-hex namespace id out of wrangler output above."
+            exit 1
+          fi
+
+          echo "namespace_id=$NS_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Print copy-paste instructions
+        run: |
+          set -euo pipefail
+          NS_ID='${{ steps.create.outputs.namespace_id }}'
+          TOML='${{ steps.validate.outputs.toml }}'
+          BINDING='${{ steps.validate.outputs.binding }}'
+          ENV_NAME='${{ steps.validate.outputs.env_name }}'
+
+          echo "::notice::Created namespace id=$NS_ID — paste this into $TOML"
+
+          {
+            echo "## Cloudflare KV namespace created"
+            echo ""
+            echo "| field        | value |"
+            echo "| ------------ | ----- |"
+            echo "| worker_dir   | \`${{ inputs.worker_dir }}\` |"
+            echo "| binding      | \`$BINDING\` |"
+            echo "| env          | \`$ENV_NAME\` |"
+            echo "| namespace id | \`$NS_ID\` |"
+            echo ""
+            echo "### Next steps (manual)"
+            echo "1. Open \`$TOML\`."
+            echo "2. Replace \`$PLACEHOLDER\` on the \`$BINDING\` entry with \`$NS_ID\`."
+            echo "3. Commit + push to main — \`DEPLOY-CLOUDFLARE-WORKERS.yml\` will deploy."
+            echo ""
+            echo "If you also need a preview namespace, rerun this workflow against the other env."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/RUN-STAGING-MIGRATION.yml
+++ b/.github/workflows/RUN-STAGING-MIGRATION.yml
@@ -1,0 +1,229 @@
+name: Run SQL Migration (STAGING ONLY)
+# VTID-Phase0-followup: separate staging migration runner.
+#
+# WHY A SEPARATE FILE (not a branch=prod|staging input on RUN-MIGRATION.yml):
+#   1. Hard physical separation — no way to accidentally select "prod" in a
+#      dropdown and clobber inmkhvwdcuyhnxkgfvsb. This file CANNOT reach prod
+#      because it never reads SUPABASE_DB_URL.
+#   2. Different secret (STAGING_SUPABASE_DB_URL) + different project_ref
+#      assertion (rsdakjqpvcpgomltdmxu) + a literal confirm phrase.
+#   3. Memory rule: "migrations are STAGING-FIRST then user manually merges to
+#      prod via Supabase dashboard" — staging path deserves its own UX so the
+#      operator's muscle memory for RUN-MIGRATION (prod) never crosses wires.
+#   4. Memory rule: "migrations are ONE FILE AT A TIME; never resurrect
+#      APPLY-MIGRATIONS.yml" — preserved here (single migration_file input).
+#
+# Prereq secret (operator must set before first run):
+#   gh secret set STAGING_SUPABASE_DB_URL --repo exafyltd/vitana-platform
+#   value = postgres connection string for project_ref rsdakjqpvcpgomltdmxu
+
+on:
+  workflow_dispatch:
+    inputs:
+      migration_file:
+        description: 'Migration file path (relative to repo root). ONE file at a time.'
+        required: true
+        default: 'supabase/migrations/20260528220000_VTID_03180_community_cache_materialized_views.sql'
+      confirm:
+        description: "Type 'I-mean-staging' to confirm this targets STAGING (rsdakjqpvcpgomltdmxu), NOT prod"
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  STAGING_PROJECT_REF: rsdakjqpvcpgomltdmxu
+  PROD_PROJECT_REF: inmkhvwdcuyhnxkgfvsb
+
+jobs:
+  migrate-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ---------------------------------------------------------------
+      # GUARD 1: Confirm phrase must match exactly.
+      # ---------------------------------------------------------------
+      - name: Confirm staging intent
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.confirm }}" != "I-mean-staging" ]; then
+            echo "::error::confirm input must be exactly 'I-mean-staging' (got: '${{ inputs.confirm }}')"
+            exit 1
+          fi
+          echo "Confirm phrase OK."
+
+      # ---------------------------------------------------------------
+      # GUARD 2: Migration file must exist and live under supabase/migrations/.
+      # ---------------------------------------------------------------
+      - name: Validate migration file path
+        run: |
+          set -euo pipefail
+          F="${{ inputs.migration_file }}"
+          case "$F" in
+            supabase/migrations/*.sql) ;;
+            *) echo "::error::migration_file must match supabase/migrations/*.sql (got: $F)"; exit 1 ;;
+          esac
+          if [ ! -f "$F" ]; then
+            echo "::error::migration file not found in checkout: $F"
+            exit 1
+          fi
+          echo "Migration file OK: $F"
+
+      # ---------------------------------------------------------------
+      # GUARD 3: Secret must exist AND must contain the staging project_ref,
+      # AND must NOT contain the prod project_ref. This is the hard prod-block.
+      # ---------------------------------------------------------------
+      - name: Verify STAGING_SUPABASE_DB_URL targets staging (HARD GUARD)
+        env:
+          STAGING_DB_URL: ${{ secrets.STAGING_SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${STAGING_DB_URL:-}" ]; then
+            echo "::error::STAGING_SUPABASE_DB_URL secret is empty or missing."
+            echo "::error::Set it with: gh secret set STAGING_SUPABASE_DB_URL --repo exafyltd/vitana-platform"
+            exit 1
+          fi
+          if ! printf '%s' "$STAGING_DB_URL" | grep -q "$STAGING_PROJECT_REF"; then
+            echo "::error::STAGING_SUPABASE_DB_URL does not contain staging project_ref ($STAGING_PROJECT_REF)."
+            echo "::error::Refusing to run — secret may be misconfigured."
+            exit 1
+          fi
+          if printf '%s' "$STAGING_DB_URL" | grep -q "$PROD_PROJECT_REF"; then
+            echo "::error::STAGING_SUPABASE_DB_URL contains PROD project_ref ($PROD_PROJECT_REF). HARD STOP."
+            exit 1
+          fi
+          echo "STAGING_SUPABASE_DB_URL targets $STAGING_PROJECT_REF — OK."
+
+      # ---------------------------------------------------------------
+      # GUARD 4: WIF auth — same pattern as EXEC-DEPLOY.yml. Used so the
+      # OASIS emit step can pull a Google ID token if the gateway endpoint
+      # requires one; also future-proofs to Cloud SQL Auth Proxy if we move
+      # the staging DB behind it.
+      # ---------------------------------------------------------------
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+          project_id: lovable-vitana-vers1
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Install psql
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client
+
+      # ---------------------------------------------------------------
+      # Apply the migration. Wrap in BEGIN/COMMIT via psql -1 so a failure
+      # rolls back cleanly (each migration file is expected to be a single
+      # logical change per the one-file-at-a-time rule).
+      # ---------------------------------------------------------------
+      - name: Apply migration to STAGING
+        id: apply
+        env:
+          STAGING_DB_URL: ${{ secrets.STAGING_SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          F="${{ inputs.migration_file }}"
+          echo "Applying $F to project_ref=$STAGING_PROJECT_REF"
+          # -v ON_ERROR_STOP=1 stops on first SQL error; -1 wraps in a tx.
+          psql "$STAGING_DB_URL" \
+            -v ON_ERROR_STOP=1 \
+            -1 \
+            -f "$F" \
+            | tee migration_output.log
+          echo "applied=true" >> "$GITHUB_OUTPUT"
+
+      - name: Reload PostgREST schema cache
+        if: success()
+        env:
+          STAGING_DB_URL: ${{ secrets.STAGING_SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          psql "$STAGING_DB_URL" -c "NOTIFY pgrst, 'reload schema';"
+          echo "Schema cache reload signal sent."
+
+      # ---------------------------------------------------------------
+      # OASIS telemetry — fire-and-forget. New topics; see risks.
+      # ---------------------------------------------------------------
+      - name: Emit OASIS success event
+        if: success()
+        env:
+          GATEWAY_SERVICE_TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "https://gateway.vitanaland.com/api/v1/oasis/emit" \
+            -H "Authorization: Bearer $GATEWAY_SERVICE_TOKEN" \
+            -H "Content-Type: application/json" \
+            --max-time 10 \
+            -d "$(jq -nc \
+              --arg topic 'staging.migration.completed' \
+              --arg project_ref "$STAGING_PROJECT_REF" \
+              --arg migration_file '${{ inputs.migration_file }}' \
+              --arg run_id '${{ github.run_id }}' \
+              --arg run_url '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+              --arg actor '${{ github.actor }}' \
+              '{topic:$topic, payload:{project_ref:$project_ref, migration_file:$migration_file, run_id:$run_id, run_url:$run_url, actor:$actor, ok:true}}')" \
+            || echo "::warning::OASIS emit failed (non-blocking)"
+
+      - name: Emit OASIS failure event
+        if: failure()
+        env:
+          GATEWAY_SERVICE_TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "https://gateway.vitanaland.com/api/v1/oasis/emit" \
+            -H "Authorization: Bearer $GATEWAY_SERVICE_TOKEN" \
+            -H "Content-Type: application/json" \
+            --max-time 10 \
+            -d "$(jq -nc \
+              --arg topic 'staging.migration.failed' \
+              --arg project_ref "$STAGING_PROJECT_REF" \
+              --arg migration_file '${{ inputs.migration_file }}' \
+              --arg run_id '${{ github.run_id }}' \
+              --arg run_url '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+              --arg actor '${{ github.actor }}' \
+              '{topic:$topic, payload:{project_ref:$project_ref, migration_file:$migration_file, run_id:$run_id, run_url:$run_url, actor:$actor, ok:false}}')" \
+            || echo "::warning::OASIS emit failed (non-blocking)"
+
+      # ---------------------------------------------------------------
+      # Run summary so `gh run view` shows green/red status clearly.
+      # ---------------------------------------------------------------
+      - name: Write run summary (success)
+        if: success()
+        run: |
+          {
+            echo "## STAGING migration applied"
+            echo ""
+            echo "- **Project ref:** \`$STAGING_PROJECT_REF\` (staging)"
+            echo "- **Migration file:** \`${{ inputs.migration_file }}\`"
+            echo "- **Actor:** @${{ github.actor }}"
+            echo ""
+            echo "### psql output (tail)"
+            echo '```'
+            tail -n 50 migration_output.log 2>/dev/null || echo '(no output captured)'
+            echo '```'
+            echo ""
+            echo "Next: verify in staging, then manually promote to prod via Supabase dashboard."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Write run summary (failure)
+        if: failure()
+        run: |
+          {
+            echo "## STAGING migration FAILED"
+            echo ""
+            echo "- **Project ref:** \`$STAGING_PROJECT_REF\` (staging)"
+            echo "- **Migration file:** \`${{ inputs.migration_file }}\`"
+            echo "- **Actor:** @${{ github.actor }}"
+            echo ""
+            echo "The migration was wrapped in a single transaction (psql -1) and rolled back on error."
+            echo ""
+            echo "### psql output (tail)"
+            echo '```'
+            tail -n 80 migration_output.log 2>/dev/null || echo '(no output captured — failure may have occurred before psql ran)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/services/gateway/src/routes/oasis-emit.ts
+++ b/services/gateway/src/routes/oasis-emit.ts
@@ -51,7 +51,11 @@ const MAX_BODY_BYTES = 16 * 1024;
 // the same panel. Without this entry the topics 400 here and silently
 // disappear — Voice Lab stays empty for LiveKit, and the failure
 // classifier sees no session-stop metrics.
-const ALLOWED_PREFIXES = ['orb.livekit.', 'livekit.', 'vtid.live.'] as const;
+// VTID-03177 follow-up: `staging.migration.` added so the new
+// RUN-STAGING-MIGRATION.yml workflow can emit success/failure telemetry from
+// GitHub Actions via this proxy (the runner has the GATEWAY_SERVICE_TOKEN but
+// no Supabase write surface, same shape as the orb-agent path).
+const ALLOWED_PREFIXES = ['orb.livekit.', 'livekit.', 'vtid.live.', 'staging.migration.'] as const;
 
 function isAllowedTopic(topic: unknown): topic is string {
   if (typeof topic !== 'string') return false;

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -863,6 +863,11 @@ export type CicdEventType =
   | 'staging.deploy.failed'
   | 'staging.metrics.snapshot'
   | 'staging.revert.completed'
+  // VTID-03177 follow-up: RUN-STAGING-MIGRATION.yml emits these per run.
+  // Allowlist for /api/v1/oasis/emit extended for the `staging.migration.`
+  // prefix in the same PR.
+  | 'staging.migration.completed'
+  | 'staging.migration.failed'
   | 'production.publish.requested'
   | 'production.publish.completed'
   | 'production.publish.failed'


### PR DESCRIPTION
Closes two W1 hand-off gaps the operator surfaced after merging the 5 scaffold PRs.

1. RUN-MIGRATION.yml only points at prod (SUPABASE_DB_URL). No safe path for staging-only migrations like the community-cache MV migration from #2381.
2. cloudflare/community-cache/wrangler.toml has REPLACE_WITH_KV_ID_AFTER_FIRST_DEPLOY placeholder; wrangler isn't installed in the operator's Windows session.

What lands

- **.github/workflows/RUN-STAGING-MIGRATION.yml** — separate file (NOT a branch input on RUN-MIGRATION.yml) for physical isolation. Four hard guards: confirm phrase 'I-mean-staging' / migration_file shape + existence / STAGING_SUPABASE_DB_URL contains staging project_ref AND does NOT contain prod project_ref / WIF auth. Applies via psql -1 with ON_ERROR_STOP, reloads PostgREST schema cache, emits staging.migration.completed/.failed via /api/v1/oasis/emit, writes a GITHUB_STEP_SUMMARY.
- **.github/workflows/BOOTSTRAP-CLOUDFLARE-KV.yml** — standalone one-shot. Refuses if placeholder string is missing in target wrangler.toml (already bootstrapped). Runs npx wrangler@3 kv:namespace create, parses the 32-hex id, prints it in the run summary. Does NOT auto-commit; operator pastes into wrangler.toml.
- services/gateway/src/types/cicd.ts: 2 new OASIS topics for the migration runner.
- services/gateway/src/routes/oasis-emit.ts: ALLOWED_PREFIXES extended with 'staging.migration.' so the runner can emit via the existing service-token path.

**Prereq (operator, one-time):**
```
gh secret set STAGING_SUPABASE_DB_URL --repo exafyltd/vitana-platform
# value = postgres URL for rsdakjqpvcpgomltdmxu (pooler or direct)
```

Tested: npm run build green. Target community-cache migration inspected — all DDL is CREATE MATERIALIZED VIEW IF NOT EXISTS + CREATE UNIQUE INDEX IF NOT EXISTS, safe inside the single-tx wrap.

Risks: memory note overstated which staging secrets actually exist as GitHub repo secrets (gh secret list shows zero staging-prefixed entries). STAGING_SUPABASE_DB_URL MUST be added before first run; workflow hard-fails with the explicit instruction if missing. Migrations with CREATE INDEX CONCURRENTLY etc will fail under psql -1 — inspect before running. wrangler stdout format may shift; raw output is echoed so the id can be recovered by eye if regex parsing breaks. CLOUDFLARE_API_TOKEN scope may need Workers KV Storage:Edit if it only has Scripts:Edit.