### PR TITLE
[FleetView] feat(orb): DEV-COMHU-0502 reactive auth contract + identity telemetry (ORB Recovery 1)

### DIFF
--- a/docs/patches/vitana-v1/ORB-1-auth-contract.md
+++ b/docs/patches/vitana-v1/ORB-1-auth-contract.md
@@ -1,0 +1,71 @@
+# vitana-v1 companion patch — ORB Recovery 1: Auth contract (DEV-COMHU-0502)
+
+**Target repo:** `exafyltd/vitana-v1` (NOT reachable from the autonomous sandbox)
+**Companion to:** vitana-platform PR — reactive `setAuth` + `clearAuth()` in
+`services/gateway/src/frontend/command-hub/orb-widget.js`, and the
+`orb.session.identity.resolved` OASIS event in `live-session-controller.ts`.
+
+## Why
+The widget now treats `setAuth(token)` as **reactive**: a real token lifts the
+anonymous lock at any time, and `setAuth('')`/`clearAuth()` wipes identity-bound
+continuity. For this to fix the "I have no access / missing memory / first-time
+greeting every reopen" cluster, the host shell must actually CALL `setAuth` on every
+token-state change and `clearAuth` on logout/account-switch.
+
+## 1. Cache-bust bump (required)
+```diff
+- orb-widget.js?v=20260529-VTID-03185-audio-queue-closure
++ orb-widget.js?v=20260531-DEV-COMHU-0502-auth-contract
+```
+
+## 2. `src/hooks/useOrbVoiceClient.ts` — call setAuth reactively
+React to Supabase session changes (login, silent refresh, account switch) and push the
+fresh access token into the widget. Example:
+
+```ts
+import { useEffect } from 'react';
+import { supabase } from '../lib/supabaseClient';
+
+export function useOrbVoiceClient() {
+  useEffect(() => {
+    // Push the current token immediately…
+    supabase.auth.getSession().then(({ data }) => {
+      const token = data.session?.access_token;
+      if (window.VitanaOrb) {
+        token ? window.VitanaOrb.setAuth(token) : window.VitanaOrb.clearAuth();
+      }
+    });
+    // …and on every subsequent change.
+    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
+      if (!window.VitanaOrb) return;
+      if (event === 'SIGNED_OUT' || !session?.access_token) {
+        window.VitanaOrb.clearAuth();
+      } else {
+        window.VitanaOrb.setAuth(session.access_token); // login + TOKEN_REFRESHED
+      }
+    });
+    return () => sub.subscription.unsubscribe();
+  }, []);
+}
+```
+
+## 3. `src/hooks/useLiveKitVoice.ts` — same reactive contract on the LiveKit path
+The LiveKit voice client must use the same token state, so a refreshed token reaches
+the LiveKit token-issuance request too. Mirror the `onAuthStateChange` wiring above
+(call `setAuth`/`clearAuth`), or share a single auth-effect hook between both clients.
+
+## 4. Shell logout / account switch — explicit clearAuth()
+Wherever the shell signs the user out or switches accounts, call:
+```ts
+window.VitanaOrb?.clearAuth();
+```
+BEFORE the new identity's first ORB open, so the previous user's conversation /
+greeting state cannot leak (preserves the VTID-AUTH-FIX anti-leak guarantee).
+
+## Acceptance (post-deploy, community surface + LiveKit canary)
+- Login as dragan3 → open ORB → `orb.session.identity.resolved` OASIS event shows
+  `is_anonymous=false`, memory + cadence resolved.
+- Logout → next ORB open shows `is_anonymous=true` (no silent authenticated drift) and
+  no dragan3 continuity.
+- Switch dragan1 → dragan3 in one session → no dragan1 conversation/identity leak.
+- Verified on BOTH Vertex and the LiveKit canary.

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -29,7 +29,7 @@
   <!-- VTID-01216: Intelligence Panel containers -->
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
-  <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0501-speaking-watchdog"></script>
+  <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0502-auth-contract"></script>
   <script src="/command-hub/app.js?v=20260528-orb-voice-health-probe"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -29,7 +29,7 @@
   <!-- VTID-01216: Intelligence Panel containers -->
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
-  <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0502-auth-contract"></script>
+  <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0502-auth-contract-r2"></script>
   <script src="/command-hub/app.js?v=20260528-orb-voice-health-probe"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -58,6 +58,19 @@
     } catch (e) { return true; } // Can't decode — treat as expired
   }
 
