### PR TITLE
fix(gateway): remove accidental node_modules symlink that broke deploy (VTID-03210)

### DIFF
--- a/services/gateway/.gitignore
+++ b/services/gateway/.gitignore
@@ -5,3 +5,8 @@ dist/
 coverage/
 *.log
 .DS_Store
+
+# Guard: ignore a node_modules *symlink* too — the rule above ("node_modules/")
+# only matches a real directory, which let an accidental symlink get committed
+# and broke the Cloud Run source deploy (VTID-03210 hotfix).
+node_modules

--- a/services/gateway/node_modules
+++ b/services/gateway/node_modules
@@ -1,1 +1,0 @@
-/mnt/c/Users/dstev/vitana-platform/services/gateway/node_modules


### PR DESCRIPTION
Hotfix for PR #2427 (VTID-03210). The merged commit accidentally committed `services/gateway/node_modules` as a symlink, which crashed the Cloud Run source deploy (`gcloud crashed (FileNotFoundError): ... services/gateway/node_modules`). It slipped past `.gitignore` because the rule `node_modules/` (trailing slash) matches only a real directory. Production was unaffected (the failed upload never created a new revision). This removes the symlink and adds a `node_modules` guard. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)