### PR TITLE
[FleetView] feat(orb): DEV-COMHU-0504 audio-ready handshake (ORB Recovery 4)

### DIFF
--- a/docs/patches/orb-agent/ORB-4-audio-ready.py
+++ b/docs/patches/orb-agent/ORB-4-audio-ready.py
@@ -1,0 +1,51 @@
+"""
+PATCH STUB — ORB Recovery 4 (DEV-COMHU-0504) — audio-ready gate (LiveKit agent).
+
+WHERE THIS GOES
+    Repo:  exafyltd/vitana-platform (services/agents/orb-agent/session.py NOT in
+           the autonomous sandbox checkout)
+    File:  services/agents/orb-agent/session.py
+
+WHY
+    Don't waste the one important greeting before the client can play it. The
+    gateway now records an audio-ready ack in orb_session_state
+    ('audio_ready_ack', keyed by user, value.session_id). The Vertex path gates
+    the greeting on ack-or-3s-timeout (see the gateway follow-up patch). The
+    LiveKit agent must apply the SAME gate before publishing its greeting track.
+
+ACCEPTANCE (after applying)
+    - If the client audio unlock is delayed, the agent waits for the ack (up to
+      3s) before publishing the greeting.
+    - If 3s elapse with no ack, the agent greets anyway (never strand the user).
+    - On reconnect where first_audio_ended was recorded within 15 min, do NOT
+      republish a full greeting.
+"""
+
+import asyncio
+
+AUDIO_READY_TIMEOUT_S = 3.0
+AUDIO_READY_POLL_MS = 150
+
+
+async def wait_for_audio_ready(read_ack, session_id: str) -> bool:
+    """Poll orb_session_state for the audio_ready_ack for this session.
+
+    `read_ack()` is an async callable returning the ack dict or None (the agent
+    wires it to a service-role GET of orb_session_state key 'audio_ready_ack').
+    Returns True if the ack arrived within the timeout, False on timeout.
+    """
+    deadline = asyncio.get_event_loop().time() + AUDIO_READY_TIMEOUT_S
+    while asyncio.get_event_loop().time() < deadline:
+        ack = await read_ack()
+        if ack and ack.get("session_id") == session_id:
+            return True
+        await asyncio.sleep(AUDIO_READY_POLL_MS / 1000.0)
+    return False
+
+
+# INTEGRATION SKETCH — before publishing the greeting:
+#
+#   ready = await wait_for_audio_ready(read_ack, session_id)
+#   if not ready:
+#       logger.info("audio-ready gate timed out (3s) — greeting anyway")
+#   await maybe_speak_greeting(session, job_metadata, ...)  # from ORB-2-3 patch

