### PR TITLE
feat(self-healing): verify-and-rollback loop for auto-fixes (Step 3)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-bridge.ts
+++ b/services/gateway/src/services/dev-autopilot-bridge.ts
@@ -39,6 +39,7 @@ import {
 } from './self-healing-triage-service';
 import { emitOasisEvent } from './oasis-event-service';
 import { isEnvironmentalBlocker } from './dev-autopilot-self-heal-log';
+import { createRevertPullRequest, mergePullRequest } from './github-service';
 
 const LOG_PREFIX = '[dev-autopilot-bridge]';
 const BRIDGE_VTID = 'VTID-DEV-AUTOPILOT';
@@ -283,13 +284,33 @@ export async function revertExecutionPR(
       return { ok: true, revert_pr_url: `${exec.pr_url}#closed` };
     }
 
-    // deploy / verification stage: PR already merged → open a revert PR.
-    // We don't have full repo write tooling wired here yet; emit a marker
-    // URL and let the execution agent (PR-9) + a follow-up pass open the
-    // actual revert PR. For now the bridge records intent.
-    const markerUrl = `https://github.com/${GITHUB_REPO}/pull/REVERT-${exec.id.slice(0, 8)}`;
-    console.warn(`${LOG_PREFIX} live revert for ${stage} stage not fully wired — emitting marker ${markerUrl}`);
-    return { ok: true, revert_pr_url: markerUrl };
+    // deploy / verification stage: PR already merged → open a revert PR and
+    // auto-merge it to restore the last-good state. createRevertPullRequest
+    // builds a reverse-tree revert based on the CURRENT main HEAD (it only
+    // overrides the merge's changed files back to their pre-merge blobs), so it
+    // stays correct even if other commits landed after the merge.
+    const mergeSha = (exec.metadata as { merge_sha?: string } | null | undefined)?.merge_sha;
+    if (!mergeSha) {
+      console.warn(`${LOG_PREFIX} cannot auto-revert ${exec.id.slice(0, 8)} (${stage}): no merge_sha on execution metadata`);
+      return { ok: false, error: 'no merge_sha on execution metadata — cannot revert merged PR' };
+    }
+    const revertBranch = `revert/auto-${exec.id.slice(0, 8)}-${Date.now()}`;
+    const title = `Revert: auto-fix ${exec.id.slice(0, 8)} failed ${stage} verification`;
+    const body =
+      `Automated rollback. Execution \`${exec.id}\` (${exec.pr_url}) failed ${stage} ` +
+      `verification after merge; reverting merge commit \`${mergeSha}\` to restore the ` +
+      `last-good state.`;
+    const revertPr = await createRevertPullRequest(GITHUB_REPO, mergeSha, revertBranch, title, body);
+    const merged = await mergePullRequest(GITHUB_REPO, revertPr.number, title, 'squash');
+    if (!merged.merged) {
+      // Revert PR is open but couldn't auto-merge (e.g. required checks pending
+      // or branch protection). Leave it for a human and report its URL — the
+      // rollback is staged, not silently dropped.
+      console.warn(`${LOG_PREFIX} revert PR #${revertPr.number} for ${exec.id.slice(0, 8)} created but auto-merge failed: ${merged.message}`);
+      return { ok: true, revert_pr_url: revertPr.html_url, error: `revert PR open but auto-merge failed: ${merged.message}` };
+    }
+    console.log(`${LOG_PREFIX} auto-reverted ${exec.id.slice(0, 8)} via PR #${revertPr.number} (merged ${merged.sha?.slice(0, 8) || '?'})`);
+    return { ok: true, revert_pr_url: revertPr.html_url };
   } catch (err) {
     return { ok: false, error: String(err) };
   }

--- a/services/gateway/src/services/dev-autopilot-self-heal-log.ts
+++ b/services/gateway/src/services/dev-autopilot-self-heal-log.ts
@@ -60,6 +60,75 @@ export interface AutopilotFailureArgs {
   attempt_number?: number;
 }
 
