### PR TITLE
[FleetView] feat(orb): DEV-COMHU-0501 cross-provider speaking-state watchdog (ORB Recovery 0.1)

### DIFF
--- a/docs/patches/vitana-v1/ORB-0.1-speaking-watchdog.md
+++ b/docs/patches/vitana-v1/ORB-0.1-speaking-watchdog.md
@@ -1,0 +1,55 @@
+# vitana-v1 companion patch — ORB Recovery 0.1 (DEV-COMHU-0501)
+
+**Target repo:** `exafyltd/vitana-v1` (NOT reachable from the autonomous sandbox)
+**Companion to:** vitana-platform PR — cross-provider speaking-state watchdog in
+`services/gateway/src/frontend/command-hub/orb-widget.js`.
+
+The gateway-served Command Hub widget now carries the watchdog. The community
+surface (`vitanaland.com`) loads the SAME `orb-widget.js` from the gateway, so the
+watchdog logic ships automatically once the gateway deploys. Two things still need a
+human hand in the `vitana-v1` repo:
+
+## 1. Cache-bust bump (required)
+
+`vitana-v1` pins the widget version in its own HTML shell. Bump it so returning users
+fetch the watchdog build.
+
+```bash
+# in the vitana-v1 checkout
+grep -rn "orb-widget.js?v=" index.html src/ 2>/dev/null
+```
+
+Change the pinned query string to match the gateway:
+
+```diff
+- orb-widget.js?v=20260529-VTID-03185-audio-queue-closure
++ orb-widget.js?v=20260531-DEV-COMHU-0501-speaking-watchdog
+```
+
+## 2. LiveKit-path parity audit (recommended)
+
+The watchdog in `orb-widget.js` is transport-agnostic by design: it stamps
+`lastAudioReceivedAt` on every inbound frame routed through `_playAudio`, and clears a
+stuck `audioPlaying` when frames stop for ≥2 s with nothing scheduled/queued.
+
+`vitana-v1` drives LiveKit directly via the `livekit-client` SDK
+(`src/hooks/useLiveKitVoice.ts`). Confirm that LiveKit audio frames also funnel through
+the same `_playAudio` entry point (so `lastAudioReceivedAt` is stamped on the WebRTC
+path too). If LiveKit plays its remote track via a separate `<audio>` element / Web
+Audio node rather than `_playAudio`, add an equivalent stamp on the LiveKit
+`TrackSubscribed` / `track.on('message')` frame handler:
+
+```ts
+// in the LiveKit remote-audio frame path
+window.VitanaOrb && window.VitanaOrb._noteAudioFrame && window.VitanaOrb._noteAudioFrame();
+```
+
+(If you want this hook, the gateway widget can expose a tiny
+`VitanaOrb._noteAudioFrame = () => { _s.lastAudioReceivedAt = Date.now(); }` —
+tracked as a follow-up; not required for the Vertex/SSE path which already stamps.)
+
+## Acceptance (post-deploy, community surface)
+- Vertex multi-chunk TTS turn → watchdog does NOT fire (frames keep arriving).
+- Simulated stalled subscription (LiveKit) → "Vitana speaking" clears within ~2 s,
+  mic re-opens.
+- `[VTOrb] session diagnostics: ...` line present in console at session open.

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -16,7 +16,7 @@
     "validate:dev-frontend-spec": "node ./scripts/validate-dev-frontend-spec.mjs",
     "nav:sync": "tsx scripts/sync-nav-catalog-from-manifest.ts",
     "nav:check": "tsx scripts/sync-nav-catalog-from-manifest.ts --check",
-    "smoke:orb-widget": "node ./scripts/orb-widget-stop-regression.mjs && node ./scripts/orb-widget-audio-playback-regression.mjs"
+    "smoke:orb-widget": "node ./scripts/orb-widget-stop-regression.mjs && node ./scripts/orb-widget-audio-playback-regression.mjs && node ./scripts/orb-widget-speaking-watchdog-regression.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",

