### PR TITLE
feat(wallet): Stripe-funded EUR/USD wallet deposits (VTID-03200 + VTID-03201)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -308,6 +308,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const stripeConnectWebhookRouter = require('./routes/stripe-connect-webhook').default;
   // VTID-03107: Billing v1 — customer-side Stripe subscriptions + credit packs + redemption
   const billingRouter = require('./routes/billing').default;
+  // VTID-03201: Stripe-funded wallet deposits (EUR + USD fiat ledger, ships in parallel with Billing v1)
+  const walletRouter = require('./routes/wallet').default;
+  const walletStripeWebhookRouter = require('./routes/wallet-stripe-webhook').default;
   // Notification System — FCM push + in-app notification history
   const notificationsRouter = require('./routes/notifications').default;
   // Chat — User-to-user direct messaging
@@ -1006,6 +1009,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/stripe', stripeConnectWebhookRouter, { owner: 'stripe-connect-webhook' });
   // VTID-03107: Billing v1 — customer-side Stripe + redemption codes + admin code mgmt
   mountRouterSync(app, '/api/v1/billing', billingRouter, { owner: 'billing' });
+  // VTID-03201: Wallet deposit webhook (raw body already applied to /api/v1/stripe/webhook).
+  // Mounted under /api/v1/stripe so the route resolves to /api/v1/stripe/webhook/wallet.
+  mountRouterSync(app, '/api/v1/stripe', walletStripeWebhookRouter, { owner: 'wallet-stripe-webhook' });
+  // VTID-03201: Wallet user-facing routes (EUR + USD fiat). Path-scoped requireAuth inside router.
+  mountRouterSync(app, '/api/v1', walletRouter, { owner: 'wallet' });
 
   // Notification System — FCM push notifications + in-app history
   mountRouterSync(app, '/api/v1/notifications', notificationsRouter, { owner: 'notifications' });

--- a/services/gateway/src/routes/wallet-stripe-webhook.ts
+++ b/services/gateway/src/routes/wallet-stripe-webhook.ts
@@ -1,0 +1,218 @@
+/**
+ * Wallet Stripe webhook handler — VTID-03201
+ *
+ * Strict signature verification (mirrors stripe-connect-webhook.ts, NOT the
+ * soft-verify in payments-stripe-webhook.ts). Subscribed to:
+ *
+ *   checkout.session.completed         → credit wallet (primary path)
+ *   checkout.session.expired           → mark deposit expired
+ *   checkout.session.async_payment_failed → mark deposit failed
+ *   payment_intent.succeeded           → reconciliation path (idempotent)
+ *   payment_intent.payment_failed      → mark deposit failed
+ *
+ * Idempotency:
+ *   1. stripe_webhook_events.stripe_event_id unique — first gate against
+ *      Stripe redelivery.
+ *   2. credit_deposit RPC's UNIQUE(reference, entry_type) — structural
+ *      guard against double-credit if a different event for the same
+ *      deposit slips past gate 1.
+ *
+ * Mount: /api/v1/stripe (raw-body middleware is already applied to
+ *        /api/v1/stripe/webhook in index.ts).
+ */
+
+import { Router, Request, Response } from 'express';
+import Stripe from 'stripe';
+import { getSupabase } from '../lib/supabase';
+import { getWalletStripe, getWalletWebhookSecret } from '../services/wallet/stripe-client';
+import { decodeCheckoutMetadata } from '../services/wallet/checkout-metadata';
+import { finalizeDeposit, markDepositTerminal } from '../services/wallet/deposit-service';
+
+const router = Router();
+
+const HANDLED_EVENT_TYPES = new Set<string>([
+  'checkout.session.completed',
+  'checkout.session.expired',
+  'checkout.session.async_payment_failed',
+  'payment_intent.succeeded',
+  'payment_intent.payment_failed',
+]);
+
+/**
+ * POST /api/v1/stripe/webhook/wallet
+ */
+router.post('/webhook/wallet', async (req: Request, res: Response) => {
+  const sig = req.headers['stripe-signature'];
+  const secret = getWalletWebhookSecret();
+
+  if (!sig) {
+    console.error('[wallet-webhook] missing stripe-signature header');
+    return res.status(400).json({ error: 'Missing signature' });
+  }
+  if (!secret) {
+    console.error('[wallet-webhook] STRIPE_WALLET_WEBHOOK_SECRET not configured');
+    return res.status(500).json({ error: 'Webhook not configured' });
+  }
+
+  let event: Stripe.Event;
+  try {
+    event = getWalletStripe().webhooks.constructEvent(req.body, sig, secret);
+  } catch (err: any) {
+    console.error('[wallet-webhook] signature verification failed:', err?.message ?? err);
+    return res.status(400).json({ error: `Webhook Error: ${err?.message ?? 'invalid signature'}` });
+  }
+
+  const supabase = getSupabase();
+  if (!supabase) {
+    console.error('[wallet-webhook] supabase unavailable; cannot persist event');
+    return res.status(500).json({ error: 'Gateway misconfigured' });
+  }
+
+  // Idempotency gate 1: insert into stripe_webhook_events. unique(stripe_event_id)
+  // makes a redelivery fail with code 23505 — we return 200 immediately so Stripe
+  // stops retrying. The event was already processed.
+  const { error: insertErr } = await supabase
+    .from('stripe_webhook_events')
+    .insert({
+      stripe_event_id: event.id,
+      event_type: event.type,
+      source: 'wallet',
+      payload: event as unknown as Record<string, unknown>,
+    });
+
+  if (insertErr) {
+    const code = (insertErr as { code?: string }).code;
+    if (code === '23505') {
+      // Already processed on a prior delivery.
+      console.log(`[wallet-webhook] duplicate event ${event.id} (${event.type}) — ack 200`);
+      return res.status(200).json({ received: true, duplicate: true });
+    }
+    console.error('[wallet-webhook] failed to insert event row:', insertErr.message);
+    return res.status(500).json({ error: 'Event persistence failed' });
+  }
+
+  // Skip event types we don't care about, but still mark processed.
+  if (!HANDLED_EVENT_TYPES.has(event.type)) {
+    console.log(`[wallet-webhook] ignoring event type ${event.type}`);
+    await markEventProcessed(event.id, null);
+    return res.status(200).json({ received: true, ignored: true });
+  }
+
+  try {
+    await handleWalletEvent(event);
+    await markEventProcessed(event.id, null);
+    return res.status(200).json({ received: true });
+  } catch (err: any) {
+    const message = err?.message ?? String(err);
+    console.error(`[wallet-webhook] processing failed for ${event.id} (${event.type}):`, message);
+    await markEventProcessed(event.id, message);
+    // 500 → Stripe will retry. Idempotency guards make retries safe.
+    return res.status(500).json({ error: 'Webhook processing failed' });
+  }
+});
+
+async function handleWalletEvent(event: Stripe.Event): Promise<void> {
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      const metadata = decodeCheckoutMetadata(session.metadata as Record<string, string> | null);
+      if (!metadata) {
+        console.warn(
+          `[wallet-webhook] checkout.session.completed ${session.id} has no wallet metadata; skipping`
+        );
+        return;
+      }
+      // Stripe sends 'complete' with payment_status='paid' on successful card
+      // charges. async payment methods may complete later via payment_intent.*
+      if (session.payment_status !== 'paid') {
+        console.log(
+          `[wallet-webhook] session ${session.id} completed but payment_status=${session.payment_status}; waiting for payment_intent`
+        );
+        return;
+      }
+      const piId =
+        typeof session.payment_intent === 'string'
+          ? session.payment_intent
+          : session.payment_intent?.id ?? null;
+      const result = await finalizeDeposit(metadata.deposit_id, event.id, piId);
+      console.log(
+        `[wallet-webhook] credited deposit ${metadata.deposit_id} (duplicate=${result.duplicate ?? false}, balance_minor=${result.balance_minor})`
+      );
+      return;
+    }
+
+    case 'checkout.session.expired': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      const metadata = decodeCheckoutMetadata(session.metadata as Record<string, string> | null);
+      if (metadata) {
+        await markDepositTerminal(metadata.deposit_id, 'expired', 'checkout_session_expired');
+      }
+      return;
+    }
+
+    case 'checkout.session.async_payment_failed': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      const metadata = decodeCheckoutMetadata(session.metadata as Record<string, string> | null);
+      if (metadata) {
+        await markDepositTerminal(
+          metadata.deposit_id,
+          'failed',
+          'checkout_async_payment_failed'
+        );
+      }
+      return;
+    }
+
+    case 'payment_intent.succeeded': {
+      // Reconciliation path. checkout.session.completed is the primary fulfillment
+      // event; this path catches async payment methods that confirm post-redirect.
+      const pi = event.data.object as Stripe.PaymentIntent;
+      const supabase = getSupabase();
+      if (!supabase) return;
+      const { data: deposit } = await supabase
+        .from('wallet_deposits')
+        .select('id')
+        .eq('stripe_payment_intent_id', pi.id)
+        .maybeSingle();
+      if (!deposit) {
+        console.log(`[wallet-webhook] payment_intent.succeeded ${pi.id} has no matching deposit; skipping`);
+        return;
+      }
+      const result = await finalizeDeposit((deposit as { id: string }).id, event.id, pi.id);
+      console.log(
+        `[wallet-webhook] PI-path credited deposit ${(deposit as { id: string }).id} (duplicate=${result.duplicate ?? false})`
+      );
+      return;
+    }
+
+    case 'payment_intent.payment_failed': {
+      const pi = event.data.object as Stripe.PaymentIntent;
+      const supabase = getSupabase();
+      if (!supabase) return;
+      const { data: deposit } = await supabase
+        .from('wallet_deposits')
+        .select('id')
+        .eq('stripe_payment_intent_id', pi.id)
+        .maybeSingle();
+      if (deposit) {
+        const reason = pi.last_payment_error?.code || pi.last_payment_error?.type || 'payment_intent_failed';
+        await markDepositTerminal((deposit as { id: string }).id, 'failed', reason);
+      }
+      return;
+    }
+  }
+}
+
+async function markEventProcessed(stripeEventId: string, error: string | null): Promise<void> {
+  const supabase = getSupabase();
+  if (!supabase) return;
+  await supabase
+    .from('stripe_webhook_events')
+    .update({
+      processed_at: new Date().toISOString(),
+      processing_error: error,
+    })
+    .eq('stripe_event_id', stripeEventId);
+}
+
+export default router;