+/**
+ * Failure classes that are inherently environmental (host / infra) rather than
+ * a code defect the autopilot can patch. The worker-queue "unclaimed" failure
+ * is the canonical case: its message is literally "worker daemon down / binary
+ * missing / network", yet that text doesn't match isEnvironmentalBlocker()'s
+ * patterns — so without this set it escalates as if a code fix could resolve it
+ * (the 2026-04-28 retry-loop outage). Normalising these to 'environmental_blocker'
+ * lets the reconciler short-circuit retries (see self-healing-reconciler.ts).
+ */
+const ENVIRONMENTAL_FAILURE_CLASSES = new Set<string>([
+  'dev_autopilot_worker_queue_unclaimed',
+]);
+
+/**
+ * Failure classes that need a human policy decision, not an auto-fix (e.g. the
+ * safety gate blocked an approval because the change is out of allow_scope).
+ * These stay visible with their own class but are flagged non-actionable so the
+ * Self-Healing view stops counting them as fixes self-healing failed to make.
+ */
+const POLICY_BLOCK_FAILURE_CLASSES = new Set<string>([
+  'dev_autopilot_safety_gate_blocked',
+]);
+
+export type NonActionableReason = 'environmental' | 'policy_block';
+
+export interface FailureActionability {
+  /** Possibly-normalised failure_class to persist. */
+  failure_class: string;
+  /** false when no autonomous code fix can resolve this failure. */
+  actionable: boolean;
+  /** Why it's non-actionable, or null when it is actionable. */
+  non_actionable_reason: NonActionableReason | null;
+}
+
+/**
+ * Decide whether a surfaced autopilot failure is something the self-healing
+ * loop could actually fix with a code change, and normalise environmental
+ * blockers so the reconciler short-circuits retries instead of spawning a
+ * SELF-HEAL VTID per failure. Pure + exported for tests.
+ *
+ * This is the "classify, don't delete" half of the Self-Healing reliability
+ * work: the dev-autopilot stage failures are intentionally surfaced, but most
+ * of them (binary missing, worker daemon down, safety-gate blocks) are infra /
+ * policy events a human must resolve — not auto-fix candidates. Tagging them
+ * keeps them visible while stopping them from drowning out the genuinely
+ * fixable failures.
+ */
+export function classifyAutopilotFailure(args: {
+  failure_class: string;
+  diagnosis?: Record<string, unknown>;
+}): FailureActionability {
+  const fc = args.failure_class;
+  const summary =
+    typeof args.diagnosis?.summary === 'string' ? args.diagnosis.summary : '';
+  const probe = `${fc} ${summary}`;
+
+  if (ENVIRONMENTAL_FAILURE_CLASSES.has(fc) || isEnvironmentalBlocker(probe)) {
+    return {
+      failure_class: 'environmental_blocker',
+      actionable: false,
+      non_actionable_reason: 'environmental',
+    };
+  }
+  if (POLICY_BLOCK_FAILURE_CLASSES.has(fc)) {
+    return { failure_class: fc, actionable: false, non_actionable_reason: 'policy_block' };
+  }
+  return { failure_class: fc, actionable: true, non_actionable_reason: null };
+}
+
 /** Time window for the writer-level idempotency check. Same vtid+endpoint+
  *  failure_class within this window is treated as a duplicate and skipped.
  *  Sized to comfortably swallow ticker-loop spam (lazyPlanTick fires every
@@ -87,12 +156,19 @@ export async function writeAutopilotFailure(
   const outcome = args.outcome || 'failed';
   const confidence = args.confidence ?? 0;
   const attempt = args.attempt_number ?? 1;
+  // Classify actionability + normalise environmental blockers BEFORE the dedup
+  // query so dedup keys on the persisted (possibly-normalised) class.
+  const classification = classifyAutopilotFailure({
+    failure_class: args.failure_class,
+    diagnosis: args.diagnosis,
+  });
+  const failureClass = classification.failure_class;
   try {
     const sinceIso = new Date(Date.now() - DEDUP_WINDOW_MS).toISOString();
     const dedupQuery =
       `?vtid=eq.${encodeURIComponent(args.vtid)}` +
       `&endpoint=eq.${encodeURIComponent(args.endpoint)}` +
-      `&failure_class=eq.${encodeURIComponent(args.failure_class)}` +
+      `&failure_class=eq.${encodeURIComponent(failureClass)}` +
       `&created_at=gte.${encodeURIComponent(sinceIso)}` +
       `&select=id&limit=1`;
     const dedupRes = await fetch(`${s.url}/rest/v1/self_healing_log${dedupQuery}`, {
@@ -119,9 +195,21 @@ export async function writeAutopilotFailure(
       body: JSON.stringify({
         vtid: args.vtid,
         endpoint: args.endpoint,
-        failure_class: args.failure_class,
+        failure_class: failureClass,
         confidence,
-        diagnosis: { stage: args.stage, ...args.diagnosis },
+        diagnosis: {
+          stage: args.stage,
+          ...args.diagnosis,
+          // Reliability tagging: lets the reconciler + UI separate infra/policy
+          // events (a human must resolve) from genuinely auto-fixable failures.
+          actionable: classification.actionable,
+          non_actionable_reason: classification.non_actionable_reason,
+          // Preserve the caller's original class when we normalised it so the
+          // specific stage failure is never lost.
+          ...(failureClass !== args.failure_class
+            ? { original_failure_class: args.failure_class }
+            : {}),
+        },
         outcome,
         attempt_number: attempt,
         resolved_at: outcome === 'pending' ? null : new Date().toISOString(),

--- a/services/gateway/src/services/dev-autopilot-watcher.ts
+++ b/services/gateway/src/services/dev-autopilot-watcher.ts
@@ -23,6 +23,7 @@
 import githubService from './github-service';
 import { emitOasisEvent } from './oasis-event-service';
 import { bridgeFailureToSelfHealing, FailureStage } from './dev-autopilot-bridge';
+import { probeEndpoint, isJsonHealthy, resolveProbeTarget } from './self-healing-probe';
 import { applyExecTerminalSideEffects } from './dev-autopilot-execute';
 
 const LOG_PREFIX = '[dev-autopilot-watcher]';
@@ -157,6 +158,27 @@ async function loadExecutions(s: SupaConfig, status: string): Promise<ExecutionR
     `/rest/v1/dev_autopilot_executions?status=eq.${status}&select=id,finding_id,status,branch,pr_url,pr_number,updated_at,metadata&limit=50`,
   );
   return r.ok && r.data ? r.data : [];
+}
+
+/**
+ * Resolve the HTTP target to re-probe for an execution's original finding.
+ * Checks the finding's spec_snapshot for an endpoint-like field, in priority
+ * order, and returns the first that is an actual HTTP target. Returns null when
+ * the finding has no probeable endpoint (e.g. a source-file code fix) — the
+ * caller then falls back to blast-radius-only verification.
+ */
+async function loadFindingProbeTarget(s: SupaConfig, findingId: string): Promise<string | null> {
+  const r = await supa<Array<{ spec_snapshot: Record<string, unknown> | null }>>(
+    s,
+    `/rest/v1/autopilot_recommendations?id=eq.${findingId}&select=spec_snapshot&limit=1`,
+  );
+  const snap = r.ok && r.data && r.data[0] ? r.data[0].spec_snapshot : null;
+  if (!snap) return null;
+  for (const key of ['probe_endpoint', 'endpoint', 'file_path']) {
+    const target = resolveProbeTarget(typeof snap[key] === 'string' ? (snap[key] as string) : null);
+    if (target) return target;
+  }
+  return null;
 }
 
 // =============================================================================
