### PR TITLE
fix(orb): stop false "internet issues" on transparent reconnects (VTID-03234, report fix #2)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-close-classifier.ts
+++ b/services/gateway/src/orb/live/session/upstream-close-classifier.ts
@@ -1,0 +1,53 @@
+/**
+ * VTID-03234 (report finding #2) — upstream Vertex WebSocket close classifier.
+ *
+ * The ORB "internet issues" loop was caused (in part) by the close handler
+ * announcing a loud `connection_alert` to the client on EVERY upstream WS
+ * close, BEFORE classifying whether the close was:
+ *   - a persona swap (handled with a silent cue),
+ *   - a TRANSPARENT reconnect — Vertex's normal ~5-min session close
+ *     (code=1000) or watchdog stall-recovery (`_stallRecoveryPending`), which
+ *     the gateway repairs server-side while the client's SSE/WS stays open, or
+ *   - a GENUINE disconnect the client must actually react to.
+ *
+ * Only the genuine case warrants the loud alert. This pure helper makes that
+ * decision testable in isolation (the close handler lives inside a ~13k-line
+ * route file that cannot be imported directly in unit tests).
+ */
+
+export type UpstreamCloseAction =
+  | 'ignore' // session inactive or setup never completed — nothing to announce
+  | 'persona_swap' // voice channel-swap — silent persona cue
+  | 'transparent_reconnect' // code=1000 / stall recovery — reconnect silently, no alert
+  | 'genuine_disconnect'; // real failure — loud connection_alert is appropriate
+
+export interface UpstreamCloseInput {
+  /** WebSocket close code (1000 = normal close / Vertex session expiry). */
+  code: number;
+  /** Whether the live session is still active (not torn down by the user). */
+  active: boolean;
+  /** Whether Vertex setup completed (a pre-setup close is a connect failure). */
+  setupComplete: boolean;
+  /** Whether the watchdog force-terminated the WS for stall recovery. */
+  stallRecoveryPending: boolean;
+  /** Whether this close was triggered by an in-flight persona swap. */
+  isPersonaSwap: boolean;
+}
+
+/**
+ * Pure: classify an upstream WS close so the handler announces the RIGHT
+ * thing (or nothing). No IO, no mutation.
+ */
+export function classifyUpstreamClose(input: UpstreamCloseInput): UpstreamCloseAction {
+  const { code, active, setupComplete, stallRecoveryPending, isPersonaSwap } = input;
+  // Pre-setup close or inactive session: the connect/teardown paths own it;
+  // the post-setup announce block must stay silent.
+  if (!active || !setupComplete) return 'ignore';
+  // Persona swap closes the upstream deliberately — silent cue, not an alert.
+  if (isPersonaSwap) return 'persona_swap';
+  // Vertex's normal ~5-min close (1000) and watchdog stall-recovery are both
+  // repaired transparently server-side — do NOT alarm the user.
+  if (code === 1000 || stallRecoveryPending) return 'transparent_reconnect';
+  // Anything else is a genuine disconnect the client must react to.
+  return 'genuine_disconnect';
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1188,6 +1188,10 @@ import {
 // / resolve) via onSetupComplete + isSetupComplete callbacks, and forwards
 // every orb-live.ts-local helper through the deps bag.
 import { createUpstreamLiveMessageHandler } from '../orb/live/session/upstream-message-handler';
+// VTID-03234 (report finding #2): classify upstream WS closes so transparent
+// reconnects (Vertex 5-min close / watchdog recovery) don't fire a loud
+// "internet issues" alert.
+import { classifyUpstreamClose } from '../orb/live/session/upstream-close-classifier';
 // VTID-03126 (Phase D.3): Live API voice resolver — externalizes the
 // LIVE_API_VOICES Record + adds telemetry on silent fallbacks.
 import { getLiveApiVoice } from '../orb/live/voice/live-api-voice';
@@ -6049,16 +6053,43 @@ async function connectToLiveAPI(
       const reasonStr = reason?.toString() || '';
       const isPersonaSwap = reasonStr === 'persona_swap' || !!(session as any)._personaSwapInFlight;
 
-      // BOOTSTRAP-ORB-DISCONNECT-ALERT: Tell the client *immediately* that the
-      // upstream went away. The existing `reconnecting` message is only sent
-      // once attemptTransparentReconnect runs (after deduplicated extraction
-      // and other bookkeeping), which can be 100ms-1s+ later. Closing that gap
-      // lets the widget stop the user mid-sentence with a spoken cue instead
-      // of letting them talk into a dead socket.
-      if (session.active && setupComplete) {
-        const alertMsg = isPersonaSwap
-          ? { type: 'persona_swap_reconnecting', reason: 'persona_swap' }
-          : { type: 'connection_alert', reason: 'upstream_ws_close' };
+      // VTID-03234 (report finding #2): CLASSIFY the close before announcing it.
+      // Transparent reconnects — Vertex's normal ~5-min session close
+      // (code=1000) and watchdog stall-recovery (_stallRecoveryPending) — are
+      // handled fully server-side below (attemptTransparentReconnect): the
+      // client's SSE/WS to the gateway stays open while we reconnect the
+      // upstream Vertex WS in place. Firing "connection_alert" for these made
+      // healthy sessions surface "internet issues" every time Vertex recycled
+      // or the watchdog fired — the 5-10x/min loop users reported. The
+      // transparent path already resumes SILENTLY on success and emits its own
+      // alert ONLY if the reconnect actually fails (see the !reconnected branch
+      // below). So the loud alert here fires ONLY for a genuine disconnect.
+      const closeAction = classifyUpstreamClose({
+        code,
+        active: !!session.active,
+        setupComplete,
+        stallRecoveryPending: !!(session as any)._stallRecoveryPending,
+        isPersonaSwap,
+      });
+
+      // BOOTSTRAP-ORB-DISCONNECT-ALERT: tell the client immediately, but ONLY
+      // when it must react (genuine disconnect, or persona swap — silent cue).
+      if (closeAction === 'persona_swap') {
+        const alertMsg = { type: 'persona_swap_reconnecting', reason: 'persona_swap' };
+        if (session.sseResponse) {
+          try { session.sseResponse.write(`data: ${JSON.stringify(alertMsg)}\n\n`); } catch (_e) { /* SSE may be closed */ }
+        } else if (session.clientWs && session.clientWs.readyState === WebSocket.OPEN) {
+          try { session.clientWs.send(JSON.stringify(alertMsg)); } catch (_e) { /* WS may be closed */ }
+        }
+      } else if (closeAction === 'transparent_reconnect') {
+        // Suppress the loud "internet issues" alert — the reconnect is
+        // transparent. Internal diagnostic only; the client keeps listening.
+        emitDiag(session, 'transparent_reconnect_alert_suppressed', {
+          code,
+          stall_recovery: !!(session as any)._stallRecoveryPending,
+        });
+      } else if (closeAction === 'genuine_disconnect') {
+        const alertMsg = { type: 'connection_alert', reason: 'upstream_ws_close' };
         if (session.sseResponse) {
           try { session.sseResponse.write(`data: ${JSON.stringify(alertMsg)}\n\n`); } catch (_e) { /* SSE may be closed */ }
         } else if (session.clientWs && session.clientWs.readyState === WebSocket.OPEN) {

--- a/services/gateway/test/orb/live/session/upstream-close-classifier.test.ts
+++ b/services/gateway/test/orb/live/session/upstream-close-classifier.test.ts
@@ -1,0 +1,60 @@
+/**
+ * VTID-03234 (report finding #2) — upstream close classifier tests.
+ *
+ * Locks the rule that fixed the "internet issues" loop: transparent reconnects
+ * (Vertex's normal ~5-min code=1000 close and watchdog stall-recovery) must
+ * NOT produce a loud connection alert; only genuine disconnects do.
+ */
+
+import { classifyUpstreamClose } from '../../../../src/orb/live/session/upstream-close-classifier';
+
+const base = {
+  code: 1011,
+  active: true,
+  setupComplete: true,
+  stallRecoveryPending: false,
+  isPersonaSwap: false,
+};
+
+describe('classifyUpstreamClose', () => {
+  it('code=1000 on an active session → transparent_reconnect (no loud alert)', () => {
+    expect(classifyUpstreamClose({ ...base, code: 1000 })).toBe('transparent_reconnect');
+  });
+
+  it('watchdog stall-recovery → transparent_reconnect (no loud alert)', () => {
+    expect(
+      classifyUpstreamClose({ ...base, code: 1006, stallRecoveryPending: true }),
+    ).toBe('transparent_reconnect');
+  });
+
+  it('persona swap → persona_swap (silent cue, not an alert)', () => {
+    expect(classifyUpstreamClose({ ...base, code: 1000, isPersonaSwap: true })).toBe('persona_swap');
+    // persona swap takes precedence even on a non-1000 close
+    expect(classifyUpstreamClose({ ...base, isPersonaSwap: true })).toBe('persona_swap');
+  });
+
+  it('abnormal close (1006) with no stall recovery → genuine_disconnect (loud alert)', () => {
+    expect(classifyUpstreamClose({ ...base, code: 1006 })).toBe('genuine_disconnect');
+  });
+
+  it('pre-setup close → ignore (connect path owns it)', () => {
+    expect(classifyUpstreamClose({ ...base, setupComplete: false })).toBe('ignore');
+  });
+
+  it('inactive session → ignore (teardown path owns it)', () => {
+    expect(classifyUpstreamClose({ ...base, active: false })).toBe('ignore');
+  });
+
+  it('the dominant production case — Vertex 5-min recycle on a healthy session — is silent', () => {
+    // This is the case that previously fired "internet issues" 5-10x/min.
+    const action = classifyUpstreamClose({
+      code: 1000,
+      active: true,
+      setupComplete: true,
+      stallRecoveryPending: false,
+      isPersonaSwap: false,
+    });
+    expect(action).not.toBe('genuine_disconnect');
+    expect(action).toBe('transparent_reconnect');
+  });
+});


### PR DESCRIPTION
Fix **#2** of the 2026-05-31 ORB "internet issues" report.

## Problem
The upstream Vertex WS close handler (`orb-live.ts`) sent a loud `connection_alert` (→ client shows *"One moment, we have internet issues"*) on **every** close, **before** classifying it. But `code=1000` (Vertex's normal ~5-min recycle) and `_stallRecoveryPending` (watchdog recovery) are repaired **transparently server-side** — the client's SSE/WS stays open and `attemptTransparentReconnect` resumes silently on success (alerting only on real failure). Announcing them up-front made healthy sessions show "internet issues" **5-10×/min**.

## Fix
Classify first via a new pure `classifyUpstreamClose` helper:
- `persona_swap` → silent cue (unchanged)
- `transparent_reconnect` (code=1000 / stall recovery) → **no alert**, diag only
- `genuine_disconnect` → loud `connection_alert` (unchanged)

Only changes **when** the loud alert fires; reconnect mechanics + genuine-failure alert are untouched.

## Scope
This stops *falsely blaming the user's internet* for recoverable events. It does **not** by itself stop the underlying reconnects — that's **#3 (restore keepalive)** + **#4 (retune watchdog)**, coming next.

## Tests
7 classifier unit tests + 8 stream-lifecycle characterization tests green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)