### PR TITLE
feat(wallet): spend + earning RPCs for cart / marketplace contract (VTID-03249)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -318,6 +318,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // VTID-03201: Stripe-funded wallet deposits (EUR + USD fiat ledger, ships in parallel with Billing v1)
   const walletRouter = require('./routes/wallet').default;
   const walletStripeWebhookRouter = require('./routes/wallet-stripe-webhook').default;
+  // VTID-03249: Wallet spend + earning admin endpoints (cart / marketplace integration contract)
+  const walletAdminRouter = require('./routes/wallet-admin').default;
   // Notification System — FCM push + in-app notification history
   const notificationsRouter = require('./routes/notifications').default;
   // Chat — User-to-user direct messaging
@@ -1026,6 +1028,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/stripe', walletStripeWebhookRouter, { owner: 'wallet-stripe-webhook' });
   // VTID-03201: Wallet user-facing routes (EUR + USD fiat). Path-scoped requireAuth inside router.
   mountRouterSync(app, '/api/v1', walletRouter, { owner: 'wallet' });
+  // VTID-03249: Wallet admin spend/credit routes (cart / marketplace integration).
+  // Path-scoped requireAuth + requireExafyAdmin inside router.
+  mountRouterSync(app, '/api/v1', walletAdminRouter, { owner: 'wallet-admin' });
 
   // Notification System — FCM push notifications + in-app history
   mountRouterSync(app, '/api/v1/notifications', notificationsRouter, { owner: 'notifications' });

