### PR TITLE
[FleetView] feat(overview): VTID-03184 plan_phase branching (re-apply after 2026-05-29 misdiagnosis revert)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
@@ -39,20 +39,59 @@ import { fetchLifeCompass, fetchVitanaIndexForProfiler } from '../../user-contex
 
 export type SignalSetupState = 'set' | 'not_set';
 
+/**
+ * VTID-03184 — the journey is endless. The "default 90-day plan" is a
+ * scaffolding for users without a personalized goal. Once a Life Compass
+ * goal is set, the user is on their own arc — wave/total_days framing
+ * drops. plan_phase discriminates the three voice-greeting cases:
+ *
+ *   - default_active            → user is in waves 1-N of the default plan
+ *                                  (day <= total_days, no Life Compass).
+ *                                  Voice anchors on wave + "Tag X von 90".
+ *
+ *   - default_finished_no_goal  → user reached end of default plan but
+ *                                  never set a Life Compass. The default
+ *                                  is done; voice invites the first
+ *                                  personalized goal as the next step.
+ *
+ *   - on_personalized_goal      → user has an active Life Compass goal,
+ *                                  regardless of plan_type or day count.
+ *                                  Voice drops the 90-day frame and
+ *                                  anchors on "Tag X mit Vitana, wir
+ *                                  arbeiten gerade an [goal]". The arc
+ *                                  is endless — goal-by-goal.
+ *
+ * VTID-03184 ships A+B+C. Goal-completion (case D — "Du hast dein Ziel
+ * erreicht, magst du das nächste setzen?") is the Phase 2 follow-up; it
+ * needs a goal-completion-inquiry continuation provider, not just a
+ * payload field, so it's intentionally NOT plumbed here yet.
+ */
+export type JourneyPlanPhase =
+  | 'default_active'
+  | 'default_finished_no_goal'
+  | 'on_personalized_goal';
+
 export interface OverviewPayload {
-  // -- JOURNEY (same source as /api/v1/my-journey) --
+  // -- JOURNEY (same source as /api/v1/my-journey, enriched with plan_phase) --
   journey: {
-    day_in_journey: number;
-    total_days: number;
-    days_left: number;
+    plan_phase: JourneyPlanPhase;
+    day_in_journey: number;            // monotonic since started_at; never resets
     is_first_session: boolean;
     plan_type: 'default' | 'personalized';
+    /** Only meaningful when plan_phase === 'default_active'. */
+    default_plan_total_days: number | null;
     current_wave: {
       name: string;
       description: string;
       day_in_wave: number;
       days_to_next_wave: number | null;
     } | null;
+    /** Days since the active Life Compass was set (when plan_phase === 'on_personalized_goal'). */
+    current_goal_day: number | null;
+    /** Positive integer when goal target_date is in the past; null otherwise. */
+    days_past_deadline: number | null;
+    /** Count of historical (non-active) life_compass rows for this user — the user's goal arc length. */
+    previous_goals_count: number;
   } | null;
 
   // -- VITANA INDEX (same source as /api/v1/my-journey + AutopilotDashboard NowCard) --
@@ -205,6 +244,7 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     journeyState,
     indexSnapshot,
     lcSnapshot,
+    previousGoalsCount,
     calToday,
     calPassed,
     autopilot,
@@ -216,6 +256,7 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     getJourneyState(args.supabase, args.userId).catch(() => null),
     fetchVitanaIndexForProfiler(args.supabase, args.userId).catch(() => null),
     fetchLifeCompass(args.supabase, args.userId).catch(() => null),
+    fetchPreviousGoalsCount(args.supabase, args.userId),
     fetchCalendarToday(args.supabase, args.userId, nowIso, endUtc),
     fetchCalendarPassed(args.supabase, args.userId, lookbackIso, nowIso),
     fetchAutopilotForVoice(args.supabase, args.userId),
@@ -225,10 +266,11 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     fetchDiaryLast7Days(args.supabase, args.userId, args.now),
   ]);
 
