### PR TITLE
fix(orb): restore upstream keepalive on VertexLiveClient path (VTID-03234, report fix #3)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-keepalive.ts
+++ b/services/gateway/src/orb/live/session/upstream-keepalive.ts
@@ -1,0 +1,105 @@
+/**
+ * VTID-03234 (report finding #3) — upstream Vertex keepalive.
+ *
+ * Vertex closes the audio stream with code=1000 after ~25-30s of no audio,
+ * and idle WS connections can be dropped by intermediaries. Two timers keep
+ * the upstream alive during natural conversational pauses:
+ *   - a 25s WS ping, and
+ *   - a silence keepalive that feeds a tiny PCM silence frame when no real
+ *     audio has been forwarded for >= the idle threshold (and the model is
+ *     not currently speaking).
+ *
+ * This logic used to be armed inside the upstream message handler's
+ * `setup_complete` branch. After the VertexLiveClient refactor (A8.3b.1)
+ * VertexLiveClient consumes `setup_complete` and never dispatches it to the
+ * legacy handler, so that branch is UNREACHABLE on the Vertex path — the
+ * keepalive silently stopped being armed, and quiet pauses started causing
+ * upstream closes that the client surfaced as "internet issues."
+ *
+ * This module restores the keepalive as a single testable unit that
+ * `connectToLiveAPI` arms immediately after `vertex.connect()` resolves.
+ */
+
+import WebSocket from 'ws';
+import {
+  getSilenceKeepaliveIntervalMs,
+  getSilenceIdleThresholdMs,
+  SILENCE_AUDIO_B64,
+} from '../../upstream/constants';
+
+/** The subset of GeminiLiveSession the keepalive reads/writes. */
+export interface KeepaliveSession {
+  sessionId: string;
+  active: boolean;
+  isModelSpeaking?: boolean;
+  lastAudioForwardedTime?: number;
+  upstreamPingInterval?: ReturnType<typeof setInterval>;
+  silenceKeepaliveInterval?: ReturnType<typeof setInterval>;
+}
+
+export interface KeepaliveDeps {
+  /** Sends a base64 PCM frame upstream (orb-live.ts local). */
+  sendAudioToLiveAPI: (ws: WebSocket, audioB64: string, mimeType?: string) => boolean;
+  /** Override the 25s ping cadence (tests). */
+  pingIntervalMs?: number;
+}
+
+const DEFAULT_PING_INTERVAL_MS = 25_000;
+
+/** Clear both keepalive intervals (idempotent). */
+export function clearUpstreamKeepalive(session: KeepaliveSession): void {
+  if (session.upstreamPingInterval) {
+    clearInterval(session.upstreamPingInterval);
+    session.upstreamPingInterval = undefined;
+  }
+  if (session.silenceKeepaliveInterval) {
+    clearInterval(session.silenceKeepaliveInterval);
+    session.silenceKeepaliveInterval = undefined;
+  }
+}
+
+/**
+ * Arm the upstream ping + silence keepalive on `session`, bound to `ws`.
+ * Idempotent: clears any existing timers first. Call once per upstream
+ * connection, immediately after the Vertex setup handshake resolves.
+ */
+export function armUpstreamKeepalive(
+  ws: WebSocket,
+  session: KeepaliveSession,
+  deps: KeepaliveDeps,
+): void {
+  clearUpstreamKeepalive(session);
+
+  const pingMs = deps.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS;
+
+  // 25s WS ping — keeps the connection from being dropped as idle.
+  session.upstreamPingInterval = setInterval(() => {
+    if (ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.ping();
+      } catch {
+        /* socket closing — ignore */
+      }
+    }
+  }, pingMs);
+
+  // Silence keepalive — feed a tiny PCM silence frame during quiet pauses so
+  // Vertex doesn't idle-close the audio stream. Never during model speech
+  // (would glitch Vertex VAD); never counts as real audio.
+  if (typeof session.lastAudioForwardedTime !== 'number') {
+    session.lastAudioForwardedTime = Date.now();
+  }
+  session.silenceKeepaliveInterval = setInterval(() => {
+    if (ws.readyState !== WebSocket.OPEN || !session.active) return;
+    if (session.isModelSpeaking) return;
+    const idleMs = Date.now() - (session.lastAudioForwardedTime ?? 0);
+    if (idleMs >= getSilenceIdleThresholdMs()) {
+      try {
+        deps.sendAudioToLiveAPI(ws, SILENCE_AUDIO_B64, 'audio/pcm;rate=16000');
+        // Don't update lastAudioForwardedTime — silence isn't real audio.
+      } catch {
+        /* socket closing — ignore */
+      }
+    }
+  }, getSilenceKeepaliveIntervalMs());
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1192,6 +1192,10 @@ import { createUpstreamLiveMessageHandler } from '../orb/live/session/upstream-m
 // reconnects (Vertex 5-min close / watchdog recovery) don't fire a loud
 // "internet issues" alert.
 import { classifyUpstreamClose } from '../orb/live/session/upstream-close-classifier';
+// VTID-03234 (report finding #3): restore the upstream ping + silence
+// keepalive that the VertexLiveClient refactor left unreachable (it lived in
+// the now-dead setup_complete branch of the message handler).
+import { armUpstreamKeepalive } from '../orb/live/session/upstream-keepalive';
 // VTID-03126 (Phase D.3): Live API voice resolver — externalizes the
 // LIVE_API_VOICES Record + adds telemetry on silent fallbacks.
 import { getLiveApiVoice } from '../orb/live/voice/live-api-voice';
@@ -5956,6 +5960,14 @@ async function connectToLiveAPI(
       return;
     }
     ws = socket;
+
+    // VTID-03234 (report finding #3): arm the upstream ping + silence keepalive
+    // HERE. It used to start in the message handler's `setup_complete` branch,
+    // but VertexLiveClient now consumes setup_complete (A8.3b.1), so that branch
+    // never runs on the Vertex path — the keepalive silently stopped arming and
+    // quiet pauses caused upstream closes surfaced to users as "internet
+    // issues." The close/error handlers below already clear these intervals.
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI });
 
     // A8.3a.2 (VTID-02968): the upstream message handler lives in
     // orb/live/session/upstream-message-handler.ts. After A8.3b.1 the

