### PR TITLE
Live: broadcast 'now live' push to Notify-me subscribers on room start

### DIFF
--- a/services/gateway/src/i18n/catalog.ts
+++ b/services/gateway/src/i18n/catalog.ts
@@ -37,6 +37,9 @@ export type GatewayI18nKey =
   | 'notif.signal_expired.body'
   | 'notif.reminder.title'
   | 'notif.fallback_app_name'
+  // Live room goes live → notify everyone who tapped "Notify me" on the scheduled session.
+  | 'notif.live_going_live.title'
+  | 'notif.live_going_live.body'
   // Daily pace check (claude/daily-pace-notifications)
   | 'notif.daily_pace.on_track.title'
   | 'notif.daily_pace.on_track.body'
@@ -94,6 +97,8 @@ const DE: LocaleCatalog = {
   'notif.signal_expired.body': 'Ein prädiktives Signal ist abgelaufen.',
   'notif.reminder.title': '🔔 Erinnerung',
   'notif.fallback_app_name': 'Vitana',
+  'notif.live_going_live.title': '🔴 Jetzt live!',
+  'notif.live_going_live.body': '„{title}" hat gerade begonnen. Schau jetzt rein.',
   // Daily pace check
   'notif.daily_pace.on_track.title': 'Auf Kurs ✨',
   'notif.daily_pace.on_track.body': 'Du bist auf einem guten Weg. Schließ heute noch deinen Tagesplan ab — dein Ziel kommt näher.',
@@ -149,6 +154,8 @@ const EN: LocaleCatalog = {
   'notif.signal_expired.body': 'A predictive signal has expired.',
   'notif.reminder.title': '🔔 Reminder',
   'notif.fallback_app_name': 'Vitana',
+  'notif.live_going_live.title': '🔴 Now live!',
+  'notif.live_going_live.body': '"{title}" just started. Tune in now.',
   // Daily pace check
   'notif.daily_pace.on_track.title': 'On track ✨',
   'notif.daily_pace.on_track.body': "You're moving well. Wrap up today's plan — your goal is getting closer.",

--- a/services/gateway/src/routes/live.ts
+++ b/services/gateway/src/routes/live.ts
@@ -514,6 +514,53 @@ router.post('/rooms/:id/start', async (req: Request, res: Response) => {
     console.warn(`[VTID-01228] community_live_streams sync (start) failed: ${err.message}`);
   }
 
+  // Notify everyone who tapped "Notify me" on this scheduled session that it's now live.
+  // Audience comes from live_stream_subscribers (the persistent Notify list); titles/bodies
+  // are localized per-recipient via the gateway i18n catalog (PR #2269 server-side i18n rule).
+  try {
+    const credsN = getSupabaseCredentials();
+    if (credsN) {
+      const { createClient } = await import('@supabase/supabase-js');
+      const supaN = createClient(credsN.url, credsN.key);
+      let hostId = '';
+      try { hostId = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).sub; } catch {}
+
+      const { data: stream } = await supaN
+        .from('community_live_streams')
+        .select('title, tenant_id')
+        .eq('id', roomId)
+        .single();
+
+      const tenantId = (stream as any)?.tenant_id;
+      if (tenantId) {
+        const { data: subs } = await supaN
+          .from('live_stream_subscribers')
+          .select('user_id')
+          .eq('stream_id', roomId)
+          .neq('user_id', hostId);
+
+        const subscriberIds = [...new Set((subs || []).map((s: any) => s.user_id as string))];
+        if (subscriberIds.length > 0) {
+          const { tt } = await import('../i18n/catalog');
+          const { bulkGetUserLocales } = await import('../i18n/server-locale');
+          const locales = await bulkGetUserLocales(supaN, subscriberIds);
+          const streamTitle = (stream as any)?.title || '';
+          for (const uid of subscriberIds) {
+            const lc = locales.get(uid);
+            notifyUserAsync(uid, tenantId, 'live_room_starting', {
+              title: tt('notif.live_going_live.title', lc),
+              body: tt('notif.live_going_live.body', lc, { title: streamTitle }),
+              data: { url: '/community/live-rooms', room_id: roomId, entity_id: roomId },
+            }, supaN);
+          }
+          console.log(`[Notifications] live go-live fan-out → ${subscriberIds.length} subscriber(s) for ${roomId}`);
+        }
+      }
+    }
+  } catch (err: any) {
+    console.warn(`[Notifications] live go-live dispatch error: ${err.message}`);
+  }
+
   console.log(`[VTID-01090] Live room started: ${roomId}`);
 
   // VTID-03107: Surface session budget so the frontend SessionTimer can


### PR DESCRIPTION
## What & why

Completes the Live Rooms "Notify me" feature end-to-end. The companion frontend PR ([vitana-v1#600](https://github.com/exafyltd/vitana-v1/pull/600)) adds a persistent `live_stream_subscribers` table (who tapped **Notify me** on a scheduled session). This PR makes the **go-live moment** actually push to those people.

## Change

In `POST /live/rooms/:id/start` (the canonical go-live path, which already syncs `community_live_streams` → `live`), after the status sync we now fan out a **"now live"** notification to everyone in `live_stream_subscribers` for that stream:

- **Audience:** `live_stream_subscribers.user_id` for the stream, excluding the host.
- **i18n:** new `notif.live_going_live.{title,body}` keys in `i18n/catalog.ts` (DE real translations; EN; ES/SR inherit EN). Localized **per recipient** via `bulkGetUserLocales` + `tt()`, per the server-side i18n hard rule (§13b) — no raw English on lock screens.
- **Type:** reuses the existing `live_room_starting` type (already in `TYPE_META`: `live_room` category, `p0`, `push_and_inapp`), so prefs/DND/push routing all work via `notifyUser`.
- **Safety:** fire-and-forget (`notifyUserAsync`), wrapped in `try/catch` — a notification failure never blocks the room start. Mirrors the existing attendee/follower fan-out block in the same file.

The frontend's `useStartStream` is rewired to call this endpoint (with a direct-Supabase fallback if a stream isn't backed by a gateway `live_room`).

## Verification
- `tsc --noEmit` on the full gateway: **clean** (installed deps locally; the only error is the pre-existing `tsconfig` `node10` deprecation under TS 6.0.2, unrelated to this change).
- Could **not** deploy or run against live infra from this environment (no GCP access here; governed EXEC-DEPLOY pipeline).

## ⚠️ Before merge / deploy
- **Requires a real VTID.** I tagged the commit `BOOTSTRAP-live-go-live-notify` so AUTO-DEPLOY can dispatch, but per governance please attach/confirm the proper VTID.
- The companion **Supabase migration** creating `live_stream_subscribers` (in vitana-v1#600) must be applied first, otherwise the subscriber query returns empty (the fan-out then simply no-ops — safe).

https://claude.ai/code/session_01SRnQYuQdZVfnCBzeuh3V8A

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRnQYuQdZVfnCBzeuh3V8A)_