### PR TITLE
feat(orb): R1 slice 1 — canonical spoken-first-name resolver (VTID-03248)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -77,6 +77,8 @@ import {
   logWakeDecisionSnapshot,
   type FirstNameSource,
 } from '../instruction/wake-decision-snapshot';
+// VTID-03248 (R1 slice 1): single canonical spoken-first-name resolver.
+import { resolveSpokenFirstName } from '../../../services/awareness-unified-context';
 import { recordAgentHeartbeat } from '../../../routes/agents-registry';
 import {
   fetchAdminBriefingBlock,
@@ -1082,35 +1084,26 @@ export async function handleLiveSessionStart(
       if (cadenceResult.status === 'fulfilled') {
         cadenceSignals = cadenceResult.value;
       }
-      let fullName = '';
-      let fullNameSource: FirstNameSource = 'none';
-      if (factResult.status === 'fulfilled' && factResult.value && !factResult.value.error) {
-        const v = (factResult.value.data as { fact_value?: string | null } | null)?.fact_value;
-        if (typeof v === 'string' && v.trim().length > 0) {
-          fullName = v.trim();
-          fullNameSource = 'memory_facts';
-        }
-      }
-      if (!fullName && profileResult.status === 'fulfilled' && profileResult.value && !profileResult.value.error) {
-        const v = (profileResult.value.data as { display_name?: string | null } | null)?.display_name;
-        if (typeof v === 'string' && v.trim().length > 0) {
-          fullName = v.trim();
-          fullNameSource = 'app_users';
-        }
-      }
-      if (fullName) {
-        firstName = fullName.split(/\s+/)[0] || null;
-        firstNameSource = firstName ? fullNameSource : 'none';
-      } else if (orbIdentity.email && orbIdentity.email.includes('@')) {
-        // Last-resort: take the email local part. Strip digits / underscores
-        // so "dragan1" → "dragan", "d_stevanovic" → "stevanovic" (best effort).
-        const local = orbIdentity.email.split('@')[0] || '';
-        const stripped = local.replace(/[0-9_.+\-]+/g, '').trim();
-        if (stripped.length >= 2) {
-          firstName = stripped[0].toUpperCase() + stripped.slice(1);
-          firstNameSource = 'email';
-        }
-      }
+      // VTID-03248 (R1 slice 1): resolve the spoken first name through the
+      // single canonical resolver. Behavior-identical to the previous inline
+      // logic (memory_facts → app_users → email local-part), now shared so
+      // LiveKit + every other call site resolve the SAME name with the SAME
+      // precedence (the audit found this field diverging 3-4× per session).
+      const factValue =
+        factResult.status === 'fulfilled' && factResult.value && !factResult.value.error
+          ? (factResult.value.data as { fact_value?: string | null } | null)?.fact_value ?? null
+          : null;
+      const profileValue =
+        profileResult.status === 'fulfilled' && profileResult.value && !profileResult.value.error
+          ? (profileResult.value.data as { display_name?: string | null } | null)?.display_name ?? null
+          : null;
+      const resolvedName = resolveSpokenFirstName({
+        memoryFactUserName: factValue,
+        displayName: profileValue,
+        email: orbIdentity.email ?? null,
+      });
+      firstName = resolvedName.firstName;
+      firstNameSource = resolvedName.source;
     }
     wakeBriefDecision = await decideWakeBriefForSession({
       sessionId,

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -41,10 +41,9 @@ import { getSupabase } from '../lib/supabase';
 // VTID-03210: single structured turn-1 wake-decision snapshot — emitted
 // identically on Vertex (live-session-controller) and here on LiveKit so
 // the turn-1 state machine is observable across both transports.
-import {
-  logWakeDecisionSnapshot,
-  type FirstNameSource,
-} from '../orb/live/instruction/wake-decision-snapshot';
+import { logWakeDecisionSnapshot } from '../orb/live/instruction/wake-decision-snapshot';
+// VTID-03248 (R1 slice 1): single canonical spoken-first-name resolver.
+import { resolveSpokenFirstName } from '../services/awareness-unified-context';
 // VTID-02855: reuse Vertex's geo-IP + UA-parse + format helpers so the
 // LiveKit bootstrap injects the same ENVIRONMENT CONTEXT block (city,
 // country, timezone, localTime, UTC, device) that Vertex's authenticated
@@ -1346,19 +1345,17 @@ router.get(
       ctxParts.push(historyContextPack.contextInstruction);
     }
 
-    // Extract first name from display_name OR memory_facts.user_name fact.
-    // app_users.display_name commonly stores the full name ("Dragan Alexander"),
-    // but the agent should address the user by their first name only.
+    // VTID-03248 (R1 slice 1): resolve the spoken first name through the SAME
+    // canonical resolver as the Vertex path so both transports use identical
+    // precedence (memory_facts → app_users → email). Gains the email
+    // last-resort the inline logic lacked. first_name_source stays comparable
+    // across transports for the wake-decision snapshot (VTID-03210).
     const userNameFact = identityFacts.find((f) => f.fact_key === 'user_name');
-    const fullName = (userNameFact?.fact_value || displayName || '').trim();
-    const firstName = fullName ? fullName.split(/\s+/)[0] : null;
-    // VTID-03210: label the source the same way the Vertex path does so the
-    // wake-decision snapshot's first_name.source is comparable across both.
-    const firstNameSource: FirstNameSource = !firstName
-      ? 'none'
-      : (userNameFact?.fact_value || '').trim()
-        ? 'memory_facts'
-        : 'app_users';
+    const { firstName, source: firstNameSource } = resolveSpokenFirstName({
+      memoryFactUserName: userNameFact?.fact_value ?? null,
+      displayName,
+      email: (req.identity as { email?: string | null } | undefined)?.email ?? null,
+    });
 
     // VTID-02855: ENVIRONMENT CONTEXT — geo-IP + UA + local time, mirrors
     // Vertex's orb-live.ts:14026 path. The fetch itself was moved INTO

--- a/services/gateway/src/services/awareness-unified-context.ts
+++ b/services/gateway/src/services/awareness-unified-context.ts
@@ -1,0 +1,104 @@
+/**
+ * VTID-03248 (R1, slice 1) — unified awareness context: foundation.
+ *
+ * The 2026-05-31 audit found ORB user-state is SCATTERED: a single session
+ * fans out into 4+ independent fetches (firstName, decision spine, journey
+ * greeting w/ its own app_users read, bootstrap pack), and the SAME field is
+ * resolved multiple times with DIVERGENT precedence — most visibly the user's
+ * first name (resolved 3-4× across Vertex + LiveKit with different source
+ * order), so different prompt blocks of one session can use different names.
+ *
+ * R1's endpoint is ONE `buildAwarenessContext(...)` that every provider +
+ * prompt assembler reads from. This file is the foundation. Slice 1 lands the
+ * type + the single CANONICAL first-name resolver and migrates the two
+ * already-aligned "spoken name" call sites to it (zero/▲tiny behavior change);
+ * later slices fold in journey / life_compass / vitana_index / cadence and
+ * migrate the remaining consumers, collapsing the duplicate fetches.
+ *
+ * Pure functions only here — no IO — so each transport keeps doing its own
+ * fetch (for now) and passes the raw values in; the PRECEDENCE (the actual
+ * drift) is unified in one tested place.
+ */
+
+/** Which source resolved the first name. Canonical precedence order below. */
+export type FirstNameSource = 'memory_facts' | 'app_users' | 'email' | 'none';
+
+export interface ResolveSpokenFirstNameInput {
+  /** memory_facts.user_name — the name the user told the assistant (Cognee). */
+  memoryFactUserName?: string | null;
+  /** app_users.display_name — provisioned at signup. */
+  displayName?: string | null;
+  /** JWT email — deterministic last resort. */
+  email?: string | null;
+}
+
+export interface ResolvedFirstName {
+  firstName: string | null;
+  source: FirstNameSource;
+}
+
+/**
+ * The ONE canonical spoken-first-name resolver. Precedence:
+ *   1. memory_facts.user_name  (what the user told us)
+ *   2. app_users.display_name  (signup)
+ *   3. email local-part        (digits/underscores stripped, capitalized)
+ *
+ * Reproduces the existing Vertex (live-session-controller) logic exactly so
+ * migrating that call site is a no-op; LiveKit's spoken-name site gains the
+ * email last-resort it lacked (a deliberate, minor improvement toward parity).
+ * Pure — safe to unit-test exhaustively.
+ */
+export function resolveSpokenFirstName(
+  input: ResolveSpokenFirstNameInput,
+): ResolvedFirstName {
+  let fullName = '';
+  let fullNameSource: FirstNameSource = 'none';
+
+  const fact = typeof input.memoryFactUserName === 'string' ? input.memoryFactUserName.trim() : '';
+  if (fact.length > 0) {
+    fullName = fact;
+    fullNameSource = 'memory_facts';
+  }
+
+  if (!fullName) {
+    const dn = typeof input.displayName === 'string' ? input.displayName.trim() : '';
+    if (dn.length > 0) {
+      fullName = dn;
+      fullNameSource = 'app_users';
+    }
+  }
+
+  if (fullName) {
+    const firstName = fullName.split(/\s+/)[0] || null;
+    return { firstName, source: firstName ? fullNameSource : 'none' };
+  }
+
+  const email = typeof input.email === 'string' ? input.email : '';
+  if (email && email.includes('@')) {
+    const local = email.split('@')[0] || '';
+    const stripped = local.replace(/[0-9_.+\-]+/g, '').trim();
+    if (stripped.length >= 2) {
+      return { firstName: stripped[0].toUpperCase() + stripped.slice(1), source: 'email' };
+    }
+  }
+
+  return { firstName: null, source: 'none' };
+}
+
+/**
+ * Target shape for the unified awareness context (populated incrementally by
+ * later R1 slices). Documented now so consumers + reviewers see the endpoint;
+ * slice 1 only exercises the identity.first_name path via resolveSpokenFirstName.
+ */
+export interface UnifiedAwarenessContext {
+  identity: {
+    user_id: string | null;
+    tenant_id: string | null;
+    first_name: string | null;
+    first_name_source: FirstNameSource;
+    display_name: string | null;
+    vitana_id: string | null;
+  };
+  // R1 later slices: surface, locale, time, journey, life_compass,
+  // vitana_index, pillar_momentum, cadence, signals, teacher, bootstrap_pack.
+}

--- a/services/gateway/test/services/awareness-unified-context.test.ts
+++ b/services/gateway/test/services/awareness-unified-context.test.ts
@@ -1,0 +1,78 @@
+/**
+ * VTID-03248 (R1 slice 1) — canonical spoken-first-name resolver tests.
+ *
+ * Locks the single precedence (memory_facts → app_users → email) that both
+ * the Vertex and LiveKit spoken-name sites now share, and proves it
+ * reproduces the prior Vertex inline logic (so that migration is a no-op).
+ */
+
+import {
+  resolveSpokenFirstName,
+  type ResolvedFirstName,
+} from '../../src/services/awareness-unified-context';
+
+describe('resolveSpokenFirstName', () => {
+  it('1) prefers memory_facts.user_name and returns the first token', () => {
+    expect(
+      resolveSpokenFirstName({
+        memoryFactUserName: 'Dragan Alexander',
+        displayName: 'Someone Else',
+        email: 'x@y.com',
+      }),
+    ).toEqual<ResolvedFirstName>({ firstName: 'Dragan', source: 'memory_facts' });
+  });
+
+  it('2) falls back to app_users.display_name when no fact', () => {
+    expect(
+      resolveSpokenFirstName({ memoryFactUserName: null, displayName: 'Maria Rossi', email: 'x@y.com' }),
+    ).toEqual<ResolvedFirstName>({ firstName: 'Maria', source: 'app_users' });
+  });
+
+  it('3) falls back to the email local-part, digit/sep-stripped + capitalized (faithful to existing logic)', () => {
+    expect(
+      resolveSpokenFirstName({ memoryFactUserName: '', displayName: '', email: 'dragan1@example.com' }),
+    ).toEqual<ResolvedFirstName>({ firstName: 'Dragan', source: 'email' });
+    // NOTE: the strip regex removes the separator char, so "d_stevanovic"
+    // collapses to "Dstevanovic" (NOT "Stevanovic"). This reproduces the prior
+    // Vertex inline behavior exactly — improving email-derived name quality is
+    // a later, separate change, not this zero-behavior-change slice.
+    expect(
+      resolveSpokenFirstName({ email: 'd_stevanovic@hotmail.com' }),
+    ).toEqual<ResolvedFirstName>({ firstName: 'Dstevanovic', source: 'email' });
+  });
+
+  it('4) returns none when nothing usable', () => {
+    expect(resolveSpokenFirstName({})).toEqual<ResolvedFirstName>({ firstName: null, source: 'none' });
+    expect(
+      resolveSpokenFirstName({ memoryFactUserName: '   ', displayName: '   ', email: '' }),
+    ).toEqual<ResolvedFirstName>({ firstName: null, source: 'none' });
+  });
+
+  it('5) does not derive from an email local-part shorter than 2 chars after stripping', () => {
+    expect(
+      resolveSpokenFirstName({ email: '1@example.com' }),
+    ).toEqual<ResolvedFirstName>({ firstName: null, source: 'none' });
+  });
+
+  it('6) trims surrounding whitespace before tokenizing', () => {
+    expect(
+      resolveSpokenFirstName({ memoryFactUserName: '  Dragan  ' }),
+    ).toEqual<ResolvedFirstName>({ firstName: 'Dragan', source: 'memory_facts' });
+  });
+
+  it('7) email fallback only triggers on a real address (must contain @)', () => {
+    expect(resolveSpokenFirstName({ email: 'not-an-email' })).toEqual<ResolvedFirstName>({
+      firstName: null,
+      source: 'none',
+    });
+  });
+
+  it('8) reproduces the prior Vertex inline behavior across the precedence chain', () => {
+    // memory_facts present → memory_facts
+    expect(resolveSpokenFirstName({ memoryFactUserName: 'Ana', displayName: 'B', email: 'c1@d.com' }).source).toBe('memory_facts');
+    // only display → app_users
+    expect(resolveSpokenFirstName({ displayName: 'Ben Stiller', email: 'c1@d.com' }).source).toBe('app_users');
+    // only email → email
+    expect(resolveSpokenFirstName({ email: 'carol2@d.com' })).toEqual<ResolvedFirstName>({ firstName: 'Carol', source: 'email' });
+  });
+});


### PR DESCRIPTION
## What
First slice of **R1 — unify the awareness layer** (the reconciliation plan's foundational fix). The 2026-05-31 audit found ORB user-state scattered across 4+ per-session fetches, with the SAME field resolved multiple times under DIVERGENT precedence — most visibly the user's **first name** (resolved 3-4× across Vertex + LiveKit with different source order), so different prompt blocks of one session could call the user different names.

## This slice (foundation + first consolidation)
- New `services/awareness-unified-context.ts`: the single canonical `resolveSpokenFirstName` (precedence: memory_facts.user_name → app_users.display_name → email local-part) + the `UnifiedAwarenessContext` target type (populated by later slices). Pure, no IO.
- **Vertex** (`live-session-controller`) migrated → behavior-identical (reproduces the prior inline logic exactly).
- **LiveKit** (`orb-livekit` spoken-name site) migrated → now uses the SAME precedence as Vertex and gains the email last-resort it previously lacked (a deliberate, minor parity improvement). Removes the duplicated inline logic.

## Why incremental
Pure resolver; both transports share one tested precedence. Later slices fold journey / life_compass / vitana_index / cadence into the builder and migrate the remaining consumers — proven slice-by-slice rather than a big-bang rewrite of the just-stabilized voice path.

## Parity (Vertex + LiveKit)
Both transports now resolve the spoken name through the same function. (LiveKit's separate prompt-identity line at orb-livekit:1244 still uses the reversed app_users-first order — left for a documented later slice.)

## Tests
8 resolver unit tests + 110 session + wake-decision-snapshot + livekit-context-parity tests green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)