### PR TITLE
feat(gateway): shadow-compare voice tool-routing via runWithShadow — Phase 1 W2 C3 (BOOTSTRAP-PHASE1-W2-SHADOW-RUNTIME-WIRE)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -55,6 +55,11 @@ import { dataExportConsentTag } from '../services/data-export-consent';
 // Phase 1 W2 (BOOTSTRAP-PHASE1-W2-VOICE-LATENCY-WIRE): the LatencyTracker class +
 // LatencyPhase are also used directly to instrument the voice WS/SSE turn timeline.
 import { withLatencyTracker, LatencyTracker, type LatencyPhase } from '../orb/live/latency-tracker';
+// Phase 1 W2 (BOOTSTRAP-PHASE1-W2-SHADOW-RUNTIME-WIRE): shadow-compare the
+// voice tool-routing decision against a candidate model. No-op (candidate never
+// invoked) when FEATURE_SHADOW_TOOL_ROUTER_ENV is off.
+import { runWithShadow } from '../services/llm-router-shadow';
+import { predictVoiceToolRoute } from '../services/voice-tool-router-candidate';
 // VTID-02917 (B0d.3): wake reliability timeline — emit + record only,
 // never block the wake path. The recorder is best-effort by design.
 import { defaultWakeTimelineRecorder } from '../services/wake-timeline/wake-timeline-recorder';
