### PR TITLE
feat(aws): prove GCS->S3 mirror wiring on non-weight artifacts (VTID-03200)

### DIFF
--- a/.github/workflows/MIRROR-ARTIFACTS-S3.yml
+++ b/.github/workflows/MIRROR-ARTIFACTS-S3.yml
@@ -8,6 +8,11 @@ name: Mirror Artifacts to S3 (dormant)
 # When live, mirrors gs://vitana-artifacts-staging/finetune-current/<target>/weights.tar.gz
 # to s3://<AWS_BUCKET>/finetune-current/<target>/weights.tar.gz so the
 # Bedrock canary path has a portable copy.
+#
+# Phase 1 W2 Track A (VTID-03200): the mirror job ALSO carries NON-WEIGHT
+# artifacts — eval-coverage reports and dataset manifests — so the GCS -> S3
+# wiring proves itself end-to-end before any weights exist (W3 Bedrock work).
+# Setup / secrets: scripts/aws/README.md.
 
 on:
   schedule:
@@ -82,4 +87,43 @@ jobs:
             aws s3 cp "${TMP}" "s3://${AWS_BUCKET}/finetune-current/${TARGET}/weights.tar.gz"
             rm -f "${TMP}"
             echo "${TARGET}: mirrored"
+          done
+
+      # --- Non-weight artifacts (VTID-03200) — prove the wiring early ---
+      - name: Mirror eval-coverage reports GCS -> S3
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+          AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+        run: |
+          set -euo pipefail
+          SRC="${STAGING_BUCKET}/eval-reports/"
+          if ! gsutil -q ls "${SRC}" 2>/dev/null; then
+            echo "eval-reports: none present; skipping"
+            exit 0
+          fi
+          LOCAL="/tmp/eval-reports"
+          mkdir -p "${LOCAL}"
+          gsutil -m rsync -r "${SRC}" "${LOCAL}/"
+          aws s3 sync "${LOCAL}/" "s3://${AWS_BUCKET}/eval-reports/" --region "${AWS_REGION}"
+          rm -rf "${LOCAL}"
+          echo "eval-reports: mirrored"
+
+      - name: Mirror dataset manifests GCS -> S3
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+          AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+        run: |
+          set -euo pipefail
+          MANIFESTS=$(gsutil ls "${STAGING_BUCKET}/datasets/*/manifest.json" 2>/dev/null || true)
+          if [ -z "$MANIFESTS" ]; then
+            echo "dataset manifests: none present; skipping"
+            exit 0
+          fi
+          for M in $MANIFESTS; do
+            NAME=$(echo "$M" | sed -E 's#.*/datasets/([^/]+)/manifest.json#\1#')
+            TMP="/tmp/${NAME}-manifest.json"
+            gsutil cp "$M" "$TMP"
+            aws s3 cp "$TMP" "s3://${AWS_BUCKET}/datasets/${NAME}/manifest.json" --region "${AWS_REGION}"
+            rm -f "$TMP"
+            echo "dataset ${NAME}: manifest mirrored"
           done

--- a/.github/workflows/SMOKE-AWS-MIRROR.yml
+++ b/.github/workflows/SMOKE-AWS-MIRROR.yml
@@ -1,0 +1,75 @@
+name: Smoke AWS Mirror (manual)
+
+# Phase 1 W2 Track A (VTID-03200 — AWS S3 runway). Proves the GCS -> S3
+# mirror wiring end-to-end against a tiny NON-WEIGHT marker file, BEFORE any
+# real fine-tune weights exist. Manual only (workflow_dispatch). Refuses with
+# a clear error when the AWS secrets are missing, so a dispatch on an
+# un-provisioned account fails loudly instead of silently passing.
+#
+# Setup: see scripts/aws/README.md (AWS_BUCKET, AWS_ROLE_ARN, AWS_REGION).
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: smoke-aws-mirror
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: lovable-vitana-vers1
+  STAGING_BUCKET: gs://vitana-artifacts-staging
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Fail fast with the exact message acceptance checks for, BEFORE the
+      # AWS OIDC step (which would otherwise error confusingly on empty role).
+      - name: Guard — require AWS secrets
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          if [ -z "$AWS_BUCKET" ]; then
+            echo "::error::AWS_BUCKET secret not set"
+            echo "AWS_BUCKET secret not set — provision AWS first (see scripts/aws/README.md)"
+            exit 1
+          fi
+          if [ -z "$AWS_ROLE_ARN" ]; then
+            echo "::error::AWS_ROLE_ARN secret not set"
+            echo "AWS_ROLE_ARN secret not set — provision AWS first (see scripts/aws/README.md)"
+            exit 1
+          fi
+          echo "AWS_BUCKET + AWS_ROLE_ARN present; proceeding with smoke test"
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Run mirror smoke test
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+          AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+        run: npx -y tsx scripts/aws/smoke-mirror.ts

