### PR TITLE
feat(gateway): wire per-turn voice latency tracker into orb-live — Phase 1 W2 C2 (BOOTSTRAP-PHASE1-W2-VOICE-LATENCY-WIRE)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -35,6 +35,7 @@
 import WebSocket from 'ws';
 import { randomUUID } from 'crypto';
 import type { GeminiLiveSession } from '../../../routes/orb-live';
+import type { LatencyPhase } from '../latency-tracker';
 import type { MemoryIdentity } from '../../../services/orb-memory-bridge';
 import { writeSseEvent } from '../transport/sse-handler';
 import {
@@ -85,6 +86,17 @@ export interface UpstreamMessageHandlerDeps {
   ) => boolean;
   sendFunctionResponseToLiveAPI: (...args: any[]) => boolean;
   sendWsMessage: (ws: WebSocket, message: Record<string, unknown>) => void;
+  // Phase 1 W2 (BOOTSTRAP-PHASE1-W2-VOICE-LATENCY-WIRE): per-turn latency marks.
+  // No-op when FEATURE_LATENCY_TELEMETRY_ENV is off.
+  markVoiceLatency: (
+    session: GeminiLiveSession,
+    phase: LatencyPhase,
+    detail?: Record<string, unknown>,
+  ) => void;
+  finalizeVoiceTurnLatency: (
+    session: GeminiLiveSession,
+    status?: 'success' | 'error',
+  ) => void;
   startResponseWatchdog: (
     session: GeminiLiveSession,
     timeoutMs: number,
@@ -217,6 +229,9 @@ export function createUpstreamLiveMessageHandler(
             }
             // Notify WS client via callback
             ctx.callbacks.onInterrupted?.();
+            // Phase 1 W2: the user barged in — finalize the (incomplete) turn so
+            // the next user audio chunk starts a fresh latency turn.
+            ctx.deps.finalizeVoiceTurnLatency(session, 'error');
             return;
           }
 
@@ -233,6 +248,9 @@ export function createUpstreamLiveMessageHandler(
             session.turnCompleteAt = Date.now();
             console.log(`[VTID-VOICE-INIT] Model stopped speaking for session ${session.sessionId} — mic audio ungated (cooldown ${getPostTurnCooldownMs()}ms)`);
             ctx.deps.emitDiag(session, 'turn_complete');
+            // Phase 1 W2: turn finished cleanly — emit voice.latency.measured and
+            // clear the tracker so the next user audio starts a fresh turn.
+            ctx.deps.finalizeVoiceTurnLatency(session, 'success');
 
             // VTID-02047 voice channel-swap: if a persona swap was queued by
             // the report_to_specialist tool, Vitana has just finished speaking
@@ -824,6 +842,8 @@ export function createUpstreamLiveMessageHandler(
                   // session in the middle of Vertex computing a follow-up turn.
                   session.vertexHasShownLife = true;
                   console.log(`[VTID-VOICE-INIT] Model started speaking for session ${session.sessionId} — mic audio gated`);
+                  // Phase 1 W2: first TTS chunk forwarded to the client.
+                  ctx.deps.markVoiceLatency(session, 'audio_out_first_chunk');
                   ctx.deps.emitDiag(session, 'model_start_speaking');
                   // BOOTSTRAP-ORB-HOTFIX-1: If this is the greeting (no turns yet
                   // and greeting was sent), emit the pre-greeting latency gauge.
@@ -930,6 +950,12 @@ export function createUpstreamLiveMessageHandler(
               // was destroying healthy sessions when first-turn inference exceeded
               // 15 s). Real WS failures are still caught by native handlers.
               session.vertexHasShownLife = true;
+              // Phase 1 W2: first STT fragment of the turn = transcript_ready.
+              // inputTranscriptBuffer is still empty until the append below, so
+              // an empty buffer marks the leading fragment exactly once per turn.
+              if (!session.inputTranscriptBuffer) {
+                ctx.deps.markVoiceLatency(session, 'transcript_ready', { chars: inputTranscription.length });
+              }
               ctx.deps.emitDiag(session, 'input_transcription', { text_preview: inputTranscription.substring(0, 80) });
               if (session.sseResponse) {
                 writeSseEvent(session.sseResponse, { type: 'input_transcript', text: inputTranscription });

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -52,7 +52,9 @@ import { emitOasisEvent } from '../services/oasis-event-service';
 import { dataExportConsentTag } from '../services/data-export-consent';
 // VTID-03177 (PROFILE): per-turn latency telemetry. The middleware is a no-op
 // when FEATURE_LATENCY_TELEMETRY_ENV is off; safe to wire on every route.
-import { withLatencyTracker } from '../orb/live/latency-tracker';
+// Phase 1 W2 (BOOTSTRAP-PHASE1-W2-VOICE-LATENCY-WIRE): the LatencyTracker class +
+// LatencyPhase are also used directly to instrument the voice WS/SSE turn timeline.
+import { withLatencyTracker, LatencyTracker, type LatencyPhase } from '../orb/live/latency-tracker';
 // VTID-02917 (B0d.3): wake reliability timeline — emit + record only,
 // never block the wake path. The recorder is best-effort by design.
 import { defaultWakeTimelineRecorder } from '../services/wake-timeline/wake-timeline-recorder';
@@ -800,6 +802,13 @@ export interface GeminiLiveSession {
   audioInChunks: number;
   videoInFrames: number;
   audioOutChunks: number;
+  // Phase 1 W2 (BOOTSTRAP-PHASE1-W2-VOICE-LATENCY-WIRE): per-turn voice latency
+  // tracker. Created on the first real mic chunk of a user turn and finalized at
+  // turn_complete / interrupted. No-op (emits nothing) when
+  // FEATURE_LATENCY_TELEMETRY_ENV is off. latencyTurnIndex is the 1-based turn
+  // counter passed to the tracker context.
+  latencyTracker?: LatencyTracker | null;
+  latencyTurnIndex?: number;
   // VTID-02637: Idempotency flag for connection_issue emission. The upstream
   // WS error handler and close handler both fire on a real disconnect, and
   // both used to emit connection_issue — producing the user-visible "internet
@@ -1975,6 +1984,8 @@ async function executeLiveApiTool(
   args: Record<string, unknown>
 ): Promise<{ success: boolean; result: string; error?: string }> {
   const startTime = Date.now();
+  // Phase 1 W2: mark the tool boundary on the active voice turn (no-op off-flag).
+  markVoiceLatency(session, 'tool_dispatch', { tool: toolName });
   // VTID-01224-FIX: Default 3 s budget. Gemini Live API has its own internal
   // timeout for function_response (~3-4s); taking longer stalls the session.
   //
@@ -2000,6 +2011,8 @@ async function executeLiveApiTool(
 
   const result = await executeWithTimeout();
   const elapsed = Date.now() - startTime;
+  // Phase 1 W2: tool returned — close the tool_dispatch→tool_response interval.
+  markVoiceLatency(session, 'tool_response', { tool: toolName, ms: elapsed, success: result.success });
   if (elapsed > TOOL_TIMEOUT_MS) {
     console.warn(`[VTID-STREAM-KEEPALIVE] Tool ${toolName} timed out (${elapsed}ms > ${TOOL_TIMEOUT_MS}ms)`);
   }
@@ -5952,6 +5965,8 @@ async function connectToLiveAPI(
         sendFunctionResponseToLiveAPI,
         sendWsMessage,
         startResponseWatchdog,
+        markVoiceLatency,
+        finalizeVoiceTurnLatency,
       },
     });
 
@@ -7237,6 +7252,52 @@ async function emitOrbSessionEnded(orbSessionId: string, conversationId: string,
       ...(await dataExportConsentTag({ userId }))
     }
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.session.ended:', err.message));
+}
+
+// =============================================================================
+// Phase 1 W2 (BOOTSTRAP-PHASE1-W2-VOICE-LATENCY-WIRE): voice per-turn latency
+// =============================================================================
+// Five canonical phase marks per voice user-turn (audio_in_first_byte →
+// transcript_ready → tool_dispatch → tool_response → audio_out_first_chunk),
+// emitted as ONE voice.latency.measured event on turn finalize. Every helper is
+// a no-op when FEATURE_LATENCY_TELEMETRY_ENV is off (LatencyTracker self-gates),
+// so this is safe to leave wired on the hot path. No raw session objects ever
+// reach prompt assembly — only the canonical marks are recorded.
+
+/**
+ * Start a fresh per-turn latency tracker on the first real mic chunk of a user
+ * turn. Idempotent within a turn: subsequent chunks no-op until the turn is
+ * finalized. Marks audio_in_first_byte at creation.
+ */
+function startVoiceTurnLatency(session: GeminiLiveSession): void {
+  if (session.latencyTracker) return; // turn already in flight
+  session.latencyTurnIndex = (session.latencyTurnIndex || 0) + 1;
+  const tracker = new LatencyTracker({
+    session_id: session.sessionId,
+    surface: 'voice',
+    actor_id: session.identity?.user_id,
+    turn: session.latencyTurnIndex,
+    provider: `vertex/${GEMINI_MODEL}`,
+  });
+  session.latencyTracker = tracker;
+  tracker.mark('audio_in_first_byte');
+}
+
+/** Record a phase mark on the active turn tracker (no-op if no turn in flight). */
+function markVoiceLatency(session: GeminiLiveSession, phase: LatencyPhase, detail?: Record<string, unknown>): void {
+  session.latencyTracker?.mark(phase, detail);
+}
+
+/**
+ * Finalize the active turn tracker (emits voice.latency.measured) and clear it
+ * so the next user audio chunk starts a fresh turn. Fire-and-forget; never
+ * blocks the WS message loop on the OASIS write.
+ */
+function finalizeVoiceTurnLatency(session: GeminiLiveSession, status: 'success' | 'error' = 'success'): void {
+  const tracker = session.latencyTracker;
+  if (!tracker) return;
+  session.latencyTracker = null;
+  void tracker.finalize(status);
 }
 
 /**
@@ -12302,6 +12363,10 @@ async function handleWsAudioMessage(clientSession: WsClientSession, message: WsC
 
   liveSession.audioInChunks++;
   liveSession.lastActivity = new Date();
+  // Phase 1 W2: this is real user mic audio (passed all drop gates). Start the
+  // per-turn latency tracker on the first such chunk (audioInChunks 0→1 within
+  // the turn); subsequent chunks no-op until the turn finalizes.
+  startVoiceTurnLatency(liveSession);
 
   // Telemetry: emit at most once per 10s window (was per-100-chunks ~1-2s)
   const now = Date.now();

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -46,6 +46,10 @@ import { randomUUID } from 'crypto';
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
+// Phase 1 W2 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA): tag events with
+// data_export_ok ONLY where tenant export consent is established, so the
+// dataset-extraction PII gate can ingest them. Default off / fail-closed.
+import { dataExportConsentTag } from '../services/data-export-consent';
 // VTID-03177 (PROFILE): per-turn latency telemetry. The middleware is a no-op
 // when FEATURE_LATENCY_TELEMETRY_ENV is off; safe to wire on every route.
 import { withLatencyTracker } from '../orb/live/latency-tracker';
@@ -7153,7 +7157,8 @@ async function emitOrbSessionStarted(orbSessionId: string, conversationId: strin
     payload: {
       orb_session_id: orbSessionId,
       conversation_id: conversationId,
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({ userId }))
     }
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.session.started:', err.message));
 }
@@ -7179,7 +7184,8 @@ async function emitOrbTurnReceived(
       conversation_id: conversationId,
       input_length: inputText.length,
       input_preview: inputText.slice(0, 140),
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({ userId }))
     }
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.turn.received:', err.message));
 }
@@ -7207,7 +7213,8 @@ async function emitOrbTurnResponded(
       reply_length: replyText.length,
       reply_preview: replyText.slice(0, 140),
       provider,
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({ userId }))
     }
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.turn.responded:', err.message));
 }
@@ -7226,7 +7233,8 @@ async function emitOrbSessionEnded(orbSessionId: string, conversationId: string,
     payload: {
       orb_session_id: orbSessionId,
       conversation_id: conversationId,
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({ userId }))
     }
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.session.ended:', err.message));
 }
@@ -7295,13 +7303,19 @@ async function emitMemoryWriteEvent(
   eventType: 'memory.write.user_message' | 'memory.write.assistant_message',
   payload: Record<string, unknown>
 ): Promise<void> {
+  // Phase 1 W2: consent gate keyed on the tenant/user already carried in the
+  // payload. Untagged events stay filtered out of the pillar-classification corpus.
+  const consentTag = await dataExportConsentTag({
+    tenantId: typeof payload.tenant_id === 'string' ? payload.tenant_id : undefined,
+    userId: typeof payload.user_id === 'string' ? payload.user_id : undefined,
+  });
   await emitOasisEvent({
     vtid: 'VTID-01105',
     type: eventType as any,
     source: 'orb-memory-auto',
     status: 'success',
     message: `ORB ${eventType.includes('user') ? 'user' : 'assistant'} message written to memory`,
-    payload
+    payload: { ...payload, ...consentTag }
   }).catch(err => console.warn(`[VTID-01105] Failed to emit ${eventType}:`, err.message));
 }
 
@@ -9292,7 +9306,11 @@ router.post('/end-session', async (req: Request, res: Response) => {
           bullets: summaryContent.bullets,
           actions: summaryContent.actions
         },
-        metadata: { mode: 'orb_voice' }
+        metadata: { mode: 'orb_voice' },
+        ...(await dataExportConsentTag({
+          tenantId: transcript.tenant_id ?? undefined,
+          userId: transcript.user_id ?? undefined,
+        }))
       }
     }).catch(err => console.warn('[VTID-01039] Failed to emit orb.session.summary:', err.message));
 
@@ -9595,7 +9613,11 @@ router.post('/session/finalize', async (req: Request, res: Response) => {
         bullets: summaryContent.bullets,
         actions: summaryContent.actions
       },
-      metadata: { mode: 'orb_voice' }
+      metadata: { mode: 'orb_voice' },
+      ...(await dataExportConsentTag({
+        tenantId: transcript.tenant_id ?? undefined,
+        userId: transcript.user_id ?? undefined,
+      }))
     }
   }).catch(err => console.warn('[VTID-01039] Failed to emit orb.session.summary:', err.message));
 

--- a/services/gateway/src/services/data-export-consent.ts
+++ b/services/gateway/src/services/data-export-consent.ts
@@ -1,0 +1,160 @@
+/**
+ * Data-export consent gate — Phase 1 W2 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA).
+ *
+ * The Phase 1 dataset-extraction loop (services/gateway/scripts/datasets/lib.ts)
+ * only ingests oasis_events whose metadata carries `data_export_ok: true`. That
+ * flag is the machine-readable record that the tenant has consented to their
+ * conversational telemetry being used to build training corpora. W1 shipped the
+ * SQL-layer PII gate (`metadata->>data_export_ok=eq.true`); W1 left every
+ * producing surface emitting events WITHOUT the flag, so the gate filtered
+ * everything and the first cron run yielded 0 rows. This module closes that wire.
+ *
+ * This is the single source of truth for "is export consent established for this
+ * surface?". Producing surfaces (orb-live turn/session events, the autopilot
+ * intent emitter, the memory-write emitter) call `dataExportConsentTag()` and
+ * spread the result into their event payload. When consent is NOT established the
+ * result is an empty object, so untagged events stay filtered out of every
+ * dataset — fail-closed by construction.
+ *
+ * Consent source (tenant policy): `tenant_settings.feature_flags.data_export_ok`
+ * must be strictly `true`. Default OFF. Any lookup error → not consented.
+ *
+ * Reads are cached in-process for 5 minutes (separately per tenant-policy and per
+ * user→tenant mapping) so the orb hot path never pays a Supabase round-trip per
+ * turn. Cron fan-outs reuse the same cache.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const TTL_MS = 5 * 60 * 1000;
+const LOG_PREFIX = '[data-export-consent]';
+
+/** tenantId → { consented, expires_at } */
+const tenantPolicyCache = new Map<string, { consented: boolean; expires_at: number }>();
+/** userId → { tenantId | null, expires_at } */
+const userTenantCache = new Map<string, { tenantId: string | null; expires_at: number }>();
+
+let _client: SupabaseClient | null | undefined;
+
+function getServiceClient(): SupabaseClient | null {
+  if (_client !== undefined) return _client;
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) {
+    console.warn(`${LOG_PREFIX} missing SUPABASE_URL / SUPABASE_SERVICE_ROLE; consent stays off`);
+    _client = null;
+    return null;
+  }
+  _client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+  return _client;
+}
+
+/**
+ * Resolve the tenant a user belongs to via the user_tenants membership table.
+ * Cached. Returns null on miss/error (→ fail-closed at the policy step).
+ */
+async function resolveTenantForUser(userId: string): Promise<string | null> {
+  const cached = userTenantCache.get(userId);
+  if (cached && cached.expires_at > Date.now()) return cached.tenantId;
+
+  let tenantId: string | null = null;
+  try {
+    const supa = getServiceClient();
+    if (supa) {
+      const { data } = await supa
+        .from('user_tenants')
+        .select('tenant_id')
+        .eq('user_id', userId)
+        .limit(1)
+        .maybeSingle();
+      tenantId = (data as { tenant_id?: string | null } | null)?.tenant_id ?? null;
+    }
+  } catch (e) {
+    console.warn(`${LOG_PREFIX} resolveTenantForUser(${userId}) error:`, e instanceof Error ? e.message : e);
+  }
+
+  userTenantCache.set(userId, { tenantId, expires_at: Date.now() + TTL_MS });
+  return tenantId;
+}
+
+/**
+ * Read tenant_settings.feature_flags.data_export_ok for a tenant. Cached.
+ * Strictly `true` ⇒ consented; anything else (missing row, missing flag,
+ * non-boolean, error) ⇒ not consented.
+ */
+async function tenantExportPolicy(tenantId: string): Promise<boolean> {
+  const cached = tenantPolicyCache.get(tenantId);
+  if (cached && cached.expires_at > Date.now()) return cached.consented;
+
+  let consented = false;
+  try {
+    const supa = getServiceClient();
+    if (supa) {
+      const { data } = await supa
+        .from('tenant_settings')
+        .select('feature_flags')
+        .eq('tenant_id', tenantId)
+        .maybeSingle();
+      const flags = (data as { feature_flags?: Record<string, unknown> } | null)?.feature_flags;
+      consented = flags?.data_export_ok === true;
+    }
+  } catch (e) {
+    console.warn(`${LOG_PREFIX} tenantExportPolicy(${tenantId}) error:`, e instanceof Error ? e.message : e);
+  }
+
+  tenantPolicyCache.set(tenantId, { consented, expires_at: Date.now() + TTL_MS });
+  return consented;
+}
+
+export interface ConsentContext {
+  /** Tenant UUID — preferred when available (resolves directly to policy). */
+  tenantId?: string | null;
+  /** User UUID — used to resolve a tenant when tenantId isn't passed. */
+  userId?: string | null;
+}
+
+/**
+ * True iff data-export consent is established for the given surface. Resolves a
+ * tenant (directly, or via userId) and reads the tenant policy. Fail-closed:
+ * no ids, no tenant, or any error ⇒ false.
+ */
+export async function isDataExportConsented(ctx: ConsentContext): Promise<boolean> {
+  let tenantId = ctx.tenantId ?? null;
+  if (!tenantId && ctx.userId) {
+    tenantId = await resolveTenantForUser(ctx.userId);
+  }
+  if (!tenantId) return false;
+  return tenantExportPolicy(tenantId);
+}
+
+/**
+ * The resolver shape, so callers (and tests) can inject a mock.
+ */
+export type ConsentResolver = (ctx: ConsentContext) => Promise<boolean>;
+
+/**
+ * Returns `{ data_export_ok: true }` when consent is established for the surface,
+ * otherwise an empty object. Spread the result into an OASIS event payload:
+ *
+ *   payload: { ...stuff, ...(await dataExportConsentTag({ userId })) }
+ *
+ * `resolver` is injectable for unit tests; production callers use the default.
+ */
+export async function dataExportConsentTag(
+  ctx: ConsentContext,
+  resolver: ConsentResolver = isDataExportConsented,
+): Promise<{ data_export_ok: true } | Record<string, never>> {
+  try {
+    return (await resolver(ctx)) ? { data_export_ok: true } : {};
+  } catch {
+    // Fail-closed — telemetry consent must never throw into the hot path.
+    return {};
+  }
+}
+
+/** Test/ops helper — clears the in-process caches. */
+export function _resetConsentCaches(): void {
+  tenantPolicyCache.clear();
+  userTenantCache.clear();
+  _client = undefined;
+}

--- a/services/gateway/src/services/data-export-consent.ts
+++ b/services/gateway/src/services/data-export-consent.ts
@@ -39,7 +39,9 @@ let _client: SupabaseClient | null | undefined;
 function getServiceClient(): SupabaseClient | null {
   if (_client !== undefined) return _client;
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  // SUPABASE_SERVICE_ROLE is the canonical var bound on every gateway deploy
+  // (CLAUDE.md §8); use it directly so we introduce no unbound env reference.
+  const key = process.env.SUPABASE_SERVICE_ROLE;
   if (!url || !key) {
     console.warn(`${LOG_PREFIX} missing SUPABASE_URL / SUPABASE_SERVICE_ROLE; consent stays off`);
     _client = null;

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -35,6 +35,7 @@ import {
   TaskStatusResponse
 } from './operator-service';
 import { emitOasisEvent, recommendationSyncEvents } from './oasis-event-service';
+import { dataExportConsentTag } from './data-export-consent';
 // VTID-01221: Sync Brief formatter for recommendation presentation
 import { formatSyncBrief, isWhatNextIntent, shouldFetchRecommendations, SyncBriefContext, Recommendation } from './sync-brief-formatter';
 // VTID-0538: Knowledge Hub integration
@@ -843,6 +844,14 @@ async function logAutopilotIntent(params: {
   action: 'created' | 'approved' | 'rejected' | 'executed';
   details: Record<string, unknown>;
 }): Promise<void> {
+  // Phase 1 W2 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA): tag with data_export_ok
+  // only where the thread's tenant has established export consent, so the
+  // intent-kind dataset extractor can ingest these events. Default off.
+  const identity = threadIdentityMap.get(params.threadId);
+  const consentTag = await dataExportConsentTag({
+    tenantId: identity?.tenant_id,
+    userId: identity?.user_id,
+  });
   await emitOasisEvent({
     vtid: params.vtid,
     type: `autopilot.intent.${params.action}`,
@@ -851,7 +860,8 @@ async function logAutopilotIntent(params: {
     message: `Autopilot intent ${params.action}`,
     payload: {
       threadId: params.threadId,
-      ...params.details
+      ...params.details,
+      ...consentTag
     }
   }).catch(err => console.warn('[VTID-0536] Failed to log autopilot intent:', err.message));
 }

--- a/services/gateway/test/data-export-consent.test.ts
+++ b/services/gateway/test/data-export-consent.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Phase 1 W2 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA) — consent-gate unit tests.
+ *
+ * Asserts the contract the dataset-extraction PII gate depends on: an emitted
+ * event's payload carries `data_export_ok: true` ONLY when export consent is
+ * established for the surface, and is absent otherwise. The producing surfaces
+ * (orb-live, intent emitter, memory writer) build their payload by spreading
+ * `dataExportConsentTag(...)`, so we exercise that exact path with a mock
+ * consent resolver standing in for the tenant-policy read.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import {
+  dataExportConsentTag,
+  isDataExportConsented,
+  type ConsentResolver,
+} from '../src/services/data-export-consent';
+
+const consentGranted: ConsentResolver = async () => true;
+const consentDenied: ConsentResolver = async () => false;
+const consentThrows: ConsentResolver = async () => {
+  throw new Error('tenant policy lookup blew up');
+};
+
+describe('dataExportConsentTag', () => {
+  test('includes data_export_ok:true when the consent resolver returns true', async () => {
+    const tag = await dataExportConsentTag({ userId: 'u-1' }, consentGranted);
+    expect(tag).toEqual({ data_export_ok: true });
+  });
+
+  test('excludes the flag entirely when the consent resolver returns false', async () => {
+    const tag = await dataExportConsentTag({ userId: 'u-1' }, consentDenied);
+    expect(tag).toEqual({});
+    expect('data_export_ok' in tag).toBe(false);
+  });
+
+  test('fail-closed: omits the flag when the resolver throws', async () => {
+    const tag = await dataExportConsentTag({ tenantId: 't-1' }, consentThrows);
+    expect(tag).toEqual({});
+  });
+});
+
+describe('emit payload assembly (mirrors orb-live / intent / memory surfaces)', () => {
+  function buildEmitPayload(tag: Record<string, unknown>) {
+    // Shape that orb-live spreads into emitOasisEvent({ payload }).
+    return {
+      orb_session_id: 'orb-123',
+      conversation_id: 'conv-456',
+      metadata: { mode: 'orb_voice' },
+      ...tag,
+    };
+  }
+
+  test('emit payload carries the flag for a consented surface', async () => {
+    const payload = buildEmitPayload(await dataExportConsentTag({ userId: 'u-1' }, consentGranted));
+    expect(payload.data_export_ok).toBe(true);
+  });
+
+  test('emit payload stays untagged for a non-consented surface', async () => {
+    const payload = buildEmitPayload(await dataExportConsentTag({ userId: 'u-1' }, consentDenied));
+    expect((payload as Record<string, unknown>).data_export_ok).toBeUndefined();
+  });
+});
+
+describe('isDataExportConsented fail-closed defaults', () => {
+  test('returns false when neither tenantId nor userId is provided', async () => {
+    await expect(isDataExportConsented({})).resolves.toBe(false);
+  });
+
+  test('returns false for empty-string ids', async () => {
+    await expect(isDataExportConsented({ tenantId: '', userId: '' })).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase 1 W2 — PR C2 of 3 (voice latency wire-in)

**Stacked on C1 (#2415).** Base branch is `claude/wonderful-hopper-c97p2-c1`, so this PR's diff shows **only** the C2 changes. Merge after C1.

> ⚠️ VTID note: allocator unreachable from sandbox → `BOOTSTRAP-PHASE1-W2-VOICE-LATENCY-WIRE`. Re-grepped `origin/main`: no collision.

### What & why
W1 (#2383) shipped `orb/live/latency-tracker.ts` but only `/orb/chat` was instrumented (via the `withLatencyTracker` middleware). The voice WS/SSE path — the part that actually matters for perceived latency — emitted nothing. This wires the five canonical phase marks into the **voice per-turn lifecycle**, emitting one `voice.latency.measured` event per real voice turn.

### Per-turn lifecycle (`GeminiLiveSession.latencyTracker`)
| Mark | Where | Boundary |
|---|---|---|
| `audio_in_first_byte` | `orb-live.ts` audio-in path (after all drop gates) | first real mic chunk of a turn; idempotent within the turn |
| `transcript_ready` | `upstream-message-handler.ts` | first STT fragment (guarded by empty `inputTranscriptBuffer`) |
| `tool_dispatch` | `executeLiveApiTool` entry | single chokepoint — covers every tool call site |
| `tool_response` | `executeLiveApiTool` return | tool completed (with `ms`, `success`) |
| `audio_out_first_chunk` | `upstream-message-handler.ts` | first TTS chunk, inside the `!isModelSpeaking` transition |

**Finalize:** `turn_complete` → `success`; `interrupted` (barge-in) → `error`. Finalizing clears the tracker so the next user audio starts a fresh turn. The greeting turn (no `audio_in`) produces no event by design.

### Design / safety
- Marks reach the handler through two new `deps` (`markVoiceLatency`, `finalizeVoiceTurnLatency`) — the handler stays decoupled from `orb-live` internals (the existing deps-bag seam). **No raw session object enters prompt assembly** — only canonical marks are recorded.
- **No-op when `FEATURE_LATENCY_TELEMETRY_ENV` is off** (the W1 tracker self-gates) → zero hot-path behavior change until the staging flag is flipped. Per-turn tracker is allocated once per turn (guarded), not per audio chunk.
- **`/orb/chat` behavior unchanged** (its middleware path is untouched).
- Instrumented the **WS audio path** (`audioInChunks`), per the W1 hand-off note.

### Verification in sandbox
- `./node_modules/.bin/tsc --noEmit` ✅ 0 errors (pinned TS 5.9.3).
- `npm run build` ✅.
- `npx jest test/orb/live/characterization/upstream-message-handler.characterization.test.ts` ✅ 16/16 (AST characterization — confirms the deps-bag seam + every event path preserved).

No dedicated unit test added: the wiring lives inside the 12.5k-line `orb-live.ts` (importing it in isolation triggers heavy module side-effects), and C2's acceptance is runtime (events in staging `oasis_events`). The no-op-when-off guarantee + characterization test + build cover the static surface.

### Owed to operator (sandbox can't reach gateway/Cloud Run)
- Merge after C1 + next staging deploy boot check.
- `FEATURE_LATENCY_TELEMETRY_ENV=staging-only` on `gateway-staging` (the W1 hand-off flag flip) if not already done.
- **Acceptance:** `voice.latency.measured` events visible in staging `oasis_events` for real voice turns within 1h of merge; replay-runner picks them up next run.

🤖 Draft per session policy (CI green → hand off; no merge from sandbox).

https://claude.ai/code/session_01H674SSPgnnYyBq1V8nptsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01H674SSPgnnYyBq1V8nptsP)_