--- a/services/gateway/scripts/orb-widget-speaking-watchdog-regression.mjs
+++ b/services/gateway/scripts/orb-widget-speaking-watchdog-regression.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Regression (DEV-COMHU-0501 — ORB Recovery 0.1): the cross-provider
+ * speaking-state watchdog must exist and gate audioPlaying on cross-provider
+ * quiet detection, independent of the Vertex-specific onended path.
+ *
+ * VTID-03185 fixed the Vertex scheduled-source leak. The watchdog is the
+ * transport-agnostic backstop: when no audio frame has arrived for >= 2s AND
+ * nothing is scheduled AND the queue is empty, it force-clears the speaking
+ * state — covering the LiveKit WebRTC path (community surface) whose track
+ * lifecycle differs from Vertex BufferSources.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const sourcePath = resolve(repoRoot, 'services/gateway/src/frontend/command-hub/orb-widget.js');
+const source = readFileSync(sourcePath, 'utf8');
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`[orb-widget-speaking-watchdog-regression] FAIL: ${message}`);
+    process.exit(1);
+  }
+}
+
+function extractFunctionBody(signature) {
+  const sigIdx = source.indexOf(signature);
+  assert(sigIdx >= 0, `missing function signature: ${signature}`);
+  const openIdx = source.indexOf('{', sigIdx);
+  assert(openIdx >= 0, `missing function body open brace: ${signature}`);
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    if (c === '}') depth--;
+    if (depth === 0) return source.slice(openIdx + 1, i);
+  }
+  throw new Error(`unclosed function body: ${signature}`);
+}
+
+// 1. The watchdog method exists.
+const body = extractFunctionBody('function _speakingStateWatchdog()');
+
+// 2. It gates on all three transport-agnostic conditions.
+assert(/lastAudioReceivedAt/.test(body), 'watchdog must compare against lastAudioReceivedAt.');
+assert(/scheduledSources\.length === 0/.test(body), 'watchdog must require zero scheduled sources.');
+assert(/audioQueue\.length === 0/.test(body), 'watchdog must require an empty audio queue.');
+assert(/audioPlaying = false/.test(body), 'watchdog must clear audioPlaying when it fires.');
+assert(/SPEAKING_WATCHDOG_QUIET_MS/.test(body), 'watchdog must use the quiet-window constant.');
+
+// 3. It early-returns when not speaking (so it is a no-op outside TTS turns).
+assert(/if \(!_s\.audioPlaying\) return;/.test(body), 'watchdog must no-op when audioPlaying is false.');
+
+// 4. Lifecycle: started on session open, stopped on session stop.
+assert(/_startSpeakingWatchdog\(\)/.test(source), 'watchdog must be started (on SSE open).');
+assert(/_stopSpeakingWatchdog\(\)/.test(source), 'watchdog must be stopped (in _sessionStop).');
+
+// 5. Every inbound frame stamps lastAudioReceivedAt (so healthy multi-chunk
+//    TTS keeps the watchdog from firing).
+const playAudioBody = extractFunctionBody('function _playAudio(base64Data, mimeType)');
+assert(
+  /_s\.lastAudioReceivedAt = Date\.now\(\);/.test(playAudioBody),
+  '_playAudio must stamp lastAudioReceivedAt on every inbound frame.',
+);
+
+// 6. The quiet window is the spec'd 2 seconds.
+assert(/SPEAKING_WATCHDOG_QUIET_MS = 2000/.test(source), 'quiet window must be 2000ms per spec.');
+
+console.log('[orb-widget-speaking-watchdog-regression] OK: cross-provider speaking-state watchdog present and wired.');

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -29,7 +29,7 @@
   <!-- VTID-01216: Intelligence Panel containers -->
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
-  <script src="/command-hub/orb-widget.js?v=20260529-VTID-03185-audio-queue-closure"></script>
+  <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0501-speaking-watchdog"></script>
   <script src="/command-hub/app.js?v=20260528-orb-voice-health-probe"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -147,6 +147,13 @@
     // Watchdogs
     clientWatchdogInterval: null,
     clientLastActivityAt: 0,
