### PR TITLE
feat(cart): Universal Cart Phase 1 gateway slice (VTID-03213)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -226,6 +226,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const domainRoutingRouter = require('./routes/domain-routing').default;
   // VTID-01119: User Preference & Constraint Modeling Engine
   const userPreferencesRouter = require('./routes/user-preferences').default;
+  // VTID-03213: Universal Cart Phase 1 gateway slice (universal_carts / universal_cart_items / universal_cart_events)
+  const universalCartRouter = require('./routes/universal-cart').default;
   // VTID-01126: D32 Situational Awareness Engine - situation understanding layer
   const situationalAwarenessRouter = require('./routes/situational-awareness').default;
   // VTID-01127: D33 Availability, Time-Window & Readiness Engine
@@ -1176,6 +1178,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // VTID-01119: User Preference & Constraint Modeling Engine
   mountRouterSync(app, '/api/v1/user-preferences', userPreferencesRouter, { owner: 'user-preferences' });
+
+  // VTID-03213: Universal Cart Phase 1 gateway slice — community-role-gated cart over universal_* tables
+  mountRouterSync(app, '/api/v1/universal-cart', universalCartRouter, { owner: 'universal-cart' });
 
   // VTID-01126: D32 Situational Awareness Engine - situation understanding layer
   mountRouterSync(app, '/api/v1/situational', situationalAwarenessRouter, { owner: 'situational-awareness' });

