### PR TITLE
feat(cart): Universal Cart Phase 1 schema, renamed under universal_* prefix (VTID-03186)

### DIFF
--- a/supabase/migrations/20260605000000_VTID_03186_universal_cart_schema.sql
+++ b/supabase/migrations/20260605000000_VTID_03186_universal_cart_schema.sql
@@ -1,0 +1,413 @@
+-- VTID-03186 — Universal Cart Phase 1, Slice A (renamed schema).
+--
+-- Supersedes the reverted VTID-03165 attempt (PR #2347, reverted in #2361)
+-- after the VTID-03175 drift audit (PR #2365) revealed that production has an
+-- entire parallel Lovable-side data layer (195 ghost tables) including an
+-- active `cart_items` table used by vitana-v1 commerce. To avoid touching
+-- ANY existing commerce/Lovable surface, this migration ships under the
+-- `universal_*` prefix and leaves the legacy `cart_items` / `checkout_sessions` /
+-- `cj_*` stack entirely untouched.
+--
+-- Introduces three tables that back the persistent multi-item Universal Cart
+-- sitting on top of the Discover marketplace (VTID-02000):
+--
+--   * public.universal_carts        — one active cart per user
+--   * public.universal_cart_items   — items staged from web / mobile / voice / autopilot / community
+--   * public.universal_cart_events  — append-only audit ledger of cart mutations
+--
+-- Phase 1 scope (per Universal Cart PRD, Section 2):
+--   - Single active cart per user, item types limited to 'supplement' /
+--     'partner_product' (anything from the existing products catalog).
+--   - No checkout, no quote, no validations, no wallet waterfall, no
+--     autopilot auto-create. Those land in Phases 2-4 on top of this schema.
+--   - Per-item exit uses the existing single-item product_orders flow with
+--     a new cart_item_id callback param (handled in VTID-B, the gateway slice).
+--
+-- Decisions locked (PRD Section 14):
+--   Q1 NO  — /discover/orders does not surface cart items.
+--   Q2 YES — source_surface attributes by intent origin; community group threads
+--            land as source_surface='community' regardless of HTTP transport.
+--   Q3 YES — universal_cart_items.metadata.autopilot_rec_id is populated day 1
+--            so the decision-contract `commerce_cart` provider's
+--            has_autopilot_link signal works before Phase 4 auto-create.
+--   Q4 EXPLICIT — completion is signalled via an explicit `cart_item_id`
+--            callback parameter, not webhook archaeology.
+--   Q5 COMMUNITY-ONLY — cart endpoints will return 403 cart_unavailable_for_role
+--            for non-community sessions (enforced in gateway VTID-B).
+--
+-- Schema-drift safeguard:
+--   Same pattern as the (reverted) VTID-03165 file. Pre-condition guard
+--   RAISEs only if any of the three TARGET tables (universal_carts /
+--   universal_cart_items / universal_cart_events) exist with columns outside
+--   the expected set. The 29 Lovable-side commerce ghosts (cart_items,
+--   checkout_sessions, cj_*, vouchers, business_packages, supplements,
+--   user_wallets, etc.) are intentionally NOT in the guard's table list —
+--   they are out of scope for this migration and tracked separately in
+--   issue #2371 (data layer reconciliation, VTID-03176).
+
+BEGIN;
+
+-- ============================================================
+-- Informational: out-of-scope ghost surfaces (NOTICE-only, never RAISEs).
+-- ============================================================
+DO $vtid_03186_oos_notice$
+BEGIN
+  RAISE NOTICE
+    'VTID-03186: This migration creates universal_carts / universal_cart_items / universal_cart_events. The following Lovable-side commerce ghost tables exist in production and are intentionally OUT OF SCOPE (no DDL, no reads, no writes here): cart_items, checkout_sessions, cj_products, cj_orders, cj_webhook_logs, bookmarked_items, business_packages, package_items, package_item_redemptions, package_purchases, vouchers, voucher_orders, voucher_redemptions, lab_tests, lab_test_orders, lab_test_results, service_payments, supplements, user_supplements, user_discount_codes, exchange_rates, reseller_attributions, reseller_payouts, reseller_profiles, user_wallets, wallet_credits, provider_appointments, provider_notes, patient_provider_assignments. See issue #2371 (VTID-03176) for the convergence decision tracker.';
+END
+$vtid_03186_oos_notice$;
+
+-- ============================================================
+-- Pre-condition: schema-drift guard (TARGET TABLES ONLY).
+-- Per-table (table_name, column_name) check via LEFT JOIN against a VALUES
+-- list of expected pairs. Same pattern as the reverted VTID-03165 file
+-- (and same fix from the original union-based version). RAISEs only when
+-- one of the three TARGET tables exists with unexpected columns.
+-- ============================================================
+DO $vtid_03186_pre_guard$
+DECLARE
+  unexpected TEXT;
+BEGIN
+  SELECT string_agg(c.table_name || '.' || c.column_name, ', ' ORDER BY c.table_name, c.column_name)
+    INTO unexpected
+    FROM information_schema.columns c
+    LEFT JOIN (VALUES
+      ('universal_carts','id'),
+      ('universal_carts','user_id'),
+      ('universal_carts','tenant_id'),
+      ('universal_carts','status'),
+      ('universal_carts','source_context'),
+      ('universal_carts','metadata'),
+      ('universal_carts','created_at'),
+      ('universal_carts','updated_at'),
+      ('universal_cart_items','id'),
+      ('universal_cart_items','cart_id'),
+      ('universal_cart_items','item_type'),
+      ('universal_cart_items','product_id'),
+      ('universal_cart_items','merchant_id'),
+      ('universal_cart_items','quantity'),
+      ('universal_cart_items','unit_price_cents_snapshot'),
+      ('universal_cart_items','currency_snapshot'),
+      ('universal_cart_items','source_surface'),
+      ('universal_cart_items','source_ref'),
+      ('universal_cart_items','status'),
+      ('universal_cart_items','metadata'),
+      ('universal_cart_items','created_at'),
+      ('universal_cart_items','updated_at'),
+      ('universal_cart_events','id'),
+      ('universal_cart_events','cart_id'),
+      ('universal_cart_events','user_id'),
+      ('universal_cart_events','event_type'),
+      ('universal_cart_events','event_payload'),
+      ('universal_cart_events','created_at')
+    ) AS allowed(tbl, col)
+      ON allowed.tbl = c.table_name AND allowed.col = c.column_name
+   WHERE c.table_schema = 'public'
+     AND c.table_name IN ('universal_carts', 'universal_cart_items', 'universal_cart_events')
+     AND allowed.tbl IS NULL;
+
+  IF unexpected IS NOT NULL THEN
+    RAISE EXCEPTION
+      'VTID-03186 pre-condition: unexpected columns on TARGET tables (universal_carts / universal_cart_items / universal_cart_events): %. The Lovable-side cart_items / checkout_sessions / cj_* stack is intentionally NOT checked here. Investigate ad-hoc DB state on the universal_* tables before re-running.',
+      unexpected;
+  END IF;
+END
+$vtid_03186_pre_guard$;
+
+-- ============================================================
+-- universal_carts
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.universal_carts (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES public.app_users(user_id) ON DELETE CASCADE,
+  tenant_id       UUID,
+  status          TEXT NOT NULL DEFAULT 'active',
+  source_context  TEXT,
+  metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Defensive column additions (idempotent under drift)
+ALTER TABLE public.universal_carts ADD COLUMN IF NOT EXISTS user_id        UUID;
+ALTER TABLE public.universal_carts ADD COLUMN IF NOT EXISTS tenant_id      UUID;
+ALTER TABLE public.universal_carts ADD COLUMN IF NOT EXISTS status         TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE public.universal_carts ADD COLUMN IF NOT EXISTS source_context TEXT;
+ALTER TABLE public.universal_carts ADD COLUMN IF NOT EXISTS metadata       JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE public.universal_carts ADD COLUMN IF NOT EXISTS created_at     TIMESTAMPTZ NOT NULL DEFAULT now();
+ALTER TABLE public.universal_carts ADD COLUMN IF NOT EXISTS updated_at     TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE public.universal_carts
+  DROP CONSTRAINT IF EXISTS universal_carts_status_check;
+ALTER TABLE public.universal_carts
+  ADD  CONSTRAINT universal_carts_status_check CHECK (status IN ('active','archived'));
+
+COMMENT ON TABLE public.universal_carts IS
+  'VTID-03186: persistent Universal Cart (renamed from `carts` after the VTID-03165 cart_items collision; see issue #2371). One active cart per user (partial-unique index). Phase 1 — staging area only; checkout lives in Phase 3.';
+COMMENT ON COLUMN public.universal_carts.tenant_id IS
+  'Optional. Cart is user-scoped; tenant_id is read from user_tenants at query time but mirrored here when known for fast filtering.';
+COMMENT ON COLUMN public.universal_carts.source_context IS
+  'Free-form hint about where the cart was first opened (e.g. discover_supplements, voice_session_id, autopilot_rec_id).';
+COMMENT ON COLUMN public.universal_carts.metadata IS
+  'JSONB. Future fields (Phase 5+): cohort hints, group_buy linkage, named-stack label. No PII.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS universal_carts_one_active_per_user
+  ON public.universal_carts (user_id) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS universal_carts_user_status_idx
+  ON public.universal_carts (user_id, status);
+CREATE INDEX IF NOT EXISTS universal_carts_tenant_idx
+  ON public.universal_carts (tenant_id) WHERE tenant_id IS NOT NULL;
+
+-- ============================================================
+-- universal_cart_items
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.universal_cart_items (
+  id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cart_id                    UUID NOT NULL REFERENCES public.universal_carts(id) ON DELETE CASCADE,
+  item_type                  TEXT NOT NULL,
+  product_id                 UUID NOT NULL REFERENCES public.products(id),
+  merchant_id                UUID REFERENCES public.merchants(id),
+  quantity                   NUMERIC NOT NULL DEFAULT 1,
+  unit_price_cents_snapshot  INT,
+  currency_snapshot          CHAR(3),
+  source_surface             TEXT,
+  source_ref                 TEXT,
+  status                     TEXT NOT NULL DEFAULT 'active',
+  metadata                   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS cart_id                   UUID;
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS item_type                 TEXT;
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS product_id                UUID;
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS merchant_id               UUID;
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS quantity                  NUMERIC NOT NULL DEFAULT 1;
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS unit_price_cents_snapshot INT;
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS currency_snapshot         CHAR(3);
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS source_surface            TEXT;
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS source_ref                TEXT;
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS status                    TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS metadata                  JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS created_at                TIMESTAMPTZ NOT NULL DEFAULT now();
+ALTER TABLE public.universal_cart_items ADD COLUMN IF NOT EXISTS updated_at                TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE public.universal_cart_items
+  DROP CONSTRAINT IF EXISTS universal_cart_items_item_type_check;
+ALTER TABLE public.universal_cart_items
+  ADD  CONSTRAINT universal_cart_items_item_type_check
+  CHECK (item_type IN ('supplement','partner_product'));
+
+ALTER TABLE public.universal_cart_items
+  DROP CONSTRAINT IF EXISTS universal_cart_items_status_check;
+ALTER TABLE public.universal_cart_items
+  ADD  CONSTRAINT universal_cart_items_status_check
+  CHECK (status IN ('active','removed','completed','expired'));
+
+ALTER TABLE public.universal_cart_items
+  DROP CONSTRAINT IF EXISTS universal_cart_items_quantity_positive;
+ALTER TABLE public.universal_cart_items
+  ADD  CONSTRAINT universal_cart_items_quantity_positive CHECK (quantity > 0);
+
+ALTER TABLE public.universal_cart_items
+  DROP CONSTRAINT IF EXISTS universal_cart_items_source_surface_check;
+ALTER TABLE public.universal_cart_items
+  ADD  CONSTRAINT universal_cart_items_source_surface_check
+  CHECK (source_surface IS NULL OR source_surface IN ('web','mobile','voice','autopilot','community'));
+
+COMMENT ON TABLE public.universal_cart_items IS
+  'VTID-03186: items staged in a Universal Cart. Distinct from the Lovable-side `cart_items` table (which is out of scope; see issue #2371). Phase 1 — supplement / partner_product only; subscriptions, lab_tests, appointments, protocol_bundles arrive in later phases.';
+COMMENT ON COLUMN public.universal_cart_items.unit_price_cents_snapshot IS
+  'Price (cents, matching products.price_cents) at add-time. Stored for future price-watch comparison (Phase 2+) and audit hygiene.';
+COMMENT ON COLUMN public.universal_cart_items.currency_snapshot IS
+  'ISO 4217 currency at add-time (matching products.currency CHAR(3)).';
+COMMENT ON COLUMN public.universal_cart_items.source_surface IS
+  'Origin of the add intent, not the HTTP transport. Adds from a community group chat thread land as ''community'' even if transport is web/mobile (PRD Q2).';
+COMMENT ON COLUMN public.universal_cart_items.source_ref IS
+  'Free-form correlation handle (e.g. voice session_id, autopilot rec_id, group thread id).';
+COMMENT ON COLUMN public.universal_cart_items.metadata IS
+  'JSONB. Phase 1 hint: metadata.autopilot_rec_id populated when add traces to an autopilot_recommendations row, even though auto-create is Phase 4 (PRD Q3). Never store PII or pricing strings here.';
+
+CREATE INDEX IF NOT EXISTS universal_cart_items_cart_active_idx
+  ON public.universal_cart_items (cart_id) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS universal_cart_items_product_idx
+  ON public.universal_cart_items (product_id);
+CREATE INDEX IF NOT EXISTS universal_cart_items_status_idx
+  ON public.universal_cart_items (cart_id, status);
+CREATE INDEX IF NOT EXISTS universal_cart_items_autopilot_rec_idx
+  ON public.universal_cart_items ((metadata->>'autopilot_rec_id'))
+  WHERE metadata ? 'autopilot_rec_id';
+
+-- ============================================================
+-- universal_cart_events  (append-only audit ledger)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.universal_cart_events (
+  id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  cart_id       UUID NOT NULL REFERENCES public.universal_carts(id) ON DELETE CASCADE,
+  user_id       UUID NOT NULL,
+  event_type    TEXT NOT NULL,
+  event_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.universal_cart_events ADD COLUMN IF NOT EXISTS cart_id       UUID;
+ALTER TABLE public.universal_cart_events ADD COLUMN IF NOT EXISTS user_id       UUID;
+ALTER TABLE public.universal_cart_events ADD COLUMN IF NOT EXISTS event_type    TEXT;
+ALTER TABLE public.universal_cart_events ADD COLUMN IF NOT EXISTS event_payload JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE public.universal_cart_events ADD COLUMN IF NOT EXISTS created_at    TIMESTAMPTZ NOT NULL DEFAULT now();
+
+COMMENT ON TABLE public.universal_cart_events IS
+  'VTID-03186: append-only ledger of universal_cart mutations. Event types in Phase 1: cart.created, item.added, item.removed, item.quantity_changed, item.completed, cart.archived. PRIVACY RULE: event_payload MUST NOT contain unit_price_cents_snapshot, full product descriptions, or PII — only ids and minimal structural fields. Writes via service_role only.';
+COMMENT ON COLUMN public.universal_cart_events.event_payload IS
+  'Minimal structural payload. Allowed keys: cart_item_id, product_id, quantity_before, quantity_after, source_surface, source_ref, removal_reason. Disallowed: prices, names, descriptions, user-identifying strings.';
+
+CREATE INDEX IF NOT EXISTS universal_cart_events_cart_recent_idx
+  ON public.universal_cart_events (cart_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS universal_cart_events_user_recent_idx
+  ON public.universal_cart_events (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS universal_cart_events_type_idx
+  ON public.universal_cart_events (event_type, created_at DESC);
+
+-- ============================================================
+-- Explicit table grants (defense-in-depth alongside RLS).
+-- Supabase configures DEFAULT PRIVILEGES on `public` for these roles, but
+-- declaring them explicitly keeps the migration self-contained and resilient
+-- to schema-level privilege drift (e.g. a future REVOKE ALL on public).
+-- universal_cart_events stays SELECT-only for `authenticated` — gateway writes
+-- via service_role, which bypasses RLS.
+-- ============================================================
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.universal_carts        TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.universal_cart_items   TO authenticated;
+GRANT SELECT                          ON public.universal_cart_events TO authenticated;
+GRANT ALL                             ON public.universal_carts        TO service_role;
+GRANT ALL                             ON public.universal_cart_items   TO service_role;
+GRANT ALL                             ON public.universal_cart_events  TO service_role;
+
+-- ============================================================
+-- updated_at trigger (shared function, two triggers)
+-- Function name unchanged from VTID-03165 (already universal_-prefixed).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.universal_cart_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS universal_carts_updated_at_trigger ON public.universal_carts;
+CREATE TRIGGER universal_carts_updated_at_trigger
+  BEFORE UPDATE ON public.universal_carts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.universal_cart_touch_updated_at();
+
+DROP TRIGGER IF EXISTS universal_cart_items_updated_at_trigger ON public.universal_cart_items;
+CREATE TRIGGER universal_cart_items_updated_at_trigger
+  BEFORE UPDATE ON public.universal_cart_items
+  FOR EACH ROW
+  EXECUTE FUNCTION public.universal_cart_touch_updated_at();
+
+-- ============================================================
+-- RLS — owner-only read/write; service_role bypasses for gateway writes.
+-- ============================================================
+ALTER TABLE public.universal_carts        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.universal_cart_items   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.universal_cart_events  ENABLE ROW LEVEL SECURITY;
+
+-- universal_carts: owner full access
+DROP POLICY IF EXISTS universal_carts_select_own ON public.universal_carts;
+CREATE POLICY universal_carts_select_own ON public.universal_carts
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS universal_carts_insert_own ON public.universal_carts;
+CREATE POLICY universal_carts_insert_own ON public.universal_carts
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS universal_carts_update_own ON public.universal_carts;
+CREATE POLICY universal_carts_update_own ON public.universal_carts
+  FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS universal_carts_delete_own ON public.universal_carts;
+CREATE POLICY universal_carts_delete_own ON public.universal_carts
+  FOR DELETE TO authenticated
+  USING (user_id = auth.uid());
+
+-- universal_cart_items: gated by parent cart ownership
+DROP POLICY IF EXISTS universal_cart_items_select_via_cart ON public.universal_cart_items;
+CREATE POLICY universal_cart_items_select_via_cart ON public.universal_cart_items
+  FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.universal_carts c
+                  WHERE c.id = universal_cart_items.cart_id AND c.user_id = auth.uid()));
+
+DROP POLICY IF EXISTS universal_cart_items_insert_via_cart ON public.universal_cart_items;
+CREATE POLICY universal_cart_items_insert_via_cart ON public.universal_cart_items
+  FOR INSERT TO authenticated
+  WITH CHECK (EXISTS (SELECT 1 FROM public.universal_carts c
+                       WHERE c.id = universal_cart_items.cart_id AND c.user_id = auth.uid()));
+
+DROP POLICY IF EXISTS universal_cart_items_update_via_cart ON public.universal_cart_items;
+CREATE POLICY universal_cart_items_update_via_cart ON public.universal_cart_items
+  FOR UPDATE TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.universal_carts c
+                  WHERE c.id = universal_cart_items.cart_id AND c.user_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.universal_carts c
+                       WHERE c.id = universal_cart_items.cart_id AND c.user_id = auth.uid()));
+
+DROP POLICY IF EXISTS universal_cart_items_delete_via_cart ON public.universal_cart_items;
+CREATE POLICY universal_cart_items_delete_via_cart ON public.universal_cart_items
+  FOR DELETE TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.universal_carts c
+                  WHERE c.id = universal_cart_items.cart_id AND c.user_id = auth.uid()));
+
+-- universal_cart_events: SELECT is gated by parent-cart ownership — we do NOT
+-- trust universal_cart_events.user_id alone (defense-in-depth: if service_role
+-- ever wrote the wrong user_id, the wrong user would be able to read it).
+-- The cart_id FK is the source of truth for ownership, mirroring the items
+-- policy pattern. No INSERT / UPDATE / DELETE policy for `authenticated`;
+-- service_role bypasses RLS and is the only writer.
+-- Idempotent: drop both legacy and current names before recreating.
+DROP POLICY IF EXISTS universal_cart_events_select_via_cart ON public.universal_cart_events;
+DROP POLICY IF EXISTS universal_cart_events_select_own      ON public.universal_cart_events;
+CREATE POLICY universal_cart_events_select_via_cart ON public.universal_cart_events
+  FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.universal_carts c
+                  WHERE c.id = universal_cart_events.cart_id AND c.user_id = auth.uid()));
+
+-- ============================================================
+-- Post-condition: required-column guard
+-- ============================================================
+DO $vtid_03186_post_guard$
+DECLARE
+  expected_columns CONSTANT TEXT[] := ARRAY[
+    'universal_carts.id','universal_carts.user_id','universal_carts.tenant_id','universal_carts.status',
+    'universal_carts.source_context','universal_carts.metadata','universal_carts.created_at','universal_carts.updated_at',
+    'universal_cart_items.id','universal_cart_items.cart_id','universal_cart_items.item_type','universal_cart_items.product_id',
+    'universal_cart_items.merchant_id','universal_cart_items.quantity','universal_cart_items.unit_price_cents_snapshot',
+    'universal_cart_items.currency_snapshot','universal_cart_items.source_surface','universal_cart_items.source_ref',
+    'universal_cart_items.status','universal_cart_items.metadata','universal_cart_items.created_at','universal_cart_items.updated_at',
+    'universal_cart_events.id','universal_cart_events.cart_id','universal_cart_events.user_id','universal_cart_events.event_type',
+    'universal_cart_events.event_payload','universal_cart_events.created_at'
+  ];
+  missing TEXT;
+BEGIN
+  SELECT string_agg(spec, ', ' ORDER BY spec)
+    INTO missing
+    FROM unnest(expected_columns) AS spec
+   WHERE NOT EXISTS (
+     SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND (table_name || '.' || column_name) = spec
+   );
+
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION
+      'VTID-03186 post-condition: required columns missing after migration: %', missing;
+  END IF;
+END
+$vtid_03186_post_guard$;
+
+COMMIT;

