### PR TITLE
[FleetView] feat(memory): BOOTSTRAP-orb-memory-ranker — relevance-ranked retrieval (Phase B)

### DIFF
--- a/services/gateway/src/services/memory-ranker.ts
+++ b/services/gateway/src/services/memory-ranker.ts
@@ -1,0 +1,133 @@
+/**
+ * Memory relevance ranker — Phase B (ORB Memory Resilience).
+ *
+ * Phase A caps the bootstrap by truncating from the bottom — arbitrary with respect to
+ * usefulness. Phase B replaces "first N memory rows" with a relevance-ranked top-K so
+ * the content that SURVIVES the cap is the most useful.
+ *
+ * Pure + dependency-free: no Supabase, no fetch, no clock except the injected `now`.
+ * This makes it exhaustively unit-testable and safe to call on the hot path. Gated in
+ * the caller behind the existing `BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL` feature flag; a
+ * `VOICE_RANKING_SHADOW` mode logs naive-vs-ranked via `compareSelections` before the
+ * flag is flipped in prod.
+ *
+ * Score = 0.4·importance + 0.4·recency + 0.2·similarity
+ *   - importance : existing 0..1 column (clamped)
+ *   - recency    : exp(-ageDays / 30) — 1.0 today, ~0.37 at 30 days, →0 older
+ *   - similarity : cosine(intentEmbedding, candidate.embedding) mapped to 0..1, or 0
+ *                  when either embedding is absent (ranking degrades to importance+recency)
+ */
+
+export interface MemoryCandidate {
+  id: string;
+  content: string;
+  importance: number; // 0..1
+  occurred_at: string; // ISO timestamp
+  embedding?: number[]; // optional pgvector
+}
+
+export interface RankInputs<T extends MemoryCandidate = MemoryCandidate> {
+  candidates: T[];
+  intentEmbedding?: number[];
+  now: Date;
+  topK: number; // hard cap on output count
+}
+
+export const RECENCY_HALFLIFE_DAYS = 30;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+/** exp(-ageDays / 30). Future timestamps clamp to 1.0; unparseable → 0. */
+export function recencyDecay(occurredAt: string, now: Date): number {
+  const t = Date.parse(occurredAt);
+  if (!Number.isFinite(t)) return 0;
+  const ageDays = (now.getTime() - t) / MS_PER_DAY;
+  if (ageDays <= 0) return 1;
+  return Math.exp(-ageDays / RECENCY_HALFLIFE_DAYS);
+}
+
+/** Cosine similarity mapped to [0,1]; 0 when shapes mismatch or either vector empty/zero. */
+export function cosineSimilarity(a?: number[], b?: number[]): number {
+  if (!a || !b || a.length === 0 || a.length !== b.length) return 0;
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  if (na === 0 || nb === 0) return 0;
+  const cos = dot / (Math.sqrt(na) * Math.sqrt(nb));
+  return clamp01((cos + 1) / 2); // map [-1,1] → [0,1]
+}
+
+export interface ScoredCandidate<T extends MemoryCandidate> {
+  candidate: T;
+  score: number;
+}
+
+/** Score every candidate (no truncation). Input order preserved for equal scores. */
+export function scoreMemory<T extends MemoryCandidate>(
+  { candidates, intentEmbedding, now }: Omit<RankInputs<T>, 'topK'>,
+): ScoredCandidate<T>[] {
+  return candidates.map((c) => {
+    const importance = clamp01(c.importance ?? 0);
+    const recency = recencyDecay(c.occurred_at, now);
+    const similarity =
+      intentEmbedding && c.embedding ? cosineSimilarity(intentEmbedding, c.embedding) : 0;
+    const score = 0.4 * importance + 0.4 * recency + 0.2 * similarity;
+    return { candidate: c, score };
+  });
+}
+
+/**
+ * Rank candidates by relevance and return the top-K. Pure; stable for equal scores
+ * (preserves original relative order). `topK <= 0` returns an empty array.
+ */
+export function rankMemory<T extends MemoryCandidate>(inputs: RankInputs<T>): T[] {
+  const { topK } = inputs;
+  if (topK <= 0) return [];
+  const scored = scoreMemory(inputs);
+  return scored
+    .map((s, i) => ({ s, i }))
+    .sort((a, b) => (b.s.score - a.s.score) || (a.i - b.i)) // stable on ties
+    .slice(0, topK)
+    .map((x) => x.s.candidate);
+}
+
+/**
+ * Shadow comparison between the current naive selection and the ranked selection.
+ * Used by the `VOICE_RANKING_SHADOW` harness to log both without changing behavior.
+ */
+export interface ShadowComparison {
+  naive_selection_ids: string[];
+  ranked_selection_ids: string[];
+  naive_chars: number;
+  ranked_chars: number;
+  overlap_pct: number; // % of ranked ids also present in naive
+}
+
+export function compareSelections(
+  naive: MemoryCandidate[],
+  ranked: MemoryCandidate[],
+): ShadowComparison {
+  const naiveIds = naive.map((c) => c.id);
+  const rankedIds = ranked.map((c) => c.id);
+  const naiveSet = new Set(naiveIds);
+  const overlap = rankedIds.filter((id) => naiveSet.has(id)).length;
+  const chars = (cs: MemoryCandidate[]) => cs.reduce((sum, c) => sum + (c.content?.length ?? 0), 0);
+  return {
+    naive_selection_ids: naiveIds,
+    ranked_selection_ids: rankedIds,
+    naive_chars: chars(naive),
+    ranked_chars: chars(ranked),
+    overlap_pct: rankedIds.length === 0 ? 0 : Math.round((1000 * overlap) / rankedIds.length) / 10,
+  };
+}

