### PR TITLE
fix(ops): CANARY-READINESS-REPORT quote escape in TARGET input (VTID-03219)

### DIFF
--- a/.github/workflows/CANARY-READINESS-REPORT.yml
+++ b/.github/workflows/CANARY-READINESS-REPORT.yml
@@ -78,7 +78,7 @@ jobs:
         id: ftstatus
         run: |
           set +e
-          TARGET='${{ inputs.target || ''voice-tool-router'' }}'
+          TARGET="${{ inputs.target || 'voice-tool-router' }}"
           PREFIX="${TARGET}-ft-"
           # Latest job with this prefix; success state = JOB_STATE_SUCCEEDED.
           OUT=$(gcloud ai custom-jobs list --region=us-central1 --project="${GCP_PROJECT}" \


### PR DESCRIPTION
VTID-03217 (#2443) used '' YAML-escape inside a run: | literal block, which doesn't apply there. Switch to TARGET="${{ inputs.target || 'voice-tool-router' }}" (bash double-quote + plain single-quote default). First dispatch attempt failed with 'Unexpected symbol' parser error; this fix restores the cascade.