### PR TITLE
fix(command-hub): hide "Allocated - Pending Title" rows from Tasks board (VTID-03229 / DEV-COMHU-03229)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -6870,6 +6870,16 @@ function renderTasksView() {
             // VTID-01055: Suppress deleted/voided tasks (client-side safety net)
             if (!isTaskRenderable(t)) return false;
 
+            // VTID-03229: hide auto-allocated artifact rows. Phase 1 W3 / EXEC-DEPLOY
+            // style flows grab a VTID purely for gating and never assign a title,
+            // so the ledger row lands with the RPC's default literal. Without this
+            // filter, >50% of "Completed" is workflow scratch tokens (330 of 603 at
+            // time of fix), drowning real work. Backend fix lives in the allocator
+            // (VTID-03230); this is the client-side belt-and-suspenders so already-
+            // landed legacy rows fall off the board immediately.
+            const _t03229 = (t.title || '').trim();
+            if (_t03229 === 'Allocated - Pending Title' || _t03229 === 'Pending Title') return false;
+
             // VTID-01005: Use OASIS-derived column as authoritative source
             if (mapStatusToColumnWithOverride(t.vtid, t.status, t.oasisColumn) !== colName) return false;
 


### PR DESCRIPTION
## Summary
- 330 of 603 completed `vtid_ledger` rows have `title="Allocated - Pending Title"` — scratch tokens allocated by Phase 1 W3 / EXEC-DEPLOY flows for their own gating, never given a real title.
- They drown the Completed column on `/command-hub/tasks/` and obscure real work (audit on 2026-05-31).
- This PR adds a client-side filter in `renderTasksView()` to hide them. Backend fix is in VTID-03230.

## Why both layers
- Backend (VTID-03230) prevents future untitled rows.
- Client (this PR) hides the 330+ legacy rows already in the ledger without a destructive backfill.

## Test plan
- [ ] After deploy, open `https://gateway.vitanaland.com/command-hub/tasks/` and confirm the Completed column shows real tasks, not "Allocated - Pending Title" rows.
- [ ] Confirm Scheduled and In Progress columns still render normally.
- [ ] Confirm legacy in_progress orb-agent rows (VTID-03045/03074/03077/03080/03086) still appear (they have real titles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)