### PR TITLE
fix(finetune): package trainer before Vertex submit

### DIFF
--- a/.github/workflows/CRON-FINETUNE-TRAINER.yml
+++ b/.github/workflows/CRON-FINETUNE-TRAINER.yml
@@ -24,6 +24,17 @@ on:
         default: 'false'
         type: choice
         options: [ 'true', 'false' ]
+      synthetic_bootstrap:
+        description: 'Manual smoke only: generate PII-free synthetic voice-tool-router rows before submit'
+        required: false
+        default: 'false'
+        type: choice
+        options: [ 'true', 'false' ]
+      base_model_override:
+        description: 'Optional manual smoke override (example: Qwen/Qwen2.5-0.5B-Instruct)'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -62,8 +73,20 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
+      - name: Package Vertex trainer
+        working-directory: services/gateway
+        run: npx tsx scripts/finetune/package-trainer.ts ${{ matrix.target }}
+
+      - name: Bootstrap synthetic voice-tool-router dataset
+        if: ${{ inputs.synthetic_bootstrap == 'true' && matrix.target == 'voice-tool-router' }}
+        working-directory: services/gateway
+        env:
+          SYNTHETIC_ROWS: '1200'
+        run: npx tsx scripts/finetune/bootstrap-synthetic-voice-tool-routing.ts
+
       - name: Submit ${{ matrix.target }}
         working-directory: services/gateway
         env:
           FINETUNE_DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
+          FINETUNE_BASE_MODEL_OVERRIDE: ${{ inputs.base_model_override || '' }}
         run: npx tsx scripts/finetune/submit-job.ts ${{ matrix.target }}

