### PR TITLE
feat(orb): turn-1 wake-decision observability snapshot (VTID-03210)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-pending-human-actions.md
+++ b/docs/superpowers/plans/2026-05-29-pending-human-actions.md
@@ -1,0 +1,20 @@
+# ORB Reconciliation — Pending Human / Out-of-Sandbox Actions
+
+Items the autonomous session cannot do, or that are in-flight. Each is logged here.
+
+## VTID-03210 — turn-1 wake-decision observability (PR-1, PR #2427)
+
+**VTID collision note:** PR-1 was originally marked VTID-03204. Between allocation-check and merge, a parallel session shipped VTID-03204 for an unrelated gateway endpoint (PR #2423, `data_export_ok`). Per the collision-at-merge rule, PR-1 was re-marked to a freshly **allocated** VTID. The branch slug `VTID-03204-wake-decision-observability` is retained (cosmetic; renaming a PR head ref is disruptive) — the authoritative marker is VTID-03210 in the commit, PR title, and ledger.
+
+**Done by the autonomous session:**
+- [x] **VTID ledger row** — allocated `VTID-03210` via `POST gateway.vitanaland.com/api/v1/vtid/allocate` (num=3210, id=dad4d62f…). `GET /api/v1/vtid/VTID-03210` confirms `status: allocated` — passes the EXEC-DEPLOY hard gate.
+- [x] Re-marked all code/doc/test references VTID-03204 → VTID-03210.
+
+**In flight / remaining:**
+- [ ] **PR merge** — merge PR #2427 once CI is green (authorized).
+- [ ] **Deploy** — AUTO-DEPLOY fires on merge to main; EXEC-DEPLOY may be triggered with `vtid=VTID-03210` if a manual deploy is needed.
+- [ ] **Production smokes** — a real authenticated vitanaland.com ORB session (Vertex) + a Command Hub LiveKit Test Bench session, then `grep '[wake-decision]'` in gateway logs to read: transport, winner, per-provider suppress reasons, turn1_collision, first_name source, and whether the spoken first line matched the selected decision.
+  - Note: server-side `[wake-decision]` lines are emitted on session start via API regardless of audio; true spoken-line confirmation needs a browser/device check (API success ≠ spoken success).
+- [ ] **gcloud reauth** — `gcloud auth login` (interactive) needed for direct Cloud Run log pulls; otherwise logs come via the `DEBUG-GATEWAY-LOGS.yml` workflow.
+
+This PR changes NO spoken behavior, so code tests suffice for code-complete; the production smoke is the *purpose* of the PR (it produces the R0-diagnostic log), not a merge gate.

--- a/docs/superpowers/plans/2026-05-30-vitana-assistant-original-plan-reconciliation.md
+++ b/docs/superpowers/plans/2026-05-30-vitana-assistant-original-plan-reconciliation.md
@@ -394,3 +394,13 @@ Otherwise: silent, continuous, autonomous. Begin.
 ```
 
 End of plan.
+
+---
+
+## 9. EXECUTION LOG (autonomous takeover)
+
+### 2026-05-31 — Audit complete + PR-1 (observability) code-complete
+- **Audit**: written to `docs/superpowers/plans/2026-05-31-orb-communication-audit.md` (sections A–G with file:line evidence). Confirmed: context wiring is SCATTERED (no unified awareness object); Teacher selection/content is SPLIT (permission line fires without content on resolver failure); Vertex/LiveKit share the decider but diverge on delivery, with a Vertex-only missing accept/dismiss telemetry gap masked by the LiveKit canary allowlist; the third companion plan doc does not exist on main.
+- **PR-1 (VTID-03210)** — turn-1 wake-decision observability, ZERO behavior change. New `orb/live/instruction/wake-decision-snapshot.ts` emits one structured `[wake-decision]` JSON line per session, identically on Vertex (`live-session-controller.ts`) and LiveKit (`orb-livekit.ts`): winner + provider key, per-provider suppress reasons, `turn1_collision` (≥2 turn-1 blocks co-present), firstName source, transport. This is recommendation G.1 — the smallest change that makes the turn-1 state machine observable and disambiguates R0 (allowlist-masking vs prompt-collision) from production logs. 11 unit tests + 232 touched-area orb tests green; `tsc` clean. Out-of-sandbox items logged in `2026-05-29-pending-human-actions.md`.
+- **Branch base decision**: all recovery work branches off `origin/main` (not the diverged `ops/autopilot-diagnose`).
+- **R0 status**: deferred — the observability line is the safe precursor; live R0 diagnosis (prod log pull / test accounts) runs after PR-1 ships so the logs exist to read.

--- a/docs/superpowers/plans/2026-05-31-orb-communication-audit.md
+++ b/docs/superpowers/plans/2026-05-31-orb-communication-audit.md
@@ -1,0 +1,66 @@
+# Vitana Assistant ORB — Communication Reconciliation Audit
+
+**Date**: 2026-05-31.
+**Basis**: `origin/main` @ `24b743dc` (read via a clean worktree, NOT a feature branch).
+**Author**: Claude (autonomous takeover session).
+**Companion to**: `2026-05-30-vitana-assistant-original-plan-reconciliation.md` (strategic R0–R9) and `2026-05-29-orb-recovery-autonomous-execution.md` (tactical 10-phase).
+
+This is the audit the reconciliation takeover required BEFORE any code. It maps which turn-1 pieces are wired, unwired, duplicated, dead, or fighting each other.
+
+## Plan-doc reality check
+- ✅ `2026-05-30-vitana-assistant-original-plan-reconciliation.md` — exists.
+- ✅ `2026-05-29-orb-recovery-autonomous-execution.md` — exists; **0 of 12 phases shipped** (every row `pending`, no Branch/PR/SHA).
+- ❌ `2026-05-29-orb-communication-recovery.md` — **DOES NOT EXIST on main.** Both surviving docs reference it as a real companion ("V1 recovery audit"). Its "Bug A / Bug D" race claims are unsourced — do not treat as authoritative.
+
+---
+
+## A. First-turn state machine
+One shared decider — `decideWakeBriefForSession` (`services/gateway/src/services/wake-brief-wiring.ts:246`) → `decideContinuation({surface:'orb_wake'})`, ranked by descending priority (`decide-continuation.ts:104-118`). Both transports call it: Vertex `live-session-controller.ts:1046`, LiveKit `routes/orb-livekit.ts:1574`. Eligibility/ranking identical; only delivery differs.
+
+| Priority | Provider | File | Notes |
+|---|---|---|---|
+| ≤100 (clamped to source) | `contextual_next_action` | `providers/next-action/index.ts:90,216` | composes 9 sources; suppresses if best < threshold 50 |
+| 90 | `new_day_return` | `providers/new-day-return.ts:64` | once per new calendar day (user TZ) |
+| 85 | `feature_discovery_teacher` | `providers/teacher/feature-discovery-teacher.ts:76` | not cadence-gated |
+| 80 | `voice_wake_brief` | `providers/voice-wake-brief.ts:199` | pure fallback; generic line / pillar nudge |
+
+**Absent providers the plan calls for:** `first-time-welcome` (only a `journey-greeting.ts` prompt block, not a ranked provider — `new-day-return.ts:496-503`), `goal-completion-inquiry` (no symbol).
+
+## B. Context wiring — VERDICT: SCATTERED. No unified awareness object.
+`awareness-unified-context.ts` / `buildUnifiedAwarenessContext` does not exist. Per session, `handleLiveSessionStart` fans out into 4+ independent pipelines writing loose `(session as any).*` fields: bootstrap/brain (`live-session-controller.ts:671-712`), decision spine (`:969-983`), firstName (`:1004-1044`), wake decision (`:1046-1079`), journey-greeting w/ its own `app_users` read (`:1187-1229`).
+- **Smoking gun 1:** `(session).decisionContext` set at `:983` but never read in `orb-live.ts` (grep → nothing); only `pillar_momentum` forwarded by value (`:1062`). The other 4 distilled fields are computed then dropped.
+- **Smoking gun 2:** two forked `AssistantDecisionContext` types (`orb/context/types.ts:469` vs `assistant-decision-context.ts:91`); the latter's compiler is reachable only via debug route `routes/voice-journey-context.ts:73`.
+- Disagreement risk: `vitana_index_scores` read limit-60 + limit-21 in same compile; firstName resolved up to 4× with different precedence; `life_compass` ~10 readers, no shared snapshot.
+
+## C. Teacher wiring — VERDICT: SPLIT (not atomic).
+- Permission line committed unconditionally: `live-session-controller.ts:1104-1121`.
+- Content resolved in a SEPARATE Supabase call AFTER the win: `:1144-1158` (`resolveTeacherModeContent`). Provider `produce()` (`feature-discovery-teacher.ts:293-479`) bundles only the line + cta payload.
+- Failure mode: blocks concatenated independently — `orb-live.ts:5822` appends the line ALWAYS; `:5850-5856` appends content only if resolved. On null/throw the catch (`:1164-1168`) logs and moves on → permission line fires with no turn-2 content (the documented VTID-03160 failure; comment at `:1230-1239`). No fall-through to next provider.
+- Ledger: `user_capability_awareness` (7 states), sole writer `advance_capability_awareness` RPC; cooldowns 7d/30d/3-strike.
+- Graduated-user track: **ABSENT** (only comment `feature-discovery-teacher.ts:316`). Suppresses → voice-wake-brief.
+
+## D. Generic-greeting drift sources
+1. `orb-live.ts:6670-6679` — legacy generic menu in `sendGreetingPromptToLiveAPI` (Vertex), reachable when no candidate + not a recognized cadence-skip. **Primary risk.**
+2. `voice-wake-brief.ts:95-110` — `DEFAULT_LINES` ("Hello! How can I help today?").
+3. `live-system-instruction.ts:413-528` — legacy `## GREETING POLICY` block; LiveKit omits it (`omitGreetingPolicy=true`), Vertex renders it under the override (soft conflict).
+4. `greeting-pools.ts:26-107` — short-gap pools (scoped, suppressed under override).
+5. `journey-greeting.ts` / `new-day-overview-prompt.ts` — forbid generic greetings but coexist with the Teacher override on new-day Vertex (VTID-03160 revert `:1230-1252`) and double-write `last_session_date`.
+
+**Cadence:** all writes fire-and-forget; `last_session_date` has TWO un-awaited writers (`new-day-return.ts:588` + `live-session-controller.ts:1263`) → race.
+
+## E. Vertex vs LiveKit parity — same decision, divergent delivery; 2 latent defects.
+- Same ranker both sides. Vertex injects once → model speaks → natively in context. LiveKit injects TWICE (gateway system-instruction override `orb-livekit.ts:1651-1678` + Python `session.say()` `session.py:2218`).
+- LiveKit `session.say(..., add_to_chat_ctx=bool(is_proactive_offer))` — generic greetings stay OUT of chat_ctx → model can deny saying it (VTID-03076 mode).
+- "Yes" handling: LiveKit intercepts + POSTs `/voice/next-action/event` (`session.py:1365`); **Vertex has no intercept** — OASIS `suggested→accepted` never closed. `active-provider-resolver.ts:104-190` pins non-allowlisted users to Vertex → the gap dominates production while the canary-only LiveKit path looks complete (the allowlist-masking asymmetry).
+- Parity tests: only `test/orb/routes/livekit-context-parity.test.ts`, a static source-text wire-up assertion. No behavioral first-turn parity test.
+
+## F. Missing pieces
+Unified awareness — ABSENT. Greeting-policy removal — NOT DONE. Atomic Teacher — PARTIAL (resolver exists, bundling absent). Graduated Teacher — ABSENT. First-time-welcome — ABSENT. Goal-completion — ABSENT. Parity tests — inadequate. 10-case acceptance suite — ABSENT. vitana-v1 ACT/DISMISS — separate repo (audit there). Match-journey hooks — STUBBED (`match-journey-context-provider.ts:140-144` returns `{journeyStage:'none'}`). Daily-greeting signals — wired except **"promises"** (`new-day-overview-payload.ts:197-241`). Also: `orb_session_state` table (Recovery ORB-2+3 dep) has no migration on main.
+
+## G. Recommended minimum PR sequence
+1. **PR-1 (VTID-03210) — observability only, zero behavior change.** One structured `[wake-decision]` log line per session on both transports: winner + per-provider suppress reasons, turn-1 block collision flag, firstName source, transport. Answers the R0 ambiguity (allowlist-masking vs prompt-collision) without touching spoken behavior. **← this PR.**
+2. PR-2 — close Teacher atomicity (C): bundle content into the candidate; errored → fall through.
+3. PR-3 — resolve Vertex turn-1 collision (D): override authoritative; suppress legacy greeting-policy on Vertex; stop the journey double-write.
+4. Then R1 unified awareness, R8 behavioral parity test, R6/R7 new providers.
+
+Each PR: one VTID, tests, Vertex+LiveKit evidence. "Done" = code tests + a real vitanaland.com ORB / LiveKit Test Bench spoken check.

--- a/services/gateway/node_modules
+++ b/services/gateway/node_modules
@@ -1,0 +1,1 @@
+/mnt/c/Users/dstev/vitana-platform/services/gateway/node_modules

--- a/services/gateway/src/orb/live/instruction/wake-decision-snapshot.ts
+++ b/services/gateway/src/orb/live/instruction/wake-decision-snapshot.ts
@@ -1,0 +1,199 @@
+/**
+ * VTID-03210 — Turn-1 wake-decision observability snapshot.
+ *
+ * PURPOSE (observability only — ZERO behavior change):
+ * The ORB's first spoken turn is decided by a fan-out of providers
+ * (contextual_next_action / new_day_return / feature_discovery_teacher /
+ * voice_wake_brief) whose ranking + suppression evidence, the set of
+ * turn-1 prompt blocks that end up co-present (wakeBriefOverride /
+ * teacherModeContent / journeyGreeting), the resolved first name + its
+ * source, and the transport (Vertex vs LiveKit) are currently scattered
+ * across several independent `console.log` lines per VTID. That makes two
+ * production questions hard to answer from logs:
+ *
+ *   1. ALLOWLIST MASKING — is a given user actually on Vertex or LiveKit?
+ *      (a single `transport` field per session answers this.)
+ *   2. TURN-1 BLOCK COLLISION — does the Vertex prompt carry the legacy
+ *      greeting policy + a verbatim wake-brief override + a journey
+ *      greeting block at the same time? (`turn1_collision` flags it.)
+ *
+ * This module emits ONE structured line per session, identically on both
+ * transports, so the turn-1 state machine becomes observable at a glance.
+ * It performs NO IO, mutates nothing, and is safe to call on every wake.
+ */
+
+import type { AssistantContinuationDecision } from '../../../services/assistant-continuation/types';
+
+export type WakeTransport = 'vertex' | 'livekit';
+
+/** Which source resolved the first name (precedence is path-specific). */
+export type FirstNameSource =
+  | 'memory_facts'
+  | 'app_users'
+  | 'email'
+  | 'none'
+  | 'unknown';
+
+export interface WakeDecisionSnapshotInput {
+  transport: WakeTransport;
+  sessionId: string;
+  /** The wake-brief decision carrier, or null when the decision threw. */
+  decision: AssistantContinuationDecision | null;
+  /** Presence of each turn-1 prompt block on the session at emit time. */
+  blocks: {
+    wakeBriefOverride: boolean;
+    teacherModeContent: boolean;
+    journeyGreeting: boolean;
+  };
+  firstName: { value: string | null; source: FirstNameSource };
+  lang: string;
+  bucket?: string | null;
+  isReconnect?: boolean;
+  timezonePresent?: boolean;
+}
+
+export interface WakeDecisionSnapshot {
+  tag: 'wake_decision';
+  transport: WakeTransport;
+  session_id: string;
+  decision_id: string | null;
+  winner: {
+    provider_key: string;
+    kind: string;
+    source_kind: string | null;
+    dedupe_key: string | null;
+    line_present: boolean;
+    line_chars: number;
+  } | null;
+  /** Rolled-up reason when no provider returned a candidate. */
+  suppression_reason: string | null;
+  /** One row per provider invoked — suppressed/errored rows included. */
+  providers: Array<{
+    key: string;
+    status: string;
+    reason: string | null;
+    latency_ms: number;
+  }>;
+  turn1_blocks: {
+    wake_brief_override: boolean;
+    teacher_mode_content: boolean;
+    journey_greeting: boolean;
+  };
+  turn1_block_count: number;
+  /** True when ≥2 turn-1 blocks are simultaneously present (drift hazard). */
+  turn1_collision: boolean;
+  first_name: { present: boolean; source: FirstNameSource; len: number };
+  lang: string;
+  bucket: string | null;
+  is_reconnect: boolean;
+  timezone_present: boolean;
+}
+
+const STRUCTURED_LOG_PREFIX = '[wake-decision]';
+
+/** Pure: derive the source kind (`source:*` evidence) from the winner. */
+function deriveSourceKind(
+  decision: AssistantContinuationDecision | null,
+): string | null {
+  const selected = decision?.selectedContinuation;
+  if (!selected || selected.kind === 'none_with_reason') return null;
+  const evidence = selected.evidence ?? [];
+  const sourced = evidence.find((e) => e.kind?.startsWith('source:'));
+  return sourced?.kind ?? null;
+}
+
+/**
+ * Pure: map the winning candidate back to the provider key that produced
+ * it, by matching on dedupeKey within sourceProviderResults. Falls back to
+ * the source kind, then the candidate kind.
+ */
+function deriveWinnerProviderKey(
+  decision: AssistantContinuationDecision | null,
+): string {
+  const selected = decision?.selectedContinuation;
+  if (!selected) return 'none';
+  const match = (decision?.sourceProviderResults ?? []).find(
+    (r) => r.status === 'returned' && r.candidate?.dedupeKey === selected.dedupeKey,
+  );
+  if (match) return match.providerKey;
+  return deriveSourceKind(decision) ?? selected.kind;
+}
+
+/** Pure builder — no IO, no clock, no mutation. Safe to unit-test. */
+export function buildWakeDecisionSnapshot(
+  input: WakeDecisionSnapshotInput,
+): WakeDecisionSnapshot {
+  const { decision } = input;
+  const selected = decision?.selectedContinuation ?? null;
+  const hasRealWinner = !!selected && selected.kind !== 'none_with_reason';
+
+  const blockCount =
+    (input.blocks.wakeBriefOverride ? 1 : 0) +
+    (input.blocks.teacherModeContent ? 1 : 0) +
+    (input.blocks.journeyGreeting ? 1 : 0);
+
+  const line = selected?.userFacingLine?.trim() ?? '';
+
+  return {
+    tag: 'wake_decision',
+    transport: input.transport,
+    session_id: input.sessionId,
+    decision_id: decision?.decisionId ?? null,
+    winner: hasRealWinner
+      ? {
+          provider_key: deriveWinnerProviderKey(decision),
+          kind: selected!.kind,
+          source_kind: deriveSourceKind(decision),
+          dedupe_key: selected!.dedupeKey ?? null,
+          line_present: line.length > 0,
+          line_chars: line.length,
+        }
+      : null,
+    suppression_reason: hasRealWinner
+      ? null
+      : decision?.suppressionReason ??
+        (selected?.kind === 'none_with_reason'
+          ? selected.suppressReason ?? null
+          : null),
+    providers: (decision?.sourceProviderResults ?? []).map((r) => ({
+      key: r.providerKey,
+      status: r.status,
+      reason: r.reason ?? null,
+      latency_ms: r.latencyMs,
+    })),
+    turn1_blocks: {
+      wake_brief_override: input.blocks.wakeBriefOverride,
+      teacher_mode_content: input.blocks.teacherModeContent,
+      journey_greeting: input.blocks.journeyGreeting,
+    },
+    turn1_block_count: blockCount,
+    turn1_collision: blockCount >= 2,
+    first_name: {
+      present: !!input.firstName.value,
+      source: input.firstName.source,
+      len: input.firstName.value?.length ?? 0,
+    },
+    lang: input.lang,
+    bucket: input.bucket ?? null,
+    is_reconnect: !!input.isReconnect,
+    timezone_present: !!input.timezonePresent,
+  };
+}
+
+/**
+ * Emit the snapshot as one structured JSON line. Stable prefix so Cloud
+ * Run / Management-API log queries can `grep '[wake-decision]'` and parse
+ * the JSON. Never throws — observability must not break the voice path.
+ */
+export function logWakeDecisionSnapshot(
+  input: WakeDecisionSnapshotInput,
+): WakeDecisionSnapshot {
+  const snapshot = buildWakeDecisionSnapshot(input);
+  try {
+    // eslint-disable-next-line no-console
+    console.log(`${STRUCTURED_LOG_PREFIX} ${JSON.stringify(snapshot)}`);
+  } catch {
+    // Serialization must never break the session.
+  }
+  return snapshot;
+}

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -72,6 +72,11 @@ import {
 import { emitOasisEvent } from '../../../services/oasis-event-service';
 import { defaultWakeTimelineRecorder } from '../../../services/wake-timeline/wake-timeline-recorder';
 import { decideWakeBriefForSession } from '../../../services/wake-brief-wiring';
+// VTID-03210: single structured turn-1 wake-decision observability line.
+import {
+  logWakeDecisionSnapshot,
+  type FirstNameSource,
+} from '../instruction/wake-decision-snapshot';
 import { recordAgentHeartbeat } from '../../../routes/agents-registry';
 import {
   fetchAdminBriefingBlock,
@@ -982,8 +987,16 @@ export async function handleLiveSessionStart(
   }
   (session as any).decisionContext = decisionContextVertex;
 
+  // VTID-03210: hoisted out of the wake-brief try below so the single
+  // turn-1 wake-decision snapshot (emitted after the journey-greeting
+  // block) can read them outside that try's scope.
+  let firstName: string | null = null;
+  let firstNameSource: FirstNameSource = 'none';
+  let wakeBucketForSnapshot: string | null = null;
+
   try {
     const temporal = deps.describeTimeSince(session.lastSessionInfo);
+    wakeBucketForSnapshot = temporal.bucket;
     const { getSupabase } = await import('../../../lib/supabase');
     const supabaseClient = getSupabase() ?? undefined;
     const { fetchWakeCadenceSignals } = await import('../../../services/wake-cadence-signals');
@@ -1001,7 +1014,10 @@ export async function handleLiveSessionStart(
     //      name in the email handle, e.g. "dragan@..." → "dragan").
     // Best-effort: every fetch failure leaves firstName null, which sends
     // the Teacher to the no-name pool (still correct, just less personal).
-    let firstName: string | null = null;
+    // VTID-03210: firstName + firstNameSource are declared in the outer
+    // scope (above this try). firstNameSource tracks which source resolved
+    // the name (memory_facts -> app_users -> email) so the documented
+    // multi-source name-disagreement risk is observable in the snapshot.
     if (supabaseClient && orbIdentity?.tenant_id && orbIdentity?.user_id) {
       const [cadenceResult, factResult, profileResult] = await Promise.allSettled([
         fetchWakeCadenceSignals({
@@ -1025,22 +1041,33 @@ export async function handleLiveSessionStart(
         cadenceSignals = cadenceResult.value;
       }
       let fullName = '';
+      let fullNameSource: FirstNameSource = 'none';
       if (factResult.status === 'fulfilled' && factResult.value && !factResult.value.error) {
         const v = (factResult.value.data as { fact_value?: string | null } | null)?.fact_value;
-        if (typeof v === 'string' && v.trim().length > 0) fullName = v.trim();
+        if (typeof v === 'string' && v.trim().length > 0) {
+          fullName = v.trim();
+          fullNameSource = 'memory_facts';
+        }
       }
       if (!fullName && profileResult.status === 'fulfilled' && profileResult.value && !profileResult.value.error) {
         const v = (profileResult.value.data as { display_name?: string | null } | null)?.display_name;
-        if (typeof v === 'string' && v.trim().length > 0) fullName = v.trim();
+        if (typeof v === 'string' && v.trim().length > 0) {
+          fullName = v.trim();
+          fullNameSource = 'app_users';
+        }
       }
       if (fullName) {
         firstName = fullName.split(/\s+/)[0] || null;
+        firstNameSource = firstName ? fullNameSource : 'none';
       } else if (orbIdentity.email && orbIdentity.email.includes('@')) {
         // Last-resort: take the email local part. Strip digits / underscores
         // so "dragan1" → "dragan", "d_stevanovic" → "stevanovic" (best effort).
         const local = orbIdentity.email.split('@')[0] || '';
         const stripped = local.replace(/[0-9_.+\-]+/g, '').trim();
-        if (stripped.length >= 2) firstName = stripped[0].toUpperCase() + stripped.slice(1);
+        if (stripped.length >= 2) {
+          firstName = stripped[0].toUpperCase() + stripped.slice(1);
+          firstNameSource = 'email';
+        }
       }
     }
     wakeBriefDecision = await decideWakeBriefForSession({
@@ -1272,6 +1299,26 @@ export async function handleLiveSessionStart(
       `[VTID-03154] journey-greeting resolution failed (non-fatal) for ${sessionId}: ${(e as Error).message}`,
     );
   }
+
+  // VTID-03210: emit ONE structured turn-1 wake-decision snapshot. Runs
+  // after both the wake-brief and journey-greeting blocks are resolved so
+  // turn1_collision can see all three turn-1 blocks at once. Observability
+  // only — never throws, mutates nothing.
+  logWakeDecisionSnapshot({
+    transport: 'vertex',
+    sessionId,
+    decision: wakeBriefDecision,
+    blocks: {
+      wakeBriefOverride: !!session.wakeBriefOverrideBlock,
+      teacherModeContent: !!(session as any).teacherModeContent,
+      journeyGreeting: !!(session as any).journeyGreetingBlock,
+    },
+    firstName: { value: firstName, source: firstNameSource },
+    lang,
+    bucket: wakeBucketForSnapshot,
+    isReconnect: isReconnectStart,
+    timezonePresent: !!session.clientContext?.timezone,
+  });
 
   // Emit OASIS event with identity context
   await deps.emitLiveSessionEvent('vtid.live.session.start', {

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -38,6 +38,13 @@ import { AccessToken } from 'livekit-server-sdk';
 import * as jose from 'jose';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import { getSupabase } from '../lib/supabase';
+// VTID-03210: single structured turn-1 wake-decision snapshot — emitted
+// identically on Vertex (live-session-controller) and here on LiveKit so
+// the turn-1 state machine is observable across both transports.
+import {
+  logWakeDecisionSnapshot,
+  type FirstNameSource,
+} from '../orb/live/instruction/wake-decision-snapshot';
 // VTID-02855: reuse Vertex's geo-IP + UA-parse + format helpers so the
 // LiveKit bootstrap injects the same ENVIRONMENT CONTEXT block (city,
 // country, timezone, localTime, UTC, device) that Vertex's authenticated
@@ -1345,6 +1352,13 @@ router.get(
     const userNameFact = identityFacts.find((f) => f.fact_key === 'user_name');
     const fullName = (userNameFact?.fact_value || displayName || '').trim();
     const firstName = fullName ? fullName.split(/\s+/)[0] : null;
+    // VTID-03210: label the source the same way the Vertex path does so the
+    // wake-decision snapshot's first_name.source is comparable across both.
+    const firstNameSource: FirstNameSource = !firstName
+      ? 'none'
+      : (userNameFact?.fact_value || '').trim()
+        ? 'memory_facts'
+        : 'app_users';
 
     // VTID-02855: ENVIRONMENT CONTEXT — geo-IP + UA + local time, mirrors
     // Vertex's orb-live.ts:14026 path. The fetch itself was moved INTO
@@ -1539,6 +1553,9 @@ router.get(
     // is not yet routed into the spoken first words (deferred per the
     // B0d.4 design rule until timeline data confirms the path is healthy).
     let wakeBriefDecision: Awaited<ReturnType<typeof decideWakeBriefForSession>> | null = null;
+    // VTID-03210: hoisted to handler scope so the wake-decision snapshot
+    // (emitted below, after the override re-render) can read the bucket.
+    let wakeBucketForSnapshot: string | null = null;
     if (userId && tenantId) {
       try {
         // LiveKit bootstrap has no long-lived session_id at this point —
@@ -1552,6 +1569,7 @@ router.get(
         // bootstrap, same value reaches both buildLiveSystemInstruction call
         // sites and the wake-brief decision.
         const temporal = describeTimeSince(lastSessionInfo);
+        wakeBucketForSnapshot = temporal.bucket;
         // VTID-03081 (B1 wiring): read cadence signals from
         // user_assistant_state so decideGreetingPolicy() can apply the
         // 15-min greet-once cap, same-style downgrade, and heavy-day
@@ -1641,10 +1659,12 @@ router.get(
     // live-system-instruction.ts detects the marker and removes the
     // competing vitana-brain opener sections so the override actually
     // owns the first turn.
+    let wakeOverrideApplied = false;
     try {
       const picked = wakeBriefDecision?.selectedContinuation ?? null;
       const line = picked?.userFacingLine?.trim();
       if (picked && line && line.length > 0 && !isReconnect) {
+        wakeOverrideApplied = true;
         const { buildVertexWakeBriefBlock } = await import(
           '../orb/live/session/live-session-controller'
         );
@@ -1685,6 +1705,31 @@ router.get(
         `[${VTID}/VTID-03100] override re-render failed (non-fatal — falls back to pre-override system_instruction): ${(exc as Error).message}`,
       );
     }
+
+    // VTID-03210: emit the SAME structured turn-1 wake-decision snapshot as
+    // the Vertex path (live-session-controller). LiveKit composes the first
+    // turn differently — the wake-brief override is the only turn-1 block in
+    // this handler (teacher-mode / journey-greeting blocks are Vertex-session
+    // constructs), so those flags are false here. The shared shape makes the
+    // Vertex/LiveKit asymmetry directly comparable in logs.
+    logWakeDecisionSnapshot({
+      transport: 'livekit',
+      sessionId: `livekit-bootstrap-${agentId}`,
+      decision: wakeBriefDecision,
+      blocks: {
+        wakeBriefOverride: wakeOverrideApplied,
+        teacherModeContent: false,
+        journeyGreeting: false,
+      },
+      firstName: { value: firstName, source: firstNameSource },
+      lang,
+      bucket: wakeBucketForSnapshot,
+      isReconnect,
+      timezonePresent: !!(
+        (envContext as { timezone?: string } | undefined)?.timezone ??
+        (envContext as { clientContext?: { timezone?: string } } | undefined)?.clientContext?.timezone
+      ),
+    });
 
     const responsePayload: Record<string, unknown> = {
       ok: true,

--- a/services/gateway/test/orb/live/instruction/wake-decision-snapshot.test.ts
+++ b/services/gateway/test/orb/live/instruction/wake-decision-snapshot.test.ts
@@ -1,0 +1,192 @@
+/**
+ * VTID-03210 — Turn-1 wake-decision observability snapshot tests.
+ *
+ * The snapshot is the smallest-drift first step of the ORB communication
+ * reconciliation: it makes the turn-1 state machine observable without
+ * changing any spoken behavior. These tests lock the builder's contract:
+ *   - winner mapping (provider key via dedupeKey, source kind, line chars)
+ *   - none/suppression path
+ *   - turn1_collision when ≥2 turn-1 blocks co-present (the documented
+ *     Vertex drift hazard)
+ *   - firstName presence/source/len passthrough
+ *   - provider-result passthrough (suppressed/errored rows kept)
+ *   - Vertex/LiveKit parity: identical builder, identical shape
+ */
+
+import {
+  buildWakeDecisionSnapshot,
+  logWakeDecisionSnapshot,
+  type WakeDecisionSnapshotInput,
+} from '../../../../src/orb/live/instruction/wake-decision-snapshot';
+import type {
+  AssistantContinuationDecision,
+  AssistantContinuation,
+  ProviderResult,
+} from '../../../../src/services/assistant-continuation/types';
+
+function makeWinner(
+  overrides: Partial<AssistantContinuation> = {},
+): AssistantContinuation {
+  return {
+    id: 'c1',
+    kind: 'feature_discovery',
+    userFacingLine: 'Welcome back, Dragan. May I show you something new?',
+    cta: { label: '', toolName: null, payload: {} } as never,
+    evidence: [{ kind: 'source:feature_discovery_teacher', detail: 'cap=life_compass' } as never],
+    dedupeKey: 'teacher:life_compass',
+  } as AssistantContinuation as never;
+}
+
+function makeDecision(
+  overrides: Partial<AssistantContinuationDecision> = {},
+): AssistantContinuationDecision {
+  const winner = makeWinner();
+  const providerResults: ProviderResult[] = [
+    { providerKey: 'contextual_next_action', status: 'suppressed', latencyMs: 12, reason: 'no_chosen_candidate' },
+    { providerKey: 'new_day_return', status: 'suppressed', latencyMs: 8, reason: 'same_day_recent' },
+    { providerKey: 'feature_discovery_teacher', status: 'returned', latencyMs: 21, candidate: winner },
+    { providerKey: 'voice_wake_brief', status: 'returned', latencyMs: 3, candidate: makeWinner({ dedupeKey: 'wake:warm', kind: 'wake_brief' } as never) },
+  ];
+  return {
+    decisionId: 'dec-123',
+    selectedContinuation: winner,
+    decisionStartedAt: '2026-05-31T08:00:00.000Z',
+    decisionFinishedAt: '2026-05-31T08:00:00.050Z',
+    sourceProviderResults: providerResults,
+    telemetryContext: { surface: 'orb_wake' },
+    ...overrides,
+  };
+}
+
+const BASE: WakeDecisionSnapshotInput = {
+  transport: 'vertex',
+  sessionId: 'sess-1',
+  decision: makeDecision(),
+  blocks: { wakeBriefOverride: true, teacherModeContent: true, journeyGreeting: false },
+  firstName: { value: 'Dragan', source: 'memory_facts' },
+  lang: 'de',
+  bucket: 'returning',
+  isReconnect: false,
+  timezonePresent: true,
+};
+
+describe('buildWakeDecisionSnapshot', () => {
+  it('maps the winner to its provider key via dedupeKey + derives source kind', () => {
+    const snap = buildWakeDecisionSnapshot(BASE);
+    expect(snap.winner).not.toBeNull();
+    expect(snap.winner!.provider_key).toBe('feature_discovery_teacher');
+    expect(snap.winner!.kind).toBe('feature_discovery');
+    expect(snap.winner!.source_kind).toBe('source:feature_discovery_teacher');
+    expect(snap.winner!.dedupe_key).toBe('teacher:life_compass');
+    expect(snap.winner!.line_present).toBe(true);
+    expect(snap.winner!.line_chars).toBeGreaterThan(0);
+    expect(snap.suppression_reason).toBeNull();
+    expect(snap.decision_id).toBe('dec-123');
+  });
+
+  it('flags turn1_collision when ≥2 turn-1 blocks are present', () => {
+    const snap = buildWakeDecisionSnapshot(BASE); // override + teacher
+    expect(snap.turn1_block_count).toBe(2);
+    expect(snap.turn1_collision).toBe(true);
+  });
+
+  it('does not flag collision when only one turn-1 block is present', () => {
+    const snap = buildWakeDecisionSnapshot({
+      ...BASE,
+      blocks: { wakeBriefOverride: true, teacherModeContent: false, journeyGreeting: false },
+    });
+    expect(snap.turn1_block_count).toBe(1);
+    expect(snap.turn1_collision).toBe(false);
+  });
+
+  it('flags the worst-case 3-block collision', () => {
+    const snap = buildWakeDecisionSnapshot({
+      ...BASE,
+      blocks: { wakeBriefOverride: true, teacherModeContent: true, journeyGreeting: true },
+    });
+    expect(snap.turn1_block_count).toBe(3);
+    expect(snap.turn1_collision).toBe(true);
+  });
+
+  it('passes every provider result through, including suppressed/errored rows', () => {
+    const snap = buildWakeDecisionSnapshot(BASE);
+    expect(snap.providers).toHaveLength(4);
+    const byKey = Object.fromEntries(snap.providers.map((p) => [p.key, p]));
+    expect(byKey.contextual_next_action.status).toBe('suppressed');
+    expect(byKey.contextual_next_action.reason).toBe('no_chosen_candidate');
+    expect(byKey.new_day_return.reason).toBe('same_day_recent');
+  });
+
+  it('reports the no-winner suppression path', () => {
+    const snap = buildWakeDecisionSnapshot({
+      ...BASE,
+      decision: makeDecision({ selectedContinuation: null, suppressionReason: 'all_providers_suppressed' }),
+    });
+    expect(snap.winner).toBeNull();
+    expect(snap.suppression_reason).toBe('all_providers_suppressed');
+  });
+
+  it('treats a none_with_reason candidate as no winner and surfaces its reason', () => {
+    const none = {
+      id: 'none-x',
+      kind: 'none_with_reason',
+      userFacingLine: '',
+      cta: { label: '', toolName: null, payload: {} },
+      evidence: [],
+      dedupeKey: 'none-x',
+      suppressReason: 'cadence_skip',
+    } as unknown as AssistantContinuation;
+    const snap = buildWakeDecisionSnapshot({
+      ...BASE,
+      decision: makeDecision({ selectedContinuation: none, suppressionReason: undefined }),
+    });
+    expect(snap.winner).toBeNull();
+    expect(snap.suppression_reason).toBe('cadence_skip');
+  });
+
+  it('passes firstName presence/source/len through', () => {
+    const snap = buildWakeDecisionSnapshot(BASE);
+    expect(snap.first_name).toEqual({ present: true, source: 'memory_facts', len: 6 });
+
+    const none = buildWakeDecisionSnapshot({
+      ...BASE,
+      firstName: { value: null, source: 'none' },
+    });
+    expect(none.first_name).toEqual({ present: false, source: 'none', len: 0 });
+  });
+
+  it('handles a null decision (decision threw) without crashing', () => {
+    const snap = buildWakeDecisionSnapshot({ ...BASE, decision: null });
+    expect(snap.winner).toBeNull();
+    expect(snap.decision_id).toBeNull();
+    expect(snap.providers).toEqual([]);
+  });
+
+  it('produces a structurally identical shape on both transports (parity)', () => {
+    const vertex = buildWakeDecisionSnapshot({ ...BASE, transport: 'vertex' });
+    const livekit = buildWakeDecisionSnapshot({ ...BASE, transport: 'livekit' });
+    expect(Object.keys(vertex).sort()).toEqual(Object.keys(livekit).sort());
+    expect(vertex.transport).toBe('vertex');
+    expect(livekit.transport).toBe('livekit');
+    // Same decision in → same winner/collision out regardless of transport.
+    expect(vertex.winner).toEqual(livekit.winner);
+    expect(vertex.turn1_collision).toEqual(livekit.turn1_collision);
+  });
+});
+
+describe('logWakeDecisionSnapshot', () => {
+  it('emits exactly one [wake-decision] line of valid JSON and returns the snapshot', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const snap = logWakeDecisionSnapshot(BASE);
+      expect(spy).toHaveBeenCalledTimes(1);
+      const arg = spy.mock.calls[0][0] as string;
+      expect(arg.startsWith('[wake-decision] ')).toBe(true);
+      const parsed = JSON.parse(arg.slice('[wake-decision] '.length));
+      expect(parsed.tag).toBe('wake_decision');
+      expect(parsed).toEqual(snap);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## What

PR-1 of the ORB communication reconciliation (recommendation **G.1** in `docs/superpowers/plans/2026-05-31-orb-communication-audit.md`). **Observability only — zero behavior change.**

Adds `orb/live/instruction/wake-decision-snapshot.ts` (pure builder + logger) emitting ONE structured `[wake-decision]` JSON line per session, identically on both transports:
- `transport` (vertex | livekit) — the **allowlist-masking** signal
- `winner` — provider key (via `dedupeKey` → `sourceProviderResults`), source kind, line chars
- `providers[]` — per-provider status + suppress/error reasons
- `turn1_collision` — true when ≥2 turn-1 blocks (`wakeBriefOverride`/`teacherModeContent`/`journeyGreeting`) co-present (Vertex prompt-collision hazard)
- `first_name` — presence + source (`memory_facts`→`app_users`→`email`) + len

## Why
Makes the turn-1 state machine observable so production logs disambiguate the R0 blocker (allowlist-masking vs prompt-collision) without changing spoken behavior.

## Parity
- **Vertex** ✓ `live-session-controller.ts` (after wake-brief + journey blocks resolve).
- **LiveKit** ✓ `routes/orb-livekit.ts` `/orb/context-bootstrap` (after override re-render). Teacher/journey blocks are Vertex-session constructs → false here; shared shape makes the asymmetry comparable.

## Tests
11 unit tests + 232 touched-area orb tests green; `tsc` (build mode) clean.

## VTID
Originally VTID-03204; re-marked to freshly-allocated **VTID-03210** (ledger row created) after VTID-03204 collided with merged PR #2423. Branch slug retains the old VTID (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)