### PR TITLE
feat(ops): SET-STAGING-TENANT-CONSENT helper workflow (VTID-03202)

### DIFF
--- a/.github/workflows/SET-STAGING-TENANT-CONSENT.yml
+++ b/.github/workflows/SET-STAGING-TENANT-CONSENT.yml
@@ -1,0 +1,198 @@
+name: Set staging tenant consent flag (one-off helper)
+
+# VTID-03202 — Phase 1 W2 acceptance helper. The Track C C1 commit
+# (98d2f4f1, #2415) introduced services/data-export-consent.ts which reads
+# tenant_settings.feature_flags.data_export_ok and defaults OFF. Until a
+# staging tenant has the flag set, every producing surface (orb-live,
+# intent emitter, memory writer) emits OASIS events WITHOUT
+# data_export_ok, and the dataset-extraction PII gate keeps filtering
+# them out. This workflow flips that flag on selected staging tenants so
+# CRON-DATASET-EXTRACTION starts yielding real rows.
+#
+# HARD GUARDS (in order):
+#   1. Confirm phrase must equal literal 'I-mean-staging-consent'
+#   2. STAGING_SUPABASE_URL must contain staging project_ref
+#      (rsdakjqpvcpgomltdmxu) AND must NOT contain prod project_ref
+#      (inmkhvwdcuyhnxkgfvsb)
+#   3. dry_run defaults to 'true' — first run prints what WOULD change
+#      without writing; operator re-runs with dry_run=false to actually
+#      flip the flag
+#
+# Prereqs:
+#   - WIF SA has secretmanager.secretAccessor on STAGING_SUPABASE_URL +
+#     STAGING_SUPABASE_SERVICE_ROLE_KEY (granted in W1)
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'I-mean-staging-consent' to confirm STAGING target"
+        required: true
+        default: ''
+      tenant_id:
+        description: "Tenant id to flip (or 'ALL' for every staging tenant). Staging has ~11 test users; ALL is the expected default."
+        required: true
+        default: 'ALL'
+      dry_run:
+        description: "true = preview rows that WOULD change (no writes). false = actually flip the flag."
+        required: true
+        default: 'true'
+        type: choice
+        options: [ 'true', 'false' ]
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  STAGING_PROJECT_REF: rsdakjqpvcpgomltdmxu
+  PROD_PROJECT_REF: inmkhvwdcuyhnxkgfvsb
+  GCP_PROJECT: lovable-vitana-vers1
+
+jobs:
+  set-consent:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Confirm staging intent
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.confirm }}" != "I-mean-staging-consent" ]; then
+            echo "::error::confirm input must be exactly 'I-mean-staging-consent' (got: '${{ inputs.confirm }}')"
+            exit 1
+          fi
+          echo "Confirm phrase OK."
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Resolve STAGING Supabase creds + HARD GUARD project_ref
+        run: |
+          set -euo pipefail
+          URL=$(gcloud secrets versions access latest --secret=STAGING_SUPABASE_URL --project="${GCP_PROJECT}")
+          KEY=$(gcloud secrets versions access latest --secret=STAGING_SUPABASE_SERVICE_ROLE_KEY --project="${GCP_PROJECT}")
+          if [ -z "$URL" ] || [ -z "$KEY" ]; then
+            echo "::error::STAGING_SUPABASE_URL or STAGING_SUPABASE_SERVICE_ROLE_KEY empty"
+            exit 1
+          fi
+          if ! printf '%s' "$URL" | grep -q "${STAGING_PROJECT_REF}"; then
+            echo "::error::STAGING_SUPABASE_URL does not contain staging project_ref (${STAGING_PROJECT_REF})"
+            exit 1
+          fi
+          if printf '%s' "$URL" | grep -q "${PROD_PROJECT_REF}"; then
+            echo "::error::STAGING_SUPABASE_URL contains PROD project_ref (${PROD_PROJECT_REF}). HARD STOP."
+            exit 1
+          fi
+          echo "::add-mask::$URL"
+          echo "::add-mask::$KEY"
+          {
+            echo "STAGING_SUPABASE_URL=$URL"
+            echo "STAGING_SUPABASE_SERVICE_ROLE_KEY=$KEY"
+          } >> "$GITHUB_ENV"
+          echo "STAGING_SUPABASE_URL targets ${STAGING_PROJECT_REF} — OK."
+
+      - name: Flip data_export_ok on staging tenant_settings
+        env:
+          TENANT_FILTER: ${{ inputs.tenant_id }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          node <<'NODE'
+          const URL = process.env.STAGING_SUPABASE_URL;
+          const KEY = process.env.STAGING_SUPABASE_SERVICE_ROLE_KEY;
+          const TENANT_FILTER = process.env.TENANT_FILTER || 'ALL';
+          const DRY_RUN = process.env.DRY_RUN !== 'false';
+
+          const headers = {
+            apikey: KEY,
+            Authorization: `Bearer ${KEY}`,
+            'Content-Type': 'application/json',
+          };
+
+          async function fetchTenants() {
+            const filter = TENANT_FILTER === 'ALL' ? '' : `&tenant_id=eq.${encodeURIComponent(TENANT_FILTER)}`;
+            const resp = await fetch(`${URL}/rest/v1/tenant_settings?select=tenant_id,feature_flags${filter}&limit=200`, { headers });
+            if (!resp.ok) {
+              console.error(`fetch tenant_settings failed: ${resp.status} ${await resp.text()}`);
+              process.exit(1);
+            }
+            return await resp.json();
+          }
+
+          async function flipOne(tenantId, currentFlags) {
+            const flags = { ...(currentFlags || {}), data_export_ok: true };
+            const resp = await fetch(
+              `${URL}/rest/v1/tenant_settings?tenant_id=eq.${encodeURIComponent(tenantId)}`,
+              {
+                method: 'PATCH',
+                headers: { ...headers, Prefer: 'return=minimal' },
+                body: JSON.stringify({ feature_flags: flags }),
+              },
+            );
+            if (!resp.ok) {
+              throw new Error(`PATCH ${tenantId} failed: ${resp.status} ${await resp.text()}`);
+            }
+          }
+
+          (async () => {
+            const tenants = await fetchTenants();
+            console.log(`Found ${tenants.length} tenant_settings row(s) matching filter='${TENANT_FILTER}'`);
+
+            const already = tenants.filter((t) => t.feature_flags?.data_export_ok === true);
+            const toFlip = tenants.filter((t) => t.feature_flags?.data_export_ok !== true);
+
+            console.log(`Already consented: ${already.length}`);
+            console.log(`Will flip:         ${toFlip.length}`);
+            console.log('');
+            for (const t of toFlip) {
+              console.log(`  ${t.tenant_id} : ${JSON.stringify(t.feature_flags || {})} -> +{data_export_ok:true}`);
+            }
+
+            if (DRY_RUN) {
+              console.log('');
+              console.log('DRY RUN — no writes performed. Re-run with dry_run=false to apply.');
+              process.exit(0);
+            }
+
+            console.log('');
+            console.log('Applying flips...');
+            let ok = 0, failed = 0;
+            for (const t of toFlip) {
+              try {
+                await flipOne(t.tenant_id, t.feature_flags);
+                ok++;
+                console.log(`  ✓ ${t.tenant_id}`);
+              } catch (err) {
+                failed++;
+                console.error(`  ✗ ${t.tenant_id} : ${err.message}`);
+              }
+            }
+
+            const summary = `Flipped ${ok}/${toFlip.length} tenants (${failed} failures, ${already.length} were already consented).`;
+            console.log('');
+            console.log(summary);
+
+            // Write GitHub step summary
+            const fs = require('fs');
+            const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+            if (summaryPath) {
+              fs.appendFileSync(summaryPath,
+                `## Staging tenant consent flip\n\n` +
+                `- Filter: \`${TENANT_FILTER}\`\n` +
+                `- Already consented: ${already.length}\n` +
+                `- Flipped this run: ${ok}\n` +
+                `- Failed: ${failed}\n` +
+                (failed > 0 ? '\n**Some PATCHes failed — see logs.**\n' : '\nAll target rows updated.\n')
+              );
+            }
+
+            if (failed > 0) process.exit(1);
+          })().catch((err) => {
+            console.error('FATAL:', err);
+            process.exit(1);
+          });
+          NODE


### PR DESCRIPTION
Phase 1 W2 acceptance bridge. Track C C1 (#2415) shipped consent-gated data_export_ok that defaults OFF. Until a staging tenant has tenant_settings.feature_flags.data_export_ok=true, CRON-DATASET-EXTRACTION returns 0 rows. This one-off helper flips the flag on selected staging tenants.

Hard guards: confirm phrase 'I-mean-staging-consent', STAGING_SUPABASE_URL must contain staging project_ref (rsdakjqpvcpgomltdmxu) AND must NOT contain prod project_ref, dry_run defaults true. WIF auth + resolves staging creds from Secret Manager (existing W1 grants). Inline Node script: GET tenant_settings -> merge {data_export_ok:true} -> PATCH back. Writes GITHUB_STEP_SUMMARY for clean gh run view output.

After merge: dispatch with dry_run=true first to preview, then dry_run=false to apply, then trigger CRON-DATASET-EXTRACTION.