--- a/services/gateway/src/routes/wallet.ts
+++ b/services/gateway/src/routes/wallet.ts
@@ -1,0 +1,167 @@
+/**
+ * Wallet user-facing routes — VTID-03201
+ *
+ *   POST /api/v1/wallet/deposits/create
+ *   GET  /api/v1/wallet/deposits/:id
+ *   GET  /api/v1/wallet/balance
+ *   GET  /api/v1/wallet/transactions
+ *
+ * All routes require an authenticated Supabase JWT (requireAuth middleware).
+ * Wallet writes happen ONLY in the webhook handler and service modules;
+ * never trust the client to mark a payment successful.
+ */
+
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import {
+  createDeposit,
+  getDepositForUser,
+  DepositServiceError,
+} from '../services/wallet/deposit-service';
+import {
+  getAccountsForUser,
+  getTransactionsForUser,
+} from '../services/wallet/balance-service';
+import { isWalletCurrency } from '../types/wallet';
+
+const router = Router();
+
+// Path-scoped auth (mirrors admin-embeddings-backfill.ts pattern, VTID-02032 lesson).
+router.use('/wallet', requireAuth);
+
+/**
+ * POST /api/v1/wallet/deposits/create
+ * Body: { amount_minor: number, currency: 'EUR' | 'USD' }
+ */
+router.post('/wallet/deposits/create', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const userId = req.identity?.user_id;
+    if (!userId) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+
+    const body = (req.body ?? {}) as { amount_minor?: unknown; currency?: unknown };
+
+    if (typeof body.amount_minor !== 'number' || !Number.isInteger(body.amount_minor)) {
+      return res
+        .status(400)
+        .json({ ok: false, error: 'INVALID_AMOUNT', message: 'amount_minor must be an integer' });
+    }
+    if (!isWalletCurrency(body.currency)) {
+      return res
+        .status(400)
+        .json({ ok: false, error: 'INVALID_CURRENCY', message: "currency must be 'EUR' or 'USD'" });
+    }
+
+    const result = await createDeposit({
+      user_id: userId,
+      amount_minor: body.amount_minor,
+      currency: body.currency,
+      email: req.identity?.email ?? null,
+    });
+
+    return res.json({
+      ok: true,
+      deposit_id: result.deposit_id,
+      checkout_url: result.checkout_url,
+      expires_at: result.expires_at,
+    });
+  } catch (err: any) {
+    if (err instanceof DepositServiceError) {
+      return res.status(err.httpStatus).json({
+        ok: false,
+        error: err.code,
+        message: err.message,
+      });
+    }
+    console.error('[wallet] deposits/create failed:', err?.message ?? err);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+/**
+ * GET /api/v1/wallet/deposits/:id
+ * Returns the deposit row (own user only). Frontend polls this after the
+ * Stripe success redirect to await webhook-driven 'succeeded'.
+ */
+router.get('/wallet/deposits/:id', async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+  const deposit = await getDepositForUser(req.params.id, userId);
+  if (!deposit) {
+    return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+  }
+  return res.json({
+    ok: true,
+    deposit: {
+      id: deposit.id,
+      amount_minor: deposit.amount_minor,
+      currency: deposit.currency,
+      status: deposit.status,
+      failure_reason: deposit.failure_reason,
+      created_at: deposit.created_at,
+      updated_at: deposit.updated_at,
+    },
+  });
+});
+
+/**
+ * GET /api/v1/wallet/balance
+ * Returns array of accounts (one per currency).
+ */
+router.get('/wallet/balance', async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+  const accounts = await getAccountsForUser(userId);
+  return res.json({
+    ok: true,
+    accounts: accounts.map((a) => ({
+      currency: a.currency,
+      balance_minor: a.balance_minor,
+      status: a.status,
+      updated_at: a.updated_at,
+    })),
+  });
+});
+
+/**
+ * GET /api/v1/wallet/transactions?currency=EUR&limit=20&cursor=<iso>
+ */
+router.get('/wallet/transactions', async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const currencyParam = req.query.currency;
+  const currency =
+    typeof currencyParam === 'string' && isWalletCurrency(currencyParam) ? currencyParam : undefined;
+
+  const limitParam = req.query.limit;
+  const limit =
+    typeof limitParam === 'string' && /^\d+$/.test(limitParam) ? parseInt(limitParam, 10) : 20;
+
+  const cursor = typeof req.query.cursor === 'string' ? req.query.cursor : null;
+
+  const page = await getTransactionsForUser({ user_id: userId, currency, limit, cursor });
+
+  return res.json({
+    ok: true,
+    entries: page.entries.map((e) => ({
+      id: e.id,
+      entry_type: e.entry_type,
+      direction: e.direction,
+      amount_minor: e.amount_minor,
+      currency: e.currency,
+      description: e.description,
+      created_at: e.created_at,
+    })),
+    next_cursor: page.next_cursor,
+  });
+});
+
+export default router;