--- a/scripts/aws/README.md
+++ b/scripts/aws/README.md
@@ -1,0 +1,77 @@
+# AWS S3 mirror runway (Phase 1 W2 Track A — VTID-03200)
+
+This directory wires the GCS → S3 artifact mirror that the W3+ Bedrock canary
+will depend on. It is **dormant** until the operator provisions AWS. Nothing
+here runs against AWS automatically; all jobs early-exit (or refuse, for the
+smoke) when the secrets below are unset.
+
+## Repository secrets the operator must set
+
+Set these on `exafyltd/vitana-platform` once an AWS account exists
+(`gh secret set <NAME>`):
+
+| Secret         | Required | Default     | Purpose                                              |
+|----------------|----------|-------------|------------------------------------------------------|
+| `AWS_BUCKET`   | yes      | —           | Target S3 bucket name (no `s3://`), e.g. `vitana-artifacts`. |
+| `AWS_ROLE_ARN` | yes      | —           | IAM role the workflows assume via GitHub OIDC.       |
+| `AWS_REGION`   | no       | `us-east-1` | Bucket region.                                       |
+
+```bash
+gh secret set AWS_BUCKET   --repo exafyltd/vitana-platform --body "vitana-artifacts"
+gh secret set AWS_ROLE_ARN --repo exafyltd/vitana-platform --body "arn:aws:iam::<ACCOUNT_ID>:role/vitana-gha-mirror"
+gh secret set AWS_REGION   --repo exafyltd/vitana-platform --body "us-east-1"   # optional
+```
+
+Do **not** commit these values. The GCP side already uses Workload Identity
+Federation (`GCP_WIF_PROVIDER` / `GCP_WIF_SA_EMAIL`); this is the AWS mirror of
+that same keyless pattern — no static AWS access keys.
+
+## One-time AWS setup (GitHub OIDC federation)
+
+1. Create the GitHub OIDC provider (once per AWS account):
+   - URL: `https://token.actions.githubusercontent.com`
+   - Audience: `sts.amazonaws.com`
+2. Create an IAM role (`vitana-gha-mirror`) with `s3:PutObject`, `s3:GetObject`,
+   `s3:ListBucket`, `s3:DeleteObject` on the bucket, and this trust policy
+   (scoped to this repo — same federation idea as our GCP WIF):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:exafyltd/vitana-platform:*"
+        }
+      }
+    }
+  ]
+}
+```
+
+Put the resulting role ARN into `AWS_ROLE_ARN`.
+
+## Proving the wiring
+
+`SMOKE-AWS-MIRROR.yml` (`workflow_dispatch` only) runs `smoke-mirror.ts`:
+writes a dated marker to `gs://vitana-artifacts-staging/smoke/`, mirrors it to
+S3, asserts it landed, then cleans up both copies.
+
+```bash
+gh workflow run SMOKE-AWS-MIRROR.yml --ref main
+```
+
+With no secrets set it fails immediately with `AWS_BUCKET secret not set` —
+that is the expected pre-provisioning state. Once the secrets land it should
+go green, after which `MIRROR-ARTIFACTS-S3.yml` will also begin mirroring
+eval-coverage reports and dataset manifests on its daily schedule (weights
+follow in W3).

