### PR TITLE
fix(eval): canary Vertex probe parity with phase-gate report (VTID-03225)

### DIFF
--- a/.github/workflows/CANARY-READINESS-REPORT.yml
+++ b/.github/workflows/CANARY-READINESS-REPORT.yml
@@ -87,13 +87,18 @@ jobs:
             --format='value(state)' 2>&1)
           RC=$?
           if [ $RC -ne 0 ]; then
-            if echo "$OUT" | grep -qE "PERMISSION_DENIED|403"; then
-              echo "FINETUNE_STATUS=skipped" >> "$GITHUB_ENV"
-              echo "Vertex IAM denied (expected if W3 gate (A) not yet open)"
+            # VTID-03225 (Phase 1 W3-C0): parity with PHASE-GATE-STATUS-REPORT
+            # widened grep. Detects IAM denial across more gcloud error
+            # variants and reports it as iam_blocked (a true FAIL signal)
+            # rather than skipped (which the canary script treats as
+            # unknown). Keeps the two reports aligned on the Vertex gate.
+            if echo "$OUT" | grep -qiE "permission|denied|403|aiplatform|forbidden|insufficient|customjobs|role/iam"; then
+              echo "FINETUNE_STATUS=iam_blocked" >> "$GITHUB_ENV"
+              echo "Vertex IAM denied — operator must grant roles/aiplatform.user on the WIF SA"
             else
               echo "FINETUNE_STATUS=skipped" >> "$GITHUB_ENV"
-              echo "Vertex probe other-error (treating as skipped):"
-              echo "$OUT" | head -5
+              echo "Vertex probe non-IAM error (treating as skipped):"
+              echo "$OUT" | head -10
             fi
           else
             # OUT is the JOB_STATE string or empty

--- a/services/gateway/scripts/eval/canary-readiness-report.ts
+++ b/services/gateway/scripts/eval/canary-readiness-report.ts
@@ -28,7 +28,7 @@
  *   PROD_SUPABASE_SERVICE_ROLE   (required — same)
  *   STAGING_SUPABASE_URL         (optional — for latency events when staging-flag is on)
  *   STAGING_SUPABASE_SERVICE_ROLE_KEY (optional — same)
- *   FINETUNE_STATUS              (passed by workflow — ok|failed|none|skipped)
+ *   FINETUNE_STATUS              (passed by workflow — ok|iam_blocked|failed|none|skipped)
  *   REPORT_MARKDOWN_PATH         (optional)
  *
  * Output:
@@ -236,14 +236,24 @@ async function generate(): Promise<CanaryReadinessReport> {
   }
 
   // Fine-tune status — must have a successful run
+  // VTID-03225 (Phase 1 W3-C0): explicit iam_blocked case so this report
+  // agrees with PHASE-GATE-STATUS-REPORT's Vertex gate verdict instead
+  // of reporting 'skipped' (which reads as "we don't know") when the
+  // real state is "WIF SA lacks aiplatform.user".
   if (FINETUNE_STATUS === 'ok') {
     reasons.push(reason('finetune_run', true, 'At least one voice-tool-router Vertex training run has completed.'));
+  } else if (FINETUNE_STATUS === 'iam_blocked') {
+    reasons.push(reason(
+      'finetune_run',
+      false,
+      'Vertex IAM blocked: WIF SA lacks roles/aiplatform.user; CRON-FINETUNE-TRAINER cannot queue. See PHASE-GATE-STATUS-REPORT for the gcloud unblock command.',
+    ));
   } else if (FINETUNE_STATUS === 'failed') {
     reasons.push(reason('finetune_run', false, 'Most recent Vertex training run failed; investigate before canary.'));
   } else if (FINETUNE_STATUS === 'none') {
     reasons.push(reason('finetune_run', false, 'No Vertex training runs found; the candidate path is a stub. Submit CRON-FINETUNE-TRAINER.'));
   } else {
-    reasons.push(reason('finetune_run', false, `Fine-tune status unknown (${FINETUNE_STATUS}); workflow should pass FINETUNE_STATUS env from the Vertex probe.`));
+    reasons.push(reason('finetune_run', false, `Fine-tune status unknown (${FINETUNE_STATUS}); workflow probe did not classify cleanly.`));
   }
 
   // Dataset rows — need consented corpus to train


### PR DESCRIPTION
Phase 1 W3-C0 PR 2 of 2. CANARY-READINESS-REPORT's independent Vertex probe still used the narrow grep after W3-B1 fixed the gate report's probe. Result: gate said blocked, canary said skipped. Fix: copy widened grep into canary workflow, classify as new 'iam_blocked' state, add explicit script case that surfaces the gcloud unblock command. Verdict remains NOT_READY but with consistent + sharpened Vertex reason. npm run build green.