--- a/services/gateway/src/services/wallet/README.md
+++ b/services/gateway/src/services/wallet/README.md
@@ -1,0 +1,214 @@
+# Vitana Wallet — Stripe Deposits
+
+VTID-03200 (schema) + VTID-03201 (gateway). Multi-currency (EUR primary, USD allowed). Stripe Checkout is the only money-in rail. The internal `wallet_ledger_entries` table is the source of truth; `wallet_accounts.balance_minor` is a cached projection.
+
+## Architecture (one screen)
+
+```
+                              ┌──────────────────────────┐
+  user clicks "Add money" ─▶  │  POST /wallet/deposits   │
+                              │  /create                 │
+                              └────────────┬─────────────┘
+                                           │
+                                           ▼
+                          ┌────────────────────────────────┐
+                          │  insert wallet_deposits row    │
+                          │  status=created                │
+                          │  generate idempotency_key      │
+                          └────────────┬───────────────────┘
+                                       │
+                                       ▼
+                          ┌────────────────────────────────┐
+                          │  stripe.checkout.sessions      │
+                          │  .create({...}, {              │
+                          │    idempotencyKey,             │
+                          │    metadata: {deposit_id,...}  │
+                          │  })                            │
+                          └────────────┬───────────────────┘
+                                       │
+                                       ▼
+                          ┌────────────────────────────────┐
+                          │  update deposit:               │
+                          │  status=checkout_started       │
+                          │  stripe_checkout_session_id    │
+                          └────────────┬───────────────────┘
+                                       │
+                                       ▼
+                            redirect to checkout_url
+                                       │
+                          ─ ─ ─ ─ ─ ─ ─┼─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+                                       │ user pays
+                                       ▼
+                          ┌────────────────────────────────┐
+                          │  Stripe → POST /api/v1/stripe/ │
+                          │             webhook/wallet     │
+                          │  (strict signature verify)     │
+                          └────────────┬───────────────────┘
+                                       │
+                                       ▼
+                          ┌────────────────────────────────┐
+                          │  insert stripe_webhook_events  │
+                          │  (UNIQUE stripe_event_id —     │
+                          │   replay returns 200, no work) │
+                          └────────────┬───────────────────┘
+                                       │
+                                       ▼
+                          ┌────────────────────────────────┐
+                          │  credit_deposit() RPC          │
+                          │   - SELECT FOR UPDATE deposit  │
+                          │   - INSERT ledger entry        │
+                          │     (UNIQUE prevents dup)      │
+                          │   - UPDATE cached balance      │
+                          │   - mark deposit succeeded     │
+                          │  …all in one transaction       │
+                          └────────────────────────────────┘
+```
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `supabase/migrations/20260529000000_VTID_03200_wallet_stripe_deposits.sql` | Schema, trigger, RPC, backfill |
+| `src/types/wallet.ts` | DTOs and the `WalletCurrency` type guard |
+| `src/services/wallet/stripe-client.ts` | Lazy Stripe client + env helpers |
+| `src/services/wallet/checkout-metadata.ts` | Versioned, strongly-typed Stripe metadata |
+| `src/services/wallet/deposit-service.ts` | `createDeposit`, `finalizeDeposit`, `markDepositTerminal` |
+| `src/services/wallet/balance-service.ts` | Read accounts + paginated ledger |
+| `src/routes/wallet.ts` | User-facing routes (auth required) |
+| `src/routes/wallet-stripe-webhook.ts` | Strict-signature webhook handler |
+| `test/wallet-checkout-metadata.test.ts` | Metadata round-trip + version guard |
+| `test/wallet-stripe-webhook.test.ts` | Signature, idempotency, dispatch |
+
+## Environment
+
+```
+STRIPE_SECRET_KEY=sk_live_...                     # shared with creators / payments
+STRIPE_WALLET_WEBHOOK_SECRET=whsec_...            # SEPARATE from connect/payments
+APP_BASE_URL=https://vitanaland.com               # success/cancel redirect base
+SUPABASE_URL=https://...supabase.co
+SUPABASE_SERVICE_ROLE_KEY=eyJ...                  # service role (RLS bypass)
+SUPABASE_JWT_SECRET=...                           # for user-route auth
+```
+
+Three separate webhook secrets (wallet / payments / connect) — rotate one without touching the others.
+
+## API
+
+All user routes require `Authorization: Bearer <supabase-jwt>`.
+
+### POST `/api/v1/wallet/deposits/create`
+```json
+{ "amount_minor": 2500, "currency": "EUR" }
+```
+Response:
+```json
+{
+  "ok": true,
+  "deposit_id": "...",
+  "checkout_url": "https://checkout.stripe.com/c/pay/...",
+  "expires_at": "2026-05-29T13:30:00.000Z"
+}
+```
+Errors: `INVALID_AMOUNT`, `INVALID_CURRENCY`, `ACCOUNT_NOT_ACTIVE`, `STRIPE_CHECKOUT_FAILED` (e.g. Stripe minimum violation).
+
+### GET `/api/v1/wallet/deposits/:id`
+Poll-after-redirect endpoint for the frontend success page. Returns `status` ∈ `created | checkout_started | succeeded | failed | canceled | expired`. Own user only.
+
+### GET `/api/v1/wallet/balance`
+```json
+{
+  "ok": true,
+  "accounts": [
+    { "currency": "EUR", "balance_minor": 12500, "status": "active", "updated_at": "..." },
+    { "currency": "USD", "balance_minor": 0,      "status": "active", "updated_at": "..." }
+  ]
+}
+```
+
+### GET `/api/v1/wallet/transactions?currency=EUR&limit=20&cursor=<iso>`
+Cursor-paginated ledger entries (most recent first).
+
+### POST `/api/v1/stripe/webhook/wallet`
+Stripe-signed. Strict verification with `STRIPE_WALLET_WEBHOOK_SECRET`. Subscribed event types:
+- `checkout.session.completed` — primary credit path
+- `checkout.session.expired` — mark deposit `expired`
+- `checkout.session.async_payment_failed` — mark deposit `failed`
+- `payment_intent.succeeded` — reconciliation path (idempotent)
+- `payment_intent.payment_failed` — mark deposit `failed`
+
+## Idempotency layers (defence in depth)
+
+| Layer | Mechanism | Catches |
+|---|---|---|
+| Stripe API call | `Stripe-Idempotency-Key` header | Retried Checkout Session creates |
+| Webhook entry | `stripe_webhook_events.stripe_event_id` unique | Stripe redelivery of the same event |
+| Ledger write | `UNIQUE(reference_type, reference_id, entry_type)` | Two distinct events finalizing the same deposit |
+| Deposit status | `wallet_deposits.status='succeeded'` early-return | Concurrent worker race |
+
+## Local dev — Stripe CLI
+
+```bash
+# Forward Stripe events to your local gateway.
+stripe listen --forward-to localhost:8787/api/v1/stripe/webhook/wallet
+
+# Copy the printed whsec_... into STRIPE_WALLET_WEBHOOK_SECRET in .env.local.
+
+# Trigger a fake successful checkout:
+stripe trigger checkout.session.completed
+
+# Replay the same event 5× — balance should not move after the first credit:
+stripe events resend evt_xxx
+```
+
+## Sample curl
+
+```bash
+# Create deposit (EUR)
+curl -X POST https://gateway.vitanaland.com/api/v1/wallet/deposits/create \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"amount_minor": 2500, "currency": "EUR"}'
+
+# Poll deposit status after Stripe redirect
+curl https://gateway.vitanaland.com/api/v1/wallet/deposits/$DEPOSIT_ID \
+  -H "Authorization: Bearer $JWT"
+
+# Read wallet balances
+curl https://gateway.vitanaland.com/api/v1/wallet/balance \
+  -H "Authorization: Bearer $JWT"
+
+# Recent EUR transactions
+curl "https://gateway.vitanaland.com/api/v1/wallet/transactions?currency=EUR&limit=10" \
+  -H "Authorization: Bearer $JWT"
+```
+
+## Test checklist (manual + automated)
+
+- [x] User signup → both EUR + USD accounts auto-created via `auth.users` trigger
+- [x] Backfill creates accounts for existing users; idempotent on re-run
+- [x] Missing `stripe-signature` → 400, no DB write *(automated)*
+- [x] Invalid signature → 400, no DB write *(automated)*
+- [x] Valid `checkout.session.completed` → balance credited once *(automated dispatch; RPC integration tested manually)*
+- [x] Replayed `stripe_event_id` → 200, no second credit *(automated)*
+- [x] Unhandled event type → 200, marked processed *(automated)*
+- [x] Missing/invalid metadata → no credit attempt *(automated)*
+- [x] `payment_status != 'paid'` → no credit *(automated)*
+- [x] `checkout.session.expired` → deposit `expired` *(automated)*
+- [x] Handler error → 500 + event marked with `processing_error` *(automated)*
+- [ ] EUR credit doesn't leak into USD balance *(manual integration)*
+- [ ] `€0.01` → Stripe rejects; deposit marked `failed` with reason *(manual)*
+- [ ] User A cannot read User B's `/balance` or `/transactions` *(RLS test, manual)*
+- [ ] `ledger.SUM(credits) - SUM(debits) = wallet_accounts.balance_minor` per account *(reconciliation invariant — schedule as ops job)*
+
+## Out of scope (later phases)
+
+- Withdrawals
+- P2P transfers between users
+- Refunds (read path only — no `refund_debit` ledger inserts yet)
+- Admin manual-adjustment endpoint (`/wallet/admin/adjust`)
+- Unifying with the existing `wallet_transactions` (rewards/automations) ledger
+- VTNA conversion flows
+
+## VTID hygiene
+
+- **VTID-03200** (schema migration) and **VTID-03201** (gateway routes) are pre-picked placeholders. Per the standing rule (`feedback_vtid_collision_check_at_merge`), re-verify with `git log origin/main --grep="VTID-03200"` and `git log origin/main --grep="VTID-03201"` immediately before merge, then claim via `POST /api/v1/vtid/allocate` (EXEC-DEPLOY hard-fails on missing ledger).

--- a/services/gateway/src/services/wallet/balance-service.ts
+++ b/services/gateway/src/services/wallet/balance-service.ts
@@ -1,0 +1,72 @@
+/**
+ * Wallet balance + history read service — VTID-03201
+ *
+ * Read-only. RLS in the DB also enforces own-row access for safety, but we
+ * filter explicitly here too so a config slip can't leak data.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import type {
+  WalletAccount,
+  WalletCurrency,
+  WalletLedgerEntry,
+} from '../../types/wallet';
+
+export async function getAccountsForUser(userId: string): Promise<WalletAccount[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const { data, error } = await supabase
+    .from('wallet_accounts')
+    .select('*')
+    .eq('user_id', userId)
+    .order('currency', { ascending: true });
+  if (error) {
+    console.error('[wallet/balance] getAccountsForUser failed:', error.message);
+    return [];
+  }
+  return (data ?? []) as WalletAccount[];
+}
+
+export interface TransactionsPage {
+  entries: WalletLedgerEntry[];
+  next_cursor: string | null;
+}
+
+export async function getTransactionsForUser(opts: {
+  user_id: string;
+  currency?: WalletCurrency;
+  limit?: number;
+  cursor?: string | null;
+}): Promise<TransactionsPage> {
+  const supabase = getSupabase();
+  if (!supabase) return { entries: [], next_cursor: null };
+
+  const limit = Math.min(Math.max(opts.limit ?? 20, 1), 100);
+
+  let q = supabase
+    .from('wallet_ledger_entries')
+    .select('*')
+    .eq('user_id', opts.user_id)
+    .order('created_at', { ascending: false })
+    .limit(limit + 1);
+
+  if (opts.currency) {
+    q = q.eq('currency', opts.currency);
+  }
+  if (opts.cursor) {
+    q = q.lt('created_at', opts.cursor);
+  }
+
+  const { data, error } = await q;
+  if (error) {
+    console.error('[wallet/balance] getTransactionsForUser failed:', error.message);
+    return { entries: [], next_cursor: null };
+  }
+
+  const rows = (data ?? []) as WalletLedgerEntry[];
+  const hasMore = rows.length > limit;
+  const entries = hasMore ? rows.slice(0, limit) : rows;
+  const next_cursor = hasMore ? entries[entries.length - 1].created_at : null;
+
+  return { entries, next_cursor };
+}

--- a/services/gateway/src/services/wallet/checkout-metadata.ts
+++ b/services/gateway/src/services/wallet/checkout-metadata.ts
@@ -1,0 +1,48 @@
+/**
+ * Strongly-typed Stripe Checkout Session metadata.
+ *
+ * Stripe stores metadata as a flat string→string map (≤ 50 keys, ≤ 500 chars
+ * each). Encode here, decode in the webhook handler. Schema version tag lets
+ * us evolve the shape later without breaking in-flight sessions.
+ */
+
+import type { WalletCurrency } from '../../types/wallet';
+
+export const CHECKOUT_METADATA_SCHEMA_VERSION = '1';
+
+export interface WalletCheckoutMetadata {
+  schema_version: typeof CHECKOUT_METADATA_SCHEMA_VERSION;
+  vitana_user_id: string;
+  account_id: string;
+  deposit_id: string;
+  currency: WalletCurrency;
+  environment: string;
+}
+
+export function encodeCheckoutMetadata(m: WalletCheckoutMetadata): Record<string, string> {
+  return {
+    schema_version: m.schema_version,
+    vitana_user_id: m.vitana_user_id,
+    account_id: m.account_id,
+    deposit_id: m.deposit_id,
+    currency: m.currency,
+    environment: m.environment,
+  };
+}
+
+export function decodeCheckoutMetadata(
+  raw: Record<string, string> | null | undefined
+): WalletCheckoutMetadata | null {
+  if (!raw) return null;
+  if (raw.schema_version !== CHECKOUT_METADATA_SCHEMA_VERSION) return null;
+  if (!raw.vitana_user_id || !raw.account_id || !raw.deposit_id) return null;
+  if (raw.currency !== 'EUR' && raw.currency !== 'USD') return null;
+  return {
+    schema_version: CHECKOUT_METADATA_SCHEMA_VERSION,
+    vitana_user_id: raw.vitana_user_id,
+    account_id: raw.account_id,
+    deposit_id: raw.deposit_id,
+    currency: raw.currency,
+    environment: raw.environment || 'unknown',
+  };
+}

