### PR TITLE
fix(orb): stop LiveKit double-greeting — session.say() owns turn-1 (BOOTSTRAP-ORB-RCV-DOUBLEGREET)

### DIFF
--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -1687,10 +1687,33 @@ router.get(
       const line = picked?.userFacingLine?.trim();
       if (picked && line && line.length > 0 && !isReconnect) {
         wakeOverrideApplied = true;
-        // LiveKit suppression block: sentinel marker (drives the brain-opener
-        // strip + SHORT-GAP pool suppression) WITHOUT the verbatim-speak
-        // directive that would make the model double the agent's session.say().
-        const suppressionBlock = `\n\n${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}
+        // LiveKit first-turn suppression — split into TWO parts so the bootstrap
+        // cap (capBootstrapContext, 12 KB, trims the BOTTOM of the bootstrap)
+        // can never strip the load-bearing directive:
+        //
+        //   1. SENTINEL MARKER — placed at the HEAD of the augmented bootstrap.
+        //      buildLiveSystemInstruction passes the bootstrap through
+        //      capBootstrapContext, which PRESERVES the head and trims the
+        //      tail. Keeping the marker at the head guarantees it survives, so
+        //      stripBrainOpenerSections() + the wakeBriefOverrideActive
+        //      detection (both read the marker out of bootstrapContext) keep
+        //      firing for heavy-context users. The marker alone produces NO
+        //      greeting (it's a sentinel), so it cannot create a rival opener.
+        //
+        //   2. "DO NOT SPEAK FIRST" DIRECTIVE — appended to the RETURNED
+        //      system_instruction, AFTER buildLiveSystemInstruction (i.e.
+        //      OUTSIDE the bootstrap region that the cap can trim). This is the
+        //      directive that actually silences the model's first turn. Placing
+        //      it last also gives it recency primacy over the generic
+        //      "you MUST speak first" GREETING RULES higher in the prompt.
+        //
+        // BOOTSTRAP-ORB-RCV-DOUBLEGREET (P2 fix): previously this whole block
+        // was appended to the END of the bootstrap, so when an authenticated
+        // user's bootstrapContext + behavioral rule exceeded 12 KB the
+        // directive was trimmed off the final system_instruction while the
+        // generic "speak first" rule survived → the double-greeting returned
+        // for heavy-context users.
+        const firstTurnSuppressionDirective = `
 
 ## FIRST TURN — DO NOT SPEAK FIRST (LiveKit transport — BOOTSTRAP-ORB-RCV-DOUBLEGREET)
 
@@ -1704,10 +1727,12 @@ WAIT for the user to speak. Only then respond normally.
 This block OVERRIDES every other greeting rule in this prompt for the
 first turn only. Subsequent turns follow the normal conversation flow.`;
         const vitanaBehavioralRule = buildPersonaBehavioralRule('vitana');
+        // Marker at the HEAD so capBootstrapContext (head-preserving) can never
+        // trim it away, regardless of bootstrap size.
         const augmentedContext =
+          `${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}\n\n` +
           (bootstrapContext ? `${bootstrapContext}\n\n` : '') +
-          `${vitanaBehavioralRule}` +
-          suppressionBlock;
+          `${vitanaBehavioralRule}`;
         const voiceStyle =
           (voiceConfig as { voice_style?: string } | null)?.voice_style?.trim() ||
           'friendly, calm, empathetic';
@@ -1726,8 +1751,11 @@ first turn only. Subsequent turns follow the normal conversation flow.`;
           req.identity?.vitana_id ?? null,
           true,
         );
+        // Append the directive OUTSIDE the bootstrap-cap region — this is what
+        // keeps it from ever being trimmed for heavy-context users.
+        systemInstruction += firstTurnSuppressionDirective;
         console.log(
-          `[${VTID}/BOOTSTRAP-ORB-RCV-DOUBLEGREET] systemInstruction re-rendered with LiveKit first-turn SUPPRESSION (kind=${picked.kind}, decision_id=${wakeBriefDecision?.decisionId}, lang=${lang}) — session.say() owns the first turn, model stays silent`,
+          `[${VTID}/BOOTSTRAP-ORB-RCV-DOUBLEGREET] systemInstruction re-rendered with LiveKit first-turn SUPPRESSION (kind=${picked.kind}, decision_id=${wakeBriefDecision?.decisionId}, lang=${lang}) — session.say() owns the first turn, model stays silent; directive appended post-cap so it survives heavy bootstrap`,
         );
       }
     } catch (exc) {

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -69,6 +69,12 @@ import {
 // now returns the rendered Vertex instruction verbatim under a new
 // `system_instruction` field; the agent reads it directly.
 import { buildLiveSystemInstruction } from '../orb/live/instruction/live-system-instruction';
+// BOOTSTRAP-ORB-RCV-DOUBLEGREET: the wake-brief override sentinel. On LiveKit
+// the marker is injected to STRIP the competing brain-opener sections, but —
+// unlike Vertex — it is NOT paired with a "speak this verbatim" directive. The
+// Python agent's session.say(user_facing_line) is the single source of truth
+// for the LiveKit first turn; the LLM must stay silent until the user replies.
+import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../orb/live/instruction/wake-brief-marker';
 import {
   optionalAuth,
   requireAuthWithTenant,
@@ -1645,36 +1651,63 @@ router.get(
       }
     }
 
-    // VTID-03100: re-render systemInstruction with the wake-brief
-    // override block when a candidate has a non-empty userFacingLine.
-    // The earlier buildLiveSystemInstruction call (line ~1431) ran
-    // BEFORE wakeBriefDecision was computed, so the override block
-    // had nowhere to go. Now we know the picked line (Teacher's
-    // two-clause greeting or voice_wake_brief's policy line), so we
-    // build the block, prepend the sentinel marker to bootstrapContext,
-    // and re-call buildLiveSystemInstruction. The strip helper in
-    // live-system-instruction.ts detects the marker and removes the
-    // competing vitana-brain opener sections so the override actually
-    // owns the first turn.
+    // VTID-03100 / BOOTSTRAP-ORB-RCV-DOUBLEGREET: re-render systemInstruction
+    // with the wake-brief SUPPRESSION block when a candidate has a non-empty
+    // userFacingLine. The earlier buildLiveSystemInstruction call (line ~1517)
+    // ran BEFORE wakeBriefDecision was computed, so the sentinel marker had
+    // nowhere to go.
+    //
+    // *** LiveKit first-turn single-source-of-truth (double-greeting fix) ***
+    // On Vertex the LLM speaks the first turn from the system instruction, so
+    // the Vertex path injects a "## SPOKEN FIRST UTTERANCE — REQUIRED VERBATIM"
+    // block (buildVertexWakeBriefBlock) telling the model to speak the line.
+    //
+    // On LiveKit the model does NOT own the first turn: the Python agent plays
+    // the line deterministically via session.say(user_facing_line) at
+    // room-join (see services/agents/orb-agent/src/orb_agent/session.py — the
+    // greeting block that reads bootstrap.wake_brief_decision). If we ALSO
+    // injected the "speak this verbatim" directive here, the model would speak
+    // the same line a second time → the dragan3 double greeting.
+    //
+    // Fix: on LiveKit we inject ONLY the sentinel marker + a hard "do NOT
+    // open / stay silent until the user speaks" directive. The marker still
+    // triggers stripBrainOpenerSections() in live-system-instruction.ts (so
+    // the competing OPENING SHAPE MATRIX / PROACTIVE OPENER CANDIDATE brain
+    // sections + the SHORT-GAP pool are suppressed and can't produce a rival
+    // opener), but there is no verbatim-speak instruction — session.say() is
+    // the single source of truth for the LiveKit first turn.
+    //
+    // The proactive-offer path is unaffected: the agent still receives the
+    // wake_brief_decision (user_facing_line + decision_id + dedupe_key) in the
+    // response payload below and decides add_to_chat_ctx based on
+    // is_proactive_offer — gateway behavior here does not touch that.
     let wakeOverrideApplied = false;
     try {
       const picked = wakeBriefDecision?.selectedContinuation ?? null;
       const line = picked?.userFacingLine?.trim();
       if (picked && line && line.length > 0 && !isReconnect) {
         wakeOverrideApplied = true;
-        const { buildVertexWakeBriefBlock } = await import(
-          '../orb/live/session/live-session-controller'
-        );
-        const overrideBlock = buildVertexWakeBriefBlock(
-          line,
-          lang,
-          picked.dedupeKey ?? null,
-        );
+        // LiveKit suppression block: sentinel marker (drives the brain-opener
+        // strip + SHORT-GAP pool suppression) WITHOUT the verbatim-speak
+        // directive that would make the model double the agent's session.say().
+        const suppressionBlock = `\n\n${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}
+
+## FIRST TURN — DO NOT SPEAK FIRST (LiveKit transport — BOOTSTRAP-ORB-RCV-DOUBLEGREET)
+
+The client app plays the opening line for this session before you receive
+control. You MUST NOT produce an opening utterance, greeting, or
+proactive offer on your first turn — the user has already heard it.
+Do NOT introduce yourself, do NOT list features, do NOT ask "How can I
+help?", and do NOT repeat or paraphrase any greeting. Remain silent and
+WAIT for the user to speak. Only then respond normally.
+
+This block OVERRIDES every other greeting rule in this prompt for the
+first turn only. Subsequent turns follow the normal conversation flow.`;
         const vitanaBehavioralRule = buildPersonaBehavioralRule('vitana');
         const augmentedContext =
           (bootstrapContext ? `${bootstrapContext}\n\n` : '') +
           `${vitanaBehavioralRule}` +
-          overrideBlock;
+          suppressionBlock;
         const voiceStyle =
           (voiceConfig as { voice_style?: string } | null)?.voice_style?.trim() ||
           'friendly, calm, empathetic';
@@ -1694,12 +1727,12 @@ router.get(
           true,
         );
         console.log(
-          `[${VTID}/VTID-03100] systemInstruction re-rendered with wake-brief override (kind=${picked.kind}, decision_id=${wakeBriefDecision?.decisionId}, lang=${lang})`,
+          `[${VTID}/BOOTSTRAP-ORB-RCV-DOUBLEGREET] systemInstruction re-rendered with LiveKit first-turn SUPPRESSION (kind=${picked.kind}, decision_id=${wakeBriefDecision?.decisionId}, lang=${lang}) — session.say() owns the first turn, model stays silent`,
         );
       }
     } catch (exc) {
       console.warn(
-        `[${VTID}/VTID-03100] override re-render failed (non-fatal — falls back to pre-override system_instruction): ${(exc as Error).message}`,
+        `[${VTID}/BOOTSTRAP-ORB-RCV-DOUBLEGREET] suppression re-render failed (non-fatal — falls back to pre-override system_instruction): ${(exc as Error).message}`,
       );
     }
 

--- a/services/gateway/test/orb/routes/livekit-first-turn-heavy-context.test.ts
+++ b/services/gateway/test/orb/routes/livekit-first-turn-heavy-context.test.ts
@@ -1,0 +1,200 @@
+/**
+ * BOOTSTRAP-ORB-RCV-DOUBLEGREET — heavy-context survival of the LiveKit
+ * first-turn suppression directive (Codex P2 fix).
+ *
+ * THE BUG this locks against:
+ *   The LiveKit route (orb-livekit.ts) re-renders system_instruction for the
+ *   first turn with a "## FIRST TURN — DO NOT SPEAK FIRST" directive so the
+ *   model stays silent and the Python agent's session.say() owns turn-1.
+ *
+ *   Originally that directive was appended to the END of the bootstrap context
+ *   that is passed into buildLiveSystemInstruction(). Inside the builder the
+ *   bootstrap is run through capBootstrapContext() (BOOTSTRAP_CONTEXT_MAX_CHARS
+ *   = 12 KB) which PRESERVES THE HEAD and TRIMS THE TAIL. So for an
+ *   authenticated user whose bootstrapContext + behavioral rule exceeds 12 KB,
+ *   the directive was sliced off the final system_instruction — while the
+ *   earlier generic non-reconnect GREETING RULES still said "you MUST speak
+ *   first with a warm, brief greeting" → the LLM produced an opener IN ADDITION
+ *   to session.say() → the dragan3 double-greeting returned for heavy users.
+ *
+ * THE FIX (asserted here):
+ *   - The sentinel marker lives at the HEAD of the bootstrap (survives the cap,
+ *     so stripBrainOpenerSections + wakeBriefOverrideActive detection keep
+ *     firing).
+ *   - The "DO NOT SPEAK FIRST" directive is appended to the RETURNED
+ *     system_instruction, OUTSIDE the bootstrap region the cap can trim — so it
+ *     can never be trimmed away regardless of bootstrap size.
+ *
+ * This is a behavioral test: it drives buildLiveSystemInstruction() with the
+ * exact composition the route uses and proves the directive survives a
+ * 12 KB-busting bootstrap, while the OLD (tail-append) composition does not.
+ */
+
+import { buildLiveSystemInstruction } from '../../../src/orb/live/instruction/live-system-instruction';
+import { BOOTSTRAP_CONTEXT_MAX_CHARS } from '../../../src/orb/live/instruction/bootstrap-cap';
+import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../../../src/orb/live/instruction/wake-brief-marker';
+
+// Mirrors the literal injected by orb-livekit.ts at the wake-brief re-render.
+// Kept in sync via the source-text assertions in
+// livekit-first-turn-single-source.test.ts.
+const FIRST_TURN_SUPPRESSION_DIRECTIVE = `
+
+## FIRST TURN — DO NOT SPEAK FIRST (LiveKit transport — BOOTSTRAP-ORB-RCV-DOUBLEGREET)
+
+The client app plays the opening line for this session before you receive
+control. You MUST NOT produce an opening utterance, greeting, or
+proactive offer on your first turn — the user has already heard it.
+Do NOT introduce yourself, do NOT list features, do NOT ask "How can I
+help?", and do NOT repeat or paraphrase any greeting. Remain silent and
+WAIT for the user to speak. Only then respond normally.
+
+This block OVERRIDES every other greeting rule in this prompt for the
+first turn only. Subsequent turns follow the normal conversation flow.`;
+
+/** A bootstrap context large enough to blow past the 12 KB cap on its own,
+ * the way a heavy authenticated user (lots of memory_items + memory_facts)
+ * accumulates. Repeats a distinctive line so we can also assert the cap fired. */
+function makeHeavyBootstrap(): string {
+  const filler =
+    '=== USER CONTEXT PROFILE ===\nThe user has a long accumulated memory history. ';
+  const line = filler.repeat(40); // ~3.4 KB per chunk
+  let out = '';
+  while (out.length <= BOOTSTRAP_CONTEXT_MAX_CHARS + 8_000) {
+    out += line + '\n';
+  }
+  return out;
+}
+
+describe('BOOTSTRAP-ORB-RCV-DOUBLEGREET heavy-context first-turn suppression survival', () => {
+  const heavyBootstrap = makeHeavyBootstrap();
+
+  beforeAll(() => {
+    // Sanity: the bootstrap really does exceed the cap, otherwise the test
+    // would pass vacuously (nothing trimmed).
+    expect(heavyBootstrap.length).toBeGreaterThan(BOOTSTRAP_CONTEXT_MAX_CHARS);
+  });
+
+  it('FIXED composition: directive survives a >12 KB bootstrap (appended post-cap)', () => {
+    // Reproduce the route's FIXED composition: marker at the HEAD of the
+    // bootstrap, then append the directive to the RETURNED instruction.
+    const augmentedContext =
+      `${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}\n\n${heavyBootstrap}\n\nBEHAVIORAL_RULE_PLACEHOLDER`;
+
+    let instruction = buildLiveSystemInstruction(
+      'en',
+      'friendly, calm, empathetic',
+      augmentedContext,
+      'COM',
+      undefined,
+      undefined,
+      false, // isReconnect — non-reconnect LiveKit turn
+      null,
+      null,
+      null,
+      undefined,
+      '@tester',
+      true, // omitGreetingPolicy — LiveKit
+    );
+    instruction += FIRST_TURN_SUPPRESSION_DIRECTIVE;
+
+    // The cap DID fire (heavy user) — proven by the trim sentinel.
+    expect(instruction).toMatch(/context trimmed: \d+ chars of older context omitted/);
+
+    // The load-bearing directive is STILL present in the final instruction.
+    expect(instruction).toMatch(/DO NOT SPEAK FIRST/);
+    expect(instruction).toMatch(/MUST NOT produce an opening utterance/);
+    expect(instruction).toMatch(/WAIT for the user to speak/);
+
+    // And it sits at the very END (recency primacy over the generic
+    // "you MUST speak first" GREETING RULES higher up).
+    expect(instruction.trimEnd().endsWith(
+      'Subsequent turns follow the normal conversation flow.',
+    )).toBe(true);
+  });
+
+  it('marker at the HEAD survives the cap so brain-opener stripping still fires', () => {
+    const augmentedContext =
+      `${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}\n\n${heavyBootstrap}`;
+
+    const instruction = buildLiveSystemInstruction(
+      'en',
+      'friendly, calm, empathetic',
+      augmentedContext,
+      'COM',
+      undefined,
+      undefined,
+      false,
+      null,
+      null,
+      null,
+      undefined,
+      '@tester',
+      true,
+    );
+
+    // Marker must survive — it drives stripBrainOpenerSections() +
+    // wakeBriefOverrideActive detection in live-system-instruction.ts.
+    expect(instruction).toContain(VERTEX_WAKE_BRIEF_OVERRIDE_MARKER);
+  });
+
+  it('REGRESSION GUARD: old tail-append composition would drop the directive', () => {
+    // This proves the bug was real: appending the directive to the END of the
+    // bootstrap (the pre-fix composition) gets it trimmed by the cap for a
+    // heavy user, so it never reaches the final instruction.
+    const oldStyleBootstrap =
+      `${heavyBootstrap}\n\nBEHAVIORAL_RULE_PLACEHOLDER${FIRST_TURN_SUPPRESSION_DIRECTIVE}`;
+
+    const instruction = buildLiveSystemInstruction(
+      'en',
+      'friendly, calm, empathetic',
+      oldStyleBootstrap,
+      'COM',
+      undefined,
+      undefined,
+      false,
+      null,
+      null,
+      null,
+      undefined,
+      '@tester',
+      true,
+    );
+
+    // The cap fired and the tail (where the directive lived) was trimmed away.
+    expect(instruction).toMatch(/context trimmed: \d+ chars of older context omitted/);
+    expect(instruction).not.toMatch(/DO NOT SPEAK FIRST/);
+  });
+
+  it('non-reconnect omitGreetingPolicy build does NOT order the model to speak first', () => {
+    // The generic GREETING RULES say "you MUST speak first" on a non-reconnect
+    // turn. With the directive appended post-cap, the LAST word on the first
+    // turn is "stay silent / WAIT for the user" — that is what the model obeys.
+    const augmentedContext =
+      `${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}\n\n${heavyBootstrap}`;
+    let instruction = buildLiveSystemInstruction(
+      'en',
+      'friendly, calm, empathetic',
+      augmentedContext,
+      'COM',
+      undefined,
+      undefined,
+      false,
+      null,
+      null,
+      null,
+      undefined,
+      '@tester',
+      true,
+    );
+    instruction += FIRST_TURN_SUPPRESSION_DIRECTIVE;
+
+    const speakFirstIdx = instruction.lastIndexOf('MUST speak first');
+    const silenceIdx = instruction.lastIndexOf('WAIT for the user to speak');
+    // The silence directive must come AFTER any "speak first" instruction so it
+    // wins on recency for the first turn.
+    expect(silenceIdx).toBeGreaterThan(-1);
+    if (speakFirstIdx > -1) {
+      expect(silenceIdx).toBeGreaterThan(speakFirstIdx);
+    }
+  });
+});

--- a/services/gateway/test/orb/routes/livekit-first-turn-single-source.test.ts
+++ b/services/gateway/test/orb/routes/livekit-first-turn-single-source.test.ts
@@ -1,0 +1,137 @@
+/**
+ * BOOTSTRAP-ORB-RCV-DOUBLEGREET — LiveKit first-turn single-source-of-truth.
+ *
+ * Regression lock for the dragan3 double-greeting (audit
+ * docs/superpowers/plans/2026-05-31-orb-communication-audit.md §E).
+ *
+ * Root cause: on LiveKit the turn-1 wake line was delivered TWICE —
+ *   1. the gateway re-rendered system_instruction with the Vertex
+ *      "## SPOKEN FIRST UTTERANCE — REQUIRED VERBATIM" override block
+ *      (buildVertexWakeBriefBlock) → the LLM spoke the line, AND
+ *   2. the Python agent spoke it again via session.say(user_facing_line)
+ *      at room-join.
+ * Vertex injects only once (the model speaks from the instruction; no
+ * session.say), so Vertex was never affected — this is a LiveKit-only fix.
+ *
+ * Decision: on LiveKit, session.say() is the single source of truth for
+ * the first turn. The gateway therefore injects ONLY the sentinel marker
+ * (which still drives stripBrainOpenerSections + SHORT-GAP pool
+ * suppression) plus a "DO NOT SPEAK FIRST" directive, so the LLM stays
+ * silent until the user replies and the agent's say() owns turn-1.
+ *
+ * These are source-text wire-up assertions, matching the established
+ * pattern in livekit-context-parity.test.ts (full HTTP integration over
+ * optionalAuth + Supabase + the dynamic-import spine is heavy; the
+ * wire-up is the load-bearing contract).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVEKIT_PATH = path.resolve(
+  __dirname,
+  '../../../src/routes/orb-livekit.ts',
+);
+
+let source: string;
+
+beforeAll(() => {
+  source = fs.readFileSync(ORB_LIVEKIT_PATH, 'utf8');
+});
+
+/** Isolate the wake-brief re-render block so assertions target the
+ * first-turn composition path and not unrelated mentions elsewhere. */
+function wakeRerenderBlock(src: string): string {
+  const start = src.indexOf('let wakeOverrideApplied = false;');
+  expect(start).toBeGreaterThan(-1);
+  // The block ends at the wake-decision snapshot emit that follows it.
+  const end = src.indexOf('logWakeDecisionSnapshot(', start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
+describe('BOOTSTRAP-ORB-RCV-DOUBLEGREET LiveKit first-turn single source of truth', () => {
+  it('does NOT inject the Vertex "speak this verbatim" override on LiveKit', () => {
+    // The whole double-greeting was the LLM ALSO speaking the line. The
+    // LiveKit route must no longer INVOKE buildVertexWakeBriefBlock (that
+    // helper emits the SPOKEN-FIRST-UTTERANCE / "speak VERBATIM" directive
+    // which the model obeys, doubling the agent's session.say()). We match
+    // an actual call site (`buildVertexWakeBriefBlock(`) and a dynamic
+    // import of it — a passing mention in a comment is fine.
+    expect(source).not.toMatch(/buildVertexWakeBriefBlock\s*\(/);
+    expect(source).not.toMatch(/import\([^)]*\)[\s\S]{0,80}buildVertexWakeBriefBlock\s*[,}]/);
+  });
+
+  it('injects the wake-brief sentinel marker so brain-opener sections are still stripped', () => {
+    // The marker is what triggers stripBrainOpenerSections() +
+    // SHORT-GAP pool suppression in live-system-instruction.ts. Without
+    // it the competing OPENING SHAPE MATRIX / PROACTIVE OPENER CANDIDATE
+    // brain sections would generate a RIVAL opener — a different double.
+    expect(source).toMatch(
+      /import\s*{\s*VERTEX_WAKE_BRIEF_OVERRIDE_MARKER\s*}\s*from\s*['"]\.\.\/orb\/live\/instruction\/wake-brief-marker['"]/,
+    );
+    const block = wakeRerenderBlock(source);
+    expect(block).toMatch(/\$\{VERTEX_WAKE_BRIEF_OVERRIDE_MARKER\}/);
+  });
+
+  it('the injected first-turn block instructs the model to stay silent (not to speak the line)', () => {
+    const block = wakeRerenderBlock(source);
+    expect(block).toMatch(/DO NOT SPEAK FIRST/i);
+    expect(block).toMatch(/MUST NOT produce an opening utterance/i);
+    expect(block).toMatch(/WAIT for the user to speak/i);
+    // The suppression block must NOT contain a verbatim-speak directive —
+    // that is the Vertex-only mechanism and the cause of the double.
+    expect(block).not.toMatch(/REQUIRED VERBATIM/);
+    expect(block).not.toMatch(/MUST\s+be\s+EXACTLY this text/i);
+  });
+
+  it('still gates the first-turn block on a picked line, not reconnect', () => {
+    // Reconnect sessions never get a fresh opener; the existing guard
+    // (picked && line.length > 0 && !isReconnect) must be preserved so a
+    // mid-session reconnect does not inject a spurious silence directive.
+    const block = wakeRerenderBlock(source);
+    expect(block).toMatch(/picked\s*&&\s*line\s*&&\s*line\.length\s*>\s*0\s*&&\s*!isReconnect/);
+  });
+
+  it('still surfaces wake_brief_decision in the response so the agent can session.say() it once', () => {
+    // session.say(user_facing_line) is the single source of truth; the
+    // agent reads it from this payload field. If this regresses, the
+    // LiveKit orb would go SILENT on turn-1 (worse than a double).
+    expect(source).toMatch(/wake_brief_decision:\s*wakeBriefDecision/);
+    expect(source).toMatch(/user_facing_line:\s*wakeBriefDecision\.selectedContinuation\?\.userFacingLine/);
+  });
+
+  it('preserves the proactive-offer lifecycle fields (dedupe_key + source_key)', () => {
+    // The agent only sets add_to_chat_ctx=True for a REAL proactive offer
+    // (decision_id + dedupe_key present). Those fields must keep flowing
+    // through the payload — this fix must not regress the proactive path.
+    expect(source).toMatch(/dedupe_key:\s*wakeBriefDecision\.selectedContinuation\?\.dedupeKey/);
+    expect(source).toMatch(/source_key:/);
+  });
+
+  it('keeps the re-render best-effort (try/catch, non-fatal fallback)', () => {
+    // A render failure must never block the bootstrap response; on throw
+    // we fall back to the pre-override system_instruction.
+    const block = wakeRerenderBlock(source);
+    expect(block).toMatch(/try\s*{/);
+    const after = source.slice(source.indexOf('let wakeOverrideApplied = false;'));
+    expect(after).toMatch(/suppression re-render failed[\s\S]{0,120}non-fatal/);
+  });
+
+  it('still passes omitGreetingPolicy=true on the LiveKit system-instruction builds', () => {
+    // The LiveKit contract is "session.say() owns the first turn, the LLM
+    // never generates it" — omitGreetingPolicy drops the ~37 KB greeting/
+    // reconnect/anti-pattern blocks. Both build call sites must keep it.
+    const calls = source.match(/buildLiveSystemInstruction\([\s\S]*?\);/g) ?? [];
+    const vitanaCalls = calls.filter(
+      (c) => c.includes('vitanaContextInstruction') || c.includes('augmentedContext'),
+    );
+    expect(vitanaCalls.length).toBeGreaterThanOrEqual(2);
+    // The final positional arg (omitGreetingPolicy) is `true` on both. It
+    // sits after vitana_id and may be trailed by an inline comment, so we
+    // assert the vitana_id arg is immediately followed by a `true` literal.
+    for (const call of vitanaCalls) {
+      expect(call).toMatch(/req\.identity\?\.vitana_id\s*\?\?\s*null,\s*true,/);
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Per the ORB communication audit `docs/superpowers/plans/2026-05-31-orb-communication-audit.md` **§E**, on **LiveKit** the turn-1 wake line was injected **twice**:

1. The gateway re-rendered `system_instruction` with the Vertex **"## SPOKEN FIRST UTTERANCE — REQUIRED VERBATIM"** override block (`buildVertexWakeBriefBlock`) → the **LLM spoke the line**, AND
2. The Python agent spoke it again via `session.say(user_facing_line)` at room-join (`services/agents/orb-agent/src/orb_agent/session.py` ~L2218).

Allowlisted users (dragan3 → LiveKit) therefore heard a **double greeting**.

## Single-source-of-truth decision

On LiveKit, **`session.say()` owns the first turn** — that is the existing, intentional contract (`omitGreetingPolicy=true`: "the LLM never generates the first utterance"). The competing source was the gateway re-injecting the Vertex "speak this verbatim" directive.

The fix (gateway-only, in `services/gateway/src/routes/orb-livekit.ts`): the LiveKit bootstrap re-render now injects **only the wake-brief sentinel marker** + a hard **"DO NOT SPEAK FIRST / stay silent until the user speaks"** directive — and no longer calls `buildVertexWakeBriefBlock`.

- The sentinel marker is preserved, so `stripBrainOpenerSections()` + SHORT-GAP-pool suppression in `live-system-instruction.ts` still fire → the competing OPENING SHAPE MATRIX / PROACTIVE OPENER CANDIDATE brain sections can't generate a *rival* opener (a different double).
- `wake_brief_decision` (`user_facing_line` + `decision_id` + `dedupe_key` + `source_key`) **still flows in the response payload**, so the agent speaks the line exactly **once** via `session.say()`.
- **Proactive-offer path unaffected:** the agent's `add_to_chat_ctx=bool(is_proactive_offer)` logic depends on `decision_id`+`dedupe_key`, which are unchanged.

## Python patch needed?

**No.** With the LLM kept silent, `session.say()` speaks once → fixed with zero agent change. `session.py` is untouched and no `docs/patches/orb-agent/` file was required.

## Tests

`services/gateway/test/orb/routes/livekit-first-turn-single-source.test.ts` (8 cases, source-text wire-up, matching the established `livekit-context-parity.test.ts` pattern):

- the verbatim override (`buildVertexWakeBriefBlock` call / import) is gone;
- the sentinel marker is still injected;
- the injected block tells the model to stay silent (no "REQUIRED VERBATIM" / "MUST be EXACTLY this text");
- the `!isReconnect` guard is preserved;
- `wake_brief_decision` + `user_facing_line` still surfaced;
- proactive-offer `dedupe_key` / `source_key` preserved;
- re-render stays best-effort (try/catch);
- `omitGreetingPolicy=true` still passed on both LiveKit builds.

## Build + test result

- `cd services/gateway && npm run build` → **green** (tsc 5.9.3, exit 0).
- `npx jest test/orb/routes/livekit-first-turn-single-source.test.ts test/orb/routes/livekit-context-parity.test.ts` → **30 passed** (8 new + 22 existing parity, no regression).

## Vertex parity ✓ / LiveKit parity ✓

- **LiveKit parity ✓** — turn-1 wake line now delivered **exactly once** (deterministic `session.say()`); the LLM is instructed to stay silent on turn-1; brain-opener strip + pool suppression retained so no rival opener.
- **Vertex parity ✓ (unaffected)** — the fix is gated entirely inside the LiveKit `/orb/context-bootstrap` re-render in `orb-livekit.ts`. Vertex speaks the first turn from `system_instruction` and has **no `session.say()`**, so it only ever injects once. The Vertex `live-session-controller.ts` path and `buildVertexWakeBriefBlock` definition are **not touched** by this PR.

## Scope / deferral

- **ORB-0.1 cross-provider watchdog is DEFERRED** out of this PR. It spans the Vertex send path that another lane is editing this wave; bundling it here would collide. This PR is LiveKit-only.
- Out of scope, noted for a future lane: when the `new_day_return` provider wins, its `user_facing_line` is a `STRUCTURED_BLOCK_PREFIX`-prefixed block meant for LLM synthesis, not a literal spoken line — the LiveKit agent would `session.say()` the marker text. Pre-existing and unrelated to the double-greeting symptom; not changed here.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_