### PR TITLE
fix(ops): seed app_users with email in VTID-03186 verification (VTID-03205)

### DIFF
--- a/supabase/ops/2026-05-29_VTID_03186_universal_cart_rls_verification.sql
+++ b/supabase/ops/2026-05-29_VTID_03186_universal_cart_rls_verification.sql
@@ -148,14 +148,24 @@ $check_triggers$;
 -- §2  Cascade & constraint behavior  (operating as service_role / superuser)
 -- ============================================================
 
--- Seed two synthetic test users in app_users (rolled back at end)
+-- Seed two synthetic test users in app_users (rolled back at end).
+-- VTID-03205 patch: app_users.email is `TEXT UNIQUE NOT NULL` per the
+-- VTID-01101 phase-A bootstrap migration. The original VTID-03186 ops
+-- script seeded only user_id, which would raise not_null_violation on
+-- email before any of the RLS / cascade assertions run. @example.invalid
+-- is RFC 6761 reserved for test use; the VTID-03186 prefix keeps email
+-- values unique even on re-run. display_name is nullable per the bootstrap
+-- migration but we set it for log readability.
 DO $seed_users$
 DECLARE
   user_a CONSTANT UUID := '00000000-0000-4000-a000-000000000a01';
   user_b CONSTANT UUID := '00000000-0000-4000-a000-000000000b01';
 BEGIN
-  INSERT INTO public.app_users (user_id) VALUES (user_a) ON CONFLICT DO NOTHING;
-  INSERT INTO public.app_users (user_id) VALUES (user_b) ON CONFLICT DO NOTHING;
+  INSERT INTO public.app_users (user_id, email, display_name)
+  VALUES
+    (user_a, 'vtid-03186-user-a@example.invalid', 'VTID-03186 User A'),
+    (user_b, 'vtid-03186-user-b@example.invalid', 'VTID-03186 User B')
+  ON CONFLICT (user_id) DO NOTHING;
 END
 $seed_users$;
 


### PR DESCRIPTION
## Why

`public.app_users.email` is `TEXT UNIQUE NOT NULL` per the VTID-01101 phase-A bootstrap migration. The VTID-03186 ops verification script (merged in [#2420](https://github.com/exafyltd/vitana-platform/pull/2420)) seeded test users with only `user_id`:

```sql
-- old (#2420):
INSERT INTO public.app_users (user_id) VALUES (user_a) ON CONFLICT DO NOTHING;
INSERT INTO public.app_users (user_id) VALUES (user_b) ON CONFLICT DO NOTHING;
```

That would `RAISE not_null_violation` on the `email` column before any of the §1–§4 RLS / cascade assertions ran — preventable red verification step right after a green migration apply. **Caught by operator review before dispatch.**

## What this changes

Single edit in `supabase/ops/2026-05-29_VTID_03186_universal_cart_rls_verification.sql`:

```sql
-- new (this PR):
INSERT INTO public.app_users (user_id, email, display_name)
VALUES
  (user_a, 'vtid-03186-user-a@example.invalid', 'VTID-03186 User A'),
  (user_b, 'vtid-03186-user-b@example.invalid', 'VTID-03186 User B')
ON CONFLICT (user_id) DO NOTHING;
```

- `@example.invalid` is RFC 6761 reserved for test use.
- `vtid-03186-user-{a,b}@example.invalid` keeps email values unique on re-run.
- `display_name` is nullable per the bootstrap migration but set for log readability.
- `ON CONFLICT (user_id) DO NOTHING` is now explicit (was bare `ON CONFLICT DO NOTHING`).

## Scope

- **No schema change.** No migration file touched.
- **No `RUN-MIGRATION.yml` dispatch.** The universal_* migration from #2420 is still held pending operator authorization.
- **Production DB state unchanged** by this PR.
- Ops verification script is read-only / ROLLBACK-at-end; even when eventually run, it leaves no rows behind.

## Test plan

- [ ] CI: `validate` check passes.
- [ ] Merge into `main`.
- [ ] Operator authorizes the VTID-03186 migration dispatch.
- [ ] After migration applies, operator runs the patched ops verification SQL via Supabase SQL editor / service-role psql.
- [ ] Expect `NOTICE: VTID-03186 RLS + schema verification: ALL CHECKS PASSED` instead of `ERROR: null value in column "email"`.

## Related

- PR [#2420](https://github.com/exafyltd/vitana-platform/pull/2420) (VTID-03186) — universal_* schema, awaiting operator dispatch authorization after this patch lands.
- Issue [#2371](https://github.com/exafyltd/vitana-platform/issues/2371) (VTID-03176) — Lovable-side vs gateway-side data layer reconciliation.
- PR [#2363](https://github.com/exafyltd/vitana-platform/pull/2363) (VTID-03174) — `RUN-MIGRATION.yml` hardening (ensures any future failure of this verification step surfaces in CI rather than getting masked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)