### PR TITLE
feat(self-healing): per-stage retry confidence calibration (Step 4)

### DIFF
--- a/services/gateway/.env.template
+++ b/services/gateway/.env.template
@@ -54,3 +54,18 @@ VERTEX_IMAGES_MODEL=imagen-3.0-fast-generate-001
 INTENT_COVERS_BUCKET=intent-covers
 INTENT_COVER_RATE_LIMIT_PER_DAY=10
 INTENT_COVER_DRY_RUN=false
+
+# Self-Healing autopilot — per-stage retry confidence thresholds
+# A failed auto-fix is retried (spawns a self-heal child execution) only when
+# the triage agent's confidence clears the bar for the stage that failed. The
+# odds a retry actually fixes the problem vary by stage, so the bars differ.
+# All optional — the code falls back to these defaults if unset.
+#
+#   AUTOPILOT_RETRY_CONFIDENCE_THRESHOLD      0.30  global fallback (unknown stage)
+#   AUTOPILOT_RETRY_CONFIDENCE_CI             0.25  CI failures — retry aggressively
+#   AUTOPILOT_RETRY_CONFIDENCE_DEPLOY         0.35  deploy failures (often flaky)
+#   AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION   0.50  post-deploy verification — gate hard
+AUTOPILOT_RETRY_CONFIDENCE_THRESHOLD=0.3
+AUTOPILOT_RETRY_CONFIDENCE_CI=0.25
+AUTOPILOT_RETRY_CONFIDENCE_DEPLOY=0.35
+AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION=0.5

--- a/services/gateway/src/services/dev-autopilot-bridge.ts
+++ b/services/gateway/src/services/dev-autopilot-bridge.ts
@@ -58,8 +58,22 @@ const GITHUB_REPO =
 // the autopilot retries more aggressively by default — the user goal is
 // "self-improving + self-healing autonomously." Failed retries still
 // escalate at the depth cap.
