### PR TITLE
fix(orb): raise response-watchdog thresholds above first-turn compute (VTID-03234, report fix #4)

### DIFF
--- a/services/gateway/src/orb/upstream/constants.ts
+++ b/services/gateway/src/orb/upstream/constants.ts
@@ -55,11 +55,21 @@ const POST_TURN_COOLDOWN_MS_FALLBACK = 2_000;
 const SILENCE_KEEPALIVE_INTERVAL_MS_FALLBACK = 3_000;
 const SILENCE_IDLE_THRESHOLD_MS_FALLBACK = 3_000;
 
-// VTID-WATCHDOG: stall detection windows. 8s greeting / 10s turn — short
-// enough to recover from a true Vertex stall, long enough to tolerate a
-// healthy 5-7s first-turn inference.
-const GREETING_RESPONSE_TIMEOUT_MS_FALLBACK = 8_000;
-const TURN_RESPONSE_TIMEOUT_MS_FALLBACK = 10_000;
+// VTID-03234 (report finding #4): stall-detection windows. The OLD values
+// (8s greeting / 10s turn) fired INSIDE the real first-turn compute window.
+// With a ~15K-char system instruction + heavy bootstrap context (the new-day
+// greeting block alone is ~12K chars) + 50+ tools, Vertex's first audio
+// routinely takes 10-20s — so the 8s greeting watchdog terminated HEALTHY
+// sessions at startup, the client re-greeted, and it looped. That is the
+// "disconnects in the first minute, constantly" symptom users reported.
+//
+// Raised well above the compute window. The watchdog RESTARTS on every
+// audio/text chunk (see upstream-message-handler), so these only bound the
+// gap BEFORE the model's first output — a genuinely stuck session still
+// recovers, just after a longer, less twitchy grace instead of killing
+// every slow-but-healthy first turn.
+const GREETING_RESPONSE_TIMEOUT_MS_FALLBACK = 30_000;
+const TURN_RESPONSE_TIMEOUT_MS_FALLBACK = 20_000;
 
 // VTID-FORWARDING-WATCHDOG (latest = VTID-01984): 45s tolerance for
 // genuine first-turn before any sign of life. With ~15K-char system

--- a/services/gateway/test/orb/upstream/voice-thresholds-policy.test.ts
+++ b/services/gateway/test/orb/upstream/voice-thresholds-policy.test.ts
@@ -66,12 +66,15 @@ describe('VTID-03124 Phase D.1 voice-threshold accessors', () => {
       expect(getSilenceIdleThresholdMs()).toBe(3000);
     });
 
-    it('greeting response timeout falls back to byte-identical 8000 ms', () => {
-      expect(getGreetingResponseTimeoutMs()).toBe(8000);
+    // VTID-03234 (report #4): raised above the real first-turn compute window
+    // (was 8000 — fired inside the 8-12s heavy-greeting inference and killed
+    // healthy sessions, causing the "first minute" disconnect loop).
+    it('greeting response timeout falls back to 30000 ms (above first-turn compute)', () => {
+      expect(getGreetingResponseTimeoutMs()).toBe(30000);
     });
 
-    it('turn response timeout falls back to byte-identical 10000 ms', () => {
-      expect(getTurnResponseTimeoutMs()).toBe(10000);
+    it('turn response timeout falls back to 20000 ms (tolerates tool turns)', () => {
+      expect(getTurnResponseTimeoutMs()).toBe(20000);
     });
 
     it('forwarding ack timeout falls back to byte-identical 45000 ms', () => {


### PR DESCRIPTION
Fix **#4** of the 2026-05-31 ORB "internet issues" report — **the primary disconnect loop**. Follows #2 (#2462) + #3 (#2464).

## Problem
The response watchdog terminates the upstream Vertex WS when no model output arrives within **8s (greeting) / 10s (turn)**. But `constants.ts` itself documents first-turn inference at **8-12s** (15K-char instruction + 50+ tools; the new-day greeting block alone is ~12K chars). So the **8s greeting watchdog fired inside the normal compute window** → killed healthy sessions at startup → client re-greeted → loop. That is the *"disconnects in the first minute, constantly"* symptom.

## Fix
Raise fallbacks above the compute window: greeting **8s → 30s**, turn **10s → 20s**. The watchdog restarts on every audio/text chunk, so these bound only the gap *before* the first output — a genuinely stuck session still recovers, without killing slow-but-healthy first turns.

## Together with #2 + #3
- #2: transparent reconnects no longer announced as "internet issues".
- #3: keepalive restored so quiet pauses don't idle-close.
- #4: watchdog stops killing healthy slow turns. → closes the loop.

## Tests
voice-thresholds-policy fallback assertions updated; 18 tests green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)