--- a/docs/patches/vitana-v1/ORB-4-audio-ready.md
+++ b/docs/patches/vitana-v1/ORB-4-audio-ready.md
@@ -1,0 +1,34 @@
+# vitana-v1 companion patch — ORB Recovery 4: audio-ready handshake (DEV-COMHU-0504)
+
+**Target repo:** `exafyltd/vitana-v1` (NOT reachable from the autonomous sandbox)
+**Companion to:** vitana-platform PR — `POST /api/v1/orb/session/:id/audio-ready`
+endpoint + `_signalAudioReady()` in `orb-widget.js`.
+
+## What ships automatically
+The audio-ready signal lives in the gateway-served `orb-widget.js` (it POSTs the ack as
+soon as the AudioContext reaches `running`). The community surface gets it on deploy.
+
+## 1. Cache-bust bump (required)
+```diff
+- orb-widget.js?v=20260529-VTID-03185-audio-queue-closure
++ orb-widget.js?v=20260531-DEV-COMHU-0504-audio-ready
+```
+
+## 2. LiveKit path (recommended)
+If `vitana-v1` plays the LiveKit remote audio track through a path that doesn't go
+through the widget's `_signalAudioReady`, post the ack when the LiveKit room's audio
+output is ready:
+
+```ts
+// once the LiveKit AudioContext / output is confirmed playable
+await fetch(`${gatewayUrl}/api/v1/orb/session/${sessionId}/audio-ready`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+  body: '{}',
+});
+```
+
+## Acceptance (post-deploy)
+- Delayed audio unlock (synthetic) → greeting waits for the ack (≤3s).
+- No ack within 3s → greeting proceeds anyway (session not stranded).
+- Reconnect with `first_audio_ended` recorded <15 min → no full greeting re-send.

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -29,7 +29,7 @@
   <!-- VTID-01216: Intelligence Panel containers -->
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
-  <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0504-audio-ready"></script>
+  <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0504-audio-ready-r3"></script>
   <script src="/command-hub/app.js?v=20260528-orb-voice-health-probe"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -29,7 +29,7 @@
   <!-- VTID-01216: Intelligence Panel containers -->
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
-  <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0503-continuity-r2"></script>
+  <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0504-audio-ready"></script>
   <script src="/command-hub/app.js?v=20260528-orb-voice-health-probe"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1044,6 +1044,12 @@
     // only meant to guard the teardown window between _sessionStop and the
     // next intentional _sessionStart.
     _s._userInitiatedStop = false;
+    // DEV-COMHU-0504 (review fix): re-arm the audio-ready ack for EVERY fresh
+    // _sessionStart, including reconnect paths (_attemptReconnect /
+    // _resetAndReconnect) that bypass _sessionStop. Without this, a recovered
+    // session keeps the prior session's _audioReadySignaled=true and never
+    // acks its new session_id, forcing the greeting gate to the 3s timeout.
+    _s._audioReadySignaled = false;
 
     // DEV-COMHU-0503 (review fix): hydrate persisted continuity on a fresh
     // reopen. _hide() persisted continuity then _sessionStop cleared the

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -173,6 +173,7 @@
     thinkingStartTime: 0,    // When thinking started — for elapsed time display
     greetingAudioReceived: false,
     greetingComplete: false,  // True after first turn_complete — mic opens only after this
+    _audioReadySignaled: false, // DEV-COMHU-0504: audio-ready ack posted once per session
 
     // UI state
     voiceState: 'IDLE', // IDLE | LISTENING | THINKING | SPEAKING | MUTED
@@ -872,6 +873,38 @@
   // 5. AUDIO PLAYBACK PIPELINE
   // ============================================================
 
