### PR TITLE
fix(finetune): drop torch from trainer install_requires + bump 0.1.0->0.1.1 (VTID-03244)

### DIFF
--- a/services/gateway/scripts/finetune/package-trainer.ts
+++ b/services/gateway/scripts/finetune/package-trainer.ts
@@ -29,7 +29,8 @@ async function main(): Promise<void> {
   const cfg = await parseYaml(configPath);
   const trainerDir = path.join(__dirname, 'trainer-package');
   const trainerUri = buildTrainerPackageUri(cfg);
-  const archivePath = path.join(os.tmpdir(), 'finetune-trainer-0.1.0.tar.gz');
+  // VTID-03244: bumped to 0.1.1 — see trainer-package/setup.py for root cause.
+  const archivePath = path.join(os.tmpdir(), 'finetune-trainer-0.1.1.tar.gz');
 
   await fs.access(path.join(trainerDir, 'setup.py'));
   execFileSync('tar', ['-czf', archivePath, '-C', trainerDir, '.'], { stdio: 'inherit' });

--- a/services/gateway/scripts/finetune/submit-job-lib.ts
+++ b/services/gateway/scripts/finetune/submit-job-lib.ts
@@ -39,7 +39,10 @@ interface BuildJobConfigInput {
 }
 
 export function buildTrainerPackageUri(config: FinetuneConfig): string {
-  return `${config.vertex_custom_job.output_uri_prefix}trainer/finetune-trainer-0.1.0.tar.gz`;
+  // VTID-03244: bumped to 0.1.1 — drops torch from install_requires so it
+  // doesn't shadow the container's pre-installed PyTorch (root cause of
+  // CustomJob 3154255301083922432 failure 2026-06-01).
+  return `${config.vertex_custom_job.output_uri_prefix}trainer/finetune-trainer-0.1.1.tar.gz`;
 }
 
 export function buildTrainingArgs(config: FinetuneConfig, outputUri: string): string[] {

--- a/services/gateway/scripts/finetune/trainer-package/setup.py
+++ b/services/gateway/scripts/finetune/trainer-package/setup.py
@@ -1,8 +1,29 @@
 from setuptools import find_packages, setup
 
+# v0.1.1 (VTID-03244): drop `torch` from install_requires.
+#
+# CustomJob 3154255301083922432 (2026-06-01) failed in transformers'
+# `requires_backends(AutoModelForCausalLM)` with
+# "ImportError: AutoModelForCausalLM requires the PyTorch library
+#  but it was not found in your environment."
+#
+# Root cause: the Vertex Custom Training base image
+# `us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-3.py310` already
+# ships PyTorch 2.3 in /opt/python/3.10/site-packages. Listing
+# `torch>=2.3.0` in install_requires made pip (re)install torch into
+# /root/.local/lib/python3.10/site-packages on top of the trainer
+# package install — a partial/broken install that shadowed the
+# pre-installed runtime PyTorch, breaking transformers' backend
+# detection.
+#
+# Fix: trust the container's pre-installed torch. The trainer's other
+# install_requires (transformers / accelerate / peft / datasets /
+# sentencepiece) all support torch 2.3 and will resolve cleanly
+# against the container's torch.
+
 setup(
     name="finetune-trainer",
-    version="0.1.0",
+    version="0.1.1",
     packages=find_packages(),
     install_requires=[
         "accelerate>=0.34.0",
@@ -10,7 +31,8 @@ setup(
         "google-cloud-storage>=2.16.0",
         "peft>=0.12.0",
         "sentencepiece>=0.2.0",
-        "torch>=2.3.0",
+        # torch intentionally NOT listed — provided by the
+        # pytorch-gpu.2-3.py310 base container.
         "transformers>=4.44.0",
     ],
 )

--- a/services/gateway/test/finetune-submit-job-lib.test.ts
+++ b/services/gateway/test/finetune-submit-job-lib.test.ts
@@ -41,7 +41,7 @@ const config: FinetuneConfig = {
 describe('finetune submit job config', () => {
   test('builds the trainer package URI from the configured output prefix', () => {
     expect(buildTrainerPackageUri(config)).toBe(
-      'gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/trainer/finetune-trainer-0.1.0.tar.gz',
+      'gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/trainer/finetune-trainer-0.1.1.tar.gz',
     );
   });
 
@@ -66,7 +66,7 @@ describe('finetune submit job config', () => {
     });
 
     expect(jobConfig.workerPoolSpecs[0].pythonPackageSpec.packageUris).toEqual([
-      'gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/trainer/finetune-trainer-0.1.0.tar.gz',
+      'gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/trainer/finetune-trainer-0.1.1.tar.gz',
     ]);
     expect(jobConfig.workerPoolSpecs[0].pythonPackageSpec.pythonModule).toBe('finetune.train');
   });


### PR DESCRIPTION
Phase 1 W3-D1/E1 PR 6 step 2. CustomJob 3154255301083922432 failed: ImportError: AutoModelForCausalLM requires PyTorch. Root cause: setup.py listed torch>=2.3.0; pip reinstalled torch into ~/.local/ on top of the container's pre-installed PyTorch, breaking transformers' backend detection. Fix: drop torch from install_requires (container's pytorch-gpu.2-3.py310 already ships torch 2.3); bump trainer 0.1.0->0.1.1; bump GCS object name in submit-job-lib + package-trainer. Relaunch via CRON-FINETUNE-TRAINER after merge. npm run build green.