### PR TITLE
fix(self-healing): classify non-actionable autopilot failures (Step 2)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-self-heal-log.ts
+++ b/services/gateway/src/services/dev-autopilot-self-heal-log.ts
@@ -60,6 +60,75 @@ export interface AutopilotFailureArgs {
   attempt_number?: number;
 }
 
+/**
+ * Failure classes that are inherently environmental (host / infra) rather than
+ * a code defect the autopilot can patch. The worker-queue "unclaimed" failure
+ * is the canonical case: its message is literally "worker daemon down / binary
+ * missing / network", yet that text doesn't match isEnvironmentalBlocker()'s
+ * patterns — so without this set it escalates as if a code fix could resolve it
+ * (the 2026-04-28 retry-loop outage). Normalising these to 'environmental_blocker'
+ * lets the reconciler short-circuit retries (see self-healing-reconciler.ts).
+ */
+const ENVIRONMENTAL_FAILURE_CLASSES = new Set<string>([
+  'dev_autopilot_worker_queue_unclaimed',
+]);
+
+/**
+ * Failure classes that need a human policy decision, not an auto-fix (e.g. the
+ * safety gate blocked an approval because the change is out of allow_scope).
+ * These stay visible with their own class but are flagged non-actionable so the
+ * Self-Healing view stops counting them as fixes self-healing failed to make.
+ */
+const POLICY_BLOCK_FAILURE_CLASSES = new Set<string>([
+  'dev_autopilot_safety_gate_blocked',
+]);
+
+export type NonActionableReason = 'environmental' | 'policy_block';
+
+export interface FailureActionability {
+  /** Possibly-normalised failure_class to persist. */
+  failure_class: string;
+  /** false when no autonomous code fix can resolve this failure. */
+  actionable: boolean;
+  /** Why it's non-actionable, or null when it is actionable. */
+  non_actionable_reason: NonActionableReason | null;
+}
+
+/**
+ * Decide whether a surfaced autopilot failure is something the self-healing
+ * loop could actually fix with a code change, and normalise environmental
+ * blockers so the reconciler short-circuits retries instead of spawning a
+ * SELF-HEAL VTID per failure. Pure + exported for tests.
+ *
+ * This is the "classify, don't delete" half of the Self-Healing reliability
+ * work: the dev-autopilot stage failures are intentionally surfaced, but most
+ * of them (binary missing, worker daemon down, safety-gate blocks) are infra /
+ * policy events a human must resolve — not auto-fix candidates. Tagging them
+ * keeps them visible while stopping them from drowning out the genuinely
+ * fixable failures.
+ */
+export function classifyAutopilotFailure(args: {
+  failure_class: string;
+  diagnosis?: Record<string, unknown>;
+}): FailureActionability {
+  const fc = args.failure_class;
+  const summary =
+    typeof args.diagnosis?.summary === 'string' ? args.diagnosis.summary : '';
+  const probe = `${fc} ${summary}`;
+
+  if (ENVIRONMENTAL_FAILURE_CLASSES.has(fc) || isEnvironmentalBlocker(probe)) {
+    return {
+      failure_class: 'environmental_blocker',
+      actionable: false,
+      non_actionable_reason: 'environmental',
+    };
+  }
+  if (POLICY_BLOCK_FAILURE_CLASSES.has(fc)) {
+    return { failure_class: fc, actionable: false, non_actionable_reason: 'policy_block' };
+  }
+  return { failure_class: fc, actionable: true, non_actionable_reason: null };
+}
+
 /** Time window for the writer-level idempotency check. Same vtid+endpoint+
  *  failure_class within this window is treated as a duplicate and skipped.
  *  Sized to comfortably swallow ticker-loop spam (lazyPlanTick fires every
@@ -87,12 +156,19 @@ export async function writeAutopilotFailure(
   const outcome = args.outcome || 'failed';
   const confidence = args.confidence ?? 0;
   const attempt = args.attempt_number ?? 1;
+  // Classify actionability + normalise environmental blockers BEFORE the dedup
+  // query so dedup keys on the persisted (possibly-normalised) class.
+  const classification = classifyAutopilotFailure({
+    failure_class: args.failure_class,
+    diagnosis: args.diagnosis,
+  });
+  const failureClass = classification.failure_class;
   try {
     const sinceIso = new Date(Date.now() - DEDUP_WINDOW_MS).toISOString();
     const dedupQuery =
       `?vtid=eq.${encodeURIComponent(args.vtid)}` +
       `&endpoint=eq.${encodeURIComponent(args.endpoint)}` +
-      `&failure_class=eq.${encodeURIComponent(args.failure_class)}` +
+      `&failure_class=eq.${encodeURIComponent(failureClass)}` +
       `&created_at=gte.${encodeURIComponent(sinceIso)}` +
       `&select=id&limit=1`;
     const dedupRes = await fetch(`${s.url}/rest/v1/self_healing_log${dedupQuery}`, {
@@ -119,9 +195,21 @@ export async function writeAutopilotFailure(
       body: JSON.stringify({
         vtid: args.vtid,
         endpoint: args.endpoint,
-        failure_class: args.failure_class,
+        failure_class: failureClass,
         confidence,
-        diagnosis: { stage: args.stage, ...args.diagnosis },
+        diagnosis: {
+          stage: args.stage,
+          ...args.diagnosis,
+          // Reliability tagging: lets the reconciler + UI separate infra/policy
+          // events (a human must resolve) from genuinely auto-fixable failures.
+          actionable: classification.actionable,
+          non_actionable_reason: classification.non_actionable_reason,
+          // Preserve the caller's original class when we normalised it so the
+          // specific stage failure is never lost.
+          ...(failureClass !== args.failure_class
+            ? { original_failure_class: args.failure_class }
+            : {}),
+        },
         outcome,
         attempt_number: attempt,
         resolved_at: outcome === 'pending' ? null : new Date().toISOString(),

--- a/services/gateway/test/dev-autopilot-failure-actionability.test.ts
+++ b/services/gateway/test/dev-autopilot-failure-actionability.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Self-Healing reliability — "classify, don't delete" (Step 2).
+ *
+ * Dev Autopilot pipeline-stage failures are intentionally surfaced into
+ * self_healing_log so the Self-Healing screen shows them. But most are infra /
+ * policy events a human must resolve, not auto-fix candidates — and they were
+ * escalating with generic classes + confidence 0, drowning out the genuinely
+ * fixable failures. classifyAutopilotFailure() tags them:
+ *   - environmental blockers are normalised to 'environmental_blocker' so the
+ *     reconciler short-circuits retries (no SELF-HEAL retry loop), and
+ *   - safety-gate / policy blocks are flagged actionable=false while keeping
+ *     their own class.
+ */
+
+import { classifyAutopilotFailure } from '../src/services/dev-autopilot-self-heal-log';
+
+describe('classifyAutopilotFailure', () => {
+  it('normalises the worker-queue "unclaimed" failure to environmental_blocker', () => {
+    // The canonical 2026-04-28 outage row: message says binary missing / daemon
+    // down, but does NOT match isEnvironmentalBlocker()'s text patterns — the
+    // class-based rule is what catches it.
+    const result = classifyAutopilotFailure({
+      failure_class: 'dev_autopilot_worker_queue_unclaimed',
+      diagnosis: {
+        summary:
+          'no worker claimed task in 42m (worker daemon down / binary missing / network) — restart worker daemon',
+      },
+    });
+    expect(result.failure_class).toBe('environmental_blocker');
+    expect(result.actionable).toBe(false);
+    expect(result.non_actionable_reason).toBe('environmental');
+  });
+
+  it('catches environmental blockers detected by isEnvironmentalBlocker (e.g. ENOENT spawn) from the summary text', () => {
+    const result = classifyAutopilotFailure({
+      failure_class: 'dev_autopilot_plan_gen_failed',
+      diagnosis: { summary: 'spawn /usr/bin/claude ENOENT — Is Claude Code installed and on PATH' },
+    });
+    expect(result.failure_class).toBe('environmental_blocker');
+    expect(result.actionable).toBe(false);
+    expect(result.non_actionable_reason).toBe('environmental');
+  });
+
+  it('flags safety-gate blocks as non-actionable policy decisions but keeps their class', () => {
+    const result = classifyAutopilotFailure({
+      failure_class: 'dev_autopilot_safety_gate_blocked',
+      diagnosis: { summary: 'Safety gate blocked approval: deny_scope hit' },
+    });
+    expect(result.failure_class).toBe('dev_autopilot_safety_gate_blocked');
+    expect(result.actionable).toBe(false);
+    expect(result.non_actionable_reason).toBe('policy_block');
+  });
+
+  it('leaves a genuinely auto-fixable code failure actionable and unchanged', () => {
+    const result = classifyAutopilotFailure({
+      failure_class: 'dev_autopilot_pr_open_failed',
+      diagnosis: { summary: 'PR creation failed: branch ref already exists' },
+    });
+    expect(result.failure_class).toBe('dev_autopilot_pr_open_failed');
+    expect(result.actionable).toBe(true);
+    expect(result.non_actionable_reason).toBeNull();
+  });
+
+  it('handles a missing diagnosis summary without throwing', () => {
+    const result = classifyAutopilotFailure({ failure_class: 'dev_autopilot_execute_run_failed' });
+    expect(result.actionable).toBe(true);
+    expect(result.non_actionable_reason).toBeNull();
+  });
+});