+  // DEV-COMHU-0502 (review fix): extract the JWT subject (user id) so setAuth
+  // can detect an ACCOUNT SWITCH (sub changes) versus a same-user silent
+  // refresh (sub unchanged). Returns null when unparseable/absent.
+  function _jwtSub(token) {
+    try {
+      if (!token) return null;
+      var parts = token.split('.');
+      if (parts.length !== 3) return null;
+      var payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+      return payload && payload.sub ? String(payload.sub) : null;
+    } catch (e) { return null; }
+  }
+
   // Auto-detect auth token from localStorage (read-only, never writes/deletes)
   // Priority: Supabase native key (managed by auth SDK) > vitana.authToken (legacy)
   var _autoToken = (function () {
@@ -2372,6 +2385,20 @@
   // Only skip if init() explicitly passed authToken (tracked by _tokenSetByInit).
   var _tokenSetByInit = false;
 
+  // DEV-COMHU-0502 (review fix): last authenticated JWT subject seen by
+  // setAuth, used to detect account switches. Null until first authed setAuth.
+  var _lastAuthSub = null;
+
+  // DEV-COMHU-0502 (review fix): wipe all identity-bound in-memory continuity
+  // so it cannot leak across a logout or account switch. Shared by setAuth
+  // (on detected identity change) and clearAuth (on logout).
+  function _wipeIdentityBoundState() {
+    _s._transcriptHistory = [];
+    _s.conversationId = null;
+    _s._preDisconnectStage = null;
+    _s._reconnectCount = 0;
+  }
+
   function _refreshToken() {
     if (_tokenSetByInit) return; // Explicit init() token — don't override
     try {
@@ -2728,6 +2755,9 @@
       if (opts.authToken !== undefined && opts.authToken !== null) {
         _cfg.token = opts.authToken || '';
         _cfg.forceAnonymous = false;
+        // DEV-COMHU-0502 (review fix): seed the identity baseline so the first
+        // post-init setAuth (same user) is NOT misread as an account switch.
+        _lastAuthSub = _jwtSub(_cfg.token);
       } else {
         // No authToken passed → anonymous. Clear any auto-detected token.
         // Also lock anonymous mode — setAuth() calls will be ignored until
@@ -2789,25 +2819,51 @@
         VitanaOrb.clearAuth();
         return;
       }
+      // DEV-COMHU-0502 (review fix): distinguish a same-user silent refresh
+      // (sub unchanged — keep continuity, that's the whole point of ORB-1)
+      // from an ACCOUNT SWITCH (sub changes — must NOT carry the prior user's
+      // transcript/conversation into the new identity's session).
+      var newSub = _jwtSub(token);
+      var prevSub = _lastAuthSub;
+      var identityChanged = !!prevSub && !!newSub && newSub !== prevSub;
+
       _cfg.token = token;
       _cfg.forceAnonymous = false; // a real token always lifts the anon lock
       _tokenSetByInit = true;      // caller now owns auth; stop localStorage auto-detect
-      console.log('[VTOrb] setAuth: hasToken=true (reactive)');
+      _lastAuthSub = newSub;
+
+      if (identityChanged) {
+        // Account switch: tear down the old-identity live session (if any) and
+        // wipe identity-bound continuity BEFORE the next _sessionStart, so the
+        // prior user's conversation/greeting state cannot leak under the new
+        // token even if the host did not call clearAuth() first.
+        _wipeIdentityBoundState();
+        if (_s.active || _s.overlayVisible) {
+          try { _sessionStop(); } catch (e) { /* best-effort teardown */ }
+        }
+        console.log('[VTOrb] setAuth: account switch detected — continuity wiped, prior session stopped');
+      } else {
+        console.log('[VTOrb] setAuth: hasToken=true (reactive)');
+      }
     },
 
-    // DEV-COMHU-0502: explicit logout / account-switch / "start over". Clears
-    // the token AND any identity-bound session continuity so the next session
-    // cannot leak the previous user's conversation or greeting state. Hosts
-    // MUST call this on logout and before switching accounts.
+    // DEV-COMHU-0502: explicit logout / account-switch / "start over". Tears
+    // down the active live session (created under the OLD identity — otherwise
+    // post-logout turns keep being handled/persisted against the prior
+    // session.identity), then clears the token AND identity-bound continuity so
+    // the next session cannot leak the previous user's state.
     clearAuth: function () {
+      // Stop the backend/SSE session FIRST, while the old token is still set,
+      // so the stop request authenticates as the departing identity.
+      if (_s.active || _s.overlayVisible || _s.sessionId) {
+        try { _sessionStop(); } catch (e) { /* best-effort teardown */ }
+      }
       _cfg.token = '';
       _cfg.forceAnonymous = false; // not locked-anonymous; just unauthenticated now
       _tokenSetByInit = true;
-      _s._transcriptHistory = [];
-      _s.conversationId = null;
-      _s._preDisconnectStage = null;
-      _s._reconnectCount = 0;
-      console.log('[VTOrb] clearAuth: token + identity-bound continuity cleared');
+      _lastAuthSub = null;
+      _wipeIdentityBoundState();
+      console.log('[VTOrb] clearAuth: live session stopped, token + identity-bound continuity cleared');
     },
 
     show: _show,

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -2769,17 +2769,45 @@
       console.log('[VTOrb] Initialized — gateway: ' + _cfg.gw + ', lang: ' + _cfg.lang + ', showFab: ' + _cfg.showFab + ', hasToken: ' + !!_cfg.token + ', forceAnonymous: ' + _cfg.forceAnonymous);
     },
 
-    // Update auth token after login/logout — call this when auth state changes.
-    // Ignored if init() was called without authToken (forceAnonymous mode).
-    // To switch from anonymous to authenticated, call init() again with authToken.
+    // Update auth token after login/logout — call this on EVERY token-state
+    // change (login, silent refresh, account switch).
+    //
+    // DEV-COMHU-0502 — ORB Recovery 1 (auth contract): setAuth is now REACTIVE.
+    // The previous implementation hard-ignored every setAuth call once init()
+    // ran without a token (`forceAnonymous`), which meant a host that called
+    // init() early (before login resolved) then setAuth(token) on login stayed
+    // anonymous forever — skipping memory, cadence, last-session, and tools.
+    // That single bug produced the "I have no access" + missing-memory +
+    // "first-time greeting every reopen" cluster.
+    //
+    // A non-empty token always lifts the widget into authenticated mode and
+    // clears the anonymous lock. setAuth('') / null is treated as a logout and
+    // routed through clearAuth so identity-bound continuity is wiped
+    // (preserving the VTID-AUTH-FIX anti-leak guarantee).
     setAuth: function (token) {
-      if (_cfg.forceAnonymous) {
-        console.log('[VTOrb] setAuth ignored — forceAnonymous mode. Call init({ authToken }) to authenticate.');
+      if (!token) {
+        VitanaOrb.clearAuth();
         return;
       }
-      _cfg.token = token || '';
+      _cfg.token = token;
+      _cfg.forceAnonymous = false; // a real token always lifts the anon lock
+      _tokenSetByInit = true;      // caller now owns auth; stop localStorage auto-detect
+      console.log('[VTOrb] setAuth: hasToken=true (reactive)');
+    },
+
+    // DEV-COMHU-0502: explicit logout / account-switch / "start over". Clears
+    // the token AND any identity-bound session continuity so the next session
+    // cannot leak the previous user's conversation or greeting state. Hosts
+    // MUST call this on logout and before switching accounts.
+    clearAuth: function () {
+      _cfg.token = '';
+      _cfg.forceAnonymous = false; // not locked-anonymous; just unauthenticated now
       _tokenSetByInit = true;
-      console.log('[VTOrb] setAuth: hasToken=' + !!_cfg.token);
+      _s._transcriptHistory = [];
+      _s.conversationId = null;
+      _s._preDisconnectStage = null;
+      _s._reconnectCount = 0;
+      console.log('[VTOrb] clearAuth: token + identity-bound continuity cleared');
     },
 
     show: _show,

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -632,6 +632,47 @@ export async function handleLiveSessionStart(
   console.log(`[VTID-ANON] Session ${sessionId}: hasJwtIdentity=${hasJwtIdentity}, isAnonymous=${isAnonymousSession}, req.identity.user_id=${req.identity?.user_id || 'none'}, orbIdentity.user_id=${orbIdentity?.user_id || 'none'}, bootstrapIdentity=${bootstrapIdentity ? bootstrapIdentity.user_id.substring(0, 8) : 'null'}`);
   console.log(`[VTID-CONTEXT] Client context: city=${clientContext.city || 'unknown'}, country=${clientContext.country || 'unknown'}, time=${clientContext.localTime || 'unknown'}, device=${clientContext.device || 'unknown'}, anonymous=${isAnonymousSession}`);
 
+  // DEV-COMHU-0502 — ORB Recovery 1 (auth contract): structured identity
+  // resolution telemetry. This is the OASIS signal that lets the Phase D
+  // cockpit count "anonymous sessions on an authenticated surface" — the
+  // metric that exposes the widget-side anonymous-drift bug from the outside.
+  // Fire-and-forget: never block session start on telemetry.
+  {
+    const idResolvedRoute =
+      typeof (body as any).current_route === 'string' ? (body as any).current_route : '';
+    const idResolvedSurface = clientContext.isMobile
+      ? 'vitanaland'
+      : idResolvedRoute.startsWith('/command-hub')
+        ? 'command-hub'
+        : idResolvedRoute.startsWith('/admin')
+          ? 'admin'
+          : 'vitanaland';
+    emitOasisEvent({
+      vtid: 'DEV-COMHU-0502',
+      type: 'orb.session.identity.resolved',
+      source: 'orb-live',
+      status: isAnonymousSession ? 'warning' : 'info',
+      message: isAnonymousSession
+        ? `session_start_anonymous (surface=${idResolvedSurface})`
+        : `session_start_authenticated (surface=${idResolvedSurface})`,
+      payload: {
+        session_id: sessionId,
+        surface: idResolvedSurface,
+        has_authorization_header: !!req.headers.authorization,
+        auth_valid: hasJwtIdentity,
+        is_anonymous: isAnonymousSession,
+        tenant_id: req.identity?.tenant_id ?? null,
+        user_id: req.identity?.user_id ?? null,
+        active_role: (req.identity as any)?.active_role ?? null,
+        // Flag the drift case explicitly: an authenticated surface running anonymous.
+        anonymous_on_authenticated_surface:
+          isAnonymousSession && (idResolvedSurface === 'command-hub' || idResolvedSurface === 'admin'),
+      },
+      actor_id: req.identity?.user_id ?? undefined,
+      surface: 'orb',
+    }).catch(() => {});
+  }
+
   // Resolve language priority:
   // 1. Client-requested lang
   // 2. Stored preference (parallel fetch)

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -205,6 +205,8 @@ export type CicdEventType =
   | 'orb.session.ended'
   // VTID-01039: ORB Conversation Aggregation
   | 'orb.session.summary'
+  // DEV-COMHU-0502 — ORB Recovery 1: auth-contract identity resolution telemetry
+  | 'orb.session.identity.resolved'
   // VTID-01032: Multi-service deploy selection event
   | 'cicd.deploy.selection'
   // VTID-01033: CICD Concurrency Lock Events

--- a/services/gateway/test/frontend/orb-widget-auth-reactive.test.ts
+++ b/services/gateway/test/frontend/orb-widget-auth-reactive.test.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// DEV-COMHU-0502 — ORB Recovery 1 (auth contract): static checks that the
+// widget's setAuth is reactive (a real token lifts the anonymous lock) and
+// that clearAuth wipes identity-bound continuity. Mirrors the static-analysis
+// style of orb-widget-audio-playback.test.ts (widget runs in the browser; we
+// assert on source so CI catches regressions to the auth contract).
+
+const WIDGET_PATH = path.resolve(
+  __dirname,
+  '../../src/frontend/command-hub/orb-widget.js',
+);
+
+function extractObjectMethodBody(source: string, methodName: string): string {
+  const sigIdx = source.indexOf(`${methodName}: function`);
+  expect(sigIdx).toBeGreaterThanOrEqual(0);
+  const openIdx = source.indexOf('{', sigIdx);
+  expect(openIdx).toBeGreaterThanOrEqual(0);
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    if (c === '}') depth--;
+    if (depth === 0) return source.slice(openIdx + 1, i);
+  }
+  throw new Error(`unclosed method body: ${methodName}`);
+}
+
+describe('orb-widget reactive auth contract (DEV-COMHU-0502)', () => {
+  const source = fs.readFileSync(WIDGET_PATH, 'utf8');
+
+  it('setAuth lifts the anonymous lock when a real token arrives', () => {
+    const body = extractObjectMethodBody(source, 'setAuth');
+    // A real token clears forceAnonymous (the old code hard-returned instead).
+    expect(body).toMatch(/_cfg\.forceAnonymous = false/);
+    expect(body).toMatch(/_cfg\.token = token/);
+    // Empty/null routes to clearAuth (logout semantics).
+    expect(body).toMatch(/if \(!token\)/);
+    expect(body).toMatch(/VitanaOrb\.clearAuth\(\)/);
+    // The anti-pattern (permanently ignoring setAuth) must be gone.
+    expect(body).not.toMatch(/setAuth ignored/);
+  });
+
+  it('clearAuth wipes token AND identity-bound continuity (anti-leak)', () => {
+    const body = extractObjectMethodBody(source, 'clearAuth');
+    expect(body).toMatch(/_cfg\.token = ''/);
+    expect(body).toMatch(/_s\._transcriptHistory = \[\]/);
+    expect(body).toMatch(/_s\.conversationId = null/);
+  });
+
+  it('exposes clearAuth on the public API', () => {
+    expect(source).toMatch(/clearAuth: function/);
+  });
+});

--- a/services/gateway/test/frontend/orb-widget-auth-reactive.test.ts
+++ b/services/gateway/test/frontend/orb-widget-auth-reactive.test.ts
@@ -27,6 +27,21 @@ function extractObjectMethodBody(source: string, methodName: string): string {
   throw new Error(`unclosed method body: ${methodName}`);
 }
 
+function extractFunctionBody(source: string, signature: string): string {
+  const sigIdx = source.indexOf(signature);
+  expect(sigIdx).toBeGreaterThanOrEqual(0);
+  const openIdx = source.indexOf('{', sigIdx);
+  expect(openIdx).toBeGreaterThanOrEqual(0);
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    if (c === '}') depth--;
+    if (depth === 0) return source.slice(openIdx + 1, i);
+  }
+  throw new Error(`unclosed function body: ${signature}`);
+}
+
 describe('orb-widget reactive auth contract (DEV-COMHU-0502)', () => {
   const source = fs.readFileSync(WIDGET_PATH, 'utf8');
 
@@ -42,11 +57,41 @@ describe('orb-widget reactive auth contract (DEV-COMHU-0502)', () => {
     expect(body).not.toMatch(/setAuth ignored/);
   });
 
-  it('clearAuth wipes token AND identity-bound continuity (anti-leak)', () => {
+  it('clearAuth stops the live session, clears token, and wipes identity-bound continuity (anti-leak)', () => {
     const body = extractObjectMethodBody(source, 'clearAuth');
+    // Must tear down the old-identity live session BEFORE dropping the token.
+    expect(body).toMatch(/_sessionStop\(\)/);
     expect(body).toMatch(/_cfg\.token = ''/);
+    expect(body).toMatch(/_wipeIdentityBoundState\(\)/);
+    // session-stop must precede the token clear so the stop authenticates as
+    // the departing identity.
+    expect(body.indexOf('_sessionStop()')).toBeLessThan(body.indexOf("_cfg.token = ''"));
+  });
+
+  it('_wipeIdentityBoundState clears all identity-bound continuity fields', () => {
+    const body = extractFunctionBody(source, 'function _wipeIdentityBoundState()');
     expect(body).toMatch(/_s\._transcriptHistory = \[\]/);
     expect(body).toMatch(/_s\.conversationId = null/);
+    expect(body).toMatch(/_s\._preDisconnectStage = null/);
+    expect(body).toMatch(/_s\._reconnectCount = 0/);
+  });
+
+  it('setAuth wipes continuity + stops the session ONLY on account switch (sub change)', () => {
+    const body = extractObjectMethodBody(source, 'setAuth');
+    // Detects identity change via JWT sub, and only then resets.
+    expect(body).toMatch(/_jwtSub\(token\)/);
+    expect(body).toMatch(/identityChanged/);
+    expect(body).toMatch(/_wipeIdentityBoundState\(\)/);
+    expect(body).toMatch(/_sessionStop\(\)/);
+  });
+
+  it('_jwtSub extracts the JWT subject for account-switch detection', () => {
+    const body = extractFunctionBody(source, 'function _jwtSub(token)');
+    expect(body).toMatch(/payload\.sub/);
+  });
+
+  it('init seeds the identity baseline so a same-user refresh is not a switch', () => {
+    expect(source).toMatch(/_lastAuthSub = _jwtSub\(_cfg\.token\)/);
   });
 
   it('exposes clearAuth on the public API', () => {


### PR DESCRIPTION
## Summary
ORB Recovery **Phase 1 — Auth contract** (the biggest UX lever). The widget's `setAuth` was a no-op once `init()` ran without a token (`forceAnonymous`/`_tokenSetByInit` permanent gate). A host that initialised the widget *before* login resolved, then called `setAuth(token)` on login, **stayed anonymous forever** — silently skipping memory, cadence, last-session info, and authenticated tools. That one bug explains the "I have no access" responses **and** missing-memory **and** the "first-time greeting on every reopen" cluster.

## What this PR ships
**Widget (`orb-widget.js`)**
- `setAuth(token)` is now **reactive**: a non-empty token always lifts the anonymous lock (`forceAnonymous = false`) and takes ownership of auth. Empty/null routes to `clearAuth()` (logout semantics).
- New **`clearAuth()`** — clears the token AND identity-bound continuity (`_transcriptHistory`, `conversationId`, `_preDisconnectStage`, `_reconnectCount`). This **preserves the VTID-AUTH-FIX anti-leak guarantee** ("Hello Jovana/Dragan" bug) on logout/account-switch — the prior `forceAnonymous` lock was a blunt instrument; `clearAuth` is the precise one.
- Cache-bust → `20260531-DEV-COMHU-0502-auth-contract`.

**Gateway**
- New typed OASIS topic `orb.session.identity.resolved`.
- `handleLiveSessionStart` emits it (fire-and-forget) with `has_authorization_header`, `auth_valid`, `is_anonymous`, `surface`, and an explicit **`anonymous_on_authenticated_surface`** flag — the exact metric the Phase D cockpit uses to detect widget-side anonymous drift from the outside.

## Deliberate deviation from the plan snippet (and why)
The plan suggested "remove the `_tokenSetByInit` permanent gate" and "refuse to start anonymous on an authenticated surface (401)". I did **not** do those verbatim, because:
1. Naively removing the gate would **reintroduce** the VTID-AUTH-FIX identity-leak bug (stale localStorage token leaking a previous user). Instead, `setAuth` is reactive *and* `clearAuth` wipes continuity — same UX outcome, anti-leak preserved.
2. A blanket 401-refuse-anonymous on community/admin would break **legitimately anonymous** public-landing sessions the gateway supports by design. The identity event makes the drift **observable** first; a hard refusal (if wanted) should ship behind a flag after the cockpit confirms the drift is gone. Flagged for your call — happy to add the gated refusal if you want it.

## Tests (green locally)
- `npm run typecheck` ✓, `npm run build` ✓, `npm run smoke:orb-widget` ✓
- `npx jest test/frontend/` ✓ (incl. 3 new reactive-auth static checks)

## Vertex parity ✓
Identity event fires on `handleLiveSessionStart` (the Vertex session-start path). Widget auth contract is upstream-agnostic.

## LiveKit parity ✓ (with companion patch)
`setAuth`/`clearAuth` are provider-agnostic and ship via the shared gateway-served widget. The host-side wiring (`useOrbVoiceClient.ts` + `useLiveKitVoice.ts` reactive `setAuth`, shell `clearAuth()` on logout) is documented in `docs/patches/vitana-v1/ORB-1-auth-contract.md`.

## Pending human actions (aggregation file)
- Merge; EXEC-DEPLOY SUCCESS; `/alive` 200.
- Apply `docs/patches/vitana-v1/ORB-1-auth-contract.md`.
- Acceptance: login dragan3 → `is_anonymous=false` + memory/cadence; logout → no silent authenticated drift; dragan1↔dragan3 switch → no leak; both providers.
- Decide whether to add the flag-gated authenticated-surface refusal.

---
🤖 ORB Recovery 1 per the autonomous-execution plan. Sandbox cannot merge/deploy/run prod smokes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApimmhkZML398iKgkgVSPC)_