### PR TITLE
perf(orb): flag-gated lean system_instruction for Vertex first-connect (ship-dark)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -23,6 +23,7 @@
 import type { ClientContext } from '../types';
 import { getPersonalityConfigSync } from '../../../services/ai-personality-service';
 import { getAwarenessConfigSync } from '../../../services/awareness-registry';
+import { isFeatureLive } from '../../../services/feature-flags';
 import {
   getContent as getNavContent,
   lookupByRoute as lookupNavByRoute,
@@ -861,6 +862,23 @@ ${trimmedHistory}
   const wakeBriefOverrideActive =
     typeof bootstrapContext === 'string' &&
     bootstrapContext.includes('<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>');
+  // ORB-CONVERSATION-LATENCY: lean system_instruction experiment (ship-dark,
+  // flag-gated, fully reversible). When FEATURE_LEAN_SYSTEM_INSTRUCTION is live
+  // AND this is a first connect (not a reconnect), drop the ~20-25 KB
+  // greeting-policy stack (GREETING POLICY time-buckets + HARD ANTI-PATTERNS)
+  // from the Vertex prompt — the SAME stack LiveKit already omits in production
+  // via omitGreetingPolicy. The hypothesis under test: Vertex's Gemini still
+  // opens well from TONE RULES + the explicit greeting prompt
+  // (sendGreetingPromptToLiveAPI), trading prompt-ingestion time for a faster
+  // first token. Reconnect ALWAYS keeps the full stack so the RECONNECT FINAL
+  // OVERRIDE (silence-on-transparent-resume) is never dropped. LiveKit callers
+  // already pass omitGreetingPolicy=true, so the flag is a no-op for them.
+  // Flag off (default) => byte-identical to current behavior.
+  const leanGreetingActive =
+    !omitGreetingPolicy &&
+    !isReconnect &&
+    isFeatureLive('LEAN_SYSTEM_INSTRUCTION');
+  const effectiveOmitGreetingPolicy = !!omitGreetingPolicy || leanGreetingActive;
   instruction += buildTemporalJourneyContextSection(
     lang,
     lastSessionInfo,
@@ -868,7 +886,7 @@ ${trimmedHistory}
     recentRoutes,
     !!isReconnect,
     clientContext?.timeOfDay,
-    omitGreetingPolicy,
+    effectiveOmitGreetingPolicy,
     wakeBriefOverrideActive,
   );
 

--- a/services/gateway/test/orb/live/instruction/lean-system-instruction.test.ts
+++ b/services/gateway/test/orb/live/instruction/lean-system-instruction.test.ts
@@ -1,0 +1,127 @@
+/**
+ * ORB-CONVERSATION-LATENCY — lean system_instruction experiment (ship-dark).
+ *
+ * FEATURE_LEAN_SYSTEM_INSTRUCTION, when live, drops the ~20-25 KB greeting-policy
+ * stack (## GREETING POLICY time-buckets + ## HARD ANTI-PATTERNS) from the Vertex
+ * first-connect prompt — the same stack LiveKit already omits in production via
+ * omitGreetingPolicy — trading prompt-ingestion time for a faster first token.
+ * It ships dark: default off => byte-identical to today, rollback = flip the env
+ * var with no redeploy.
+ *
+ * These are behavioural unit tests (buildLiveSystemInstruction is a pure sync
+ * function), so they assert the ACTUAL rendered output, not source structure.
+ * They lock four invariants the experiment must never violate:
+ *   1. Flag OFF: the full greeting stack is present (no silent behaviour change).
+ *   2. Flag ON: the greeting stack is dropped but TONE RULES + JOURNEY AWARENESS
+ *      (and the identity lock + LANGUAGE rule) survive.
+ *   3. Reconnect is NEVER slimmed — the RECONNECT FINAL OVERRIDE (silence on a
+ *      transparent resume) is preserved even with the flag on.
+ *   4. LiveKit (omitGreetingPolicy=true) is unaffected by the flag.
+ */
+
+import { buildLiveSystemInstruction } from '../../../../src/orb/live/instruction/live-system-instruction';
+
+const H_GREETING = '## GREETING POLICY';
+const H_ANTIPATTERN = '## HARD ANTI-PATTERNS';
+const H_TONE = '## TONE RULES';
+const H_JOURNEY = '## JOURNEY AWARENESS';
+const H_RECONNECT = '## RECONNECT FINAL OVERRIDE';
+const IDENTITY_LOCK = '=== IDENTITY LOCK ===';
+const LANGUAGE_RULE = 'LANGUAGE: Respond ONLY in';
+
+const FLAG = 'FEATURE_LEAN_SYSTEM_INSTRUCTION_ENV';
+
+/** Vertex first-connect call: omitGreetingPolicy undefined, isReconnect false. */
+function vertexFirstConnect(): string {
+  return buildLiveSystemInstruction(
+    'en', 'conversational', '', 'community', '', '', false, null, '/', [], undefined, '@x',
+  );
+}
+
+/** Vertex transparent reconnect: isReconnect true. */
+function vertexReconnect(): string {
+  return buildLiveSystemInstruction(
+    'en', 'conversational', '', 'community', '', '', true,
+    { time: '1 minute ago', wasFailure: false }, '/', [], undefined, '@x',
+  );
+}
+
+/** LiveKit call: omitGreetingPolicy=true (13th positional). */
+function liveKitConnect(): string {
+  return buildLiveSystemInstruction(
+    'en', 'conversational', '', 'community', '', '', false, null, '/', [], undefined, '@x', true,
+  );
+}
+
+describe('ORB-CONVERSATION-LATENCY: lean system_instruction flag', () => {
+  let prev: string | undefined;
+  beforeEach(() => { prev = process.env[FLAG]; });
+  afterEach(() => {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+  });
+
+  describe('flag OFF (default — production behaviour today)', () => {
+    beforeEach(() => { delete process.env[FLAG]; });
+
+    it('Vertex first-connect renders the FULL greeting-policy stack', () => {
+      const out = vertexFirstConnect();
+      expect(out).toContain(H_GREETING);
+      expect(out).toContain(H_ANTIPATTERN);
+      expect(out).toContain(H_TONE);
+    });
+  });
+
+  describe('flag ON (staging+prod)', () => {
+    beforeEach(() => { process.env[FLAG] = 'staging+prod'; });
+
+    it('Vertex first-connect DROPS the greeting-policy stack', () => {
+      const out = vertexFirstConnect();
+      expect(out).not.toContain(H_GREETING);
+      expect(out).not.toContain(H_ANTIPATTERN);
+    });
+
+    it('still keeps TONE RULES + JOURNEY AWARENESS (the lean greeting guidance)', () => {
+      const out = vertexFirstConnect();
+      expect(out).toContain(H_TONE);
+      expect(out).toContain(H_JOURNEY);
+    });
+
+    it('still keeps the behaviour-critical IDENTITY LOCK + LANGUAGE rule', () => {
+      const out = vertexFirstConnect();
+      expect(out).toContain(IDENTITY_LOCK);
+      expect(out).toContain(LANGUAGE_RULE);
+    });
+
+    it('produces a strictly shorter prompt than flag-off (the latency win)', () => {
+      const lean = vertexFirstConnect();
+      delete process.env[FLAG];
+      const full = vertexFirstConnect();
+      expect(lean.length).toBeLessThan(full.length);
+    });
+
+    it('NEVER slims a reconnect — RECONNECT FINAL OVERRIDE is preserved', () => {
+      const out = vertexReconnect();
+      expect(out).toContain(H_RECONNECT);
+      // The reconnect path keeps the full temporal stack, so the greeting
+      // section header is still present on reconnect even with the flag on.
+      expect(out).toContain(H_GREETING);
+    });
+  });
+
+  describe('LiveKit (omitGreetingPolicy=true) is independent of the flag', () => {
+    it('omits the greeting stack with the flag OFF (unchanged behaviour)', () => {
+      delete process.env[FLAG];
+      const out = liveKitConnect();
+      expect(out).not.toContain(H_GREETING);
+      expect(out).toContain(H_TONE);
+    });
+
+    it('still omits the greeting stack with the flag ON (no regression)', () => {
+      process.env[FLAG] = 'staging+prod';
+      const out = liveKitConnect();
+      expect(out).not.toContain(H_GREETING);
+      expect(out).toContain(H_TONE);
+    });
+  });
+});


### PR DESCRIPTION
## Lean system_instruction for Vertex — ship dark, measure, then graduate

The final lever from the ORB conversation-start latency plan. Profiling (see PR #2471) showed the gateway compute path and context pre-warm are **already optimised** — the remaining lever is the **size** of the Vertex setup `system_instruction`, which drives the model's first-token time. This PR cuts the single biggest block, behind a flag, with **zero behaviour change until the flag is flipped**.

### The lever
The biggest block in the Vertex prompt is the **~20-25 KB greeting-policy stack** (`## GREETING POLICY` time-buckets + `## HARD ANTI-PATTERNS`). LiveKit **already drops this exact stack in production** via the existing `omitGreetingPolicy` param — there the first line is a pre-rendered `session.say()` greeting, so the LLM never generates it. Vertex keeps it today because Gemini Live generates the greeting.

This PR gates that **same, proven omission** for Vertex behind `FEATURE_LEAN_SYSTEM_INSTRUCTION` — reusing the battle-tested code path rather than inventing new trimming.

### Behaviour
| State | Vertex first-connect | Reconnect | LiveKit |
|-------|---------------------|-----------|---------|
| **Flag off (default)** | full stack — **byte-identical to today** | full | unchanged (already omits) |
| **Flag on** | lean: `TONE RULES` + `JOURNEY AWARENESS` kept; greeting buckets + anti-patterns dropped | **full (never slimmed)** | unchanged (already omits) |

- **Reconnect is never slimmed** → the `RECONNECT FINAL OVERRIDE` (silence-on-transparent-resume) is always preserved.
- **Identity lock + `LANGUAGE: Respond ONLY in …` are always preserved** (they live outside the greeting stack).
- Flag is read **at call time** → rollback = flip the env var, no redeploy. Graduates `off → staging-only → staging+prod`.

### The hypothesis under test
Gemini still opens well on Vertex from `TONE RULES` + the explicit opener that `sendGreetingPromptToLiveAPI` already sends, trading ~20-25 KB of prompt-ingestion for a faster first token. **This is a real behavioural bet** — that's why it ships dark.

### Risks to evaluate before graduating (honest list)
Enabling the flag drops, for first-connect only:
- **Time-bucket greeting templates** ("Good morning, {name}" vs short-gap openers).
- **HARD ANTI-PATTERNS** (no "Hello {name}" on short-gap, no self-intro to returning users, no fact-reciting). Note: the 3×-greeting re-emit is independently backstopped by the structural guard in `upstream-message-handler.ts`.

These must be checked in voice-lab / live dev before `staging+prod`.

### Verification
- Behavioural unit tests (`lean-system-instruction.test.ts`) lock all four invariants: flag-off full stack, flag-on drop + TONE/JOURNEY/identity/LANGUAGE kept, reconnect never slimmed, LiveKit unaffected. Assertions validated against source; `node_modules` isn't installed in the authoring container so CI runs them.
- The existing `system-instruction.characterization.test.ts` **snapshot is unchanged** (flag off ⇒ identical output).

### Rollout
1. Merge this + **#2471** (turn-0 establishment metric: `time_to_first_audio_ms`).
2. `FEATURE_LATENCY_TELEMETRY_ENV=staging+prod` + `FEATURE_LEAN_SYSTEM_INSTRUCTION_ENV=staging-only`.
3. Compare `time_to_first_audio_ms` p50/p95 and greeting quality (voice-lab) lean vs full.
4. If clean → graduate to `staging+prod`. If greeting quality regresses → flip the env var back, no redeploy.

🤖 Draft — ships dark, do not enable the flag until measured.

https://claude.ai/code/session_015ksCuqQXUog3KXUhfyvXMY

---
_Generated by [Claude Code](https://claude.ai/code/session_015ksCuqQXUog3KXUhfyvXMY)_