+  // DEV-COMHU-0504 — ORB Recovery 4: audio-ready handshake.
+  // POST once per session when the playback pipeline is genuinely ready
+  // (AudioContext exists + running). The backend records the ack so it can
+  // release the greeting on ack-or-3s. Idempotent + best-effort.
+  function _signalAudioReady() {
+    if (_s._audioReadySignaled) return;
+    if (!_s.sessionId) return;
+    // Ensure a playback context exists; if it's suspended, kick a resume so the
+    // pipeline reaches 'running' (the canonical "ready" state).
+    try {
+      if (!_s.playbackCtx || _s.playbackCtx.state === 'closed') {
+        _s.playbackCtx = new (window.AudioContext || window.webkitAudioContext)();
+      }
+      var ctx = _s.playbackCtx;
+      if (ctx.state === 'suspended' && ctx.resume) {
+        ctx.resume().catch(function () {});
+      }
+      if (ctx.state !== 'running') return; // not ready yet; will retry on resume
+    } catch (e) {
+      return; // no audio context available — let the server 3s timeout cover it
+    }
+    _s._audioReadySignaled = true;
+    try {
+      var headers = { 'Content-Type': 'application/json' };
+      if (_cfg.token) headers['Authorization'] = 'Bearer ' + _cfg.token;
+      fetch(_cfg.gw + '/api/v1/orb/session/' + encodeURIComponent(_s.sessionId) + '/audio-ready', {
+        method: 'POST', headers: headers, cache: 'no-store', keepalive: true, body: '{}'
+      }).catch(function () { /* greeting falls back to the 3s server timeout */ });
+      console.log('[VTOrb] audio-ready signaled for session ' + _s.sessionId);
+    } catch (e) { /* best-effort */ }
+  }
+
   function _playAudio(base64Data, mimeType) {
     // Belt-and-suspenders: drop chunks that arrive after a user-initiated stop
     // or while the overlay is hidden. _processQueue auto-recreates a closed
@@ -910,6 +943,8 @@
       }
       ctx.resume().then(function () {
         _s._resumeRetryStartedAt = 0;
+        // DEV-COMHU-0504: ctx just reached 'running' → pipeline now ready.
+        _signalAudioReady();
         // Re-enter on next tick so any pending chunks drain.
         setTimeout(_processQueue, 0);
       }).catch(function (e) {
@@ -1200,6 +1235,10 @@
 
       _s.sessionId = data.session_id;
       _s.active = true;
+      // DEV-COMHU-0504 — ORB Recovery 4: as soon as we have a session id, try to
+      // signal audio-pipeline readiness so the backend can release the greeting
+      // the moment the client can actually play it (ack-or-3s gate server-side).
+      _signalAudioReady();
       // VTID-02020: pin the conversation_id returned by the backend so future
       // reconnects can re-thread the same conversation. The backend will
       // either echo back the one we sent or mint a fresh UUID on first start.
@@ -1317,6 +1356,7 @@
     clearTimeout(_s.stuckGuardTimer);
     _s.stuckGuardTimer = null;
     _s.greetingAudioReceived = false;
+    _s._audioReadySignaled = false; // DEV-COMHU-0504: re-arm ack for next session
     _s.lastScheduledEnd = 0;
 
     // Close SSE — VTID-03098: detach handlers FIRST so the manual close

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -10802,6 +10802,47 @@ router.post('/session/continuity', optionalAuth, async (req: AuthenticatedReques
       surface: 'orb',
     }).catch(() => {});
     return res.json({ ok: r.ok, reason: r.reason });
+ * DEV-COMHU-0504 — ORB Recovery 4: audio-ready handshake.
+ *
+ * The client posts this as soon as its audio pipeline is genuinely ready
+ * (AudioContext unlocked + output device available + player initialized). The
+ * gateway records the ack in orb_session_state keyed by session_id so the
+ * greeting trigger can wait for ack-or-3s-timeout instead of wasting the one
+ * important greeting before the client can play it.
+ *
+ *   POST /api/v1/orb/session/:id/audio-ready
+ *
+ * Authenticated only (anonymous still works — the gate falls back to the 3s
+ * timeout). Fails soft.
+ */
+router.post('/session/:id/audio-ready', optionalAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  const sessionId = String(req.params.id || '');
+  if (!sessionId) return res.status(400).json({ ok: false, error: 'missing_session_id' });
+  if (!userId) return res.status(200).json({ ok: false, reason: 'anonymous_no_ack' });
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'supabase_unavailable' });
+  try {
+    const { writeOrbSessionState } = await import('../services/orb/orb-session-state');
+    // Short TTL: the ack is only meaningful within the session-start window.
+    const r = await writeOrbSessionState(
+      supabase,
+      userId,
+      'audio_ready_ack',
+      { session_id: sessionId, ready_at: new Date().toISOString() },
+      10, // minutes
+    );
+    void emitOasisEvent({
+      vtid: 'DEV-COMHU-0504',
+      type: 'orb.session.audio_ready.acked',
+      source: 'orb-live',
+      status: 'info',
+      message: `audio pipeline ready ack for session ${sessionId}`,
+      payload: { session_id: sessionId, user_id: userId, ok: r.ok },
+      actor_id: userId,
+      surface: 'orb',
+    }).catch(() => {});
+    return res.json({ ok: r.ok });
   } catch (e) {
     return res.status(200).json({ ok: false, reason: e instanceof Error ? e.message : String(e) });
   }

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -10802,6 +10802,12 @@ router.post('/session/continuity', optionalAuth, async (req: AuthenticatedReques
       surface: 'orb',
     }).catch(() => {});
     return res.json({ ok: r.ok, reason: r.reason });
+  } catch (e) {
+    return res.status(200).json({ ok: false, reason: e instanceof Error ? e.message : String(e) });
+  }
+});
+
+/**
  * DEV-COMHU-0504 — ORB Recovery 4: audio-ready handshake.
  *
  * The client posts this as soon as its audio pipeline is genuinely ready

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -210,6 +210,8 @@ export type CicdEventType =
   // DEV-COMHU-0503 — ORB Recovery 2+3: close/reopen continuity state transitions
   | 'orb.session.continuity.persisted'
   | 'orb.session.continuity.cleared'
+  // DEV-COMHU-0504 — ORB Recovery 4: audio-ready handshake ack
+  | 'orb.session.audio_ready.acked'
   // VTID-01032: Multi-service deploy selection event
   | 'cicd.deploy.selection'
   // VTID-01033: CICD Concurrency Lock Events

--- a/services/gateway/test/frontend/orb-widget-audio-ready.test.ts
+++ b/services/gateway/test/frontend/orb-widget-audio-ready.test.ts
@@ -51,4 +51,11 @@ describe('orb-widget audio-ready handshake (DEV-COMHU-0504)', () => {
   it('re-arms the ack flag on session stop', () => {
     expect(source).toMatch(/_s\._audioReadySignaled = false;.*re-arm|_audioReadySignaled = false; \/\/ DEV-COMHU-0504/);
   });
+
+  it('re-arms the ack flag at the top of _sessionStart so reconnect paths re-ack (review fix)', () => {
+    // _attemptReconnect/_resetAndReconnect call _sessionStart without _sessionStop;
+    // the reset must live in _sessionStart to cover those recovery paths.
+    const body = extractFunctionBody(source, 'async function _sessionStart()');
+    expect(body).toMatch(/_s\._audioReadySignaled = false/);
+  });
 });

--- a/services/gateway/test/frontend/orb-widget-audio-ready.test.ts
+++ b/services/gateway/test/frontend/orb-widget-audio-ready.test.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// DEV-COMHU-0504 — ORB Recovery 4: static checks that the widget signals
+// audio-pipeline readiness (idempotent, gated on a running AudioContext) and
+// posts to the audio-ready endpoint, and that the ack flag re-arms per session.
+
+const WIDGET_PATH = path.resolve(
+  __dirname,
+  '../../src/frontend/command-hub/orb-widget.js',
+);
+
+function extractFunctionBody(source: string, signature: string): string {
+  const sigIdx = source.indexOf(signature);
+  expect(sigIdx).toBeGreaterThanOrEqual(0);
+  const openIdx = source.indexOf('{', sigIdx);
+  expect(openIdx).toBeGreaterThanOrEqual(0);
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    if (c === '}') depth--;
+    if (depth === 0) return source.slice(openIdx + 1, i);
+  }
+  throw new Error(`unclosed function body: ${signature}`);
+}
+
+describe('orb-widget audio-ready handshake (DEV-COMHU-0504)', () => {
+  const source = fs.readFileSync(WIDGET_PATH, 'utf8');
+
+  it('_signalAudioReady is idempotent and gated on a running context', () => {
+    const body = extractFunctionBody(source, 'function _signalAudioReady()');
+    expect(body).toMatch(/if \(_s\._audioReadySignaled\) return;/);
+    expect(body).toMatch(/if \(!_s\.sessionId\) return;/);
+    expect(body).toMatch(/ctx\.state !== 'running'/);
+    expect(body).toMatch(/_s\._audioReadySignaled = true/);
+  });
+
+  it('_signalAudioReady POSTs to the audio-ready endpoint with keepalive', () => {
+    const body = extractFunctionBody(source, 'function _signalAudioReady()');
+    expect(body).toMatch(/\/api\/v1\/orb\/session\/'/);
+    expect(body).toMatch(/\/audio-ready/);
+    expect(body).toMatch(/keepalive: true/);
+  });
+
+  it('is invoked on session start and on ctx resume', () => {
+    // called right after sessionId is set, and inside the resume() success path
+    expect(source.match(/_signalAudioReady\(\)/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
+  });
+
+  it('re-arms the ack flag on session stop', () => {
+    expect(source).toMatch(/_s\._audioReadySignaled = false;.*re-arm|_audioReadySignaled = false; \/\/ DEV-COMHU-0504/);
+  });
+});


### PR DESCRIPTION
## Summary
ORB Recovery **Phase 4 — audio-ready handshake**. Don't waste the one important greeting before the client's audio pipeline can play it. The client signals readiness as soon as its AudioContext is unlocked; the backend records the ack so the greeting can be released on **ack-or-3s-timeout**.

## What this PR ships
**Widget (`orb-widget.js`)**
- `_signalAudioReady()` — POSTs `/api/v1/orb/session/:id/audio-ready` the moment the playback `AudioContext` reaches `running`. Idempotent per session (`_audioReadySignaled`), best-effort (`keepalive`), gated on a running ctx. Invoked right after `sessionId` is set **and** on `ctx.resume()` success; re-armed in `_sessionStop`.
- Cache-bust → `20260531-DEV-COMHU-0504-audio-ready`.

**Gateway**
- `POST /api/v1/orb/session/:id/audio-ready` — records the ack in `orb_session_state` (`audio_ready_ack`, 10-min TTL) and emits the new `orb.session.audio_ready.acked` OASIS topic. `optionalAuth` (anonymous falls back to the 3s timeout). Fails soft.
- Includes the shared `orb-session-state.ts` helper (also introduced by ORB-2+3 #2435 — **identical file, merge-order independent**).

## Scope note (honest)
The substrate (client signal + ack endpoint + state) is here and testable. The **greeting-release gate itself** — making `connectToLiveAPI` / the wake-brief trigger *wait* on the ack-or-3s before emitting the first audio — is the piece that needs live-session timing verification I can't do in the sandbox. It's documented in the patch files (gateway-side wiring + LiveKit `wait_for_audio_ready`) for a follow-up. Flagging so it isn't mistaken for complete.

## Tests (green locally)
- `npm run typecheck` ✓, `npm run build` ✓, `npm run smoke:orb-widget` ✓
- `npx jest test/frontend/orb-widget-audio-ready.test.ts` ✓ (4 cases)
- (`orb-session-state` helper unit-tested in #2435.)

## Vertex parity ✓
Ack endpoint records the signal the Vertex greeting-gate consumes.

## LiveKit parity ✓ (with companion patches)
- `docs/patches/orb-agent/ORB-4-audio-ready.py` — agent `wait_for_audio_ready` (3s timeout) before publishing the greeting track.
- `docs/patches/vitana-v1/ORB-4-audio-ready.md` — cache-bust + optional LiveKit ack post.

## Pending human actions (aggregation file)
- Depends on the ORB-2+3 migration (`orb_session_state`) being applied.
- Merge; EXEC-DEPLOY SUCCESS; `/alive` 200.
- Implement the greeting-release gate (gateway + agent) with live-session timing tests.
- Acceptance: delayed unlock → greeting waits for ack; 3s timeout → greeting proceeds; reconnect <15 min → no greeting re-send.

---
🤖 ORB Recovery 4 per the autonomous-execution plan. Sandbox cannot merge/deploy/apply migrations/run prod smokes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApimmhkZML398iKgkgVSPC)_