### PR TITLE
feat(autopilot): Vitana Assistant can read + activate the Autopilot queue by voice (VTID-03201)

### DIFF
--- a/services/gateway/src/orb/live/tools/live-tool-catalog.ts
+++ b/services/gateway/src/orb/live/tools/live-tool-catalog.ts
@@ -1457,6 +1457,60 @@ export function buildLiveApiTools(
           },
         },
         {
+          name: 'get_autopilot_recommendations',
+          description: [
+            'Read out what is prepared in the user\'s Autopilot — the SAME',
+            'list shown in the Autopilot popup. Call this when the user asks',
+            '"what\'s in my Autopilot?", "what has Autopilot prepared?",',
+            '"what do you suggest I do today?", "read my recommendations",',
+            'or "was hat der Autopilot für mich?".',
+            '',
+            'Returns { ok, count, spoken, items:[{id,title}] }. Speak the',
+            '`spoken` summary verbatim (it is already ordered and concise).',
+            'The user can then say "activate those" / "do the first two" and',
+            'you call activate_autopilot_recommendations — the ids are',
+            'remembered from THIS call, so you never need to pass them back.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              limit: {
+                type: 'number',
+                description: 'Max actions to read out. Defaults to 5. Keep small for voice.',
+              },
+            },
+            required: [],
+          },
+        },
+        {
+          name: 'activate_autopilot_recommendations',
+          description: [
+            'Activate one or more Autopilot recommendations on the user\'s',
+            'behalf — the same full activation the popup performs (schedules',
+            'a calendar slot where applicable, notifies, and replenishes the',
+            'queue). Use ONLY after the user has explicitly agreed to act',
+            '("yes, do those", "activate the first one", "los geht\'s").',
+            '',
+            'You normally call this with NO arguments right after',
+            'get_autopilot_recommendations — it activates the actions you',
+            'just read aloud. To activate a subset, pass `ids` with the',
+            'specific recommendation ids from the items list (never guess an',
+            'id). Returns { ok, activated, spoken }; speak `spoken` verbatim.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              ids: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'OPTIONAL — specific recommendation ids to activate. Omit to activate everything just read aloud by get_autopilot_recommendations.',
+              },
+            },
+            required: [],
+          },
+        },
+        {
           name: 'share_link',
           description: [
             'Share a link with another Vitana user as a chat message with a',

--- a/services/gateway/src/routes/autopilot-recommendations.ts
+++ b/services/gateway/src/routes/autopilot-recommendations.ts
@@ -762,6 +762,327 @@ router.post('/generate-personal', async (req: Request, res: Response) => {
 });
 
 // =============================================================================
+// Shared community Autopilot service (VTID-03201)
+//
+// Single source of truth for LISTING and ACTIVATING community Autopilot
+// recommendations, so the REST popup (this router) and the ORB voice tools
+// behave identically. Voice previously had its own minimal activation path in
+// orb-tools-shared.ts that only flipped status — it skipped activated_at, the
+// calendar event, the OASIS event, the push notification, and replenishment.
+// Both surfaces now call activateCommunityAutopilotRecommendation().
+// =============================================================================
+
+/** A community recommendation projected for the popup AND for voice. */
+export interface CommunityRecommendationView {
+  id: string;
+  title: string;
+  summary: string | null;
+  source_ref: string | null;
+  domain: string | null;
+  impact_score: number | null;
+  time_estimate_seconds: number | null;
+  status: string;
+}
+
+/**
+ * List the community recommendations a user currently sees in the Autopilot
+ * popup. Uses the SAME canonical query (queryRecommendationsByRole), the SAME
+ * COMMUNITY_ACTIONS filter, and the SAME G4 index-pillar re-rank as the GET
+ * handler, so the spoken list and the visual list always agree on order and
+ * membership. Never throws — returns [] on any internal failure.
+ */
+export async function listCommunityAutopilotRecommendations(
+  userId: string,
+  limit = 5,
+): Promise<CommunityRecommendationView[]> {
+  try {
+    if (!userId) return [];
+    const clamped = Math.min(Math.max(limit, 1), 20);
+    // Over-fetch to survive dedup + retired-action filtering, mirroring the
+    // GET handler's fetchLimit heuristic.
+    const fetchLimit = Math.max((clamped + 1) * 4, 40);
+    const result = await queryRecommendationsByRole('community', userId, ['new'], fetchLimit, 0);
+    if (!result.ok || !result.data) return [];
+
+    // Dedup by source_ref then title (same rules as the popup).
+    const seen = new Map<string, any>();
+    for (const rec of result.data) {
+      const key = rec.source_ref || rec.title;
+      if (!seen.has(key)) seen.set(key, rec);
+    }
+    const seenTitles = new Set<string>();
+    let recs: any[] = [];
+    for (const rec of seen.values()) {
+      if (seenTitles.has(rec.title)) continue;
+      seenTitles.add(rec.title);
+      recs.push(rec);
+    }
+
+    // Retired-action filter: only refs that map to a real community action.
+    recs = recs.filter(rec => !rec.source_ref || COMMUNITY_ACTIONS[rec.source_ref]);
+
+    // G4 index-weighted re-rank (same module the popup uses).
+    try {
+      const { buildRankerContext, rankBatch } = await import('../services/recommendation-engine/ranking/index-pillar-weighter');
+      const { createClient } = await import('@supabase/supabase-js');
+      const svc = process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE
+        ? createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE)
+        : null;
+      if (svc && recs.length > 0) {
+        const ctx = await buildRankerContext(svc, userId);
+        recs = rankBatch(recs as any, ctx).map(r => r.rec as any);
+      }
+    } catch (rankErr: any) {
+      console.warn(`${LOG_PREFIX} listCommunity re-rank failed (non-fatal):`, rankErr?.message);
+    }
+
+    return recs.slice(0, clamped).map(rec => ({
+      id: rec.id,
+      title: rec.title,
+      summary: rec.summary ?? null,
+      source_ref: rec.source_ref ?? null,
+      domain: rec.domain ?? null,
+      impact_score: rec.impact_score ?? null,
+      time_estimate_seconds: rec.time_estimate_seconds ?? null,
+      status: rec.status,
+    }));
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} listCommunityAutopilotRecommendations failed (non-fatal):`, err?.message);
+    return [];
+  }
+}
+
+/**
+ * Project a list of community recommendations into a short, voice-friendly
+ * summary string Gemini can read aloud, plus the ordered ids so a follow-up
+ * "activate these" resolves to exactly what was read.
+ */
+export function summarizeAutopilotForVoice(
+  recs: CommunityRecommendationView[],
+): { spoken: string; ids: string[]; count: number } {
+  const ids = recs.map(r => r.id);
+  if (recs.length === 0) {
+    return { spoken: 'You have no Autopilot actions prepared right now.', ids, count: 0 };
+  }
+  const titles = recs.map((r, i) => `${i + 1}. ${r.title}`);
+  const lead = recs.length === 1
+    ? 'You have one Autopilot action prepared:'
+    : `You have ${recs.length} Autopilot actions prepared:`;
+  return { spoken: `${lead} ${titles.join('; ')}.`, ids, count: recs.length };
+}
+
+/** Structured result for community activation, mapped to HTTP by the route and to speech by voice. */
+export interface ActivateCommunityResult {
+  ok: boolean;
+  httpStatus: number;
+  error?: string;
+  already_activated?: boolean;
+  recommendation_id?: string;
+  title?: string;
+  action_type?: 'navigate' | 'notify';
+  target?: string | null;
+  completion_message?: string;
+  calendar_event_id?: string | null;
+  replenished?: number;
+}
+
+/**
+ * Canonical community Autopilot activation. Performs ALL side effects:
+ * status → activated + activated_at, calendar event (for schedulable actions),
+ * OASIS event, push notification, and last-rec auto-replenishment. Used by both
+ * the REST popup and the ORB voice tool. VTID-03201.
+ */
+export async function activateCommunityAutopilotRecommendation(
+  userId: string | null,
+  id: string,
+  opts: { tenantId?: string; skipReplenish?: boolean } = {},
+): Promise<ActivateCommunityResult> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const svcKey = process.env.SUPABASE_SERVICE_ROLE;
+  if (!supabaseUrl || !svcKey) {
+    return { ok: false, httpStatus: 503, error: 'Supabase not configured' };
+  }
+
+  // Fetch the recommendation to get source_type, source_ref, user_id, status
+  const recResp = await fetch(
+    `${supabaseUrl}/rest/v1/autopilot_recommendations?id=eq.${id}&select=id,title,summary,source_type,source_ref,user_id,status,domain&limit=1`,
+    { headers: { apikey: svcKey, Authorization: `Bearer ${svcKey}` } }
+  );
+  if (!recResp.ok) {
+    return { ok: false, httpStatus: 400, error: 'Failed to fetch recommendation' };
+  }
+  const recRows = await recResp.json() as any[];
+  const rec = recRows[0];
+  if (!rec) {
+    return { ok: false, httpStatus: 404, error: 'Recommendation not found' };
+  }
+
+  // Verify this is a community recommendation belonging to this user
+  if (rec.source_type !== 'community') {
+    return { ok: false, httpStatus: 403, error: 'Not a community recommendation' };
+  }
+  if (rec.user_id && userId && rec.user_id !== userId) {
+    return { ok: false, httpStatus: 403, error: 'Recommendation belongs to another user' };
+  }
+
+  // Already activated? Return idempotent response
+  if (rec.status === 'activated') {
+    const action = COMMUNITY_ACTIONS[rec.source_ref] || null;
+    return {
+      ok: true,
+      httpStatus: 200,
+      already_activated: true,
+      recommendation_id: id,
+      title: rec.title,
+      action_type: action?.action_type || 'notify',
+      target: action?.target || null,
+      completion_message: action?.completion_message || 'Already done!',
+    };
+  }
+
+  // Must be in activatable state
+  if (rec.status !== 'new' && rec.status !== 'snoozed') {
+    return { ok: false, httpStatus: 400, error: `Cannot activate recommendation in status: ${rec.status}` };
+  }
+
+  // Look up the community action
+  const action = COMMUNITY_ACTIONS[rec.source_ref] || {
+    action_type: 'notify' as const,
+    completion_message: 'Done!',
+  };
+
+  // Update recommendation status to 'activated' via PostgREST — NO VTID
+  const patchResp = await fetch(
+    `${supabaseUrl}/rest/v1/autopilot_recommendations?id=eq.${id}`,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: svcKey,
+        Authorization: `Bearer ${svcKey}`,
+      },
+      body: JSON.stringify({
+        status: 'activated',
+        activated_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }),
+    }
+  );
+  if (!patchResp.ok) {
+    console.error(`${LOG_PREFIX} Community activate PATCH failed:`, await patchResp.text());
+    return { ok: false, httpStatus: 500, error: 'Failed to update recommendation status' };
+  }
+
+  // Intelligent Calendar: create calendar event for schedulable actions
+  let calendarEvent = null;
+  if (action.calendar_event && userId) {
+    try {
+      const { computeNextAvailableSlot, createCalendarEvent } = await import('../services/calendar-service');
+      const slot = await computeNextAvailableSlot(userId, 'community', action.calendar_event.duration_minutes);
+      const endSlot = new Date(slot.getTime() + action.calendar_event.duration_minutes * 60 * 1000);
+      calendarEvent = await createCalendarEvent(userId, {
+        title: action.calendar_event.title_template || rec.title,
+        description: rec.summary || action.completion_message,
+        start_time: slot.toISOString(),
+        end_time: endSlot.toISOString(),
+        event_type: action.calendar_event.event_type,
+        status: 'confirmed',
+        priority: 'medium',
+        role_context: 'community',
+        source_type: 'autopilot',
+        source_ref_id: id,
+        source_ref_type: 'autopilot_recommendation',
+        priority_score: 60,
+        wellness_tags: action.calendar_event.wellness_tags,
+        metadata: { recommendation_title: rec.title, source_ref: rec.source_ref },
+      } as any);
+      if (calendarEvent) {
+        console.log(`${LOG_PREFIX} Calendar event created for recommendation ${id.slice(0, 8)}... → ${calendarEvent.id.slice(0, 8)}...`);
+      }
+    } catch (calErr: any) {
+      console.warn(`${LOG_PREFIX} Calendar event creation failed (non-fatal): ${calErr.message}`);
+    }
+  }
+
+  // Emit OASIS event
+  await emitOasisEvent({
+    vtid: 'SYSTEM',
+    type: 'autopilot.recommendation.activated' as any,
+    source: 'autopilot-recommendations',
+    status: 'info',
+    message: `Community recommendation activated: ${rec.title}`,
+    payload: {
+      recommendation_id: id,
+      user_id: userId,
+      role: 'community',
+      action_type: action.action_type,
+      target: action.target || null,
+      source_ref: rec.source_ref,
+      calendar_event_id: calendarEvent?.id || null,
+    },
+  });
+
+  // Send push notification
+  if (userId) {
+    try {
+      const { createClient } = await import('@supabase/supabase-js');
+      const supa = createClient(supabaseUrl, svcKey);
+      const { data: tenantRow } = await supa
+        .from('user_tenants')
+        .select('tenant_id')
+        .eq('user_id', userId)
+        .eq('is_primary', true)
+        .maybeSingle();
+      if (tenantRow?.tenant_id) {
+        notifyUserAsync(userId, tenantRow.tenant_id, 'recommendation_activated', {
+          title: rec.title,
+          body: action.completion_message,
+          data: { url: action.target || '/', recommendation_id: id },
+        }, supa);
+      }
+    } catch (notifErr: any) {
+      console.warn(`${LOG_PREFIX} Notification error (non-fatal): ${notifErr.message}`);
+    }
+  }
+
+  console.log(`${LOG_PREFIX} Community activation: ${rec.source_ref} → ${action.action_type}:${action.target || 'none'}`);
+
+  // Auto-replenishment: if this was the user's last 'new' rec, generate fresh ones.
+  // Voice skips this inline (it runs analyzers and can be slow) — the popup/list
+  // auto-generates on next open, so the queue still refills.
+  let replenished = 0;
+  if (userId && !opts.skipReplenish) {
+    try {
+      const remainingResp = await fetch(
+        `${supabaseUrl}/rest/v1/autopilot_recommendations?user_id=eq.${userId}&status=eq.new&select=id&limit=1`,
+        { headers: { apikey: svcKey, Authorization: `Bearer ${svcKey}` } }
+      );
+      const remainingRows = remainingResp.ok ? await remainingResp.json() as any[] : [];
+      if (remainingRows.length === 0) {
+        console.log(`${LOG_PREFIX} Last community rec activated for user ${userId.slice(0, 8)} — triggering auto-replenishment`);
+        const genResult = await generatePersonalRecommendations(userId, opts.tenantId || '', { trigger_type: 'auto_replenish' });
+        replenished = genResult?.generated || 0;
+        console.log(`${LOG_PREFIX} Auto-replenishment generated ${replenished} new recommendations`);
+      }
+    } catch (replenishErr: any) {
+      console.warn(`${LOG_PREFIX} Auto-replenishment failed (non-fatal): ${replenishErr.message}`);
+    }
+  }
+
+  return {
+    ok: true,
+    httpStatus: 200,
+    recommendation_id: id,
+    title: rec.title,
+    action_type: action.action_type,
+    target: action.target || null,
+    completion_message: action.completion_message,
+    calendar_event_id: calendarEvent?.id || null,
+    replenished,
+  };
+}
+
+// =============================================================================
 // POST /recommendations/:id/activate - Activate recommendation (creates VTID)
 // =============================================================================
 /**
@@ -798,191 +1119,24 @@ router.post('/:id/activate', async (req: Request, res: Response) => {
     // Community activation path — NO VTIDs, returns action for frontend
     // =========================================================================
     if (role === 'community') {
-      const supabaseUrl = process.env.SUPABASE_URL;
-      const svcKey = process.env.SUPABASE_SERVICE_ROLE;
-      if (!supabaseUrl || !svcKey) {
-        return res.status(503).json({ ok: false, error: 'Supabase not configured' });
+      // Single source: REST and ORB voice share this activation flow.
+      const tenantId = req.get('X-Vitana-Tenant') || '';
+      const result = await activateCommunityAutopilotRecommendation(userId, id, { tenantId });
+      if (!result.ok) {
+        return res.status(result.httpStatus).json({ ok: false, error: result.error });
       }
-
-      // Fetch the recommendation to get source_type, source_ref, user_id, status
-      const recResp = await fetch(
-        `${supabaseUrl}/rest/v1/autopilot_recommendations?id=eq.${id}&select=id,title,summary,source_type,source_ref,user_id,status,domain&limit=1`,
-        { headers: { apikey: svcKey, Authorization: `Bearer ${svcKey}` } }
-      );
-      if (!recResp.ok) {
-        return res.status(400).json({ ok: false, error: 'Failed to fetch recommendation' });
-      }
-      const recRows = await recResp.json() as any[];
-      const rec = recRows[0];
-      if (!rec) {
-        return res.status(404).json({ ok: false, error: 'Recommendation not found' });
-      }
-
-      // Verify this is a community recommendation belonging to this user
-      if (rec.source_type !== 'community') {
-        return res.status(403).json({ ok: false, error: 'Not a community recommendation' });
-      }
-      if (rec.user_id && userId && rec.user_id !== userId) {
-        return res.status(403).json({ ok: false, error: 'Recommendation belongs to another user' });
-      }
-
-      // Already activated? Return idempotent response
-      if (rec.status === 'activated') {
-        const action = COMMUNITY_ACTIONS[rec.source_ref] || null;
-        return res.status(200).json({
-          ok: true,
-          already_activated: true,
-          recommendation_id: id,
-          title: rec.title,
-          action_type: action?.action_type || 'notify',
-          target: action?.target || null,
-          completion_message: action?.completion_message || 'Already done!',
-          vtid: 'VTID-01180',
-          timestamp: new Date().toISOString(),
-        });
-      }
-
-      // Must be in activatable state
-      if (rec.status !== 'new' && rec.status !== 'snoozed') {
-        return res.status(400).json({ ok: false, error: `Cannot activate recommendation in status: ${rec.status}` });
-      }
-
-      // Look up the community action
-      const action = COMMUNITY_ACTIONS[rec.source_ref] || {
-        action_type: 'notify' as const,
-        completion_message: 'Done!',
-      };
-
-      // Update recommendation status to 'activated' via PostgREST — NO VTID
-      const patchResp = await fetch(
-        `${supabaseUrl}/rest/v1/autopilot_recommendations?id=eq.${id}`,
-        {
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-            apikey: svcKey,
-            Authorization: `Bearer ${svcKey}`,
-          },
-          body: JSON.stringify({
-            status: 'activated',
-            activated_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-          }),
-        }
-      );
-      if (!patchResp.ok) {
-        console.error(`${LOG_PREFIX} Community activate PATCH failed:`, await patchResp.text());
-        return res.status(500).json({ ok: false, error: 'Failed to update recommendation status' });
-      }
-
-      // Intelligent Calendar: create calendar event for schedulable actions
-      let calendarEvent = null;
-      if (action.calendar_event && userId) {
-        try {
-          const { computeNextAvailableSlot, createCalendarEvent } = await import('../services/calendar-service');
-          const slot = await computeNextAvailableSlot(userId, 'community', action.calendar_event.duration_minutes);
-          const endSlot = new Date(slot.getTime() + action.calendar_event.duration_minutes * 60 * 1000);
-          calendarEvent = await createCalendarEvent(userId, {
-            title: action.calendar_event.title_template || rec.title,
-            description: rec.summary || action.completion_message,
-            start_time: slot.toISOString(),
-            end_time: endSlot.toISOString(),
-            event_type: action.calendar_event.event_type,
-            status: 'confirmed',
-            priority: 'medium',
-            role_context: 'community',
-            source_type: 'autopilot',
-            source_ref_id: id,
-            source_ref_type: 'autopilot_recommendation',
-            priority_score: 60,
-            wellness_tags: action.calendar_event.wellness_tags,
-            metadata: { recommendation_title: rec.title, source_ref: rec.source_ref },
-          } as any);
-          if (calendarEvent) {
-            console.log(`${LOG_PREFIX} Calendar event created for recommendation ${id.slice(0, 8)}... → ${calendarEvent.id.slice(0, 8)}...`);
-          }
-        } catch (calErr: any) {
-          console.warn(`${LOG_PREFIX} Calendar event creation failed (non-fatal): ${calErr.message}`);
-        }
-      }
-
-      // Emit OASIS event
-      await emitOasisEvent({
-        vtid: 'SYSTEM',
-        type: 'autopilot.recommendation.activated' as any,
-        source: 'autopilot-recommendations',
-        status: 'info',
-        message: `Community recommendation activated: ${rec.title}`,
-        payload: {
-          recommendation_id: id,
-          user_id: userId,
-          role: 'community',
-          action_type: action.action_type,
-          target: action.target || null,
-          source_ref: rec.source_ref,
-          calendar_event_id: calendarEvent?.id || null,
-        },
-      });
-
-      // Send push notification
-      if (userId) {
-        try {
-          const { createClient } = await import('@supabase/supabase-js');
-          const supa = createClient(supabaseUrl, svcKey);
-          const { data: tenantRow } = await supa
-            .from('user_tenants')
-            .select('tenant_id')
-            .eq('user_id', userId)
-            .eq('is_primary', true)
-            .maybeSingle();
-          if (tenantRow?.tenant_id) {
-            notifyUserAsync(userId, tenantRow.tenant_id, 'recommendation_activated', {
-              title: rec.title,
-              body: action.completion_message,
-              data: { url: action.target || '/', recommendation_id: id },
-            }, supa);
-          }
-        } catch (notifErr: any) {
-          console.warn(`${LOG_PREFIX} Notification error (non-fatal): ${notifErr.message}`);
-        }
-      }
-
-      console.log(`${LOG_PREFIX} Community activation: ${rec.source_ref} → ${action.action_type}:${action.target || 'none'}`);
-
-      // Auto-replenishment: check if user has any remaining 'new' recs.
-      // If this was the last one, trigger generation of fresh recommendations.
-      let replenished = 0;
-      if (userId) {
-        try {
-          const remainingResp = await fetch(
-            `${supabaseUrl}/rest/v1/autopilot_recommendations?user_id=eq.${userId}&status=eq.new&select=id&limit=1`,
-            { headers: { apikey: svcKey!, Authorization: `Bearer ${svcKey}` } }
-          );
-          const remainingRows = remainingResp.ok ? await remainingResp.json() as any[] : [];
-          if (remainingRows.length === 0) {
-            console.log(`${LOG_PREFIX} Last community rec activated for user ${userId.slice(0, 8)} — triggering auto-replenishment`);
-            const tenantId = req.get('X-Vitana-Tenant') || '';
-            const authToken = req.get('Authorization')?.replace('Bearer ', '') || '';
-            const { generatePersonalRecommendations: genPersonal } = await import('../services/recommendation-engine');
-            const genResult = await genPersonal(userId, tenantId, { trigger_type: 'auto_replenish' });
-            replenished = genResult?.generated || 0;
-            console.log(`${LOG_PREFIX} Auto-replenishment generated ${replenished} new recommendations`);
-          }
-        } catch (replenishErr: any) {
-          console.warn(`${LOG_PREFIX} Auto-replenishment failed (non-fatal): ${replenishErr.message}`);
-        }
-      }
-
-      return res.status(200).json({
+      return res.status(result.httpStatus).json({
         ok: true,
-        recommendation_id: id,
-        title: rec.title,
+        already_activated: result.already_activated,
+        recommendation_id: result.recommendation_id,
+        title: result.title,
         status: 'activated',
         activated_at: new Date().toISOString(),
-        action_type: action.action_type,
-        target: action.target || null,
-        completion_message: action.completion_message,
-        replenished,
+        action_type: result.action_type,
+        target: result.target ?? null,
+        completion_message: result.completion_message,
+        calendar_event_id: result.calendar_event_id ?? null,
+        replenished: result.replenished ?? 0,
         vtid: 'VTID-01180',
         timestamp: new Date().toISOString(),
       });

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -829,6 +829,10 @@ export interface GeminiLiveSession {
   thread_id?: string;
   conversation_id?: string;
   turn_count: number;
+  // VTID-03201: ids of the Autopilot recommendations most recently read aloud
+  // by get_autopilot_recommendations, so a follow-up "activate those" resolves
+  // to exactly what Vitana just listed (in order).
+  lastListedAutopilotIds?: { ids: string[]; ts: number };
   // VTID-01224: Bootstrap context (injected into system instruction)
   contextInstruction?: string;
   contextPack?: ContextPack;
@@ -2016,7 +2020,15 @@ async function executeLiveApiTool(
   // (OpenAI/Anthropic/Google AI). The delegation executor already hard-caps
   // at 15 s internally (orb/delegation/execute.ts), so we mirror that here
   // as the outer tool budget. All other tools keep the 3 s budget.
-  const TOOL_TIMEOUT_MS = toolName === 'consult_external_ai' ? 16_000 : 3_000;
+  // VTID-03201: the Autopilot tools do a Supabase query + G4 re-rank (list) or
+  // several sequential activations with calendar-slot computation (activate),
+  // which can exceed the default 3 s. Replenishment is skipped inline for voice
+  // (the popup auto-generates on next open) so these stay bounded.
+  const AUTOPILOT_VOICE_TOOLS = new Set(['get_autopilot_recommendations', 'activate_autopilot_recommendations']);
+  const TOOL_TIMEOUT_MS =
+    toolName === 'consult_external_ai' ? 16_000 :
+    AUTOPILOT_VOICE_TOOLS.has(toolName) ? 12_000 :
+    3_000;
 
   const executeWithTimeout = async (): Promise<{ success: boolean; result: string; error?: string }> => {
     return Promise.race([
@@ -4211,6 +4223,97 @@ async function executeLiveApiToolInner(
           },
           supabase,
         );
+      }
+
+      // VTID-03201: read + activate the user's Autopilot queue by voice, via
+      // the SAME shared service the popup uses (listCommunity… / activateCommunity…),
+      // so the spoken list and the visual list never diverge.
+      case 'get_autopilot_recommendations': {
+        const userId = lens.user_id;
+        if (!userId) {
+          return { success: false, result: '', error: 'NOT_SIGNED_IN' };
+        }
+        const { listCommunityAutopilotRecommendations, summarizeAutopilotForVoice } = await import('./autopilot-recommendations');
+        const limit = typeof args?.limit === 'number' && args.limit > 0 ? Math.min(args.limit, 10) : 5;
+        const recs = await listCommunityAutopilotRecommendations(userId, limit);
+        const summary = summarizeAutopilotForVoice(recs);
+        // Remember exactly what we read aloud so "activate those" resolves to it.
+        session.lastListedAutopilotIds = { ids: summary.ids, ts: Date.now() };
+        return {
+          success: true,
+          result: JSON.stringify({
+            ok: true,
+            count: summary.count,
+            spoken: summary.spoken,
+            items: recs.map(r => ({ id: r.id, title: r.title })),
+          }),
+        };
+      }
+
+      case 'activate_autopilot_recommendations': {
+        const userId = lens.user_id;
+        if (!userId) {
+          return { success: false, result: '', error: 'NOT_SIGNED_IN' };
+        }
+        const { activateCommunityAutopilotRecommendation } = await import('./autopilot-recommendations');
+
+        // Resolve target ids: explicit `ids` arg, else the last-listed set.
+        const explicit: string[] = Array.isArray(args?.ids)
+          ? (args.ids as unknown[]).filter((x): x is string => typeof x === 'string')
+          : [];
+        const listed = session.lastListedAutopilotIds?.ids ?? [];
+        const targetIds = explicit.length > 0 ? explicit : listed;
+
+        if (targetIds.length === 0) {
+          return {
+            success: true,
+            result: JSON.stringify({
+              ok: false,
+              activated: 0,
+              spoken: "I don't have any prepared actions queued to activate yet — ask me what's in your Autopilot first.",
+            }),
+          };
+        }
+
+        // Activate sequentially (calendar slotting reads the live calendar, so
+        // parallel runs could double-book the same slot). Replenishment is
+        // skipped inline for voice latency — the popup refills on next open.
+        const tenantId = lens.tenant_id ?? '';
+        const activated: string[] = [];
+        const failed: string[] = [];
+        for (const id of targetIds) {
+          try {
+            const r = await activateCommunityAutopilotRecommendation(userId, id, {
+              tenantId: tenantId || undefined,
+              skipReplenish: true,
+            });
+            if (r.ok) activated.push(r.title || id);
+            else failed.push(id);
+          } catch {
+            failed.push(id);
+          }
+        }
+
+        let spoken: string;
+        if (activated.length === 0) {
+          spoken = "I couldn't activate those — they may have already been done or aren't yours to action.";
+        } else if (activated.length === 1) {
+          spoken = `Done — I've activated "${activated[0]}".`;
+        } else {
+          spoken = `Done — I've activated ${activated.length} actions: ${activated.join('; ')}.`;
+        }
+        // Clear the remembered list so a stray repeat call can't re-activate.
+        session.lastListedAutopilotIds = { ids: [], ts: Date.now() };
+
+        return {
+          success: true,
+          result: JSON.stringify({
+            ok: activated.length > 0,
+            activated: activated.length,
+            failed: failed.length,
+            spoken,
+          }),
+        };
       }
 
       case 'share_link': {

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -1190,6 +1190,32 @@ Returns { ok, title, completion_message }. If ok=false, briefly
 acknowledge ("Hmm, couldn't schedule that one") and offer to
 open the Autopilot screen instead via navigate_to_screen.
 
+### get_autopilot_recommendations
+Read out what is prepared in the user's Autopilot — the SAME
+list shown in the Autopilot popup. Call this when the user asks
+"what's in my Autopilot?", "what has Autopilot prepared?",
+"what do you suggest I do today?", "read my recommendations",
+or "was hat der Autopilot für mich?".
+
+Returns { ok, count, spoken, items:[{id,title}] }. Speak the
+\`spoken\` summary verbatim (it is already ordered and concise).
+The user can then say "activate those" / "do the first two" and
+you call activate_autopilot_recommendations — the ids are
+remembered from THIS call, so you never need to pass them back.
+
+### activate_autopilot_recommendations
+Activate one or more Autopilot recommendations on the user's
+behalf — the same full activation the popup performs (schedules
+a calendar slot where applicable, notifies, and replenishes the
+queue). Use ONLY after the user has explicitly agreed to act
+("yes, do those", "activate the first one", "los geht's").
+
+You normally call this with NO arguments right after
+get_autopilot_recommendations — it activates the actions you
+just read aloud. To activate a subset, pass \`ids\` with the
+specific recommendation ids from the items list (never guess an
+id). Returns { ok, activated, spoken }; speak \`spoken\` verbatim.
+
 ### share_link
 Share a link with another Vitana user as a chat message with a
 link-card preview. Same confirmation contract as send_chat_message:
@@ -2385,6 +2411,32 @@ initiative's \`build_voice_on_complete\` template.
 Returns { ok, title, completion_message }. If ok=false, briefly
 acknowledge ("Hmm, couldn't schedule that one") and offer to
 open the Autopilot screen instead via navigate_to_screen.
+
+### get_autopilot_recommendations
+Read out what is prepared in the user's Autopilot — the SAME
+list shown in the Autopilot popup. Call this when the user asks
+"what's in my Autopilot?", "what has Autopilot prepared?",
+"what do you suggest I do today?", "read my recommendations",
+or "was hat der Autopilot für mich?".
+
+Returns { ok, count, spoken, items:[{id,title}] }. Speak the
+\`spoken\` summary verbatim (it is already ordered and concise).
+The user can then say "activate those" / "do the first two" and
+you call activate_autopilot_recommendations — the ids are
+remembered from THIS call, so you never need to pass them back.
+
+### activate_autopilot_recommendations
+Activate one or more Autopilot recommendations on the user's
+behalf — the same full activation the popup performs (schedules
+a calendar slot where applicable, notifies, and replenishes the
+queue). Use ONLY after the user has explicitly agreed to act
+("yes, do those", "activate the first one", "los geht's").
+
+You normally call this with NO arguments right after
+get_autopilot_recommendations — it activates the actions you
+just read aloud. To activate a subset, pass \`ids\` with the
+specific recommendation ids from the items list (never guess an
+id). Returns { ok, activated, spoken }; speak \`spoken\` verbatim.
 
 ### share_link
 Share a link with another Vitana user as a chat message with a

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -1473,6 +1473,57 @@ open the Autopilot screen instead via navigate_to_screen.",
         },
       },
       {
+        "description": "Read out what is prepared in the user's Autopilot — the SAME
+list shown in the Autopilot popup. Call this when the user asks
+"what's in my Autopilot?", "what has Autopilot prepared?",
+"what do you suggest I do today?", "read my recommendations",
+or "was hat der Autopilot für mich?".
+
+Returns { ok, count, spoken, items:[{id,title}] }. Speak the
+\`spoken\` summary verbatim (it is already ordered and concise).
+The user can then say "activate those" / "do the first two" and
+you call activate_autopilot_recommendations — the ids are
+remembered from THIS call, so you never need to pass them back.",
+        "name": "get_autopilot_recommendations",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max actions to read out. Defaults to 5. Keep small for voice.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Activate one or more Autopilot recommendations on the user's
+behalf — the same full activation the popup performs (schedules
+a calendar slot where applicable, notifies, and replenishes the
+queue). Use ONLY after the user has explicitly agreed to act
+("yes, do those", "activate the first one", "los geht's").
+
+You normally call this with NO arguments right after
+get_autopilot_recommendations — it activates the actions you
+just read aloud. To activate a subset, pass \`ids\` with the
+specific recommendation ids from the items list (never guess an
+id). Returns { ok, activated, spoken }; speak \`spoken\` verbatim.",
+        "name": "activate_autopilot_recommendations",
+        "parameters": {
+          "properties": {
+            "ids": {
+              "description": "OPTIONAL — specific recommendation ids to activate. Omit to activate everything just read aloud by get_autopilot_recommendations.",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
         "description": "Share a link with another Vitana user as a chat message with a
 link-card preview. Same confirmation contract as send_chat_message:
 ALWAYS resolve_recipient first, ALWAYS read back the link target
@@ -3619,6 +3670,57 @@ open the Autopilot screen instead via navigate_to_screen.",
           "required": [
             "id",
           ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read out what is prepared in the user's Autopilot — the SAME
+list shown in the Autopilot popup. Call this when the user asks
+"what's in my Autopilot?", "what has Autopilot prepared?",
+"what do you suggest I do today?", "read my recommendations",
+or "was hat der Autopilot für mich?".
+
+Returns { ok, count, spoken, items:[{id,title}] }. Speak the
+\`spoken\` summary verbatim (it is already ordered and concise).
+The user can then say "activate those" / "do the first two" and
+you call activate_autopilot_recommendations — the ids are
+remembered from THIS call, so you never need to pass them back.",
+        "name": "get_autopilot_recommendations",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max actions to read out. Defaults to 5. Keep small for voice.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Activate one or more Autopilot recommendations on the user's
+behalf — the same full activation the popup performs (schedules
+a calendar slot where applicable, notifies, and replenishes the
+queue). Use ONLY after the user has explicitly agreed to act
+("yes, do those", "activate the first one", "los geht's").
+
+You normally call this with NO arguments right after
+get_autopilot_recommendations — it activates the actions you
+just read aloud. To activate a subset, pass \`ids\` with the
+specific recommendation ids from the items list (never guess an
+id). Returns { ok, activated, spoken }; speak \`spoken\` verbatim.",
+        "name": "activate_autopilot_recommendations",
+        "parameters": {
+          "properties": {
+            "ids": {
+              "description": "OPTIONAL — specific recommendation ids to activate. Omit to activate everything just read aloud by get_autopilot_recommendations.",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          "required": [],
           "type": "object",
         },
       },

--- a/services/gateway/test/services/autopilot-voice-tools.test.ts
+++ b/services/gateway/test/services/autopilot-voice-tools.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Voice surface tests for the shared Autopilot service — VTID-03201.
+ *
+ * The ORB voice tools (get_autopilot_recommendations /
+ * activate_autopilot_recommendations) project the SAME list the popup shows
+ * (listCommunityAutopilotRecommendations) into speech via
+ * summarizeAutopilotForVoice, and remember the listed ids so a follow-up
+ * "activate those" resolves to exactly what was read aloud.
+ *
+ * These tests lock the projection contract: the spoken summary, the count,
+ * and — critically — that the ids carried for activation are the SAME ids, in
+ * the SAME order, as the recommendations that were listed (so the spoken list
+ * and the popup list can never diverge).
+ */
+
+import {
+  summarizeAutopilotForVoice,
+  type CommunityRecommendationView,
+} from '../../src/routes/autopilot-recommendations';
+
+function view(id: string, title: string): CommunityRecommendationView {
+  return {
+    id,
+    title,
+    summary: null,
+    source_ref: null,
+    domain: null,
+    impact_score: null,
+    time_estimate_seconds: null,
+    status: 'new',
+  };
+}
+
+describe('summarizeAutopilotForVoice', () => {
+  it('handles an empty queue without inventing actions', () => {
+    const s = summarizeAutopilotForVoice([]);
+    expect(s.count).toBe(0);
+    expect(s.ids).toEqual([]);
+    expect(s.spoken).toMatch(/no Autopilot actions/i);
+  });
+
+  it('uses the singular form for exactly one action', () => {
+    const s = summarizeAutopilotForVoice([view('a', 'Try a live room')]);
+    expect(s.count).toBe(1);
+    expect(s.ids).toEqual(['a']);
+    expect(s.spoken).toMatch(/one Autopilot action/i);
+    expect(s.spoken).toContain('Try a live room');
+  });
+
+  it('lists multiple actions in order with a count', () => {
+    const recs = [
+      view('a', 'Attend a meetup'),
+      view('b', 'Hydration check-in'),
+      view('c', 'Meditation / breathwork'),
+    ];
+    const s = summarizeAutopilotForVoice(recs);
+    expect(s.count).toBe(3);
+    expect(s.spoken).toMatch(/3 Autopilot actions/i);
+    // numbered + ordered
+    expect(s.spoken).toContain('1. Attend a meetup');
+    expect(s.spoken).toContain('2. Hydration check-in');
+    expect(s.spoken).toContain('3. Meditation / breathwork');
+  });
+
+  it('carries the SAME ids in the SAME order as the listed recs (popup/voice parity)', () => {
+    const recs = [view('id-1', 'A'), view('id-2', 'B'), view('id-3', 'C')];
+    const s = summarizeAutopilotForVoice(recs);
+    // The ids the voice layer stashes for "activate those" must equal the
+    // ids of the recommendations that were read aloud, in the same order.
+    expect(s.ids).toEqual(recs.map(r => r.id));
+  });
+});

--- a/voice-pipeline-spec/spec.json
+++ b/voice-pipeline-spec/spec.json
@@ -55,6 +55,8 @@
     { "name": "send_chat_message",            "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": null,         "notes": "Step 3 of send_message flow." },
 
     { "name": "activate_recommendation",      "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01180" },
+    { "name": "get_autopilot_recommendations", "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-03201", "notes": "Read the user's Autopilot queue aloud — same list as the popup. Session-state-coupled (remembers listed ids)." },
+    { "name": "activate_autopilot_recommendations", "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-03201", "notes": "Activate Autopilot recommendations on the user's behalf via the shared popup flow. Resolves 'activate those' to the last listed ids." },
     { "name": "share_link",                   "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
 
     { "name": "post_intent",                  "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-01975" },


### PR DESCRIPTION
## Context

Phase 3–5 of the community Autopilot work. The popup-replenishment fix shipped in #2450 (Phase 1–2). This PR delivers the second half of the request: **Vitana Assistant can read the Autopilot and activate it on the user's behalf**, through the *same* service the popup uses — so the spoken list and the visual list never diverge.

## The problem with voice today

- `get_recommendations` read `community_recommendations`/`matches_daily` — **not** the Autopilot queue, so "what's in my Autopilot?" never reflected the popup.
- `activate_recommendation` (`orb-tools-shared.ts`) only flipped `status='activated'` — it **skipped** `activated_at`, the calendar event, the OASIS event, the push notification, and replenishment that the REST popup performs.

## Changes

**Shared service (`routes/autopilot-recommendations.ts`)**
- `activateCommunityAutopilotRecommendation()` — extracted the full community activation flow (status + `activated_at`, calendar event, OASIS event, push, last-rec replenishment) out of the inline route handler into one exported function. **The REST route now calls it; voice calls it too.** Added `skipReplenish` so voice stays latency-bounded (the popup auto-generates on next open).
- `listCommunityAutopilotRecommendations()` — same canonical query (`queryRecommendationsByRole`) + dedup + `COMMUNITY_ACTIONS` filter + G4 re-rank as the popup.
- `summarizeAutopilotForVoice()` — projects the list into a short spoken summary plus the ordered ids.

**ORB voice (`routes/orb-live.ts` + `orb/live/tools/live-tool-catalog.ts`)**
- New tools **`get_autopilot_recommendations`** and **`activate_autopilot_recommendations`**.
- `GeminiLiveSession.lastListedAutopilotIds` remembers what was read aloud, so "activate those" resolves to exactly that list, in order, then clears to prevent accidental re-activation.
- 12s tool-timeout budget for these two tools (Supabase query + re-rank / sequential activations) vs the default 3s.

## Verification

- `tsc --noEmit` clean across the gateway.
- `jest`: new voice tests (`summarizeAutopilotForVoice` + list/spoken-id parity) + the Phase 1–2 dedupe/coverage suites = 23 green; generator provenance suite (9) still green.

## Notes / decisions

- `get_recommendations` (suggested groups/events/matches) is intentionally **left as-is** — it's a different surface (discovery) from the Autopilot action queue, and the two tool descriptions are distinct enough for the model to disambiguate.
- Voice activation security relies on `activateCommunityAutopilotRecommendation`'s ownership check (rejects recs belonging to another user); the session's last-listed set is the UX anchor for "activate those".

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqFvDoJm2aR4zQzanWZCck)_