### PR TITLE
fix(ops): bind GATEWAY_SERVICE_TOKEN on staging + fix consent heredoc (VTID-03207)

### DIFF
--- a/.github/workflows/BIND-STAGING-SERVICE-TOKEN.yml
+++ b/.github/workflows/BIND-STAGING-SERVICE-TOKEN.yml
@@ -1,0 +1,86 @@
+name: Bind GATEWAY_SERVICE_TOKEN env on gateway-staging (one-off)
+
+# VTID-03207 — bridge so the staging admin endpoints can authenticate.
+#
+# gateway-staging was not given a GATEWAY_SERVICE_TOKEN env var in Phase 0's
+# STAGE-DEPLOY.yml. The admin-staging.ts endpoint (VTID-03204) checks
+# process.env.GATEWAY_SERVICE_TOKEN; without it bound, every request is
+# rejected with 'invalid service token' even with a correct bearer.
+#
+# This workflow sets the env var on gateway-staging using the repo secret
+# GATEWAY_SERVICE_TOKEN (already exists, same value used by orb-agent
+# against prod gateway). One-off; once bound, future STAGE-DEPLOY runs
+# need to preserve it via the env_vars block in STAGE-DEPLOY.yml. That
+# preservation is a follow-up — for now we set it and trust the next
+# STAGE-DEPLOY's --set-env-vars (which replaces) doesn't clobber it
+# unless STAGE-DEPLOY.yml is updated to include it.
+#
+# IMPORTANT: --update-env-vars MERGES, not replaces. So this binding
+# survives across UPDATE-GATEWAY-ENV calls. It only gets clobbered if
+# STAGE-DEPLOY.yml re-runs with --set-env-vars that omits it. A
+# permanent fix would update STAGE-DEPLOY.yml; deferred as a small
+# follow-up commit.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'I-mean-bind' to confirm"
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bind:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Confirm intent
+        run: |
+          if [ "${{ inputs.confirm }}" != "I-mean-bind" ]; then
+            echo "::error::confirm input must be exactly 'I-mean-bind'"
+            exit 1
+          fi
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Bind GATEWAY_SERVICE_TOKEN on gateway-staging
+        env:
+          TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TOKEN:-}" ]; then
+            echo "::error::GATEWAY_SERVICE_TOKEN repo secret is empty"
+            exit 1
+          fi
+          # --update-env-vars MERGES with the existing env block (vs
+          # --set-env-vars which replaces). Cloud Run masks the value in
+          # logs since it appears in --update-env-vars (it's still in the
+          # service config which is queryable by anyone with run.services.get,
+          # but that's the existing surface area).
+          gcloud run services update gateway-staging \
+            --region=us-central1 --project=lovable-vitana-vers1 \
+            --update-env-vars="GATEWAY_SERVICE_TOKEN=${TOKEN}" \
+            --quiet
+
+          # Verify it's set (don't print the value)
+          HAS=$(gcloud run services describe gateway-staging \
+            --region=us-central1 --project=lovable-vitana-vers1 \
+            --format='value(spec.template.spec.containers[0].env)' \
+            | grep -c 'GATEWAY_SERVICE_TOKEN' || true)
+          echo "GATEWAY_SERVICE_TOKEN entries in spec: $HAS"
+
+          {
+            echo "## GATEWAY_SERVICE_TOKEN bound on gateway-staging"
+            echo ""
+            echo "Cloud Run revision will roll on next request; subsequent admin-staging"
+            echo "endpoint calls will validate the bearer token."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/SET-STAGING-TENANT-CONSENT.yml
+++ b/.github/workflows/SET-STAGING-TENANT-CONSENT.yml
@@ -94,10 +94,14 @@ jobs:
           echo "HTTP $HTTP_CODE"
           echo "Response: $BODY_RESP"
 
-          # Pretty-print summary into the GH step summary.
-          python3 <<PY
+          # Pretty-print summary into the GH step summary. Single-quoted
+          # heredoc so bash doesn't try to interpret backticks/${} inside
+          # the Python source. Values are passed via env to keep the
+          # heredoc body literal.
+          BODY_RESP="$BODY_RESP" HTTP_CODE="$HTTP_CODE" python3 <<'PY'
           import json, os
-          body = '''${BODY_RESP}'''
+          body = os.environ.get('BODY_RESP', '')
+          http_code = os.environ.get('HTTP_CODE', '?')
           try:
               d = json.loads(body)
           except Exception as e:
@@ -107,25 +111,25 @@ jobs:
           lines = []
           lines.append('## Staging tenant consent flip')
           lines.append('')
-          lines.append(f"- HTTP: `${HTTP_CODE}`")
-          lines.append(f"- ok: `{d.get('ok')}`")
-          lines.append(f"- dry_run: `{d.get('dry_run')}`")
-          lines.append(f"- scanned: `{d.get('scanned')}`")
-          lines.append(f"- already_consented: `{d.get('already_consented')}`")
+          lines.append(f'- HTTP: {http_code}')
+          lines.append(f'- ok: {d.get("ok")}')
+          lines.append(f'- dry_run: {d.get("dry_run")}')
+          lines.append(f'- scanned: {d.get("scanned")}')
+          lines.append(f'- already_consented: {d.get("already_consented")}')
           if d.get('dry_run'):
-              lines.append(f"- to_flip: `{d.get('to_flip')}`")
+              lines.append(f'- to_flip: {d.get("to_flip")}')
               sample = d.get('sample_to_flip', [])
               if sample:
-                  lines.append(f"- sample_to_flip: {', '.join('`'+s+'`' for s in sample[:5])}")
+                  lines.append('- sample_to_flip: ' + ', '.join(sample[:5]))
           else:
-              lines.append(f"- flipped: `{d.get('flipped')}`")
-              lines.append(f"- failed: `{d.get('failed')}`")
+              lines.append(f'- flipped: {d.get("flipped")}')
+              lines.append(f'- failed: {d.get("failed")}')
               fids = d.get('flipped_tenant_ids', [])
               if fids:
                   lines.append('')
                   lines.append('### Flipped tenants')
                   for t in fids[:20]:
-                      lines.append(f'  - `{t}`')
+                      lines.append('  - ' + t)
 
           summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
           if summary_path:


### PR DESCRIPTION
Two bundled fixes for the W2 cascade. (1) BIND-STAGING-SERVICE-TOKEN.yml — gateway-staging was never given GATEWAY_SERVICE_TOKEN as a Cloud Run env var (Phase 0 STAGE-DEPLOY.yml omits it), so the admin-staging endpoint shipped in #2423 always 401s on 'invalid service token'. New one-off workflow uses --update-env-vars (MERGE) to bind from the existing repo secret. (2) SET-STAGING-TENANT-CONSENT.yml bash heredoc was unquoted, so backticks inside d.get(...) were interpreted as command substitution and the summary script crashed. Switch to single-quoted heredoc + env-var passing pattern. After merge: bind → dry-run preview → apply → dataset cron → fine-tune submit.