### PR TITLE
[FleetView] fix(orb): activate_recommendation reads pending_cta on bare "yes" (ORB-5 runtime follow-up)

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -2107,7 +2107,36 @@ export async function tool_activate_recommendation(
   id: OrbToolIdentity,
   sb: SupabaseClient,
 ): Promise<OrbToolResult> {
-  const recId = String(args.id ?? '').trim();
+  let recId = String(args.id ?? '').trim();
+  // DEV-COMHU-0505 (review follow-up): when the model calls this after a spoken
+  // "yes" it often has no id in context — the offer's id lives in the persisted
+  // pending CTA (written by wake-brief-wiring into orb_session_state). Fall back
+  // to it so the affirmative turn resolves deterministically instead of erroring
+  // with "id is required" (the "I have no access" symptom). Authed users only.
+  if (!recId && id.user_id) {
+    try {
+      const { readOrbSessionState, clearOrbSessionState } = await import('./orb/orb-session-state');
+      const pending = await readOrbSessionState<{ tool?: string; payload?: { id?: string } }>(
+        sb,
+        id.user_id,
+        'pending_cta',
+      );
+      const pendingId =
+        pending &&
+        pending.value &&
+        pending.value.tool === 'activate_recommendation' &&
+        typeof pending.value.payload?.id === 'string'
+          ? pending.value.payload.id.trim()
+          : '';
+      if (pendingId) {
+        recId = pendingId;
+        // Consume it so a later turn can't re-activate the same stale offer.
+        void clearOrbSessionState(sb, id.user_id, 'pending_cta').catch(() => {});
+      }
+    } catch {
+      // pending-CTA fallback is best-effort; fall through to the id check below.
+    }
+  }
   if (!recId) {
     return { ok: false, error: 'id is required' };
   }

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -2113,9 +2113,10 @@ export async function tool_activate_recommendation(
   // pending CTA (written by wake-brief-wiring into orb_session_state). Fall back
   // to it so the affirmative turn resolves deterministically instead of erroring
   // with "id is required" (the "I have no access" symptom). Authed users only.
+  let recIdFromPendingCta = false;
   if (!recId && id.user_id) {
     try {
-      const { readOrbSessionState, clearOrbSessionState } = await import('./orb/orb-session-state');
+      const { readOrbSessionState } = await import('./orb/orb-session-state');
       const pending = await readOrbSessionState<{ tool?: string; payload?: { id?: string } }>(
         sb,
         id.user_id,
@@ -2130,8 +2131,11 @@ export async function tool_activate_recommendation(
           : '';
       if (pendingId) {
         recId = pendingId;
-        // Consume it so a later turn can't re-activate the same stale offer.
-        void clearOrbSessionState(sb, id.user_id, 'pending_cta').catch(() => {});
+        recIdFromPendingCta = true;
+        // NOTE: do NOT consume the pending CTA here — only after activation
+        // actually succeeds (below). Clearing on read would drop the user's
+        // only recovery context if the fetch/update hits a transient error,
+        // turning a retryable "yes" into a permanent "id is required".
       }
     } catch {
       // pending-CTA fallback is best-effort; fall through to the id check below.
@@ -2183,6 +2187,15 @@ export async function tool_activate_recommendation(
         }).catch(() => {});
       })
       .catch(() => {});
+
+    // DEV-COMHU-0505 (review follow-up): consume the pending CTA ONLY now that
+    // activation has verified+succeeded, so a transient fetch/update error
+    // above leaves the row intact for the user's retry. Fire-and-forget.
+    if (recIdFromPendingCta && id.user_id) {
+      void import('./orb/orb-session-state')
+        .then(({ clearOrbSessionState }) => clearOrbSessionState(sb, id.user_id, 'pending_cta'))
+        .catch(() => {});
+    }
 
     const title = recRow.title ?? 'that recommendation';
     return {

--- a/services/gateway/test/voice-activate-recommendation-shared.test.ts
+++ b/services/gateway/test/voice-activate-recommendation-shared.test.ts
@@ -45,9 +45,34 @@ function makeStubSupabase(opts: {
   updateError?: { message: string } | null;
   fetchError?: { message: string } | null;
   updates: CapturedUpdate[];
+  // DEV-COMHU-0505: optional persisted pending CTA (orb_session_state row).
+  pendingCta?: { value: unknown; expires_at: string } | null;
+  pendingCtaDeletes?: string[];
 }) {
   return {
     from(table: string) {
+      if (table === 'orb_session_state') {
+        // Minimal chain used by readOrbSessionState / clearOrbSessionState:
+        //   .select(...).eq(user_id).eq(key).maybeSingle()
+        //   .delete().eq(user_id).eq(key)
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({ data: opts.pendingCta ?? null, error: null }),
+              }),
+            }),
+          }),
+          delete: () => ({
+            eq: () => ({
+              eq: async () => {
+                opts.pendingCtaDeletes?.push('pending_cta');
+                return { error: null };
+              },
+            }),
+          }),
+        } as unknown;
+      }
       if (table !== 'autopilot_recommendations') {
         return {} as never;
       }