--- a/supabase/ops/2026-05-29_VTID_03186_universal_cart_rls_verification.sql
+++ b/supabase/ops/2026-05-29_VTID_03186_universal_cart_rls_verification.sql
@@ -1,0 +1,426 @@
+-- VTID-03186 — Universal Cart Phase 1, Slice A — RLS + schema verification.
+--
+-- Run AFTER applying 20260605000000_VTID_03186_universal_cart_schema.sql.
+-- Runs entirely inside a transaction that is ROLLED BACK at the end, so it
+-- leaves no rows behind. RAISEs on first failure with a descriptive message.
+--
+-- Touches ONLY the new universal_carts / universal_cart_items /
+-- universal_cart_events tables. Does NOT read or write any Lovable-side
+-- commerce table (cart_items, checkout_sessions, cj_*, vouchers,
+-- business_packages, supplements, user_wallets, etc.) — those are out of
+-- scope per issue #2371 (VTID-03176).
+--
+-- Coverage:
+--   §1  Structural checks  — tables, columns, constraints, indexes, triggers, policies all present.
+--   §2  Cascade & constraint behavior — INSERT, partial-unique, CHECK, ON DELETE CASCADE.
+--   §3  RLS — authenticated user A sees own cart, cannot see user B's cart, cannot insert into user B's cart.
+--   §4  RLS — authenticated user cannot INSERT into universal_cart_events; can only SELECT events for carts they own.
+--
+-- Test fixtures: a synthetic merchant + product are inserted at the head of §2
+-- so the script tests every assertion regardless of whether the target DB has
+-- any real products. All fixture rows (merchants, products, app_users,
+-- universal_carts, universal_cart_items, universal_cart_events) are rolled
+-- back at the end.
+--
+-- Invocation (psql, with a service-role connection string):
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/ops/2026-05-29_VTID_03186_universal_cart_rls_verification.sql
+
+BEGIN;
+
+-- ============================================================
+-- §1  Structural checks
+-- ============================================================
+
+DO $check_tables$
+DECLARE
+  missing TEXT;
+BEGIN
+  SELECT string_agg(t, ', ' ORDER BY t)
+    INTO missing
+    FROM unnest(ARRAY['universal_carts','universal_cart_items','universal_cart_events']) AS t
+   WHERE NOT EXISTS (
+     SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = t
+   );
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION '§1 missing tables: %', missing;
+  END IF;
+END
+$check_tables$;
+
+DO $check_rls_enabled$
+DECLARE
+  unprotected TEXT;
+BEGIN
+  SELECT string_agg(c.relname::text, ', ' ORDER BY c.relname)
+    INTO unprotected
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relname IN ('universal_carts','universal_cart_items','universal_cart_events')
+     AND NOT c.relrowsecurity;
+  IF unprotected IS NOT NULL THEN
+    RAISE EXCEPTION '§1 RLS not enabled on: %', unprotected;
+  END IF;
+END
+$check_rls_enabled$;
+
+DO $check_policies$
+DECLARE
+  missing TEXT;
+BEGIN
+  SELECT string_agg(spec, ', ' ORDER BY spec)
+    INTO missing
+    FROM (VALUES
+      ('universal_carts','universal_carts_select_own'),
+      ('universal_carts','universal_carts_insert_own'),
+      ('universal_carts','universal_carts_update_own'),
+      ('universal_carts','universal_carts_delete_own'),
+      ('universal_cart_items','universal_cart_items_select_via_cart'),
+      ('universal_cart_items','universal_cart_items_insert_via_cart'),
+      ('universal_cart_items','universal_cart_items_update_via_cart'),
+      ('universal_cart_items','universal_cart_items_delete_via_cart'),
+      ('universal_cart_events','universal_cart_events_select_via_cart')
+    ) AS expected(tbl, pol),
+    LATERAL (SELECT tbl || '.' || pol AS spec) s
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_policies
+       WHERE schemaname = 'public'
+         AND tablename = expected.tbl
+         AND policyname = expected.pol
+    );
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION '§1 missing policies: %', missing;
+  END IF;
+END
+$check_policies$;
+
+DO $check_indexes$
+DECLARE
+  missing TEXT;
+BEGIN
+  SELECT string_agg(idx, ', ' ORDER BY idx)
+    INTO missing
+    FROM unnest(ARRAY[
+      'universal_carts_one_active_per_user',
+      'universal_carts_user_status_idx',
+      'universal_cart_items_cart_active_idx',
+      'universal_cart_items_product_idx',
+      'universal_cart_events_cart_recent_idx',
+      'universal_cart_events_user_recent_idx'
+    ]) AS idx
+   WHERE NOT EXISTS (
+     SELECT 1 FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = idx
+   );
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION '§1 missing indexes: %', missing;
+  END IF;
+END
+$check_indexes$;
+
+DO $check_triggers$
+DECLARE
+  missing TEXT;
+BEGIN
+  SELECT string_agg(spec, ', ' ORDER BY spec)
+    INTO missing
+    FROM (VALUES
+      ('universal_carts','universal_carts_updated_at_trigger'),
+      ('universal_cart_items','universal_cart_items_updated_at_trigger')
+    ) AS expected(tbl, trg),
+    LATERAL (SELECT tbl || '.' || trg AS spec) s
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_trigger t
+        JOIN pg_class c ON c.oid = t.tgrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public'
+         AND c.relname = expected.tbl
+         AND t.tgname = expected.trg
+    );
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION '§1 missing triggers: %', missing;
+  END IF;
+END
+$check_triggers$;
+
+-- ============================================================
+-- §2  Cascade & constraint behavior  (operating as service_role / superuser)
+-- ============================================================
+
+-- Seed two synthetic test users in app_users (rolled back at end)
+DO $seed_users$
+DECLARE
+  user_a CONSTANT UUID := '00000000-0000-4000-a000-000000000a01';
+  user_b CONSTANT UUID := '00000000-0000-4000-a000-000000000b01';
+BEGIN
+  INSERT INTO public.app_users (user_id) VALUES (user_a) ON CONFLICT DO NOTHING;
+  INSERT INTO public.app_users (user_id) VALUES (user_b) ON CONFLICT DO NOTHING;
+END
+$seed_users$;
+
+-- Seed a synthetic merchant + product so §2.3 / §2.4 / §3.2 always have a
+-- valid FK target. Without this, an empty-products staging DB would either
+-- silently skip those assertions (false-pass) or fail loudly on the FK to
+-- products(id). Fixture rows persist only inside this transaction (rolled
+-- back at end).
+DO $seed_marketplace_fixture$
+DECLARE
+  fx_merchant_id CONSTANT UUID := '00000000-0000-4000-c000-000000000c01';
+  fx_product_id  CONSTANT UUID := '00000000-0000-4000-c000-000000000c02';
+BEGIN
+  INSERT INTO public.merchants (id, name, source_network)
+    VALUES (fx_merchant_id, '__vtid_03186_test_merchant', 'manual')
+    ON CONFLICT (id) DO NOTHING;
+  INSERT INTO public.products (
+    id, merchant_id, source_network, source_product_id, title, affiliate_url
+  ) VALUES (
+    fx_product_id, fx_merchant_id, 'manual', '__vtid_03186_test_product',
+    'VTID-03186 Test Product', 'https://example.test/vtid-03186'
+  )
+  ON CONFLICT (id) DO NOTHING;
+END
+$seed_marketplace_fixture$;
+
+-- §2.1 partial-unique index: two active universal_carts for same user must fail
+DO $partial_unique$
+DECLARE
+  cart_a UUID;
+  caught BOOLEAN := FALSE;
+BEGIN
+  INSERT INTO public.universal_carts (user_id, status)
+    VALUES ('00000000-0000-4000-a000-000000000a01', 'active')
+    RETURNING id INTO cart_a;
+  BEGIN
+    INSERT INTO public.universal_carts (user_id, status)
+      VALUES ('00000000-0000-4000-a000-000000000a01', 'active');
+  EXCEPTION WHEN unique_violation THEN
+    caught := TRUE;
+  END;
+  IF NOT caught THEN
+    RAISE EXCEPTION '§2.1 partial-unique index DID NOT block second active universal_cart for same user';
+  END IF;
+END
+$partial_unique$;
+
+-- §2.2 status CHECK constraint rejects unknown value
+DO $status_check$
+DECLARE
+  caught BOOLEAN := FALSE;
+BEGIN
+  BEGIN
+    INSERT INTO public.universal_carts (user_id, status)
+      VALUES ('00000000-0000-4000-a000-000000000b01', 'banana');
+  EXCEPTION WHEN check_violation THEN
+    caught := TRUE;
+  END;
+  IF NOT caught THEN
+    RAISE EXCEPTION '§2.2 universal_carts.status CHECK constraint did NOT reject "banana"';
+  END IF;
+END
+$status_check$;
+
+-- §2.3 universal_cart_items source_surface CHECK rejects unknown value
+DO $source_surface_check$
+DECLARE
+  cart_id_a UUID;
+  fx_product_id CONSTANT UUID := '00000000-0000-4000-c000-000000000c02';
+  caught    BOOLEAN := FALSE;
+BEGIN
+  SELECT id INTO cart_id_a FROM public.universal_carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
+  BEGIN
+    INSERT INTO public.universal_cart_items (cart_id, item_type, product_id, source_surface)
+      VALUES (cart_id_a, 'supplement', fx_product_id, 'sms');
+  EXCEPTION WHEN check_violation THEN
+    caught := TRUE;
+  END;
+  IF NOT caught THEN
+    RAISE EXCEPTION '§2.3 universal_cart_items.source_surface CHECK did NOT reject "sms"';
+  END IF;
+END
+$source_surface_check$;
+
+-- §2.4 ON DELETE CASCADE: deleting universal_cart removes its items
+DO $cascade_check$
+DECLARE
+  cart_id_a UUID;
+  fx_product_id CONSTANT UUID := '00000000-0000-4000-c000-000000000c02';
+  remaining INT;
+BEGIN
+  SELECT id INTO cart_id_a FROM public.universal_carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
+  INSERT INTO public.universal_cart_items (cart_id, item_type, product_id, source_surface)
+    VALUES (cart_id_a, 'supplement', fx_product_id, 'web');
+  DELETE FROM public.universal_carts WHERE id = cart_id_a;
+  SELECT count(*) INTO remaining FROM public.universal_cart_items WHERE cart_id = cart_id_a;
+  IF remaining <> 0 THEN
+    RAISE EXCEPTION '§2.4 ON DELETE CASCADE failed: % universal_cart_items survived parent delete', remaining;
+  END IF;
+END
+$cascade_check$;
+
+-- ============================================================
+-- §3  RLS  — authenticated user A sees only own universal_cart
+-- ============================================================
+-- Restore data for RLS phase (parent was deleted in §2.4)
+DO $rebuild_carts$
+DECLARE
+  cart_a UUID;
+  cart_b UUID;
+BEGIN
+  INSERT INTO public.universal_carts (user_id, status)
+    VALUES ('00000000-0000-4000-a000-000000000a01', 'active') RETURNING id INTO cart_a;
+  INSERT INTO public.universal_carts (user_id, status)
+    VALUES ('00000000-0000-4000-a000-000000000b01', 'active') RETURNING id INTO cart_b;
+END
+$rebuild_carts$;
+
+-- §3.1 user A sees only their own universal_cart
+DO $rls_select$
+DECLARE
+  visible_a INT;
+  visible_b INT;
+BEGIN
+  PERFORM set_config('role', 'authenticated', true);
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub','00000000-0000-4000-a000-000000000a01','role','authenticated')::text,
+    true);
+
+  SET LOCAL ROLE authenticated;
+
+  SELECT count(*) INTO visible_a
+    FROM public.universal_carts WHERE user_id = '00000000-0000-4000-a000-000000000a01';
+  SELECT count(*) INTO visible_b
+    FROM public.universal_carts WHERE user_id = '00000000-0000-4000-a000-000000000b01';
+
+  IF visible_a <> 1 THEN
+    RAISE EXCEPTION '§3.1 user A should see own universal_cart (1), saw %', visible_a;
+  END IF;
+  IF visible_b <> 0 THEN
+    RAISE EXCEPTION '§3.1 RLS LEAK: user A saw % rows of user B''s universal_cart', visible_b;
+  END IF;
+
+  RESET ROLE;
+END
+$rls_select$;
+
+-- §3.2 user A cannot INSERT a universal_cart_item into user B's universal_cart
+DO $rls_cross_insert$
+DECLARE
+  cart_b UUID;
+  fx_product_id CONSTANT UUID := '00000000-0000-4000-c000-000000000c02';
+  caught BOOLEAN := FALSE;
+BEGIN
+  -- Resolve cart_b while still service_role (RLS would hide it from user A)
+  SELECT id INTO cart_b FROM public.universal_carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000b01' AND status = 'active' LIMIT 1;
+
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub','00000000-0000-4000-a000-000000000a01','role','authenticated')::text,
+    true);
+  SET LOCAL ROLE authenticated;
+
+  BEGIN
+    INSERT INTO public.universal_cart_items (cart_id, item_type, product_id, source_surface)
+      VALUES (cart_b, 'supplement', fx_product_id, 'web');
+  EXCEPTION WHEN insufficient_privilege OR check_violation THEN
+    caught := TRUE;
+  END;
+
+  RESET ROLE;
+
+  IF NOT caught THEN
+    RAISE EXCEPTION '§3.2 RLS LEAK: user A inserted a universal_cart_item into user B''s universal_cart';
+  END IF;
+END
+$rls_cross_insert$;
+
+-- ============================================================
+-- §4  universal_cart_events — authenticated cannot INSERT; SELECT gated by parent cart.
+-- ============================================================
+DO $events_no_insert$
+DECLARE
+  cart_a UUID;
+  caught BOOLEAN := FALSE;
+BEGIN
+  SELECT id INTO cart_a FROM public.universal_carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
+
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub','00000000-0000-4000-a000-000000000a01','role','authenticated')::text,
+    true);
+  SET LOCAL ROLE authenticated;
+
+  BEGIN
+    INSERT INTO public.universal_cart_events (cart_id, user_id, event_type, event_payload)
+      VALUES (cart_a, '00000000-0000-4000-a000-000000000a01', 'cart.created', '{}'::jsonb);
+  EXCEPTION WHEN insufficient_privilege THEN
+    caught := TRUE;
+  END;
+
+  RESET ROLE;
+
+  IF NOT caught THEN
+    RAISE EXCEPTION '§4 RLS LEAK: authenticated user inserted into universal_cart_events (must be service_role only)';
+  END IF;
+END
+$events_no_insert$;
+
+-- §4.2 universal_cart_events SELECT uses parent-cart ownership, not self user_id.
+-- We seed two events as service_role: one on user A's cart, one on user B's
+-- cart. Switching to authenticated user A, the policy must allow only the
+-- event whose parent cart belongs to user A. We also seed a spoofed row
+-- (user_id = A) on user B's cart to prove the policy ignores
+-- universal_cart_events.user_id and trusts cart_id only.
+DO $events_select_via_parent_cart$
+DECLARE
+  cart_a UUID;
+  cart_b UUID;
+  visible_via_a INT;
+  visible_via_b INT;
+BEGIN
+  SELECT id INTO cart_a FROM public.universal_carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000a01' AND status = 'active' LIMIT 1;
+  SELECT id INTO cart_b FROM public.universal_carts
+   WHERE user_id = '00000000-0000-4000-a000-000000000b01' AND status = 'active' LIMIT 1;
+
+  -- still service_role: write three rows
+  INSERT INTO public.universal_cart_events (cart_id, user_id, event_type, event_payload)
+    VALUES (cart_a, '00000000-0000-4000-a000-000000000a01', 'cart.created', '{}'::jsonb);
+  INSERT INTO public.universal_cart_events (cart_id, user_id, event_type, event_payload)
+    VALUES (cart_b, '00000000-0000-4000-a000-000000000b01', 'cart.created', '{}'::jsonb);
+  -- Spoof: row on user B's cart with user_id falsely set to user A.
+  -- The OLD policy (USING user_id = auth.uid()) would have leaked this row to A.
+  -- The NEW policy (parent-cart ownership) must NOT.
+  INSERT INTO public.universal_cart_events (cart_id, user_id, event_type, event_payload)
+    VALUES (cart_b, '00000000-0000-4000-a000-000000000a01', 'cart.spoofed', '{}'::jsonb);
+
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub','00000000-0000-4000-a000-000000000a01','role','authenticated')::text,
+    true);
+  SET LOCAL ROLE authenticated;
+
+  SELECT count(*) INTO visible_via_a FROM public.universal_cart_events WHERE cart_id = cart_a;
+  SELECT count(*) INTO visible_via_b FROM public.universal_cart_events WHERE cart_id = cart_b;
+
+  RESET ROLE;
+
+  IF visible_via_a <> 1 THEN
+    RAISE EXCEPTION
+      '§4.2 user A should see exactly 1 universal_cart_event on own cart, saw %', visible_via_a;
+  END IF;
+  IF visible_via_b <> 0 THEN
+    RAISE EXCEPTION
+      '§4.2 RLS LEAK: user A saw % universal_cart_events on user B''s cart (one was spoofed with user_id=A — the new parent-cart policy must reject it)',
+      visible_via_b;
+  END IF;
+END
+$events_select_via_parent_cart$;
+
+-- ============================================================
+-- All checks passed. Roll back synthetic data so the DB is unchanged.
+-- ============================================================
+ROLLBACK;
+
+DO $ok$ BEGIN RAISE NOTICE 'VTID-03186 RLS + schema verification: ALL CHECKS PASSED'; END $ok$;


