### PR TITLE
fix(autopilot): bound + label AUTOPILOT backlog badge as "awaiting approval" (Phase 3, staged)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -5601,10 +5601,21 @@ function renderHeader() {
     autopilotBtn.className = 'header-pill header-pill--neutral';
     autopilotBtn.textContent = 'AUTOPILOT';
     // VTID-01180: Add badge if there are new recommendations
+    // Phase 3 (autopilot-error-capture): the AUTOPILOT backlog is human-gated —
+    // these are scanner/impact findings awaiting a go/no-go decision, drained
+    // only by human approval (or the auto-exec triage rule). With autonomy off
+    // the queue is an expected standby pile, not an unbounded alarm. Bound the
+    // display at 99+ and label it "awaiting approval" (with an exact-count
+    // tooltip / aria-label) so a steady-state standby queue reads as standby.
     if (state.autopilotRecommendationsCount > 0) {
+        const n = state.autopilotRecommendationsCount;
         const badge = document.createElement('span');
         badge.className = 'header-pill-badge';
-        badge.textContent = state.autopilotRecommendationsCount > 99 ? '99+' : state.autopilotRecommendationsCount;
+        badge.textContent = n > 99 ? '99+' : String(n);
+        const approvalLabel = n + ' finding' + (n === 1 ? '' : 's') + ' awaiting approval';
+        badge.setAttribute('aria-label', approvalLabel);
+        autopilotBtn.title = approvalLabel;
+        autopilotBtn.setAttribute('aria-label', 'AUTOPILOT — ' + approvalLabel);
         autopilotBtn.appendChild(badge);
     }
     autopilotBtn.onclick = async () => {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260529-VTID-03185-audio-queue-closure"></script>
-  <script src="/command-hub/app.js?v=20260528-orb-voice-health-probe"></script>
+  <script src="/command-hub/app.js?v=20260530-autopilot-awaiting-approval-badge"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
   <!-- Phase 0 staging build (P0.5): PUBLISH→staging-source card + CLOCK revert -->


### PR DESCRIPTION
## Session 4 — Phase 3 (staged, pending live Phase 2 confirmation)

Follows Phase 1 (#2374, merged — `unknown_error` error capture). Scope: autopilot service + its frontend badge only.

> ⚠️ **Staged, not validated.** This env's network policy blocks Supabase + the Cloud Run gateway (`Host not in allowlist`), so I haven't yet confirmed the live backlog classification or screenshotted the badge. This implements the fix behind the **most likely diagnosis** so it's ready to validate the instant egress opens. Hold merge until then.

### Phase 2 diagnosis (from code, pending live counts)
The `AUTOPILOT` pill badge counts `autopilot_recommendations` where `status='new'` AND `auto_exec_eligible IS NOT true` AND not snoozed (`dev-autopilot.ts` `/pending-approvals`). That's a **human-gated queue** — drained only by human approval or the auto-exec triage rule.

The consumer is **not** the bottleneck: the event loop polls every 2s in batches of 100 (~50 events/s ceiling). So an unbounded backlog is **starvation** — the producer (scanner/impact rules) outpaces human triage while autonomy is off (`AUTO_ACTIVATE_RECOMMENDATIONS` / `AUTOPILOT_LOOP_ENABLED` gates). That is an *expected steady state* under governance ("Never enable autonomy without explicit approval"), not a broken consumer.

Decision tree to confirm with live data:
- **Dead** ⟺ `AUTOPILOT_LOOP_ENABLED !== 'true'` (loop never runs)
- **Rate-limited** → ruled out by code (throughput ≫ plausible production)
- **Starved (expected)** ⟺ loop alive, autonomy off, no human triage

### The staged fix
Given starvation-by-design, the right move is to stop the badge reading as an unbounded alarm and make it read as standby:
- Bound display at `99+` (kept) and add `"<n> findings awaiting approval"` as `title` + `aria-label` on both badge and button (WCAG 2.2 AA).
- Backend `/pending-approvals/count` already returns the exact bounded count — **no backend change needed**.
- Frontend-only, CSP-safe (no inline JS/CSS), `app.js` `?v=` bumped.

### Before merge (when egress opens)
1. Pull `AUTOPILOT_LOOP_ENABLED` / `AUTO_ACTIVATE_RECOMMENDATIONS` + the `allocated` / pending-approval counts sampled over time → confirm starved vs dead.
2. If **dead** instead → this badge change is still correct but the real fix is restarting the loop / enabling the gate (separate change).
3. Screenshot the badge (desktop 1400×900 + mobile 390×844) per the visual-verification protocol.
4. Confirm Phase 1 killed `unknown_error` in the live feed.

**Done-when (Session 4):** no more `unknown_error` in the feed (Phase 1 ✅ merged) **and** backlog decreasing or documented as expected steady state (this PR documents it + de-alarms the badge).

https://claude.ai/code/session_01ApVSfZ6m9YdPbCAkpdSs4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApVSfZ6m9YdPbCAkpdSs4k)_