@@ -737,7 +759,43 @@ export async function verificationWatcherTick(): Promise<void> {
       continue;
     }
 
-    // pass
+    // Blast radius is clean — but "no new errors" is not the same as "the
+    // original failure is gone". If the finding has a probeable HTTP endpoint,
+    // re-hit it now and require it healthy (2xx + JSON) before declaring the
+    // fix verified. A fix that deploys cleanly but doesn't actually resolve the
+    // original failure must NOT pass. Findings without a probeable endpoint
+    // (source-file code fixes) fall back to the blast-radius verdict above.
+    const probeTarget = await loadFindingProbeTarget(s, exec.finding_id);
+    if (probeTarget) {
+      const probe = await probeEndpoint(probeTarget);
+      if (!isJsonHealthy(probe)) {
+        await transitionStatus(s, exec.id, 'verifying', 'failed', {
+          metadata: {
+            ...(exec.metadata || {}),
+            verification_reprobe: {
+              endpoint: probeTarget,
+              http_status: probe.http_status,
+              healthy: false,
+            },
+          },
+        });
+        const reason = `original endpoint still failing after deploy (${probeTarget} → ${probe.http_status ?? 'no response'})`;
+        await emitOasisEvent({
+          vtid: WATCHER_VTID,
+          type: 'dev_autopilot.execution.verification_failed',
+          source: 'dev-autopilot-watcher',
+          status: 'error',
+          message: `Execution ${exec.id.slice(0, 8)} verification failed: ${reason}`,
+          payload: { execution_id: exec.id, pr_url: exec.pr_url, reprobe: { endpoint: probeTarget, http_status: probe.http_status } },
+        });
+        await bridgeFailure(exec.id, 'verification', reason, {
+          verification_result: { state: 'fail', reason: 'reprobe_unhealthy', endpoint: probeTarget, http_status: probe.http_status },
+        });
+        continue;
+      }
+    }
+
+    // pass — blast radius clean AND (re-probe healthy OR no probeable endpoint)
     await transitionStatus(s, exec.id, 'verifying', 'completed', {
       completed_at: new Date().toISOString(),
     });