+  const lifeCompass = projectLifeCompass(lcSnapshot);
   return {
-    journey: projectJourney(journeyState),
+    journey: projectJourney(journeyState, lifeCompass, previousGoalsCount, args.now),
     vitana_index: projectIndex(indexSnapshot),
-    life_compass: projectLifeCompass(lcSnapshot),
+    life_compass: lifeCompass,
     calendar_today: calToday,
     calendar_passed: calPassed,
     autopilot,
@@ -244,9 +286,45 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
 // Projections — narrow the shared-service shapes into the voice contract
 // ---------------------------------------------------------------------------
 
-function projectJourney(s: JourneyState | null): OverviewPayload['journey'] {
+/**
+ * Compute the plan_phase discriminator + the fields each phase needs.
+ *
+ * Branching rules (the user's mental model — see VTID-03184 header):
+ *
+ *   - life_compass.state === 'set'
+ *       → 'on_personalized_goal'. The 90-day frame drops; greeting
+ *         anchors on "Tag X mit Vitana, wir arbeiten an [goal]". The
+ *         arc is endless, goal-by-goal.
+ *
+ *   - life_compass.state === 'not_set' AND day_in_journey <= total_days
+ *       → 'default_active'. User is still in the scaffolding plan;
+ *         greeting includes wave name + "Tag X von Y in deinem Start-Plan".
+ *
+ *   - life_compass.state === 'not_set' AND day_in_journey > total_days
+ *       → 'default_finished_no_goal'. Scaffolding plan is complete but
+ *         no personalized goal yet — greeting invites the first goal as
+ *         the next step in the endless journey.
+ */
+function projectJourney(
+  s: JourneyState | null,
+  lifeCompass: OverviewPayload['life_compass'],
+  previousGoalsCount: number,
+  now: Date,
+): OverviewPayload['journey'] {
   if (!s) return null;
-  const wave = s.current_wave
+
+  // Phase resolution.
+  let plan_phase: JourneyPlanPhase;
+  if (lifeCompass.state === 'set') {
+    plan_phase = 'on_personalized_goal';
+  } else if (s.day_in_journey > s.total_days) {
+    plan_phase = 'default_finished_no_goal';
+  } else {
+    plan_phase = 'default_active';
+  }
+
+  // current_wave only meaningful while the default plan is active.
+  const wave = plan_phase === 'default_active' && s.current_wave
     ? {
         name: s.current_wave.name,
         description: s.current_wave.description,
@@ -254,14 +332,54 @@ function projectJourney(s: JourneyState | null): OverviewPayload['journey'] {
         days_to_next_wave: Math.max(0, s.current_wave.end_day - s.day_in_journey),
       }
     : null;
+
+  // Goal-anchored fields populate only when on a personalized goal.
+  let current_goal_day: number | null = null;
+  let days_past_deadline: number | null = null;
+  if (plan_phase === 'on_personalized_goal') {
+    if (lifeCompass.set_at) {
+      const setAtMs = Date.parse(lifeCompass.set_at);
+      if (Number.isFinite(setAtMs)) {
+        current_goal_day = Math.max(1, Math.floor((now.getTime() - setAtMs) / 86_400_000) + 1);
+      }
+    }
+    if (lifeCompass.target_date) {
+      const deadlineMs = Date.parse(`${lifeCompass.target_date}T23:59:59Z`);
+      if (Number.isFinite(deadlineMs) && deadlineMs < now.getTime()) {
+        days_past_deadline = Math.max(1, Math.floor((now.getTime() - deadlineMs) / 86_400_000));
+      }
+    }
+  }
+
   return {
+    plan_phase,
     day_in_journey: s.day_in_journey,
-    total_days: s.total_days,
-    days_left: s.days_left,
     is_first_session: s.is_first_session,
     plan_type: s.plan_type,
+    default_plan_total_days: plan_phase === 'default_active' ? s.total_days : null,
     current_wave: wave,
+    current_goal_day,
+    days_past_deadline,
+    previous_goals_count: previousGoalsCount,
   };
+}
+
+/**
+ * Count the user's non-active life_compass rows — the "previous goals"
+ * arc length. Active row is excluded. Best-effort: returns 0 on error.
+ */
+async function fetchPreviousGoalsCount(sb: SupabaseClient, userId: string): Promise<number> {
+  try {
+    const { count, error } = await sb
+      .from('life_compass')
+      .select('id', { head: true, count: 'exact' })
+      .eq('user_id', userId)
+      .eq('is_active', false);
+    if (error) return 0;
+    return Number(count ?? 0);
+  } catch {
+    return 0;
+  }
 }
 
 function projectIndex(snap: any | null): OverviewPayload['vitana_index'] {

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
@@ -60,11 +60,14 @@ function timeOfDay(localHour: number): 'morning' | 'afternoon' | 'evening' {
  */
 function buildShapeExample(lang: string): string {
   if (lang.startsWith('de')) {
+    // Anna's plan_phase is 'on_personalized_goal' in this example — she has
+    // an active Life Compass goal (half an hour of stillness daily), so the
+    // greeting drops "X von 90" framing and anchors on "Tag X mit Vitana".
     return `### ❌ Dashboard-Ton — SO SOLLST DU NICHT SPRECHEN:
 "Guten Abend, Anna. Dein Vitana-Index liegt bei 84. Dein Ziel ist 30 Minuten Meditation am Tag. Du hast einen Termin um 19 Uhr und drei ungelesene Erinnerungen. Was möchtest du zuerst machen?"
 
 ### ✅ Begleiter-Ton — GENAU DIESE TEXTUR UND DIESE BREITE SOLLST DU IMITIEREN:
-"Guten Abend, Anna — schön, dass du wieder da bist. Heute ist Tag 23 von 90 in deiner Reise, du bist mitten in der Erkundungs-Phase. Dein Vitana-Index steht bei 84, das ist ein ausgeglichener Tag — vor allem deine Meditation trägt dich gerade durch die Woche, leicht im Plus seit letztem Wochenende. An deinem Ziel, jeden Tag eine halbe Stunde Stille zu finden, sind wir mit dem heutigen Tag wieder ein Stück konsequenter dran.
+"Guten Abend, Anna — schön, dass du wieder da bist. Heute ist dein 132. Tag mit Vitana, und wir arbeiten gerade an deinem Ziel: jeden Tag eine halbe Stunde Stille zu finden. Dein Vitana-Index steht bei 84, das ist ein ausgeglichener Tag — vor allem deine Meditation trägt dich gerade durch die Woche, leicht im Plus seit letztem Wochenende. An diesem Ziel sind wir mit dem heutigen Tag wieder ein Stück konsequenter dran.
 
 Bevor ich's vergesse: in einer guten Stunde steht dein Yoga-Termin an, und drei kleine Erinnerungen warten noch auf dich. Ich hab heute auch den nächsten Schritt für dich vorbereitet — eine kurze Atem-Sequenz vor dem Schlafengehen. Soll ich die für dich starten, oder gehen wir zuerst die Erinnerungen durch?"`;
   }
@@ -73,7 +76,7 @@ Bevor ich's vergesse: in einer guten Stunde steht dein Yoga-Termin an, und drei 
 "Good evening, Anna. Your Vitana Index is 84. Your goal is 30 minutes of meditation a day. You have one event at 7 pm and three unread reminders. What would you like to do first?"
 
 ### ✅ Companion tone — IMITATE THIS TEXTURE AND THIS BREADTH:
-"Good evening, Anna — glad to have you back. Today is day 23 of 90 on your journey, right in the middle of the exploration phase. Your Vitana Index is at 84, that reads like a balanced day — your meditation pillar is really carrying the week, slightly up since last weekend. On your goal of half an hour of stillness every day, today moves us one notch more consistent.
+"Good evening, Anna — glad to have you back. Today is your day 132 with Vitana, and we're working on your goal of finding half an hour of stillness every day. Your Vitana Index is at 84, that reads like a balanced day — your meditation pillar is really carrying the week, slightly up since last weekend. On that goal, today moves us one notch more consistent.
 
 Before I forget: your yoga class kicks off in just over an hour, and three small reminders are waiting too. I've also prepared the next step for you — a short breath sequence before bed. Want me to start that for you, or shall we walk through the reminders first?"`;
 }
@@ -162,11 +165,51 @@ greetings are forbidden.
    clause ("schön, dass du wieder da bist" / "glad to have you back"
    / equivalent). NEVER go from the salutation straight into a stat.
 
-2. JOURNEY CONTEXT FIRST. If \`journey\` is present, name the day in
-   the journey + the current wave/phase right after the warmth
-   clause. "Heute ist Tag X von Y, du bist mitten in der [phase]" /
-   "Today is day X of Y, you're in [phase]". This anchors the entire
-   greeting in the user's longer arc.
+2. JOURNEY CONTEXT FIRST — BRANCH ON \`journey.plan_phase\`. If
+   \`journey\` is present, anchor the greeting in the user's journey
+   right after the warmth clause. The framing depends on plan_phase:
+
+   - plan_phase === 'default_active' (scaffolding plan still running,
+     no personalized goal yet): name the day + the wave —
+     "Heute ist Tag X von Y in deinem Start-Plan, du bist gerade in
+     der [current_wave.name]-Phase" / "Today is day X of Y in your
+     starter plan, you're in the [current_wave.name] phase". The
+     wave gives the user a sense of WHERE they are in the onboarding
+     arc.
+
+   - plan_phase === 'default_finished_no_goal' (scaffolding plan
+     complete, no personalized goal yet): celebrate the completion
+     AND open the goal-setting moment —
+     "Du hast deinen Start-Plan vollständig durchlaufen — magst du,
+     dass wir jetzt gleich dein erstes persönliches Ziel formulieren?"
+     / "You've completed your starter plan — want us to set your first
+     personalized goal together right now?". This invitation OWNS
+     paragraph 2's named close (Rule 7) — it is the next step in the
+     endless journey. Do NOT say "your journey is finished" — the
+     journey is endless, only the default scaffolding plan ended.
+
+   - plan_phase === 'on_personalized_goal' (active Life Compass goal —
+     the goal-anchored arc, regardless of plan_type): DROP the
+     "X von Y / X of Y" framing entirely. The user is no longer on
+     scaffolding — they are on their own arc. Anchor instead on the
+     goal:
+       "Heute ist dein {day_in_journey}. Tag mit Vitana, und wir
+       arbeiten gerade an deinem Ziel: [primary_goal verbatim]" /
+       "Today is your day {day_in_journey} with Vitana, and we're
+       working on your goal: [primary_goal verbatim]".
+     If \`current_goal_day\` is set, you may add "seit {current_goal_day}
+     Tagen". If \`previous_goals_count\` > 0, you may weave in
+     "dein {previous_goals_count + 1}. Ziel mit mir" — the goal
+     arc length, the user's history.
+     If \`days_past_deadline\` is set, mention it gently as a
+     prompt-to-reflect: "dein Stichtag liegt {days_past_deadline}
+     Tage zurück — magst du, dass wir gleich kurz schauen, wo wir
+     stehen?". Do NOT treat the past deadline as failure.
+
+   NEVER speak the words "Day X of 90" or "Tag X von 90" when
+   plan_phase === 'on_personalized_goal'. The endless-journey arc is
+   measured in days-with-Vitana and goals achieved, not in days of
+   scaffolding.
 
 3. NO BARE NUMBERS. Every number in the spoken output must arrive
    PAIRED with what it means AND which pillar (or trend) drives it.
@@ -301,9 +344,28 @@ function buildCoverageChecklist(p: OverviewPayload): string {
   const items: string[] = [];
 
   if (p.journey) {
-    items.push(`- [ ] ADDRESS: journey day ${p.journey.day_in_journey} of ${p.journey.total_days}` +
-      (p.journey.current_wave ? `, currently in "${p.journey.current_wave.name}" phase` : '') +
-      ` (Rule 2 — name the day + phase in paragraph 1).`);
+    const j = p.journey;
+    if (j.plan_phase === 'on_personalized_goal') {
+      // Goal-anchored arc — no "X of Y" framing.
+      const goalArc = j.previous_goals_count > 0
+        ? ` This is goal number ${j.previous_goals_count + 1} in the user arc.`
+        : ' This is the first personalized goal for this user.';
+      const goalDayHint = j.current_goal_day !== null
+        ? ` Day ${j.current_goal_day} on this goal.`
+        : '';
+      const deadlineHint = j.days_past_deadline !== null
+        ? ` ⚠ Target date passed ${j.days_past_deadline} days ago — mention gently, never as failure.`
+        : '';
+      items.push(`- [ ] ADDRESS (Rule 2, plan_phase='on_personalized_goal'): Day ${j.day_in_journey} with Vitana, working on the active Life Compass goal.${goalArc}${goalDayHint}${deadlineHint} DO NOT use "Tag X von 90" framing.`);
+    } else if (j.plan_phase === 'default_finished_no_goal') {
+      items.push(`- [ ] ADDRESS (Rule 2, plan_phase='default_finished_no_goal'): User has completed the ${j.default_plan_total_days}-day starter plan (now day ${j.day_in_journey}) but has NOT set a personalized goal. Open the goal-setting moment — this becomes the named close (Rule 7).`);
+    } else {
+      // default_active
+      const waveHint = j.current_wave
+        ? `, currently in "${j.current_wave.name}" phase (day ${j.current_wave.day_in_wave}, ${j.current_wave.days_to_next_wave ?? '?'} days to next wave)`
+        : '';
+      items.push(`- [ ] ADDRESS (Rule 2, plan_phase='default_active'): Day ${j.day_in_journey} of ${j.default_plan_total_days} in the starter plan${waveHint}.`);
+    }
   }
 
   if (p.vitana_index.state === 'ok' && p.vitana_index.today !== null) {


### PR DESCRIPTION
## Summary

Re-applies **PR #2390** (VTID-03184, endless-journey `plan_phase` branching on the new-day overview prompt), which was reverted on 2026-05-29 by `bb1b8fe3` (#2396).

The 2026-05-29 revert was a **misdiagnosis**. The reported symptom (dragan1 voice setup failing) was caused by that account's accumulated `memory_items`/`memory_facts` overflowing the Vertex `system_instruction` budget — a **data-side** problem — not by this prompt change. Root cause is now addressed by (a) the manual prune of dragan1 to 200 items, and (b) the Phase A bootstrap hard-cap (separate PR). This restores the legitimate journey-overview work to trunk.

This is a clean cherry-pick of `6f37bcdd` onto current `main`.

## What this PR ships
Three-case `plan_phase` discriminator on the journey payload:
- **A. default_active** — `day_in_journey <= total_days` AND `life_compass.state = 'not_set'` → keeps "Tag X von Y im Start-Plan" wave framing.
- **B. default_finished_no_goal** — `day_in_journey > total_days` AND `life_compass.state = 'not_set'` → prompts the user to set their first personal goal (fixes "Day 152 of 90").
- **C. on_personalized_goal** — `life_compass.state = 'set'` → goal-anchored arc, drops the "X von 90" framing.

Files: `new-day-overview-payload.ts` (+138/-…), `new-day-overview-prompt.ts` (+82/-…).

## What it does NOT do
- No infra/auth/memory-pipeline changes.
- Case D (goal_completed celebration) remains deferred to a later phase, as in the original.

## Vertex parity ✓ / LiveKit parity ✓
Community-only continuation-provider prompt content. The greeting line is composed by the continuation-provider stack and rendered identically into the wake brief regardless of upstream provider (Vertex `system_instruction` override block, or LiveKit agent greeting). No provider-specific code paths touched — both surfaces consume the same `new-day-overview-prompt` output.

## Test plan
- [x] `npm run build` green
- [x] jest `new-day-*` suites green — **29 passed / 4 suites**
- [ ] (human/prod) EXEC-DEPLOY SUCCESS, `/alive` 200
- [ ] (human/prod) dragan3 mobile audio still works after deploy

## Rollback
Single-revert PR; the change is isolated to two continuation-provider files.

---
🤖 Re-applied autonomously per `docs/superpowers/plans/2026-05-29-orb-recovery-autonomous-execution.md` Phase Re-Apply. Sandbox cannot merge/deploy — see `docs/superpowers/plans/2026-05-29-pending-human-actions.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApimmhkZML398iKgkgVSPC)_