### PR TITLE
[FleetView] test(orb): DEV-COMHU-0506 recovery E2E regression + observability spec (ORB Recovery 6)

### DIFF
--- a/docs/superpowers/plans/orb-recovery-observability-and-e2e.md
+++ b/docs/superpowers/plans/orb-recovery-observability-and-e2e.md
@@ -1,0 +1,63 @@
+# ORB Recovery — Observability dashboard + E2E flow (ORB-6, DEV-COMHU-0506)
+
+Companion reference for ORB Recovery Phase 6. Two deliverables: dashboard panels
+that extend the Phase D cockpit, and the synthetic browser flow spec (which needs a
+real deployed surface + Playwright, so it's documented here for the human to run).
+
+## 1. Dashboard panels (extend Phase D `/command-hub/voice-budget.html` cockpit)
+
+All panels read OASIS events emitted by the recovery phases. Add as cards/queries on the
+existing cockpit. Each row is `event type → what it surfaces → why it matters`.
+
+| Panel | OASIS source | Surfaces |
+|---|---|---|
+| Anonymous on authenticated surface | `orb.session.identity.resolved` where `payload.anonymous_on_authenticated_surface = true` | The ORB-1 widget anonymous-drift bug, observed from outside. Should trend to ~0 after the auth-contract fix deploys. |
+| Repeated daily greeting within 15 min | `orb.session.continuity.persisted` + greeting telemetry, or absence of `skip` policy on quick reopen | The ORB-2+3 regression (re-greeting on reopen). |
+| Greeting selected but no audio scheduled | `orb.live.greeting.delivered` without a following audio frame; `voice.instruction.budget_trimmed` correlation | The original "Vitana won't talk" class. |
+| Autopilot offer without executable CTA | continuation telemetry where `cta.type='ask_permission'` AND `cta.onYesTool` missing | The ORB-5 contract gap — should be 0 after deploy. |
+| Tool activation failures by reason | `guide.initiative.executed` failures + `activate_recommendation` error reasons (`recommendation_not_found` / `recommendation_belongs_to_another_user`) | Truthful-fallback health (ORB-5). |
+| Speaking-state watchdog fires | `[VTOrb] speaking-state watchdog` client logs (Cloud Logging) | ORB-0.1 — how often the cross-provider backstop has to intervene. |
+| Audio-ready ack latency | `orb.session.audio_ready.acked` vs session start | ORB-4 — how often the 3s greeting-gate timeout is hit vs a real ack. |
+
+Suggested implementation: a `GET /api/v1/admin/orb-recovery-health?window=24h` route
+that aggregates these `oasis_events` counts, rendered as a second card on the existing
+voice-budget cockpit page (DEV-COMHU marker required for the Command Hub edit).
+
+## 2. Synthetic browser flow (Playwright — run on a deployed surface)
+
+Cannot run in the autonomous sandbox (no browser, no prod network). Run after deploy
+on `vitanaland.com` (community) — NOT Command Hub (dev persona).
+
+```
+Login (e2e-test@vitana.dev) → open ORB → receive greeting audio
+  → close 60s → reopen → assert NO first-time greeting (policy skip/brief_resume)
+  → trigger an autopilot recommendation offer → say "yes"
+  → assert activate_recommendation invoked with the rec id (not "I have no access")
+```
+
+Run twice:
+1. Vertex active (default).
+2. LiveKit canary forced on (`voice.livekit_canary_enabled` + allowlist the e2e user).
+
+Acceptance:
+- Greeting audio plays on first open (watchdog silent).
+- Reopen within 60s → no first-time greeting (`orb.session.identity.resolved` shows
+  authenticated; greeting policy = skip/brief_resume).
+- Autopilot "yes" → activation succeeds; unauthorized variant → truthful fallback.
+- Both providers pass.
+
+## 3. Test suites shipped in-repo (ORB-6 + earlier phases)
+
+| Suite | Phase | Status |
+|---|---|---|
+| `test/frontend/orb-widget-speaking-watchdog.test.ts` | 0.1 | ✓ in #2431 |
+| `test/frontend/orb-widget-auth-reactive.test.ts` | 1 | ✓ in #2432 |
+| `test/frontend/orb-widget-continuity.test.ts` | 2+3 | ✓ in #2435 |
+| `test/services/orb-session-state.test.ts` | 2+3 | ✓ in #2435 |
+| `test/services/wake-cadence-signals.test.ts` (recordWakeTurn) | 2+3 | ✓ in #2435 |
+| `test/frontend/orb-widget-audio-ready.test.ts` | 4 | ✓ in #2437 |
+| `.../autopilot-recommendation.test.ts` (CTA contract) | 5 | ✓ in #2438 |
+| `test/services/orb-recovery-greeting-cadence.test.ts` | 6 | ✓ this PR |
+
+The synthetic browser flow + the dashboard route are the only ORB-6 items that require
+a deployed surface / Command Hub edit; both are specified above for the human to land.

--- a/services/gateway/test/services/orb-recovery-greeting-cadence.test.ts
+++ b/services/gateway/test/services/orb-recovery-greeting-cadence.test.ts
@@ -1,0 +1,76 @@
+/**
+ * DEV-COMHU-0506 — ORB Recovery 6: greeting-policy ↔ cadence-signal wiring.
+ *
+ * Proves the end-to-end behavior the ORB-2+3 cadence writer enables: once
+ * wake_cadence:last_turn_at / last_greeting_at are populated (the ORB-2+3 fix),
+ * the authoritative greeting policy produces the RECOVERY buckets — never a
+ * spurious first-time greeting on a quick reopen. This is the regression that
+ * VTID-03172 tried (and failed) to fix at the prompt layer.
+ */
+
+import { fetchWakeCadenceSignals } from '../../src/services/wake-cadence-signals';
+import { decideGreetingPolicy } from '../../src/orb/live/instruction/greeting-policy';
+import type { GreetingPolicyInput } from '../../src/orb/live/instruction/greeting-policy';
+
+function sbWithSignals(rows: Array<{ signal_name: string; value: unknown; last_seen_at: string }>) {
+  const chain: any = {
+    eq: () => chain,
+    in: () => Promise.resolve({ data: rows, error: null }),
+  };
+  return {
+    from: () => ({ select: () => chain }),
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+const NOW = '2026-05-31T12:00:00.000Z';
+
+describe('ORB Recovery: quick reopen does not re-greet (cadence → policy)', () => {
+  it('recent turn (<5min) → policy skip (cross-surface continuation)', async () => {
+    // last_turn_at 60s ago → recordWakeTurn would have written this on the prior turn.
+    const signals = await fetchWakeCadenceSignals({
+      supabase: sbWithSignals([
+        { signal_name: 'wake_cadence:last_turn_at', value: { iso: '2026-05-31T11:59:00.000Z' }, last_seen_at: NOW },
+      ]),
+      tenantId: 't1',
+      userId: 'u1',
+      nowIso: NOW,
+    });
+    expect(signals.seconds_since_last_turn_anywhere).toBe(60);
+    const policy = decideGreetingPolicy({ bucket: 'morning', ...signals } as GreetingPolicyInput);
+    expect(policy).toBe('skip');
+  });
+
+  it('greeted <15min ago → policy skip (greet-once-per-window)', async () => {
+    const signals = await fetchWakeCadenceSignals({
+      supabase: sbWithSignals([
+        // turn was a while ago (no continuation), but a greeting fired 5 min ago
+        { signal_name: 'wake_cadence:last_turn_at', value: { iso: '2026-05-31T10:00:00.000Z' }, last_seen_at: NOW },
+        { signal_name: 'wake_cadence:last_greeting_at', value: { iso: '2026-05-31T11:55:00.000Z' }, last_seen_at: NOW },
+      ]),
+      tenantId: 't1',
+      userId: 'u1',
+      nowIso: NOW,
+    });
+    expect(signals.time_since_last_greeting_today_ms).toBe(5 * 60 * 1000);
+    const policy = decideGreetingPolicy({ bucket: 'morning', ...signals } as GreetingPolicyInput);
+    expect(policy).toBe('skip');
+  });
+
+  it('no prior signals (genuinely fresh) → NOT skip (greets normally)', async () => {
+    const signals = await fetchWakeCadenceSignals({
+      supabase: sbWithSignals([]),
+      tenantId: 't1',
+      userId: 'u1',
+      nowIso: NOW,
+    });
+    expect(signals.seconds_since_last_turn_anywhere).toBeUndefined();
+    const policy = decideGreetingPolicy({ bucket: 'morning', ...signals } as GreetingPolicyInput);
+    expect(policy).not.toBe('skip');
+  });
+
+  it('isReconnect forces skip regardless of cadence', () => {
+    const policy = decideGreetingPolicy({ bucket: 'morning', isReconnect: true } as GreetingPolicyInput);
+    expect(policy).toBe('skip');
+  });
+});


### PR DESCRIPTION
## Summary
ORB Recovery **Phase 6 — E2E regression + observability**. Ties the recovery work together with an end-to-end regression test and the observability/synthetic-flow spec.

## What this PR ships
- **`test/services/orb-recovery-greeting-cadence.test.ts`** — proves the ORB-2+3 cadence writer produces the recovery behavior **end-to-end** (cadence signals → authoritative greeting policy):
  - recent turn (<5 min) → policy `skip` (cross-surface continuation)
  - greeted <15 min ago → policy `skip` (greet-once-per-window)
  - genuinely fresh (no signals) → **not** skip (greets normally)
  - `isReconnect` → `skip`
  This is exactly the "first-time greeting on every reopen" regression VTID-03172 tried to fix at the prompt layer (wrong layer) — now covered at the data→policy layer.
- **`docs/superpowers/plans/orb-recovery-observability-and-e2e.md`** — dashboard panels extending the Phase D cockpit (anonymous-on-authenticated-surface, repeated-greeting, greeting-no-audio, autopilot-offer-without-CTA, activation-failures-by-reason, watchdog-fires, audio-ready-latency), the synthetic Playwright flow spec (Vertex + LiveKit canary), and the in-repo test-suite inventory across all recovery phases.

## Scope note (honest)
The two ORB-6 items that need a **deployed surface** can't run in the sandbox:
1. The synthetic Playwright flow (no browser / no prod network) — specified in the doc to run post-deploy on `vitanaland.com`.
2. The `GET /api/v1/admin/orb-recovery-health` aggregation route + cockpit card — specified in the doc (needs a Command Hub edit + live `oasis_events`).
Everything testable in-repo is shipped; the widget/backend unit + regression suites for phases 0.1–5 already landed with their respective PRs (inventory table in the doc).

## Tests (green locally)
- `npm run typecheck` ✓, `npm run build` ✓
- `npx jest test/services/orb-recovery-greeting-cadence.test.ts` ✓ (4 cases)

## Vertex parity ✓ / LiveKit parity ✓
The test asserts the shared cadence→policy path both providers consume; the synthetic flow spec runs on both (Vertex + LiveKit canary). Docs-and-tests only — no runtime code paths changed.

## Pending human actions (aggregation file)
- Merge.
- Implement the `orb-recovery-health` cockpit route/card + run the synthetic Playwright flow on a deployed surface (both providers) per the doc.

---
🤖 ORB Recovery 6 per the autonomous-execution plan. Sandbox cannot run Playwright / hit prod.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApimmhkZML398iKgkgVSPC)_