### PR TITLE
feat(gateway): gate OASIS data_export_ok on tenant consent — Phase 1 W2 C1 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -46,6 +46,10 @@ import { randomUUID } from 'crypto';
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
+// Phase 1 W2 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA): tag events with
+// data_export_ok ONLY where tenant export consent is established, so the
+// dataset-extraction PII gate can ingest them. Default off / fail-closed.
+import { dataExportConsentTag } from '../services/data-export-consent';
 // VTID-03177 (PROFILE): per-turn latency telemetry. The middleware is a no-op
 // when FEATURE_LATENCY_TELEMETRY_ENV is off; safe to wire on every route.
 import { withLatencyTracker } from '../orb/live/latency-tracker';
@@ -7153,7 +7157,8 @@ async function emitOrbSessionStarted(orbSessionId: string, conversationId: strin
     payload: {
       orb_session_id: orbSessionId,
       conversation_id: conversationId,
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({ userId }))
     }
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.session.started:', err.message));
 }
@@ -7179,7 +7184,8 @@ async function emitOrbTurnReceived(
       conversation_id: conversationId,
       input_length: inputText.length,
       input_preview: inputText.slice(0, 140),
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({ userId }))
     }
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.turn.received:', err.message));
 }
@@ -7207,7 +7213,8 @@ async function emitOrbTurnResponded(
       reply_length: replyText.length,
       reply_preview: replyText.slice(0, 140),
       provider,
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({ userId }))
     }
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.turn.responded:', err.message));
 }
@@ -7226,7 +7233,8 @@ async function emitOrbSessionEnded(orbSessionId: string, conversationId: string,
     payload: {
       orb_session_id: orbSessionId,
       conversation_id: conversationId,
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({ userId }))
     }
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.session.ended:', err.message));
 }
@@ -7295,13 +7303,19 @@ async function emitMemoryWriteEvent(
   eventType: 'memory.write.user_message' | 'memory.write.assistant_message',
   payload: Record<string, unknown>
 ): Promise<void> {
+  // Phase 1 W2: consent gate keyed on the tenant/user already carried in the
+  // payload. Untagged events stay filtered out of the pillar-classification corpus.
+  const consentTag = await dataExportConsentTag({
+    tenantId: typeof payload.tenant_id === 'string' ? payload.tenant_id : undefined,
+    userId: typeof payload.user_id === 'string' ? payload.user_id : undefined,
+  });
   await emitOasisEvent({
     vtid: 'VTID-01105',
     type: eventType as any,
     source: 'orb-memory-auto',
     status: 'success',
     message: `ORB ${eventType.includes('user') ? 'user' : 'assistant'} message written to memory`,
-    payload
+    payload: { ...payload, ...consentTag }
   }).catch(err => console.warn(`[VTID-01105] Failed to emit ${eventType}:`, err.message));
 }
 
@@ -9292,7 +9306,11 @@ router.post('/end-session', async (req: Request, res: Response) => {
           bullets: summaryContent.bullets,
           actions: summaryContent.actions
         },
-        metadata: { mode: 'orb_voice' }
+        metadata: { mode: 'orb_voice' },
+        ...(await dataExportConsentTag({
+          tenantId: transcript.tenant_id ?? undefined,
+          userId: transcript.user_id ?? undefined,
+        }))
       }
     }).catch(err => console.warn('[VTID-01039] Failed to emit orb.session.summary:', err.message));
 
@@ -9595,7 +9613,11 @@ router.post('/session/finalize', async (req: Request, res: Response) => {
         bullets: summaryContent.bullets,
         actions: summaryContent.actions
       },
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({
+        tenantId: transcript.tenant_id ?? undefined,
+        userId: transcript.user_id ?? undefined,
+      }))
     }
   }).catch(err => console.warn('[VTID-01039] Failed to emit orb.session.summary:', err.message));
 

