### PR TITLE
feat(eval): shadow-comparison report tooling (VTID-03212)

### DIFF
--- a/.github/workflows/CRON-SHADOW-COMPARISON-REPORT.yml
+++ b/.github/workflows/CRON-SHADOW-COMPARISON-REPORT.yml
@@ -1,0 +1,90 @@
+name: Cron Shadow Comparison Report
+
+# Phase 1 W3-A (VTID-03212) — daily report on staging shadow-comparison
+# events. Runs after the graduation recommender's 09:00 CET tick so its
+# output is visible in the same time window the operator reviews
+# auto-promote decisions.
+#
+# Reads from the staging-only admin endpoint
+# (GET /api/v1/admin/staging/eval/shadow-comparison-report) — does NOT
+# touch Supabase directly, so no extra IAM grants are needed beyond the
+# existing GATEWAY_SERVICE_TOKEN repo secret.
+#
+# Insufficient-data behavior: emits a "no data yet" report and exits 0.
+# Workflow only fails when the endpoint itself errors (5xx, network).
+
+on:
+  schedule:
+    # Daily at 09:15 CET (08:15 UTC winter / 07:15 UTC summer). 15 min
+    # after the graduation recommender (08:00 UTC) so the comparison
+    # report is the second thing the operator sees after the FCM digest.
+    - cron: '15 8 * * *'
+  workflow_dispatch:
+    inputs:
+      window_hours:
+        description: 'Lookback window in hours (1-168)'
+        required: true
+        default: '24'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cron-shadow-comparison-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/gateway/package-lock.json
+
+      - name: Install gateway deps
+        working-directory: services/gateway
+        run: npm ci --no-audit --no-fund
+
+      - name: Run shadow-comparison report
+        working-directory: services/gateway
+        env:
+          GATEWAY_SERVICE_TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}
+          STAGING_GATEWAY_URL: https://gateway-staging-q74ibpv6ia-uc.a.run.app
+          WINDOW_HOURS: ${{ inputs.window_hours || '24' }}
+          REPORT_MARKDOWN_PATH: /tmp/shadow-comparison-report.md
+        run: |
+          set -euo pipefail
+          if [ -z "${GATEWAY_SERVICE_TOKEN:-}" ]; then
+            echo "::error::GATEWAY_SERVICE_TOKEN repo secret is missing"
+            exit 1
+          fi
+          npx tsx scripts/eval/shadow-comparison-report.ts > /tmp/shadow-comparison-report.json
+          echo "JSON written: $(wc -c < /tmp/shadow-comparison-report.json) bytes"
+          echo "Markdown written: $(wc -c < /tmp/shadow-comparison-report.md 2>/dev/null || echo 0) bytes"
+
+      - name: Append summary
+        if: always()
+        run: |
+          if [ -f /tmp/shadow-comparison-report.md ]; then
+            cat /tmp/shadow-comparison-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## Shadow-comparison report' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo 'Report script did not produce a Markdown file. Check the run logs.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shadow-comparison-report-${{ github.run_id }}
+          path: |
+            /tmp/shadow-comparison-report.json
+            /tmp/shadow-comparison-report.md
+          if-no-files-found: warn
+          retention-days: 90