--- a/services/gateway/src/routes/wallet-admin.ts
+++ b/services/gateway/src/routes/wallet-admin.ts
@@ -1,0 +1,152 @@
+/**
+ * Wallet admin routes — VTID-03249
+ *
+ * Internal money-movement endpoints called by the cart and Vitanaland
+ * Marketplace services, and by ops tooling. Behind requireExafyAdmin so
+ * only operator / service identities can hit them today; cart/marketplace
+ * services running in the same gateway codebase should prefer the in-process
+ * import path (services/wallet/spend-earning-service.ts) instead of HTTP.
+ *
+ * These do NOT replace the user-facing /api/v1/wallet/* routes (balance,
+ * transactions, deposits). Those stay user-JWT-only. These admin routes are
+ * for "the system spends/credits on behalf of a transaction".
+ */
+
+import { Router, Response } from 'express';
+import {
+  requireAuth,
+  requireExafyAdmin,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import {
+  debitWalletForSpend,
+  creditWalletForEarning,
+  type SpendEarningReferenceType,
+} from '../services/wallet/spend-earning-service';
+import { isWalletCurrency } from '../types/wallet';
+
+const router = Router();
+
+// Path-scoped auth (mirrors admin-embeddings-backfill.ts, VTID-02032 lesson).
+router.use('/wallet/admin', requireAuth, requireExafyAdmin);
+
+const ALLOWED_REFERENCE_TYPES: ReadonlySet<string> = new Set<SpendEarningReferenceType>([
+  'cart_checkout',
+  'marketplace_order',
+  'marketplace_earning',
+  'live_room_tip',
+  'manual',
+]);
+
+interface AdminMovementBody {
+  account_id?: unknown;
+  amount_minor?: unknown;
+  currency?: unknown;
+  reference_type?: unknown;
+  reference_id?: unknown;
+  description?: unknown;
+  metadata?: unknown;
+}
+
+function validateMovementBody(body: AdminMovementBody): { ok: true } | { ok: false; error: string; message?: string } {
+  if (typeof body.account_id !== 'string' || body.account_id.length === 0) {
+    return { ok: false, error: 'INVALID_ACCOUNT_ID' };
+  }
+  if (typeof body.amount_minor !== 'number' || !Number.isInteger(body.amount_minor) || body.amount_minor <= 0) {
+    return { ok: false, error: 'INVALID_AMOUNT' };
+  }
+  if (!isWalletCurrency(body.currency)) {
+    return { ok: false, error: 'INVALID_CURRENCY' };
+  }
+  if (typeof body.reference_type !== 'string' || !ALLOWED_REFERENCE_TYPES.has(body.reference_type)) {
+    return { ok: false, error: 'INVALID_REFERENCE_TYPE', message: `must be one of: ${Array.from(ALLOWED_REFERENCE_TYPES).join(', ')}` };
+  }
+  if (typeof body.reference_id !== 'string' || body.reference_id.length === 0) {
+    return { ok: false, error: 'INVALID_REFERENCE_ID' };
+  }
+  if (body.description !== undefined && typeof body.description !== 'string') {
+    return { ok: false, error: 'INVALID_DESCRIPTION' };
+  }
+  if (body.metadata !== undefined && (typeof body.metadata !== 'object' || body.metadata === null || Array.isArray(body.metadata))) {
+    return { ok: false, error: 'INVALID_METADATA' };
+  }
+  return { ok: true };
+}
+
+/**
+ * POST /api/v1/wallet/admin/spend
+ * Body: { account_id, amount_minor, currency, reference_type, reference_id, description?, metadata? }
+ */
+router.post('/wallet/admin/spend', async (req: AuthenticatedRequest, res: Response) => {
+  const body = (req.body ?? {}) as AdminMovementBody;
+  const validation = validateMovementBody(body);
+  if (!validation.ok) {
+    return res.status(400).json({ ok: false, error: validation.error, message: validation.message });
+  }
+
+  const result = await debitWalletForSpend({
+    account_id: body.account_id as string,
+    amount_minor: body.amount_minor as number,
+    currency: body.currency as 'EUR' | 'USD',
+    reference_type: body.reference_type as SpendEarningReferenceType,
+    reference_id: body.reference_id as string,
+    description: body.description as string | undefined,
+    metadata: body.metadata as Record<string, unknown> | undefined,
+  });
+
+  if (!result.ok) {
+    const status = httpStatusForMovementError(result.error);
+    return res.status(status).json(result);
+  }
+  return res.json(result);
+});
+
+/**
+ * POST /api/v1/wallet/admin/credit
+ * Body: same shape as /spend (typically reference_type='marketplace_earning')
+ */
+router.post('/wallet/admin/credit', async (req: AuthenticatedRequest, res: Response) => {
+  const body = (req.body ?? {}) as AdminMovementBody;
+  const validation = validateMovementBody(body);
+  if (!validation.ok) {
+    return res.status(400).json({ ok: false, error: validation.error, message: validation.message });
+  }
+
+  const result = await creditWalletForEarning({
+    account_id: body.account_id as string,
+    amount_minor: body.amount_minor as number,
+    currency: body.currency as 'EUR' | 'USD',
+    reference_type: body.reference_type as SpendEarningReferenceType,
+    reference_id: body.reference_id as string,
+    description: body.description as string | undefined,
+    metadata: body.metadata as Record<string, unknown> | undefined,
+  });
+
+  if (!result.ok) {
+    const status = httpStatusForMovementError(result.error);
+    return res.status(status).json(result);
+  }
+  return res.json(result);
+});
+
+function httpStatusForMovementError(code: string): number {
+  switch (code) {
+    case 'ACCOUNT_NOT_FOUND':
+      return 404;
+    case 'INSUFFICIENT_BALANCE':
+      return 409;
+    case 'ACCOUNT_NOT_ACTIVE':
+    case 'CURRENCY_MISMATCH':
+      return 409;
+    case 'INVALID_AMOUNT':
+    case 'INVALID_CURRENCY':
+    case 'INVALID_REFERENCE':
+      return 400;
+    case 'GATEWAY_MISCONFIGURED':
+    case 'RPC_FAILED':
+    default:
+      return 500;
+  }
+}
+
+export default router;

--- a/services/gateway/src/services/wallet/README.md
+++ b/services/gateway/src/services/wallet/README.md
@@ -1,6 +1,62 @@
-# Vitana Wallet — Stripe Deposits
+# Vitana Wallet — Stripe Deposits + Spend / Earning
 
-VTID-03200 (schema) + VTID-03201 (gateway). Multi-currency (EUR primary, USD allowed). Stripe Checkout is the only money-in rail. The internal `wallet_ledger_entries` table is the source of truth; `wallet_accounts.balance_minor` is a cached projection.
+VTID-03200 (schema) + VTID-03201 (gateway) + **VTID-03249 (spend + earning RPCs)**. Multi-currency (EUR primary, USD allowed). Stripe Checkout is the money-in rail; cart and Vitanaland Marketplace are the money-out and money-back-in rails respectively. The internal `wallet_ledger_entries` table is the source of truth; `wallet_accounts.balance_minor` is a cached projection.
+
+## Cart / Marketplace integration contract (VTID-03249)
+
+Cart and marketplace services in this gateway codebase should **import the service module directly** instead of going over HTTP:
+
+```ts
+import {
+  debitWalletForSpend,
+  creditWalletForEarning,
+} from '../services/wallet/spend-earning-service';
+
+// buyer-side cart checkout
+const result = await debitWalletForSpend({
+  account_id: buyerAccountId,
+  amount_minor: 2500,
+  currency: 'EUR',
+  reference_type: 'cart_checkout',  // or 'marketplace_order' for marketplace
+  reference_id: orderId,             // YOUR business id — drives idempotency
+  description: 'Cart checkout #42',
+  metadata: { items: cartLineCount },
+});
+if (!result.ok) {
+  // 'INSUFFICIENT_BALANCE' → redirect user to top-up flow
+  // 'CURRENCY_MISMATCH'    → present in the user's account currency
+  // 'ACCOUNT_NOT_FOUND'    → wallet not provisioned yet (very rare; trigger missed)
+  // 'ACCOUNT_NOT_ACTIVE'   → wallet frozen — do not retry
+  return handle(result);
+}
+// result.balance_minor is the new cached balance
+// result.duplicate=true means a previous call already wrote this entry; safe
+
+// seller-side marketplace earning
+const earning = await creditWalletForEarning({
+  account_id: sellerAccountId,
+  amount_minor: payoutAmountMinor,
+  currency: 'EUR',
+  reference_type: 'marketplace_earning',
+  reference_id: orderId,             // same reference_id as the buyer debit is fine
+  description: 'Sale #42 payout',
+});
+```
+
+The `(reference_type, reference_id, entry_type)` unique constraint on `wallet_ledger_entries` makes both functions idempotent — replay the same call and you get `duplicate: true` with the current balance, no double-write. The cart/marketplace teams pick `reference_id` (their own order ID); a single business event yields one debit + one credit even if either call retries.
+
+**Out-of-process callers** (services in other Cloud Run instances) hit the gateway:
+
+| Endpoint | Body | Auth |
+|---|---|---|
+| `POST /api/v1/wallet/admin/spend` | `{account_id, amount_minor, currency, reference_type, reference_id, description?, metadata?}` | `requireExafyAdmin` |
+| `POST /api/v1/wallet/admin/credit` | same shape | `requireExafyAdmin` |
+
+HTTP status codes mirror the service: `400` invalid input, `404` ACCOUNT_NOT_FOUND, `409` INSUFFICIENT_BALANCE / CURRENCY_MISMATCH / ACCOUNT_NOT_ACTIVE, `500` GATEWAY_MISCONFIGURED / RPC_FAILED.
+
+### Allowed `reference_type` values
+
+`cart_checkout`, `marketplace_order`, `marketplace_earning`, `live_room_tip`, `manual`. New surfaces add their value to `SpendEarningReferenceType` + the `ALLOWED_REFERENCE_TYPES` set in `wallet-admin.ts` in the same PR.
 
 ## Architecture (one screen)
 

--- a/services/gateway/src/services/wallet/spend-earning-service.ts
+++ b/services/gateway/src/services/wallet/spend-earning-service.ts
@@ -1,0 +1,132 @@
+/**
+ * Wallet spend + earning service — VTID-03249
+ *
+ * The cart and Vitanaland Marketplace services call these functions when
+ * money moves through the wallet. Both wrap the same-named DB RPCs, which
+ * own the transactional integrity (SELECT FOR UPDATE → ledger insert →
+ * balance update) and idempotency.
+ *
+ * Callers in this codebase: import directly and use service-role supabase.
+ * Out-of-process callers: use the gateway routes at /api/v1/wallet/admin/*.
+ *
+ * Never INSERT into wallet_ledger_entries directly from a feature module.
+ * Always go through these helpers (or the RPCs) so the chokepoint stays
+ * single-sourced for audit, idempotency, and future invariants.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import type { WalletCurrency } from '../../types/wallet';
+
+export type SpendEarningReferenceType =
+  | 'cart_checkout'
+  | 'marketplace_order'
+  | 'marketplace_earning'
+  | 'live_room_tip'
+  | 'manual';
+
+export interface SpendInput {
+  account_id: string;
+  amount_minor: number;
+  currency: WalletCurrency;
+  reference_type: SpendEarningReferenceType;
+  reference_id: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EarningInput {
+  account_id: string;
+  amount_minor: number;
+  currency: WalletCurrency;
+  reference_type: SpendEarningReferenceType;
+  reference_id: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type WalletMovementErrorCode =
+  | 'INVALID_AMOUNT'
+  | 'INVALID_CURRENCY'
+  | 'INVALID_REFERENCE'
+  | 'ACCOUNT_NOT_FOUND'
+  | 'ACCOUNT_NOT_ACTIVE'
+  | 'CURRENCY_MISMATCH'
+  | 'INSUFFICIENT_BALANCE'
+  | 'GATEWAY_MISCONFIGURED'
+  | 'RPC_FAILED';
+
+export interface WalletMovementSuccess {
+  ok: true;
+  duplicate: boolean;
+  balance_minor: number;
+  currency: WalletCurrency;
+  ledger_entry_id?: string;
+}
+
+export interface WalletMovementError {
+  ok: false;
+  error: WalletMovementErrorCode;
+  message?: string;
+  // Additional context the RPC may return for specific errors:
+  balance_minor?: number;
+  required_minor?: number;
+  account_currency?: string;
+  requested_currency?: string;
+  status?: string;
+}
+
+export type WalletMovementResult = WalletMovementSuccess | WalletMovementError;
+
+export async function debitWalletForSpend(input: SpendInput): Promise<WalletMovementResult> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return { ok: false, error: 'GATEWAY_MISCONFIGURED', message: 'Supabase not configured' };
+  }
+
+  if (!Number.isSafeInteger(input.amount_minor) || input.amount_minor <= 0) {
+    return { ok: false, error: 'INVALID_AMOUNT' };
+  }
+
+  const { data, error } = await supabase.rpc('debit_wallet_for_spend', {
+    p_account_id: input.account_id,
+    p_amount_minor: input.amount_minor,
+    p_currency: input.currency,
+    p_reference_type: input.reference_type,
+    p_reference_id: input.reference_id,
+    p_description: input.description ?? null,
+    p_metadata: input.metadata ?? {},
+  });
+
+  if (error) {
+    console.error('[wallet/spend-earning] debit_wallet_for_spend RPC failed:', error.message);
+    return { ok: false, error: 'RPC_FAILED', message: error.message };
+  }
+  return data as WalletMovementResult;
+}
+
+export async function creditWalletForEarning(input: EarningInput): Promise<WalletMovementResult> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return { ok: false, error: 'GATEWAY_MISCONFIGURED', message: 'Supabase not configured' };
+  }
+
+  if (!Number.isSafeInteger(input.amount_minor) || input.amount_minor <= 0) {
+    return { ok: false, error: 'INVALID_AMOUNT' };
+  }
+
+  const { data, error } = await supabase.rpc('credit_wallet_for_earning', {
+    p_account_id: input.account_id,
+    p_amount_minor: input.amount_minor,
+    p_currency: input.currency,
+    p_reference_type: input.reference_type,
+    p_reference_id: input.reference_id,
+    p_description: input.description ?? null,
+    p_metadata: input.metadata ?? {},
+  });
+
+  if (error) {
+    console.error('[wallet/spend-earning] credit_wallet_for_earning RPC failed:', error.message);
+    return { ok: false, error: 'RPC_FAILED', message: error.message };
+  }
+  return data as WalletMovementResult;
+}

--- a/services/gateway/test/wallet-spend-earning.test.ts
+++ b/services/gateway/test/wallet-spend-earning.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Wallet spend + earning service — VTID-03249
+ *
+ * The RPC owns transactional correctness (SELECT FOR UPDATE, ledger insert,
+ * balance update). These tests verify the TS service:
+ *   1. Calls the right RPC with the right shape
+ *   2. Surfaces RPC error rows as ok:false objects
+ *   3. Rejects out-of-band invalid amounts BEFORE calling the RPC
+ *   4. Pass-through of the RPC's INSUFFICIENT_BALANCE / CURRENCY_MISMATCH /
+ *      ACCOUNT_NOT_FOUND error codes
+ *   5. duplicate=true reaches the caller intact (idempotent retry)
+ */
+
+const mockRpc = jest.fn();
+
+const mockSupabase = {
+  rpc: mockRpc,
+};
+
+jest.mock('../src/lib/supabase', () => ({
+  getSupabase: jest.fn(() => mockSupabase),
+}));
+
+import {
+  debitWalletForSpend,
+  creditWalletForEarning,
+} from '../src/services/wallet/spend-earning-service';
+
+const ACCOUNT_ID = '11111111-1111-1111-1111-111111111111';
+
+describe('wallet spend + earning service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('debitWalletForSpend', () => {
+    it('rejects non-integer amount without hitting the RPC', async () => {
+      const result = await debitWalletForSpend({
+        account_id: ACCOUNT_ID,
+        amount_minor: 1.5 as unknown as number,
+        currency: 'EUR',
+        reference_type: 'cart_checkout',
+        reference_id: 'order-1',
+      });
+      expect(result.ok).toBe(false);
+      expect((result as any).error).toBe('INVALID_AMOUNT');
+      expect(mockRpc).not.toHaveBeenCalled();
+    });
+
+    it('rejects zero / negative amount without hitting the RPC', async () => {
+      for (const amount of [0, -1, -1000]) {
+        const result = await debitWalletForSpend({
+          account_id: ACCOUNT_ID,
+          amount_minor: amount,
+          currency: 'EUR',
+          reference_type: 'cart_checkout',
+          reference_id: 'order-1',
+        });
+        expect(result.ok).toBe(false);
+        expect((result as any).error).toBe('INVALID_AMOUNT');
+      }
+      expect(mockRpc).not.toHaveBeenCalled();
+    });
+
+    it('calls debit_wallet_for_spend with the right RPC params', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: { ok: true, duplicate: false, balance_minor: 4500, currency: 'EUR', ledger_entry_id: 'le-1' },
+        error: null,
+      });
+      const result = await debitWalletForSpend({
+        account_id: ACCOUNT_ID,
+        amount_minor: 500,
+        currency: 'EUR',
+        reference_type: 'cart_checkout',
+        reference_id: 'cart-123',
+        description: 'Cart checkout #123',
+        metadata: { items: 3 },
+      });
+
+      expect(mockRpc).toHaveBeenCalledWith('debit_wallet_for_spend', {
+        p_account_id: ACCOUNT_ID,
+        p_amount_minor: 500,
+        p_currency: 'EUR',
+        p_reference_type: 'cart_checkout',
+        p_reference_id: 'cart-123',
+        p_description: 'Cart checkout #123',
+        p_metadata: { items: 3 },
+      });
+      expect(result.ok).toBe(true);
+      expect((result as any).balance_minor).toBe(4500);
+    });
+
+    it('surfaces INSUFFICIENT_BALANCE from the RPC', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: {
+          ok: false,
+          error: 'INSUFFICIENT_BALANCE',
+          balance_minor: 200,
+          required_minor: 500,
+          currency: 'EUR',
+        },
+        error: null,
+      });
+      const result = await debitWalletForSpend({
+        account_id: ACCOUNT_ID,
+        amount_minor: 500,
+        currency: 'EUR',
+        reference_type: 'cart_checkout',
+        reference_id: 'cart-456',
+      });
+      expect(result.ok).toBe(false);
+      expect((result as any).error).toBe('INSUFFICIENT_BALANCE');
+      expect((result as any).balance_minor).toBe(200);
+    });
+
+    it('passes duplicate=true through on idempotent retry', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: { ok: true, duplicate: true, balance_minor: 4500, currency: 'EUR' },
+        error: null,
+      });
+      const result = await debitWalletForSpend({
+        account_id: ACCOUNT_ID,
+        amount_minor: 500,
+        currency: 'EUR',
+        reference_type: 'cart_checkout',
+        reference_id: 'cart-789',
+      });
+      expect(result.ok).toBe(true);
+      expect((result as any).duplicate).toBe(true);
+      expect((result as any).balance_minor).toBe(4500);
+    });
+
+    it('returns RPC_FAILED on Supabase error', async () => {
+      mockRpc.mockResolvedValueOnce({ data: null, error: { message: 'connection refused' } });
+      const result = await debitWalletForSpend({
+        account_id: ACCOUNT_ID,
+        amount_minor: 500,
+        currency: 'EUR',
+        reference_type: 'cart_checkout',
+        reference_id: 'cart-fail',
+      });
+      expect(result.ok).toBe(false);
+      expect((result as any).error).toBe('RPC_FAILED');
+      expect((result as any).message).toContain('connection refused');
+    });
+  });
+
+  describe('creditWalletForEarning', () => {
+    it('calls credit_wallet_for_earning with the right RPC params', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: { ok: true, duplicate: false, balance_minor: 12000, currency: 'EUR', ledger_entry_id: 'le-2' },
+        error: null,
+      });
+      const result = await creditWalletForEarning({
+        account_id: ACCOUNT_ID,
+        amount_minor: 2500,
+        currency: 'EUR',
+        reference_type: 'marketplace_earning',
+        reference_id: 'sale-42',
+        description: 'Marketplace sale #42',
+      });
+      expect(mockRpc).toHaveBeenCalledWith('credit_wallet_for_earning', expect.objectContaining({
+        p_account_id: ACCOUNT_ID,
+        p_amount_minor: 2500,
+        p_currency: 'EUR',
+        p_reference_type: 'marketplace_earning',
+        p_reference_id: 'sale-42',
+      }));
+      expect(result.ok).toBe(true);
+      expect((result as any).balance_minor).toBe(12000);
+    });
+
+    it('surfaces CURRENCY_MISMATCH', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: {
+          ok: false,
+          error: 'CURRENCY_MISMATCH',
+          account_currency: 'EUR',
+          requested_currency: 'USD',
+        },
+        error: null,
+      });
+      const result = await creditWalletForEarning({
+        account_id: ACCOUNT_ID,
+        amount_minor: 1000,
+        currency: 'USD',
+        reference_type: 'marketplace_earning',
+        reference_id: 'sale-mismatch',
+      });
+      expect(result.ok).toBe(false);
+      expect((result as any).error).toBe('CURRENCY_MISMATCH');
+    });
+
+    it('surfaces ACCOUNT_NOT_FOUND', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: { ok: false, error: 'ACCOUNT_NOT_FOUND' },
+        error: null,
+      });
+      const result = await creditWalletForEarning({
+        account_id: 'does-not-exist',
+        amount_minor: 1000,
+        currency: 'EUR',
+        reference_type: 'marketplace_earning',
+        reference_id: 'sale-x',
+      });
+      expect(result.ok).toBe(false);
+      expect((result as any).error).toBe('ACCOUNT_NOT_FOUND');
+    });
+
+    it('passes duplicate=true through on idempotent earning retry', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: { ok: true, duplicate: true, balance_minor: 12000, currency: 'EUR' },
+        error: null,
+      });
+      const result = await creditWalletForEarning({
+        account_id: ACCOUNT_ID,
+        amount_minor: 2500,
+        currency: 'EUR',
+        reference_type: 'marketplace_earning',
+        reference_id: 'sale-replay',
+      });
+      expect(result.ok).toBe(true);
+      expect((result as any).duplicate).toBe(true);
+    });
+  });
+});