+    // DEV-COMHU-0501 — ORB Recovery 0.1: cross-provider speaking-state watchdog.
+    // lastAudioReceivedAt is stamped on every inbound audio frame (any source);
+    // the watchdog clears a stuck audioPlaying when frames stop arriving AND
+    // nothing is scheduled/queued, regardless of transport (Vertex SSE today,
+    // LiveKit WebRTC on the community surface tomorrow).
+    lastAudioReceivedAt: 0,
+    speakingWatchdogInterval: null,
     stuckGuardTimer: null,
     thinkingDelayTimer: null, // Delayed thinking state — only show if response takes > 1.5s
     thinkingProgressTimer: null, // Progress updates during long thinking
@@ -858,6 +865,9 @@
     // playbackCtx, so without this guard any late SSE audio (e.g. from a racy
     // _sessionStart that resolved after _sessionStop) plays in the background.
     if (_s._userInitiatedStop || !_s.overlayVisible) return;
+    // DEV-COMHU-0501: stamp the moment of the most recent inbound audio frame
+    // (transport-agnostic — every provider funnels playback through here).
+    _s.lastAudioReceivedAt = Date.now();
     _s.audioQueue.push({ data: base64Data, mime: mimeType });
     _processQueue();
   }
@@ -1166,6 +1176,17 @@
       es.onopen = function () {
         console.log('[VTOrb] SSE connected');
         _startWatchdog();
+        // DEV-COMHU-0501: arm the cross-provider speaking-state watchdog + emit
+        // a one-line session-shape diagnostic so stuck-speaking reports are
+        // debuggable from console logs alone.
+        _startSpeakingWatchdog();
+        console.log(
+          '[VTOrb] session diagnostics: ACstate=' +
+          (_s.playbackCtx ? _s.playbackCtx.state : 'none') +
+          ', queueLen=' + _s.audioQueue.length +
+          ', sourcesLen=' + _s.scheduledSources.length +
+          ', audioPlaying=' + _s.audioPlaying
+        );
       };
       es.onmessage = function (event) {
         try {
@@ -1211,6 +1232,7 @@
     // setTimeout reconnect callbacks) must see this flag and bail.
     _s._userInitiatedStop = true;
     _stopWatchdog();
+    _stopSpeakingWatchdog(); // DEV-COMHU-0501
     clearTimeout(_s._listeningIdleTimer);
 
     // VTID-03098: always cancel the disconnect-recovery probe, even when
@@ -2082,6 +2104,56 @@
 
   function _resetWatchdog() {
     _s.clientLastActivityAt = Date.now();
+  }
+
+  // ============================================================
+  // DEV-COMHU-0501 — ORB Recovery 0.1: cross-provider speaking-state watchdog
+  // ============================================================
+  //
+  // VTID-03185 fixed the Vertex-path closure bug in _processQueue that left
+  // _s.scheduledSources with stale entries → "Vitana speaking..." stuck on,
+  // mic gated. LiveKit (community surface) uses WebRTC tracks rather than
+  // scheduled BufferSources — a different lifecycle, but the SAME end-user
+  // symptom can still occur through different mechanics (e.g. a subscribed
+  // track that stops delivering frames without firing onended).
+  //
+  // This watchdog is transport-agnostic. It ticks every 500ms while
+  // audioPlaying is true, and force-clears the speaking state when:
+  //   - it has been >= QUIET_MS since the last inbound audio frame, AND
+  //   - no BufferSources are still scheduled, AND
+  //   - the playback queue is empty.
+  // Under healthy multi-chunk TTS, frames keep arriving (lastAudioReceivedAt
+  // refreshes) or sources stay scheduled, so the watchdog does NOT fire.
+  var SPEAKING_WATCHDOG_QUIET_MS = 2000;
+  var SPEAKING_WATCHDOG_TICK_MS = 500;
+
+  function _speakingStateWatchdog() {
+    if (!_s.audioPlaying) return;
+    var quietFor = Date.now() - (_s.lastAudioReceivedAt || 0);
+    var nothingScheduled = _s.scheduledSources.length === 0;
+    var queueEmpty = _s.audioQueue.length === 0;
+    if (quietFor >= SPEAKING_WATCHDOG_QUIET_MS && nothingScheduled && queueEmpty) {
+      console.warn(
+        '[VTOrb] speaking-state watchdog: forcing audioPlaying=false ' +
+        '(quietFor=' + quietFor + 'ms, scheduled=0, queue=0)'
+      );
+      clearTimeout(_s.audioEndGraceTimer);
+      _s.audioPlaying = false;
+      _s.lastAudioEndTime = Date.now();
+      try { _updateUI(); } catch (e) { /* UI optional during teardown */ }
+    }
+  }
+
+  function _startSpeakingWatchdog() {
+    _stopSpeakingWatchdog();
+    _s.speakingWatchdogInterval = setInterval(_speakingStateWatchdog, SPEAKING_WATCHDOG_TICK_MS);
+  }
+
+  function _stopSpeakingWatchdog() {
+    if (_s.speakingWatchdogInterval) {
+      clearInterval(_s.speakingWatchdogInterval);
+      _s.speakingWatchdogInterval = null;
+    }
   }
 
   // ============================================================

--- a/services/gateway/test/frontend/orb-widget-speaking-watchdog.test.ts
+++ b/services/gateway/test/frontend/orb-widget-speaking-watchdog.test.ts
@@ -1,0 +1,61 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// DEV-COMHU-0501 — ORB Recovery 0.1: static checks that the cross-provider
+// speaking-state watchdog exists in orb-widget.js and is wired into the
+// session lifecycle. Mirrors the static-analysis style of
+// orb-widget-audio-playback.test.ts (the widget runs in the browser; we assert
+// on its source so CI catches accidental removal/regression).
+
+const WIDGET_PATH = path.resolve(
+  __dirname,
+  '../../src/frontend/command-hub/orb-widget.js',
+);
+
+function extractFunctionBody(source: string, signature: string): string {
+  const sigIdx = source.indexOf(signature);
+  expect(sigIdx).toBeGreaterThanOrEqual(0);
+  const openIdx = source.indexOf('{', sigIdx);
+  expect(openIdx).toBeGreaterThanOrEqual(0);
+
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    if (c === '}') depth--;
+    if (depth === 0) return source.slice(openIdx + 1, i);
+  }
+  throw new Error(`unclosed function body: ${signature}`);
+}
+
+describe('orb-widget cross-provider speaking-state watchdog (DEV-COMHU-0501)', () => {
+  const source = fs.readFileSync(WIDGET_PATH, 'utf8');
+
+  it('defines _speakingStateWatchdog gating on quiet + no sources + empty queue', () => {
+    const body = extractFunctionBody(source, 'function _speakingStateWatchdog()');
+    expect(body).toMatch(/if \(!_s\.audioPlaying\) return;/);
+    expect(body).toMatch(/lastAudioReceivedAt/);
+    expect(body).toMatch(/scheduledSources\.length === 0/);
+    expect(body).toMatch(/audioQueue\.length === 0/);
+    expect(body).toMatch(/audioPlaying = false/);
+    expect(body).toMatch(/SPEAKING_WATCHDOG_QUIET_MS/);
+  });
+
+  it('uses a 2-second quiet window', () => {
+    expect(source).toMatch(/SPEAKING_WATCHDOG_QUIET_MS = 2000/);
+  });
+
+  it('stamps lastAudioReceivedAt on every inbound audio frame', () => {
+    const playAudioBody = extractFunctionBody(source, 'function _playAudio(base64Data, mimeType)');
+    expect(playAudioBody).toMatch(/_s\.lastAudioReceivedAt = Date\.now\(\);/);
+  });
+
+  it('starts the watchdog on SSE open and stops it on session stop', () => {
+    expect(source).toMatch(/_startSpeakingWatchdog\(\)/);
+    expect(source).toMatch(/_stopSpeakingWatchdog\(\)/);
+  });
+
+  it('emits a session-shape diagnostic line on session open', () => {
+    expect(source).toMatch(/session diagnostics: ACstate=/);
+  });
+});


### PR DESCRIPTION
## Summary
ORB Recovery **Phase 0.1** — a transport-agnostic speaking-state watchdog in `orb-widget.js`. VTID-03185 fixed the Vertex scheduled-source closure leak; this is the backstop that covers the *same* end-user symptom ("Vitana speaking" stuck on, mic gated) when it arrives through a *different* mechanism — notably the LiveKit WebRTC track lifecycle on the community surface.

## What this PR ships
- `lastAudioReceivedAt` stamped on **every** inbound audio frame (in `_playAudio`, the single transport-agnostic playback entry point).
- `_speakingStateWatchdog()` — ticks every 500 ms while `audioPlaying`; force-clears the speaking state when **all** of: ≥2 s since last frame, `scheduledSources.length === 0`, `audioQueue.length === 0`. No-ops when not speaking, so healthy multi-chunk TTS never trips it (frames keep arriving or sources stay scheduled).
- `_startSpeakingWatchdog()` / `_stopSpeakingWatchdog()` wired into SSE `onopen` and `_sessionStop`.
- Session-shape **diagnostic** line on session open (`ACstate / queueLen / sourcesLen / audioPlaying`) so stuck-speaking reports are debuggable from console alone.
- New regression script `scripts/orb-widget-speaking-watchdog-regression.mjs` (added to `smoke:orb-widget`) + jest static test `test/frontend/orb-widget-speaking-watchdog.test.ts`.
- Cache-bust bumped to `20260531-DEV-COMHU-0501-speaking-watchdog`.

## DEV-COMHU marker
Branch + title carry `DEV-COMHU-0501` (numeric — the Path Ownership Guard regex is `DEV-COMHU-\d+`). Touches `command-hub/**`. Commit also carries `BOOTSTRAP-orb-speaking-watchdog` so EXEC-DEPLOY dispatches.

## Tests (green locally)
- `npm run typecheck` ✓, `npm run build` ✓
- `npm run smoke:orb-widget` ✓ (3 regression scripts incl. the new one)
- `npx jest test/frontend/` ✓ (6/6, incl. 5 new watchdog cases)

## Vertex parity ✓
Watchdog clears a stuck `audioPlaying` on the Vertex/SSE path; verified the existing onended-drain path (VTID-03185) is untouched and complementary.

## LiveKit parity ✓ (with companion patch)
The community surface loads this *same* `orb-widget.js` from the gateway, so the watchdog ships to LiveKit users automatically. The one open item — confirming LiveKit remote-track frames also funnel through `_playAudio` (so they stamp `lastAudioReceivedAt`) — is documented in `docs/patches/vitana-v1/ORB-0.1-speaking-watchdog.md`, along with the required vitana-v1 cache-bust bump.

## Pending human actions (aggregation file)
- Merge; EXEC-DEPLOY SUCCESS; `/alive` 200.
- Apply `docs/patches/vitana-v1/ORB-0.1-speaking-watchdog.md` (cache-bust + LiveKit frame-stamp audit).
- Community smoke: multi-chunk Vertex turn (watchdog silent) + simulated stalled LiveKit subscription (clears within ~2 s).

---
🤖 ORB Recovery 0.1 per the autonomous-execution plan. Sandbox cannot merge/deploy/run prod smokes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApimmhkZML398iKgkgVSPC)_