### PR DESCRIPTION
## Step 2 of Self-Healing reliability: classify non-actionable failures (don't delete them)

### Context
The Self-Healing screen showed ~1500 rows, nearly all `escalated / not resolved`. Investigation showed most are **Dev Autopilot pipeline-stage failures** (`plan_gen`, `approve_safety`, `worker_queue`, `execute_ci`) surfaced into `self_healing_log` by `dev-autopilot-self-heal-log.ts`. That surfacing is **intentional** (so autopilot failures are visible) — so the fix is *not* to remove them.

The real problem: most of these are **infra/policy events a human must resolve**, but they were written with generic `dev_autopilot_*` classes + `confidence: 0` and escalated **as if they were auto-fixable code defects**, drowning out the genuinely fixable failures. Worse, `dev_autopilot_worker_queue_unclaimed` ("worker daemon down / binary missing / network") didn't match `isEnvironmentalBlocker()`'s text patterns, so it escalated normally — the exact retry-loop pattern the code comments blame for the 2026-04-28 outage.

### Change
Centralise classification in the **single** `writeAutopilotFailure` writer via a pure, exported `classifyAutopilotFailure()`:

- **Environmental blockers** → normalised to `failure_class='environmental_blocker'` so the reconciler's existing short-circuit (`self-healing-reconciler.ts`) stops retrying them. Covers both the class-based case (`worker_queue_unclaimed`) and anything `isEnvironmentalBlocker()` matches in the diagnosis summary. Original class preserved in `diagnosis.original_failure_class`.
- **Safety-gate / policy blocks** → keep their class but get `diagnosis.actionable=false`, `non_actionable_reason='policy_block'`.
- **Genuinely fixable failures** → untouched, `actionable=true`.

No rows are removed; the surfaced failures stay visible, but the reconciler/UI can now separate "infra & policy (human needed)" from "auto-fixable", and environmental blockers stop spawning retry loops.

### Why centralised
Every stage writer (`dev-autopilot-execute.ts`, `dev-autopilot-worker-queue.ts`, `dev-autopilot-planning.ts`, `routes/dev-autopilot.ts`) calls the same writer, so classifying there fixes all call sites at once with one tested function.

### Verification
- `npm run build` ✅ (TS 5.3.3, 0 errors)
- New test `dev-autopilot-failure-actionability.test.ts` ✅ (5/5)
- Existing `self-healing-reconciler-autopilot-link` + `self-healing-injector-autopilot-bridge` ✅ (16/16, unchanged)

### Note on scope
This is the backend "classify at source" half. The optional companion (a dashboard segment that visually splits *fixable* vs *infra/policy blocked* using the new `actionable` flag) was deferred — happy to follow up if wanted.

https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB)_