### PR TITLE
fix(orb): stop greeting + "My Journey" summary being re-spoken on ORB open

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -852,6 +852,62 @@ export function createUpstreamLiveMessageHandler(
                     });
                     console.log(`[BOOTSTRAP-ORB-HOTFIX-1] pre_greeting_ms=${preGreetingMs} for session ${session.sessionId}`);
                   }
+
+                  // BOOTSTRAP-ORB-GREETING-REEMIT: Gemini Live occasionally
+                  // auto-continues after a "Say exactly: …" greeting directive
+                  // and re-speaks the SAME opener / "My Journey" summary as a
+                  // brand-new model turn — with NO user input in between. This
+                  // is the user-reported "greeting spoken 3 times, again and
+                  // again" symptom.
+                  //
+                  // VTID-03143 (transcript-prefix suppression below) only
+                  // catches this AFTER ~30 chars of OUTPUT TRANSCRIPTION match a
+                  // prior turn, so the first words still leak, and it does
+                  // nothing when output transcription is sparse/absent. Here we
+                  // catch it STRUCTURALLY, from the very first audio chunk, with
+                  // no dependency on transcription:
+                  //
+                  //   greetingSent              → the only thing the model was
+                  //                               ever told to produce so far is
+                  //                               the opener.
+                  //   turn_count >= 1           → the greeting already completed
+                  //                               at least once.
+                  //   consecutiveModelTurns
+                  //     >= turn_count           → the user has NEVER spoken. The
+                  //                               counter resets to 0 the instant
+                  //                               a user transcription arrives
+                  //                               (see input-transcription path),
+                  //                               so equality means every turn so
+                  //                               far was a consecutive model
+                  //                               turn — i.e. the opener + its
+                  //                               re-emits, nothing else.
+                  //   inputTranscriptBuffer
+                  //     empty                   → no user utterance mid-flight.
+                  //
+                  // When all hold, this NEW model turn can only be an unsolicited
+                  // re-emit of the opener. Flip the audio-suppression flag BEFORE
+                  // the forward decision below so the entire turn is dropped (no
+                  // first-word leak). The loopguard further down pauses the
+                  // silence keepalive so Vertex idles the loop out naturally; a
+                  // real user utterance resets consecutiveModelTurns and lifts
+                  // the suppression on the next turn.
+                  if (
+                    session.greetingSent
+                    && session.turn_count >= 1
+                    && session.consecutiveModelTurns >= session.turn_count
+                    && (session.inputTranscriptBuffer || '').trim().length === 0
+                    && (session as any).suppressCurrentTurnAudio !== true
+                  ) {
+                    (session as any).suppressCurrentTurnAudio = true;
+                    console.warn(
+                      `[BOOTSTRAP-ORB-GREETING-REEMIT] Suppressing unsolicited greeting re-emit for session ${session.sessionId} ` +
+                      `(turn_count=${session.turn_count}, consecutiveModelTurns=${session.consecutiveModelTurns}) — user has not spoken yet`,
+                    );
+                    ctx.deps.emitDiag(session, 'greeting_reemit_suppressed', {
+                      turn_count: session.turn_count,
+                      consecutive_model_turns: session.consecutiveModelTurns,
+                    });
+                  }
                 }
                 // VTID-WATCHDOG: Model is sending audio — restart watchdog.
                 // If audio stops mid-stream (no turn_complete), watchdog fires.