--- a/services/gateway/scripts/eval/README.md
+++ b/services/gateway/scripts/eval/README.md
@@ -1,0 +1,88 @@
+# Eval scripts — Phase 1 W3-A (VTID-03212)
+
+Operator-facing eval tooling that runs OUTSIDE the gateway request path.
+This directory is distinct from `services/gateway/test/eval/` (W1's
+golden-corpus replay runner, which is a test harness).
+
+## `shadow-comparison-report.ts`
+
+Aggregates `eval.shadow.compared` events from the last N hours into a
+per-feature rollup so the graduation recommender + canary-readiness
+report have evidence to look at.
+
+### Run it
+
+Locally (one-shot):
+```bash
+GATEWAY_SERVICE_TOKEN=<token> \
+WINDOW_HOURS=24 \
+REPORT_MARKDOWN_PATH=/tmp/shadow-report.md \
+  npx tsx services/gateway/scripts/eval/shadow-comparison-report.ts > /tmp/shadow-report.json
+```
+
+In CI: see `.github/workflows/CRON-SHADOW-COMPARISON-REPORT.yml` — daily
+schedule, runs after the graduation recommender's 09:00 CET tick.
+
+### What it reads
+
+A staging-only admin endpoint added in the same PR:
+```
+GET /api/v1/admin/staging/eval/shadow-comparison-report?window_hours=24
+Authorization: Bearer ${GATEWAY_SERVICE_TOKEN}
+```
+
+The endpoint does the SQL aggregation in-process using the gateway's
+already-bound staging Supabase client (`getSupabase()`), so the script
+itself needs no Supabase access — same pattern as the consent-flip
+endpoint shipped in W2. Authentication is via `GATEWAY_SERVICE_TOKEN`;
+the endpoint refuses with 403 outside `VITANA_ENV=staging`.
+
+### Insufficient-data behavior
+
+When no `eval.shadow.compared` events exist in the window, the endpoint
+returns `200 OK` with `insufficient_data: true` and an empty
+`features: []` array. The script writes a Markdown report that says
+"Insufficient shadow data" explicitly rather than failing — that's the
+expected state until staging voice traffic accumulates against the
+`FEATURE_SHADOW_TOOL_ROUTER_ENV=staging-only` path.
+
+The W2 cascade enabled the shadow path on staging but staging carries
+zero organic voice traffic, so reports will start populating once
+operators actually exercise the staging Command Hub voice surfaces (or
+the user-facing `/orb/chat` text path on staging).
+
+### Per-feature rollup columns
+
+| Column | What it means |
+|---|---|
+| `n` | Total comparisons in window |
+| `agreement` | % where primary + candidate produced the same `extractKey` result |
+| `mismatch` | % where they disagreed (only counted when both produced a comparable key) |
+| `primary p50/p95` | Latency percentiles of the primary path |
+| `candidate p50/p95` | Same for the candidate (shadow) path |
+| `Δ p50 / Δ p95` | Candidate latency relative to primary (negative = faster) |
+| `err rate` | Fraction of comparisons where candidate threw |
+| `fallback` | Count of `no_decision` or `candidate_fallback` outcomes |
+
+### Graduation thresholds
+
+Same as the hourly auto-promoter (`scripts/auto-promoter.ts`):
+
+- min samples per feature: **200**
+- min agreement: **92%**
+- max candidate p95: **800ms**
+- max candidate error rate: **2%**
+
+A feature passing all four for ≥5 consecutive days is what the
+graduation recommender (`scripts/graduation-recommender.ts`) flags as
+PUBLISH-ready in its daily FCM digest. This script is the evidence the
+operator inspects before clicking PUBLISH on the prod Command Hub
+canary path.
+
+### What this script does NOT do
+
+- Does not modify auto-promoter DRY/LIVE state.
+- Does not promote any fine-tune.
+- Does not touch prod telemetry — staging only by hard guard.
+- Does not synthesize rows when staging is empty — "insufficient data"
+  is honest output, not a hidden failure.

