### PR TITLE
fix(finetune): install torch in Vertex trainer

### DIFF
--- a/services/gateway/scripts/finetune/trainer-package/setup.py
+++ b/services/gateway/scripts/finetune/trainer-package/setup.py
@@ -10,6 +10,7 @@ setup(
         "google-cloud-storage>=2.16.0",
         "peft>=0.12.0",
         "sentencepiece>=0.2.0",
+        "torch>=2.3.0",
         "transformers>=4.44.0",
     ],
 )


### PR DESCRIPTION
## Summary
- adds explicit torch dependency to the Vertex trainer package

## Why
The first synthetic smoke CustomJob got past IAM, trainer-package upload, and dataset preflight, then failed in Vertex because AutoModelForCausalLM could not import PyTorch from the package runtime.

Failed job: projects/86804897789/locations/us-central1/customJobs/6669323606339616768

## Validation
- npm test -- --runTestsByPath test/finetune-submit-job-lib.test.ts test/finetune-synthetic-voice-tool-routing.test.ts
- npx tsc --noEmit