-const CHILD_SPAWN_CONFIDENCE_THRESHOLD = Number.parseFloat(
-  process.env.AUTOPILOT_RETRY_CONFIDENCE_THRESHOLD || '0.3',
+/**
+ * Parse a confidence-threshold env override, falling back to `fallback` for
+ * missing, empty, or non-finite values. Without the finite guard a typo like
+ * `AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION=false` parses to NaN, and since
+ * `confidence < NaN` is always false the stage would spawn retries regardless
+ * of confidence — silently defeating the calibration. Exported for tests.
+ */
+export function parseThreshold(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const n = Number.parseFloat(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+const CHILD_SPAWN_CONFIDENCE_THRESHOLD = parseThreshold(
+  process.env.AUTOPILOT_RETRY_CONFIDENCE_THRESHOLD,
+  0.3,
 );
 
 /**
@@ -75,9 +89,9 @@ const CHILD_SPAWN_CONFIDENCE_THRESHOLD = Number.parseFloat(
  * Each is overridable via env; unknown stages fall back to the global default.
  */
 const RETRY_THRESHOLD_BY_STAGE: Record<FailureStage, number> = {
-  ci: Number.parseFloat(process.env.AUTOPILOT_RETRY_CONFIDENCE_CI || '0.25'),
-  deploy: Number.parseFloat(process.env.AUTOPILOT_RETRY_CONFIDENCE_DEPLOY || '0.35'),
-  verification: Number.parseFloat(process.env.AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION || '0.5'),
+  ci: parseThreshold(process.env.AUTOPILOT_RETRY_CONFIDENCE_CI, 0.25),
+  deploy: parseThreshold(process.env.AUTOPILOT_RETRY_CONFIDENCE_DEPLOY, 0.35),
+  verification: parseThreshold(process.env.AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION, 0.5),
 };
 
 /**

--- a/services/gateway/src/services/dev-autopilot-bridge.ts
+++ b/services/gateway/src/services/dev-autopilot-bridge.ts
@@ -63,6 +63,39 @@ const CHILD_SPAWN_CONFIDENCE_THRESHOLD = Number.parseFloat(
 );
 
 /**
+ * Per-stage retry confidence thresholds (Step 4 calibration). A single global
+ * gate is miscalibrated: the odds that an autonomous retry actually fixes the
+ * problem vary a lot by WHERE the fix failed.
+ *   - ci: lint/test/typecheck failures are usually a productive code retry →
+ *     retry aggressively (low bar).
+ *   - deploy: often flaky / infra-ish → medium bar.
+ *   - verification: the fix already deployed but didn't clear the original
+ *     failure (or regressed production) — the riskiest case to retry blindly,
+ *     so demand higher agent confidence before spending another attempt.
+ * Each is overridable via env; unknown stages fall back to the global default.
+ */
+const RETRY_THRESHOLD_BY_STAGE: Record<FailureStage, number> = {
+  ci: Number.parseFloat(process.env.AUTOPILOT_RETRY_CONFIDENCE_CI || '0.25'),
+  deploy: Number.parseFloat(process.env.AUTOPILOT_RETRY_CONFIDENCE_DEPLOY || '0.35'),
+  verification: Number.parseFloat(process.env.AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION || '0.5'),
+};
+
+/**
+ * Resolve the confidence bar a triage report must clear to earn an autonomous
+ * retry, given the failure stage/class. Environmental blockers never retry
+ * (defense-in-depth — they are normally short-circuited before triage). When no
+ * stage is supplied we fall back to the global CHILD_SPAWN_CONFIDENCE_THRESHOLD
+ * so prior behavior is preserved. Pure — exported for tests.
+ */
+export function resolveRetryThreshold(failureStage?: FailureStage, failureClass?: string): number {
+  if (failureClass === 'environmental_blocker') return Number.POSITIVE_INFINITY;
+  if (failureStage && Object.prototype.hasOwnProperty.call(RETRY_THRESHOLD_BY_STAGE, failureStage)) {
+    return RETRY_THRESHOLD_BY_STAGE[failureStage];
+  }
+  return CHILD_SPAWN_CONFIDENCE_THRESHOLD;
+}
+
+/**
  * Write a row into self_healing_log so the Self-Healing UI surfaces this
  * autopilot failure alongside the system-level health probes. Without this,
  * the bridge's escalation only updates dev_autopilot_executions and the
@@ -562,11 +595,19 @@ export async function bridgeFailureToSelfHealing(input: BridgeInput): Promise<Br
     });
   }
 
-  // 3. Decide next action: spawn child vs escalate.
-  const canRetry =
-    report.confidence_numeric >= CHILD_SPAWN_CONFIDENCE_THRESHOLD &&
-    (exec.auto_fix_depth || 0) < maxDepth &&
-    !(cfg?.kill_switch);
+  // 3. Decide next action: spawn child vs escalate. Route through the pure
+  //    decideBridgeAction with the failure stage so the per-stage confidence
+  //    bar (Step 4) actually applies in production — previously the live path
+  //    inlined a single global threshold and the helper was only unit-tested.
+  const retryThreshold = resolveRetryThreshold(input.failure_stage);
+  const decision = decideBridgeAction({
+    confidence_numeric: report.confidence_numeric,
+    auto_fix_depth: exec.auto_fix_depth || 0,
+    max_auto_fix_depth: maxDepth,
+    kill_switch: !!cfg?.kill_switch,
+    failure_stage: input.failure_stage,
+  });
+  const canRetry = decision.action === 'spawn_child';
 
   const patchBase: Record<string, unknown> = {
     failure_stage: input.failure_stage,
@@ -709,7 +750,7 @@ export async function bridgeFailureToSelfHealing(input: BridgeInput): Promise<Br
     diagnosis: {
       summary: `Escalated: ${cfg?.kill_switch ? 'kill switch armed'
         : (exec.auto_fix_depth || 0) >= maxDepth ? `max retries reached (${exec.auto_fix_depth}/${maxDepth})`
-        : `confidence ${report.confidence_numeric.toFixed(2)} below threshold ${CHILD_SPAWN_CONFIDENCE_THRESHOLD}`}`,
+        : `confidence ${report.confidence_numeric.toFixed(2)} below ${input.failure_stage} threshold ${retryThreshold}`}`,
       execution_id: exec.id,
       finding_id: exec.finding_id,
       stage: input.failure_stage,
@@ -762,6 +803,10 @@ export interface DecisionInput {
   auto_fix_depth: number;
   max_auto_fix_depth: number;
   kill_switch: boolean;
+  /** Where the fix failed — selects the per-stage confidence bar (Step 4). */
+  failure_stage?: FailureStage;
+  /** Optional class override (e.g. 'environmental_blocker' never retries). */
+  failure_class?: string;
 }
 
 export type BridgeDecision =
@@ -771,8 +816,9 @@ export type BridgeDecision =
 export function decideBridgeAction(input: DecisionInput): BridgeDecision {
   if (input.kill_switch) return { action: 'escalate', reason: 'kill_switch_armed' };
   if (input.auto_fix_depth >= input.max_auto_fix_depth) return { action: 'escalate', reason: 'depth_cap_reached' };
-  if (input.confidence_numeric < CHILD_SPAWN_CONFIDENCE_THRESHOLD) return { action: 'escalate', reason: 'low_confidence' };
+  const threshold = resolveRetryThreshold(input.failure_stage, input.failure_class);
+  if (input.confidence_numeric < threshold) return { action: 'escalate', reason: 'low_confidence' };
   return { action: 'spawn_child' };
 }
 
-export { CHILD_SPAWN_CONFIDENCE_THRESHOLD, LOG_PREFIX, DRY_RUN };
+export { CHILD_SPAWN_CONFIDENCE_THRESHOLD, RETRY_THRESHOLD_BY_STAGE, LOG_PREFIX, DRY_RUN };

--- a/services/gateway/test/dev-autopilot-bridge.test.ts
+++ b/services/gateway/test/dev-autopilot-bridge.test.ts
@@ -11,6 +11,7 @@
 import {
   decideBridgeAction,
   resolveRetryThreshold,
+  parseThreshold,
   CHILD_SPAWN_CONFIDENCE_THRESHOLD,
   RETRY_THRESHOLD_BY_STAGE,
 } from '../src/services/dev-autopilot-bridge';
@@ -152,6 +153,18 @@ describe('resolveRetryThreshold + per-stage calibration', () => {
     // 0.3 ≥ ci bar (0.25) → spawn; 0.3 < verification bar (0.5) → escalate.
     expect(decideBridgeAction({ ...base, failure_stage: 'ci' })).toEqual({ action: 'spawn_child' });
     expect(decideBridgeAction({ ...base, failure_stage: 'verification' })).toEqual({ action: 'escalate', reason: 'low_confidence' });
+  });
+
+  it('parseThreshold falls back to the default for non-finite / missing overrides (Codex P2)', () => {
+    // A non-numeric override must NOT become NaN — otherwise `confidence < NaN`
+    // is always false and the stage retries regardless of confidence.
+    expect(parseThreshold('false', 0.5)).toBe(0.5);
+    expect(parseThreshold('', 0.5)).toBe(0.5);
+    expect(parseThreshold(undefined, 0.5)).toBe(0.5);
+    expect(parseThreshold('not-a-number', 0.5)).toBe(0.5);
+    // Valid numeric overrides are honoured.
+    expect(parseThreshold('0.4', 0.5)).toBe(0.4);
+    expect(parseThreshold('0', 0.5)).toBe(0);
   });
 
   it('depth cap and kill switch still take precedence over the per-stage bar', () => {

--- a/services/gateway/test/dev-autopilot-bridge.test.ts
+++ b/services/gateway/test/dev-autopilot-bridge.test.ts
@@ -10,7 +10,9 @@
 
 import {
   decideBridgeAction,
+  resolveRetryThreshold,
   CHILD_SPAWN_CONFIDENCE_THRESHOLD,
+  RETRY_THRESHOLD_BY_STAGE,
 } from '../src/services/dev-autopilot-bridge';
 
 // =============================================================================
@@ -108,6 +110,57 @@ describe('decideBridgeAction', () => {
       max_auto_fix_depth: 2,
       kill_switch: false,
     })).toEqual({ action: 'spawn_child' });
+  });
+
+  it('no failure_stage falls back to the global threshold (backward compatible)', () => {
+    // 0.28 < global 0.3 → escalate; same input with no stage as the legacy path.
+    expect(decideBridgeAction({
+      confidence_numeric: 0.28,
+      auto_fix_depth: 0,
+      max_auto_fix_depth: 2,
+      kill_switch: false,
+    })).toEqual({ action: 'escalate', reason: 'low_confidence' });
+  });
+});
+
+// =============================================================================
+// Per-stage confidence calibration (Step 4)
+// =============================================================================
+
+describe('resolveRetryThreshold + per-stage calibration', () => {
+  it('uses a low bar for CI and a high bar for verification', () => {
+    // ci ≤ deploy ≤ verification: retry CI aggressively, gate verification hard.
+    expect(RETRY_THRESHOLD_BY_STAGE.ci).toBe(0.25);
+    expect(RETRY_THRESHOLD_BY_STAGE.deploy).toBe(0.35);
+    expect(RETRY_THRESHOLD_BY_STAGE.verification).toBe(0.5);
+    expect(RETRY_THRESHOLD_BY_STAGE.ci).toBeLessThan(RETRY_THRESHOLD_BY_STAGE.verification);
+  });
+
+  it('environmental_blocker never retries regardless of confidence', () => {
+    expect(resolveRetryThreshold('verification', 'environmental_blocker')).toBe(Number.POSITIVE_INFINITY);
+    expect(decideBridgeAction({
+      confidence_numeric: 1,
+      auto_fix_depth: 0,
+      max_auto_fix_depth: 2,
+      kill_switch: false,
+      failure_class: 'environmental_blocker',
+    })).toEqual({ action: 'escalate', reason: 'low_confidence' });
+  });
+
+  it('same confidence: retries a CI failure but escalates a verification failure', () => {
+    const base = { confidence_numeric: 0.3, auto_fix_depth: 0, max_auto_fix_depth: 2, kill_switch: false };
+    // 0.3 ≥ ci bar (0.25) → spawn; 0.3 < verification bar (0.5) → escalate.
+    expect(decideBridgeAction({ ...base, failure_stage: 'ci' })).toEqual({ action: 'spawn_child' });
+    expect(decideBridgeAction({ ...base, failure_stage: 'verification' })).toEqual({ action: 'escalate', reason: 'low_confidence' });
+  });
+
+  it('depth cap and kill switch still take precedence over the per-stage bar', () => {
+    expect(decideBridgeAction({
+      confidence_numeric: 0.99, auto_fix_depth: 2, max_auto_fix_depth: 2, kill_switch: false, failure_stage: 'ci',
+    })).toEqual({ action: 'escalate', reason: 'depth_cap_reached' });
+    expect(decideBridgeAction({
+      confidence_numeric: 0.99, auto_fix_depth: 0, max_auto_fix_depth: 2, kill_switch: true, failure_stage: 'ci',
+    })).toEqual({ action: 'escalate', reason: 'kill_switch_armed' });
   });
 });
 


