### PR TITLE
fix(autopilot): graded dedupe + action-map coverage so community popup replenishes (VTID-03201)

### DIFF
--- a/services/gateway/src/routes/autopilot-recommendations.ts
+++ b/services/gateway/src/routes/autopilot-recommendations.ts
@@ -116,7 +116,7 @@ interface CommunityAction {
   };
 }
 
-const COMMUNITY_ACTIONS: Record<string, CommunityAction> = {
+export const COMMUNITY_ACTIONS: Record<string, CommunityAction> = {
   // Onboarding
   onboarding_profile:           { action_type: 'navigate', target: '/profile/edit', completion_message: 'Let\'s complete your profile!' },
   onboarding_avatar:            { action_type: 'navigate', target: '/profile/edit', completion_message: 'Add a photo so others can recognize you!' },
@@ -139,6 +139,14 @@ const COMMUNITY_ACTIONS: Record<string, CommunityAction> = {
   // Advanced
   share_expertise:      { action_type: 'navigate', target: '/groups', completion_message: 'Share your knowledge in a group!' },
   start_streak:         { action_type: 'navigate', target: '/diary', completion_message: 'Start your wellness streak!', calendar_event: { title_template: 'Start a wellness streak', duration_minutes: 15, event_type: 'health', wellness_tags: ['wellness'] } },
+  try_live_room:        { action_type: 'navigate', target: '/events', completion_message: 'Drop into a live room!', calendar_event: { title_template: 'Try a live room', duration_minutes: 15, event_type: 'community', wellness_tags: ['social', 'mental'] } },
+  // Index-gap pillar templates (index-gap-analyzer fallback) — schedulable wellness blocks.
+  // source_ref === `pillar_template_${pillar}`; MUST stay in sync with index-gap-analyzer.ts.
+  pillar_template_nutrition: { action_type: 'navigate', target: '/health', completion_message: 'Plan a balanced meal block.', calendar_event: { title_template: 'Meal planning block', duration_minutes: 15, event_type: 'nutrition', wellness_tags: ['nutrition'] } },
+  pillar_template_hydration: { action_type: 'navigate', target: '/health', completion_message: 'Time for a hydration check-in.', calendar_event: { title_template: 'Hydration check-in', duration_minutes: 10, event_type: 'health', wellness_tags: ['hydration'] } },
+  pillar_template_exercise:  { action_type: 'navigate', target: '/health', completion_message: 'Time to move.', calendar_event: { title_template: '30-minute movement block', duration_minutes: 30, event_type: 'workout', wellness_tags: ['movement'] } },
+  pillar_template_sleep:     { action_type: 'navigate', target: '/health', completion_message: 'Set up your wind-down.', calendar_event: { title_template: 'Wind-down block', duration_minutes: 30, event_type: 'health', wellness_tags: ['sleep'] } },
+  pillar_template_mental:    { action_type: 'navigate', target: '/chat', completion_message: 'A few minutes for your mind.', calendar_event: { title_template: 'Meditation / breathwork', duration_minutes: 10, event_type: 'health', wellness_tags: ['mindfulness', 'mental'] } },
   // mentor_new and organize_meetup removed — not automatable by autopilot
   // Weakness-driven
   weakness_movement:    { action_type: 'navigate', target: '/health', completion_message: 'Let\'s get moving!', calendar_event: { title_template: 'Exercise session', duration_minutes: 30, event_type: 'workout', wellness_tags: ['movement'] } },
@@ -252,6 +260,9 @@ export async function queryRecommendationsByRole(
 
   // Exclude snoozed recs
   params.append('or', '(snoozed_until.is.null,snoozed_until.lt.now())');
+  // Exclude expired recs (VTID-03201): stale rows must not surface in the
+  // popup/count. Repeated `or` params are ANDed by PostgREST.
+  params.append('or', '(expires_at.is.null,expires_at.gt.now())');
 
   if (role === 'community') {
     // Community role: only personal recs from community analyzer
@@ -314,6 +325,7 @@ async function queryRecommendationsFallback(
   params.set('limit', String(limit));
   params.set('offset', String(offset));
   params.append('or', '(snoozed_until.is.null,snoozed_until.lt.now())');
+  params.append('or', '(expires_at.is.null,expires_at.gt.now())');
   params.set('user_id', `eq.${userId}`);
 
   try {

--- a/services/gateway/src/services/recommendation-engine/analyzers/index-gap-analyzer.ts
+++ b/services/gateway/src/services/recommendation-engine/analyzers/index-gap-analyzer.ts
@@ -45,7 +45,7 @@ const PILLAR_FEATURE_KEY: Record<PillarKey, string> = {
 // Community source_refs to rotate through when the Mental pillar's
 // completions sub-score is low — picks the first one the user has
 // NOT completed in the last 7 days.
-const MENTAL_COMMUNITY_SOURCE_REFS = [
+export const MENTAL_COMMUNITY_SOURCE_REFS = [
   'engage_meetup',
   'deepen_connection',
   'engage_matches',

--- a/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
+++ b/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
@@ -774,6 +774,64 @@ function convertCommunityUserSignal(
   };
 }
 
+/**
+ * One-off (set-once) community actions that should NOT be regenerated once the
+ * user has activated or completed them — onboarding steps only make sense the
+ * first time. Everything else (engagement, weakness nudges, pillar templates)
+ * is repeatable and may re-surface after expiry. VTID-03201.
+ */
+function isOneOffSourceRef(sourceRef: string | null): boolean {
+  if (!sourceRef) return false;
+  return sourceRef.startsWith('onboarding_');
+}
+
+/** How long a rejected recommendation stays suppressed before it may re-surface. */
+export const REJECTED_COOLDOWN_DAYS = 14;
+
+/** A historical autopilot_recommendations row, as read for the dedupe pre-check. */
+export interface FingerprintHistoryRow {
+  fingerprint: string;
+  source_ref: string | null;
+  status: string;
+  updated_at: string | null;
+  expires_at: string | null;
+}
+
+/**
+ * Graded dedupe decision (VTID-03201): does this existing row block
+ * regeneration of the same fingerprint?
+ *
+ *   - expired (expires_at < now)         → allow  (stale, replaceable)
+ *   - new / snoozed (not expired)        → block  (live duplicate)
+ *   - rejected within cooldown window    → block  (don't re-nag instantly)
+ *   - rejected older than cooldown       → allow
+ *   - activated/completed one-off ref    → block  (set-once actions)
+ *   - activated/completed repeatable ref → allow  (re-surface periodically)
+ *
+ * Pure and side-effect free so it can be unit-tested without the network.
+ */
+export function isFingerprintBlocked(row: FingerprintHistoryRow, nowMs: number = Date.now()): boolean {
+  // A stale (expired) row never blocks regeneration — replacing it is the
+  // whole point of replenishment.
+  const expired = row.expires_at != null && new Date(row.expires_at).getTime() < nowMs;
+  if (expired) return false;
+
+  switch (row.status) {
+    case 'new':
+    case 'snoozed':
+      return true;
+    case 'rejected': {
+      const updatedMs = row.updated_at ? new Date(row.updated_at).getTime() : 0;
+      return nowMs - updatedMs < REJECTED_COOLDOWN_DAYS * 86400000;
+    }
+    case 'activated':
+    case 'completed':
+      return isOneOffSourceRef(row.source_ref);
+    default:
+      return false;
+  }
+}
+
 // =============================================================================
 // Per-User Personal Recommendation Generator
 // =============================================================================
@@ -912,33 +970,40 @@ export async function generatePersonalRecommendations(
       console.warn(`${LOG_PREFIX} rankBatch failed (non-fatal):`, rankErr?.message);
     }
 
-    // Pre-check: fetch ALL existing fingerprints for this user (ANY status)
-    // to prevent re-creating recommendations that were already activated/rejected.
-    // The RPC only checks new/snoozed, so we need this extra guard.
-    const existingFingerprints = new Set<string>();
+    // Pre-check: fetch existing fingerprints + their state and apply the GRADED
+    // dedupe policy (VTID-03201). The previous implementation blocked any
+    // fingerprint that had EVER existed in any status, so a user whose recs had
+    // all expired or been rejected could never get fresh ones — the popup
+    // permanently emptied out. The RPC already blocks live duplicates (status
+    // new/snoozed); isFingerprintBlocked() adds the guards the RPC can't (see
+    // its docstring for the full policy).
+    const blockedFingerprints = new Set<string>();
     try {
       const fpResp = await fetch(
-        `${supabaseUrl}/rest/v1/autopilot_recommendations?user_id=eq.${userId}&select=fingerprint&fingerprint=not.is.null`,
+        `${supabaseUrl}/rest/v1/autopilot_recommendations?user_id=eq.${userId}&select=fingerprint,source_ref,status,updated_at,expires_at&fingerprint=not.is.null`,
         { headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` } }
       );
       if (fpResp.ok) {
-        const fpRows = await fpResp.json() as { fingerprint: string }[];
+        const fpRows = await fpResp.json() as FingerprintHistoryRow[];
+        const now = Date.now();
         for (const row of fpRows) {
-          if (row.fingerprint) existingFingerprints.add(row.fingerprint);
+          if (!row.fingerprint) continue;
+          // Block wins across duplicate fingerprints with mixed history.
+          if (isFingerprintBlocked(row, now)) blockedFingerprints.add(row.fingerprint);
         }
-        console.log(`${LOG_PREFIX} Pre-check: ${existingFingerprints.size} existing fingerprints for user ${userId.slice(0, 8)}`);
+        console.log(`${LOG_PREFIX} Graded dedupe: ${blockedFingerprints.size}/${fpRows.length} fingerprints blocked for user ${userId.slice(0, 8)}`);
       }
     } catch (fpErr) {
       console.warn(`${LOG_PREFIX} Pre-check fingerprint query failed (non-fatal):`, fpErr);
     }
 
-    // Insert with deduplication (skip if fingerprint exists in ANY status)
+    // Insert with deduplication (graded policy above + RPC active-dup guard)
     let generated = 0;
     let duplicatesSkipped = 0;
 
     for (const rec of recommendations) {
-      // Skip if this fingerprint already exists (activated, rejected, etc.)
-      if (rec.fingerprint && existingFingerprints.has(rec.fingerprint)) {
+      // Skip only if the graded policy says this fingerprint is still blocked.
+      if (rec.fingerprint && blockedFingerprints.has(rec.fingerprint)) {
         duplicatesSkipped++;
         continue;
       }

--- a/services/gateway/test/services/autopilot-community-actions-coverage.test.ts
+++ b/services/gateway/test/services/autopilot-community-actions-coverage.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Coverage guard for the community action map — VTID-03201.
+ *
+ * The Autopilot popup hides any community recommendation whose `source_ref` is
+ * not present in COMMUNITY_ACTIONS (autopilot-recommendations.ts). The
+ * index-gap analyzer emits `pillar_template_<pillar>` and `try_live_room`
+ * source_refs; before this fix they were generated and then silently dropped,
+ * which (combined with the dedupe bug) helped empty the popup.
+ *
+ * This test fails if an analyzer-produced source_ref ever drifts out of the
+ * action map again.
+ */
+
+import { COMMUNITY_ACTIONS } from '../../src/routes/autopilot-recommendations';
+import { MENTAL_COMMUNITY_SOURCE_REFS } from '../../src/services/recommendation-engine/analyzers/index-gap-analyzer';
+import { PILLAR_KEYS } from '../../src/lib/vitana-pillars';
+
+describe('COMMUNITY_ACTIONS coverage', () => {
+  it('maps every per-pillar template source_ref the index-gap analyzer emits', () => {
+    for (const pillar of PILLAR_KEYS) {
+      const ref = `pillar_template_${pillar}`;
+      expect(COMMUNITY_ACTIONS[ref]).toBeDefined();
+    }
+  });
+
+  it('maps every mental-community source_ref the index-gap analyzer rotates through', () => {
+    for (const ref of MENTAL_COMMUNITY_SOURCE_REFS) {
+      expect(COMMUNITY_ACTIONS[ref]).toBeDefined();
+    }
+  });
+
+  it('maps the previously-unmapped refs that this fix added', () => {
+    for (const ref of [
+      'try_live_room',
+      'pillar_template_nutrition',
+      'pillar_template_hydration',
+      'pillar_template_exercise',
+      'pillar_template_sleep',
+      'pillar_template_mental',
+    ]) {
+      expect(COMMUNITY_ACTIONS[ref]).toBeDefined();
+    }
+  });
+
+  it('every action has a valid action_type and a completion message', () => {
+    for (const [ref, action] of Object.entries(COMMUNITY_ACTIONS)) {
+      expect(['navigate', 'notify']).toContain(action.action_type);
+      expect(action.completion_message.length).toBeGreaterThan(0);
+      // navigate actions must carry a target route
+      if (action.action_type === 'navigate') {
+        expect(typeof action.target).toBe('string');
+        expect((action.target ?? '').startsWith('/')).toBe(true);
+        expect(ref.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/services/gateway/test/services/recommendation-generator-dedupe.test.ts
+++ b/services/gateway/test/services/recommendation-generator-dedupe.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the GRADED Autopilot dedupe policy — VTID-03201.
+ *
+ * Regression: the generator used to block regeneration of ANY fingerprint that
+ * had ever existed in ANY status. A community user whose recommendations had
+ * all expired or been rejected could therefore never get fresh ones, and the
+ * Autopilot popup permanently emptied out.
+ *
+ * `isFingerprintBlocked` now encodes a graded policy:
+ *   - expired rows never block (they're stale and replaceable)
+ *   - live (new/snoozed) rows block
+ *   - rejected rows block only inside a cooldown window
+ *   - activated/completed one-off (onboarding_*) rows block forever
+ *   - activated/completed repeatable rows do not block
+ */
+
+import {
+  isFingerprintBlocked,
+  REJECTED_COOLDOWN_DAYS,
+  type FingerprintHistoryRow,
+} from '../../src/services/recommendation-engine/recommendation-generator';
+
+const NOW = Date.parse('2026-05-31T12:00:00Z');
+const DAY = 86400000;
+
+function row(overrides: Partial<FingerprintHistoryRow>): FingerprintHistoryRow {
+  return {
+    fingerprint: 'fp-test',
+    source_ref: 'engage_meetup',
+    status: 'new',
+    updated_at: new Date(NOW).toISOString(),
+    expires_at: new Date(NOW + 7 * DAY).toISOString(), // not expired by default
+    ...overrides,
+  };
+}
+
+describe('isFingerprintBlocked — graded dedupe policy', () => {
+  describe('live recommendations', () => {
+    it('blocks a live "new" rec', () => {
+      expect(isFingerprintBlocked(row({ status: 'new' }), NOW)).toBe(true);
+    });
+
+    it('blocks a live "snoozed" rec', () => {
+      expect(isFingerprintBlocked(row({ status: 'snoozed' }), NOW)).toBe(true);
+    });
+  });
+
+  describe('expiry always wins', () => {
+    it('allows a "new" rec whose expires_at has passed', () => {
+      expect(
+        isFingerprintBlocked(row({ status: 'new', expires_at: new Date(NOW - DAY).toISOString() }), NOW),
+      ).toBe(false);
+    });
+
+    it('allows a recently-rejected rec once it has expired', () => {
+      expect(
+        isFingerprintBlocked(
+          row({ status: 'rejected', updated_at: new Date(NOW).toISOString(), expires_at: new Date(NOW - DAY).toISOString() }),
+          NOW,
+        ),
+      ).toBe(false);
+    });
+
+    it('allows a one-off activated rec once it has expired', () => {
+      expect(
+        isFingerprintBlocked(
+          row({ status: 'activated', source_ref: 'onboarding_profile', expires_at: new Date(NOW - DAY).toISOString() }),
+          NOW,
+        ),
+      ).toBe(false);
+    });
+
+    it('treats a null expires_at as never-expiring (still subject to status rules)', () => {
+      expect(isFingerprintBlocked(row({ status: 'new', expires_at: null }), NOW)).toBe(true);
+    });
+  });
+
+  describe('rejected cooldown', () => {
+    it('blocks a rec rejected inside the cooldown window', () => {
+      const updated = new Date(NOW - (REJECTED_COOLDOWN_DAYS - 1) * DAY).toISOString();
+      expect(isFingerprintBlocked(row({ status: 'rejected', updated_at: updated }), NOW)).toBe(true);
+    });
+
+    it('allows a rec rejected before the cooldown window', () => {
+      const updated = new Date(NOW - (REJECTED_COOLDOWN_DAYS + 1) * DAY).toISOString();
+      expect(isFingerprintBlocked(row({ status: 'rejected', updated_at: updated }), NOW)).toBe(false);
+    });
+
+    it('allows a rejected rec with a null updated_at (treated as long ago)', () => {
+      expect(isFingerprintBlocked(row({ status: 'rejected', updated_at: null }), NOW)).toBe(false);
+    });
+  });
+
+  describe('activated / completed', () => {
+    it('blocks a completed one-off onboarding rec', () => {
+      expect(
+        isFingerprintBlocked(row({ status: 'completed', source_ref: 'onboarding_diary' }), NOW),
+      ).toBe(true);
+    });
+
+    it('allows a completed repeatable rec to re-surface', () => {
+      expect(
+        isFingerprintBlocked(row({ status: 'completed', source_ref: 'pillar_template_sleep' }), NOW),
+      ).toBe(false);
+    });
+
+    it('allows an activated repeatable engagement rec to re-surface', () => {
+      expect(
+        isFingerprintBlocked(row({ status: 'activated', source_ref: 'engage_meetup' }), NOW),
+      ).toBe(false);
+    });
+
+    it('does not treat a null source_ref as one-off', () => {
+      expect(
+        isFingerprintBlocked(row({ status: 'activated', source_ref: null }), NOW),
+      ).toBe(false);
+    });
+  });
+
+  describe('unknown status', () => {
+    it('does not block an unrecognized status', () => {
+      expect(isFingerprintBlocked(row({ status: 'archived' }), NOW)).toBe(false);
+    });
+  });
+
+  describe('end-to-end scenario: only expired + rejected rows remain', () => {
+    it('a user whose recs are all expired/long-rejected gets nothing blocked', () => {
+      const history: FingerprintHistoryRow[] = [
+        row({ fingerprint: 'a', status: 'rejected', updated_at: new Date(NOW - 60 * DAY).toISOString(), expires_at: new Date(NOW - 30 * DAY).toISOString() }),
+        row({ fingerprint: 'b', status: 'new', expires_at: new Date(NOW - 2 * DAY).toISOString() }),
+        row({ fingerprint: 'c', status: 'completed', source_ref: 'pillar_template_mental', expires_at: new Date(NOW - DAY).toISOString() }),
+      ];
+      const blocked = history.filter((r) => isFingerprintBlocked(r, NOW));
+      expect(blocked).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The Community Autopilot popup goes **permanently empty** once a user's first batch of recommendations has all expired or been rejected. Verified in production for the E2E user: `/autopilot/recommendations` returns count `0` / list `0` while Supabase still holds 15 `rejected`, expired, fingerprinted rows for that user.

## Root causes (Phase 1 of the larger plan)

1. **Replenishment was permanently blocked.** `recommendation-generator.ts` pre-fetched *every* fingerprint for the user in *any* status and skipped re-inserting them. So expired/rejected rows suppressed their own replacements forever. (The DB RPC `insert_autopilot_recommendation` was already correct — it only blocks `new`/`snoozed` duplicates.)

2. **Generated-then-hidden recs.** The index-gap analyzer emits `pillar_template_<pillar>` and `try_live_room` source_refs, but `COMMUNITY_ACTIONS` had no entries for them — so `GET /recommendations` generated them and then silently filtered them out.

3. **No expiry filter** on the list/count queries — stale `new` rows could still surface.

## Changes

- **Graded dedupe policy** (`isFingerprintBlocked`, now an exported pure function):
  - expired rows → **allow** (stale, replaceable)
  - live `new`/`snoozed` → **block**
  - `rejected` → block only within a **14-day cooldown**, then allow
  - `activated`/`completed` → block only for **one-off** `onboarding_*` refs; repeatable refs re-surface
- **Action-map coverage**: added `try_live_room` and `pillar_template_{nutrition,hydration,exercise,sleep,mental}` to `COMMUNITY_ACTIONS` (with calendar metadata for the schedulable ones).
- **Expiry filter** `(expires_at.is.null,expires_at.gt.now())` added to `queryRecommendationsByRole` and the fallback query (so `/count` inherits it too).
- **Tests** (`test/services/`): 15 cases for the graded policy + 4 cases asserting every analyzer-emitted source_ref maps. All green.

## Verification

- `tsc --noEmit` clean (project TS 5.x).
- `jest` — 19/19 new tests pass.

## Not in this PR (follow-up)

Phase 3–5 of the agreed plan: extract a shared `listCommunityAutopilotRecommendations` / `activateCommunityAutopilotRecommendation` / `summarizeAutopilotForVoice` service, route both REST and ORB voice through it, and add the `get_autopilot_recommendations` / `activate_autopilot_recommendations` voice tools so Vitana Assistant can read and activate the Autopilot queue on the user's behalf.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqFvDoJm2aR4zQzanWZCck)_