--- a/services/gateway/src/services/memory-ranker.ts
+++ b/services/gateway/src/services/memory-ranker.ts
@@ -37,9 +37,9 @@ export const RECENCY_HALFLIFE_DAYS = 30;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export function clamp01(n: number): number {
-  if (!Number.isFinite(n)) return 0;
-  if (n < 0) return 0;
-  if (n > 1) return 1;
+  if (Number.isNaN(n)) return 0; // NaN has no position on the line → treat as 0
+  if (n < 0) return 0; // catches -Infinity
+  if (n > 1) return 1; // catches +Infinity
   return n;
 }
 

--- a/services/gateway/test/services/memory-ranker.test.ts
+++ b/services/gateway/test/services/memory-ranker.test.ts
@@ -1,0 +1,143 @@
+import {
+  clamp01,
+  recencyDecay,
+  cosineSimilarity,
+  scoreMemory,
+  rankMemory,
+  compareSelections,
+  RECENCY_HALFLIFE_DAYS,
+  type MemoryCandidate,
+} from '../../src/services/memory-ranker';
+
+const NOW = new Date('2026-05-30T12:00:00Z');
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
+
+function cand(over: Partial<MemoryCandidate> & { id: string }): MemoryCandidate {
+  return {
+    content: 'x'.repeat(100),
+    importance: 0.5,
+    occurred_at: daysAgo(1),
+    ...over,
+  };
+}
+
+describe('clamp01', () => {
+  it('clamps out-of-range and non-finite to [0,1]', () => {
+    expect(clamp01(-1)).toBe(0);
+    expect(clamp01(2)).toBe(1);
+    expect(clamp01(0.5)).toBe(0.5);
+    expect(clamp01(NaN)).toBe(0);
+    expect(clamp01(Infinity)).toBe(1);
+  });
+});
+
+describe('recencyDecay', () => {
+  it('is 1.0 for "now" and decays toward 0', () => {
+    expect(recencyDecay(NOW.toISOString(), NOW)).toBeCloseTo(1, 5);
+    expect(recencyDecay(daysAgo(RECENCY_HALFLIFE_DAYS), NOW)).toBeCloseTo(Math.exp(-1), 5);
+    expect(recencyDecay(daysAgo(365), NOW)).toBeLessThan(0.01);
+  });
+  it('clamps future timestamps to 1.0 and unparseable to 0', () => {
+    expect(recencyDecay(daysAgo(-5), NOW)).toBe(1); // 5 days in the future
+    expect(recencyDecay('not-a-date', NOW)).toBe(0);
+  });
+});
+
+describe('cosineSimilarity', () => {
+  it('maps identical vectors to 1 and opposite to 0', () => {
+    expect(cosineSimilarity([1, 0], [1, 0])).toBeCloseTo(1, 5);
+    expect(cosineSimilarity([1, 0], [-1, 0])).toBeCloseTo(0, 5);
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0.5, 5); // orthogonal → midpoint
+  });
+  it('returns 0 for missing / mismatched / zero vectors', () => {
+    expect(cosineSimilarity(undefined, [1])).toBe(0);
+    expect(cosineSimilarity([1, 2], [1])).toBe(0);
+    expect(cosineSimilarity([0, 0], [0, 0])).toBe(0);
+  });
+});
+
+describe('scoreMemory', () => {
+  it('weights importance 0.4 + recency 0.4 + similarity 0.2', () => {
+    const c = cand({ id: 'a', importance: 1, occurred_at: NOW.toISOString(), embedding: [1, 0] });
+    const [scored] = scoreMemory({ candidates: [c], intentEmbedding: [1, 0], now: NOW });
+    // importance 1*0.4 + recency 1*0.4 + similarity 1*0.2 = 1.0
+    expect(scored.score).toBeCloseTo(1.0, 5);
+  });
+  it('omits similarity when no intent embedding', () => {
+    const c = cand({ id: 'a', importance: 1, occurred_at: NOW.toISOString(), embedding: [1, 0] });
+    const [scored] = scoreMemory({ candidates: [c], now: NOW });
+    expect(scored.score).toBeCloseTo(0.8, 5); // 0.4 + 0.4, no similarity term
+  });
+});
+
+describe('rankMemory', () => {
+  it('returns at most topK candidates', () => {
+    const cands = Array.from({ length: 10 }, (_, i) => cand({ id: String(i) }));
+    expect(rankMemory({ candidates: cands, now: NOW, topK: 3 })).toHaveLength(3);
+  });
+
+  it('topK <= 0 returns empty', () => {
+    const cands = [cand({ id: 'a' })];
+    expect(rankMemory({ candidates: cands, now: NOW, topK: 0 })).toEqual([]);
+  });
+
+  it('high importance dominates low importance at equal recency', () => {
+    const hi = cand({ id: 'hi', importance: 0.9, occurred_at: daysAgo(2) });
+    const lo = cand({ id: 'lo', importance: 0.1, occurred_at: daysAgo(2) });
+    const out = rankMemory({ candidates: [lo, hi], now: NOW, topK: 1 });
+    expect(out[0].id).toBe('hi');
+  });
+
+  it('recent dominates stale at equal importance', () => {
+    const recent = cand({ id: 'recent', importance: 0.5, occurred_at: daysAgo(1) });
+    const stale = cand({ id: 'stale', importance: 0.5, occurred_at: daysAgo(200) });
+    const out = rankMemory({ candidates: [stale, recent], now: NOW, topK: 1 });
+    expect(out[0].id).toBe('recent');
+  });
+
+  it('embedding match can lift an otherwise-weaker candidate', () => {
+    const intent = [1, 0, 0];
+    const match = cand({ id: 'match', importance: 0.3, occurred_at: daysAgo(10), embedding: [1, 0, 0] });
+    const noMatch = cand({ id: 'noMatch', importance: 0.35, occurred_at: daysAgo(10), embedding: [0, 1, 0] });
+    const out = rankMemory({ candidates: [noMatch, match], intentEmbedding: intent, now: NOW, topK: 1 });
+    expect(out[0].id).toBe('match');
+  });
+
+  it('is stable for tied scores (preserves input order)', () => {
+    const a = cand({ id: 'a', importance: 0.5, occurred_at: daysAgo(1) });
+    const b = cand({ id: 'b', importance: 0.5, occurred_at: daysAgo(1) });
+    const out = rankMemory({ candidates: [a, b], now: NOW, topK: 2 });
+    expect(out.map((c) => c.id)).toEqual(['a', 'b']);
+  });
+
+  it('heavy-user drop: keeps the most useful subset under a tight cap', () => {
+    const cands: MemoryCandidate[] = [
+      cand({ id: 'old-trivial', importance: 0.1, occurred_at: daysAgo(180) }),
+      cand({ id: 'recent-important', importance: 0.9, occurred_at: daysAgo(1) }),
+      cand({ id: 'mid', importance: 0.5, occurred_at: daysAgo(15) }),
+    ];
+    const out = rankMemory({ candidates: cands, now: NOW, topK: 2 });
+    expect(out.map((c) => c.id)).toEqual(['recent-important', 'mid']);
+  });
+
+  it('light user: returns everything when topK exceeds count', () => {
+    const cands = [cand({ id: 'a' }), cand({ id: 'b' })];
+    expect(rankMemory({ candidates: cands, now: NOW, topK: 50 })).toHaveLength(2);
+  });
+});
+
+describe('compareSelections (shadow harness)', () => {
+  it('reports overlap pct, ids, and char totals', () => {
+    const naive = [cand({ id: 'a', content: 'aa' }), cand({ id: 'b', content: 'bbb' })];
+    const ranked = [cand({ id: 'a', content: 'aa' }), cand({ id: 'c', content: 'cccc' })];
+    const cmp = compareSelections(naive, ranked);
+    expect(cmp.naive_selection_ids).toEqual(['a', 'b']);
+    expect(cmp.ranked_selection_ids).toEqual(['a', 'c']);
+    expect(cmp.naive_chars).toBe(5);
+    expect(cmp.ranked_chars).toBe(6);
+    expect(cmp.overlap_pct).toBe(50); // 1 of 2 ranked ids in naive
+  });
+  it('overlap is 0 for an empty ranked selection', () => {
+    expect(compareSelections([cand({ id: 'a' })], []).overlap_pct).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Phase B of ORB Memory Resilience. When the bootstrap approaches the Phase A cap, the cap drops content arbitrarily (trim-from-bottom). Phase B replaces "first N memory rows" with a **relevance-ranked top-K** so the content that *survives* is the most useful.

## What this PR ships
- **Pure module** `services/memory-ranker.ts` (no Supabase/fetch/clock except injected `now`):
  - `rankMemory` — score = `0.4·importance + 0.4·recency + 0.2·similarity`, returns top-K, stable on ties.
  - `recencyDecay` (`exp(-ageDays/30)`), `cosineSimilarity` (mapped to 0..1, safe on shape mismatch), `scoreMemory`, `clamp01`.
  - `compareSelections` — the **shadow harness** primitive (naive vs ranked: ids, char totals, overlap %).
- **Integration** `context-pack-builder.ts` — both memory-hit selection sites routed through a flag-gated `selectMemoryHits(hits, limit)` helper:
  - Flag **OFF** (default) → **byte-identical** to prior `slice(0, limit)`.
  - Flag `BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL` **ON** → ranked top-K (importance+recency; no intent embedding at this site, so similarity=0 and it degrades gracefully).
  - Flag-lookup failure → falls back to naive (never breaks context assembly).
- The flags `BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL` + `VOICE_RANKING_SHADOW` already exist in `feature-flags.ts` (default false) — no flag plumbing needed.

## Tests (green locally: typecheck + build + FULL suite 4755 passed, 0 failed)
`memory-ranker.test.ts` — 18 cases: clamp, decay (now/half-life/future/unparseable), cosine (identical/opposite/orthogonal/mismatch/zero), weighting, topK bounds, importance-dominant, recency-dominant, embedding-lift, stable ties, heavy-user drop, light-user passthrough, shadow compare.

## What it does NOT do (prod-gated, per plan §4.B.4–4.B.5)
- Flip the flag (stays false). The plan requires a 48h **shadow** run (`VOICE_RANKING_SHADOW`) on prod traffic via `compareSelections`, then a `dragan1` canary, before flipping. Those steps need prod + DB and are listed in pending-human-actions.
- Wire an intent embedding into this selection site (deeper integration; similarity term is 0 here for now — ranking still improves via importance+recency).

## Vertex parity ✓ / LiveKit parity ✓
`context-pack-builder` feeds the bootstrap context that BOTH providers consume — the ranked selection benefits Vertex and LiveKit identically. Pure ranker has no provider-specific code. No upstream paths touched; flag-off path is unchanged.

## Pending human actions
- Merge; EXEC-DEPLOY SUCCESS; `/alive` 200.
- Enable `VOICE_RANKING_SHADOW`, run 48h on prod, confirm `compareSelections` overlap ≥80% with the most-important naive selection AND ≥40% char drop on heavy users.
- Canary `BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL` on dragan1 24h, then expand.

---
🤖 Phase B per the autonomous-execution plan. Sandbox cannot merge/deploy/run prod shadow — see `docs/superpowers/plans/2026-05-29-pending-human-actions.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApimmhkZML398iKgkgVSPC)_