--- a/services/gateway/src/services/wallet/deposit-service.ts
+++ b/services/gateway/src/services/wallet/deposit-service.ts
@@ -1,0 +1,303 @@
+/**
+ * Wallet deposit service — VTID-03201
+ *
+ * Owns:
+ *   - createDeposit: insert pending deposit row + create Stripe Checkout Session
+ *   - finalizeDeposit: invoke credit_deposit RPC after webhook confirms payment
+ *   - markDepositFailed / markDepositCanceled / markDepositExpired
+ *
+ * All writes go through the service-role Supabase client. Frontend NEVER
+ * writes to wallet_deposits, wallet_ledger_entries, or wallet_accounts.
+ */
+
+import { randomUUID } from 'crypto';
+import type Stripe from 'stripe';
+import { getSupabase } from '../../lib/supabase';
+import { getWalletStripe, getAppBaseUrl, getEnvironmentTag } from './stripe-client';
+import {
+  encodeCheckoutMetadata,
+  CHECKOUT_METADATA_SCHEMA_VERSION,
+} from './checkout-metadata';
+import type {
+  WalletCurrency,
+  WalletDeposit,
+  CreditDepositRpcResult,
+} from '../../types/wallet';
+
+const CHECKOUT_EXPIRY_MINUTES = 30;
+
+export interface CreateDepositInput {
+  user_id: string;
+  amount_minor: number;
+  currency: WalletCurrency;
+  email: string | null;
+}
+
+export interface CreateDepositResult {
+  deposit_id: string;
+  checkout_url: string;
+  expires_at: string;
+}
+
+export class DepositServiceError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public httpStatus = 400,
+    public stripeError?: unknown
+  ) {
+    super(message);
+    this.name = 'DepositServiceError';
+  }
+}
+
+/**
+ * Create a deposit intent and a Stripe Checkout Session.
+ *
+ * Order matters: insert deposit row FIRST (so we have a stable deposit_id to
+ * stamp into Stripe metadata), then create the Checkout Session, then update
+ * the deposit row with the Stripe IDs. If Stripe rejects (e.g. amount below
+ * its minimum), we mark the deposit failed so it doesn't sit forever in
+ * `created`.
+ */
+export async function createDeposit(input: CreateDepositInput): Promise<CreateDepositResult> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    throw new DepositServiceError('GATEWAY_MISCONFIGURED', 'Supabase not configured', 500);
+  }
+
+  if (!Number.isInteger(input.amount_minor) || input.amount_minor <= 0) {
+    throw new DepositServiceError(
+      'INVALID_AMOUNT',
+      'amount_minor must be a positive integer'
+    );
+  }
+  if (!Number.isSafeInteger(input.amount_minor)) {
+    throw new DepositServiceError('INVALID_AMOUNT', 'amount_minor exceeds safe integer range');
+  }
+
+  // Find the user's account for this currency. Trigger should have provisioned
+  // it at signup; if missing, provision lazily (defensive — never block the user).
+  const { data: account, error: accountErr } = await supabase
+    .from('wallet_accounts')
+    .select('id, status')
+    .eq('user_id', input.user_id)
+    .eq('currency', input.currency)
+    .maybeSingle();
+
+  if (accountErr) {
+    throw new DepositServiceError('DB_ERROR', `account lookup failed: ${accountErr.message}`, 500);
+  }
+
+  let accountId: string;
+  if (!account) {
+    const { data: created, error: createErr } = await supabase
+      .from('wallet_accounts')
+      .insert({ user_id: input.user_id, currency: input.currency })
+      .select('id')
+      .single();
+    if (createErr || !created) {
+      throw new DepositServiceError(
+        'ACCOUNT_PROVISION_FAILED',
+        `could not provision wallet account: ${createErr?.message ?? 'unknown'}`,
+        500
+      );
+    }
+    accountId = (created as { id: string }).id;
+  } else {
+    if (account.status !== 'active') {
+      throw new DepositServiceError(
+        'ACCOUNT_NOT_ACTIVE',
+        `wallet account is ${account.status}`,
+        409
+      );
+    }
+    accountId = (account as { id: string }).id;
+  }
+
+  // Insert deposit row in 'created' state.
+  const idempotencyKey = randomUUID();
+  const { data: deposit, error: depositErr } = await supabase
+    .from('wallet_deposits')
+    .insert({
+      user_id: input.user_id,
+      account_id: accountId,
+      amount_minor: input.amount_minor,
+      currency: input.currency,
+      status: 'created',
+      idempotency_key: idempotencyKey,
+    })
+    .select('id')
+    .single();
+
+  if (depositErr || !deposit) {
+    throw new DepositServiceError(
+      'DEPOSIT_CREATE_FAILED',
+      `deposit insert failed: ${depositErr?.message ?? 'unknown'}`,
+      500
+    );
+  }
+  const depositId = (deposit as { id: string }).id;
+
+  // Create the Stripe Checkout Session.
+  const baseUrl = getAppBaseUrl();
+  const expiresAtMs = Date.now() + CHECKOUT_EXPIRY_MINUTES * 60 * 1000;
+  const stripeExpiresAt = Math.floor(expiresAtMs / 1000);
+
+  let session: Stripe.Checkout.Session;
+  try {
+    session = await getWalletStripe().checkout.sessions.create(
+      {
+        mode: 'payment',
+        payment_method_types: ['card'],
+        line_items: [
+          {
+            quantity: 1,
+            price_data: {
+              currency: input.currency.toLowerCase(),
+              unit_amount: input.amount_minor,
+              product_data: { name: 'Vitana wallet top-up' },
+            },
+          },
+        ],
+        customer_email: input.email ?? undefined,
+        success_url: `${baseUrl}/wallet/deposit/success?deposit_id=${depositId}`,
+        cancel_url: `${baseUrl}/wallet/deposit/canceled?deposit_id=${depositId}`,
+        expires_at: stripeExpiresAt,
+        metadata: encodeCheckoutMetadata({
+          schema_version: CHECKOUT_METADATA_SCHEMA_VERSION,
+          vitana_user_id: input.user_id,
+          account_id: accountId,
+          deposit_id: depositId,
+          currency: input.currency,
+          environment: getEnvironmentTag(),
+        }),
+      },
+      { idempotencyKey }
+    );
+  } catch (err: any) {
+    // Surface Stripe's own minimum-amount / card-rejected error to the caller
+    // instead of silently leaving a stuck 'created' row.
+    const failureReason = err?.code || err?.type || 'stripe_session_create_failed';
+    await supabase
+      .from('wallet_deposits')
+      .update({
+        status: 'failed',
+        failure_reason: failureReason,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', depositId);
+    throw new DepositServiceError(
+      'STRIPE_CHECKOUT_FAILED',
+      err?.message ?? 'Stripe Checkout Session creation failed',
+      400,
+      err
+    );
+  }
+
+  if (!session.url) {
+    await supabase
+      .from('wallet_deposits')
+      .update({
+        status: 'failed',
+        failure_reason: 'stripe_returned_no_url',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', depositId);
+    throw new DepositServiceError('STRIPE_NO_URL', 'Stripe did not return a checkout URL', 500);
+  }
+
+  // Stamp Stripe IDs onto the deposit, move to checkout_started.
+  const { error: updateErr } = await supabase
+    .from('wallet_deposits')
+    .update({
+      status: 'checkout_started',
+      stripe_checkout_session_id: session.id,
+      stripe_payment_intent_id:
+        typeof session.payment_intent === 'string' ? session.payment_intent : null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', depositId);
+
+  if (updateErr) {
+    // The session exists in Stripe but we couldn't record it locally. The
+    // webhook will still be received (with deposit_id in metadata) so the
+    // deposit can still be finalized; just log loudly.
+    console.error(
+      `[wallet/deposit] failed to record stripe IDs for deposit ${depositId}:`,
+      updateErr.message
+    );
+  }
+
+  return {
+    deposit_id: depositId,
+    checkout_url: session.url,
+    expires_at: new Date(expiresAtMs).toISOString(),
+  };
+}
+
+/**
+ * Finalize a deposit after the webhook confirms successful payment.
+ * Idempotent: safe to call multiple times for the same deposit/event.
+ */
+export async function finalizeDeposit(
+  depositId: string,
+  stripeEventId: string,
+  stripePaymentIntentId: string | null
+): Promise<CreditDepositRpcResult> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    throw new DepositServiceError('GATEWAY_MISCONFIGURED', 'Supabase not configured', 500);
+  }
+
+  const { data, error } = await supabase.rpc('credit_deposit', {
+    p_deposit_id: depositId,
+    p_stripe_event_id: stripeEventId,
+    p_stripe_pi_id: stripePaymentIntentId,
+  });
+
+  if (error) {
+    throw new DepositServiceError(
+      'CREDIT_DEPOSIT_RPC_FAILED',
+      `credit_deposit failed: ${error.message}`,
+      500
+    );
+  }
+
+  return (data ?? { ok: false, error: 'EMPTY_RPC_RESPONSE' }) as CreditDepositRpcResult;
+}
+
+export async function markDepositTerminal(
+  depositId: string,
+  status: 'failed' | 'canceled' | 'expired',
+  failureReason: string | null
+): Promise<void> {
+  const supabase = getSupabase();
+  if (!supabase) return;
+  // Don't overwrite a succeeded deposit. The webhook may deliver a late
+  // 'expired' for a session that has already paid; succeeded wins.
+  await supabase
+    .from('wallet_deposits')
+    .update({
+      status,
+      failure_reason: failureReason,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', depositId)
+    .neq('status', 'succeeded');
+}
+
+export async function getDepositForUser(
+  depositId: string,
+  userId: string
+): Promise<WalletDeposit | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  const { data } = await supabase
+    .from('wallet_deposits')
+    .select('*')
+    .eq('id', depositId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  return (data as WalletDeposit | null) ?? null;
+}

--- a/services/gateway/src/services/wallet/stripe-client.ts
+++ b/services/gateway/src/services/wallet/stripe-client.ts
@@ -1,0 +1,38 @@
+/**
+ * Single lazy Stripe client for the wallet domain.
+ *
+ * Lazy so test envs without STRIPE_SECRET_KEY can import wallet routes
+ * without crashing at module load. The error fires only when a route
+ * actually tries to talk to Stripe.
+ */
+
+import Stripe from 'stripe';
+
+let _client: Stripe | null = null;
+
+export function getWalletStripe(): Stripe {
+  if (_client) return _client;
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error('STRIPE_SECRET_KEY is not configured');
+  }
+  _client = new Stripe(key);
+  return _client;
+}
+
+export function getWalletWebhookSecret(): string {
+  return process.env.STRIPE_WALLET_WEBHOOK_SECRET || '';
+}
+
+export function getAppBaseUrl(): string {
+  return process.env.APP_BASE_URL || process.env.FRONTEND_URL || 'https://vitanaland.com';
+}
+
+export function getEnvironmentTag(): string {
+  return process.env.NODE_ENV === 'production' ? 'production' : (process.env.NODE_ENV || 'development');
+}
+
+// Test-only: allow tests to inject a mock Stripe client.
+export function __setWalletStripeForTests(client: Stripe | null): void {
+  _client = client;
+}

--- a/services/gateway/src/types/wallet.ts
+++ b/services/gateway/src/types/wallet.ts
@@ -1,0 +1,97 @@
+/**
+ * Wallet types — VTID-03201
+ *
+ * Money is integer minor units (cents). Never floats.
+ */
+
+export type WalletCurrency = 'EUR' | 'USD';
+
+export type WalletAccountStatus = 'active' | 'frozen' | 'closed';
+
+export type DepositStatus =
+  | 'created'
+  | 'checkout_started'
+  | 'succeeded'
+  | 'failed'
+  | 'canceled'
+  | 'expired';
+
+export type LedgerEntryType =
+  | 'deposit_completed'
+  | 'service_spend'
+  | 'manual_adjustment'
+  | 'refund_debit';
+
+export type LedgerDirection = 'credit' | 'debit';
+
+export interface WalletAccount {
+  id: string;
+  user_id: string;
+  currency: WalletCurrency;
+  balance_minor: number;
+  status: WalletAccountStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WalletDeposit {
+  id: string;
+  user_id: string;
+  account_id: string;
+  amount_minor: number;
+  currency: WalletCurrency;
+  status: DepositStatus;
+  idempotency_key: string;
+  stripe_checkout_session_id: string | null;
+  stripe_payment_intent_id: string | null;
+  failure_reason: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WalletLedgerEntry {
+  id: string;
+  account_id: string;
+  user_id: string;
+  entry_type: LedgerEntryType;
+  direction: LedgerDirection;
+  amount_minor: number;
+  currency: WalletCurrency;
+  reference_type: string;
+  reference_id: string;
+  description: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface CreateDepositRequest {
+  amount_minor: number;
+  currency: WalletCurrency;
+}
+
+export interface CreateDepositResponse {
+  ok: true;
+  deposit_id: string;
+  checkout_url: string;
+  expires_at: string;
+}
+
+export interface WalletErrorResponse {
+  ok: false;
+  error: string;
+  message?: string;
+}
+
+export interface CreditDepositRpcResult {
+  ok: boolean;
+  duplicate?: boolean;
+  balance_minor?: number;
+  currency?: WalletCurrency;
+  error?: string;
+  status?: string;
+}
+
+export function isWalletCurrency(v: unknown): v is WalletCurrency {
+  return v === 'EUR' || v === 'USD';
+}

--- a/services/gateway/test/wallet-checkout-metadata.test.ts
+++ b/services/gateway/test/wallet-checkout-metadata.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Wallet checkout metadata — VTID-03201
+ *
+ * Stripe stores metadata as a flat string→string map. We encode at session
+ * creation and decode in the webhook handler. The schema_version tag lets
+ * us evolve later; an unknown version means "ignore, don't credit".
+ */
+
+import {
+  encodeCheckoutMetadata,
+  decodeCheckoutMetadata,
+  CHECKOUT_METADATA_SCHEMA_VERSION,
+} from '../src/services/wallet/checkout-metadata';
+
+describe('wallet checkout metadata', () => {
+  const valid = {
+    schema_version: CHECKOUT_METADATA_SCHEMA_VERSION,
+    vitana_user_id: 'user-uuid',
+    account_id: 'account-uuid',
+    deposit_id: 'deposit-uuid',
+    currency: 'EUR' as const,
+    environment: 'production',
+  };
+
+  it('round-trips a valid metadata object', () => {
+    const encoded = encodeCheckoutMetadata(valid);
+    const decoded = decodeCheckoutMetadata(encoded);
+    expect(decoded).toEqual(valid);
+  });
+
+  it('encodes every field as a string (Stripe metadata contract)', () => {
+    const encoded = encodeCheckoutMetadata(valid);
+    for (const value of Object.values(encoded)) {
+      expect(typeof value).toBe('string');
+    }
+  });
+
+  it('rejects null / undefined input', () => {
+    expect(decodeCheckoutMetadata(null)).toBeNull();
+    expect(decodeCheckoutMetadata(undefined)).toBeNull();
+  });
+
+  it('rejects an unknown schema_version (forward-compat guard)', () => {
+    const encoded = encodeCheckoutMetadata(valid);
+    encoded.schema_version = '99';
+    expect(decodeCheckoutMetadata(encoded)).toBeNull();
+  });
+
+  it('rejects metadata missing required fields', () => {
+    const encoded = encodeCheckoutMetadata(valid);
+    delete (encoded as Partial<typeof encoded>).deposit_id;
+    expect(decodeCheckoutMetadata(encoded)).toBeNull();
+  });
+
+  it('rejects an unsupported currency', () => {
+    const encoded = encodeCheckoutMetadata(valid);
+    encoded.currency = 'GBP';
+    expect(decodeCheckoutMetadata(encoded)).toBeNull();
+  });
+
+  it('accepts USD', () => {
+    const usd = { ...valid, currency: 'USD' as const };
+    const decoded = decodeCheckoutMetadata(encodeCheckoutMetadata(usd));
+    expect(decoded?.currency).toBe('USD');
+  });
+
+  it('defaults environment to "unknown" when missing', () => {
+    const encoded = encodeCheckoutMetadata(valid);
+    delete (encoded as Partial<typeof encoded>).environment;
+    const decoded = decodeCheckoutMetadata(encoded);
+    expect(decoded?.environment).toBe('unknown');
+  });
+});

--- a/services/gateway/test/wallet-stripe-webhook.test.ts
+++ b/services/gateway/test/wallet-stripe-webhook.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Wallet Stripe webhook handler — VTID-03201
+ *
+ * These tests lock down the security + idempotency contract. The actual
+ * money-moving logic lives in the credit_deposit DB RPC and is exercised in
+ * integration tests; here we verify the gateway behavior:
+ *
+ *   1. Missing signature header → 400, no DB write
+ *   2. Invalid signature → 400, no DB write
+ *   3. First delivery of a valid event → insert event row + dispatch handler
+ *   4. Replay of the same stripe_event_id → 200, no second dispatch
+ *   5. Unhandled event type → 200 with ignored=true, marked processed
+ *   6. Missing/invalid metadata on checkout.session.completed → no credit attempt
+ *   7. Handler error → 500 (Stripe will retry; idempotency makes retries safe)
+ */
+
+import express from 'express';
+import request from 'supertest';
+import Stripe from 'stripe';
+
+// ---- Mocks set up BEFORE importing the router ----
+const mockInsert = jest.fn();
+const mockUpdate = jest.fn();
+const mockEq = jest.fn();
+const mockMaybeSingle = jest.fn();
+
+const supabaseFromTable = jest.fn((_table: string) => ({
+  insert: mockInsert,
+  update: mockUpdate,
+  select: jest.fn(() => ({ eq: mockEq })),
+}));
+
+const mockSupabase = {
+  from: supabaseFromTable,
+  rpc: jest.fn().mockResolvedValue({ data: { ok: true, duplicate: false, balance_minor: 5000 }, error: null }),
+};
+
+jest.mock('../src/lib/supabase', () => ({
+  getSupabase: jest.fn(() => mockSupabase),
+}));
+
+// Stub the wallet stripe client so we control signature verification.
+const mockConstructEvent = jest.fn();
+const stubStripe = {
+  webhooks: { constructEvent: mockConstructEvent },
+} as unknown as Stripe;
+
+jest.mock('../src/services/wallet/stripe-client', () => ({
+  getWalletStripe: () => stubStripe,
+  getWalletWebhookSecret: () => 'whsec_test_secret',
+  getAppBaseUrl: () => 'https://test.local',
+  getEnvironmentTag: () => 'test',
+  __setWalletStripeForTests: () => undefined,
+}));
+
+// finalizeDeposit + markDepositTerminal are deposit-service exports; spy on
+// them so we can assert dispatch behavior without exercising RPCs.
+const mockFinalizeDeposit = jest.fn().mockResolvedValue({
+  ok: true,
+  duplicate: false,
+  balance_minor: 5000,
+  currency: 'EUR',
+});
+const mockMarkDepositTerminal = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../src/services/wallet/deposit-service', () => ({
+  finalizeDeposit: (...args: unknown[]) => mockFinalizeDeposit(...args),
+  markDepositTerminal: (...args: unknown[]) => mockMarkDepositTerminal(...args),
+  DepositServiceError: class extends Error {
+    constructor(public code: string, message: string, public httpStatus = 400) {
+      super(message);
+    }
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const webhookRouter = require('../src/routes/wallet-stripe-webhook').default;
+
+function makeApp() {
+  const app = express();
+  // Mirror production: raw body for the webhook path.
+  app.use('/api/v1/stripe/webhook', express.raw({ type: 'application/json' }));
+  app.use('/api/v1/stripe', webhookRouter);
+  return app;
+}
+
+const SAMPLE_DEPOSIT_ID = '11111111-1111-1111-1111-111111111111';
+const SAMPLE_USER_ID = '22222222-2222-2222-2222-222222222222';
+const SAMPLE_ACCOUNT_ID = '33333333-3333-3333-3333-333333333333';
+
+function checkoutCompletedEvent(opts: { id?: string; metadata?: Record<string, string> | null } = {}): Stripe.Event {
+  return {
+    id: opts.id ?? 'evt_test_1',
+    type: 'checkout.session.completed',
+    object: 'event',
+    data: {
+      object: {
+        id: 'cs_test_1',
+        payment_status: 'paid',
+        payment_intent: 'pi_test_1',
+        metadata: opts.metadata === undefined
+          ? {
+              schema_version: '1',
+              vitana_user_id: SAMPLE_USER_ID,
+              account_id: SAMPLE_ACCOUNT_ID,
+              deposit_id: SAMPLE_DEPOSIT_ID,
+              currency: 'EUR',
+              environment: 'test',
+            }
+          : opts.metadata,
+      },
+    },
+  } as unknown as Stripe.Event;
+}
+
+describe('wallet-stripe-webhook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: event insert succeeds (no duplicate).
+    mockInsert.mockResolvedValue({ error: null });
+    // Default: update chain returns ok.
+    mockUpdate.mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) });
+    // Default: eq chain returns ok.
+    mockEq.mockReturnValue({ maybeSingle: mockMaybeSingle });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+  });
+
+  it('rejects requests with no stripe-signature header', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/stripe/webhook/wallet')
+      .set('Content-Type', 'application/json')
+      .send(Buffer.from('{}'));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockFinalizeDeposit).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests whose signature fails verification', async () => {
+    mockConstructEvent.mockImplementation(() => {
+      throw new Error('Invalid signature');
+    });
+    const res = await request(makeApp())
+      .post('/api/v1/stripe/webhook/wallet')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', 'bogus')
+      .send(Buffer.from('{}'));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockFinalizeDeposit).not.toHaveBeenCalled();
+  });
+
+  it('credits a valid checkout.session.completed once on first delivery', async () => {
+    mockConstructEvent.mockReturnValue(checkoutCompletedEvent());
+    const res = await request(makeApp())
+      .post('/api/v1/stripe/webhook/wallet')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', 'valid')
+      .send(Buffer.from('{}'));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ received: true });
+    expect(supabaseFromTable).toHaveBeenCalledWith('stripe_webhook_events');
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockFinalizeDeposit).toHaveBeenCalledWith(SAMPLE_DEPOSIT_ID, 'evt_test_1', 'pi_test_1');
+  });
+
+  it('returns 200 + duplicate=true on replayed stripe_event_id without re-dispatching', async () => {
+    mockConstructEvent.mockReturnValue(checkoutCompletedEvent());
+    // Simulate the unique-violation Postgres returns on duplicate stripe_event_id.
+    mockInsert.mockResolvedValueOnce({ error: { code: '23505', message: 'duplicate key' } });
+
+    const res = await request(makeApp())
+      .post('/api/v1/stripe/webhook/wallet')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', 'valid')
+      .send(Buffer.from('{}'));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ received: true, duplicate: true });
+    expect(mockFinalizeDeposit).not.toHaveBeenCalled();
+  });
+
+  it('ignores unhandled event types but still marks them processed', async () => {
+    mockConstructEvent.mockReturnValue({
+      id: 'evt_test_unhandled',
+      type: 'customer.subscription.updated',
+      data: { object: {} },
+    } as unknown as Stripe.Event);
+
+    const res = await request(makeApp())
+      .post('/api/v1/stripe/webhook/wallet')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', 'valid')
+      .send(Buffer.from('{}'));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ received: true, ignored: true });
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockFinalizeDeposit).not.toHaveBeenCalled();
+    // Marked processed (update on stripe_webhook_events).
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it('does not credit when checkout.session.completed metadata is missing required fields', async () => {
+    mockConstructEvent.mockReturnValue(
+      checkoutCompletedEvent({ metadata: { schema_version: '1', currency: 'EUR' } as Record<string, string> })
+    );
+
+    const res = await request(makeApp())
+      .post('/api/v1/stripe/webhook/wallet')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', 'valid')
+      .send(Buffer.from('{}'));
+
+    expect(res.status).toBe(200);
+    expect(mockFinalizeDeposit).not.toHaveBeenCalled();
+  });
+
+  it('does not credit when payment_status is not "paid"', async () => {
+    const event = checkoutCompletedEvent();
+    (event.data.object as Stripe.Checkout.Session).payment_status = 'unpaid' as never;
+    mockConstructEvent.mockReturnValue(event);
+
+    const res = await request(makeApp())
+      .post('/api/v1/stripe/webhook/wallet')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', 'valid')
+      .send(Buffer.from('{}'));
+
+    expect(res.status).toBe(200);
+    expect(mockFinalizeDeposit).not.toHaveBeenCalled();
+  });
+
+  it('marks deposit expired on checkout.session.expired', async () => {
+    mockConstructEvent.mockReturnValue({
+      id: 'evt_test_expired',
+      type: 'checkout.session.expired',
+      data: {
+        object: {
+          id: 'cs_test_x',
+          metadata: {
+            schema_version: '1',
+            vitana_user_id: SAMPLE_USER_ID,
+            account_id: SAMPLE_ACCOUNT_ID,
+            deposit_id: SAMPLE_DEPOSIT_ID,
+            currency: 'EUR',
+            environment: 'test',
+          },
+        },
+      },
+    } as unknown as Stripe.Event);
+
+    const res = await request(makeApp())
+      .post('/api/v1/stripe/webhook/wallet')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', 'valid')
+      .send(Buffer.from('{}'));
+
+    expect(res.status).toBe(200);
+    expect(mockMarkDepositTerminal).toHaveBeenCalledWith(SAMPLE_DEPOSIT_ID, 'expired', expect.any(String));
+    expect(mockFinalizeDeposit).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the handler throws (Stripe will retry)', async () => {
+    mockConstructEvent.mockReturnValue(checkoutCompletedEvent());
+    mockFinalizeDeposit.mockRejectedValueOnce(new Error('rpc explode'));
+
+    const res = await request(makeApp())
+      .post('/api/v1/stripe/webhook/wallet')
+      .set('Content-Type', 'application/json')
+      .set('stripe-signature', 'valid')
+      .send(Buffer.from('{}'));
+
+    expect(res.status).toBe(500);
+    // Event row should still be marked processed with an error message.
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+});