--- a/services/gateway/scripts/finetune/bootstrap-synthetic-voice-tool-routing.ts
+++ b/services/gateway/scripts/finetune/bootstrap-synthetic-voice-tool-routing.ts
@@ -1,0 +1,113 @@
+/**
+ * Creates a PII-free synthetic voice-tool-routing dataset for infrastructure
+ * smoke training. This is not promotion evidence; consented production rows
+ * still gate real model graduation.
+ */
+
+import { execSync } from 'child_process';
+import { promises as fs } from 'fs';
+import path from 'path';
+import toolManifest from '../../src/services/tool-manifest.json';
+
+interface ToolManifestEntry {
+  name: string;
+  surface?: string;
+  category?: string;
+  status?: string;
+  description?: string;
+}
+
+interface SyntheticRow {
+  source_id: string;
+  source_at: string;
+  payload: {
+    user_input: string;
+    tool_chosen: string;
+    tool_arguments: null;
+    synthetic: true;
+    training_only: true;
+    generator: 'bootstrap-synthetic-voice-tool-routing';
+  };
+}
+
+const TARGET = 'voice-tool-routing';
+const ROWS = Number(process.env.SYNTHETIC_ROWS || 1200);
+const GCS_BUCKET = process.env.DATASET_GCS_BUCKET || 'gs://vitana-artifacts-staging';
+const OUTPUT_ROOT = process.env.DATASET_OUTPUT_ROOT || '/tmp/vitana-datasets';
+const DRY_RUN = process.env.DATASET_DRY_RUN === '1';
+
+export function buildSyntheticVoiceToolRows(tools: ToolManifestEntry[], rows: number, now = new Date()): SyntheticRow[] {
+  const liveTools = tools.filter((tool) => tool.name && (tool.status ?? 'live') === 'live');
+  if (liveTools.length === 0) {
+    throw new Error('tool manifest has no live tools');
+  }
+
+  const templates = [
+    (tool: ToolManifestEntry) => `Can you ${humanizeToolName(tool.name)} for me?`,
+    (tool: ToolManifestEntry) => `I need help with ${tool.surface ?? tool.category ?? humanizeToolName(tool.name)}.`,
+    (tool: ToolManifestEntry) => `Use ${tool.name} to handle this request.`,
+    (tool: ToolManifestEntry) => tool.description ? `Please ${sentenceToRequest(tool.description)}` : `Please run ${humanizeToolName(tool.name)}.`,
+    (tool: ToolManifestEntry) => `Hey Orb, ${humanizeToolName(tool.name)} now.`,
+    (tool: ToolManifestEntry) => `Start the ${tool.category ?? tool.surface ?? 'Vitana'} action for ${humanizeToolName(tool.name)}.`,
+    (tool: ToolManifestEntry) => `Find the right Vitana action to ${humanizeToolName(tool.name)}.`,
+    (tool: ToolManifestEntry) => `Voice command: ${humanizeToolName(tool.name)}.`,
+  ];
+
+  const out: SyntheticRow[] = [];
+  for (let i = 0; i < rows; i += 1) {
+    const tool = liveTools[i % liveTools.length];
+    const template = templates[Math.floor(i / liveTools.length) % templates.length];
+    out.push({
+      source_id: `synthetic-${TARGET}-${tool.name}-${i}`,
+      source_at: now.toISOString(),
+      payload: {
+        user_input: template(tool),
+        tool_chosen: tool.name,
+        tool_arguments: null,
+        synthetic: true,
+        training_only: true,
+        generator: 'bootstrap-synthetic-voice-tool-routing',
+      },
+    });
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const runId = `${TARGET}-synthetic-bootstrap-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+  const rows = buildSyntheticVoiceToolRows((toolManifest as { tools: ToolManifestEntry[] }).tools, ROWS);
+  const outDir = path.join(OUTPUT_ROOT, TARGET);
+  await fs.mkdir(outDir, { recursive: true });
+  const localPath = path.join(outDir, `${runId}.jsonl`);
+  await fs.writeFile(localPath, rows.map((row) => JSON.stringify(row)).join('\n') + '\n');
+  console.log(`[synthetic-dataset] wrote ${rows.length} rows -> ${localPath}`);
+
+  if (DRY_RUN) {
+    console.log('[synthetic-dataset] dry run; not uploading');
+    return;
+  }
+
+  const gcsUri = `${GCS_BUCKET}/datasets/${TARGET}/${runId}.jsonl`;
+  execSync(`gcloud storage cp ${shellQuote(localPath)} ${shellQuote(gcsUri)}`, { stdio: 'inherit' });
+  console.log(`[synthetic-dataset] uploaded ${gcsUri}`);
+}
+
+function humanizeToolName(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function sentenceToRequest(description: string): string {
+  const trimmed = description.trim().replace(/\.$/, '');
+  return trimmed.charAt(0).toLowerCase() + trimmed.slice(1);
+}
+
+function shellQuote(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[synthetic-dataset] FAILED:', err);
+    process.exit(1);
+  });
+}

--- a/services/gateway/scripts/finetune/package-trainer.ts
+++ b/services/gateway/scripts/finetune/package-trainer.ts
@@ -1,0 +1,47 @@
+/**
+ * Builds and uploads the Python trainer package consumed by Vertex AI Custom
+ * Training. The submitter preflights this exact GCS object before creating
+ * the Vertex job.
+ */
+
+import { execFileSync, execSync } from 'child_process';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { buildTrainerPackageUri, type FinetuneConfig } from './submit-job-lib';
+
+const TARGET = process.argv[2];
+const VALID_TARGETS = new Set(['voice-tool-router', 'intent-kind', 'pillar-classifier']);
+
+if (!TARGET || !VALID_TARGETS.has(TARGET)) {
+  console.error(`Usage: tsx package-trainer.ts <target>\n  target: ${[...VALID_TARGETS].join(' | ')}`);
+  process.exit(2);
+}
+
+async function parseYaml(file: string): Promise<FinetuneConfig> {
+  const raw = await fs.readFile(file, 'utf-8');
+  const jsYaml = await import('js-yaml');
+  return jsYaml.load(raw) as FinetuneConfig;
+}
+
+async function main(): Promise<void> {
+  const configPath = path.join(__dirname, TARGET, 'config.yaml');
+  const cfg = await parseYaml(configPath);
+  const trainerDir = path.join(__dirname, 'trainer-package');
+  const trainerUri = buildTrainerPackageUri(cfg);
+  const archivePath = path.join(os.tmpdir(), 'finetune-trainer-0.1.0.tar.gz');
+
+  await fs.access(path.join(trainerDir, 'setup.py'));
+  execFileSync('tar', ['-czf', archivePath, '-C', trainerDir, '.'], { stdio: 'inherit' });
+  execSync(`gcloud storage cp ${shellQuote(archivePath)} ${shellQuote(trainerUri)}`, { stdio: 'inherit' });
+  console.log(`[package-trainer] uploaded ${trainerUri}`);
+}
+
+function shellQuote(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+main().catch((err) => {
+  console.error('[package-trainer] FAILED:', err);
+  process.exit(1);
+});

--- a/services/gateway/scripts/finetune/submit-job-lib.ts
+++ b/services/gateway/scripts/finetune/submit-job-lib.ts
@@ -1,0 +1,120 @@
+import { execSync } from 'child_process';
+
+export interface FinetuneConfig {
+  target: string;
+  base_model: string;
+  adapter_method?: string;
+  lora_r?: number;
+  lora_alpha?: number;
+  lora_dropout?: number;
+  target_modules?: string[];
+  dataset: {
+    gcs_prefix: string;
+    format?: string;
+    field_input?: string;
+    field_output?: string;
+    min_rows_required: number;
+  };
+  training: Record<string, unknown>;
+  vertex_custom_job: {
+    project: string;
+    region: string;
+    display_name_prefix: string;
+    worker_pool: {
+      machine_type: string;
+      accelerator_type: string;
+      accelerator_count: number;
+      replica_count: number;
+    };
+    container_image: string;
+    python_module: string;
+    output_uri_prefix: string;
+  };
+}
+
+interface BuildJobConfigInput {
+  config: FinetuneConfig;
+  outputUri: string;
+  trainerPackageUri: string;
+}
+
+export function buildTrainerPackageUri(config: FinetuneConfig): string {
+  return `${config.vertex_custom_job.output_uri_prefix}trainer/finetune-trainer-0.1.0.tar.gz`;
+}
+
+export function buildTrainingArgs(config: FinetuneConfig, outputUri: string): string[] {
+  return [
+    `--target=${config.target}`,
+    `--base-model=${config.base_model}`,
+    `--dataset-prefix=${config.dataset.gcs_prefix}`,
+    `--field-input=${config.dataset.field_input ?? 'payload.user_input'}`,
+    `--field-output=${config.dataset.field_output ?? 'payload.tool_chosen'}`,
+    `--min-rows-required=${config.dataset.min_rows_required}`,
+    `--output-uri=${outputUri}`,
+    ...Object.entries(config.training).map(([k, v]) => `--${k.replace(/_/g, '-')}=${v}`),
+  ];
+}
+
+export function buildJobConfig({ config, outputUri, trainerPackageUri }: BuildJobConfigInput) {
+  return {
+    workerPoolSpecs: [
+      {
+        machineSpec: {
+          machineType: config.vertex_custom_job.worker_pool.machine_type,
+          acceleratorType: config.vertex_custom_job.worker_pool.accelerator_type,
+          acceleratorCount: config.vertex_custom_job.worker_pool.accelerator_count,
+        },
+        replicaCount: config.vertex_custom_job.worker_pool.replica_count,
+        pythonPackageSpec: {
+          executorImageUri: config.vertex_custom_job.container_image,
+          packageUris: [trainerPackageUri],
+          pythonModule: config.vertex_custom_job.python_module,
+          args: buildTrainingArgs(config, outputUri),
+        },
+      },
+    ],
+  };
+}
+
+export function countDatasetRowsFromJsonl(files: string[]): number {
+  return files.reduce((total, raw) => {
+    return total + raw.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
+  }, 0);
+}
+
+export function assertGcsObjectExists(uri: string): void {
+  try {
+    execSync(`gcloud storage ls ${shellQuote(uri)}`, { stdio: 'pipe' });
+  } catch {
+    throw new Error(`Missing required GCS object: ${uri}`);
+  }
+}
+
+export function countGcsJsonlRows(prefix: string): number {
+  try {
+    const raw = execSync(`gcloud storage cat ${shellQuote(`${prefix}*.jsonl`)}`, {
+      encoding: 'utf-8',
+      maxBuffer: 1024 * 1024 * 512,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return countDatasetRowsFromJsonl([raw]);
+  } catch {
+    return 0;
+  }
+}
+
+export function assertDatasetReady(config: FinetuneConfig): void {
+  const rows = countGcsJsonlRows(config.dataset.gcs_prefix);
+  const minRows = config.dataset.min_rows_required;
+  if (rows < minRows) {
+    throw new Error(
+      `Dataset ${config.dataset.gcs_prefix} has ${rows} JSONL rows; ${minRows} required. ` +
+      'Run consented extraction or a synthetic bootstrap smoke dataset before submitting Vertex training.',
+    );
+  }
+  console.log(`[submit-job] dataset preflight ok: ${rows} rows >= ${minRows}`);
+}
+
+function shellQuote(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}

--- a/services/gateway/scripts/finetune/submit-job.ts
+++ b/services/gateway/scripts/finetune/submit-job.ts
@@ -18,33 +18,17 @@ import { execSync } from 'child_process';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { randomUUID } from 'crypto';
-
-interface FinetuneConfig {
-  target: string;
-  base_model: string;
-  dataset: {
-    gcs_prefix: string;
-    min_rows_required: number;
-  };
-  training: Record<string, unknown>;
-  vertex_custom_job: {
-    project: string;
-    region: string;
-    display_name_prefix: string;
-    worker_pool: {
-      machine_type: string;
-      accelerator_type: string;
-      accelerator_count: number;
-      replica_count: number;
-    };
-    container_image: string;
-    python_module: string;
-    output_uri_prefix: string;
-  };
-}
+import {
+  assertDatasetReady,
+  assertGcsObjectExists,
+  buildJobConfig,
+  buildTrainerPackageUri,
+  type FinetuneConfig,
+} from './submit-job-lib';
 
 const TARGET = process.argv[2];
 const DRY_RUN = process.env.FINETUNE_DRY_RUN === '1';
+const BASE_MODEL_OVERRIDE = process.env.FINETUNE_BASE_MODEL_OVERRIDE;
 const VALID_TARGETS = new Set(['voice-tool-router', 'intent-kind', 'pillar-classifier']);
 
 if (!TARGET || !VALID_TARGETS.has(TARGET)) {
@@ -62,38 +46,16 @@ async function main(): Promise<void> {
   const configPath = path.join(__dirname, TARGET, 'config.yaml');
   console.log(`[submit-job] loading ${configPath}`);
   const cfg = await parseYaml(configPath);
+  if (BASE_MODEL_OVERRIDE) {
+    console.log(`[submit-job] overriding base_model ${cfg.base_model} -> ${BASE_MODEL_OVERRIDE}`);
+    cfg.base_model = BASE_MODEL_OVERRIDE;
+  }
 
   const runId = `${cfg.vertex_custom_job.display_name_prefix}-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}-${randomUUID().slice(0, 8)}`;
   const outputUri = `${cfg.vertex_custom_job.output_uri_prefix}${runId}/`;
+  const trainerPackageUri = buildTrainerPackageUri(cfg);
 
-  // gcloud ai custom-jobs --worker-pool-spec accepts comma-separated
-  // key=value pairs, NOT JSON. For nested specs (python_package_spec) the
-  // canonical workaround is a YAML/JSON config passed via --config; this
-  // also keeps shell-quoting sane.
-  const jobConfig = {
-    workerPoolSpecs: [
-      {
-        machineSpec: {
-          machineType: cfg.vertex_custom_job.worker_pool.machine_type,
-          acceleratorType: cfg.vertex_custom_job.worker_pool.accelerator_type,
-          acceleratorCount: cfg.vertex_custom_job.worker_pool.accelerator_count,
-        },
-        replicaCount: cfg.vertex_custom_job.worker_pool.replica_count,
-        pythonPackageSpec: {
-          executorImageUri: cfg.vertex_custom_job.container_image,
-          packageUris: [`${cfg.vertex_custom_job.output_uri_prefix}trainer/finetune-trainer-0.1.0.tar.gz`],
-          pythonModule: cfg.vertex_custom_job.python_module,
-          args: [
-            `--target=${cfg.target}`,
-            `--base-model=${cfg.base_model}`,
-            `--dataset-prefix=${cfg.dataset.gcs_prefix}`,
-            `--output-uri=${outputUri}`,
-            ...Object.entries(cfg.training).map(([k, v]) => `--${k.replace(/_/g, '-')}=${v}`),
-          ],
-        },
-      },
-    ],
-  };
+  const jobConfig = buildJobConfig({ config: cfg, outputUri, trainerPackageUri });
 
   const tmpConfigPath = `/tmp/finetune-job-${runId}.yaml`;
   const jsYaml = await import('js-yaml');
@@ -109,6 +71,7 @@ async function main(): Promise<void> {
 
   console.log(`[submit-job] job: ${runId}`);
   console.log(`[submit-job] output_uri: ${outputUri}`);
+  console.log(`[submit-job] trainer_package: ${trainerPackageUri}`);
   console.log(`[submit-job] config file: ${tmpConfigPath}`);
   console.log(`[submit-job] command: gcloud ${args.join(' ')}`);
 
@@ -118,6 +81,8 @@ async function main(): Promise<void> {
   }
 
   try {
+    assertGcsObjectExists(trainerPackageUri);
+    assertDatasetReady(cfg);
     execSync(['gcloud', ...args].join(' '), { stdio: 'inherit' });
     console.log(`[submit-job] submitted ${runId}`);
   } catch (err) {

--- a/services/gateway/scripts/finetune/trainer-package/finetune/__init__.py
+++ b/services/gateway/scripts/finetune/trainer-package/finetune/__init__.py
@@ -1,0 +1,1 @@
+"""Vitana portable fine-tune trainer package."""

--- a/services/gateway/scripts/finetune/trainer-package/finetune/train.py
+++ b/services/gateway/scripts/finetune/trainer-package/finetune/train.py
@@ -1,0 +1,193 @@
+import argparse
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from google.cloud import storage
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--base-model", required=True)
+    parser.add_argument("--dataset-prefix", required=True)
+    parser.add_argument("--field-input", default="payload.user_input")
+    parser.add_argument("--field-output", default="payload.tool_chosen")
+    parser.add_argument("--min-rows-required", type=int, default=1000)
+    parser.add_argument("--output-uri", required=True)
+    parser.add_argument("--epochs", type=float, default=3)
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--learning-rate", type=float, default=2e-4)
+    parser.add_argument("--warmup-steps", type=int, default=50)
+    parser.add_argument("--gradient-accumulation-steps", type=int, default=2)
+    parser.add_argument("--max-seq-len", type=int, default=512)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    print(f"[trainer] target={args.target} base_model={args.base_model}")
+    rows = load_jsonl_rows(args.dataset_prefix)
+    rows = [
+        row for row in rows
+        if get_path(row, args.field_input) and get_path(row, args.field_output)
+    ]
+    print(f"[trainer] usable_rows={len(rows)} min_rows_required={args.min_rows_required}")
+    if len(rows) < args.min_rows_required:
+        raise RuntimeError(
+            f"dataset has {len(rows)} usable rows; {args.min_rows_required} required"
+        )
+
+    train_texts = [
+        format_training_text(
+            str(get_path(row, args.field_input)),
+            str(get_path(row, args.field_output)),
+        )
+        for row in rows
+    ]
+
+    # Import heavy ML dependencies only after dataset validation, so data/setup
+    # errors fail fast without spending GPU time.
+    import torch
+    from datasets import Dataset
+    from peft import LoraConfig, TaskType, get_peft_model
+    from transformers import (
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        DataCollatorForLanguageModeling,
+        Trainer,
+        TrainingArguments,
+    )
+
+    hf_token = os.environ.get("HF_TOKEN") or None
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model, token=hf_token, trust_remote_code=True)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    dtype = torch.bfloat16 if torch.cuda.is_available() else torch.float32
+    model = AutoModelForCausalLM.from_pretrained(
+        args.base_model,
+        token=hf_token,
+        trust_remote_code=True,
+        torch_dtype=dtype,
+    )
+    model.config.use_cache = False
+
+    lora = LoraConfig(
+        r=16,
+        lora_alpha=32,
+        lora_dropout=0.05,
+        task_type=TaskType.CAUSAL_LM,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+    )
+    model = get_peft_model(model, lora)
+    model.print_trainable_parameters()
+
+    dataset = Dataset.from_dict({"text": train_texts})
+
+    def tokenize(batch: dict[str, list[str]]) -> dict[str, Any]:
+        return tokenizer(
+            batch["text"],
+            truncation=True,
+            max_length=args.max_seq_len,
+            padding=False,
+        )
+
+    tokenized = dataset.map(tokenize, batched=True, remove_columns=["text"])
+    output_dir = tempfile.mkdtemp(prefix="vitana-finetune-")
+    training_args = TrainingArguments(
+        output_dir=output_dir,
+        num_train_epochs=args.epochs,
+        per_device_train_batch_size=args.batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        learning_rate=args.learning_rate,
+        warmup_steps=args.warmup_steps,
+        logging_steps=10,
+        save_strategy="epoch",
+        report_to=[],
+        bf16=torch.cuda.is_available(),
+    )
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized,
+        data_collator=DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False),
+    )
+    trainer.train()
+
+    final_dir = Path(output_dir) / "final"
+    model.save_pretrained(final_dir)
+    tokenizer.save_pretrained(final_dir)
+    write_manifest(final_dir, args, len(rows))
+    upload_directory(final_dir, args.output_uri)
+    print(f"[trainer] uploaded artifacts to {args.output_uri}")
+
+
+def load_jsonl_rows(gcs_prefix: str) -> list[dict[str, Any]]:
+    client = storage.Client()
+    bucket_name, prefix = split_gcs_uri(gcs_prefix)
+    bucket = client.bucket(bucket_name)
+    rows: list[dict[str, Any]] = []
+    for blob in client.list_blobs(bucket, prefix=prefix):
+        if not blob.name.endswith(".jsonl"):
+            continue
+        print(f"[trainer] reading gs://{bucket_name}/{blob.name}")
+        raw = blob.download_as_text()
+        for line in raw.splitlines():
+            if line.strip():
+                rows.append(json.loads(line))
+    return rows
+
+
+def upload_directory(local_dir: Path, output_uri: str) -> None:
+    client = storage.Client()
+    bucket_name, prefix = split_gcs_uri(output_uri)
+    bucket = client.bucket(bucket_name)
+    for path in local_dir.rglob("*"):
+        if path.is_file():
+            rel = path.relative_to(local_dir).as_posix()
+            blob = bucket.blob(f"{prefix.rstrip('/')}/{rel}")
+            blob.upload_from_filename(path)
+            print(f"[trainer] uploaded gs://{bucket_name}/{blob.name}")
+
+
+def write_manifest(local_dir: Path, args: argparse.Namespace, row_count: int) -> None:
+    manifest = {
+        "target": args.target,
+        "base_model": args.base_model,
+        "dataset_prefix": args.dataset_prefix,
+        "row_count": row_count,
+        "output_uri": args.output_uri,
+    }
+    (local_dir / "vitana_training_manifest.json").write_text(json.dumps(manifest, indent=2))
+
+
+def split_gcs_uri(uri: str) -> tuple[str, str]:
+    parsed = urlparse(uri)
+    if parsed.scheme != "gs" or not parsed.netloc:
+        raise ValueError(f"not a gs:// URI: {uri}")
+    return parsed.netloc, parsed.path.lstrip("/")
+
+
+def get_path(row: dict[str, Any], dotted: str) -> Any:
+    current: Any = row
+    for part in dotted.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def format_training_text(user_input: str, tool_name: str) -> str:
+    return (
+        "Route this Vitana voice request to the single best tool.\n"
+        f"User request: {user_input}\n"
+        f"Tool: {tool_name}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/gateway/scripts/finetune/trainer-package/setup.py
+++ b/services/gateway/scripts/finetune/trainer-package/setup.py
@@ -1,0 +1,15 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="finetune-trainer",
+    version="0.1.0",
+    packages=find_packages(),
+    install_requires=[
+        "accelerate>=0.34.0",
+        "datasets>=2.20.0",
+        "google-cloud-storage>=2.16.0",
+        "peft>=0.12.0",
+        "sentencepiece>=0.2.0",
+        "transformers>=4.44.0",
+    ],
+)

--- a/services/gateway/test/finetune-submit-job-lib.test.ts
+++ b/services/gateway/test/finetune-submit-job-lib.test.ts
@@ -1,0 +1,84 @@
+import {
+  buildJobConfig,
+  buildTrainerPackageUri,
+  buildTrainingArgs,
+  countDatasetRowsFromJsonl,
+  type FinetuneConfig,
+} from '../scripts/finetune/submit-job-lib';
+
+const config: FinetuneConfig = {
+  target: 'voice-tool-router',
+  base_model: 'Qwen/Qwen2.5-0.5B-Instruct',
+  adapter_method: 'lora',
+  dataset: {
+    gcs_prefix: 'gs://vitana-artifacts-staging/datasets/voice-tool-routing/',
+    format: 'jsonl',
+    field_input: 'payload.user_input',
+    field_output: 'payload.tool_chosen',
+    min_rows_required: 1000,
+  },
+  training: {
+    epochs: 3,
+    batch_size: 16,
+    learning_rate: '2.0e-4',
+  },
+  vertex_custom_job: {
+    project: 'lovable-vitana-vers1',
+    region: 'us-central1',
+    display_name_prefix: 'voice-tool-router-ft',
+    worker_pool: {
+      machine_type: 'g2-standard-8',
+      accelerator_type: 'NVIDIA_L4',
+      accelerator_count: 1,
+      replica_count: 1,
+    },
+    container_image: 'us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-3.py310:latest',
+    python_module: 'finetune.train',
+    output_uri_prefix: 'gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/',
+  },
+};
+
+describe('finetune submit job config', () => {
+  test('builds the trainer package URI from the configured output prefix', () => {
+    expect(buildTrainerPackageUri(config)).toBe(
+      'gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/trainer/finetune-trainer-0.1.0.tar.gz',
+    );
+  });
+
+  test('passes dataset contract arguments into the Vertex trainer', () => {
+    expect(buildTrainingArgs(config, 'gs://out/run-1/')).toEqual(
+      expect.arrayContaining([
+        '--target=voice-tool-router',
+        '--dataset-prefix=gs://vitana-artifacts-staging/datasets/voice-tool-routing/',
+        '--field-input=payload.user_input',
+        '--field-output=payload.tool_chosen',
+        '--min-rows-required=1000',
+        '--output-uri=gs://out/run-1/',
+      ]),
+    );
+  });
+
+  test('uses the uploaded trainer tarball in the Vertex python package spec', () => {
+    const jobConfig = buildJobConfig({
+      config,
+      outputUri: 'gs://out/run-1/',
+      trainerPackageUri: buildTrainerPackageUri(config),
+    });
+
+    expect(jobConfig.workerPoolSpecs[0].pythonPackageSpec.packageUris).toEqual([
+      'gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/trainer/finetune-trainer-0.1.0.tar.gz',
+    ]);
+    expect(jobConfig.workerPoolSpecs[0].pythonPackageSpec.pythonModule).toBe('finetune.train');
+  });
+});
+
+describe('countDatasetRowsFromJsonl', () => {
+  test('counts non-empty JSONL rows across multiple files', () => {
+    const files = [
+      '{"payload":{"user_input":"a","tool_chosen":"search_knowledge"}}\n\n',
+      '{"payload":{"user_input":"b","tool_chosen":"get_schedule"}}\n',
+    ];
+
+    expect(countDatasetRowsFromJsonl(files)).toBe(2);
+  });
+});

--- a/services/gateway/test/finetune-synthetic-voice-tool-routing.test.ts
+++ b/services/gateway/test/finetune-synthetic-voice-tool-routing.test.ts
@@ -1,0 +1,58 @@
+import { buildSyntheticVoiceToolRows } from '../scripts/finetune/bootstrap-synthetic-voice-tool-routing';
+
+describe('buildSyntheticVoiceToolRows', () => {
+  test('creates PII-free training rows with the expected payload contract', () => {
+    const rows = buildSyntheticVoiceToolRows(
+      [
+        {
+          name: 'search_knowledge',
+          surface: 'Knowledge',
+          category: 'knowledge',
+          status: 'live',
+          description: 'Search the Vitana knowledge base.',
+        },
+        {
+          name: 'create_calendar_event',
+          surface: 'Calendar',
+          category: 'calendar',
+          status: 'live',
+          description: 'Create a calendar event.',
+        },
+      ],
+      4,
+      new Date('2026-05-31T19:00:00Z'),
+    );
+
+    expect(rows).toHaveLength(4);
+    expect(rows[0]).toMatchObject({
+      source_id: 'synthetic-voice-tool-routing-search_knowledge-0',
+      source_at: '2026-05-31T19:00:00.000Z',
+      payload: {
+        tool_chosen: 'search_knowledge',
+        tool_arguments: null,
+        synthetic: true,
+        training_only: true,
+        generator: 'bootstrap-synthetic-voice-tool-routing',
+      },
+    });
+    expect(rows.map((row) => row.payload.tool_chosen)).toEqual([
+      'search_knowledge',
+      'create_calendar_event',
+      'search_knowledge',
+      'create_calendar_event',
+    ]);
+    expect(rows.every((row) => row.payload.user_input.length > 0)).toBe(true);
+  });
+
+  test('ignores non-live tools', () => {
+    const rows = buildSyntheticVoiceToolRows(
+      [
+        { name: 'draft_tool', status: 'draft' },
+        { name: 'live_tool', status: 'live' },
+      ],
+      2,
+    );
+
+    expect(rows.every((row) => row.payload.tool_chosen === 'live_tool')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- packages and uploads the Vertex Python trainer tarball before creating CustomJobs
- adds submit-time preflight for trainer package and minimum dataset rows
- adds a manual synthetic voice-tool-router bootstrap dataset path for smoke training before prod consented rows exist
- adds an optional base model override for manual smoke runs

## Validation
- npm test -- --runTestsByPath test/finetune-submit-job-lib.test.ts test/finetune-synthetic-voice-tool-routing.test.ts
- npx tsc --noEmit

## Runtime evidence
- Cancelled defective CustomJob: projects/86804897789/locations/us-central1/customJobs/1603899925454651392
- Uploaded trainer package to gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/trainer/finetune-trainer-0.1.0.tar.gz
- Uploaded 1,200-row synthetic smoke dataset to gs://vitana-artifacts-staging/datasets/voice-tool-routing/
- Submitted active smoke CustomJob: projects/86804897789/locations/us-central1/customJobs/6669323606339616768

Note: synthetic bootstrap is infrastructure smoke only, not graduation evidence. Consented production rows still gate promotion.