### PR TITLE
fix(eval): Vertex IAM probe accuracy + deterministic first_blocker (VTID-03222)

### DIFF
--- a/.github/workflows/PHASE-GATE-STATUS-REPORT.yml
+++ b/.github/workflows/PHASE-GATE-STATUS-REPORT.yml
@@ -78,22 +78,31 @@ jobs:
         id: vertex
         run: |
           set +e
-          # Cheapest read against Vertex to detect aiplatform.user. If the WIF
-          # SA has aiplatform.user OR aiplatform.viewer, this returns 0.
-          gcloud ai operations list --region=us-central1 --project="${GCP_PROJECT}" --limit=1 > /tmp/vertex-probe.txt 2>&1
+          # VTID-03222 (Phase 1 W3-B1): broadened IAM detection.
+          # Switched from `gcloud ai operations list` to `gcloud ai
+          # custom-jobs list` — the latter is the exact API surface
+          # CRON-FINETUNE-TRAINER hits, so a denial here is a true
+          # blocker. The grep also widened: case-insensitive +
+          # additional terms (permission, denied, 403, aiplatform,
+          # forbidden, insufficient, customJobs) so any reasonable
+          # gcloud error variant resolves to `denied` not `skipped`.
+          gcloud ai custom-jobs list \
+            --region=us-central1 --project="${GCP_PROJECT}" --limit=1 \
+            > /tmp/vertex-probe.txt 2>&1
           RC=$?
           if [ $RC -eq 0 ]; then
             echo "VERTEX_IAM_CHECK_RESULT=ok" >> "$GITHUB_ENV"
             echo "Vertex IAM probe: ok"
           else
-            if grep -qE "PERMISSION_DENIED|403" /tmp/vertex-probe.txt; then
+            if grep -qiE "permission|denied|403|aiplatform|forbidden|insufficient|customjobs|role/iam" /tmp/vertex-probe.txt; then
               echo "VERTEX_IAM_CHECK_RESULT=denied" >> "$GITHUB_ENV"
               echo "Vertex IAM probe: denied"
             else
               echo "VERTEX_IAM_CHECK_RESULT=skipped" >> "$GITHUB_ENV"
-              echo "Vertex IAM probe: skipped (other gcloud error)"
-              head -5 /tmp/vertex-probe.txt || true
+              echo "Vertex IAM probe: skipped (non-IAM gcloud error)"
             fi
+            echo '--- gcloud stderr (head) ---'
+            head -10 /tmp/vertex-probe.txt 2>/dev/null || true
           fi
 
       - name: Probe AWS mirror

--- a/services/gateway/scripts/eval/phase-gate-status-report.ts
+++ b/services/gateway/scripts/eval/phase-gate-status-report.ts
@@ -306,6 +306,7 @@ interface PhaseGateReport {
     gates_unknown: number;
     ready_for_w3_b_to_g: boolean;
     first_blocker: string | null;
+    blocked_by_priority: string[];
   };
   gates: GateResult[];
 }
@@ -321,7 +322,37 @@ async function generate(): Promise<PhaseGateReport> {
   const open = gates.filter((g) => g.status === 'open').length;
   const blocked = gates.filter((g) => g.status === 'blocked').length;
   const unknown = gates.filter((g) => g.status === 'unknown').length;
-  const firstBlocker = gates.find((g) => g.status === 'blocked');
+
+  // VTID-03222 (Phase 1 W3-B1): deterministic first_blocker ordering.
+  // Previously `gates.find(blocked)` returned whichever blocked gate
+  // happened to be first in array order. Operators iterating "unblock
+  // them in order" need a stable priority so the same gate appears
+  // first across runs even as gate state changes. Priority reflects
+  // dependency order — prod_consent unblocks dataset_rows; vertex_iam
+  // unblocks fine-tune training; aws_mirror unblocks W3-D; shadow
+  // traffic + dataset_rows are downstream gates whose state depends on
+  // the upstream ones being open.
+  const GATE_PRIORITY = [
+    'prod_consent',
+    'vertex_iam',
+    'aws_mirror',
+    'shadow_traffic',
+    'dataset_rows',
+  ] as const;
+  const blockedByPriority: GateResult[] = [];
+  for (const name of GATE_PRIORITY) {
+    const g = gates.find((x) => x.name === name);
+    if (g && g.status === 'blocked') blockedByPriority.push(g);
+  }
+  // Any gates blocked but NOT in the priority list (future additions)
+  // append at the end, preserving the explicit order for the known ones.
+  for (const g of gates) {
+    if (g.status === 'blocked' && !GATE_PRIORITY.includes(g.name as typeof GATE_PRIORITY[number])) {
+      blockedByPriority.push(g);
+    }
+  }
+  const firstBlocker = blockedByPriority[0];
+
   return {
     generated_at: new Date().toISOString(),
     overall: {
@@ -331,6 +362,7 @@ async function generate(): Promise<PhaseGateReport> {
       gates_unknown: unknown,
       ready_for_w3_b_to_g: blocked === 0 && unknown === 0,
       first_blocker: firstBlocker?.name ?? null,
+      blocked_by_priority: blockedByPriority.map((g) => g.name),
     },
     gates,
   };


### PR DESCRIPTION
W3-B0 showed vertex_iam=unknown instead of blocked (probe used wrong API + narrow grep). Two fixes: (1) switch probe to gcloud ai custom-jobs list (the exact API CRON-FINETUNE-TRAINER hits) + widen grep case-insensitive with permission|denied|403|aiplatform|forbidden|insufficient|customjobs|role/iam; (2) deterministic first_blocker via explicit GATE_PRIORITY (prod_consent > vertex_iam > aws_mirror > shadow_traffic > dataset_rows), plus new blocked_by_priority[] output. Expected today: vertex_iam=denied, first_blocker=prod_consent. npm run build green.