### PR TITLE
fix(gateway): persist live-stream cover_image_url on session create

### DIFF
--- a/services/gateway/src/routes/live.ts
+++ b/services/gateway/src/routes/live.ts
@@ -1659,6 +1659,8 @@ router.post('/rooms/:id/sessions', sessionCreateLimiter, async (req: Request, re
           created_by: userId,
           status: streamStatus,
           stream_type: 'audio',
+          cover_image_url: validation.data.metadata?.cover_image_url || null,
+          description: validation.data.metadata?.description || null,
           started_at: streamStatus === 'live' ? new Date().toISOString() : null,
           scheduled_for: validation.data.starts_at,
           access_level: validation.data.access_level || 'public',


### PR DESCRIPTION
## Problem

Live-stream cover images upload to the `covers` bucket successfully, but never appear — the cover is invisible in the LiveRooms listing.

**Root cause (verified against production data):**
- Reporter: `maksinamariia@outlook.de`, stream `9c55506a-…` ("Community-Abend mit Mariia 🥰").
- The image **did** upload — `covers/67c971fc-…/live-1780150992307.jpg`, 873 KB `image/jpeg`, twice (she retried when nothing showed). URL serves `200`.
- But `community_live_streams.cover_image_url` stayed `null`. The row was updated 5 s after upload, yet the cover field was empty.
- The `covers` bucket has **no** size/mime limits, and RLS lets the owner update her own row — so neither storage config nor RLS is the cause.

The frontend (`GoLivePopup.tsx`) uploads the file and correctly passes the public URL as `metadata.cover_image_url` to the gateway `POST /rooms/:id/sessions`. But the gateway's `community_live_streams` sync upsert built the row **without** `cover_image_url` (or `description`) — so it was dropped on every create.

## Fix

Map `cover_image_url` and `description` from `validation.data.metadata` into the `community_live_streams` upsert body, matching the frontend payload. Two-line additive change; no behavior change for any other field.

## Verification
- Diagnosed via direct production reads (storage.objects, community_live_streams, pg_policies, bucket config).
- Same bug confirmed present on `main` (sync block omits the field).
- Mariia's existing stream was backfilled to her uploaded image as an immediate remediation (verified the cover now serves `200`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)