--- a/scripts/aws/smoke-mirror.ts
+++ b/scripts/aws/smoke-mirror.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env -S npx -y tsx
+/**
+ * smoke-mirror.ts — VTID-03200 (Phase 1 W2, Track A — AWS S3 runway)
+ *
+ * Proves the GCS -> S3 mirror wiring end-to-end against a tiny NON-WEIGHT
+ * marker file, BEFORE any real fine-tune weights exist. Used by
+ * .github/workflows/SMOKE-AWS-MIRROR.yml (workflow_dispatch only).
+ *
+ *   1. Write a dated marker file to GCS  (gs://<staging>/smoke/<marker>)
+ *   2. Run the same mirror logic the dormant MIRROR-ARTIFACTS-S3 job uses
+ *      (gsutil cp -> local -> aws s3 cp)
+ *   3. Assert the marker appears in S3  (aws s3api head-object)
+ *   4. Best-effort cleanup of both copies
+ *
+ * Refuses (exit 1) with a clear message if the AWS secrets are not set, so
+ * a dispatch with empty secrets fails loudly instead of silently no-op-ing.
+ *
+ * No new npm deps: shells out to the `gsutil` and `aws` CLIs that the GitHub
+ * runner already provides (same approach as the YAML mirror job).
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const STAGING_BUCKET = process.env.STAGING_BUCKET || 'gs://vitana-artifacts-staging';
+const AWS_BUCKET = process.env.AWS_BUCKET || '';
+const AWS_ROLE_ARN = process.env.AWS_ROLE_ARN || '';
+const AWS_REGION = process.env.AWS_REGION || 'us-east-1';
+
+function fail(msg: string): never {
+  console.error(`smoke-mirror: ERROR — ${msg}`);
+  process.exit(1);
+}
+
+function run(cmd: string, args: string[]): string {
+  return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] });
+}
+
+// --- Guard: refuse without AWS secrets (clear, exact messages) ----------
+if (!AWS_BUCKET) fail('AWS_BUCKET secret not set');
+if (!AWS_ROLE_ARN) fail('AWS_ROLE_ARN secret not set');
+
+console.log(`smoke-mirror: staging=${STAGING_BUCKET} aws_bucket=${AWS_BUCKET} region=${AWS_REGION}`);
+
+// --- 1. Build a dated marker file --------------------------------------
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const rand = Math.random().toString(36).slice(2, 8);
+const markerName = `marker-${stamp}-${rand}.txt`;
+const gcsMarker = `${STAGING_BUCKET}/smoke/${markerName}`;
+const s3Marker = `s3://${AWS_BUCKET}/smoke/${markerName}`;
+const s3Key = `smoke/${markerName}`;
+
+const workdir = mkdtempSync(join(tmpdir(), 'aws-smoke-'));
+const localUp = join(workdir, markerName);
+const localDown = join(workdir, `down-${markerName}`);
+writeFileSync(localUp, `vitana aws-mirror smoke @ ${new Date().toISOString()}\n`);
+
+let ok = false;
+try {
+  // --- 1. Write marker to GCS -----------------------------------------
+  console.log(`smoke-mirror: writing marker -> ${gcsMarker}`);
+  run('gsutil', ['cp', localUp, gcsMarker]);
+
+  // --- 2. Mirror GCS -> S3 (same shape as the YAML weights mirror) ----
+  console.log('smoke-mirror: mirroring GCS -> S3');
+  run('gsutil', ['cp', gcsMarker, localDown]);
+  run('aws', ['s3', 'cp', localDown, s3Marker, '--region', AWS_REGION]);
+
+  // --- 3. Assert it landed in S3 --------------------------------------
+  console.log(`smoke-mirror: asserting ${s3Marker} exists`);
+  run('aws', ['s3api', 'head-object', '--bucket', AWS_BUCKET, '--key', s3Key, '--region', AWS_REGION]);
+  ok = true;
+  console.log('smoke-mirror: PASS — marker round-tripped GCS -> S3');
+} catch (err) {
+  console.error('smoke-mirror: mirror/assert step failed');
+  if (err instanceof Error) console.error(err.message);
+} finally {
+  // --- 4. Best-effort cleanup -----------------------------------------
+  try { run('gsutil', ['rm', '-f', gcsMarker]); } catch { /* ignore */ }
+  try { run('aws', ['s3', 'rm', s3Marker, '--region', AWS_REGION]); } catch { /* ignore */ }
+  try { rmSync(workdir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+if (!ok) fail('smoke test did not confirm the marker in S3');


### PR DESCRIPTION
## Phase 1 W2 — Track A — AWS S3 runway (VTID-03200)

Makes the dormant AWS mirror provable **end-to-end before any fine-tune
weights exist**, so the W3+ Bedrock canary inherits a verified GCS → S3 path.
No runtime behavior change; no new npm deps; operator sets the AWS secrets.

### What changed
- **`MIRROR-ARTIFACTS-S3.yml`** — the dormant weights step is left **untouched**.
  Added two non-weight mirror steps to the existing `mirror` job:
  - eval-coverage reports: `gs://vitana-artifacts-staging/eval-reports/` → `s3://<bucket>/eval-reports/`
  - dataset manifests: `gs://vitana-artifacts-staging/datasets/*/manifest.json` → `s3://<bucket>/datasets/<name>/manifest.json`
  Both skip cleanly when the source is absent (still gated by the existing guard job).
- **`scripts/aws/smoke-mirror.ts`** — standalone `tsx` script: writes a dated
  marker to GCS, mirrors it to S3 (same `gsutil`/`aws` shape as the YAML job),
  asserts it landed via `s3api head-object`, then cleans up both copies.
  Refuses with `AWS_BUCKET secret not set` when secrets are missing.
- **`SMOKE-AWS-MIRROR.yml`** — `workflow_dispatch`-only runner. A guard step
  fails loudly with the exact message **before** the AWS OIDC step so an
  un-provisioned dispatch fails clearly instead of erroring confusingly.
- **`scripts/aws/README.md`** (77 lines) — operator setup: `AWS_BUCKET`,
  `AWS_ROLE_ARN`, optional `AWS_REGION` (default `us-east-1`), plus the GitHub
  OIDC IAM trust-policy snippet (keyless federation, mirroring our GCP WIF).

### Acceptance
- `npm run build` (gateway) — **green** (changes are repo-root scripts + workflows only).
- `gh workflow run SMOKE-AWS-MIRROR.yml --ref main` with no secrets → fails with `AWS_BUCKET secret not set` (verified the script guard locally).
- README < 100 lines.

### Notes
- The allocator endpoint (`gateway.vitanaland.com/api/v1/vtid/allocate`) is
  unreachable from this environment's network allowlist; VTID-03200 was chosen
  as the next free id (last allocated on `main` is 03199, no collision).
- **Operator follow-up:** set `AWS_BUCKET` / `AWS_ROLE_ARN` (+ optional
  `AWS_REGION`) via `gh secret set` once the AWS account exists — see
  `scripts/aws/README.md`. This PR does not set them.
- Out of scope (W3): `@aws-sdk/client-bedrock-runtime`, real weights mirror.

https://claude.ai/code/session_01N9siYTn17hNTbte4rU6K2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9siYTn17hNTbte4rU6K2n)_