--- a/services/gateway/src/routes/universal-cart.ts
+++ b/services/gateway/src/routes/universal-cart.ts
@@ -1,0 +1,856 @@
+/**
+ * VTID-03213 — Universal Cart gateway slice (Phase 1).
+ *
+ * Endpoints (mounted at /api/v1/universal-cart):
+ *   POST   /                      — Get-or-create the caller's active universal_cart.
+ *   GET    /                      — Read active cart with active items.
+ *   POST   /items                 — Add an item (or bump quantity if product already in cart).
+ *   PATCH  /items/:itemId         — Update quantity / metadata of an active item.
+ *   DELETE /items/:itemId         — Soft-remove an item (status='removed').
+ *   POST   /items/:itemId/complete — Mark item completed (callback from the per-item flow).
+ *   GET    /events                — Read recent events for the caller's active cart.
+ *   GET    /health                — Health check.
+ *
+ * Scope (strict, per handoff):
+ *   - Reads / writes only `universal_carts`, `universal_cart_items`, `universal_cart_events`.
+ *   - Does NOT touch Lovable-side `cart_items`, `checkout_sessions`, `cj_*`, `vouchers`,
+ *     `business_packages`, `user_wallets`, `wallet_credits`, or any other ghost commerce table.
+ *   - No checkout, no Stripe, no wallet waterfall, no autopilot bridge, no matchmaking.
+ *
+ * Access control:
+ *   - Community-role-only. Non-community sessions get HTTP 403 with `error: 'cart_unavailable_for_role'`.
+ *   - Role is read from `user_tenants.active_role` via the service-role client.
+ *   - Cart + cart_items mutations use the user-JWT-scoped client so RLS enforces owner isolation.
+ *   - cart_events INSERTs use the service-role client (RLS blocks `authenticated` writes; audit
+ *     emission is the gateway's responsibility).
+ *
+ * Conventions mirrored from existing routes (user-preferences.ts, locations.ts) and middleware
+ * (require-tenant-admin.ts):
+ *   - getBearerToken / getUserContext via me_context RPC.
+ *   - createUserSupabaseClient(token) for RLS-evaluated work.
+ *   - getSupabase() for service-role audit writes.
+ *   - All responses shaped as { ok: boolean, error?: string, ... }.
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { createUserSupabaseClient } from '../lib/supabase-user';
+import { getSupabase } from '../lib/supabase';
+
+export const VTID = 'VTID-03213';
+
+// =============================================================================
+// Constants — keep in sync with supabase/migrations/20260605000000_VTID_03186_universal_cart_schema.sql
+// =============================================================================
+
+/** item_type CHECK: must match cart_items_item_type_check. */
+const ALLOWED_ITEM_TYPES = ['supplement', 'partner_product'] as const;
+
+/** source_surface CHECK: must match cart_items_source_surface_check. NULL is also allowed. */
+const ALLOWED_SOURCE_SURFACES = ['web', 'mobile', 'voice', 'autopilot', 'community'] as const;
+
+/**
+ * Whitelist of keys permitted inside `universal_cart_events.event_payload`.
+ * The PRIVACY RULE on the schema COMMENT says payloads must NOT contain prices,
+ * full product descriptions, or user-identifying strings — only ids and minimal
+ * structural fields. Enforce at write time.
+ */
+const ALLOWED_EVENT_PAYLOAD_KEYS = new Set([
+  'cart_item_id',
+  'product_id',
+  'quantity_before',
+  'quantity_after',
+  'source_surface',
+  'source_ref',
+  'removal_reason',
+]);
+
+/** Soft cap on event-payload string fields to prevent accidental PII leakage via metadata blob. */
+const EVENT_PAYLOAD_STRING_MAX = 200;
+
+const COMMUNITY_ROLE = 'community';
+
+const router = Router();
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Extract Bearer token from the Authorization header. */
+export function getBearerToken(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+  return authHeader.slice(7);
+}
+
+export type UserContext =
+  | { ok: true; tenant_id: string | null; user_id: string }
+  | { ok: false; error: string };
+
+/**
+ * Resolve user_id / tenant_id from the caller's JWT via the me_context RPC.
+ * Mirrors the pattern in user-preferences.ts.
+ */
+export async function getUserContext(token: string): Promise<UserContext> {
+  try {
+    const supabase = createUserSupabaseClient(token);
+    const { data, error } = await supabase.rpc('me_context');
+    if (error) return { ok: false, error: error.message };
+    const user_id = (data?.user_id || data?.id) as string | undefined;
+    if (!user_id) return { ok: false, error: 'me_context returned no user_id' };
+    return {
+      ok: true,
+      tenant_id: (data?.tenant_id as string | null | undefined) ?? null,
+      user_id,
+    };
+  } catch (err: any) {
+    return { ok: false, error: err?.message || 'me_context call failed' };
+  }
+}
+
+/**
+ * Resolve the caller's active_role in the given tenant.
+ * Uses the service-role client so the lookup is consistent regardless of RLS on
+ * `user_tenants` (avoids hiding the role from the very query that gates the route).
+ *
+ * If tenant_id is null we still proceed — the route returns the standard 403 since
+ * active_role can't be resolved without a tenant context.
+ */
+export async function getActiveRole(
+  user_id: string,
+  tenant_id: string | null
+): Promise<string | null> {
+  if (!tenant_id) return null;
+  const supabase = getSupabase();
+  if (!supabase) {
+    console.error(`[${VTID}] active-role lookup: service-role client unavailable`);
+    return null;
+  }
+  const { data, error } = await supabase
+    .from('user_tenants')
+    .select('active_role')
+    .eq('user_id', user_id)
+    .eq('tenant_id', tenant_id)
+    .maybeSingle();
+  if (error) {
+    console.error(`[${VTID}] active-role lookup error:`, error.message);
+    return null;
+  }
+  return (data?.active_role as string | undefined) ?? null;
+}
+
+/**
+ * Standardized 403 response for non-community sessions.
+ */
+function denyForRole(res: Response, callerRole: string | null): Response {
+  return res.status(403).json({
+    ok: false,
+    error: 'cart_unavailable_for_role',
+    role: callerRole, // for client-side diagnostics; not PII
+  });
+}
+
+/**
+ * Combined auth + role gate. Returns the resolved identity on success, or sends
+ * a 401/403 response and returns null so callers can early-exit.
+ */
+async function authorizeCommunityCaller(
+  req: Request,
+  res: Response
+): Promise<{ token: string; user_id: string; tenant_id: string | null } | null> {
+  const token = getBearerToken(req);
+  if (!token) {
+    res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    return null;
+  }
+  const ctx = await getUserContext(token);
+  if (!ctx.ok) {
+    res.status(401).json({ ok: false, error: 'UNAUTHENTICATED', detail: ctx.error });
+    return null;
+  }
+  const role = await getActiveRole(ctx.user_id, ctx.tenant_id);
+  if (role !== COMMUNITY_ROLE) {
+    denyForRole(res, role);
+    return null;
+  }
+  return { token, user_id: ctx.user_id, tenant_id: ctx.tenant_id };
+}
+
+/**
+ * Sanitize event_payload to the whitelist + length cap. Drops unknown keys silently;
+ * truncates string values; preserves number / boolean values; coerces unknown nested
+ * structures to a JSON-stringified, truncated form (never recurses).
+ */
+export function sanitizeEventPayload(input: Record<string, unknown> | undefined | null): Record<string, unknown> {
+  if (!input || typeof input !== 'object') return {};
+  const out: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(input)) {
+    if (!ALLOWED_EVENT_PAYLOAD_KEYS.has(key)) continue;
+    if (raw === null || raw === undefined) continue;
+    if (typeof raw === 'string') {
+      out[key] = raw.length > EVENT_PAYLOAD_STRING_MAX
+        ? raw.slice(0, EVENT_PAYLOAD_STRING_MAX)
+        : raw;
+    } else if (typeof raw === 'number' || typeof raw === 'boolean') {
+      out[key] = raw;
+    } else {
+      // Last-resort coerce; truncate aggressively.
+      const s = JSON.stringify(raw);
+      out[key] = (s || '').slice(0, EVENT_PAYLOAD_STRING_MAX);
+    }
+  }
+  return out;
+}
+
+/**
+ * Emit one row into universal_cart_events using the service-role client.
+ * Audit emission is best-effort: a failed insert is logged but does NOT fail
+ * the user-facing mutation that just succeeded against universal_cart_items.
+ * (We accept brief audit gaps over breaking the cart UX; future ops can detect
+ * gaps by joining cart_items against cart_events.)
+ */
+export async function emitCartEvent(args: {
+  cart_id: string;
+  user_id: string;
+  event_type: string;
+  event_payload?: Record<string, unknown>;
+}): Promise<void> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    console.error(`[${VTID}] cart event drop (${args.event_type}): service-role client unavailable`);
+    return;
+  }
+  const { error } = await supabase
+    .from('universal_cart_events')
+    .insert({
+      cart_id: args.cart_id,
+      user_id: args.user_id,
+      event_type: args.event_type,
+      event_payload: sanitizeEventPayload(args.event_payload),
+    });
+  if (error) {
+    console.error(
+      `[${VTID}] cart event insert failed (${args.event_type}, cart ${args.cart_id}):`,
+      error.message
+    );
+  }
+}
+
+// =============================================================================
+// Request schemas
+// =============================================================================
+
+const AddItemBody = z.object({
+  product_id: z.string().uuid(),
+  item_type: z.enum(ALLOWED_ITEM_TYPES),
+  quantity: z.number().positive().default(1),
+  source_surface: z.enum(ALLOWED_SOURCE_SURFACES).optional(),
+  source_ref: z.string().max(200).optional(),
+  merchant_id: z.string().uuid().optional(),
+  unit_price_cents_snapshot: z.number().int().nonnegative().optional(),
+  currency_snapshot: z.string().length(3).optional(),
+  autopilot_rec_id: z.string().uuid().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+const PatchItemBody = z.object({
+  quantity: z.number().positive().optional(),
+  metadata: z.record(z.unknown()).optional(),
+}).refine(
+  (b) => b.quantity !== undefined || b.metadata !== undefined,
+  { message: 'At least one of `quantity` or `metadata` must be provided.' }
+);
+
+// =============================================================================
+// Routes
+// =============================================================================
+
+/** GET /health — sanity check; no auth needed. */
+router.get('/health', (_req: Request, res: Response) => {
+  return res.status(200).json({ ok: true, vtid: VTID, scope: 'universal_cart_phase_1' });
+});
+
+/**
+ * POST / — Get-or-create the caller's active universal_cart.
+ *
+ * One active cart per user is enforced by the partial-unique index
+ * `universal_carts_one_active_per_user`. We attempt insert; on conflict we
+ * SELECT the existing row.
+ *
+ * Emits `cart.created` on actual create (not on no-op fetch).
+ */
+router.post('/', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  const supabase = createUserSupabaseClient(id.token);
+
+  // Look up an existing active cart first to keep the response shape consistent
+  // and avoid emitting cart.created on every POST.
+  const existing = await supabase
+    .from('universal_carts')
+    .select('*')
+    .eq('user_id', id.user_id)
+    .eq('status', 'active')
+    .maybeSingle();
+
+  if (existing.data) {
+    return res.status(200).json({ ok: true, cart: existing.data, created: false });
+  }
+  if (existing.error && existing.error.code && existing.error.code !== 'PGRST116') {
+    return res.status(500).json({
+      ok: false,
+      error: 'cart_lookup_failed',
+      detail: existing.error.message,
+    });
+  }
+
+  // Best-effort source_context for diagnostics; capped + sanitized.
+  const sourceContext =
+    typeof req.body?.source_context === 'string'
+      ? String(req.body.source_context).slice(0, 200)
+      : null;
+
+  const created = await supabase
+    .from('universal_carts')
+    .insert({
+      user_id: id.user_id,
+      tenant_id: id.tenant_id,
+      status: 'active',
+      source_context: sourceContext,
+      metadata: {},
+    })
+    .select('*')
+    .single();
+
+  if (created.error) {
+    return res.status(500).json({
+      ok: false,
+      error: 'cart_create_failed',
+      detail: created.error.message,
+    });
+  }
+
+  await emitCartEvent({
+    cart_id: created.data.id,
+    user_id: id.user_id,
+    event_type: 'cart.created',
+    event_payload: {},
+  });
+
+  return res.status(201).json({ ok: true, cart: created.data, created: true });
+});
+
+/**
+ * GET / — Read the caller's active cart + active items.
+ * Returns 200 with `cart: null, items: []` if no active cart exists (no autocreate).
+ */
+router.get('/', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  const supabase = createUserSupabaseClient(id.token);
+
+  const cartRes = await supabase
+    .from('universal_carts')
+    .select('*')
+    .eq('user_id', id.user_id)
+    .eq('status', 'active')
+    .maybeSingle();
+
+  if (cartRes.error && cartRes.error.code !== 'PGRST116') {
+    return res.status(500).json({
+      ok: false,
+      error: 'cart_lookup_failed',
+      detail: cartRes.error.message,
+    });
+  }
+
+  if (!cartRes.data) {
+    return res.status(200).json({ ok: true, cart: null, items: [] });
+  }
+
+  const itemsRes = await supabase
+    .from('universal_cart_items')
+    .select('*')
+    .eq('cart_id', cartRes.data.id)
+    .eq('status', 'active')
+    .order('created_at', { ascending: true });
+
+  if (itemsRes.error) {
+    return res.status(500).json({
+      ok: false,
+      error: 'cart_items_lookup_failed',
+      detail: itemsRes.error.message,
+    });
+  }
+
+  return res.status(200).json({ ok: true, cart: cartRes.data, items: itemsRes.data ?? [] });
+});
+
+/**
+ * POST /items — Add an item to the caller's active cart.
+ * If the product is already in the cart with status='active', bump its quantity
+ * instead of creating a duplicate row.
+ *
+ * Emits `item.added` on either insert OR quantity bump (both are "added" events
+ * from the user's perspective; analytics can disambiguate via quantity_before).
+ */
+router.post('/items', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  const parsed = AddItemBody.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: 'invalid_request',
+      detail: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+    });
+  }
+  const body = parsed.data;
+
+  const supabase = createUserSupabaseClient(id.token);
+
+  // 1. Resolve or create the active cart.
+  const cartLookup = await supabase
+    .from('universal_carts')
+    .select('id')
+    .eq('user_id', id.user_id)
+    .eq('status', 'active')
+    .maybeSingle();
+
+  if (cartLookup.error && cartLookup.error.code !== 'PGRST116') {
+    return res.status(500).json({
+      ok: false,
+      error: 'cart_lookup_failed',
+      detail: cartLookup.error.message,
+    });
+  }
+
+  let cartId = cartLookup.data?.id as string | undefined;
+  let cartCreatedThisRequest = false;
+
+  if (!cartId) {
+    const newCart = await supabase
+      .from('universal_carts')
+      .insert({
+        user_id: id.user_id,
+        tenant_id: id.tenant_id,
+        status: 'active',
+        metadata: {},
+      })
+      .select('id')
+      .single();
+    if (newCart.error || !newCart.data) {
+      return res.status(500).json({
+        ok: false,
+        error: 'cart_create_failed',
+        detail: newCart.error?.message,
+      });
+    }
+    cartId = newCart.data.id as string;
+    cartCreatedThisRequest = true;
+    await emitCartEvent({
+      cart_id: cartId,
+      user_id: id.user_id,
+      event_type: 'cart.created',
+      event_payload: {},
+    });
+  }
+
+  // 2. Check whether the product is already in the cart with status='active'.
+  const existingItem = await supabase
+    .from('universal_cart_items')
+    .select('*')
+    .eq('cart_id', cartId!)
+    .eq('product_id', body.product_id)
+    .eq('status', 'active')
+    .maybeSingle();
+
+  if (existingItem.error && existingItem.error.code !== 'PGRST116') {
+    return res.status(500).json({
+      ok: false,
+      error: 'item_lookup_failed',
+      detail: existingItem.error.message,
+    });
+  }
+
+  const incomingMetadata: Record<string, unknown> = { ...(body.metadata || {}) };
+  if (body.autopilot_rec_id) {
+    // PRD Q3 — populate the day-1 autopilot linkage hint.
+    incomingMetadata.autopilot_rec_id = body.autopilot_rec_id;
+  }
+
+  if (existingItem.data) {
+    const before = Number(existingItem.data.quantity ?? 0);
+    const after = before + body.quantity;
+    const mergedMetadata = { ...(existingItem.data.metadata || {}), ...incomingMetadata };
+    const updated = await supabase
+      .from('universal_cart_items')
+      .update({
+        quantity: after,
+        metadata: mergedMetadata,
+      })
+      .eq('id', existingItem.data.id)
+      .select('*')
+      .single();
+    if (updated.error) {
+      return res.status(500).json({
+        ok: false,
+        error: 'item_update_failed',
+        detail: updated.error.message,
+      });
+    }
+    await emitCartEvent({
+      cart_id: cartId!,
+      user_id: id.user_id,
+      event_type: 'item.added',
+      event_payload: {
+        cart_item_id: updated.data.id,
+        product_id: body.product_id,
+        quantity_before: before,
+        quantity_after: after,
+        source_surface: body.source_surface,
+        source_ref: body.source_ref,
+      },
+    });
+    return res.status(200).json({
+      ok: true,
+      cart_id: cartId,
+      item: updated.data,
+      action: 'quantity_bumped',
+      cart_created: cartCreatedThisRequest,
+    });
+  }
+
+  // 3. INSERT a new cart_items row.
+  const insertPayload: Record<string, unknown> = {
+    cart_id: cartId,
+    item_type: body.item_type,
+    product_id: body.product_id,
+    quantity: body.quantity,
+    status: 'active',
+    metadata: incomingMetadata,
+  };
+  if (body.merchant_id !== undefined) insertPayload.merchant_id = body.merchant_id;
+  if (body.unit_price_cents_snapshot !== undefined) insertPayload.unit_price_cents_snapshot = body.unit_price_cents_snapshot;
+  if (body.currency_snapshot !== undefined) insertPayload.currency_snapshot = body.currency_snapshot;
+  if (body.source_surface !== undefined) insertPayload.source_surface = body.source_surface;
+  if (body.source_ref !== undefined) insertPayload.source_ref = body.source_ref;
+
+  const inserted = await supabase
+    .from('universal_cart_items')
+    .insert(insertPayload)
+    .select('*')
+    .single();
+
+  if (inserted.error) {
+    return res.status(500).json({
+      ok: false,
+      error: 'item_insert_failed',
+      detail: inserted.error.message,
+    });
+  }
+
+  await emitCartEvent({
+    cart_id: cartId!,
+    user_id: id.user_id,
+    event_type: 'item.added',
+    event_payload: {
+      cart_item_id: inserted.data.id,
+      product_id: body.product_id,
+      quantity_before: 0,
+      quantity_after: body.quantity,
+      source_surface: body.source_surface,
+      source_ref: body.source_ref,
+    },
+  });
+
+  return res.status(201).json({
+    ok: true,
+    cart_id: cartId,
+    item: inserted.data,
+    action: 'created',
+    cart_created: cartCreatedThisRequest,
+  });
+});
+
+/**
+ * PATCH /items/:itemId — Update quantity / metadata for an active item.
+ * RLS rejects updates to other users' items via parent-cart ownership; the
+ * gateway never needs to check user_id explicitly on the items table.
+ */
+router.patch('/items/:itemId', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  const parsed = PatchItemBody.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: 'invalid_request',
+      detail: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+    });
+  }
+  const body = parsed.data;
+  const itemId = req.params.itemId;
+
+  const supabase = createUserSupabaseClient(id.token);
+
+  // Read the current row to capture quantity_before for the event payload.
+  // RLS scopes this to the caller; cross-user reads return null.
+  const current = await supabase
+    .from('universal_cart_items')
+    .select('id, cart_id, quantity, metadata, status')
+    .eq('id', itemId)
+    .maybeSingle();
+
+  if (current.error && current.error.code !== 'PGRST116') {
+    return res.status(500).json({
+      ok: false,
+      error: 'item_lookup_failed',
+      detail: current.error.message,
+    });
+  }
+  if (!current.data) {
+    return res.status(404).json({ ok: false, error: 'item_not_found' });
+  }
+  if (current.data.status !== 'active') {
+    return res.status(409).json({
+      ok: false,
+      error: 'item_not_active',
+      current_status: current.data.status,
+    });
+  }
+
+  const updatePayload: Record<string, unknown> = {};
+  if (body.quantity !== undefined) updatePayload.quantity = body.quantity;
+  if (body.metadata !== undefined) {
+    updatePayload.metadata = { ...(current.data.metadata || {}), ...body.metadata };
+  }
+
+  const updated = await supabase
+    .from('universal_cart_items')
+    .update(updatePayload)
+    .eq('id', itemId)
+    .select('*')
+    .single();
+
+  if (updated.error) {
+    return res.status(500).json({
+      ok: false,
+      error: 'item_update_failed',
+      detail: updated.error.message,
+    });
+  }
+
+  if (body.quantity !== undefined && body.quantity !== Number(current.data.quantity)) {
+    await emitCartEvent({
+      cart_id: current.data.cart_id,
+      user_id: id.user_id,
+      event_type: 'item.quantity_changed',
+      event_payload: {
+        cart_item_id: itemId,
+        quantity_before: Number(current.data.quantity),
+        quantity_after: body.quantity,
+      },
+    });
+  }
+
+  return res.status(200).json({ ok: true, item: updated.data });
+});
+
+/**
+ * DELETE /items/:itemId — Soft-remove (status='removed').
+ * Hard delete is intentionally not exposed; audit trail relies on the row + event log.
+ */
+router.delete('/items/:itemId', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  const itemId = req.params.itemId;
+  const removalReason = typeof req.body?.removal_reason === 'string'
+    ? String(req.body.removal_reason).slice(0, 200)
+    : undefined;
+
+  const supabase = createUserSupabaseClient(id.token);
+
+  const current = await supabase
+    .from('universal_cart_items')
+    .select('id, cart_id, status')
+    .eq('id', itemId)
+    .maybeSingle();
+
+  if (current.error && current.error.code !== 'PGRST116') {
+    return res.status(500).json({
+      ok: false,
+      error: 'item_lookup_failed',
+      detail: current.error.message,
+    });
+  }
+  if (!current.data) {
+    return res.status(404).json({ ok: false, error: 'item_not_found' });
+  }
+  if (current.data.status !== 'active') {
+    return res.status(409).json({
+      ok: false,
+      error: 'item_not_active',
+      current_status: current.data.status,
+    });
+  }
+
+  const updated = await supabase
+    .from('universal_cart_items')
+    .update({ status: 'removed' })
+    .eq('id', itemId)
+    .select('*')
+    .single();
+
+  if (updated.error) {
+    return res.status(500).json({
+      ok: false,
+      error: 'item_remove_failed',
+      detail: updated.error.message,
+    });
+  }
+
+  await emitCartEvent({
+    cart_id: current.data.cart_id,
+    user_id: id.user_id,
+    event_type: 'item.removed',
+    event_payload: {
+      cart_item_id: itemId,
+      removal_reason: removalReason,
+    },
+  });
+
+  return res.status(200).json({ ok: true, item: updated.data });
+});
+
+/**
+ * POST /items/:itemId/complete — Mark item completed (PRD Q4: explicit callback).
+ * Called by the existing per-item flow (single-item product_orders) on success.
+ */
+router.post('/items/:itemId/complete', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  const itemId = req.params.itemId;
+
+  const supabase = createUserSupabaseClient(id.token);
+
+  const current = await supabase
+    .from('universal_cart_items')
+    .select('id, cart_id, status, product_id')
+    .eq('id', itemId)
+    .maybeSingle();
+
+  if (current.error && current.error.code !== 'PGRST116') {
+    return res.status(500).json({
+      ok: false,
+      error: 'item_lookup_failed',
+      detail: current.error.message,
+    });
+  }
+  if (!current.data) {
+    return res.status(404).json({ ok: false, error: 'item_not_found' });
+  }
+  if (current.data.status === 'completed') {
+    // Idempotent: caller may retry the callback safely.
+    return res.status(200).json({
+      ok: true,
+      item: current.data,
+      already_completed: true,
+    });
+  }
+  if (current.data.status !== 'active') {
+    return res.status(409).json({
+      ok: false,
+      error: 'item_not_active',
+      current_status: current.data.status,
+    });
+  }
+
+  const updated = await supabase
+    .from('universal_cart_items')
+    .update({ status: 'completed' })
+    .eq('id', itemId)
+    .select('*')
+    .single();
+
+  if (updated.error) {
+    return res.status(500).json({
+      ok: false,
+      error: 'item_complete_failed',
+      detail: updated.error.message,
+    });
+  }
+
+  await emitCartEvent({
+    cart_id: current.data.cart_id,
+    user_id: id.user_id,
+    event_type: 'item.completed',
+    event_payload: {
+      cart_item_id: itemId,
+      product_id: current.data.product_id,
+    },
+  });
+
+  return res.status(200).json({ ok: true, item: updated.data });
+});
+
+/**
+ * GET /events — Read recent events for the caller's active cart.
+ * RLS gates SELECT via parent-cart ownership (universal_cart_events_select_via_cart),
+ * so the user-JWT-scoped client will only return events the caller owns.
+ */
+router.get('/events', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  const supabase = createUserSupabaseClient(id.token);
+
+  // Find the caller's active cart first so we can scope the events query to it.
+  const cartRes = await supabase
+    .from('universal_carts')
+    .select('id')
+    .eq('user_id', id.user_id)
+    .eq('status', 'active')
+    .maybeSingle();
+
+  if (cartRes.error && cartRes.error.code !== 'PGRST116') {
+    return res.status(500).json({
+      ok: false,
+      error: 'cart_lookup_failed',
+      detail: cartRes.error.message,
+    });
+  }
+  if (!cartRes.data) {
+    return res.status(200).json({ ok: true, events: [] });
+  }
+
+  const rawLimit = Number(req.query.limit);
+  const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, 200) : 50;
+
+  const eventsRes = await supabase
+    .from('universal_cart_events')
+    .select('*')
+    .eq('cart_id', cartRes.data.id)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (eventsRes.error) {
+    return res.status(500).json({
+      ok: false,
+      error: 'events_lookup_failed',
+      detail: eventsRes.error.message,
+    });
+  }
+
+  return res.status(200).json({ ok: true, events: eventsRes.data ?? [] });
+});
+
+export default router;

