### PR TITLE
fix(voice): metric de-inflation (#2397) + Track A forwarded-only under-responds counter

### DIFF
--- a/docs/HANDOFF-voice-quality.md
+++ b/docs/HANDOFF-voice-quality.md
@@ -9,6 +9,58 @@ Branch: `claude/funny-carson-DMTJh`.
 
 ---
 
+## ✅ UPDATE 2026-06-01 — validation RAN, Track A SHIPPED
+
+A later session reached the VITANA Supabase via the **Supabase MCP server**
+(it routes outside the container's network allowlist, so the
+`Host not in allowlist` block that stopped `voice-validation.py` from the
+sandbox did not apply). Q1–Q4 were run against live production data. Results:
+
+- **Q1 (validates #2397) — confirmed strongly.** Last 24h, 206 `session.stop`
+  events. Audio-in-zero **before** filter = 172/206 = **83.5%**; **after**
+  excluding phantoms (81 `expired_ttl` + 75 `superseded_by_new_session`) =
+  **20/50 = 40.0%**. The headline was ~2× inflated by lifecycle double-counting.
+
+- **Q2 — handoff source was MIS-ATTRIBUTED (corrected).** There are **zero**
+  `self_healing_log` `rolled_back` rows (7d). The score's **3 criticals are the
+  3 open quarantines** — the `healing_quarantine` source in
+  `voice-improvement-aggregator.ts` marks each `severity:'critical'`
+  (`3 × −15 = −45`). The *conclusion* (model_under_responds is the lever) was
+  right; the table was wrong. `self_healing_log` 7d had 5 `escalated`
+  (2× model_under_responds, 2× low_turn_progression, 1× autopilot) and 0 critical.
+
+- **Q3 (validates Track A) — confirmed.** Of 50 real sessions, 36 responded;
+  avg `audio_in` 241.8 vs `audio_out` 90.3; **12/36 ratio ≥3, 8/36 ≥5**.
+  Concrete responded-yet-inflated cases: `864/285 t14`, `505/73 t8 (6.9)`,
+  `368/14 t4 (26.3)`.
+
+- **Q4 — smoking gun.** Exactly 3 quarantined rows, all
+  `voice.model_under_responds`, reason `failed_fix_threshold`, signatures
+  `model_under_responds_r5to10 / _r10to20 / _r20to100` — i.e. **audio_in/out
+  ratio buckets**. Echo inflates exactly that ratio (Q3), so the classifier
+  quarantined healthy talkative sessions.
+
+**Track A is now implemented on this branch** (VTID-VOICE-FWD): a forwarded-only
+counter `audioInForwarded` increments solely in the real `sendAudioToLiveAPI`
+forward path (WS in `orb-live.ts`, SSE in `live-session-controller.ts`), is
+emitted on `session.stop` as `audio_in_forwarded_chunks`, and the
+`model_under_responds` classifier now computes its ratio from
+`audio_in_forwarded` (falling back to raw `audio_in_chunks` for old events).
+`npx tsc --noEmit` clean; `jest voice-failure-taxonomy` 49/49 (5 new) and
+`jest voice-improvement-aggregator` 22/22 green.
+
+**Script bug fixed:** `voice-validation.py` filtered `oasis_events?type=eq.…`,
+but the event name lives in **`topic`** (no `type` column). Fixed to
+`topic=eq.vtid.live.session.stop`; Q2 corrected to read quarantines; Q3 now
+prints the `fwd_ratio` column.
+
+**Still TODO:** Track B (release the 3 quarantines — needs a gateway/admin
+token, NOT the Supabase key) and Track C (the warnings). Verify Track A
+post-deploy: once traffic flows, `fwd_ratio` should pull these sessions below
+the classifier's ≥5 threshold so the class stops re-quarantining.
+
+---
+
 ## 0. First thing to do in the new session
 
 Confirm Supabase is reachable and creds are present as **env secrets**

--- a/docs/HANDOFF-voice-quality.md
+++ b/docs/HANDOFF-voice-quality.md
@@ -1,0 +1,141 @@
+# Handoff — Voice Improve cockpit quality score (resume here)
+
+**Why this file exists:** the prior session was blocked because the sandbox's
+network policy refused Supabase (`Host not in allowlist`), and a running
+container can't pick up an allowlist/secret change mid-session. This doc +
+`scripts/voice-validation.py` let a **fresh session** resume in one command.
+
+Branch: `claude/funny-carson-DMTJh`.
+
+---
+
+## 0. First thing to do in the new session
+
+Confirm Supabase is reachable and creds are present as **env secrets**
+(not pasted in chat — the earlier key was exposed and should be rotated):
+
+```bash
+env | grep SUPABASE          # expect SUPABASE_URL + SUPABASE_SERVICE_ROLE
+python3 scripts/voice-validation.py
+```
+
+If you still see `403 Host not in allowlist`, the allowlist change didn't take
+— verify the host saved is `inmkhvwdcuyhnxkgfvsb.supabase.co` (or
+`*.supabase.co`), no `https://`/trailing slash, then start another fresh
+session. The script is **read-only** (PostgREST SELECT only); it writes nothing.
+
+---
+
+## 1. The situation
+
+Voice Improve cockpit quality score sits at ~**40/100**. Score math
+(`voice-improvement-aggregator.ts:164-173`): start 100, **−15 per critical,
+−5 per warning, −1 per info**, floor 0. So `40 = 100 − 3×15 − 3×5` → **3
+criticals + 3 warnings**.
+
+The **3 criticals** are `self_healing_log` rows with `outcome='rolled_back'`
+for failure_class `model_under_responds`
+(`voice-improvement-aggregator.ts:405`). The auto-heal loop keeps trying to
+"fix" under-responds, the fix rolls back, → critical, → after
+`failed_fix_threshold` (4) it quarantines (`voice-recurrence-sentinel.ts:288`).
+
+**Hypothesis (code-verified, data-pending):** those `model_under_responds`
+signals are **false positives from echo counter-inflation** — the same bug
+class as merged PR #2397.
+
+---
+
+## 2. Code evidence already gathered (verified, not guessed)
+
+`audio_in_chunks` is incremented in **four** places in
+`services/gateway/src/routes/orb-live.ts`, but **three of them are for chunks
+that are dropped and never forwarded to Gemini**:
+
+| line  | branch                                   | forwarded? |
+|-------|------------------------------------------|------------|
+| 12253 | `navigationDispatched` (widget closing)  | **no**     |
+| 12268 | `isModelSpeaking` — **echo-prevention gate** | **no**  |
+| 12276 | post-turn cooldown                       | **no**     |
+| 12281 | real path → `sendAudioToLiveAPI`         | yes        |
+
+The `model_under_responds` classifier compares `audio_in / audio_out`. On
+mobile without hardware AEC, the speaker output is picked up by the mic while
+the model talks; those echo chunks hit the 12268 gate — **dropped, but still
+counted as `audio_in`**. The more the model talks, the more echo is counted,
+the worse the ratio, the more a *healthy talkative* session is misclassified
+as "under-responds." → ghost fix → rollback → quarantine. That's the 40.
+
+There is **no forwarded-only counter today**. Adding one is **Track A**.
+
+---
+
+## 3. What's already shipped
+
+- **PR #2397** (`9353319f`, on this branch): excludes phantom lifecycle
+  session-stops (`superseded_by_new_session`, `expired_ttl`) from the
+  "audio-in-zero" headline metric. Adds pure predicate
+  `isLifecycleArtifactStop()` + 6 unit tests. **CI green, no actionable review
+  comments, ready to merge.** Merging (VTID in squash msg) triggers
+  AUTO-DEPLOY → EXEC-DEPLOY; verify EXEC-DEPLOY actually dispatched (see
+  CLAUDE.md §16 — Auto Deploy "success" ≠ deployed).
+
+---
+
+## 4. Run the validation, then act on the output
+
+`python3 scripts/voice-validation.py` prints four blocks:
+
+- **Q1** — phantom vs real audio-in-zero. Confirms PR #2397's impact (the gap
+  between before/after filter = phantom inflation removed).
+- **Q2** — the rolled_back criticals (and how many are `model_under_responds`).
+- **Q3** — recent session metrics. **This validates Track A:** sessions that
+  *produced output* (`audio_out>0 AND turns>0`) yet show a high
+  `audio_in/audio_out` ratio are the false under-responds. If these are
+  common → hypothesis confirmed → build Track A.
+- **Q4** — open quarantines = Track B release candidates.
+
+### Track A — the score lever (do ONLY after Q3 confirms)
+Add a forwarded-only counter and switch the classifier to it. Surgical,
+additive, mirrors the #2397 approach. Sketch:
+1. Add `audioInForwarded: number` to the session type (init 0).
+2. Increment it **only on the real forward path** in `orb-live.ts` (the 12281
+   branch, ideally only when `sent === true`), NOT in the 12253/12268/12276
+   drop branches.
+3. Emit it on `vtid.live.session.stop` metadata as `audio_in_forwarded_chunks`.
+4. Point the `model_under_responds` classifier at
+   `audio_in_forwarded` instead of raw `audio_in_chunks`.
+5. Keep raw `audio_in_chunks` for back-compat. Unit-test the classifier with
+   an echo-heavy fixture (high raw in, low forwarded, healthy audio_out → must
+   NOT classify as under-responds).
+6. **Do not** touch the echo gate's behaviour — only the counting/metric.
+
+### Track B — release the false quarantines (governed, NOT a raw DB write)
+Endpoint: `POST {GATEWAY}/api/v1/voice-lab/healing/quarantine/release`
+(VTID-01962, `voice-lab.ts:944`). Body `{ class, normalized_signature }`.
+Moves `quarantined → probation` (72h, halved thresholds). **Needs an admin /
+gateway token, not the Supabase service-role key.** Release each
+`model_under_responds` entry Q4/Q3 confirm as false. Each clears a critical
+(+15).
+
+### Track C — the 3 warnings
+Enumerate from Q2 (escalated rows) + architecture-report items
+(`voice-improvement-aggregator.ts:225+`) and triage. Each is −5.
+
+---
+
+## 5. Key files / refs
+
+| thing | location |
+|-------|----------|
+| echo gate + counters | `services/gateway/src/routes/orb-live.ts:12250-12330` |
+| classifier metric read | `services/gateway/src/routes/orb-live.ts:10380-10460` |
+| score math | `services/gateway/src/services/voice-improvement-aggregator.ts:164-173` |
+| criticals source | `voice-improvement-aggregator.ts:405` (self_healing_log rolled_back) |
+| quarantine logic | `services/gateway/src/services/voice-recurrence-sentinel.ts` |
+| release endpoint | `services/gateway/src/routes/voice-lab.ts:944` (VTID-01962) |
+| quarantine table | `voice_healing_quarantine` (status: active/quarantined/probation/released) |
+| PR #2397 commit | `9353319f` |
+
+**Order of operations:** run script → if Q3 confirms, build Track A (validate
+post-deploy too) → Track B release confirmed-false quarantines → Track C
+triage warnings → re-check the score.

--- a/docs/voice-quality-track-b-runbook.md
+++ b/docs/voice-quality-track-b-runbook.md
@@ -1,0 +1,65 @@
+# Track B runbook — release the 3 false `model_under_responds` quarantines
+
+**Status:** prepared, NOT yet executed. Track B is a **governed production state
+change** and intentionally was not run from the handoff container because:
+
+1. No gateway/admin auth token was available there.
+2. The deployed gateway host was outside that container's network allowlist
+   (`403 Host not in allowlist`), same block that stopped the Supabase REST path.
+3. CLAUDE.md forbids substituting a raw DB write to bypass the governed endpoint.
+
+## Run AFTER Track A is deployed (ordering matters)
+
+Releasing the quarantines while the unfixed classifier is still live just lets
+it re-quarantine the same class within `failed_fix_threshold` (4) failed fixes.
+So the sequence is: **merge → deploy Track A (gateway) → confirm `fwd_ratio`
+pulls live sessions below the ≥5 threshold → then release.**
+
+## The 3 rows to release (validated 2026-06-01)
+
+| class | signature (`body.signature`) |
+|-------|------------------------------|
+| `voice.model_under_responds` | `model_under_responds_r5to10` |
+| `voice.model_under_responds` | `model_under_responds_r10to20` |
+| `voice.model_under_responds` | `model_under_responds_r20to100` |
+
+> Note: the endpoint reads `body.signature` (NOT `normalized_signature` as an
+> earlier handoff draft said). It moves `quarantined → probation` (72h, halved
+> thresholds, auto-expires to `released`). Each release clears one critical (+15).
+
+## Auth
+
+`POST /api/v1/voice-lab/healing/quarantine/release` is below
+`router.use(requireAuth)` → needs a **Supabase user JWT** (`auth-supabase-jwt`
+middleware), i.e. an authenticated gateway session token. NOT the Supabase
+service-role key, and NOT an unauthenticated call.
+
+## Commands (fill in `$GATEWAY` and `$JWT`)
+
+```bash
+GATEWAY="https://gateway-86804897789.us-central1.run.app"
+JWT="<supabase user access_token>"
+
+for sig in model_under_responds_r5to10 model_under_responds_r10to20 model_under_responds_r20to100; do
+  echo "releasing $sig ..."
+  curl -sS -X POST "$GATEWAY/api/v1/voice-lab/healing/quarantine/release" \
+    -H "Authorization: Bearer $JWT" \
+    -H "Content-Type: application/json" \
+    -d "{\"class\":\"voice.model_under_responds\",\"signature\":\"$sig\",\"reason\":\"track-a-forwarded-counter-shipped\"}"
+  echo
+done
+```
+
+Expected success per row: `{"ok":true,"new_status":"probation","probation_until":"<+72h>"}`.
+
+## Verify (read-only, via Supabase MCP `execute_sql` or PostgREST)
+
+```sql
+select class, normalized_signature, status, probation_until
+from voice_healing_quarantine
+where class = 'voice.model_under_responds'
+order by quarantined_at desc;
+```
+
+All three should read `status='probation'` with a `probation_until` ~72h out.
+Then re-check the cockpit quality score — each released critical is +15.

--- a/scripts/voice-validation.py
+++ b/scripts/voice-validation.py
@@ -7,11 +7,17 @@ Run from the next session once Supabase is reachable:
     SUPABASE_URL=...  SUPABASE_SERVICE_ROLE=...  python3 scripts/voice-validation.py
 
 Or rely on env secrets already set in the environment config. Everything here
-is SELECT-only via PostgREST — it writes nothing. It produces the three
-validations the previous session was blocked on:
+is SELECT-only via PostgREST — it writes nothing.
+
+NOTE (fixed 2026-06-01): the event name lives in oasis_events.`topic`, not a
+`type` column (the table has no `type` column). The earlier draft filtered on
+`type=eq.…` and returned nothing. All session-stop queries now use
+`topic=eq.vtid.live.session.stop`.
+
+It produces the four validations the previous session was blocked on:
 
   Q1  Phantom vs real "audio-in-zero" (validates merged PR #2397)
-  Q2  The 3 `model_under_responds` criticals dragging the score (self_healing_log rolled_back)
+  Q2  The criticals dragging the score (open quarantines; NOT rolled_back rows — corrected)
   Q3  model_under_responds quarantine rows + recent session metrics (validates Track A before code)
   Q4  Open quarantines = Track B release candidates
 
@@ -73,7 +79,7 @@ since_7d = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
 hr("Q1  Phantom vs real audio-in-zero (last 24h) — validates PR #2397")
 q = urllib.parse.quote(since_24h, safe="")
 rows = rest(
-    f"oasis_events?type=eq.vtid.live.session.stop&created_at=gte.{q}"
+    f"oasis_events?topic=eq.vtid.live.session.stop&created_at=gte.{q}"
     f"&select=created_at,metadata&order=created_at.desc&limit=2000"
 )
 reason_counts = Counter()
@@ -104,22 +110,36 @@ print("  -> The gap between these two numbers is the phantom inflation PR #2397 
 
 
 # ---------------------------------------------------------------------------
-# Q2 — The criticals dragging the score (self_healing_log rolled_back)
+# Q2 — The criticals dragging the score
+#
+# CORRECTION (validated 2026-06-01 against live data): the score's criticals
+# come from the OPEN QUARANTINES, not self_healing_log rolled_back rows.
+# composeQualityScore (voice-improvement-aggregator.ts:141-147) does
+# 100 −15·critical −5·warning −1·info; the `healing_quarantine` source
+# (same file ~155-180) marks every quarantined row severity='critical'.
+# There were ZERO rolled_back rows in the last 7d — the earlier handoff
+# mis-attributed the source table. self_healing_log escalated/rolled_back is
+# still shown below as supporting context (warnings + heal history).
 # ---------------------------------------------------------------------------
-hr("Q2  Criticals behind the score: self_healing_log rolled_back/escalated (7d)")
+hr("Q2  Criticals behind the score: open quarantines + self_healing_log (7d)")
+quar = rest(
+    "voice_healing_quarantine?status=eq.quarantined"
+    "&select=class,normalized_signature&order=quarantined_at.desc&limit=50"
+)
+print(f"  open quarantines (=critical, -15 each): {len(quar)}  -> score hit -{15 * len(quar)}")
+mur = [r for r in quar if (r.get("class") or "") == "voice.model_under_responds"]
+print(f"    of those, class=voice.model_under_responds: {len(mur)}  (Track A target)")
+print()
 q = urllib.parse.quote(since_7d, safe="")
 rows = rest(
     f"self_healing_log?outcome=in.(escalated,rolled_back)&created_at=gte.{q}"
     f"&select=vtid,endpoint,failure_class,outcome,created_at&order=created_at.desc&limit=50"
 )
 crit = [r for r in rows if r.get("outcome") == "rolled_back"]
-print(f"  rolled_back (=critical, -15 each): {len(crit)}")
-print(f"  escalated   (=warning,  -5 each):  {len(rows) - len(crit)}")
-ur = [r for r in rows if (r.get("failure_class") or "") == "model_under_responds"]
-print(f"  of those, failure_class=model_under_responds: {len(ur)}")
+print(f"  self_healing_log rolled_back (7d): {len(crit)}   escalated (7d): {len(rows) - len(crit)}")
 for r in rows[:20]:
-    print(f"    {r['outcome']:11s}  {r.get('failure_class') or '(none)':22s}"
-          f"  {r['endpoint']:28s}  {r['vtid']}  {r['created_at'][:19]}")
+    print(f"    {r['outcome']:11s}  {r.get('failure_class') or '(none)':28s}"
+          f"  {r['endpoint']:34s}  {r['vtid']}  {r['created_at'][:19]}")
 
 
 # ---------------------------------------------------------------------------
@@ -128,29 +148,40 @@ for r in rows[:20]:
 hr("Q3  Track A evidence: recent session metrics (audio_in vs audio_out vs turns)")
 q = urllib.parse.quote(since_24h, safe="")
 rows = rest(
-    f"oasis_events?type=eq.vtid.live.session.stop&created_at=gte.{q}"
+    f"oasis_events?topic=eq.vtid.live.session.stop&created_at=gte.{q}"
     f"&select=created_at,metadata&order=created_at.desc&limit=500"
 )
 print("  Sessions that PRODUCED output (audio_out>0 AND turns>0) but have a high")
-print("  audio_in/audio_out ratio are the false 'under-responds' — audio_in is")
-print("  inflated by echo chunks counted at orb-live.ts:12253/12268/12276 but")
-print("  never forwarded to Gemini. (No forwarded-only counter exists yet = Track A.)\n")
-print(f"    {'audio_in':>9} {'audio_out':>10} {'turns':>6} {'ratio':>7}  reason")
+print("  audio_in/audio_out ratio are the false 'under-responds' — raw audio_in is")
+print("  inflated by echo chunks counted at the orb-live drop gates but never")
+print("  forwarded to the model.")
+print("  Track A SHIPPED a forwarded-only counter (audio_in_forwarded_chunks).")
+print("  For events that carry it, the 'fwd_ratio' column is the echo-robust")
+print("  ratio the classifier now uses; compare it to the raw 'ratio'.\n")
+print(f"    {'audio_in':>9} {'fwd_in':>8} {'audio_out':>10} {'turns':>6} {'ratio':>7} {'fwd_ratio':>9}  reason")
 suspicious = 0
 real_rows = [r for r in rows if (r.get('metadata') or {}).get('reason') not in PHANTOM_REASONS]
 for r in real_rows[:40]:
     m = r.get("metadata") or {}
     ai = int(m.get("audio_in_chunks") or 0)
+    fwd = m.get("audio_in_forwarded_chunks")
+    fwd = int(fwd) if fwd is not None else None
     ao = int(m.get("audio_out_chunks") or 0)
     tc = int(m.get("turn_count") or 0)
     ratio = (ai / ao) if ao else float("inf")
+    fwd_ratio = (fwd / ao) if (fwd is not None and ao) else None
     flag = ""
     if ao > 0 and tc > 0 and ratio >= 3:
-        flag = "  <- responded but high in/out ratio (echo-inflated?)"
+        flag = "  <- responded but high RAW ratio (echo-inflated?)"
         suspicious += 1
     rstr = f"{ratio:7.1f}" if ao else "    inf"
-    print(f"    {ai:9d} {ao:10d} {tc:6d} {rstr}  {m.get('reason') or '(normal)'}{flag}")
-print(f"\n  suspicious (responded yet high ratio): {suspicious}/{min(len(real_rows),40)} shown")
+    fstr = (f"{fwd_ratio:9.1f}" if fwd_ratio is not None else "        -")
+    fwdstr = (f"{fwd:8d}" if fwd is not None else "       -")
+    print(f"    {ai:9d} {fwdstr} {ao:10d} {tc:6d} {rstr} {fstr}  {m.get('reason') or '(normal)'}{flag}")
+print(f"\n  suspicious (responded yet high RAW ratio): {suspicious}/{min(len(real_rows),40)} shown")
+print("  Once Track A is deployed and traffic flows, fwd_ratio should drop these")
+print("  below the classifier's >=5 threshold — the under-responds class stops")
+print("  re-quarantining and Track B releases can hold.")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/voice-validation.py
+++ b/scripts/voice-validation.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Voice-quality validation harness (read-only).
+
+Run from the next session once Supabase is reachable:
+
+    SUPABASE_URL=...  SUPABASE_SERVICE_ROLE=...  python3 scripts/voice-validation.py
+
+Or rely on env secrets already set in the environment config. Everything here
+is SELECT-only via PostgREST — it writes nothing. It produces the three
+validations the previous session was blocked on:
+
+  Q1  Phantom vs real "audio-in-zero" (validates merged PR #2397)
+  Q2  The 3 `model_under_responds` criticals dragging the score (self_healing_log rolled_back)
+  Q3  model_under_responds quarantine rows + recent session metrics (validates Track A before code)
+  Q4  Open quarantines = Track B release candidates
+
+See docs/HANDOFF-voice-quality.md for full context and what to do with the output.
+"""
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+URL = os.environ.get("SUPABASE_URL", "https://inmkhvwdcuyhnxkgfvsb.supabase.co").rstrip("/")
+KEY = os.environ.get("SUPABASE_SERVICE_ROLE") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+
+# Reasons PR #2397 classifies as phantom bookkeeping stops (not real conversations).
+PHANTOM_REASONS = {"superseded_by_new_session", "expired_ttl"}
+
+
+def die(msg: str) -> None:
+    print(f"\n  ERROR: {msg}\n", file=sys.stderr)
+    sys.exit(1)
+
+
+if not KEY:
+    die("SUPABASE_SERVICE_ROLE not set. Provide it as an env secret in this session's config.")
+
+
+def rest(path: str):
+    req = urllib.request.Request(
+        f"{URL}/rest/v1/{path}",
+        headers={"apikey": KEY, "Authorization": f"Bearer {KEY}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()[:300]
+        die(f"{e.code} on {path}\n  {body}\n  (403 'Host not in allowlist' => start a fresh session after allowlisting *.supabase.co)")
+    except Exception as e:  # noqa: BLE001
+        die(f"{type(e).__name__} on {path}: {e}")
+
+
+def hr(title: str) -> None:
+    print(f"\n{'=' * 72}\n{title}\n{'=' * 72}")
+
+
+def pct(n: int, d: int) -> str:
+    return f"{(100.0 * n / d):.1f}%" if d else "n/a"
+
+
+since_24h = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+since_7d = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+
+# ---------------------------------------------------------------------------
+# Q1 — Phantom vs real audio-in-zero (validates PR #2397)
+# ---------------------------------------------------------------------------
+hr("Q1  Phantom vs real audio-in-zero (last 24h) — validates PR #2397")
+q = urllib.parse.quote(since_24h, safe="")
+rows = rest(
+    f"oasis_events?type=eq.vtid.live.session.stop&created_at=gte.{q}"
+    f"&select=created_at,metadata&order=created_at.desc&limit=2000"
+)
+reason_counts = Counter()
+zero_all = zero_real = total_real = 0
+for row in rows:
+    meta = row.get("metadata") or {}
+    reason = meta.get("reason")
+    reason_counts[reason or "(none/normal-end)"] += 1
+    audio_in = int(meta.get("audio_in_chunks") or 0)
+    if audio_in == 0:
+        zero_all += 1
+    if reason not in PHANTOM_REASONS:
+        total_real += 1
+        if audio_in == 0:
+            zero_real += 1
+
+print(f"  total session.stop events (24h): {len(rows)}")
+print("  by reason:")
+for reason, n in reason_counts.most_common():
+    tag = "  <- PHANTOM (excluded by #2397)" if reason in PHANTOM_REASONS else ""
+    print(f"    {n:5d}  {reason}{tag}")
+print()
+print(f"  audio-in-zero BEFORE filter (old metric): {zero_all}/{len(rows)}"
+      f" = {pct(zero_all, len(rows))}")
+print(f"  audio-in-zero AFTER  filter (PR #2397):   {zero_real}/{total_real}"
+      f" = {pct(zero_real, total_real)}")
+print("  -> The gap between these two numbers is the phantom inflation PR #2397 removes.")
+
+
+# ---------------------------------------------------------------------------
+# Q2 — The criticals dragging the score (self_healing_log rolled_back)
+# ---------------------------------------------------------------------------
+hr("Q2  Criticals behind the score: self_healing_log rolled_back/escalated (7d)")
+q = urllib.parse.quote(since_7d, safe="")
+rows = rest(
+    f"self_healing_log?outcome=in.(escalated,rolled_back)&created_at=gte.{q}"
+    f"&select=vtid,endpoint,failure_class,outcome,created_at&order=created_at.desc&limit=50"
+)
+crit = [r for r in rows if r.get("outcome") == "rolled_back"]
+print(f"  rolled_back (=critical, -15 each): {len(crit)}")
+print(f"  escalated   (=warning,  -5 each):  {len(rows) - len(crit)}")
+ur = [r for r in rows if (r.get("failure_class") or "") == "model_under_responds"]
+print(f"  of those, failure_class=model_under_responds: {len(ur)}")
+for r in rows[:20]:
+    print(f"    {r['outcome']:11s}  {r.get('failure_class') or '(none)':22s}"
+          f"  {r['endpoint']:28s}  {r['vtid']}  {r['created_at'][:19]}")
+
+
+# ---------------------------------------------------------------------------
+# Q3 — Validate Track A: do under-responds sessions actually look healthy?
+# ---------------------------------------------------------------------------
+hr("Q3  Track A evidence: recent session metrics (audio_in vs audio_out vs turns)")
+q = urllib.parse.quote(since_24h, safe="")
+rows = rest(
+    f"oasis_events?type=eq.vtid.live.session.stop&created_at=gte.{q}"
+    f"&select=created_at,metadata&order=created_at.desc&limit=500"
+)
+print("  Sessions that PRODUCED output (audio_out>0 AND turns>0) but have a high")
+print("  audio_in/audio_out ratio are the false 'under-responds' — audio_in is")
+print("  inflated by echo chunks counted at orb-live.ts:12253/12268/12276 but")
+print("  never forwarded to Gemini. (No forwarded-only counter exists yet = Track A.)\n")
+print(f"    {'audio_in':>9} {'audio_out':>10} {'turns':>6} {'ratio':>7}  reason")
+suspicious = 0
+real_rows = [r for r in rows if (r.get('metadata') or {}).get('reason') not in PHANTOM_REASONS]
+for r in real_rows[:40]:
+    m = r.get("metadata") or {}
+    ai = int(m.get("audio_in_chunks") or 0)
+    ao = int(m.get("audio_out_chunks") or 0)
+    tc = int(m.get("turn_count") or 0)
+    ratio = (ai / ao) if ao else float("inf")
+    flag = ""
+    if ao > 0 and tc > 0 and ratio >= 3:
+        flag = "  <- responded but high in/out ratio (echo-inflated?)"
+        suspicious += 1
+    rstr = f"{ratio:7.1f}" if ao else "    inf"
+    print(f"    {ai:9d} {ao:10d} {tc:6d} {rstr}  {m.get('reason') or '(normal)'}{flag}")
+print(f"\n  suspicious (responded yet high ratio): {suspicious}/{min(len(real_rows),40)} shown")
+
+
+# ---------------------------------------------------------------------------
+# Q4 — Track B: open quarantines to release
+# ---------------------------------------------------------------------------
+hr("Q4  Track B candidates: open quarantines (status=quarantined)")
+rows = rest(
+    "voice_healing_quarantine?status=eq.quarantined"
+    "&select=class,normalized_signature,quarantined_at,reason&order=quarantined_at.desc&limit=50"
+)
+print(f"  quarantined rows: {len(rows)}")
+for r in rows:
+    print(f"    {r['class']:24s}  reason={r.get('reason')}"
+          f"  sig={str(r.get('normalized_signature'))[:24]}  at={str(r.get('quarantined_at'))[:19]}")
+print()
+print("  To release a confirmed-false one (governed, moves -> probation):")
+print("    POST {GATEWAY}/api/v1/voice-lab/healing/quarantine/release")
+print('    body: { "class": "<class>", "normalized_signature": "<sig>" }')
+print("  (VTID-01962. Needs an admin/gateway token, NOT the Supabase key.)")
+
+print("\nDone. See docs/HANDOFF-voice-quality.md for interpretation + next actions.\n")

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -790,6 +790,7 @@ export async function handleLiveSessionStart(
     createdAt: new Date(),
     lastActivity: new Date(),
     audioInChunks: 0,
+    audioInForwarded: 0, // VTID-VOICE-FWD: only ++ when a chunk is actually sent upstream
     videoInFrames: 0,
     audioOutChunks: 0,
     turn_count: 0,
@@ -1441,6 +1442,7 @@ export async function handleLiveSessionStop(
     user_id: session.identity?.user_id || null,
     tenant_id: session.identity?.tenant_id || null,
     audio_in_chunks: session.audioInChunks,
+    audio_in_forwarded_chunks: session.audioInForwarded, // VTID-VOICE-FWD (Track A)
     video_in_frames: session.videoInFrames,
     audio_out_chunks: session.audioOutChunks,
     duration_ms: Date.now() - session.createdAt.getTime(),
@@ -1457,6 +1459,7 @@ export async function handleLiveSessionStop(
     metadata: { synthetic: (session as any).synthetic === true },
     sessionMetrics: {
       audio_in_chunks: session.audioInChunks,
+      audio_in_forwarded: session.audioInForwarded, // VTID-VOICE-FWD (Track A)
       audio_out_chunks: session.audioOutChunks,
       duration_ms: Date.now() - session.createdAt.getTime(),
       turn_count: session.turn_count,
@@ -1678,6 +1681,10 @@ export async function handleLiveStreamSend(
           body.mime || 'audio/pcm;rate=16000',
         );
         if (sent) {
+          // VTID-VOICE-FWD (Track A): forwarded-only count (SSE path mirror of
+          // the WS path in orb-live.ts). Only chunks the model actually
+          // received; the three drop gates above return before reaching here.
+          session.audioInForwarded++;
           session.lastAudioForwardedTime = Date.now();
           // VTID-FORWARDING-WATCHDOG + VTID-01984 (R5) sliding logic
           if (!session.isModelSpeaking) {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -794,6 +794,13 @@ export interface GeminiLiveSession {
   createdAt: Date;
   lastActivity: Date;
   audioInChunks: number;
+  // VTID-VOICE-FWD (Track A): mic chunks actually forwarded to the model.
+  // audioInChunks counts every chunk including the ones dropped at the
+  // echo-prevention / cooldown / navigation gates below; this counts only the
+  // chunks that passed all gates AND were accepted by sendAudioToLiveAPI.
+  // The quality classifier reads this (not raw audioInChunks) so mic-recaptured
+  // speaker echo can't inflate the under-responds ratio.
+  audioInForwarded: number;
   videoInFrames: number;
   audioOutChunks: number;
   // VTID-02637: Idempotency flag for connection_issue emission. The upstream
@@ -1009,6 +1016,7 @@ setInterval(() => {
         metadata: { synthetic: (s as any).synthetic === true },
         sessionMetrics: {
           audio_in_chunks: s.audioInChunks,
+          audio_in_forwarded: s.audioInForwarded, // VTID-VOICE-FWD (Track A)
           audio_out_chunks: s.audioOutChunks,
           duration_ms: Date.now() - s.createdAt.getTime(),
           turn_count: s.turn_count,
@@ -1103,6 +1111,7 @@ function terminateExistingSessionsForUser(userId: string, excludeSessionId?: str
       metadata: { synthetic: (existingSession as any).synthetic === true },
       sessionMetrics: {
         audio_in_chunks: existingSession.audioInChunks,
+        audio_in_forwarded: existingSession.audioInForwarded, // VTID-VOICE-FWD (Track A)
         audio_out_chunks: existingSession.audioOutChunks,
         duration_ms: Date.now() - existingSession.createdAt.getTime(),
         turn_count: existingSession.turn_count,
@@ -11966,6 +11975,7 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
     createdAt: new Date(),
     lastActivity: new Date(),
     audioInChunks: 0,
+    audioInForwarded: 0, // VTID-VOICE-FWD: only ++ when a chunk is actually sent upstream
     videoInFrames: 0,
     audioOutChunks: 0,
     // VTID-01224: Identity and context (use effective identity for dev-sandbox fallback)
@@ -12303,6 +12313,11 @@ async function handleWsAudioMessage(clientSession: WsClientSession, message: WsC
     );
 
     if (sent) {
+      // VTID-VOICE-FWD (Track A): count only chunks the model actually received.
+      // This is the lone increment site for audioInForwarded — the three drop
+      // gates above (navigation, echo-prevention, post-turn cooldown) bump
+      // audioInChunks but return early, so they never reach here.
+      liveSession.audioInForwarded++;
       liveSession.lastAudioForwardedTime = Date.now(); // VTID-STREAM-SILENCE: reset idle timer
       // VTID-FORWARDING-WATCHDOG / BOOTSTRAP-ORB-RELIABILITY-R4: sliding
       // watchdog. See SSE path for full rationale — mirrored here so the
@@ -12506,6 +12521,9 @@ function handleWsStopSession(clientSession: WsClientSession): void {
       user_id: liveSession.identity?.user_id || null,
       tenant_id: liveSession.identity?.tenant_id || null,
       audio_in_chunks: liveSession.audioInChunks,
+      // VTID-VOICE-FWD (Track A): forwarded-only count for echo-robust quality
+      // classification. Kept alongside raw audio_in_chunks for back-compat.
+      audio_in_forwarded_chunks: liveSession.audioInForwarded,
       audio_out_chunks: liveSession.audioOutChunks,
       video_frames: liveSession.videoInFrames,
       transport: 'websocket',
@@ -12521,6 +12539,8 @@ function handleWsStopSession(clientSession: WsClientSession): void {
       metadata: { synthetic: (liveSession as any).synthetic === true },
       sessionMetrics: {
         audio_in_chunks: liveSession.audioInChunks,
+        // VTID-VOICE-FWD (Track A): classifier reads this for the under-responds ratio.
+        audio_in_forwarded: liveSession.audioInForwarded,
         audio_out_chunks: liveSession.audioOutChunks,
         duration_ms: Date.now() - liveSession.createdAt.getTime(),
         turn_count: liveSession.turn_count,

--- a/services/gateway/src/services/voice-failure-taxonomy.ts
+++ b/services/gateway/src/services/voice-failure-taxonomy.ts
@@ -225,6 +225,15 @@ export function detectAudioOneWay(input: {
 
 export interface SessionStopMetrics {
   audio_in_chunks: number;
+  /**
+   * VTID-VOICE-FWD (Track A): mic chunks actually forwarded to the model,
+   * i.e. raw audio_in minus the chunks dropped at the orb-live gates
+   * (echo-prevention while the model speaks, post-turn cooldown, navigation
+   * teardown). Optional for back-compat: session.stop events emitted before
+   * this field shipped won't carry it, so the classifier falls back to
+   * audio_in_chunks when it's undefined.
+   */
+  audio_in_forwarded?: number;
   audio_out_chunks: number;
   duration_ms: number;
   turn_count: number;
@@ -250,15 +259,27 @@ function bucketRatio(ratio: number): string {
  * Thresholds:
  *   voice.no_engagement         turn_count==0 AND duration_ms>30s AND audio_in>=20
  *                               (user spoke but model never started speaking)
- *   voice.model_under_responds  audio_in>=100 AND audio_out/audio_in<0.15 AND turn_count>=1
+ *   voice.model_under_responds  audio_in_fwd>=100 AND audio_out/audio_in_fwd<0.2 AND turn_count>=1
  *                               (real conversation but model under-responded)
  *   voice.low_turn_progression  duration_ms>60s AND turn_count<3 AND audio_in>=50
  *                               (long session that never developed)
+ *
+ * VTID-VOICE-FWD (Track A): the model_under_responds ratio is computed from
+ * audio_in_forwarded (chunks actually sent to the model) rather than raw
+ * audio_in_chunks. On mobile without hardware AEC the mic re-captures the
+ * speaker output while the model talks; those echo chunks are counted into
+ * audio_in_chunks but dropped at the echo gate (orb-live.ts) and never reach
+ * the model. Using raw audio_in inflated the ratio and misclassified healthy,
+ * talkative sessions as "under-responds" — which then quarantined the class.
+ * We fall back to raw audio_in when the forwarded count is absent (old events).
  */
 export function classifyQualityFromSessionStop(
   metrics: SessionStopMetrics,
 ): ClassifierOutput | null {
   const ai = metrics.audio_in_chunks || 0;
+  // Forwarded-only count drives the under-responds ratio; fall back to raw
+  // audio_in for session.stop events emitted before this field existed.
+  const aiFwd = metrics.audio_in_forwarded ?? ai;
   const ao = metrics.audio_out_chunks || 0;
   const dur = metrics.duration_ms || 0;
   const turns = metrics.turn_count || 0;
@@ -277,8 +298,10 @@ export function classifyQualityFromSessionStop(
   }
 
   // 2. Model under-responds: real turn cycle but model produced very little.
-  if (turns >= 1 && ai >= 100) {
-    const ratio = ao > 0 ? ai / ao : ai;
+  // VTID-VOICE-FWD: gate and ratio both use the forwarded-only count so echo
+  // chunks (dropped before reaching the model) can't inflate the signal.
+  if (turns >= 1 && aiFwd >= 100) {
+    const ratio = ao > 0 ? aiFwd / ao : aiFwd;
     if (ratio >= 5) {
       return {
         class: 'voice.model_under_responds',

--- a/services/gateway/src/services/voice-improvement-aggregator.ts
+++ b/services/gateway/src/services/voice-improvement-aggregator.ts
@@ -56,6 +56,32 @@ export function isZombieEscalation(endpoint: string, failureClass: string | null
   return false;
 }
 
+// BOOTSTRAP-VOICE-AUDIO-IN-ZERO-METRIC: phantom session-stop filter.
+//
+// `vtid.live.session.stop` is emitted from four sites in orb-live.ts. Two of
+// them are session-management bookkeeping, NOT user-perceived conversations:
+//   - `superseded_by_new_session` — terminateExistingSessionsForUser() kills a
+//     prior session whenever the user (re)opens the ORB (reload, reconnect-as-
+//     new-session, multi-tab). The single-session-per-user rule guarantees one
+//     of these per re-open.
+//   - `expired_ttl` — the 30-min zombie reaper closes sessions the client never
+//     cleanly stopped.
+// These carry `audio_in_chunks: 0` whenever the superseded/expired session had
+// not spoken yet, so counting them as "observed sessions" double-counts a single
+// real conversation and inflates the audio-in-zero ratio (the headline the
+// Improve cockpit alarms on). A genuinely abandoned session (user opened, said
+// nothing, closed normally) has NO such `reason` and is still counted — that is
+// a real no-show worth measuring. We only drop the bookkeeping artifacts.
+const LIFECYCLE_ARTIFACT_STOP_REASONS = new Set([
+  'superseded_by_new_session',
+  'expired_ttl',
+]);
+
+export function isLifecycleArtifactStop(metadata: unknown): boolean {
+  const reason = (metadata as { reason?: unknown } | null | undefined)?.reason;
+  return typeof reason === 'string' && LIFECYCLE_ARTIFACT_STOP_REASONS.has(reason);
+}
+
 export type ActionSeverity = 'critical' | 'warning' | 'info';
 
 export type ActionSource =
@@ -648,8 +674,14 @@ async function fetchVoiceSessionHealth(cfg: SupabaseConfig): Promise<VoiceImprov
       audioInZero = 0,
       oneWay = 0;
     for (const row of rows) {
-      total += 1;
       const meta = row.metadata || {};
+      // BOOTSTRAP-VOICE-AUDIO-IN-ZERO-METRIC: skip session-management
+      // bookkeeping stops (superseded_by_new_session / expired_ttl). They are
+      // not user-perceived conversations and carry audio_in_chunks=0 whenever
+      // the superseded/expired session never spoke — counting them double-
+      // counts a single real conversation and inflates the audio-in-zero ratio.
+      if (isLifecycleArtifactStop(meta)) continue;
+      total += 1;
       const audioIn = Number(meta.audio_in_chunks ?? meta.audio_in ?? 0);
       const audioOut = Number(meta.audio_out_chunks ?? meta.audio_out ?? 0);
       if (audioIn === 0) audioInZero += 1;

--- a/services/gateway/src/services/voice-quality-by-provider.ts
+++ b/services/gateway/src/services/voice-quality-by-provider.ts
@@ -13,6 +13,7 @@
  */
 
 import { getSupabase } from '../lib/supabase';
+import { isLifecycleArtifactStop } from './voice-improvement-aggregator';
 
 export interface ProviderQualityRow {
   provider: string;
@@ -80,6 +81,11 @@ export async function getProviderQualityRollup(windowDays = 7): Promise<Provider
 
   for (const row of data as Array<{ topic: string; metadata: any; occurred_at: string }>) {
     const meta = row.metadata || {};
+    // BOOTSTRAP-VOICE-AUDIO-IN-ZERO-METRIC: exclude session-management
+    // bookkeeping stops (superseded_by_new_session / expired_ttl) — same
+    // rationale as fetchVoiceSessionHealth. They are not real conversations
+    // and would inflate the per-provider audio-in-zero ratio.
+    if (isLifecycleArtifactStop(meta)) continue;
     const provider = attributeProvider(meta);
     const ai = Number(meta.audio_in_chunks ?? meta.audio_in ?? 0);
     const ao = Number(meta.audio_out_chunks ?? meta.audio_out ?? 0);

--- a/services/gateway/src/services/voice-self-healing-adapter.ts
+++ b/services/gateway/src/services/voice-self-healing-adapter.ts
@@ -112,6 +112,9 @@ export interface DispatchOptions {
    */
   sessionMetrics?: {
     audio_in_chunks?: number;
+    // VTID-VOICE-FWD (Track A): forwarded-only mic count; classifier prefers
+    // this over raw audio_in_chunks for the under-responds ratio.
+    audio_in_forwarded?: number;
     audio_out_chunks?: number;
     duration_ms?: number;
     turn_count?: number;
@@ -341,6 +344,7 @@ async function handleQualityFailure(
         trigger: 'quality_failure',
         session_id: opts.sessionId,
         audio_in_chunks: opts.sessionMetrics?.audio_in_chunks,
+        audio_in_forwarded: opts.sessionMetrics?.audio_in_forwarded, // VTID-VOICE-FWD
         audio_out_chunks: opts.sessionMetrics?.audio_out_chunks,
         turn_count: opts.sessionMetrics?.turn_count,
         duration_ms: opts.sessionMetrics?.duration_ms,
@@ -374,6 +378,9 @@ async function _dispatchVoiceFailureCore(
   if (opts.sessionMetrics) {
     const qc = classifyQualityFromSessionStop({
       audio_in_chunks: opts.sessionMetrics.audio_in_chunks ?? 0,
+      // VTID-VOICE-FWD (Track A): pass through when present; classifier falls
+      // back to raw audio_in_chunks when undefined (older callers / events).
+      audio_in_forwarded: opts.sessionMetrics.audio_in_forwarded,
       audio_out_chunks: opts.sessionMetrics.audio_out_chunks ?? 0,
       duration_ms: opts.sessionMetrics.duration_ms ?? 0,
       turn_count: opts.sessionMetrics.turn_count ?? 0,

--- a/services/gateway/test/services/voice-improvement-aggregator.test.ts
+++ b/services/gateway/test/services/voice-improvement-aggregator.test.ts
@@ -9,6 +9,7 @@ import {
   sortActionItems,
   dedupeActionItems,
   isZombieEscalation,
+  isLifecycleArtifactStop,
   type ActionItem,
 } from '../../src/services/voice-improvement-aggregator';
 
@@ -167,5 +168,38 @@ describe('isZombieEscalation', () => {
 
   it('does NOT mark null failure_class as zombie (preserve everything we cannot categorize)', () => {
     expect(isZombieEscalation('/api/v1/self-healing/canary/failing-health', null)).toBe(false);
+  });
+});
+
+describe('isLifecycleArtifactStop', () => {
+  it('marks superseded_by_new_session stops as lifecycle artifacts', () => {
+    expect(isLifecycleArtifactStop({ reason: 'superseded_by_new_session', audio_in_chunks: 0 })).toBe(true);
+  });
+
+  it('marks expired_ttl stops as lifecycle artifacts', () => {
+    expect(isLifecycleArtifactStop({ reason: 'expired_ttl', audio_in_chunks: 0 })).toBe(true);
+  });
+
+  it('marks a superseded stop as an artifact even when it carried real audio', () => {
+    // A reloaded mid-conversation session is a fragment of one user
+    // conversation that continues in the new session — still not counted
+    // separately, regardless of audio.
+    expect(isLifecycleArtifactStop({ reason: 'superseded_by_new_session', audio_in_chunks: 240 })).toBe(true);
+  });
+
+  it('does NOT mark a normally-ended session (no reason) — a genuine no-show still counts', () => {
+    // User opened the ORB, said nothing, closed normally. This IS a real
+    // audio-in-zero conversation attempt worth measuring.
+    expect(isLifecycleArtifactStop({ audio_in_chunks: 0 })).toBe(false);
+  });
+
+  it('does NOT mark a user-requested stop as an artifact', () => {
+    expect(isLifecycleArtifactStop({ reason: 'session_stop_requested', audio_in_chunks: 130 })).toBe(false);
+  });
+
+  it('is null/undefined safe', () => {
+    expect(isLifecycleArtifactStop(null)).toBe(false);
+    expect(isLifecycleArtifactStop(undefined)).toBe(false);
+    expect(isLifecycleArtifactStop({})).toBe(false);
   });
 });

--- a/services/gateway/test/voice-failure-taxonomy.test.ts
+++ b/services/gateway/test/voice-failure-taxonomy.test.ts
@@ -438,4 +438,78 @@ describe('VTID-01958: Voice Failure Taxonomy', () => {
       expect(r).toBeNull();
     });
   });
+
+  describe('VTID-VOICE-FWD (Track A): forwarded-only ratio for model_under_responds', () => {
+    const { classifyQualityFromSessionStop } = require('../src/services/voice-failure-taxonomy');
+
+    test('echo-inflated session (high raw audio_in, healthy forwarded) → null, NOT under-responds', () => {
+      // Raw ratio 505/73 ≈ 6.9 would have classified as under-responds and
+      // quarantined the class. But most of those 505 raw chunks were echo the
+      // mic re-captured while the model spoke — dropped at the echo gate, never
+      // forwarded. Forwarded ratio 146/73 = 2.0 is a healthy talkative session.
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 505,
+        audio_in_forwarded: 146,
+        audio_out_chunks: 73,
+        duration_ms: 64000,
+        turn_count: 8,
+      });
+      expect(r).toBeNull();
+    });
+
+    test('genuine under-respond (forwarded ratio still high) → still classifies', () => {
+      // Even on forwarded-only counts the model produced almost nothing:
+      // forwarded 300 vs output 10 = ratio 30. This is a real failure and must
+      // still be caught.
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 360,
+        audio_in_forwarded: 300,
+        audio_out_chunks: 10,
+        duration_ms: 70000,
+        turn_count: 3,
+      });
+      expect(r?.class).toBe('voice.model_under_responds');
+      expect(r?.normalized_signature).toBe('model_under_responds_r20to100');
+    });
+
+    test('back-compat: no audio_in_forwarded falls back to raw audio_in_chunks', () => {
+      // Old session.stop events (emitted before Track A shipped) carry no
+      // forwarded field; the classifier must behave exactly as before.
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 945,
+        audio_out_chunks: 46,
+        duration_ms: 80000,
+        turn_count: 5,
+      });
+      expect(r?.class).toBe('voice.model_under_responds');
+      expect(r?.normalized_signature).toBe('model_under_responds_r20to100');
+    });
+
+    test('forwarded count below 100 gate → not enough real input to judge → null', () => {
+      // Raw audio_in 480 clears the old >=100 gate, but only 40 chunks were
+      // actually forwarded — too little real conversation to call a failure.
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 480,
+        audio_in_forwarded: 40,
+        audio_out_chunks: 5,
+        duration_ms: 20000,
+        turn_count: 2,
+      });
+      expect(r).toBeNull();
+    });
+
+    test('forwarded ratio recomputes the bucket (r100plus on raw → r5to10 on forwarded)', () => {
+      // Raw 585/5 = 117 (r100plus, the worst-case fixture). Forwarded 30/5 = 6
+      // lands in r5to10 — a much milder, real signal.
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 585,
+        audio_in_forwarded: 300,
+        audio_out_chunks: 50,
+        duration_ms: 93700,
+        turn_count: 1,
+      });
+      expect(r?.class).toBe('voice.model_under_responds');
+      expect(r?.normalized_signature).toBe('model_under_responds_r5to10');
+    });
+  });
 });


### PR DESCRIPTION
## Two related voice-quality fixes on this branch

### 1. Audio-in-zero metric de-inflation (original PR, commit `9353319`)
Excludes phantom lifecycle session-stops (`superseded_by_new_session`, `expired_ttl`) from the **Audio-in-zero** headline. Adds pure predicate `isLifecycleArtifactStop()` + 6 unit tests.

**Validated live (2026-06-01, via Supabase MCP):** last 24h, 206 `session.stop` events. Audio-in-zero **before** filter = 172/206 = **83.5%**; **after** = 20/50 = **40.0%**. 156 of the 206 were bookkeeping stops (81 `expired_ttl` + 75 `superseded_by_new_session`). The headline was ~2× inflated. ✅

### 2. Track A — forwarded-only mic counter (commit `68ea201`, BOOTSTRAP-VOICE-QUALITY-TRACK-A)
The `voice.model_under_responds` classifier computed its ratio from **raw** `audio_in_chunks`. On mobile without hardware AEC, the mic re-captures speaker output while the model talks; those echo chunks are dropped at the echo gate (`orb-live.ts`) — **never forwarded to the model** — yet still counted. That inflates `audio_in/audio_out`, pushing healthy talkative sessions into the under-responds buckets, which then **quarantine the class** and drag the cockpit quality score to 40.

**Live evidence (Q3/Q4):** the 3 open quarantines are all `voice.model_under_responds`, signatures `r5to10 / r10to20 / r20to100` — literally audio_in/out **ratio buckets**. 8/36 responded sessions show raw ratio ≥5 (e.g. `505/73`=6.9, `368/14`=26.3). These are the score's 3 criticals (3×−15).

**Change (additive; echo-gate behaviour untouched):**
- `GeminiLiveSession` gains `audioInForwarded`, incremented **only** in the real `sendAudioToLiveAPI(sent===true)` path — WS in `orb-live.ts`, SSE in `live-session-controller.ts` — never in the 3 drop gates.
- Emitted on `vtid.live.session.stop` as `audio_in_forwarded_chunks`; passed to the classifier via `sessionMetrics.audio_in_forwarded`.
- `classifyQualityFromSessionStop` uses `audio_in_forwarded` for the gate + ratio, **falling back to raw `audio_in_chunks`** when absent (back-compat for old events).

### Correction to the prior handoff
The handoff doc claimed the 3 criticals were `self_healing_log` `rolled_back` rows. Live data shows **zero** `rolled_back` rows — the criticals are the **3 open quarantines** (the `healing_quarantine` aggregator source marks each `severity:'critical'`). Conclusion held; source table was wrong. Doc + `voice-validation.py` corrected (also fixed: the script filtered `oasis_events?type=eq.…` but the event name is in **`topic`**).

## Verification
- `npx tsc --noEmit` → clean.
- `jest voice-failure-taxonomy` → **49/49** (5 new Track A tests incl. echo-inflated→null, genuine-under-respond→still-classifies, back-compat fallback).
- `jest voice-improvement-aggregator` → **22/22**.
- Live DB checks via Supabase MCP (read-only SELECTs).

## Follow-ups (NOT in this PR)
- **Track B:** release the 3 `model_under_responds` quarantines via `POST /api/v1/voice-lab/healing/quarantine/release` (VTID-01962) — needs a gateway/admin token, not the Supabase key.
- **Track C:** triage the warnings.
- **Post-deploy:** confirm `fwd_ratio` pulls these sessions below the classifier's ≥5 threshold so the class stops re-quarantining.

https://claude.ai/code/session_012nfLZEuvssW6SEyTBvfyaN