### PR DESCRIPTION
## Summary

Supersedes the reverted **VTID-03165** attempt ([#2347](https://github.com/exafyltd/vitana-platform/pull/2347), reverted in [#2361](https://github.com/exafyltd/vitana-platform/pull/2361)).

After the **VTID-03175** drift audit ([#2365](https://github.com/exafyltd/vitana-platform/pull/2365)) revealed **195 ghost tables** in production — an entire Lovable-side data layer including an active `cart_items` table used by the vitana-v1 Discover Marketplace cart — Phase 1 of the Universal Cart ships under the `universal_*` prefix to coexist cleanly with the existing commerce surface.

Convergence between the two cart systems (and the broader Lovable-side data layer) is tracked separately in issue [#2371](https://github.com/exafyltd/vitana-platform/issues/2371) (**VTID-03176**, decision-only).

## What this changes

Three new tables:

- `public.universal_carts` — one active cart per user (partial-unique index)
- `public.universal_cart_items` — items staged from web / mobile / voice / autopilot / community
- `public.universal_cart_events` — append-only audit ledger (service_role writes only)

Plus the supporting infrastructure: `updated_at` triggers, 6 indexes, 9 RLS policies, explicit GRANTs for `authenticated` + `service_role`, and pre/post-condition drift guards.

The Lovable-side commerce stack (29 tables: `cart_items`, `checkout_sessions`, `cj_products`, `cj_orders`, `cj_webhook_logs`, `bookmarked_items`, `business_packages`, `package_items`, `package_item_redemptions`, `package_purchases`, `vouchers`, `voucher_orders`, `voucher_redemptions`, `lab_tests`, `lab_test_orders`, `lab_test_results`, `service_payments`, `supplements`, `user_supplements`, `user_discount_codes`, `exchange_rates`, `reseller_attributions`, `reseller_payouts`, `reseller_profiles`, `user_wallets`, `wallet_credits`, `provider_appointments`, `provider_notes`, `patient_provider_assignments`) is **completely untouched**. A `RAISE NOTICE` block at the top of the migration documents this for audit trail.

## Pre-condition guard scope (important)

Per operator guardrail: **the pre-condition guard checks only the three TARGET tables** (`universal_carts` / `universal_cart_items` / `universal_cart_events`). It does NOT treat the 29 commerce ghosts as drift — they are production tables serving real users, tracked separately.

The guard pattern is the same per-table `(table_name, column_name)` LEFT JOIN-against-VALUES that the reverted VTID-03165 file used after its review fix. The intentional out-of-scope list is documented in the NOTICE block, not enforced as a hard error.

## PRD Q1-Q5 decisions

| # | Decision | Reflected here |
|---|---|---|
| Q1 | `/discover/orders` does NOT surface cart items | No indexes added for that surface |
| Q2 | `source_surface` attributes by intent origin, not transport | `universal_cart_items_source_surface_check` includes `'community'` |
| Q3 | Autopilot linkage in Phase 1 | partial JSONB index `universal_cart_items_autopilot_rec_idx` on `metadata->>'autopilot_rec_id'` |
| Q4 | Explicit `cart_item_id` callback for completion | `'completed'` state in `universal_cart_items_status_check` |
| Q5 | Community-role-only feature | enforced in gateway slice (VTID-B), schema neutral |

## RLS posture

- `universal_carts` — owner: SELECT, INSERT, UPDATE, DELETE
- `universal_cart_items` — gated by parent cart ownership: SELECT, INSERT, UPDATE, DELETE
- `universal_cart_events` — SELECT gated by parent cart ownership (does NOT trust self `user_id`); no INSERT/UPDATE/DELETE policy for `authenticated` — `service_role` is the only writer

## Ops verification

[supabase/ops/2026-05-29_VTID_03186_universal_cart_rls_verification.sql](supabase/ops/2026-05-29_VTID_03186_universal_cart_rls_verification.sql)

Same §1–§4 coverage from the reverted PR including the §4.2 spoofed-event regression test: seed a `universal_cart_event` on user B's cart with `user_id` falsely set to user A; assert the parent-cart RLS policy still rejects it.

Read-only, rolls back at the end, safe to run any time. Touches only the three new tables — no Lovable-side reads or writes.

## Test plan

- [ ] CI: `validate` check passes
- [ ] Merge into `main`
- [ ] **Operator authorization explicitly required** before `RUN-MIGRATION.yml` dispatch (per operator instruction, dispatch is frozen until post-merge go-ahead)
- [ ] Operator authorizes → I dispatch `RUN-MIGRATION.yml` against the migration file
- [ ] Post-dispatch: check the workflow run logs end with `Migration applied successfully` (now meaningful after VTID-03174 hardening)
- [ ] Operator runs the ops verification script via Supabase SQL editor / service-role psql → expects `RAISE NOTICE 'ALL CHECKS PASSED'`

## What this does NOT do

- No gateway routes — separate VTID
- No drawer / frontend — separate VTID
- No ORB `post_intent(commercial_buy, stage='staged')` extension — separate VTID
- No `commerce_cart` decision-contract provider — separate VTID
- No checkout / Stripe / wallet waterfall — Phase 3 **blocked** until [#2371](https://github.com/exafyltd/vitana-platform/issues/2371) decides the wallet system
- No Health Rules Engine — Phase 2
- No autopilot auto-create — Phase 4 **blocked** until [#2371](https://github.com/exafyltd/vitana-platform/issues/2371) decides the autopilot system
- No cohort / group-buy signals — Phase 5 **blocked** until [#2371](https://github.com/exafyltd/vitana-platform/issues/2371) decides the matchmaking system
- **No changes to any Lovable-side cart / commerce / wallet / autopilot / profile table**

## Related

- Issue [#2371](https://github.com/exafyltd/vitana-platform/issues/2371) — Lovable-side vs gateway-side data layer reconciliation (VTID-03176)
- PR [#2347](https://github.com/exafyltd/vitana-platform/pull/2347) — original Universal Cart Phase 1 schema (VTID-03165), reverted
- PR [#2361](https://github.com/exafyltd/vitana-platform/pull/2361) — revert of #2347 (VTID-03173)
- PR [#2363](https://github.com/exafyltd/vitana-platform/pull/2363) — `RUN-MIGRATION.yml` hardening (VTID-03174)
- PR [#2365](https://github.com/exafyltd/vitana-platform/pull/2365) — production drift audit ops SQL (VTID-03175)

🤖 Generated with [Claude Code](https://claude.com/claude-code)