@@ -222,6 +247,55 @@ describe('VTID-02975 — activate_recommendation lifted to shared dispatcher', (
       sb,
     );
 
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error).toBe('id is required');
+    }
+  });
+
+  // DEV-COMHU-0505 (review follow-up): "yes" with no id falls back to the
+  // persisted pending CTA so the affirmative turn resolves deterministically.
+  test('6b. empty id → resolves rec from persisted pending_cta + consumes it', async () => {
+    const updates: CapturedUpdate[] = [];
+    const pendingCtaDeletes: string[] = [];
+    const sb = makeStubSupabase({
+      updates,
+      pendingCtaDeletes,
+      recs: {
+        [REC_UUID_NEW]: {
+          id: REC_UUID_NEW,
+          title: 'Schedule a focus block',
+          summary: null,
+          status: 'new',
+          user_id: SENDER_UUID,
+        },
+      },
+      pendingCta: {
+        value: { tool: 'activate_recommendation', payload: { id: REC_UUID_NEW } },
+        expires_at: new Date(Date.now() + 5 * 60_000).toISOString(),
+      },
+    });
+
+    const result = await tool_activate_recommendation(
+      { id: '' }, // model said "yes" — no id in context
+      { user_id: SENDER_UUID, tenant_id: 'tenant-1', role: 'user', vitana_id: 'vit_send' },
+      sb,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({ recId: REC_UUID_NEW, patch: { status: 'activated' } });
+    // pending CTA consumed so it can't re-fire on a later turn.
+    expect(pendingCtaDeletes).toContain('pending_cta');
+  });
+
+  test('6c. empty id + no pending_cta → still "id is required"', async () => {
+    const sb = makeStubSupabase({ updates: [], recs: {}, pendingCta: null });
+    const result = await tool_activate_recommendation(
+      { id: '' },
+      { user_id: SENDER_UUID, tenant_id: 'tenant-1', role: 'user', vitana_id: 'vit_send' },
+      sb,
+    );
     expect(result.ok).toBe(false);
     if (result.ok === false) {
       expect(result.error).toBe('id is required');

--- a/services/gateway/test/voice-activate-recommendation-shared.test.ts
+++ b/services/gateway/test/voice-activate-recommendation-shared.test.ts
@@ -285,7 +285,10 @@ describe('VTID-02975 — activate_recommendation lifted to shared dispatcher', (
     expect(result.ok).toBe(true);
     expect(updates).toHaveLength(1);
     expect(updates[0]).toMatchObject({ recId: REC_UUID_NEW, patch: { status: 'activated' } });
-    // pending CTA consumed so it can't re-fire on a later turn.
+    // pending CTA consumed ONLY after activation succeeds — the clear is a
+    // fire-and-forget dynamic import on the success path, so let pending
+    // microtasks/timers drain before asserting the delete happened.
+    await new Promise((r) => setTimeout(r, 20));
     expect(pendingCtaDeletes).toContain('pending_cta');
   });
 


### PR DESCRIPTION
## Summary
Runtime follow-up to ORB Recovery 5 (#2438) — closes the **read side** Codex flagged. #2438 made the autopilot CTA *carry* `onYesTool` and persisted it to `orb_session_state` (`pending_cta`). This wires the **consumer**: when the model calls `activate_recommendation` after a spoken "yes" with no `id` in context, the tool now resolves the id from the persisted pending CTA instead of dead-ending on `"id is required"` (the "I have no access" symptom).

## What this PR ships
- `tool_activate_recommendation` (`orb-tools-shared.ts`): if `args.id` is empty and the user is authenticated, read `orb_session_state` key `pending_cta`; if it holds `{ tool: 'activate_recommendation', payload.id }`, use that id and **consume the row** (`clearOrbSessionState`) so a later turn can't re-activate a stale offer. Best-effort — any failure falls through to the existing `"id is required"` guard.
- Used by the shared dispatcher, so **both Vertex and the LiveKit tool wrapper** get it.

## Tests
- `voice-activate-recommendation-shared.test.ts`: +2 cases — (6b) empty id resolves the rec from `pending_cta` and consumes it; (6c) empty id + no `pending_cta` still returns `"id is required"`. Full suite **9/9**. typecheck + build green.

## Vertex parity ✓ / LiveKit parity ✓
Pure shared-dispatcher logic; no provider-specific path. The LiveKit agent reads `pending_cta` per `docs/patches/orb-agent/ORB-5-autopilot-cta.py`.

## Dependency
Reads `orb_session_state` (helper from #2435). **Requires the `orb_session_state` migration applied** to function; without it, `readOrbSessionState` returns null and behavior degrades to the prior `"id is required"` — no regression.

---
🤖 ORB Recovery 5 runtime follow-up. Sandbox cannot merge/deploy/run prod smokes — but this PR is pure code + unit-tested.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApimmhkZML398iKgkgVSPC)_