@@ -1986,6 +1991,19 @@ async function executeLiveApiTool(
   const startTime = Date.now();
   // Phase 1 W2: mark the tool boundary on the active voice turn (no-op off-flag).
   markVoiceLatency(session, 'tool_dispatch', { tool: toolName });
+  // Phase 1 W2: shadow-compare the tool-routing decision. Primary = the tool
+  // Vertex already chose (toolName); candidate = the W2 stub (echoes it until a
+  // fine-tune is served). Fire-and-forget — never blocks or alters execution,
+  // and runWithShadow doesn't even invoke the candidate unless the flag is on.
+  const shadowTranscript = (session.inputTranscriptBuffer || '').slice(0, 2000);
+  void runWithShadow<{ transcript: string; primaryTool: string }, string>({
+    feature: 'voice-tool-router',
+    input: { transcript: shadowTranscript, primaryTool: toolName },
+    primary: async () => toolName,
+    candidate: async () => predictVoiceToolRoute({ transcript: shadowTranscript, primaryTool: toolName }),
+    extractKey: (tool) => tool,
+    context: { actor_id: session.identity?.user_id, session_id: session.sessionId },
+  });
   // VTID-01224-FIX: Default 3 s budget. Gemini Live API has its own internal
   // timeout for function_response (~3-4s); taking longer stalls the session.
   //

--- a/services/gateway/src/services/voice-tool-router-candidate.ts
+++ b/services/gateway/src/services/voice-tool-router-candidate.ts
@@ -1,0 +1,33 @@
+/**
+ * Voice tool-router candidate — Phase 1 W2 (BOOTSTRAP-PHASE1-W2-SHADOW-RUNTIME-WIRE).
+ *
+ * The shadow "candidate" side of the voice-tool-router experiment. Given the
+ * user's transcript, it predicts which tool the voice assistant should call —
+ * the same decision the primary path (Vertex/Gemini function-calling) makes at
+ * runtime. runWithShadow() runs this in the background and emits
+ * eval.shadow.compared so the auto-promoter can track agreement vs the primary.
+ *
+ * W2 is shadow-only and NO trained fine-tune exists yet, so this stub simply
+ * echoes the primary's chosen tool — agreement is trivially 1.0. Its job in W2
+ * is to prove the wire end-to-end (events flow, auto-promoter sees non-zero
+ * samples, stays in DRY mode). When the first voice-tool-router fine-tune lands
+ * (later week), swap the body for a real call to the served candidate model;
+ * the call site in orb-live.ts does not change.
+ */
+
+export interface VoiceToolRouteInput {
+  /** The user utterance that drove the tool decision (current turn transcript). */
+  transcript: string;
+  /** The tool the primary (Vertex) path chose — the supervision signal in W2. */
+  primaryTool: string;
+}
+
+/**
+ * Predict the tool name from the transcript. W2 stub: echo the primary choice.
+ * Returns the tool name (the comparable key extractKey() reads).
+ */
+export async function predictVoiceToolRoute(input: VoiceToolRouteInput): Promise<string> {
+  // W2 stub — no fine-tune served yet. Echo the primary's decision so the
+  // shadow pipeline produces well-formed eval.shadow.compared events.
+  return input.primaryTool;
+}

--- a/services/gateway/test/voice-tool-router-shadow.test.ts
+++ b/services/gateway/test/voice-tool-router-shadow.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Phase 1 W2 (BOOTSTRAP-PHASE1-W2-SHADOW-RUNTIME-WIRE) — shadow wire unit tests.
+ *
+ * Verifies the contract the auto-promoter depends on:
+ *   - When FEATURE_SHADOW_TOOL_ROUTER is OFF, the candidate is never invoked
+ *     and no eval.shadow.compared event is emitted (zero overhead).
+ *   - When ON, primary is returned to the caller unchanged, the candidate runs
+ *     fire-and-forget, and exactly one eval.shadow.compared event is emitted with
+ *     primary_key / candidate_key / agreement / latencies.
+ *   - The W2 candidate stub echoes the primary tool (agreement trivially true).
+ */
+
+process.env.NODE_ENV = 'test';
+
+jest.mock('../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn().mockResolvedValue({ ok: true }),
+}));
+jest.mock('../src/services/feature-flags', () => ({
+  isFeatureLive: jest.fn(),
+}));
+
+import { runWithShadow } from '../src/services/llm-router-shadow';
+import { predictVoiceToolRoute } from '../src/services/voice-tool-router-candidate';
+import { emitOasisEvent } from '../src/services/oasis-event-service';
+import { isFeatureLive } from '../src/services/feature-flags';
+
+const mockEmit = emitOasisEvent as jest.Mock;
+const mockFlag = isFeatureLive as jest.Mock;
+
+/** Let the fire-and-forget candidate IIFE drain its microtasks. */
+async function flush(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+beforeEach(() => {
+  mockEmit.mockClear();
+  mockFlag.mockReset();
+});
+
+describe('predictVoiceToolRoute (W2 stub)', () => {
+  test('echoes the primary tool name', async () => {
+    await expect(
+      predictVoiceToolRoute({ transcript: 'remind me to drink water', primaryTool: 'set_reminder' }),
+    ).resolves.toBe('set_reminder');
+  });
+});
+
+describe('runWithShadow — flag OFF', () => {
+  test('returns primary, never invokes candidate, emits nothing', async () => {
+    mockFlag.mockReturnValue(false);
+    const candidate = jest.fn(async () => 'set_reminder');
+
+    const result = await runWithShadow<{ t: string }, string>({
+      feature: 'voice-tool-router',
+      input: { t: 'x' },
+      primary: async () => 'search_calendar',
+      candidate,
+      extractKey: (t) => t,
+    });
+    await flush();
+
+    expect(result).toBe('search_calendar');
+    expect(candidate).not.toHaveBeenCalled();
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('runWithShadow — flag ON', () => {
+  test('returns primary unchanged and emits eval.shadow.compared with agreement', async () => {
+    mockFlag.mockReturnValue(true);
+    const candidate = jest.fn(async () => 'set_reminder');
+
+    const result = await runWithShadow<{ t: string }, string>({
+      feature: 'voice-tool-router',
+      input: { t: 'remind me' },
+      primary: async () => 'set_reminder',
+      candidate,
+      extractKey: (t) => t,
+      context: { actor_id: 'u-1', session_id: 's-1' },
+    });
+    await flush();
+
+    expect(result).toBe('set_reminder');
+    expect(candidate).toHaveBeenCalledTimes(1);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+
+    const evt = mockEmit.mock.calls[0][0];
+    expect(evt.type).toBe('eval.shadow.compared');
+    expect(evt.payload.feature).toBe('voice-tool-router');
+    expect(evt.payload.primary_key).toBe('set_reminder');
+    expect(evt.payload.candidate_key).toBe('set_reminder');
+    expect(evt.payload.agreement).toBe(true);
+    expect(typeof evt.payload.primary_ms).toBe('number');
+    expect(typeof evt.payload.candidate_ms).toBe('number');
+  });
+
+  test('records disagreement when candidate diverges', async () => {
+    mockFlag.mockReturnValue(true);
+
+    await runWithShadow<{ t: string }, string>({
+      feature: 'voice-tool-router',
+      input: { t: 'x' },
+      primary: async () => 'set_reminder',
+      candidate: async () => 'search_calendar',
+      extractKey: (t) => t,
+    });
+    await flush();
+
+    const evt = mockEmit.mock.calls[0][0];
+    expect(evt.payload.agreement).toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase 1 W2 — PR C3 of 3 (shadow runtime wire)

**Stacked on C2 (#2416), which is stacked on C1 (#2415).** Base branch is `claude/wonderful-hopper-c97p2-c2`, so this PR's diff shows **only** the C3 changes. Merge last (C1 → C2 → C3).

> ⚠️ VTID note: allocator unreachable from sandbox → `BOOTSTRAP-PHASE1-W2-SHADOW-RUNTIME-WIRE`. Re-grepped `origin/main`: no collision.

### What & why
W1 (#2380) shipped the shadow harness `services/llm-router-shadow.ts` with **no real call site**. This wires `runWithShadow` into the voice tool-router runtime chokepoint (`executeLiveApiTool`) so the auto-promoter starts seeing samples.

### How it works (per tool invocation)
- **primary** = the tool Vertex/Gemini already chose (`toolName`) — returned to the caller **unchanged**; execution is never altered.
- **candidate** = `predictVoiceToolRoute()` — a new W2 **stub** (`services/voice-tool-router-candidate.ts`) that echoes the primary tool (no fine-tune served yet). When the first voice-tool-router fine-tune lands, swap the stub body for a served-model call — **the call site doesn't change**.
- **emits** `eval.shadow.compared` with `primary_key` / `candidate_key` / `agreement` / latencies → auto-promoter reads these.

### Safety
- **Fire-and-forget** (`void runWithShadow(...)`): the candidate runs in the background; the call never extends or blocks tool execution.
- **Gated behind `FEATURE_SHADOW_TOOL_ROUTER_ENV`** — when off, `runWithShadow` returns the primary immediately and **never even invokes the candidate** (zero overhead). Default off; flip staging-only post-merge.
- W2 keeps the auto-promoter in **DRY mode** — no promotion is triggered. No canary PUBLISH. orb-live is **not** moved to conversation-router (W4 work, deferred).

### Verification in sandbox
- `./node_modules/.bin/tsc --noEmit` ✅ 0 errors (pinned TS 5.9.3).
- `npm run build` ✅.
- `npx jest test/voice-tool-router-shadow.test.ts` ✅ 4/4 — stub echo; flag-off (candidate never called, no event); flag-on (primary returned unchanged + one `eval.shadow.compared` with agreement + latencies); disagreement recording.

### Owed to operator (sandbox can't reach gateway/Cloud Run)
- Merge after C2 + next staging deploy boot check.
- `FEATURE_SHADOW_TOOL_ROUTER_ENV=staging-only` on `gateway-staging`.
- **Acceptance:** `eval.shadow.compared` events visible in staging `oasis_events` once the flag flips; auto-promoter's next hourly run shows non-zero samples for `voice-tool-router` (promotion NOT triggered — DRY mode).

🤖 Draft per session policy (CI green → hand off; no merge from sandbox).

https://claude.ai/code/session_01H674SSPgnnYyBq1V8nptsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01H674SSPgnnYyBq1V8nptsP)_