### PR TITLE
feat(command-hub): intelligence cockpit spine (VTID-03247)

### DIFF
--- a/services/gateway/src/frontend/command-hub/intelligence-cockpit.css
+++ b/services/gateway/src/frontend/command-hub/intelligence-cockpit.css
@@ -1,0 +1,96 @@
+/* Intelligence Cockpit — Phase 1 W3-D1 PR 5 (VTID-03247).
+ * Spine + 1 live panel + 3 placeholder panels.
+ * Inherits base typography from styles.css; only layout + cockpit-
+ * specific affordances live here. */
+
+.cockpit-container {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px 16px 64px;
+}
+
+.cockpit-header { margin-bottom: 24px; }
+.cockpit-header h1 { margin: 0 0 6px; font-size: 22px; }
+.cockpit-sub { margin: 0 0 12px; color: var(--text-2, #6b7280); font-size: 14px; line-height: 1.4; }
+.cockpit-controls { display: flex; gap: 12px; align-items: center; }
+.cockpit-controls button { padding: 6px 12px; cursor: pointer; }
+.cockpit-meta { color: var(--text-2, #6b7280); font-size: 12px; }
+
+.cockpit-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+  gap: 16px;
+}
+
+.cockpit-panel {
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 10px;
+  background: var(--surface, #ffffff);
+  display: flex;
+  flex-direction: column;
+}
+.cockpit-panel__header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.cockpit-panel__header h2 { margin: 0; font-size: 15px; font-weight: 600; }
+.cockpit-panel__body { padding: 14px 16px; font-size: 13px; line-height: 1.4; }
+.cockpit-panel__hint { color: var(--text-2, #6b7280); font-size: 12px; margin: 6px 0 0; }
+.cockpit-panel__hint--bad { color: #b91c1c; }
+.cockpit-panel__subhead {
+  margin: 12px 0 6px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-2, #6b7280);
+}
+.cockpit-panel__subhead:first-child { margin-top: 0; }
+
+.cockpit-panel__badge {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 8px;
+  border-radius: 999px;
+}
+.cockpit-panel__badge--live { background: #dcfce7; color: #166534; }
+.cockpit-panel__badge--placeholder { background: #f3f4f6; color: #6b7280; }
+
+.cockpit-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.cockpit-table th, .cockpit-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border, #f1f5f9);
+  text-align: left;
+  vertical-align: top;
+}
+.cockpit-table th {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-2, #6b7280);
+}
+.cockpit-table__sub { color: var(--text-2, #6b7280); font-size: 11px; font-family: ui-monospace, monospace; }
+
+.cockpit-pill {
+  display: inline-block;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+.cockpit-pill--ok { background: #dcfce7; color: #166534; }
+.cockpit-pill--bad { background: #fee2e2; color: #991b1b; }
+.cockpit-pill--pending { background: #fef3c7; color: #92400e; }
+.cockpit-pill--neutral { background: #f3f4f6; color: #4b5563; }
+
+.cockpit-footer {
+  margin-top: 24px;
+  color: var(--text-2, #6b7280);
+  font-size: 11px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}

--- a/services/gateway/src/frontend/command-hub/intelligence-cockpit.html
+++ b/services/gateway/src/frontend/command-hub/intelligence-cockpit.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Intelligence Cockpit — Command Hub</title>
+  <link rel="stylesheet" href="/command-hub/styles.css?v=20260601-VTID-03247" />
+  <link rel="stylesheet" href="/command-hub/intelligence-cockpit.css?v=20260601-VTID-03247" />
+</head>
+<body>
+  <div class="cockpit-container">
+    <header class="cockpit-header">
+      <h1>Intelligence Cockpit</h1>
+      <p class="cockpit-sub">
+        Phase 1 W3 spine. One page for the operator to see whether the
+        assistant-intelligence loop's inputs are healthy:
+        dataset &rarr; training &rarr; context quality &rarr; role-aware
+        delivery &rarr; shadow eval &rarr; self-healing. Panels marked
+        <em>placeholder</em> ship in follow-up PRs.
+      </p>
+      <div class="cockpit-controls">
+        <button id="cockpit-refresh" type="button">Refresh</button>
+        <span id="cockpit-last-update" class="cockpit-meta">never</span>
+      </div>
+    </header>
+
+    <main class="cockpit-grid">
+      <section class="cockpit-panel cockpit-panel--live" id="panel-training">
+        <header class="cockpit-panel__header">
+          <h2>Training &amp; dataset pipeline</h2>
+          <span class="cockpit-panel__badge cockpit-panel__badge--live">live</span>
+        </header>
+        <div class="cockpit-panel__body" id="panel-training-body">Loading&hellip;</div>
+      </section>
+
+      <section class="cockpit-panel cockpit-panel--placeholder" id="panel-context-quality">
+        <header class="cockpit-panel__header">
+          <h2>Context quality score</h2>
+          <span class="cockpit-panel__badge cockpit-panel__badge--placeholder">placeholder</span>
+        </header>
+        <div class="cockpit-panel__body">
+          <p>Consumes the daily <code>CRON-CONTEXT-QUALITY-SCORE</code> artifact
+            (VTID-03246, PR 2). Wiring lands in the follow-up endpoint
+            <code>GET /api/v1/admin/cockpit/context-quality</code>.</p>
+          <p class="cockpit-panel__hint">
+            Will surface: overall <strong>context_quality_score / 100</strong>,
+            per-source freshness/trust/coverage/consent breakdown, and the
+            tenant-consent gate status.
+          </p>
+        </div>
+      </section>
+
+      <section class="cockpit-panel cockpit-panel--placeholder" id="panel-role-registry">
+        <header class="cockpit-panel__header">
+          <h2>Role registry &amp; shadow</h2>
+          <span class="cockpit-panel__badge cockpit-panel__badge--placeholder">placeholder</span>
+        </header>
+        <div class="cockpit-panel__body">
+          <p>Consumes the <code>assistant.role.context_pack.shadow</code> OASIS
+            stream (VTID-03241, PR 4) and the role registry
+            (VTID-03240, PR 3). Wiring lands in
+            <code>GET /api/v1/admin/cockpit/role-registry-shadow</code>.</p>
+          <p class="cockpit-panel__hint">
+            Will surface: role distribution per surface, would_allow vs
+            would_block counts per (role, source), and per-role
+            <strong>policy_match_rate</strong> with a 7-day trend.
+          </p>
+        </div>
+      </section>
+
+      <section class="cockpit-panel cockpit-panel--placeholder" id="panel-self-healing">
+        <header class="cockpit-panel__header">
+          <h2>Self-healing &amp; eval</h2>
+          <span class="cockpit-panel__badge cockpit-panel__badge--placeholder">placeholder</span>
+        </header>
+        <div class="cockpit-panel__body">
+          <p>Consumes the autonomous self-healing feed. Wiring lands in
+            <code>GET /api/v1/admin/cockpit/self-healing</code>.</p>
+          <p class="cockpit-panel__hint">
+            Will surface: failure clusters, applied self-heal interventions,
+            and eval-suite pass/fail trends so the operator can see whether
+            the loop is closing.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="cockpit-footer">
+      <span>VTID-03247 spine</span>
+      <span>·</span>
+      <span>Read-only</span>
+    </footer>
+  </div>
+
+  <script src="/command-hub/intelligence-cockpit.js?v=20260601-VTID-03247"></script>
+</body>
+</html>

--- a/services/gateway/src/frontend/command-hub/intelligence-cockpit.js
+++ b/services/gateway/src/frontend/command-hub/intelligence-cockpit.js
@@ -1,0 +1,168 @@
+(function () {
+  'use strict';
+
+  // Phase 1 W3-D1 PR 5 (VTID-03247) — Intelligence Cockpit spine.
+  // Single page wiring. Panel 1 (Training & dataset pipeline) is live;
+  // remaining panels render placeholders pointing at the planned
+  // follow-up endpoint each one will consume.
+  // CSP-compliant: external script, no inline JS, DOM built via API.
+
+  const TOKEN_KEY = 'vitana.command_hub.token';
+  function authHeaders() {
+    const token = (window.localStorage && window.localStorage.getItem(TOKEN_KEY)) || '';
+    return token ? { Authorization: 'Bearer ' + token } : {};
+  }
+
+  const API_BASE = '/api/v1';
+
+  async function fetchJSON(url) {
+    const res = await fetch(url, { headers: authHeaders() });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    return res.json();
+  }
+
+  function fmtRel(iso) {
+    if (!iso) return '—';
+    var t = Date.parse(iso);
+    if (!isFinite(t)) return iso;
+    var deltaMs = Date.now() - t;
+    var mins = Math.round(deltaMs / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return mins + 'm ago';
+    var hours = Math.round(mins / 60);
+    if (hours < 48) return hours + 'h ago';
+    return Math.round(hours / 24) + 'd ago';
+  }
+
+  function conclusionClass(conclusion, status) {
+    if (status && status !== 'completed') return 'cockpit-pill cockpit-pill--pending';
+    if (conclusion === 'success') return 'cockpit-pill cockpit-pill--ok';
+    if (conclusion === 'failure' || conclusion === 'cancelled' || conclusion === 'timed_out') {
+      return 'cockpit-pill cockpit-pill--bad';
+    }
+    return 'cockpit-pill cockpit-pill--neutral';
+  }
+
+  function conclusionLabel(conclusion, status) {
+    if (status && status !== 'completed') return status;
+    return conclusion || 'unknown';
+  }
+
+  function renderTrainingPanel(payload) {
+    var body = document.getElementById('panel-training-body');
+    if (!body) return;
+    body.innerHTML = '';
+
+    if (!payload || !Array.isArray(payload.workflows) || payload.workflows.length === 0) {
+      var empty = document.createElement('p');
+      empty.className = 'cockpit-panel__hint';
+      empty.textContent = 'No workflow runs returned. Check GitHub API credentials.';
+      body.appendChild(empty);
+      return;
+    }
+
+    var byCat = { dataset: [], training: [], context: [] };
+    payload.workflows.forEach(function (w) {
+      (byCat[w.category] || (byCat[w.category] = [])).push(w);
+    });
+
+    ['dataset', 'training', 'context'].forEach(function (cat) {
+      var items = byCat[cat] || [];
+      if (items.length === 0) return;
+
+      var heading = document.createElement('h3');
+      heading.className = 'cockpit-panel__subhead';
+      heading.textContent = cat;
+      body.appendChild(heading);
+
+      var table = document.createElement('table');
+      table.className = 'cockpit-table';
+      var thead = document.createElement('thead');
+      var thr = document.createElement('tr');
+      ['Workflow', 'Status', 'When', ''].forEach(function (h) {
+        var th = document.createElement('th');
+        th.textContent = h;
+        thr.appendChild(th);
+      });
+      thead.appendChild(thr);
+      table.appendChild(thead);
+
+      var tbody = document.createElement('tbody');
+      items.forEach(function (w) {
+        var tr = document.createElement('tr');
+
+        var tdLabel = document.createElement('td');
+        tdLabel.textContent = w.label;
+        var lbl = document.createElement('div');
+        lbl.className = 'cockpit-table__sub';
+        lbl.textContent = w.id;
+        tdLabel.appendChild(lbl);
+        tr.appendChild(tdLabel);
+
+        var tdStatus = document.createElement('td');
+        var pill = document.createElement('span');
+        pill.className = conclusionClass(w.conclusion, w.status);
+        pill.textContent = w.error
+          ? 'error'
+          : conclusionLabel(w.conclusion, w.status);
+        tdStatus.appendChild(pill);
+        tr.appendChild(tdStatus);
+
+        var tdWhen = document.createElement('td');
+        tdWhen.textContent = fmtRel(w.created_at);
+        tr.appendChild(tdWhen);
+
+        var tdLink = document.createElement('td');
+        if (w.html_url) {
+          var a = document.createElement('a');
+          a.href = w.html_url;
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          a.textContent = 'open';
+          tdLink.appendChild(a);
+        } else {
+          tdLink.textContent = '—';
+        }
+        tr.appendChild(tdLink);
+
+        tbody.appendChild(tr);
+      });
+      table.appendChild(tbody);
+      body.appendChild(table);
+    });
+  }
+
+  function renderTrainingError(err) {
+    var body = document.getElementById('panel-training-body');
+    if (!body) return;
+    body.innerHTML = '';
+    var p = document.createElement('p');
+    p.className = 'cockpit-panel__hint cockpit-panel__hint--bad';
+    p.textContent = 'Failed to load: ' + (err && err.message ? err.message : err);
+    body.appendChild(p);
+  }
+
+  async function refresh() {
+    var meta = document.getElementById('cockpit-last-update');
+    try {
+      var data = await fetchJSON(API_BASE + '/admin/cockpit/training-status');
+      renderTrainingPanel(data);
+      if (meta) meta.textContent = 'updated ' + new Date().toLocaleTimeString();
+    } catch (err) {
+      renderTrainingError(err);
+      if (meta) meta.textContent = 'load failed';
+    }
+  }
+
+  function init() {
+    var btn = document.getElementById('cockpit-refresh');
+    if (btn) btn.addEventListener('click', function () { refresh(); });
+    refresh();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -332,6 +332,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // Phase D (DEV-COMHU voice budget watch): admin observability for the Vertex
   // system_instruction budget. See services/voice-budget-watch.ts.
   const voiceBudgetWatchRouter = require('./routes/voice-budget-watch').default;
+  // Phase 1 W3-D1 PR 5 (VTID-03247): Intelligence Cockpit spine — backs the
+  // single-page Command Hub cockpit at /command-hub/intelligence-cockpit.html.
+  // Read-only; one live panel (training+dataset workflow status); rest are
+  // placeholders pointing at planned follow-up endpoints.
+  const adminCockpitRouter = require('./routes/admin-cockpit').default;
   const usersVitanaIdRouter = require('./routes/users-vitana-id').default;
   // VTID-01973: Vitana Intent Engine (P2-A). Voice-dictated intent registry +
   // kind-aware matcher. Behind FEATURE_INTENT_ENGINE_A — disabled by default.
@@ -1044,6 +1049,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // Phase 0 staging build (P0.3): /admin/health + /admin/build-info — auth-free
   // env-identity probes used by the STAGE-DEPLOY smoke and isolation checks.
   mountRouterSync(app, '/api/v1/admin', adminHealthRouter, { owner: 'admin-health' });
+  // Phase 1 W3-D1 PR 5 (VTID-03247): Intelligence Cockpit spine endpoint.
+  // Mounted at /api/v1/admin/cockpit so route paths read naturally
+  // (/training-status, /context-quality, etc. in follow-ups).
+  mountRouterSync(app, '/api/v1/admin/cockpit', adminCockpitRouter, { owner: 'admin-cockpit' });
 
   // VTID-01973: Vitana Intent Engine (P2-A) — gated by FEATURE_INTENT_ENGINE_A.
   if (intentsRouter) mountRouterSync(app, '/api/v1/intents', intentsRouter, { owner: 'intents' });

--- a/services/gateway/src/routes/admin-cockpit.ts
+++ b/services/gateway/src/routes/admin-cockpit.ts
@@ -1,0 +1,121 @@
+/**
+ * Intelligence Cockpit spine — Phase 1 W3-D1 PR 5 (VTID-03247).
+ *
+ * Read-only admin endpoint that backs the single-page Intelligence
+ * Cockpit at /command-hub/intelligence-cockpit.html. Pulls the most
+ * recent runs of the cron workflows that drive Phase 1 W3 (dataset
+ * extraction, trainer submission, context source inventory, context
+ * quality score, etc.) so the operator can see, on one page, whether
+ * the assistant intelligence loop's input pipeline is healthy.
+ *
+ * GET /api/v1/admin/cockpit/training-status
+ *   → { ok, generated_at, workflows: WorkflowRunSummary[] }
+ *
+ * No mutation. No production behavior change. requireAdminAuth.
+ *
+ * Follow-up PRs will add:
+ *   - GET /api/v1/admin/cockpit/context-quality       (consumes PR 2 artifact)
+ *   - GET /api/v1/admin/cockpit/role-registry-shadow  (consumes PR 4 emits)
+ *   - GET /api/v1/admin/cockpit/self-healing          (consumes self-heal feed)
+ * Each panel on the cockpit page already has a placeholder pointing at
+ * the planned endpoint id.
+ */
+
+import { Router, Request, Response } from 'express';
+import { requireAdminAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getWorkflowRuns } from '../services/github-service';
+
+const router = Router();
+
+const REPO = 'exafyltd/vitana-platform';
+
+interface WorkflowDescriptor {
+  id: string;         // workflow file name (e.g. 'CRON-FINETUNE-TRAINER.yml')
+  label: string;
+  category: 'dataset' | 'training' | 'context';
+}
+
+const WORKFLOWS: WorkflowDescriptor[] = [
+  { id: 'CRON-DATASET-EXTRACTION.yml',       label: 'Consented dataset extraction', category: 'dataset' },
+  { id: 'CRON-FINETUNE-TRAINER.yml',         label: 'Vertex trainer submission',    category: 'training' },
+  { id: 'DESCRIBE-VERTEX-CUSTOMJOB.yml',     label: 'Vertex CustomJob describe',    category: 'training' },
+  { id: 'CRON-CONTEXT-SOURCE-INVENTORY.yml', label: 'Context source inventory',     category: 'context' },
+  { id: 'CRON-CONTEXT-QUALITY-SCORE.yml',    label: 'Context quality score',        category: 'context' },
+];
+
+interface WorkflowRunSummary {
+  id: string;
+  label: string;
+  category: WorkflowDescriptor['category'];
+  available: boolean;
+  latest_run_id: number | null;
+  status: string | null;
+  conclusion: string | null;
+  created_at: string | null;
+  html_url: string | null;
+  error: string | null;
+}
+
+async function fetchWorkflowSummary(wf: WorkflowDescriptor): Promise<WorkflowRunSummary> {
+  try {
+    const runs = await getWorkflowRuns(REPO, wf.id);
+    const latest = runs.workflow_runs?.[0];
+    if (!latest) {
+      return {
+        id: wf.id,
+        label: wf.label,
+        category: wf.category,
+        available: true,
+        latest_run_id: null,
+        status: null,
+        conclusion: null,
+        created_at: null,
+        html_url: null,
+        error: 'no_runs_yet',
+      };
+    }
+    return {
+      id: wf.id,
+      label: wf.label,
+      category: wf.category,
+      available: true,
+      latest_run_id: latest.id,
+      status: latest.status,
+      conclusion: latest.conclusion,
+      created_at: latest.created_at,
+      html_url: latest.html_url,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      id: wf.id,
+      label: wf.label,
+      category: wf.category,
+      available: false,
+      latest_run_id: null,
+      status: null,
+      conclusion: null,
+      created_at: null,
+      html_url: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+router.get('/training-status', requireAdminAuth, async (req: Request, res: Response) => {
+  const _auth = req as AuthenticatedRequest; // requireAdminAuth has validated identity
+  void _auth;
+  try {
+    const workflows = await Promise.all(WORKFLOWS.map(fetchWorkflowSummary));
+    return res.json({
+      ok: true,
+      generated_at: new Date().toISOString(),
+      workflows,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return res.status(500).json({ ok: false, error: 'training_status_failed', message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
Phase 1 W3-D1 PR 5 of 6. Single-page cockpit at /command-hub/intelligence-cockpit.html. 1 LIVE panel (training+dataset pipeline) wired to GitHub Actions API via existing github-service; 3 PLACEHOLDER panels pointing at planned follow-up endpoints (context-quality consumes PR 2 artifact, role-registry-shadow consumes PR 4 OASIS stream, self-healing TBD). Backend: read-only GET /api/v1/admin/cockpit/training-status. Frontend: vanilla JS, CSP-compliant, localStorage admin bearer (mirrors voice-budget pattern). Mounted under /api/v1/admin/cockpit with requireAdminAuth. `npm run build` green.