--- a/services/gateway/src/services/data-export-consent.ts
+++ b/services/gateway/src/services/data-export-consent.ts
@@ -1,0 +1,160 @@
+/**
+ * Data-export consent gate — Phase 1 W2 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA).
+ *
+ * The Phase 1 dataset-extraction loop (services/gateway/scripts/datasets/lib.ts)
+ * only ingests oasis_events whose metadata carries `data_export_ok: true`. That
+ * flag is the machine-readable record that the tenant has consented to their
+ * conversational telemetry being used to build training corpora. W1 shipped the
+ * SQL-layer PII gate (`metadata->>data_export_ok=eq.true`); W1 left every
+ * producing surface emitting events WITHOUT the flag, so the gate filtered
+ * everything and the first cron run yielded 0 rows. This module closes that wire.
+ *
+ * This is the single source of truth for "is export consent established for this
+ * surface?". Producing surfaces (orb-live turn/session events, the autopilot
+ * intent emitter, the memory-write emitter) call `dataExportConsentTag()` and
+ * spread the result into their event payload. When consent is NOT established the
+ * result is an empty object, so untagged events stay filtered out of every
+ * dataset — fail-closed by construction.
+ *
+ * Consent source (tenant policy): `tenant_settings.feature_flags.data_export_ok`
+ * must be strictly `true`. Default OFF. Any lookup error → not consented.
+ *
+ * Reads are cached in-process for 5 minutes (separately per tenant-policy and per
+ * user→tenant mapping) so the orb hot path never pays a Supabase round-trip per
+ * turn. Cron fan-outs reuse the same cache.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const TTL_MS = 5 * 60 * 1000;
+const LOG_PREFIX = '[data-export-consent]';
+
+/** tenantId → { consented, expires_at } */
+const tenantPolicyCache = new Map<string, { consented: boolean; expires_at: number }>();
+/** userId → { tenantId | null, expires_at } */
+const userTenantCache = new Map<string, { tenantId: string | null; expires_at: number }>();
+
+let _client: SupabaseClient | null | undefined;
+
+function getServiceClient(): SupabaseClient | null {
+  if (_client !== undefined) return _client;
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) {
+    console.warn(`${LOG_PREFIX} missing SUPABASE_URL / SUPABASE_SERVICE_ROLE; consent stays off`);
+    _client = null;
+    return null;
+  }
+  _client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+  return _client;
+}
+
+/**
+ * Resolve the tenant a user belongs to via the user_tenants membership table.
+ * Cached. Returns null on miss/error (→ fail-closed at the policy step).
+ */
+async function resolveTenantForUser(userId: string): Promise<string | null> {
+  const cached = userTenantCache.get(userId);
+  if (cached && cached.expires_at > Date.now()) return cached.tenantId;
+
+  let tenantId: string | null = null;
+  try {
+    const supa = getServiceClient();
+    if (supa) {
+      const { data } = await supa
+        .from('user_tenants')
+        .select('tenant_id')
+        .eq('user_id', userId)
+        .limit(1)
+        .maybeSingle();
+      tenantId = (data as { tenant_id?: string | null } | null)?.tenant_id ?? null;
+    }
+  } catch (e) {
+    console.warn(`${LOG_PREFIX} resolveTenantForUser(${userId}) error:`, e instanceof Error ? e.message : e);
+  }
+
+  userTenantCache.set(userId, { tenantId, expires_at: Date.now() + TTL_MS });
+  return tenantId;
+}
+
+/**
+ * Read tenant_settings.feature_flags.data_export_ok for a tenant. Cached.
+ * Strictly `true` ⇒ consented; anything else (missing row, missing flag,
+ * non-boolean, error) ⇒ not consented.
+ */
+async function tenantExportPolicy(tenantId: string): Promise<boolean> {
+  const cached = tenantPolicyCache.get(tenantId);
+  if (cached && cached.expires_at > Date.now()) return cached.consented;
+
+  let consented = false;
+  try {
+    const supa = getServiceClient();
+    if (supa) {
+      const { data } = await supa
+        .from('tenant_settings')
+        .select('feature_flags')
+        .eq('tenant_id', tenantId)
+        .maybeSingle();
+      const flags = (data as { feature_flags?: Record<string, unknown> } | null)?.feature_flags;
+      consented = flags?.data_export_ok === true;
+    }
+  } catch (e) {
+    console.warn(`${LOG_PREFIX} tenantExportPolicy(${tenantId}) error:`, e instanceof Error ? e.message : e);
+  }
+
+  tenantPolicyCache.set(tenantId, { consented, expires_at: Date.now() + TTL_MS });
+  return consented;
+}
+
+export interface ConsentContext {
+  /** Tenant UUID — preferred when available (resolves directly to policy). */
+  tenantId?: string | null;
+  /** User UUID — used to resolve a tenant when tenantId isn't passed. */
+  userId?: string | null;
+}
+
+/**
+ * True iff data-export consent is established for the given surface. Resolves a
+ * tenant (directly, or via userId) and reads the tenant policy. Fail-closed:
+ * no ids, no tenant, or any error ⇒ false.
+ */
+export async function isDataExportConsented(ctx: ConsentContext): Promise<boolean> {
+  let tenantId = ctx.tenantId ?? null;
+  if (!tenantId && ctx.userId) {
+    tenantId = await resolveTenantForUser(ctx.userId);
+  }
+  if (!tenantId) return false;
+  return tenantExportPolicy(tenantId);
+}
+
+/**
+ * The resolver shape, so callers (and tests) can inject a mock.
+ */
+export type ConsentResolver = (ctx: ConsentContext) => Promise<boolean>;
+
+/**
+ * Returns `{ data_export_ok: true }` when consent is established for the surface,
+ * otherwise an empty object. Spread the result into an OASIS event payload:
+ *
+ *   payload: { ...stuff, ...(await dataExportConsentTag({ userId })) }
+ *
+ * `resolver` is injectable for unit tests; production callers use the default.
+ */
+export async function dataExportConsentTag(
+  ctx: ConsentContext,
+  resolver: ConsentResolver = isDataExportConsented,
+): Promise<{ data_export_ok: true } | Record<string, never>> {
+  try {
+    return (await resolver(ctx)) ? { data_export_ok: true } : {};
+  } catch {
+    // Fail-closed — telemetry consent must never throw into the hot path.
+    return {};
+  }
+}
+
+/** Test/ops helper — clears the in-process caches. */
+export function _resetConsentCaches(): void {
+  tenantPolicyCache.clear();
+  userTenantCache.clear();
+  _client = undefined;
+}