--- a/services/gateway/test/orb/live/session/upstream-keepalive.test.ts
+++ b/services/gateway/test/orb/live/session/upstream-keepalive.test.ts
@@ -1,0 +1,99 @@
+/**
+ * VTID-03234 (report finding #3) — upstream keepalive tests.
+ *
+ * Locks the regression the report asked for: after connect, BOTH
+ * `upstreamPingInterval` and `silenceKeepaliveInterval` must be armed, and a
+ * quiet pause must produce a silence frame (so Vertex doesn't idle-close).
+ */
+
+import {
+  armUpstreamKeepalive,
+  clearUpstreamKeepalive,
+  type KeepaliveSession,
+} from '../../../../src/orb/live/session/upstream-keepalive';
+
+const WS_OPEN = 1; // WebSocket.OPEN
+
+function makeWs(readyState = WS_OPEN) {
+  return { readyState, ping: jest.fn() } as any;
+}
+
+function makeSession(over: Partial<KeepaliveSession> = {}): KeepaliveSession {
+  return { sessionId: 's1', active: true, ...over };
+}
+
+describe('armUpstreamKeepalive', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('arms BOTH ping and silence keepalive intervals after connect', () => {
+    const ws = makeWs();
+    const session = makeSession();
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: jest.fn(() => true) });
+    expect(session.upstreamPingInterval).toBeDefined();
+    expect(session.silenceKeepaliveInterval).toBeDefined();
+  });
+
+  it('pings the upstream WS on the ping cadence', () => {
+    const ws = makeWs();
+    const session = makeSession();
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: jest.fn(() => true), pingIntervalMs: 25_000 });
+    jest.advanceTimersByTime(25_000);
+    expect(ws.ping).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(25_000);
+    expect(ws.ping).toHaveBeenCalledTimes(2);
+  });
+
+  it('feeds a silence frame during a quiet pause (idle past threshold, model not speaking)', () => {
+    const ws = makeWs();
+    const send = jest.fn(() => true);
+    // lastAudioForwardedTime well in the past → idle exceeds the 3s threshold.
+    const session = makeSession({ lastAudioForwardedTime: Date.now() - 10_000, isModelSpeaking: false });
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: send });
+    jest.advanceTimersByTime(3_000);
+    expect(send).toHaveBeenCalled();
+    expect(send.mock.calls[0][2]).toBe('audio/pcm;rate=16000');
+  });
+
+  it('does NOT feed silence while the model is speaking', () => {
+    const ws = makeWs();
+    const send = jest.fn(() => true);
+    const session = makeSession({ lastAudioForwardedTime: Date.now() - 10_000, isModelSpeaking: true });
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: send });
+    jest.advanceTimersByTime(6_000);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does NOT ping or feed silence once the socket is closed', () => {
+    const ws = makeWs(3 /* CLOSED */);
+    const send = jest.fn(() => true);
+    const session = makeSession({ lastAudioForwardedTime: Date.now() - 10_000 });
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: send, pingIntervalMs: 25_000 });
+    jest.advanceTimersByTime(25_000);
+    expect(ws.ping).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — re-arming clears the previous timers (no leak/double-fire)', () => {
+    const ws = makeWs();
+    const session = makeSession();
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: jest.fn(() => true), pingIntervalMs: 25_000 });
+    const firstPing = session.upstreamPingInterval;
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: jest.fn(() => true), pingIntervalMs: 25_000 });
+    expect(session.upstreamPingInterval).not.toBe(firstPing);
+    jest.advanceTimersByTime(25_000);
+    expect(ws.ping).toHaveBeenCalledTimes(1); // only the live interval fires, not the cleared one
+  });
+
+  it('clearUpstreamKeepalive removes both intervals', () => {
+    const ws = makeWs();
+    const session = makeSession();
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: jest.fn(() => true) });
+    clearUpstreamKeepalive(session);
+    expect(session.upstreamPingInterval).toBeUndefined();
+    expect(session.silenceKeepaliveInterval).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fix **#3** of the 2026-05-31 ORB "internet issues" report. Follows #2 (PR #2462, merged).

## Problem
The 25s WS ping + silence keepalive were armed in the upstream message handler's `setup_complete` branch. After the VertexLiveClient refactor (A8.3b.1), VertexLiveClient **consumes `setup_complete`** and never dispatches it to the legacy handler — so that branch is **unreachable** on the Vertex path and the keepalive **silently stopped arming**. Vertex idle-closes the audio stream after ~25-30s of no audio, so natural conversational pauses caused upstream closes → surfaced as "internet issues."

## Fix
Extract the keepalive into a testable `armUpstreamKeepalive` helper and arm it in `connectToLiveAPI` immediately after `vertex.connect()` resolves. The existing close/error handlers already clear the intervals.

## Tests
7 unit tests (both intervals armed after connect; ping cadence; silence frame on quiet pause; not while model speaking; no-op when socket closed; idempotent re-arm; clear). `tsc` clean.

## Scope
Pairs with **#4 (watchdog retune, next)** to stop the actual disconnect loop. #2 stopped the false alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)