--- a/supabase/migrations/20260601000000_VTID_03249_wallet_spend_earning.sql
+++ b/supabase/migrations/20260601000000_VTID_03249_wallet_spend_earning.sql
@@ -1,0 +1,236 @@
+/**
+ * Vitana Wallet — Spend + Earning RPCs (cart / marketplace contract)
+ *
+ * VTID: VTID-03249
+ *
+ * Adds the two backend chokepoints the universal cart + Vitanaland Marketplace
+ * services call when money moves through the wallet:
+ *
+ *   debit_wallet_for_spend  — buyer pays for cart checkout or marketplace order
+ *   credit_wallet_for_earning — seller/creator receives marketplace earning
+ *
+ * Both follow the same transactional pattern as credit_deposit() (VTID-03200):
+ *   SELECT FOR UPDATE → ledger insert (UNIQUE makes it idempotent) → balance
+ *   update → return jsonb. Single transaction, fails atomically on any step.
+ *
+ * Schema delta:
+ *   - wallet_ledger_entries.entry_type CHECK gains 'earning_credit'
+ *
+ * Currency: passed in by caller; must match the account's currency or RPC
+ * returns CURRENCY_MISMATCH (no implicit FX).
+ *
+ * Idempotency: caller picks reference_type + reference_id (e.g. cart_order_id,
+ * marketplace_order_id). Same (reference_type, reference_id, entry_type) → no
+ * duplicate write — caller is told duplicate:true with the current balance so
+ * retries are safe.
+ */
+
+-- ============================================================================
+-- 1. Expand entry_type to include 'earning_credit'
+-- ============================================================================
+-- Postgres can't ALTER a CHECK constraint in place; drop + recreate.
+ALTER TABLE public.wallet_ledger_entries
+  DROP CONSTRAINT IF EXISTS wallet_ledger_entries_entry_type_check;
+
+ALTER TABLE public.wallet_ledger_entries
+  ADD CONSTRAINT wallet_ledger_entries_entry_type_check
+  CHECK (entry_type IN (
+    'deposit_completed',
+    'service_spend',
+    'earning_credit',
+    'manual_adjustment',
+    'refund_debit'
+  ));
+
+-- ============================================================================
+-- 2. RPC: debit_wallet_for_spend — cart checkout, marketplace purchase
+-- ============================================================================
+CREATE OR REPLACE FUNCTION debit_wallet_for_spend(
+  p_account_id     uuid,
+  p_amount_minor   bigint,
+  p_currency       text,
+  p_reference_type text,
+  p_reference_id   text,
+  p_description    text DEFAULT NULL,
+  p_metadata       jsonb DEFAULT '{}'::jsonb
+) RETURNS jsonb AS $$
+DECLARE
+  v_account  wallet_accounts%ROWTYPE;
+  v_balance  bigint;
+  v_entry_id uuid;
+BEGIN
+  -- Input validation
+  IF p_amount_minor IS NULL OR p_amount_minor <= 0 THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'INVALID_AMOUNT');
+  END IF;
+  IF p_currency NOT IN ('EUR', 'USD') THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'INVALID_CURRENCY');
+  END IF;
+  IF p_reference_type IS NULL OR p_reference_id IS NULL
+     OR length(p_reference_type) = 0 OR length(p_reference_id) = 0 THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'INVALID_REFERENCE');
+  END IF;
+
+  -- Lock account row to serialize concurrent debits
+  SELECT * INTO v_account
+    FROM wallet_accounts
+    WHERE id = p_account_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'ACCOUNT_NOT_FOUND');
+  END IF;
+
+  IF v_account.status <> 'active' THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'ACCOUNT_NOT_ACTIVE', 'status', v_account.status);
+  END IF;
+
+  IF v_account.currency <> p_currency THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'error', 'CURRENCY_MISMATCH',
+      'account_currency', v_account.currency,
+      'requested_currency', p_currency
+    );
+  END IF;
+
+  -- Check sufficient balance BEFORE the UPDATE so we return a friendly error
+  -- rather than a CHECK-constraint violation surfacing as a generic SQL error.
+  IF v_account.balance_minor < p_amount_minor THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'error', 'INSUFFICIENT_BALANCE',
+      'balance_minor', v_account.balance_minor,
+      'required_minor', p_amount_minor,
+      'currency', v_account.currency
+    );
+  END IF;
+
+  -- Append ledger entry. UNIQUE(reference_type, reference_id, entry_type) is
+  -- the structural guard against double-debiting a single business event.
+  INSERT INTO wallet_ledger_entries (
+    account_id, user_id, entry_type, direction,
+    amount_minor, currency,
+    reference_type, reference_id, description, metadata
+  ) VALUES (
+    v_account.id, v_account.user_id, 'service_spend', 'debit',
+    p_amount_minor, v_account.currency,
+    p_reference_type, p_reference_id, p_description, COALESCE(p_metadata, '{}'::jsonb)
+  )
+  RETURNING id INTO v_entry_id;
+
+  -- Update cached balance
+  UPDATE wallet_accounts
+     SET balance_minor = balance_minor - p_amount_minor,
+         updated_at    = now()
+   WHERE id = v_account.id
+   RETURNING balance_minor INTO v_balance;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'duplicate', false,
+    'ledger_entry_id', v_entry_id,
+    'balance_minor', v_balance,
+    'currency', v_account.currency
+  );
+
+EXCEPTION WHEN unique_violation THEN
+  -- Replay of the same business event. Report current balance as success
+  -- so the caller's retry loop terminates cleanly.
+  SELECT balance_minor INTO v_balance
+    FROM wallet_accounts WHERE id = p_account_id;
+  RETURN jsonb_build_object(
+    'ok', true,
+    'duplicate', true,
+    'balance_minor', v_balance,
+    'currency', (SELECT currency FROM wallet_accounts WHERE id = p_account_id)
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================================
+-- 3. RPC: credit_wallet_for_earning — marketplace sale earning to seller
+-- ============================================================================
+CREATE OR REPLACE FUNCTION credit_wallet_for_earning(
+  p_account_id     uuid,
+  p_amount_minor   bigint,
+  p_currency       text,
+  p_reference_type text,
+  p_reference_id   text,
+  p_description    text DEFAULT NULL,
+  p_metadata       jsonb DEFAULT '{}'::jsonb
+) RETURNS jsonb AS $$
+DECLARE
+  v_account  wallet_accounts%ROWTYPE;
+  v_balance  bigint;
+  v_entry_id uuid;
+BEGIN
+  IF p_amount_minor IS NULL OR p_amount_minor <= 0 THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'INVALID_AMOUNT');
+  END IF;
+  IF p_currency NOT IN ('EUR', 'USD') THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'INVALID_CURRENCY');
+  END IF;
+  IF p_reference_type IS NULL OR p_reference_id IS NULL
+     OR length(p_reference_type) = 0 OR length(p_reference_id) = 0 THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'INVALID_REFERENCE');
+  END IF;
+
+  SELECT * INTO v_account
+    FROM wallet_accounts
+    WHERE id = p_account_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'ACCOUNT_NOT_FOUND');
+  END IF;
+
+  IF v_account.status <> 'active' THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'ACCOUNT_NOT_ACTIVE', 'status', v_account.status);
+  END IF;
+
+  IF v_account.currency <> p_currency THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'error', 'CURRENCY_MISMATCH',
+      'account_currency', v_account.currency,
+      'requested_currency', p_currency
+    );
+  END IF;
+
+  INSERT INTO wallet_ledger_entries (
+    account_id, user_id, entry_type, direction,
+    amount_minor, currency,
+    reference_type, reference_id, description, metadata
+  ) VALUES (
+    v_account.id, v_account.user_id, 'earning_credit', 'credit',
+    p_amount_minor, v_account.currency,
+    p_reference_type, p_reference_id, p_description, COALESCE(p_metadata, '{}'::jsonb)
+  )
+  RETURNING id INTO v_entry_id;
+
+  UPDATE wallet_accounts
+     SET balance_minor = balance_minor + p_amount_minor,
+         updated_at    = now()
+   WHERE id = v_account.id
+   RETURNING balance_minor INTO v_balance;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'duplicate', false,
+    'ledger_entry_id', v_entry_id,
+    'balance_minor', v_balance,
+    'currency', v_account.currency
+  );
+
+EXCEPTION WHEN unique_violation THEN
+  SELECT balance_minor INTO v_balance
+    FROM wallet_accounts WHERE id = p_account_id;
+  RETURN jsonb_build_object(
+    'ok', true,
+    'duplicate', true,
+    'balance_minor', v_balance,
+    'currency', (SELECT currency FROM wallet_accounts WHERE id = p_account_id)
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary

Follow-up to PR #2422 (VTID-03200+03201) that adds the two backend chokepoints the **universal cart** and **Vitanaland Marketplace** services will call when money moves through the wallet shipped previously. Both services need to debit buyer balances on checkout and credit seller balances on earnings — these are the contract.

### Schema (migration 20260601000000_VTID_03249_wallet_spend_earning.sql)
- ALTER `wallet_ledger_entries` entry_type CHECK to add `'earning_credit'`
- `debit_wallet_for_spend(account_id, amount_minor, currency, reference_type, reference_id, description, metadata)` RPC
- `credit_wallet_for_earning(...)` RPC (same signature)
- Both follow the same `SELECT FOR UPDATE -> ledger insert -> balance update` pattern as `credit_deposit()`, single transaction
- `UNIQUE(reference_type, reference_id, entry_type)` makes both idempotent: replay returns `duplicate:true` with current balance
- Debit RPC returns friendly `INSUFFICIENT_BALANCE` before the balance CHECK constraint would fire

### Service (`services/gateway/src/services/wallet/spend-earning-service.ts`)
In-process callers in this gateway codebase:
```ts
import { debitWalletForSpend, creditWalletForEarning } from '../services/wallet/spend-earning-service';

await debitWalletForSpend({ account_id, amount_minor: 2500, currency: 'EUR', reference_type: 'cart_checkout', reference_id: orderId });
await creditWalletForEarning({ account_id, amount_minor: 2200, currency: 'EUR', reference_type: 'marketplace_earning', reference_id: orderId });
```

### Routes (`services/gateway/src/routes/wallet-admin.ts`)
Out-of-process callers (other Cloud Run services):
- `POST /api/v1/wallet/admin/spend` — body shape matches the service input
- `POST /api/v1/wallet/admin/credit`
- Both behind `requireAuth + requireExafyAdmin`
- HTTP status mirrors RPC: 400 invalid input / 404 ACCOUNT_NOT_FOUND / 409 INSUFFICIENT_BALANCE | CURRENCY_MISMATCH | ACCOUNT_NOT_ACTIVE / 500 RPC_FAILED

### Allowed reference_type values
`cart_checkout`, `marketplace_order`, `marketplace_earning`, `live_room_tip`, `manual`. New surfaces add to `SpendEarningReferenceType` + `ALLOWED_REFERENCE_TYPES` in the same PR.

## Test plan

- [x] `npx tsc --noEmit` -> 0 errors
- [x] `npx jest test/wallet-*.test.ts` -> 27/27 passing (17 prior + 10 new)
  - Invalid amount rejected before RPC call (3 cases)
  - RPC called with correct param shape
  - `INSUFFICIENT_BALANCE` surfaced with balance + required values
  - `CURRENCY_MISMATCH` surfaced with account + requested currencies
  - `ACCOUNT_NOT_FOUND` surfaced
  - `duplicate=true` passes through on idempotent retry (both debit + credit)
  - `RPC_FAILED` surfaced on Supabase error
- [ ] **Live integration after deploy**: insert test deposit, call `/wallet/admin/spend` with `exafy_admin` JWT, verify ledger entry + balance change, replay -> `duplicate:true`
- [ ] **Live integration**: call `/wallet/admin/credit`, verify `earning_credit` entry created and balance moves
- [ ] **Reconciliation invariant**: `SUM(credits) - SUM(debits) = wallet_accounts.balance_minor` per account

## Deploy order (autonomous after merge)

1. `RUN-MIGRATION.yml` with `migration_file=supabase/migrations/20260601000000_VTID_03249_wallet_spend_earning.sql` (creates the two new RPCs)
2. `AUTO-DEPLOY` -> `EXEC-DEPLOY` (gateway code uses the new RPCs)
3. Live smoke: 401/403/JSON checks on both new admin routes

## VTID

VTID-03249 allocated via `POST /api/v1/vtid/allocate` -> ledger row `378b2367-b1bd-4f10-90b9-d084bb8bdb06`. EXEC-DEPLOY VTID gate satisfied.

Generated with [Claude Code](https://claude.com/claude-code)