--- a/services/gateway/src/routes/universal-cart.ts
+++ b/services/gateway/src/routes/universal-cart.ts
@@ -238,6 +238,14 @@ export async function emitCartEvent(args: {
   }
 }
 
+function isNoRowsError(error: any): boolean {
+  return error?.code === 'PGRST116';
+}
+
+function isUniqueViolation(error: any): boolean {
+  return error?.code === '23505';
+}
+
 // =============================================================================
 // Request schemas
 // =============================================================================
@@ -299,7 +307,7 @@ router.post('/', async (req: Request, res: Response) => {
   if (existing.data) {
     return res.status(200).json({ ok: true, cart: existing.data, created: false });
   }
-  if (existing.error && existing.error.code && existing.error.code !== 'PGRST116') {
+  if (existing.error && existing.error.code && !isNoRowsError(existing.error)) {
     return res.status(500).json({
       ok: false,
       error: 'cart_lookup_failed',
@@ -324,6 +332,26 @@ router.post('/', async (req: Request, res: Response) => {
     })
     .select('*')
     .single();
+
+  if (created.error && isUniqueViolation(created.error)) {
+    const racedExisting = await supabase
+      .from('universal_carts')
+      .select('*')
+      .eq('user_id', id.user_id)
+      .eq('status', 'active')
+      .maybeSingle();
+
+    if (racedExisting.data) {
+      return res.status(200).json({ ok: true, cart: racedExisting.data, created: false });
+    }
+    if (racedExisting.error && !isNoRowsError(racedExisting.error)) {
+      return res.status(500).json({
+        ok: false,
+        error: 'cart_lookup_failed',
+        detail: racedExisting.error.message,
+      });
+    }
+  }
 
   if (created.error) {
     return res.status(500).json({
@@ -360,7 +388,7 @@ router.get('/', async (req: Request, res: Response) => {
     .eq('status', 'active')
     .maybeSingle();
 
-  if (cartRes.error && cartRes.error.code !== 'PGRST116') {
+  if (cartRes.error && !isNoRowsError(cartRes.error)) {
     return res.status(500).json({
       ok: false,
       error: 'cart_lookup_failed',
@@ -422,7 +450,7 @@ router.post('/items', async (req: Request, res: Response) => {
     .eq('status', 'active')
     .maybeSingle();
 
-  if (cartLookup.error && cartLookup.error.code !== 'PGRST116') {
+  if (cartLookup.error && !isNoRowsError(cartLookup.error)) {
     return res.status(500).json({
       ok: false,
       error: 'cart_lookup_failed',
@@ -444,21 +472,48 @@ router.post('/items', async (req: Request, res: Response) => {
       })
       .select('id')
       .single();
-    if (newCart.error || !newCart.data) {
+    if (newCart.error && isUniqueViolation(newCart.error)) {
+      const racedCart = await supabase
+        .from('universal_carts')
+        .select('id')
+        .eq('user_id', id.user_id)
+        .eq('status', 'active')
+        .maybeSingle();
+
+      if (racedCart.error && !isNoRowsError(racedCart.error)) {
+        return res.status(500).json({
+          ok: false,
+          error: 'cart_lookup_failed',
+          detail: racedCart.error.message,
+        });
+      }
+      if (racedCart.data?.id) {
+        cartId = racedCart.data.id as string;
+      }
+    } else if (newCart.error || !newCart.data) {
       return res.status(500).json({
         ok: false,
         error: 'cart_create_failed',
         detail: newCart.error?.message,
       });
     }
-    cartId = newCart.data.id as string;
-    cartCreatedThisRequest = true;
-    await emitCartEvent({
-      cart_id: cartId,
-      user_id: id.user_id,
-      event_type: 'cart.created',
-      event_payload: {},
-    });
+    if (!cartId && newCart.data?.id) {
+      cartId = newCart.data.id as string;
+      cartCreatedThisRequest = true;
+      await emitCartEvent({
+        cart_id: cartId,
+        user_id: id.user_id,
+        event_type: 'cart.created',
+        event_payload: {},
+      });
+    }
+    if (!cartId) {
+      return res.status(500).json({
+        ok: false,
+        error: 'cart_create_failed',
+        detail: newCart.error?.message,
+      });
+    }
   }
 
   // 2. Check whether the product is already in the cart with status='active'.
@@ -470,7 +525,7 @@ router.post('/items', async (req: Request, res: Response) => {
     .eq('status', 'active')
     .maybeSingle();
 
-  if (existingItem.error && existingItem.error.code !== 'PGRST116') {
+  if (existingItem.error && !isNoRowsError(existingItem.error)) {
     return res.status(500).json({
       ok: false,
       error: 'item_lookup_failed',
@@ -608,7 +663,7 @@ router.patch('/items/:itemId', async (req: Request, res: Response) => {
     .eq('id', itemId)
     .maybeSingle();
 
-  if (current.error && current.error.code !== 'PGRST116') {
+  if (current.error && !isNoRowsError(current.error)) {
     return res.status(500).json({
       ok: false,
       error: 'item_lookup_failed',
@@ -684,7 +739,7 @@ router.delete('/items/:itemId', async (req: Request, res: Response) => {
     .eq('id', itemId)
     .maybeSingle();
 
-  if (current.error && current.error.code !== 'PGRST116') {
+  if (current.error && !isNoRowsError(current.error)) {
     return res.status(500).json({
       ok: false,
       error: 'item_lookup_failed',
@@ -748,7 +803,7 @@ router.post('/items/:itemId/complete', async (req: Request, res: Response) => {
     .eq('id', itemId)
     .maybeSingle();
 
-  if (current.error && current.error.code !== 'PGRST116') {
+  if (current.error && !isNoRowsError(current.error)) {
     return res.status(500).json({
       ok: false,
       error: 'item_lookup_failed',
@@ -821,7 +876,7 @@ router.get('/events', async (req: Request, res: Response) => {
     .eq('status', 'active')
     .maybeSingle();
 
-  if (cartRes.error && cartRes.error.code !== 'PGRST116') {
+  if (cartRes.error && !isNoRowsError(cartRes.error)) {
     return res.status(500).json({
       ok: false,
       error: 'cart_lookup_failed',

--- a/services/gateway/test/universal-cart.test.ts
+++ b/services/gateway/test/universal-cart.test.ts
@@ -1,0 +1,734 @@
+/**
+ * VTID-03213 — Universal Cart gateway slice tests.
+ *
+ * Coverage:
+ *   §1  Role gating          — 401 unauthenticated, 403 cart_unavailable_for_role for non-community.
+ *   §2  Owner isolation      — RLS-blank reads surface as 404, gateway never trusts cross-user inputs.
+ *   §3  Active-cart behavior — POST / get-or-create idempotency; emits cart.created only on actual create.
+ *   §4  Item mutation        — add (insert), add (quantity bump), patch quantity, soft-remove, complete (idempotent).
+ *   §5  Event emission       — every mutation lands one row in universal_cart_events with the right type.
+ *   §6  Payload sanitizer    — pure-function tests on whitelist + length cap.
+ *
+ * The Supabase client is mocked at the lib level (both `createUserSupabaseClient`
+ * and `getSupabase`). Each test queues responses on a chainable mock; routes call
+ * the mock through their normal code path. Mirrors the pattern in
+ * test/autopilot-pipeline.test.ts.
+ */
+
+import request from 'supertest';
+
+// =============================================================================
+// Chainable Supabase mock — mirrors the helper in autopilot-pipeline.test.ts
+// =============================================================================
+
+type SupaResponse = { data: any; error: any };
+
+const createChainableMock = () => {
+  let defaultData: SupaResponse = { data: null, error: null };
+  const responseQueue: SupaResponse[] = [];
+  const calls: { op: string; args: any[] }[] = [];
+
+  const record = (op: string, args: any[]) => calls.push({ op, args });
+
+  const chain: any = {
+    from: jest.fn((...args: any[]) => { record('from', args); return chain; }),
+    select: jest.fn((...args: any[]) => { record('select', args); return chain; }),
+    insert: jest.fn((...args: any[]) => { record('insert', args); return chain; }),
+    update: jest.fn((...args: any[]) => { record('update', args); return chain; }),
+    delete: jest.fn((...args: any[]) => { record('delete', args); return chain; }),
+    eq: jest.fn((...args: any[]) => { record('eq', args); return chain; }),
+    neq: jest.fn(() => chain),
+    gt: jest.fn(() => chain),
+    gte: jest.fn(() => chain),
+    lt: jest.fn(() => chain),
+    lte: jest.fn(() => chain),
+    is: jest.fn(() => chain),
+    in: jest.fn(() => chain),
+    order: jest.fn(() => chain),
+    limit: jest.fn(() => chain),
+    single: jest.fn(() => chain),
+    maybeSingle: jest.fn(() => chain),
+    rpc: jest.fn((...args: any[]) => { record('rpc', args); return chain; }),
+    then: jest.fn((resolve: any) => {
+      const data = responseQueue.length > 0 ? responseQueue.shift()! : defaultData;
+      return Promise.resolve(data).then(resolve);
+    }),
+    __seed: (response: SupaResponse) => { responseQueue.push(response); return chain; },
+    __setDefault: (response: SupaResponse) => { defaultData = response; return chain; },
+    __clear: () => {
+      responseQueue.length = 0;
+      defaultData = { data: null, error: null };
+      calls.length = 0;
+    },
+    __calls: () => calls,
+    __countInserts: (table: string) => {
+      let count = 0;
+      let inFrom = false;
+      for (const c of calls) {
+        if (c.op === 'from') inFrom = c.args[0] === table;
+        if (c.op === 'insert' && inFrom) count++;
+      }
+      return count;
+    },
+    __insertsFor: (table: string) => {
+      const inserts: any[] = [];
+      let lastFrom: string | null = null;
+      for (const c of calls) {
+        if (c.op === 'from') lastFrom = c.args[0];
+        if (c.op === 'insert' && lastFrom === table) inserts.push(c.args[0]);
+      }
+      return inserts;
+    },
+    __updatesFor: (table: string) => {
+      const updates: any[] = [];
+      let lastFrom: string | null = null;
+      for (const c of calls) {
+        if (c.op === 'from') lastFrom = c.args[0];
+        if (c.op === 'update' && lastFrom === table) updates.push(c.args[0]);
+      }
+      return updates;
+    },
+  };
+  return chain;
+};
+
+const mockSupabase = createChainableMock();
+
+// Mock both lib entry points so the route sees the same chainable mock.
+jest.mock('../src/lib/supabase', () => ({
+  getSupabase: jest.fn(() => mockSupabase),
+}));
+jest.mock('../src/lib/supabase-user', () => ({
+  createUserSupabaseClient: jest.fn(() => mockSupabase),
+}));
+
+// Required env so the imported module's process.env reads don't throw at import time.
+process.env.SUPABASE_URL = 'http://localhost:54321';
+process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+
+// Suppress noisy console.error from the route during expected-failure tests.
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+// Import the router AFTER mocks are in place.
+import express from 'express';
+import universalCartRouter, {
+  sanitizeEventPayload,
+  getBearerToken,
+} from '../src/routes/universal-cart';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/universal-cart', universalCartRouter);
+  return app;
+}
+
+const USER_A = '11111111-1111-4000-a000-000000000a01';
+const USER_B = '22222222-2222-4000-b000-000000000b01';
+const TENANT_1 = '00000000-0000-4000-c000-000000000c01';
+const CART_A = '33333333-3333-4000-d000-000000000d01';
+const CART_B = '44444444-4444-4000-d000-000000000d02';
+const ITEM_A = '55555555-5555-4000-e000-000000000e01';
+const PRODUCT_A = '66666666-6666-4000-f000-000000000f01';
+const PRODUCT_B = '77777777-7777-4000-f000-000000000f02';
+
+const BEARER_A = 'Bearer fake-jwt-user-a';
+const BEARER_B = 'Bearer fake-jwt-user-b';
+
+/** Seed the me_context + active_role lookups for a given user / role. */
+function seedAuth(opts: { user_id?: string; tenant_id?: string | null; role: string | null }) {
+  // me_context RPC
+  mockSupabase.__seed({
+    data: { user_id: opts.user_id ?? USER_A, tenant_id: opts.tenant_id === undefined ? TENANT_1 : opts.tenant_id },
+    error: null,
+  });
+  // user_tenants.active_role lookup
+  if (opts.role !== null && opts.tenant_id !== null) {
+    mockSupabase.__seed({ data: { active_role: opts.role }, error: null });
+  } else if (opts.tenant_id !== null) {
+    // explicit no-row → maybeSingle returns data: null
+    mockSupabase.__seed({ data: null, error: null });
+  }
+  // If tenant_id is null, getActiveRole short-circuits without querying — no seed needed.
+}
+
+beforeEach(() => {
+  mockSupabase.__clear();
+  consoleErrorSpy.mockClear();
+});
+
+// =============================================================================
+// §6  Payload sanitizer (pure unit)
+// =============================================================================
+
+describe(`${'VTID-03213'} §6 sanitizeEventPayload`, () => {
+  test('drops unknown keys', () => {
+    const out = sanitizeEventPayload({
+      cart_item_id: 'a',
+      product_id: 'b',
+      unit_price_cents_snapshot: 1234, // forbidden per PRIVACY RULE
+      currency_snapshot: 'EUR',        // forbidden per PRIVACY RULE
+      user_id: 'leaked',               // forbidden per PRIVACY RULE
+      email: 'leaked@x.com',
+    });
+    expect(out).toEqual({ cart_item_id: 'a', product_id: 'b' });
+  });
+
+  test('truncates long string values to the cap', () => {
+    const long = 'x'.repeat(500);
+    const out = sanitizeEventPayload({ source_ref: long });
+    expect((out.source_ref as string).length).toBe(200);
+  });
+
+  test('preserves numbers and booleans on allowed keys', () => {
+    const out = sanitizeEventPayload({
+      quantity_before: 1,
+      quantity_after: 2,
+    });
+    expect(out).toEqual({ quantity_before: 1, quantity_after: 2 });
+  });
+
+  test('handles null / undefined input', () => {
+    expect(sanitizeEventPayload(null)).toEqual({});
+    expect(sanitizeEventPayload(undefined)).toEqual({});
+    expect(sanitizeEventPayload({})).toEqual({});
+  });
+
+  test('coerces nested objects to truncated string and keeps key', () => {
+    const out = sanitizeEventPayload({ source_ref: { a: 1, b: 'x'.repeat(500) } as any });
+    expect(typeof out.source_ref).toBe('string');
+    expect((out.source_ref as string).length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe(`${'VTID-03213'} §6 getBearerToken`, () => {
+  test('extracts token from Bearer header', () => {
+    const req: any = { headers: { authorization: 'Bearer abc.def.ghi' } };
+    expect(getBearerToken(req)).toBe('abc.def.ghi');
+  });
+  test('returns null for missing header', () => {
+    expect(getBearerToken({ headers: {} } as any)).toBeNull();
+  });
+  test('returns null for non-Bearer scheme', () => {
+    expect(getBearerToken({ headers: { authorization: 'Basic xyz' } } as any)).toBeNull();
+  });
+});
+
+// =============================================================================
+// §1  Role gating
+// =============================================================================
+
+describe(`${'VTID-03213'} §1 role gating`, () => {
+  test('GET /health is open (no auth required)', async () => {
+    const res = await request(buildApp()).get('/api/v1/universal-cart/health');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  test('POST / without Bearer → 401', async () => {
+    const res = await request(buildApp()).post('/api/v1/universal-cart');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  test('POST / when me_context errors → 401', async () => {
+    mockSupabase.__seed({ data: null, error: { message: 'jwt expired' } });
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  test('POST / with role=admin → 403 cart_unavailable_for_role', async () => {
+    seedAuth({ role: 'admin' });
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cart_unavailable_for_role');
+    expect(res.body.role).toBe('admin');
+  });
+
+  test('POST / with role=developer → 403', async () => {
+    seedAuth({ role: 'developer' });
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cart_unavailable_for_role');
+  });
+
+  test('POST / with no active_role row → 403', async () => {
+    seedAuth({ role: null });
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cart_unavailable_for_role');
+    expect(res.body.role).toBeNull();
+  });
+
+  test('GET / requires same gate (sanity)', async () => {
+    seedAuth({ role: 'admin' });
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cart_unavailable_for_role');
+  });
+});
+
+// =============================================================================
+// §3  Active-cart behavior
+// =============================================================================
+
+describe(`${'VTID-03213'} §3 active-cart behavior`, () => {
+  test('POST / creates a new active cart and emits cart.created when none exists', async () => {
+    seedAuth({ role: 'community' });
+    // universal_carts SELECT → no existing
+    mockSupabase.__seed({ data: null, error: null });
+    // universal_carts INSERT → returns new cart
+    mockSupabase.__seed({
+      data: { id: CART_A, user_id: USER_A, status: 'active', tenant_id: TENANT_1 },
+      error: null,
+    });
+    // universal_cart_events INSERT (audit)
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.created).toBe(true);
+    expect(res.body.cart.id).toBe(CART_A);
+    expect(mockSupabase.__insertsFor('universal_carts')).toHaveLength(1);
+    expect(mockSupabase.__insertsFor('universal_cart_events')).toHaveLength(1);
+    expect(mockSupabase.__insertsFor('universal_cart_events')[0].event_type).toBe('cart.created');
+  });
+
+  test('POST / returns existing cart and emits NO event when active cart exists', async () => {
+    seedAuth({ role: 'community' });
+    // universal_carts SELECT → existing active cart
+    mockSupabase.__seed({
+      data: { id: CART_A, user_id: USER_A, status: 'active' },
+      error: null,
+    });
+
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.created).toBe(false);
+    expect(res.body.cart.id).toBe(CART_A);
+    expect(mockSupabase.__insertsFor('universal_carts')).toHaveLength(0);
+    expect(mockSupabase.__insertsFor('universal_cart_events')).toHaveLength(0);
+  });
+
+  test('GET / returns null cart + empty items when none exists', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({ data: null, error: null }); // no cart
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cart).toBeNull();
+    expect(res.body.items).toEqual([]);
+  });
+
+  test('GET / returns active cart with active items', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({
+      data: { id: CART_A, user_id: USER_A, status: 'active' },
+      error: null,
+    });
+    mockSupabase.__seed({
+      data: [
+        { id: ITEM_A, cart_id: CART_A, product_id: PRODUCT_A, quantity: 2, status: 'active' },
+      ],
+      error: null,
+    });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cart.id).toBe(CART_A);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].id).toBe(ITEM_A);
+  });
+});
+
+// =============================================================================
+// §4  Item mutation + §5 event emission
+// =============================================================================
+
+describe(`${'VTID-03213'} §4 item mutation + §5 event emission`, () => {
+  test('POST /items — 400 on invalid body', async () => {
+    seedAuth({ role: 'community' });
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart/items')
+      .set('Authorization', BEARER_A)
+      .send({ product_id: 'not-a-uuid', item_type: 'supplement' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+  });
+
+  test('POST /items — 400 on unknown source_surface', async () => {
+    seedAuth({ role: 'community' });
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart/items')
+      .set('Authorization', BEARER_A)
+      .send({ product_id: PRODUCT_A, item_type: 'supplement', source_surface: 'sms' });
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /items — 400 on unknown item_type', async () => {
+    seedAuth({ role: 'community' });
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart/items')
+      .set('Authorization', BEARER_A)
+      .send({ product_id: PRODUCT_A, item_type: 'lab_test' });
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /items — creates new item with autopilot_rec_id metadata and emits item.added', async () => {
+    seedAuth({ role: 'community' });
+    // cart lookup → existing
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    // existing-item lookup → none
+    mockSupabase.__seed({ data: null, error: null });
+    // item insert
+    mockSupabase.__seed({
+      data: {
+        id: ITEM_A, cart_id: CART_A, product_id: PRODUCT_A, quantity: 1,
+        status: 'active',
+        metadata: { autopilot_rec_id: '99999999-9999-4000-a000-000000000099' },
+      },
+      error: null,
+    });
+    // cart_events insert
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart/items')
+      .set('Authorization', BEARER_A)
+      .send({
+        product_id: PRODUCT_A,
+        item_type: 'supplement',
+        quantity: 1,
+        source_surface: 'community',
+        autopilot_rec_id: '99999999-9999-4000-a000-000000000099',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.action).toBe('created');
+    expect(res.body.item.id).toBe(ITEM_A);
+
+    const itemInserts = mockSupabase.__insertsFor('universal_cart_items');
+    expect(itemInserts).toHaveLength(1);
+    expect(itemInserts[0].metadata.autopilot_rec_id).toBe('99999999-9999-4000-a000-000000000099');
+    expect(itemInserts[0].source_surface).toBe('community');
+
+    const eventInserts = mockSupabase.__insertsFor('universal_cart_events');
+    expect(eventInserts).toHaveLength(1);
+    expect(eventInserts[0].event_type).toBe('item.added');
+    expect(eventInserts[0].event_payload.quantity_before).toBe(0);
+    expect(eventInserts[0].event_payload.quantity_after).toBe(1);
+    expect(eventInserts[0].event_payload.cart_item_id).toBe(ITEM_A);
+    // Sanitizer must drop disallowed keys like product_id wait — product_id IS allowed.
+    expect(eventInserts[0].event_payload.product_id).toBe(PRODUCT_A);
+  });
+
+  test('POST /items — bumps quantity on duplicate product and emits item.added with before/after', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    // existing-item lookup → found
+    mockSupabase.__seed({
+      data: {
+        id: ITEM_A, cart_id: CART_A, product_id: PRODUCT_A, quantity: 2,
+        status: 'active', metadata: {},
+      },
+      error: null,
+    });
+    // update
+    mockSupabase.__seed({
+      data: { id: ITEM_A, quantity: 5, status: 'active' },
+      error: null,
+    });
+    // event
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart/items')
+      .set('Authorization', BEARER_A)
+      .send({
+        product_id: PRODUCT_A,
+        item_type: 'supplement',
+        quantity: 3,
+        source_surface: 'web',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('quantity_bumped');
+    expect(mockSupabase.__insertsFor('universal_cart_items')).toHaveLength(0);
+    expect(mockSupabase.__updatesFor('universal_cart_items')).toHaveLength(1);
+    expect(mockSupabase.__updatesFor('universal_cart_items')[0].quantity).toBe(5);
+
+    const eventInserts = mockSupabase.__insertsFor('universal_cart_events');
+    expect(eventInserts).toHaveLength(1);
+    expect(eventInserts[0].event_type).toBe('item.added');
+    expect(eventInserts[0].event_payload.quantity_before).toBe(2);
+    expect(eventInserts[0].event_payload.quantity_after).toBe(5);
+  });
+
+  test('PATCH /items/:id — quantity change emits item.quantity_changed event', async () => {
+    seedAuth({ role: 'community' });
+    // current item lookup
+    mockSupabase.__seed({
+      data: { id: ITEM_A, cart_id: CART_A, quantity: 1, metadata: {}, status: 'active' },
+      error: null,
+    });
+    // update
+    mockSupabase.__seed({
+      data: { id: ITEM_A, quantity: 4, status: 'active' },
+      error: null,
+    });
+    // event
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .patch(`/api/v1/universal-cart/items/${ITEM_A}`)
+      .set('Authorization', BEARER_A)
+      .send({ quantity: 4 });
+
+    expect(res.status).toBe(200);
+    const eventInserts = mockSupabase.__insertsFor('universal_cart_events');
+    expect(eventInserts).toHaveLength(1);
+    expect(eventInserts[0].event_type).toBe('item.quantity_changed');
+    expect(eventInserts[0].event_payload.quantity_before).toBe(1);
+    expect(eventInserts[0].event_payload.quantity_after).toBe(4);
+  });
+
+  test('PATCH /items/:id — metadata-only update does NOT emit a quantity event', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({
+      data: { id: ITEM_A, cart_id: CART_A, quantity: 1, metadata: { a: 1 }, status: 'active' },
+      error: null,
+    });
+    mockSupabase.__seed({
+      data: { id: ITEM_A, quantity: 1, metadata: { a: 1, b: 2 }, status: 'active' },
+      error: null,
+    });
+
+    const res = await request(buildApp())
+      .patch(`/api/v1/universal-cart/items/${ITEM_A}`)
+      .set('Authorization', BEARER_A)
+      .send({ metadata: { b: 2 } });
+
+    expect(res.status).toBe(200);
+    expect(mockSupabase.__insertsFor('universal_cart_events')).toHaveLength(0);
+  });
+
+  test('PATCH /items/:id — 404 when item not visible (RLS-blank read surfaces as not found)', async () => {
+    seedAuth({ role: 'community' });
+    // RLS would hide a cross-user item; the route receives data: null and returns 404.
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .patch(`/api/v1/universal-cart/items/${ITEM_A}`)
+      .set('Authorization', BEARER_A)
+      .send({ quantity: 2 });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('item_not_found');
+  });
+
+  test('DELETE /items/:id — soft-removes and emits item.removed', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({
+      data: { id: ITEM_A, cart_id: CART_A, status: 'active' },
+      error: null,
+    });
+    mockSupabase.__seed({
+      data: { id: ITEM_A, status: 'removed' },
+      error: null,
+    });
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .delete(`/api/v1/universal-cart/items/${ITEM_A}`)
+      .set('Authorization', BEARER_A)
+      .send({ removal_reason: 'too expensive' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.item.status).toBe('removed');
+    const updates = mockSupabase.__updatesFor('universal_cart_items');
+    expect(updates).toHaveLength(1);
+    expect(updates[0].status).toBe('removed');
+
+    const eventInserts = mockSupabase.__insertsFor('universal_cart_events');
+    expect(eventInserts).toHaveLength(1);
+    expect(eventInserts[0].event_type).toBe('item.removed');
+    expect(eventInserts[0].event_payload.removal_reason).toBe('too expensive');
+  });
+
+  test('DELETE /items/:id — 409 when item already removed', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({
+      data: { id: ITEM_A, cart_id: CART_A, status: 'removed' },
+      error: null,
+    });
+
+    const res = await request(buildApp())
+      .delete(`/api/v1/universal-cart/items/${ITEM_A}`)
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('item_not_active');
+  });
+
+  test('POST /items/:id/complete — marks completed and emits item.completed', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({
+      data: { id: ITEM_A, cart_id: CART_A, status: 'active', product_id: PRODUCT_A },
+      error: null,
+    });
+    mockSupabase.__seed({
+      data: { id: ITEM_A, status: 'completed' },
+      error: null,
+    });
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post(`/api/v1/universal-cart/items/${ITEM_A}/complete`)
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.item.status).toBe('completed');
+    const eventInserts = mockSupabase.__insertsFor('universal_cart_events');
+    expect(eventInserts).toHaveLength(1);
+    expect(eventInserts[0].event_type).toBe('item.completed');
+    expect(eventInserts[0].event_payload.cart_item_id).toBe(ITEM_A);
+    expect(eventInserts[0].event_payload.product_id).toBe(PRODUCT_A);
+  });
+
+  test('POST /items/:id/complete — idempotent on already-completed item, no second event', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({
+      data: { id: ITEM_A, cart_id: CART_A, status: 'completed', product_id: PRODUCT_A },
+      error: null,
+    });
+
+    const res = await request(buildApp())
+      .post(`/api/v1/universal-cart/items/${ITEM_A}/complete`)
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.already_completed).toBe(true);
+    expect(mockSupabase.__insertsFor('universal_cart_events')).toHaveLength(0);
+    expect(mockSupabase.__updatesFor('universal_cart_items')).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// §2  Owner isolation
+// =============================================================================
+
+describe(`${'VTID-03213'} §2 owner isolation (RLS-mediated)`, () => {
+  test('PATCH on another user\'s item → 404 (RLS hides the row)', async () => {
+    // User B authenticates and tries to PATCH user A's item.
+    // RLS will return null from the lookup since the parent cart isn't B's.
+    seedAuth({ user_id: USER_B, role: 'community' });
+    mockSupabase.__seed({ data: null, error: null }); // RLS-blank
+
+    const res = await request(buildApp())
+      .patch(`/api/v1/universal-cart/items/${ITEM_A}`)
+      .set('Authorization', BEARER_B)
+      .send({ quantity: 99 });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('item_not_found');
+    expect(mockSupabase.__updatesFor('universal_cart_items')).toHaveLength(0);
+    expect(mockSupabase.__insertsFor('universal_cart_events')).toHaveLength(0);
+  });
+
+  test('GET / returns user B\'s cart, not user A\'s (RLS-scoped read)', async () => {
+    seedAuth({ user_id: USER_B, role: 'community' });
+    // User B's active cart (different id than user A's)
+    mockSupabase.__seed({
+      data: { id: CART_B, user_id: USER_B, status: 'active' },
+      error: null,
+    });
+    mockSupabase.__seed({ data: [], error: null });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart')
+      .set('Authorization', BEARER_B);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cart.id).toBe(CART_B);
+    expect(res.body.cart.user_id).toBe(USER_B);
+  });
+});
+
+// =============================================================================
+// Events endpoint
+// =============================================================================
+
+describe(`${'VTID-03213'} GET /events`, () => {
+  test('returns empty when no active cart', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/events')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.events).toEqual([]);
+  });
+
+  test('returns events scoped to active cart', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    mockSupabase.__seed({
+      data: [
+        { id: 1, cart_id: CART_A, event_type: 'cart.created' },
+        { id: 2, cart_id: CART_A, event_type: 'item.added' },
+      ],
+      error: null,
+    });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/events?limit=10')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.events).toHaveLength(2);
+    expect(res.body.events[0].event_type).toBe('cart.created');
+  });
+
+  test('caps limit at 200', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    mockSupabase.__seed({ data: [], error: null });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/events?limit=9999')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    // The limit() call argument was clamped; we don't assert the exact value because
+    // the chainable mock doesn't capture .limit() args via __calls in a stable way,
+    // but the request must not error and must return the events list.
+    expect(Array.isArray(res.body.events)).toBe(true);
+  });
+});

--- a/services/gateway/test/universal-cart.test.ts
+++ b/services/gateway/test/universal-cart.test.ts
@@ -329,6 +329,35 @@ describe(`${'VTID-03213'} §3 active-cart behavior`, () => {
     expect(mockSupabase.__insertsFor('universal_cart_events')).toHaveLength(0);
   });
 
+  test('POST / recovers when a concurrent request creates the active cart first', async () => {
+    seedAuth({ role: 'community' });
+    // initial universal_carts SELECT → no existing
+    mockSupabase.__seed({ data: null, error: null });
+    // universal_carts INSERT → unique conflict from the partial active-cart index
+    mockSupabase.__seed({
+      data: null,
+      error: {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint "universal_carts_one_active_per_user"',
+      },
+    });
+    // follow-up SELECT after the conflict → cart created by the racing request
+    mockSupabase.__seed({
+      data: { id: CART_A, user_id: USER_A, status: 'active', tenant_id: TENANT_1 },
+      error: null,
+    });
+
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.created).toBe(false);
+    expect(res.body.cart.id).toBe(CART_A);
+    expect(mockSupabase.__insertsFor('universal_carts')).toHaveLength(1);
+    expect(mockSupabase.__insertsFor('universal_cart_events')).toHaveLength(0);
+  });
+
   test('GET / returns null cart + empty items when none exists', async () => {
     seedAuth({ role: 'community' });
     mockSupabase.__seed({ data: null, error: null }); // no cart
@@ -445,6 +474,54 @@ describe(`${'VTID-03213'} §4 item mutation + §5 event emission`, () => {
     expect(eventInserts[0].event_payload.cart_item_id).toBe(ITEM_A);
     // Sanitizer must drop disallowed keys like product_id wait — product_id IS allowed.
     expect(eventInserts[0].event_payload.product_id).toBe(PRODUCT_A);
+  });
+
+  test('POST /items — recovers active-cart unique conflict and still inserts item', async () => {
+    seedAuth({ role: 'community' });
+    // cart lookup → none
+    mockSupabase.__seed({ data: null, error: null });
+    // cart insert → concurrent creator won the unique race
+    mockSupabase.__seed({
+      data: null,
+      error: {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint "universal_carts_one_active_per_user"',
+      },
+    });
+    // raced-cart lookup → existing active cart
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    // existing-item lookup → none
+    mockSupabase.__seed({ data: null, error: null });
+    // item insert
+    mockSupabase.__seed({
+      data: { id: ITEM_A, cart_id: CART_A, product_id: PRODUCT_A, quantity: 1, status: 'active' },
+      error: null,
+    });
+    // item.added event insert
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/universal-cart/items')
+      .set('Authorization', BEARER_A)
+      .send({
+        product_id: PRODUCT_A,
+        item_type: 'supplement',
+        quantity: 1,
+        source_surface: 'web',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.cart_id).toBe(CART_A);
+    expect(res.body.cart_created).toBe(false);
+    expect(res.body.action).toBe('created');
+
+    const itemInserts = mockSupabase.__insertsFor('universal_cart_items');
+    expect(itemInserts).toHaveLength(1);
+    expect(itemInserts[0].cart_id).toBe(CART_A);
+
+    const eventInserts = mockSupabase.__insertsFor('universal_cart_events');
+    expect(eventInserts).toHaveLength(1);
+    expect(eventInserts[0].event_type).toBe('item.added');
   });
 
   test('POST /items — bumps quantity on duplicate product and emits item.added with before/after', async () => {


### PR DESCRIPTION
## Summary

Universal Cart Phase 1 gateway routes against the production `universal_*` tables shipped in [#2420](https://github.com/exafyltd/vitana-platform/pull/2420) (VTID-03186). Community-role-only, RLS-enforced, audit-event-emitting. Strictly within the universal_* schema — **no Lovable-side commerce table is touched**.

## Endpoints (mounted at `/api/v1/universal-cart`)

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/` | Get-or-create the caller's active cart |
| `GET` | `/` | Read active cart + active items |
| `POST` | `/items` | Add an item (or quantity-bump on duplicate product) |
| `PATCH` | `/items/:itemId` | Update quantity / metadata |
| `DELETE` | `/items/:itemId` | Soft-remove (`status='removed'`) |
| `POST` | `/items/:itemId/complete` | Mark completed (PRD Q4 callback) |
| `GET` | `/events` | Recent events for the active cart |
| `GET` | `/health` | Health check (no auth) |

## Access control

- **Community-role-only.** Non-community sessions → `HTTP 403 { error: 'cart_unavailable_for_role' }`.
- Bearer JWT → `me_context` RPC → `user_id` + `tenant_id`.
- `user_tenants.active_role` looked up via service-role client, mirroring `require-tenant-admin.ts`.
- Cart + cart_items mutations use the **user-JWT-scoped client** so RLS enforces owner isolation at the database level. The gateway never trusts caller-supplied `user_id` or `cart_id` ownership claims.

## Event emission

`universal_cart_events` is service-role-only-INSERT (RLS blocks `authenticated` writes). Audit emission is the gateway's responsibility, done via `getSupabase()` after each successful mutation.

| Event | Emitted on |
|---|---|
| `cart.created` | Initial cart insert (not on no-op fetches) |
| `item.added` | `POST /items` — both fresh insert AND quantity-bump (analytics disambiguate via `quantity_before/after`) |
| `item.quantity_changed` | `PATCH` that actually changes quantity (metadata-only PATCH emits nothing) |
| `item.removed` | `DELETE /items/:itemId` |
| `item.completed` | `POST /items/:itemId/complete` (idempotent — no event on already-completed) |

`sanitizeEventPayload()` enforces the **PRIVACY RULE** documented on the `universal_cart_events` schema COMMENT:

- Only whitelisted keys: `cart_item_id`, `product_id`, `quantity_before/after`, `source_surface`, `source_ref`, `removal_reason`.
- String values capped at 200 chars.
- `unit_price_cents_snapshot`, `currency_snapshot`, `email`, `user_id`-as-payload → dropped silently.
- Failed event INSERT logs but **does not fail the user-facing mutation** (audit-gap recoverable; broken cart UX is not).

## Tests (36, all green)

```
PASS test/universal-cart.test.ts
Tests:       36 passed, 36 total
Time:        24.202 s
```

Coverage matches the deliverables in the handoff:

- **§1 role gating** — 401 without Bearer, 401 on `me_context` error, 403 for `admin` / `developer` / no-row / non-community on every route.
- **§2 owner isolation (RLS-mediated)** — `PATCH` on another user's item surfaces as 404 (RLS hides the row); `GET /` returns only the caller's cart.
- **§3 active-cart behavior** — `POST /` creates + emits on first call; returns existing + emits nothing on subsequent calls; `GET /` returns `{ cart: null, items: [] }` when none exists.
- **§4 item mutation** — 400 on invalid body / unknown `source_surface` / unknown `item_type`; create new item; quantity-bump on duplicate; PATCH quantity; PATCH metadata-only (no event); DELETE soft-remove; complete idempotent; 409 on duplicate remove.
- **§5 event emission** — every mutation lands exactly one row in `universal_cart_events` with the correct `event_type` and payload shape.
- **§6 sanitizer + getBearerToken** — pure-function tests on the whitelist, truncation, null/undefined inputs.

Mock pattern mirrors `test/autopilot-pipeline.test.ts`: chainable Supabase mock at the lib level + `supertest` for the route.

## Schema reference (no migration in this PR)

| Field | Value | Source |
|---|---|---|
| `item_type` CHECK | `supplement`, `partner_product` | `universal_cart_items_item_type_check` |
| `source_surface` CHECK | `web`, `mobile`, `voice`, `autopilot`, `community` (nullable) | `universal_cart_items_source_surface_check` |
| `quantity > 0` | enforced | `universal_cart_items_quantity_positive` |
| One active cart per user | enforced | `universal_carts_one_active_per_user` partial-unique index |
| `metadata.autopilot_rec_id` | day-1 hint per PRD Q3 | `universal_cart_items_autopilot_rec_idx` (partial JSONB) |

## Hard out-of-scope (verified)

- No checkout, no Stripe, no payment intents.
- No wallet waterfall (Phase 3 blocked pending [#2371](https://github.com/exafyltd/vitana-platform/issues/2371)).
- No autopilot bridge auto-create (Phase 4 blocked pending #2371).
- No cohort / matchmaking signals (Phase 5 blocked pending #2371).
- No reads / writes against `cart_items`, `checkout_sessions`, `cj_products`, `cj_orders`, `cj_webhook_logs`, `user_wallets`, `wallet_credits`, `vouchers`, `business_packages`, `supplements`, `lab_test_*`, or any other Lovable-side ghost commerce table.

`grep -nE 'cart_items|checkout_sessions|user_wallets|wallet_credits|cj_products|cj_orders|vouchers|business_packages|supplements|lab_test_' services/gateway/src/routes/universal-cart.ts services/gateway/test/universal-cart.test.ts` returns **no matches**.

## Test plan

- [x] `npm run build` green (`tsc && copy-frontend && copy-data`)
- [x] `npx jest test/universal-cart.test.ts` — 36/36 green
- [ ] Required CI check `validate` green
- [ ] Merge into `main` (triggers AUTO-DEPLOY → EXEC-DEPLOY for gateway service)
- [ ] Post-deploy: `curl -s -o /dev/null -w "%{http_code} %{content_type}" https://gateway.vitanaland.com/api/v1/universal-cart/health` returns `200 application/json`
- [ ] Post-deploy: real community-user JWT smoke against `POST /api/v1/universal-cart`

## Related

- PR [#2420](https://github.com/exafyltd/vitana-platform/pull/2420) (VTID-03186) — universal_* schema this slice runs on
- PR [#2424](https://github.com/exafyltd/vitana-platform/pull/2424) (VTID-03205) — ops verification email-NOT-NULL fix
- Issue [#2371](https://github.com/exafyltd/vitana-platform/issues/2371) (VTID-03176) — Lovable-side vs gateway-side data layer reconciliation (blocks Phases 3-5)
- PR [#2363](https://github.com/exafyltd/vitana-platform/pull/2363) (VTID-03174) — RUN-MIGRATION.yml hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)