### PR DESCRIPTION
## Step 4 of Self-Healing reliability: per-stage retry confidence calibration

### The problem
The bridge gated autonomous retries on a **single global** confidence threshold (`0.3`) regardless of *where* the fix failed. Worse, the live path **inlined** that gate — so the pure `decideBridgeAction` helper (with its kill-switch → depth → confidence ordering) was only ever exercised by unit tests, **never in production**.

### The fix

**1. Per-stage thresholds.** The odds that an autonomous retry actually fixes the problem vary a lot by stage, so a flat bar is miscalibrated:

| Stage | Bar | Rationale |
|-------|-----|-----------|
| `ci` | **0.25** | lint/test/typecheck — usually a productive code retry, retry aggressively |
| `deploy` | **0.35** | often flaky / infra-ish |
| `verification` | **0.50** | fix deployed but didn't clear the failure (or regressed prod) — riskiest to retry blindly, demand more confidence |
| `environmental_blocker` | **∞ (never)** | defense-in-depth on top of the upstream short-circuit |

All overridable via env (`AUTOPILOT_RETRY_CONFIDENCE_CI` / `_DEPLOY` / `_VERIFICATION`); unknown / no stage falls back to the global `0.3`, so prior behavior is preserved.

**2. Wire the live path through `decideBridgeAction`** with the failure stage, so the calibrated bar actually applies in production instead of the inlined global one. The escalation log now reports the resolved per-stage threshold (e.g. *"confidence 0.30 below verification threshold 0.5"*).

New pure `resolveRetryThreshold()` + `RETRY_THRESHOLD_BY_STAGE`, exported for tests.

### Why this matters together with Steps 2–3
- Step 2 stopped non-actionable failures polluting the queue.
- Step 3 made "completed" mean the failure is actually gone, and auto-reverts regressions.
- **Step 4** stops the loop from burning retries (and self-heal-child depth) on the cases least likely to succeed, while retrying cheap CI fixes aggressively — so the autonomy budget is spent where it pays off.

### Verification
- `npm run build` ✅ (0 TS errors)
- New per-stage calibration tests + backward-compat test in `dev-autopilot-bridge.test.ts` ✅
- Full self-healing + dev-autopilot suite ✅ **256/256** (the live `bridgeFailureToSelfHealing` flow now runs through the calibrated decision and still passes its existing cases).

https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB)_