--- a/services/gateway/src/services/data-export-consent.ts
+++ b/services/gateway/src/services/data-export-consent.ts
@@ -39,7 +39,9 @@ let _client: SupabaseClient | null | undefined;
 function getServiceClient(): SupabaseClient | null {
   if (_client !== undefined) return _client;
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  // SUPABASE_SERVICE_ROLE is the canonical var bound on every gateway deploy
+  // (CLAUDE.md §8); use it directly so we introduce no unbound env reference.
+  const key = process.env.SUPABASE_SERVICE_ROLE;
   if (!url || !key) {
     console.warn(`${LOG_PREFIX} missing SUPABASE_URL / SUPABASE_SERVICE_ROLE; consent stays off`);
     _client = null;

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -35,6 +35,7 @@ import {
   TaskStatusResponse
 } from './operator-service';
 import { emitOasisEvent, recommendationSyncEvents } from './oasis-event-service';
+import { dataExportConsentTag } from './data-export-consent';
 // VTID-01221: Sync Brief formatter for recommendation presentation
 import { formatSyncBrief, isWhatNextIntent, shouldFetchRecommendations, SyncBriefContext, Recommendation } from './sync-brief-formatter';
 // VTID-0538: Knowledge Hub integration
@@ -843,6 +844,14 @@ async function logAutopilotIntent(params: {
   action: 'created' | 'approved' | 'rejected' | 'executed';
   details: Record<string, unknown>;
 }): Promise<void> {
+  // Phase 1 W2 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA): tag with data_export_ok
+  // only where the thread's tenant has established export consent, so the
+  // intent-kind dataset extractor can ingest these events. Default off.
+  const identity = threadIdentityMap.get(params.threadId);
+  const consentTag = await dataExportConsentTag({
+    tenantId: identity?.tenant_id,
+    userId: identity?.user_id,
+  });
   await emitOasisEvent({
     vtid: params.vtid,
     type: `autopilot.intent.${params.action}`,
@@ -851,7 +860,8 @@ async function logAutopilotIntent(params: {
     message: `Autopilot intent ${params.action}`,
     payload: {
       threadId: params.threadId,
-      ...params.details
+      ...params.details,
+      ...consentTag
     }
   }).catch(err => console.warn('[VTID-0536] Failed to log autopilot intent:', err.message));
 }

--- a/services/gateway/test/data-export-consent.test.ts
+++ b/services/gateway/test/data-export-consent.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Phase 1 W2 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA) — consent-gate unit tests.
+ *
+ * Asserts the contract the dataset-extraction PII gate depends on: an emitted
+ * event's payload carries `data_export_ok: true` ONLY when export consent is
+ * established for the surface, and is absent otherwise. The producing surfaces
+ * (orb-live, intent emitter, memory writer) build their payload by spreading
+ * `dataExportConsentTag(...)`, so we exercise that exact path with a mock
+ * consent resolver standing in for the tenant-policy read.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import {
+  dataExportConsentTag,
+  isDataExportConsented,
+  type ConsentResolver,
+} from '../src/services/data-export-consent';
+
+const consentGranted: ConsentResolver = async () => true;
+const consentDenied: ConsentResolver = async () => false;
+const consentThrows: ConsentResolver = async () => {
+  throw new Error('tenant policy lookup blew up');
+};
+
+describe('dataExportConsentTag', () => {
+  test('includes data_export_ok:true when the consent resolver returns true', async () => {
+    const tag = await dataExportConsentTag({ userId: 'u-1' }, consentGranted);
+    expect(tag).toEqual({ data_export_ok: true });
+  });
+
+  test('excludes the flag entirely when the consent resolver returns false', async () => {
+    const tag = await dataExportConsentTag({ userId: 'u-1' }, consentDenied);
+    expect(tag).toEqual({});
+    expect('data_export_ok' in tag).toBe(false);
+  });
+
+  test('fail-closed: omits the flag when the resolver throws', async () => {
+    const tag = await dataExportConsentTag({ tenantId: 't-1' }, consentThrows);
+    expect(tag).toEqual({});
+  });
+});
+
+describe('emit payload assembly (mirrors orb-live / intent / memory surfaces)', () => {
+  function buildEmitPayload(tag: Record<string, unknown>) {
+    // Shape that orb-live spreads into emitOasisEvent({ payload }).
+    return {
+      orb_session_id: 'orb-123',
+      conversation_id: 'conv-456',
+      metadata: { mode: 'orb_voice' },
+      ...tag,
+    };
+  }
+
+  test('emit payload carries the flag for a consented surface', async () => {
+    const payload = buildEmitPayload(await dataExportConsentTag({ userId: 'u-1' }, consentGranted));
+    expect(payload.data_export_ok).toBe(true);
+  });
+
+  test('emit payload stays untagged for a non-consented surface', async () => {
+    const payload = buildEmitPayload(await dataExportConsentTag({ userId: 'u-1' }, consentDenied));
+    expect((payload as Record<string, unknown>).data_export_ok).toBeUndefined();
+  });
+});
+
+describe('isDataExportConsented fail-closed defaults', () => {
+  test('returns false when neither tenantId nor userId is provided', async () => {
+    await expect(isDataExportConsented({})).resolves.toBe(false);
+  });
+
+  test('returns false for empty-string ids', async () => {
+    await expect(isDataExportConsented({ tenantId: '', userId: '' })).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase 1 W2 — PR C1 of 3 (consent metadata)

**Stacked PR series (Track C, orb-live trio):** C1 → C2 → C3. This is **C1**, the smallest, shipped first because it unblocks dataset extraction.

> ⚠️ VTID note: the gateway VTID allocator (`POST /api/v1/vtid/allocate`) is **not reachable from the build sandbox** (host not in network allowlist), so per CLAUDE.md §16 this uses a `BOOTSTRAP-PHASE1-W2-CONSENT-METADATA` slug. Re-grepped `origin/main` for collisions: none.

### What & why
W1 (#2378) shipped the dataset-extraction PII gate — `scripts/datasets/lib.ts` only ingests `oasis_events` whose `metadata->>data_export_ok=eq.true`. But W1 left **every producing surface emitting events without the flag**, so the first `CRON-DATASET-EXTRACTION` run yielded **0 rows** for all three datasets (per `docs/PHASE-1-W1-ACCEPTANCE.md` §5). This PR closes that wire.

### Changes
- **New `services/gateway/src/services/data-export-consent.ts`** — single source of truth for *"is export consent established for this surface?"*
  - Reads tenant policy `tenant_settings.feature_flags.data_export_ok` (strictly `true`).
  - **Default OFF, fail-closed** on any missing id / missing row / error.
  - 5-min in-process cache (per tenant-policy + per user→tenant mapping) so the orb hot path never pays a Supabase round-trip per turn.
  - `dataExportConsentTag(ctx)` → `{ data_export_ok: true }` when consented, else `{}`. Resolver is injectable for tests.
- **Tagged producing surfaces ONLY** (flag spread into event payload):
  - `orb-live.ts`: `orb.session.started` / `orb.session.ended` / `orb.session.summary` (×2) / `orb.turn.received` / `orb.turn.responded`, and `memory.write.user_message` / `memory.write.assistant_message`.
  - `gemini-operator.ts`: `autopilot.intent.*` (gated on the thread's tenant via `threadIdentityMap`).
- **Unit test** `test/data-export-consent.test.ts` (7 tests): flag present iff mock consent resolver returns true; absent when false; fail-closed when resolver throws; `isDataExportConsented` false with no/empty ids.

### Surface → dataset mapping
| Surface tagged | Topic | Feeds dataset |
|---|---|---|
| orb.turn.responded | `orb.turn.responded` | voice-tool-routing |
| autopilot.intent.created | `autopilot.intent.created` | intent-kind |
| memory.write.user/assistant_message | `memory.write.*` | pillar-classification |

### Verification done in sandbox
- `npm run build` ✅ (pinned TS 5.9.3 — the build/CI compiler; **note** `npx tsc` here pulls TS 6 which falsely errors on a pre-existing `tsconfig` `moduleResolution` deprecation — that error exists on clean `main` too and is not introduced here).
- `npx jest test/data-export-consent.test.ts` ✅ 7/7.

### Owed to operator (cannot do from sandbox — gateway/Cloud Run not in allowlist)
- Merge + next staging deploy boot check.
- **Acceptance** (§C1): set `data_export_ok: true` on a test tenant's `tenant_settings.feature_flags`, accumulate consented events, then `gh workflow run CRON-DATASET-EXTRACTION.yml --ref main -f dry_run=false -f max_rows=5000` → expect >0 rows for ≥1 dataset.

### Scope guard
Consent flag only. **Not** in scope: adding extractor-required payload fields (e.g. `tool_name`/`transcript` on `orb.turn.responded`, `content`/`vitana_pillars` on memory writes). If a dataset still yields 0 rows after consent is granted, that's a separate follow-up — flagging it here for visibility.

🤖 Draft per session policy (CI green → hand off; no merge from sandbox).

https://claude.ai/code/session_01H674SSPgnnYyBq1V8nptsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01H674SSPgnnYyBq1V8nptsP)_