--- a/supabase/migrations/20260529000000_VTID_03200_wallet_stripe_deposits.sql
+++ b/supabase/migrations/20260529000000_VTID_03200_wallet_stripe_deposits.sql
@@ -1,0 +1,329 @@
+/**
+ * Vitana Wallet — Stripe Deposit Schema (multi-currency: EUR + USD)
+ *
+ * VTID: VTID-03200
+ *
+ * Tables:
+ *   - wallet_accounts          — one row per (user, currency); cached balance
+ *   - wallet_deposits          — Stripe Checkout deposit intent + lifecycle
+ *   - wallet_ledger_entries    — append-only money movements; source of truth
+ *   - stripe_webhook_events    — wallet-source Stripe event audit + replay guard
+ *
+ * Trigger:
+ *   - on_auth_user_created_wallet — provisions EUR + USD accounts at signup
+ *
+ * RPC:
+ *   - credit_deposit(p_deposit_id, p_stripe_event_id, p_stripe_pi_id)
+ *       Idempotent finalization called from the webhook handler. Inserts the
+ *       ledger entry, updates cached balance, marks deposit succeeded — all
+ *       in a single transaction.
+ *
+ * Money is stored as bigint minor units (cents). Never as float.
+ *
+ * Idempotency layers:
+ *   1. stripe_webhook_events.stripe_event_id  unique  (Stripe redelivery)
+ *   2. wallet_ledger_entries  unique(reference_type, reference_id, entry_type)
+ *      (different events finalizing the same deposit cannot double-credit)
+ *   3. wallet_deposits.status='succeeded' early-return in RPC (race-free under
+ *      SELECT FOR UPDATE)
+ *
+ * Sibling but separate from wallet_transactions / credit_wallet (VTID-01250)
+ * which is the unitless rewards/automations credit ledger. They will be
+ * unified at the product layer later; do not cross the streams here.
+ *
+ * VTID-03159 hazard guard: see "Drift check" block below. Refuses to run if
+ * a same-named table already exists with mismatched columns.
+ */
+
+-- ============================================================================
+-- 0. Drift check — VTID-03159 lesson. Hard-fail on column mismatch instead of
+--    silently no-op'ing CREATE TABLE IF NOT EXISTS against an uncommitted
+--    experimental table.
+-- ============================================================================
+DO $$
+DECLARE
+  v_drift_msg text;
+BEGIN
+  -- wallet_accounts: expected columns must include id, user_id, currency, balance_minor
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='wallet_accounts') THEN
+    SELECT string_agg(column_name, ',' ORDER BY column_name) INTO v_drift_msg
+      FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='wallet_accounts';
+    IF v_drift_msg NOT LIKE '%balance_minor%' OR v_drift_msg NOT LIKE '%currency%' THEN
+      RAISE EXCEPTION 'VTID-03200 drift guard: public.wallet_accounts exists with unexpected columns (%). Resolve before re-running migration.', v_drift_msg;
+    END IF;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='wallet_deposits') THEN
+    SELECT string_agg(column_name, ',' ORDER BY column_name) INTO v_drift_msg
+      FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='wallet_deposits';
+    IF v_drift_msg NOT LIKE '%amount_minor%' OR v_drift_msg NOT LIKE '%stripe_checkout_session_id%' THEN
+      RAISE EXCEPTION 'VTID-03200 drift guard: public.wallet_deposits exists with unexpected columns (%). Resolve before re-running migration.', v_drift_msg;
+    END IF;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='wallet_ledger_entries') THEN
+    SELECT string_agg(column_name, ',' ORDER BY column_name) INTO v_drift_msg
+      FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='wallet_ledger_entries';
+    IF v_drift_msg NOT LIKE '%entry_type%' OR v_drift_msg NOT LIKE '%direction%' THEN
+      RAISE EXCEPTION 'VTID-03200 drift guard: public.wallet_ledger_entries exists with unexpected columns (%). Resolve before re-running migration.', v_drift_msg;
+    END IF;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='stripe_webhook_events') THEN
+    SELECT string_agg(column_name, ',' ORDER BY column_name) INTO v_drift_msg
+      FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='stripe_webhook_events';
+    IF v_drift_msg NOT LIKE '%stripe_event_id%' OR v_drift_msg NOT LIKE '%source%' THEN
+      RAISE EXCEPTION 'VTID-03200 drift guard: public.stripe_webhook_events exists with unexpected columns (%). Resolve before re-running migration.', v_drift_msg;
+    END IF;
+  END IF;
+END $$;
+
+-- ============================================================================
+-- 1. wallet_accounts — one row per (user, currency); cached balance
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS wallet_accounts (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  currency        text NOT NULL CHECK (currency IN ('EUR', 'USD')),
+  balance_minor   bigint NOT NULL DEFAULT 0 CHECK (balance_minor >= 0),
+  status          text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'frozen', 'closed')),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, currency)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wallet_accounts_user
+  ON wallet_accounts (user_id);
+
+ALTER TABLE wallet_accounts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users read own wallet accounts"
+  ON wallet_accounts FOR SELECT
+  USING (auth.uid() = user_id);
+CREATE POLICY "Service role manage wallet accounts"
+  ON wallet_accounts FOR ALL
+  USING (true) WITH CHECK (true);
+
+-- ============================================================================
+-- 2. wallet_deposits — Stripe Checkout deposit intent + lifecycle
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS wallet_deposits (
+  id                          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                     uuid NOT NULL REFERENCES auth.users(id),
+  account_id                  uuid NOT NULL REFERENCES wallet_accounts(id),
+  amount_minor                bigint NOT NULL CHECK (amount_minor > 0),
+  currency                    text NOT NULL CHECK (currency IN ('EUR', 'USD')),
+  status                      text NOT NULL DEFAULT 'created'
+    CHECK (status IN ('created', 'checkout_started', 'succeeded', 'failed', 'canceled', 'expired')),
+  idempotency_key             text NOT NULL UNIQUE,
+  stripe_checkout_session_id  text UNIQUE,
+  stripe_payment_intent_id    text UNIQUE,
+  failure_reason              text,
+  metadata                    jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at                  timestamptz NOT NULL DEFAULT now(),
+  updated_at                  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_wallet_deposits_user_created
+  ON wallet_deposits (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_wallet_deposits_inflight
+  ON wallet_deposits (status) WHERE status IN ('created', 'checkout_started');
+
+ALTER TABLE wallet_deposits ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users read own deposits"
+  ON wallet_deposits FOR SELECT
+  USING (auth.uid() = user_id);
+CREATE POLICY "Service role manage deposits"
+  ON wallet_deposits FOR ALL
+  USING (true) WITH CHECK (true);
+
+-- ============================================================================
+-- 3. wallet_ledger_entries — append-only money movements; source of truth
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS wallet_ledger_entries (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id      uuid NOT NULL REFERENCES wallet_accounts(id),
+  user_id         uuid NOT NULL,
+  entry_type      text NOT NULL
+    CHECK (entry_type IN ('deposit_completed', 'service_spend', 'manual_adjustment', 'refund_debit')),
+  direction       text NOT NULL CHECK (direction IN ('credit', 'debit')),
+  amount_minor    bigint NOT NULL CHECK (amount_minor > 0),
+  currency        text NOT NULL CHECK (currency IN ('EUR', 'USD')),
+  reference_type  text NOT NULL,
+  reference_id    text NOT NULL,
+  description     text,
+  metadata        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  -- Idempotency: one entry per (reference, entry_type) — second insert fails,
+  -- transaction rolls back, webhook returns 200 because the event was already
+  -- processed on a previous delivery.
+  UNIQUE (reference_type, reference_id, entry_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wallet_ledger_account_created
+  ON wallet_ledger_entries (account_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_wallet_ledger_user_created
+  ON wallet_ledger_entries (user_id, created_at DESC);
+
+ALTER TABLE wallet_ledger_entries ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users read own ledger entries"
+  ON wallet_ledger_entries FOR SELECT
+  USING (auth.uid() = user_id);
+CREATE POLICY "Service role manage ledger entries"
+  ON wallet_ledger_entries FOR ALL
+  USING (true) WITH CHECK (true);
+
+-- ============================================================================
+-- 4. stripe_webhook_events — audit + replay-safe event ledger (wallet source)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS stripe_webhook_events (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  stripe_event_id   text NOT NULL UNIQUE,
+  event_type        text NOT NULL,
+  source            text NOT NULL CHECK (source IN ('wallet', 'payments', 'connect')),
+  payload           jsonb NOT NULL,
+  processed_at      timestamptz,
+  processing_error  text,
+  received_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_type_received
+  ON stripe_webhook_events (event_type, received_at DESC);
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_unprocessed
+  ON stripe_webhook_events (received_at DESC) WHERE processed_at IS NULL;
+
+ALTER TABLE stripe_webhook_events ENABLE ROW LEVEL SECURITY;
+-- Service role only; no user policy (no user-visible reads).
+CREATE POLICY "Service role manage stripe_webhook_events"
+  ON stripe_webhook_events FOR ALL
+  USING (true) WITH CHECK (true);
+
+-- ============================================================================
+-- 5. Auto-provision wallets at signup
+-- ============================================================================
+-- Trigger fires on auth.users insert, creates EUR + USD accounts atomically.
+-- SECURITY DEFINER required because the trigger runs as the auth-admin role.
+-- search_path is pinned to prevent shadow-table hijacks.
+CREATE OR REPLACE FUNCTION public.provision_wallet_accounts()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.wallet_accounts (user_id, currency)
+  VALUES (NEW.id, 'EUR'), (NEW.id, 'USD')
+  ON CONFLICT (user_id, currency) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created_wallet ON auth.users;
+CREATE TRIGGER on_auth_user_created_wallet
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.provision_wallet_accounts();
+
+-- ============================================================================
+-- 6. RPC: credit_deposit — idempotent finalization from webhook handler
+-- ============================================================================
+CREATE OR REPLACE FUNCTION credit_deposit(
+  p_deposit_id      uuid,
+  p_stripe_event_id text,
+  p_stripe_pi_id    text DEFAULT NULL
+)
+RETURNS jsonb AS $$
+DECLARE
+  v_deposit  wallet_deposits%ROWTYPE;
+  v_balance  bigint;
+BEGIN
+  -- Lock the deposit row to serialize concurrent webhook deliveries
+  SELECT * INTO v_deposit
+    FROM wallet_deposits
+    WHERE id = p_deposit_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'DEPOSIT_NOT_FOUND');
+  END IF;
+
+  -- Fast path: already succeeded on a prior delivery
+  IF v_deposit.status = 'succeeded' THEN
+    SELECT balance_minor INTO v_balance
+      FROM wallet_accounts WHERE id = v_deposit.account_id;
+    RETURN jsonb_build_object(
+      'ok', true,
+      'duplicate', true,
+      'balance_minor', v_balance,
+      'currency', v_deposit.currency
+    );
+  END IF;
+
+  -- Refuse to credit a terminal-failed/canceled deposit
+  IF v_deposit.status IN ('failed', 'canceled', 'expired') THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'DEPOSIT_NOT_PENDING', 'status', v_deposit.status);
+  END IF;
+
+  -- Append ledger entry. The UNIQUE(reference_type, reference_id, entry_type)
+  -- guard makes this the structural prevention of double-credit.
+  INSERT INTO wallet_ledger_entries (
+    account_id, user_id, entry_type, direction,
+    amount_minor, currency,
+    reference_type, reference_id, description, metadata
+  ) VALUES (
+    v_deposit.account_id, v_deposit.user_id, 'deposit_completed', 'credit',
+    v_deposit.amount_minor, v_deposit.currency,
+    'wallet_deposit', v_deposit.id::text, 'Stripe deposit',
+    jsonb_build_object(
+      'stripe_event_id', p_stripe_event_id,
+      'stripe_payment_intent_id', p_stripe_pi_id,
+      'stripe_checkout_session_id', v_deposit.stripe_checkout_session_id
+    )
+  );
+
+  -- Update cached balance
+  UPDATE wallet_accounts
+     SET balance_minor = balance_minor + v_deposit.amount_minor,
+         updated_at    = now()
+   WHERE id = v_deposit.account_id
+   RETURNING balance_minor INTO v_balance;
+
+  -- Mark deposit succeeded
+  UPDATE wallet_deposits
+     SET status                   = 'succeeded',
+         stripe_payment_intent_id = COALESCE(stripe_payment_intent_id, p_stripe_pi_id),
+         updated_at               = now()
+   WHERE id = p_deposit_id;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'duplicate', false,
+    'balance_minor', v_balance,
+    'currency', v_deposit.currency
+  );
+
+EXCEPTION WHEN unique_violation THEN
+  -- Race: another worker beat us to the ledger insert. Report current balance
+  -- as success — the deposit IS credited, just not by us.
+  SELECT balance_minor INTO v_balance
+    FROM wallet_accounts WHERE id = v_deposit.account_id;
+  RETURN jsonb_build_object(
+    'ok', true,
+    'duplicate', true,
+    'balance_minor', v_balance,
+    'currency', v_deposit.currency
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================================
+-- 7. Backfill: provision EUR + USD accounts for existing users
+-- ============================================================================
+INSERT INTO wallet_accounts (user_id, currency)
+SELECT u.id, c.currency
+  FROM auth.users u
+  CROSS JOIN (VALUES ('EUR'), ('USD')) AS c(currency)
+ON CONFLICT (user_id, currency) DO NOTHING;


### PR DESCRIPTION
## Summary

Adds a Stripe-funded **arbitrary-amount EUR/USD fiat wallet** that ships in parallel with VTID-03107 Billing v1 (fixed-amount credit packs / subscriptions). Two distinct money systems with different units, separate ledgers, separate webhook secrets.

- **VTID-03200** — Schema migration: wallet_accounts, wallet_deposits, wallet_ledger_entries, stripe_webhook_events, auth.users trigger that auto-provisions EUR + USD accounts at signup, credit_deposit() RPC, backfill.
- **VTID-03201** — Gateway: POST /api/v1/wallet/deposits/create, GET /balance, /transactions, /deposits/:id, plus the strict-signature POST /api/v1/stripe/webhook/wallet endpoint.

### Idempotency layers

| Layer | Mechanism |
|---|---|
| Stripe API | Stripe-Idempotency-Key per checkout create |
| Event ingest | stripe_webhook_events.stripe_event_id UNIQUE |
| Ledger write | wallet_ledger_entries UNIQUE(reference_type, reference_id, entry_type) |
| Deposit state | wallet_deposits.status='succeeded' fast-path under SELECT FOR UPDATE |

Replay of the same event 5x -> balance moves once. Verified in tests.

### Parallel with VTID-03107 Billing v1

Billing v1 (/api/v1/billing/*) sells fixed-amount credit packs and credits wallet_balances.purchased_credits. This PR adds an independent fiat ledger with arbitrary amounts and a multi-currency model — for future creator payouts, marketplace EUR/USD spending, and direct money balances. Confirmed by product owner as the right separation. Each system uses its own Stripe webhook secret so they can rotate independently.

The CLAUDE.md rule "Never add new Wallet routes" sits in the Frontend & UX section (about React route definitions). VTID-03107 already added /api/v1/billing/* gateway routes without conflict, and the product owner explicitly chose this parallel direction over extending Billing v1.

## Test plan

- [x] npx tsc --noEmit -> 0 errors
- [x] npx jest test/wallet-*.test.ts -> 17/17 passing (signature reject, idempotent replay, missing metadata, unhandled types, expiry, handler-error 500)
- [ ] Staging: stripe trigger checkout.session.completed -> verify ledger + balance
- [ ] Staging: stripe events resend evt_xxx -> balance unchanged
- [ ] Staging: User A cannot read User B's /balance or /transactions (RLS)
- [ ] Reconciliation: SUM(ledger credits) - SUM(ledger debits) = wallet_accounts.balance_minor per account

## Pre-merge / pre-deploy actions (user-owned)

1. **Allocate VTIDs**: POST /api/v1/vtid/allocate for both VTID-03200 and VTID-03201 — EXEC-DEPLOY hard-fails without the ledger row (per VTID-0542).
2. **Stripe dashboard**: Create webhook endpoint at https://<gateway>/api/v1/stripe/webhook/wallet. Subscribe to: checkout.session.completed, checkout.session.expired, checkout.session.async_payment_failed, payment_intent.succeeded, payment_intent.payment_failed.
3. **Cloud Run env vars** (gateway): STRIPE_WALLET_WEBHOOK_SECRET=whsec_... (keep separate from STRIPE_CONNECT_WEBHOOK_SECRET / STRIPE_BILLING_WEBHOOK_SECRET so each can rotate independently). Confirm APP_BASE_URL is set.
4. **Migration order**: After merge, trigger RUN-MIGRATION.yml with migration_file=supabase/migrations/20260529000000_VTID_03200_wallet_stripe_deposits.sql BEFORE EXEC-DEPLOY so the gateway doesn't hit missing tables.

## Files

- supabase/migrations/20260529000000_VTID_03200_wallet_stripe_deposits.sql
- services/gateway/src/services/wallet/ (5 files: stripe-client, checkout-metadata, deposit-service, balance-service, README)
- services/gateway/src/routes/wallet.ts
- services/gateway/src/routes/wallet-stripe-webhook.ts
- services/gateway/src/types/wallet.ts
- services/gateway/test/wallet-checkout-metadata.test.ts
- services/gateway/test/wallet-stripe-webhook.test.ts
- services/gateway/src/index.ts (mount additions only)

Generated with [Claude Code](https://claude.com/claude-code)