--- a/services/gateway/test/orb/live/characterization/upstream-greeting-reemit-suppression.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/upstream-greeting-reemit-suppression.characterization.test.ts
@@ -1,0 +1,81 @@
+/**
+ * BOOTSTRAP-ORB-GREETING-REEMIT — structural greeting/journey re-emit suppression.
+ *
+ * User report: opening the ORB ("Vitana Assistant") speaks the greeting +
+ * "My Journey" summary 3 times in a row, "again and again". Root cause:
+ * Gemini Live occasionally auto-continues after a `Say exactly: "…"` opener
+ * directive and re-speaks the SAME opener as a brand-new model turn with NO
+ * user input in between.
+ *
+ * The pre-existing VTID-03143 transcript-prefix filter only catches this
+ * AFTER ~30 chars of OUTPUT TRANSCRIPTION match a prior turn — so the first
+ * words still leak, and it does nothing when output transcription is
+ * sparse/absent. This guard catches the re-emit STRUCTURALLY, from the very
+ * first audio chunk, with no dependency on transcription.
+ *
+ * This file locks the structural contract of that guard in
+ * services/gateway/src/orb/live/session/upstream-message-handler.ts:
+ *
+ *   - It lives in the new-model-turn-start block (the `if (!session.isModelSpeaking)`
+ *     branch that fires on the first audio chunk of a turn), so the flag is
+ *     set BEFORE the audio-forward decision — no first-word leak.
+ *   - It only fires when the user has NEVER spoken yet:
+ *       greetingSent && turn_count >= 1 && consecutiveModelTurns >= turn_count
+ *       && inputTranscriptBuffer empty.
+ *     (consecutiveModelTurns resets to 0 the instant a user transcription
+ *     arrives, so equality with turn_count proves no user turn happened.)
+ *   - It reuses session.suppressCurrentTurnAudio so the existing forward
+ *     gate drops the whole turn.
+ *   - It emits a [BOOTSTRAP-ORB-GREETING-REEMIT] warn + greeting_reemit_suppressed diag.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const HANDLER_PATH = path.resolve(
+  __dirname,
+  '../../../../src/orb/live/session/upstream-message-handler.ts',
+);
+
+let src: string;
+
+beforeAll(() => {
+  src = fs.readFileSync(HANDLER_PATH, 'utf8');
+});
+
+describe('BOOTSTRAP-ORB-GREETING-REEMIT: structural greeting re-emit suppression', () => {
+  it('guards on greetingSent + the "user never spoke" counter relation', () => {
+    // greetingSent: the only thing produced so far is the opener.
+    expect(src).toMatch(/session\.greetingSent/);
+    // turn_count >= 1: the greeting already completed at least once.
+    expect(src).toMatch(/session\.turn_count\s*>=\s*1/);
+    // consecutiveModelTurns >= turn_count: the user has NEVER interjected
+    // (the counter resets to 0 on user speech, so equality == no user turn).
+    expect(src).toMatch(/session\.consecutiveModelTurns\s*>=\s*session\.turn_count/);
+    // No user utterance mid-flight either.
+    expect(src).toMatch(/\(session\.inputTranscriptBuffer\s*\|\|\s*''\)\.trim\(\)\.length\s*===\s*0/);
+  });
+
+  it('flips session.suppressCurrentTurnAudio so the existing forward gate drops the turn', () => {
+    // Reuses the VTID-03143 suppression flag rather than a parallel path.
+    expect(src).toMatch(/suppressCurrentTurnAudio\s*=\s*true;/);
+    // Idempotency guard so the warn/diag fires once per re-emit turn, not per chunk.
+    expect(src).toMatch(/suppressCurrentTurnAudio\s*!==\s*true/);
+  });
+
+  it('emits a [BOOTSTRAP-ORB-GREETING-REEMIT] warn + greeting_reemit_suppressed diag', () => {
+    expect(src).toMatch(/\[BOOTSTRAP-ORB-GREETING-REEMIT\] Suppressing unsolicited greeting re-emit/);
+    expect(src).toMatch(/greeting_reemit_suppressed/);
+  });
+
+  it('sets the flag inside the new-turn-start (isModelSpeaking) block, before audio is forwarded', () => {
+    // The guard must sit between the start-of-turn marker and the
+    // onAudioResponse forward, so a re-emit is dropped from chunk 1.
+    const idxIsSpeaking = src.indexOf('if (!session.isModelSpeaking)');
+    const idxGuard = src.indexOf('[BOOTSTRAP-ORB-GREETING-REEMIT] Suppressing');
+    const idxForward = src.indexOf('ctx.callbacks.onAudioResponse(audioB64)');
+    expect(idxIsSpeaking).toBeGreaterThan(-1);
+    expect(idxGuard).toBeGreaterThan(idxIsSpeaking);
+    expect(idxForward).toBeGreaterThan(idxGuard);
+  });
+});


### PR DESCRIPTION
## Problem

Opening the ORB ("Vitana Assistant") speaks the greeting **and the "My Journey" summary 3 times in a row** — *"again and again and again"*. ORB ↔ assistant communication felt like chaos.

## Root cause

Gemini Live occasionally **auto-continues** after a `Say exactly: "<opener>"` greeting directive (the wake-brief / new-day "My Journey" overview line, sent via `sendGreetingPromptToLiveAPI`) and **re-speaks the SAME opener as a brand-new model turn, with no user input in between**.

The code already knew about this class of bug — the VTID-03143 comment in `upstream-message-handler.ts` literally says *"Gemini Live occasionally re-emits the same response... the user hears the same intro twice or three times."* But the existing VTID-03143 filter only catches it:
- **after ~30 chars of OUTPUT TRANSCRIPTION** match a prior turn (so the first words still leak), and
- **only when output transcription is flowing** (it does nothing when transcription is sparse/absent — which is exactly when the user hears the *full* opener repeated).

## Fix

A tight structural guard at the start of each new model turn (the `if (!session.isModelSpeaking)` first-chunk hook) that drops the audio of any turn which begins **before the user has ever spoken** but **after the greeting already completed once**:

```ts
session.greetingSent
&& session.turn_count >= 1
&& session.consecutiveModelTurns >= session.turn_count  // user never interjected
&& (session.inputTranscriptBuffer || '').trim().length === 0
```

`consecutiveModelTurns` resets to `0` the instant a user transcription arrives, so `consecutiveModelTurns >= turn_count` proves **no user turn ever happened** — meaning the only thing the model has produced so far is the opener and its re-emits. The guard reuses the existing `suppressCurrentTurnAudio` forward gate, so the whole re-emit is dropped **from the first chunk** (no first-word leak) with **no dependency on transcription**. A real user utterance resets the counter and lifts suppression on the next turn.

### Why it's low-risk (won't suppress legitimate turns)
- The legitimate first greeting plays normally: when its first chunk arrives `turn_count === 0`, so `turn_count >= 1` is false.
- Any model turn *after the user speaks* is never suppressed: the user's transcription set `consecutiveModelTurns = 0`, so `consecutiveModelTurns >= turn_count` is false.
- Genuine stall-recovery re-greets (greeting never completed, `turn_count` still 0) are unaffected — they play normally.

## Tests

Adds `upstream-greeting-reemit-suppression.characterization.test.ts` locking the guard's structural contract (placement before the audio forward, the counter relation, flag reuse, and diag/log), in the same style as the existing VTID-03143 characterization test.

## Scope

Backend-only change in `services/gateway` — applies to all ORB transports (SSE widget + WS), so no frontend change is needed; the repeated audio simply never leaves the gateway.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3AQ4dbYGr4FY3pV9x8hTm)_