--- a/services/gateway/scripts/eval/shadow-comparison-report.ts
+++ b/services/gateway/scripts/eval/shadow-comparison-report.ts
@@ -1,0 +1,164 @@
+/**
+ * Shadow-comparison report — Phase 1 W3-A (VTID-03212).
+ *
+ * Calls the staging-only admin endpoint
+ *   GET /api/v1/admin/staging/eval/shadow-comparison-report?window_hours=N
+ * (added in the same PR; see services/gateway/src/routes/admin-staging.ts)
+ * and emits a structured report to stdout as JSON, plus a human-readable
+ * Markdown rendering to a sibling file.
+ *
+ * Used by the daily CRON-SHADOW-COMPARISON-REPORT workflow and runnable
+ * locally for spot-checks.
+ *
+ * Output:
+ *   - stdout: JSON (machine-readable, suitable for piping into jq / further
+ *     analysis)
+ *   - $REPORT_MARKDOWN_PATH (env, optional): Markdown file written to disk
+ *     for the workflow to upload as an artifact
+ *
+ * Insufficient-data behavior: exits 0 with a clearly-marked
+ * "insufficient shadow data" payload. Never throws on empty windows —
+ * that's the expected state until staging voice traffic accumulates.
+ *
+ * Env:
+ *   STAGING_GATEWAY_URL (default: https://gateway-staging-q74ibpv6ia-uc.a.run.app)
+ *   GATEWAY_SERVICE_TOKEN (required)
+ *   WINDOW_HOURS (default 24)
+ *   REPORT_MARKDOWN_PATH (optional)
+ */
+
+import { promises as fs } from 'fs';
+
+const STAGING_GATEWAY_URL = process.env.STAGING_GATEWAY_URL
+  || 'https://gateway-staging-q74ibpv6ia-uc.a.run.app';
+const SERVICE_TOKEN = process.env.GATEWAY_SERVICE_TOKEN;
+const WINDOW_HOURS = Number(process.env.WINDOW_HOURS ?? 24);
+const REPORT_MARKDOWN_PATH = process.env.REPORT_MARKDOWN_PATH;
+
+interface FeatureRollup {
+  feature: string;
+  total_comparisons: number;
+  agreement_rate: number | null;
+  mismatch_rate: number | null;
+  primary_p50_ms: number;
+  primary_p95_ms: number;
+  candidate_p50_ms: number;
+  candidate_p95_ms: number;
+  delta_p50_pct: number | null;
+  delta_p95_pct: number | null;
+  candidate_error_rate: number;
+  candidate_fallback_count: number;
+}
+
+interface ReportResponse {
+  ok: boolean;
+  env: string;
+  window_hours: number;
+  since_iso: string;
+  generated_at: string;
+  total_events: number;
+  insufficient_data: boolean;
+  message?: string;
+  features: FeatureRollup[];
+}
+
+function pct(n: number | null): string {
+  if (n === null) return '—';
+  return `${n.toFixed(2)}%`;
+}
+
+function num(n: number | null | undefined, suffix = ''): string {
+  if (n === null || n === undefined) return '—';
+  return `${n.toFixed(1)}${suffix}`;
+}
+
+function rate(n: number | null): string {
+  if (n === null) return '—';
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function renderMarkdown(report: ReportResponse): string {
+  const lines: string[] = [];
+  lines.push('# Shadow-comparison report');
+  lines.push('');
+  lines.push(`- **Generated:** ${report.generated_at}`);
+  lines.push(`- **Env:** ${report.env}`);
+  lines.push(`- **Window:** last ${report.window_hours}h (since ${report.since_iso})`);
+  lines.push(`- **Total comparisons:** ${report.total_events}`);
+  lines.push('');
+
+  if (report.insufficient_data) {
+    lines.push('> **Insufficient shadow data.** No `eval.shadow.compared` events were emitted in this window.');
+    lines.push('> Expected until staging voice traffic accumulates against the `FEATURE_SHADOW_TOOL_ROUTER_ENV=staging-only` path.');
+    lines.push('');
+    lines.push(`Status: \`${report.message ?? 'insufficient data'}\``);
+    return lines.join('\n') + '\n';
+  }
+
+  lines.push('## Per-feature rollup');
+  lines.push('');
+  lines.push('| Feature | n | Agreement | Mismatch | Primary p50/p95 | Candidate p50/p95 | Δ p50 / Δ p95 | Err rate | Fallback |');
+  lines.push('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+  for (const f of report.features) {
+    lines.push(
+      `| \`${f.feature}\` | ${f.total_comparisons} | ${rate(f.agreement_rate)} | ${rate(f.mismatch_rate)}`
+      + ` | ${num(f.primary_p50_ms, 'ms')} / ${num(f.primary_p95_ms, 'ms')}`
+      + ` | ${num(f.candidate_p50_ms, 'ms')} / ${num(f.candidate_p95_ms, 'ms')}`
+      + ` | ${pct(f.delta_p50_pct)} / ${pct(f.delta_p95_pct)}`
+      + ` | ${rate(f.candidate_error_rate)} | ${f.candidate_fallback_count} |`,
+    );
+  }
+  lines.push('');
+  lines.push('## Reading the columns');
+  lines.push('');
+  lines.push('- **Agreement** = primary and candidate produced the same `extractKey()` result.');
+  lines.push('- **Δ p50 / Δ p95** = candidate latency relative to primary (negative = faster).');
+  lines.push('- **Err rate** = fraction of comparisons where the candidate path threw.');
+  lines.push('- **Fallback** = count of comparisons where the candidate returned `no_decision` or `candidate_fallback`.');
+  lines.push('');
+  lines.push('## Graduation thresholds (auto-promoter defaults)');
+  lines.push('');
+  lines.push('- min samples per feature: 200');
+  lines.push('- min agreement: 92%');
+  lines.push('- max candidate p95: 800ms');
+  lines.push('- max candidate error rate: 2%');
+  lines.push('');
+  lines.push('These are the same thresholds the hourly auto-promoter applies. A feature meeting all four is what the graduation recommender will eventually flag as PUBLISH-ready.');
+
+  return lines.join('\n') + '\n';
+}
+
+async function fetchReport(): Promise<ReportResponse> {
+  if (!SERVICE_TOKEN) {
+    throw new Error('GATEWAY_SERVICE_TOKEN env var is required');
+  }
+  const url = `${STAGING_GATEWAY_URL}/api/v1/admin/staging/eval/shadow-comparison-report?window_hours=${WINDOW_HOURS}`;
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${SERVICE_TOKEN}` },
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '<no body>');
+    throw new Error(`endpoint returned HTTP ${resp.status}: ${body.slice(0, 300)}`);
+  }
+  return (await resp.json()) as ReportResponse;
+}
+
+async function main(): Promise<void> {
+  const report = await fetchReport();
+  console.log(JSON.stringify(report, null, 2));
+
+  if (REPORT_MARKDOWN_PATH) {
+    await fs.writeFile(REPORT_MARKDOWN_PATH, renderMarkdown(report), 'utf-8');
+    console.error(`[shadow-comparison-report] markdown written: ${REPORT_MARKDOWN_PATH}`);
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[shadow-comparison-report] FAILED:', err);
+    process.exit(1);
+  });
+}
+
+export { fetchReport, renderMarkdown };
+export type { ReportResponse, FeatureRollup };

--- a/services/gateway/src/routes/admin-staging.ts
+++ b/services/gateway/src/routes/admin-staging.ts
@@ -163,4 +163,169 @@ router.post(
   },
 );
 
+// ===========================================================================
+// VTID-03212 (Phase 1 W3-A): shadow-comparison report.
+//
+// Aggregates eval.shadow.compared events from the last N hours into a per-
+// feature rollup so the graduation recommender + canary-readiness report
+// have evidence to look at once staging traffic accumulates.
+//
+// Reads STAGING oasis_events directly via the gateway's in-process supabase
+// client — same pattern as the consent-flip endpoint, no extra IAM grants
+// needed. Service-token + staging-only guards apply.
+//
+// Insufficient-data behavior is explicit: a 200 with `insufficient_data:
+// true` instead of a 4xx/5xx, so the caller (CRON-SHADOW-COMPARISON-REPORT
+// workflow) can emit a "no data yet" report cleanly rather than failing.
+// ===========================================================================
+
+interface ShadowEventRow {
+  id: string;
+  created_at: string;
+  metadata: Record<string, unknown> | null;
+}
+
+interface ShadowFeatureRollup {
+  feature: string;
+  total_comparisons: number;
+  agreement_rate: number | null;
+  mismatch_rate: number | null;
+  primary_p50_ms: number;
+  primary_p95_ms: number;
+  candidate_p50_ms: number;
+  candidate_p95_ms: number;
+  delta_p50_pct: number | null;
+  delta_p95_pct: number | null;
+  candidate_error_rate: number;
+  candidate_fallback_count: number;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, idx))];
+}
+
+function rollupFeature(feature: string, rows: ShadowEventRow[]): ShadowFeatureRollup {
+  const total = rows.length;
+  let agreed = 0;
+  let mismatched = 0;
+  let errored = 0;
+  let fallback = 0;
+  const primaryMs: number[] = [];
+  const candidateMs: number[] = [];
+
+  for (const r of rows) {
+    const m = (r.metadata ?? {}) as {
+      agreement?: boolean | null;
+      primary_ms?: number;
+      candidate_ms?: number;
+      candidate_error?: string | null;
+      candidate_fallback?: boolean;
+      no_decision?: boolean;
+    };
+    if (m.agreement === true) agreed++;
+    else if (m.agreement === false) mismatched++;
+    if (m.candidate_error) errored++;
+    if (m.candidate_fallback === true || m.no_decision === true) fallback++;
+    if (typeof m.primary_ms === 'number' && Number.isFinite(m.primary_ms)) primaryMs.push(m.primary_ms);
+    if (typeof m.candidate_ms === 'number' && Number.isFinite(m.candidate_ms)) candidateMs.push(m.candidate_ms);
+  }
+  primaryMs.sort((a, b) => a - b);
+  candidateMs.sort((a, b) => a - b);
+
+  const p50p = percentile(primaryMs, 50);
+  const p95p = percentile(primaryMs, 95);
+  const p50c = percentile(candidateMs, 50);
+  const p95c = percentile(candidateMs, 95);
+
+  const ratedTotal = agreed + mismatched;
+  return {
+    feature,
+    total_comparisons: total,
+    agreement_rate: ratedTotal > 0 ? agreed / ratedTotal : null,
+    mismatch_rate: ratedTotal > 0 ? mismatched / ratedTotal : null,
+    primary_p50_ms: p50p,
+    primary_p95_ms: p95p,
+    candidate_p50_ms: p50c,
+    candidate_p95_ms: p95c,
+    delta_p50_pct: p50p > 0 ? ((p50c - p50p) / p50p) * 100 : null,
+    delta_p95_pct: p95p > 0 ? ((p95c - p95p) / p95p) * 100 : null,
+    candidate_error_rate: total > 0 ? errored / total : 0,
+    candidate_fallback_count: fallback,
+  };
+}
+
+router.get(
+  '/eval/shadow-comparison-report',
+  serviceTokenAuth,
+  stagingOnlyGuard,
+  async (req: Request, res: Response) => {
+    const windowHours = Math.max(1, Math.min(168, Number(req.query.window_hours ?? 24)));
+    const supabase = getSupabase();
+    if (!supabase) {
+      res.status(503).json({ ok: false, error: 'db_unavailable' });
+      return;
+    }
+
+    const sinceIso = new Date(Date.now() - windowHours * 3600_000).toISOString();
+    const { data: rows, error } = await supabase
+      .from('oasis_events')
+      .select('id, created_at, metadata')
+      .eq('topic', 'eval.shadow.compared')
+      .gte('created_at', sinceIso)
+      .order('created_at', { ascending: false })
+      .limit(50_000);
+
+    if (error) {
+      res.status(500).json({ ok: false, error: 'query_failed', message: error.message });
+      return;
+    }
+
+    const all = (rows ?? []) as ShadowEventRow[];
+    if (all.length === 0) {
+      res.json({
+        ok: true,
+        env: 'staging',
+        window_hours: windowHours,
+        since_iso: sinceIso,
+        generated_at: new Date().toISOString(),
+        total_events: 0,
+        insufficient_data: true,
+        message: 'insufficient shadow data — no eval.shadow.compared events in window',
+        features: [],
+      });
+      return;
+    }
+
+    // Bucket per `feature` (set by runWithShadow's invocation context, e.g.
+    // `voice-tool-router` / `intent-kind` / `pillar-classifier`).
+    const byFeature = new Map<string, ShadowEventRow[]>();
+    for (const r of all) {
+      const m = (r.metadata ?? {}) as { feature?: string };
+      const f = m.feature && typeof m.feature === 'string' ? m.feature : 'unspecified';
+      const bucket = byFeature.get(f) ?? [];
+      bucket.push(r);
+      byFeature.set(f, bucket);
+    }
+
+    const features: ShadowFeatureRollup[] = [];
+    for (const [feature, rs] of byFeature.entries()) {
+      features.push(rollupFeature(feature, rs));
+    }
+    features.sort((a, b) => b.total_comparisons - a.total_comparisons);
+
+    res.json({
+      ok: true,
+      env: 'staging',
+      window_hours: windowHours,
+      since_iso: sinceIso,
+      generated_at: new Date().toISOString(),
+      total_events: all.length,
+      insufficient_data: false,
+      features,
+    });
+  },
+);
+
 export { router as adminStagingRouter };


### PR DESCRIPTION
Phase 1 W3-A. Converts eval.shadow.compared events from staging into a daily report for the graduation recommender + future canary-readiness report. Same pattern as W2 consent-flip bridge: SQL aggregation runs inside the gateway (already has staging Supabase creds bound), script is thin curl wrapper. No extra IAM grants needed.

Files:
- src/routes/admin-staging.ts — extends with GET /eval/shadow-comparison-report (serviceTokenAuth + stagingOnlyGuard; aggregates per feature; 0 events → 200 insufficient_data:true)
- scripts/eval/shadow-comparison-report.ts — calls endpoint, emits JSON + Markdown
- scripts/eval/README.md — usage, columns, graduation thresholds
- .github/workflows/CRON-SHADOW-COMPARISON-REPORT.yml — daily 08:15 UTC, uploads JSON + Markdown artifacts (90d retention), appends to GITHUB_STEP_SUMMARY

Insufficient-data behavior: report runs today producing 'no data yet'. Once staging voice traffic emits eval.shadow.compared, the same workflow produces real aggregates. No production behavior change. Auto-promoter stays DRY. No promotion. npm run build green.