@@ -746,8 +804,10 @@ export async function verificationWatcherTick(): Promise<void> {
       type: 'dev_autopilot.execution.completed',
       source: 'dev-autopilot-watcher',
       status: 'success',
-      message: `Execution ${exec.id.slice(0, 8)} completed — verification window clean`,
-      payload: { execution_id: exec.id, pr_url: exec.pr_url },
+      message: probeTarget
+        ? `Execution ${exec.id.slice(0, 8)} completed — verification clean + ${probeTarget} healthy`
+        : `Execution ${exec.id.slice(0, 8)} completed — verification window clean`,
+      payload: { execution_id: exec.id, pr_url: exec.pr_url, reprobed: probeTarget || null },
     });
 
     // If this was a self-heal child, also mark the parent self_healed.

--- a/services/gateway/src/services/self-healing-probe.ts
+++ b/services/gateway/src/services/self-healing-probe.ts
@@ -35,6 +35,31 @@ function buildProbeUrl(endpoint: string, gatewayUrl: string): string {
   return `${gatewayUrl}/${endpoint}`;
 }
 
+/**
+ * A finding's recorded endpoint is only worth re-probing post-deploy when it is
+ * an actual HTTP target — a "/path" or a full "http(s)://…" URL. Dev Autopilot
+ * code/scanner findings record a *source file path* (e.g.
+ * "services/gateway/src/foo.ts") and lifecycle markers record dotted ids (e.g.
+ * "autopilot.approve_safety"); neither is reachable over HTTP, and probing them
+ * would always 404 and falsely fail every fix. Voice-synthetic markers are
+ * verified by the dedicated voice probe, not here.
+ *
+ * Returns the probeable target string, or null when the endpoint isn't an HTTP
+ * target (caller should then fall back to non-probe verification).
+ */
+export function resolveProbeTarget(endpoint: string | null | undefined): string | null {
+  if (!endpoint || typeof endpoint !== 'string') return null;
+  const e = endpoint.trim();
+  if (!e) return null;
+  if (isVoiceSyntheticEndpoint(e)) return null;
+  if (/^https?:\/\//i.test(e)) return e;
+  // A leading slash means an absolute HTTP path on the gateway (e.g.
+  // "/api/v1/live/rooms"). Source file paths are repo-relative ("services/…")
+  // and never start with "/".
+  if (e.startsWith('/')) return e;
+  return null;
+}
+
 export async function probeEndpoint(
   endpoint: string,
   opts: ProbeOptions = {},

--- a/services/gateway/test/dev-autopilot-failure-actionability.test.ts
+++ b/services/gateway/test/dev-autopilot-failure-actionability.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Self-Healing reliability — "classify, don't delete" (Step 2).
+ *
+ * Dev Autopilot pipeline-stage failures are intentionally surfaced into
+ * self_healing_log so the Self-Healing screen shows them. But most are infra /
+ * policy events a human must resolve, not auto-fix candidates — and they were
+ * escalating with generic classes + confidence 0, drowning out the genuinely
+ * fixable failures. classifyAutopilotFailure() tags them:
+ *   - environmental blockers are normalised to 'environmental_blocker' so the
+ *     reconciler short-circuits retries (no SELF-HEAL retry loop), and
+ *   - safety-gate / policy blocks are flagged actionable=false while keeping
+ *     their own class.
+ */
+
+import { classifyAutopilotFailure } from '../src/services/dev-autopilot-self-heal-log';
+
+describe('classifyAutopilotFailure', () => {
+  it('normalises the worker-queue "unclaimed" failure to environmental_blocker', () => {
+    // The canonical 2026-04-28 outage row: message says binary missing / daemon
+    // down, but does NOT match isEnvironmentalBlocker()'s text patterns — the
+    // class-based rule is what catches it.
+    const result = classifyAutopilotFailure({
+      failure_class: 'dev_autopilot_worker_queue_unclaimed',
+      diagnosis: {
+        summary:
+          'no worker claimed task in 42m (worker daemon down / binary missing / network) — restart worker daemon',
+      },
+    });
+    expect(result.failure_class).toBe('environmental_blocker');
+    expect(result.actionable).toBe(false);
+    expect(result.non_actionable_reason).toBe('environmental');
+  });
+
+  it('catches environmental blockers detected by isEnvironmentalBlocker (e.g. ENOENT spawn) from the summary text', () => {
+    const result = classifyAutopilotFailure({
+      failure_class: 'dev_autopilot_plan_gen_failed',
+      diagnosis: { summary: 'spawn /usr/bin/claude ENOENT — Is Claude Code installed and on PATH' },
+    });
+    expect(result.failure_class).toBe('environmental_blocker');
+    expect(result.actionable).toBe(false);
+    expect(result.non_actionable_reason).toBe('environmental');
+  });
+
+  it('flags safety-gate blocks as non-actionable policy decisions but keeps their class', () => {
+    const result = classifyAutopilotFailure({
+      failure_class: 'dev_autopilot_safety_gate_blocked',
+      diagnosis: { summary: 'Safety gate blocked approval: deny_scope hit' },
+    });
+    expect(result.failure_class).toBe('dev_autopilot_safety_gate_blocked');
+    expect(result.actionable).toBe(false);
+    expect(result.non_actionable_reason).toBe('policy_block');
+  });
+
+  it('leaves a genuinely auto-fixable code failure actionable and unchanged', () => {
+    const result = classifyAutopilotFailure({
+      failure_class: 'dev_autopilot_pr_open_failed',
+      diagnosis: { summary: 'PR creation failed: branch ref already exists' },
+    });
+    expect(result.failure_class).toBe('dev_autopilot_pr_open_failed');
+    expect(result.actionable).toBe(true);
+    expect(result.non_actionable_reason).toBeNull();
+  });
+
+  it('handles a missing diagnosis summary without throwing', () => {
+    const result = classifyAutopilotFailure({ failure_class: 'dev_autopilot_execute_run_failed' });
+    expect(result.actionable).toBe(true);
+    expect(result.non_actionable_reason).toBeNull();
+  });
+});

--- a/services/gateway/test/self-healing-pre-probe.test.ts
+++ b/services/gateway/test/self-healing-pre-probe.test.ts
@@ -15,13 +15,44 @@
  *      `injectIntoAutopilotPipeline`.
  */
 
-import { probeEndpoint, isJsonHealthy } from '../src/services/self-healing-probe';
+import { probeEndpoint, isJsonHealthy, resolveProbeTarget } from '../src/services/self-healing-probe';
 
 const ORIGINAL_FETCH = global.fetch;
 
 afterEach(() => {
   global.fetch = ORIGINAL_FETCH;
   jest.resetModules();
+});
+
+describe('resolveProbeTarget (post-deploy verify gate)', () => {
+  // Step 3 verify-and-rollback: the watcher only re-probes the original failure
+  // when the finding has an actual HTTP target. Source-file code fixes and
+  // lifecycle markers must fall through to blast-radius-only verification.
+  it('returns full http(s) URLs as-is', () => {
+    expect(resolveProbeTarget('https://gateway.vitanaland.com/api/v1/x')).toBe(
+      'https://gateway.vitanaland.com/api/v1/x',
+    );
+    expect(resolveProbeTarget('http://localhost:8080/alive')).toBe('http://localhost:8080/alive');
+  });
+
+  it('returns absolute "/path" endpoints (probed against the gateway base)', () => {
+    expect(resolveProbeTarget('/api/v1/live/rooms')).toBe('/api/v1/live/rooms');
+    expect(resolveProbeTarget('  /alive  ')).toBe('/alive');
+  });
+
+  it('returns null for source file paths (dev_autopilot code/scanner findings)', () => {
+    expect(resolveProbeTarget('services/gateway/src/foo.ts')).toBeNull();
+    expect(resolveProbeTarget('supabase/migrations/20260101_x.sql')).toBeNull();
+  });
+
+  it('returns null for lifecycle markers, voice-synthetic, and empty/nullish input', () => {
+    expect(resolveProbeTarget('autopilot.approve_safety')).toBeNull();
+    expect(resolveProbeTarget('voice-error://no_audio_in')).toBeNull();
+    expect(resolveProbeTarget('')).toBeNull();
+    expect(resolveProbeTarget('   ')).toBeNull();
+    expect(resolveProbeTarget(null)).toBeNull();
+    expect(resolveProbeTarget(undefined)).toBeNull();
+  });
 });
 
 describe('probeEndpoint (shared helper)', () => {


### PR DESCRIPTION
## Step 3 of Self-Healing reliability: close the verify-and-rollback loop

This makes FULL AUTO safe at scale — a fix only counts as "done" if the original failure is actually gone, and a fix that regresses production is rolled back automatically.

### The problem
The post-deploy verification + rollback machinery existed but was hollow in two load-bearing ways:

1. **Verification was blast-radius-only.** `analyzeVerificationWindow()` just checked *"did any unrelated error events fire in the 5-min window?"* — "no new errors" is **not** "the original failure is gone." A fix that deployed cleanly but didn't actually resolve the problem **passed**.
2. **Rollback for merged PRs was a stub.** `revertExecutionPR()` emitted a dead marker URL (`pull/REVERT-<id>`) with a stale comment: *"we don't have full repo write tooling wired here yet."* That tooling has since been built in `github-service`, but the bridge never called it — so nothing actually rolled back.

### The fix

**Verify — re-probe the original failure** (`dev-autopilot-watcher.ts`, `self-healing-probe.ts`)
- New pure, tested `resolveProbeTarget()` decides whether a finding has a real HTTP target (a `/path` or `http(s)://` URL → yes; source file paths, `autopilot.*` lifecycle markers, `voice-error://` → no).
- When the verification window is blast-radius-clean **and** the finding has a probeable endpoint, the watcher now re-hits it and requires it healthy (2xx + JSON, via the existing `isJsonHealthy`) before marking `completed`. An unhealthy re-probe routes through `bridgeFailure('verification', …)` exactly like a blast-radius failure → triage + revert + self-heal-child.
- Findings **without** a probeable endpoint (source-file code fixes) fall back to the existing blast-radius verdict — **no regression**.

**Rollback — auto-create AND auto-merge the revert** (`dev-autopilot-bridge.ts`)
- For already-merged PRs the bridge now builds a **real** revert PR from `exec.metadata.merge_sha` via `createRevertPullRequest()` (a correct reverse-tree revert based on current `main` HEAD — it only overrides the merge's changed files back to their pre-merge blobs, so it stays correct even if other commits landed after) and **auto-merges** it via `mergePullRequest()` to restore the last-good state.
- If the auto-merge can't complete (required checks pending / branch protection), the revert PR is left open for a human and its URL is reported — the rollback is **staged, never silently dropped**.

### Decisions (confirmed with the requester)
- Verify check: **re-probe original + blast-radius** (safe fallback for non-endpoint findings).
- Rollback aggressiveness: **auto-create AND auto-merge** the revert.

### Verification
- `npm run build` ✅ (0 TS errors)
- New `resolveProbeTarget` cases in `self-healing-pre-probe.test.ts` ✅
- Full self-healing + dev-autopilot suite ✅ **251/251**, including the existing `analyzeVerificationWindow` and bridge tests over the changed modules.

### Note on test coverage
The pure decision surface (`resolveProbeTarget`) is unit-tested. The live re-probe and the GitHub revert/auto-merge calls reuse already-proven primitives (`probeEndpoint`/`isJsonHealthy` and `createRevertPullRequest`/`mergePullRequest` — the same path the CI-watcher already uses to auto-merge) and could not be integration-tested from this sandbox (outbound GitHub/Cloud Run is blocked, 403). Worth a smoke check on the first real verification-failure post-merge.

https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB)_