### PR TITLE
feat(orb): R1 slice 2 — life_compass + journey plan_phase resolvers (BOOTSTRAP-ORB-R1-AWARENESS-SLICE2)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1303,6 +1303,16 @@ export async function handleLiveSessionStart(
             // the Teacher Mode block so it cedes turn 1 cleanly, or (b)
             // suppressing the wake-brief's Teacher-winner selection
             // upstream when journey-greeting will fire.
+            // TODO(R1 slice): migrate the plan_phase + life_compass-state
+            // derivation onto resolveJourneyPlanPhase / resolveLifeCompassState
+            // (services/awareness-unified-context.ts). NOT done here because it
+            // is NOT a no-op: the live derivation in new-day-overview-payload.ts
+            // is 3-way (it folds a past target_date into on_personalized_goal +
+            // a separate days_past_deadline), whereas the canonical resolver is
+            // the §1.4 4-way that promotes a past target_date to 'goal_completed'.
+            // The 'set'/'unset' below is also object-presence, not the canonical
+            // primary_goal/set_at rule. Migrating either changes behavior, so it
+            // waits for the R7 goal-completion provider that consumes the 4th phase.
             console.log(
               `[VTID-03154] Journey greeting prepared for ${sessionId}: kind=${result.meta.kind} day=${journey.day_in_journey}/${journey.total_days} phase=${journey.current_wave?.id ?? 'none'} life_compass=${lifeCompass ? 'set' : 'unset'}`,
             );

--- a/services/gateway/src/services/awareness-unified-context.ts
+++ b/services/gateway/src/services/awareness-unified-context.ts
@@ -129,6 +129,168 @@ export function resolveSessionTimezone(input: ResolveSessionTimezoneInput): stri
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// R1 slice 2 — life_compass state + journey plan_phase resolvers.
+//
+// ADDITIVE to slice 1: nothing above this line changes. Two more pieces of
+// the divergent-precedence problem get unified into pure, tested resolvers:
+//
+//   1. life_compass state ('set' | 'not_set') — today every caller decides
+//      "is there a goal?" ad-hoc (truthy primary_goal? non-null set_at? an
+//      is_active row?). We collapse that to ONE rule.
+//
+//   2. journey plan_phase — the §1.4 canon (spec line 86) is a 4-way
+//      discriminator with a strict PRECEDENCE that the live derivation in
+//      new-day-overview-payload.ts only implements as 3 ways (it folds the
+//      4th, `goal_completed`, into `on_personalized_goal` and tracks the
+//      past-deadline separately as `days_past_deadline`). This resolver lands
+//      the full canonical 4-way precedence so later slices can migrate the
+//      ad-hoc sites onto it. Because adding `goal_completed` is a *behavior
+//      change* for any site that previously emitted `on_personalized_goal`
+//      for a past-target goal, migrating such a site is NOT a no-op and is
+//      deferred (see the TODO in new-day-overview-payload.ts).
+//
+// Pure functions only — callers pass raw values in; precedence lives here.
+// ---------------------------------------------------------------------------
+
+/** Whether the user has an active Life Compass goal set. */
+export type LifeCompassState = 'set' | 'not_set';
+
+export interface ResolveLifeCompassStateInput {
+  /** The active life_compass row's primary goal text, if any. */
+  primaryGoal?: string | null;
+  /** When the active Life Compass was set (ISO); presence is a strong signal. */
+  setAt?: string | null;
+  /**
+   * Explicit "an active row exists" flag, when the caller already knows it
+   * (e.g. it queried `is_active=true`). When provided as `false` it forces
+   * 'not_set' regardless of the other fields (no active row → no goal).
+   */
+  hasActiveRow?: boolean | null;
+}
+
+/**
+ * The ONE canonical Life Compass state resolver.
+ *
+ * Rule (strictest-wins, mirrors §1.4 `life_compass.state`):
+ *   - If `hasActiveRow === false` → 'not_set' (an explicit "no active row"
+ *     beats any stale goal text the caller may still be carrying).
+ *   - Else 'set' iff there is a non-empty primary goal OR a parseable set_at
+ *     OR `hasActiveRow === true`; otherwise 'not_set'.
+ *
+ * Pure — no IO. Trims/validates inputs so callers don't each re-implement the
+ * "is this goal real?" check with divergent truthiness.
+ */
+export function resolveLifeCompassState(
+  input: ResolveLifeCompassStateInput,
+): LifeCompassState {
+  if (input.hasActiveRow === false) return 'not_set';
+
+  const goal = typeof input.primaryGoal === 'string' ? input.primaryGoal.trim() : '';
+  if (goal.length > 0) return 'set';
+
+  const setAt = typeof input.setAt === 'string' ? input.setAt.trim() : '';
+  if (setAt.length > 0 && Number.isFinite(Date.parse(setAt))) return 'set';
+
+  if (input.hasActiveRow === true) return 'set';
+
+  return 'not_set';
+}
+
+/**
+ * The canonical journey plan_phase discriminator (§1.4, spec line 86).
+ *
+ * default_active            → day_in_journey <= total_days, no Life Compass goal.
+ * default_finished_no_goal  → day_in_journey >  total_days, no Life Compass goal.
+ * on_personalized_goal      → Life Compass goal set, target_date NOT in the past.
+ * goal_completed            → Life Compass goal set, target_date IS in the past.
+ *                             (Phase 2 / R7 surface; the live 3-way derivation
+ *                              folds this into on_personalized_goal today.)
+ */
+export type JourneyPlanPhase =
+  | 'default_active'
+  | 'default_finished_no_goal'
+  | 'on_personalized_goal'
+  | 'goal_completed';
+
+export interface ResolveJourneyPlanPhaseInput {
+  /** Monotonic day since the journey started (never resets). */
+  dayInJourney: number;
+  /** Length of the default scaffolding plan (e.g. 90). */
+  totalDays: number;
+  /** Canonical Life Compass state — pass the result of resolveLifeCompassState. */
+  lifeCompassState: LifeCompassState;
+  /**
+   * Active goal target date (ISO date `YYYY-MM-DD` or full ISO). Only consulted
+   * when the goal is set; a past target_date promotes to `goal_completed`.
+   */
+  targetDate?: string | null;
+  /** Reference instant for the past/future target_date comparison. */
+  now: Date;
+}
+
+export interface ResolvedJourneyPlanPhase {
+  plan_phase: JourneyPlanPhase;
+  /** True when target_date parsed and is strictly before `now` (end-of-day). */
+  target_date_in_past: boolean;
+}
+
+/**
+ * The ONE canonical plan_phase resolver. PRECEDENCE (strictest-first):
+ *
+ *   1. life_compass set + target_date in the past   → 'goal_completed'
+ *   2. life_compass set (no / future target_date)    → 'on_personalized_goal'
+ *   3. not_set + day_in_journey >  total_days        → 'default_finished_no_goal'
+ *   4. not_set + day_in_journey <= total_days        → 'default_active'
+ *
+ * Boundary: `day_in_journey === total_days` is still `default_active` (the
+ * user is ON the last day of the plan, not past it) — matches the live
+ * `day > total_days` cutoff exactly.
+ *
+ * target_date "in the past" uses end-of-day UTC (`T23:59:59Z`) so a goal due
+ * *today* is NOT yet completed — identical to the live `days_past_deadline`
+ * cutoff in new-day-overview-payload.ts.
+ *
+ * Pure — no IO. Exhaustively unit-tested.
+ */
+export function resolveJourneyPlanPhase(
+  input: ResolveJourneyPlanPhaseInput,
+): ResolvedJourneyPlanPhase {
+  const targetDateInPast = isTargetDateInPast(input.targetDate, input.now);
+
+  if (input.lifeCompassState === 'set') {
+    return {
+      plan_phase: targetDateInPast ? 'goal_completed' : 'on_personalized_goal',
+      target_date_in_past: targetDateInPast,
+    };
+  }
+
+  if (input.dayInJourney > input.totalDays) {
+    return { plan_phase: 'default_finished_no_goal', target_date_in_past: targetDateInPast };
+  }
+
+  return { plan_phase: 'default_active', target_date_in_past: targetDateInPast };
+}
+
+/**
+ * Whether a goal `target_date` is strictly before `now`, using end-of-day UTC.
+ * Accepts a bare `YYYY-MM-DD` (anchored to `T23:59:59Z`) or any Date.parse-able
+ * ISO string. Unparseable or null → false (not in the past). Exported so
+ * downstream slices/tests can reuse the exact deadline semantics.
+ */
+export function isTargetDateInPast(targetDate: string | null | undefined, now: Date): boolean {
+  if (typeof targetDate !== 'string') return false;
+  const raw = targetDate.trim();
+  if (raw.length === 0) return false;
+
+  // Date-only → anchor to end-of-day UTC (a goal due "today" is not yet past).
+  const iso = /^\d{4}-\d{2}-\d{2}$/.test(raw) ? `${raw}T23:59:59Z` : raw;
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return false;
+
+  return ms < now.getTime();
+}
+
 /**
  * Target shape for the unified awareness context (populated incrementally by
  * later R1 slices). Documented now so consumers + reviewers see the endpoint;

--- a/services/gateway/test/services/awareness-unified-context.test.ts
+++ b/services/gateway/test/services/awareness-unified-context.test.ts
@@ -9,6 +9,10 @@
 import {
   resolveSpokenFirstName,
   type ResolvedFirstName,
+  resolveLifeCompassState,
+  resolveJourneyPlanPhase,
+  isTargetDateInPast,
+  type JourneyPlanPhase,
 } from '../../src/services/awareness-unified-context';
 
 describe('resolveSpokenFirstName', () => {
@@ -74,5 +78,176 @@ describe('resolveSpokenFirstName', () => {
     expect(resolveSpokenFirstName({ displayName: 'Ben Stiller', email: 'c1@d.com' }).source).toBe('app_users');
     // only email → email
     expect(resolveSpokenFirstName({ email: 'carol2@d.com' })).toEqual<ResolvedFirstName>({ firstName: 'Carol', source: 'email' });
+  });
+});
+
+// ===========================================================================
+// R1 slice 2 — life_compass state resolver.
+// ===========================================================================
+
+describe('resolveLifeCompassState', () => {
+  it('hasActiveRow === false forces not_set even with stale goal text / set_at', () => {
+    expect(
+      resolveLifeCompassState({ hasActiveRow: false, primaryGoal: 'Run a marathon', setAt: '2026-01-01' }),
+    ).toBe('not_set');
+  });
+
+  it('non-empty primary goal → set', () => {
+    expect(resolveLifeCompassState({ primaryGoal: 'Sleep 8h' })).toBe('set');
+  });
+
+  it('whitespace-only primary goal does NOT count as set', () => {
+    expect(resolveLifeCompassState({ primaryGoal: '   ' })).toBe('not_set');
+  });
+
+  it('parseable set_at alone → set', () => {
+    expect(resolveLifeCompassState({ setAt: '2026-05-01T10:00:00Z' })).toBe('set');
+  });
+
+  it('unparseable set_at alone → not_set', () => {
+    expect(resolveLifeCompassState({ setAt: 'not-a-date' })).toBe('not_set');
+  });
+
+  it('explicit hasActiveRow === true → set even with no goal/setAt', () => {
+    expect(resolveLifeCompassState({ hasActiveRow: true })).toBe('set');
+  });
+
+  it('empty input → not_set', () => {
+    expect(resolveLifeCompassState({})).toBe('not_set');
+    expect(resolveLifeCompassState({ primaryGoal: null, setAt: null, hasActiveRow: null })).toBe('not_set');
+  });
+
+  it('goal wins over an explicit false? No — false hard-overrides (strictest)', () => {
+    // hasActiveRow:false is the strictest signal and must win.
+    expect(resolveLifeCompassState({ hasActiveRow: false, primaryGoal: 'X' })).toBe('not_set');
+  });
+});
+
+// ===========================================================================
+// R1 slice 2 — isTargetDateInPast helper.
+// ===========================================================================
+
+describe('isTargetDateInPast', () => {
+  const now = new Date('2026-06-01T12:00:00Z');
+
+  it('null / undefined / empty → false', () => {
+    expect(isTargetDateInPast(null, now)).toBe(false);
+    expect(isTargetDateInPast(undefined, now)).toBe(false);
+    expect(isTargetDateInPast('   ', now)).toBe(false);
+  });
+
+  it('unparseable string → false', () => {
+    expect(isTargetDateInPast('someday', now)).toBe(false);
+  });
+
+  it('date-only in the past → true', () => {
+    expect(isTargetDateInPast('2026-05-31', now)).toBe(true);
+  });
+
+  it('date-only in the future → false', () => {
+    expect(isTargetDateInPast('2026-06-02', now)).toBe(false);
+  });
+
+  it('date-only == today is NOT past (anchored to end-of-day UTC)', () => {
+    // 2026-06-01T23:59:59Z is after now (12:00Z) → not past.
+    expect(isTargetDateInPast('2026-06-01', now)).toBe(false);
+  });
+
+  it('full ISO timestamp earlier today IS past', () => {
+    expect(isTargetDateInPast('2026-06-01T06:00:00Z', now)).toBe(true);
+  });
+
+  it('full ISO timestamp later today is NOT past', () => {
+    expect(isTargetDateInPast('2026-06-01T18:00:00Z', now)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// R1 slice 2 — journey plan_phase resolver (the §1.4 4-way discriminator).
+// ===========================================================================
+
+describe('resolveJourneyPlanPhase', () => {
+  const now = new Date('2026-06-01T12:00:00Z');
+
+  const phase = (
+    over: Partial<Parameters<typeof resolveJourneyPlanPhase>[0]>,
+  ): JourneyPlanPhase =>
+    resolveJourneyPlanPhase({
+      dayInJourney: 1,
+      totalDays: 90,
+      lifeCompassState: 'not_set',
+      now,
+      ...over,
+    }).plan_phase;
+
+  // --- not_set branch (day vs total_days boundary) ---
+
+  it('not_set, day < total_days → default_active', () => {
+    expect(phase({ dayInJourney: 45, totalDays: 90 })).toBe('default_active');
+  });
+
+  it('not_set, day == total_days → default_active (boundary: on last day, not past)', () => {
+    expect(phase({ dayInJourney: 90, totalDays: 90 })).toBe('default_active');
+  });
+
+  it('not_set, day == total_days + 1 → default_finished_no_goal', () => {
+    expect(phase({ dayInJourney: 91, totalDays: 90 })).toBe('default_finished_no_goal');
+  });
+
+  it('not_set, day >> total_days → default_finished_no_goal', () => {
+    expect(phase({ dayInJourney: 200, totalDays: 90 })).toBe('default_finished_no_goal');
+  });
+
+  // --- set branch (target_date past/future/null) ---
+
+  it('set, no target_date → on_personalized_goal', () => {
+    const r = resolveJourneyPlanPhase({ dayInJourney: 5, totalDays: 90, lifeCompassState: 'set', now });
+    expect(r.plan_phase).toBe('on_personalized_goal');
+    expect(r.target_date_in_past).toBe(false);
+  });
+
+  it('set, future target_date → on_personalized_goal', () => {
+    const r = resolveJourneyPlanPhase({
+      dayInJourney: 5, totalDays: 90, lifeCompassState: 'set', targetDate: '2026-12-31', now,
+    });
+    expect(r.plan_phase).toBe('on_personalized_goal');
+    expect(r.target_date_in_past).toBe(false);
+  });
+
+  it('set, past target_date → goal_completed', () => {
+    const r = resolveJourneyPlanPhase({
+      dayInJourney: 5, totalDays: 90, lifeCompassState: 'set', targetDate: '2026-05-01', now,
+    });
+    expect(r.plan_phase).toBe('goal_completed');
+    expect(r.target_date_in_past).toBe(true);
+  });
+
+  it('set, target_date == today → on_personalized_goal (today not yet past)', () => {
+    expect(
+      phase({ lifeCompassState: 'set', targetDate: '2026-06-01' }),
+    ).toBe('on_personalized_goal');
+  });
+
+  it('set state takes precedence over day count (goal overrides plan window)', () => {
+    // Even when day > total_days, a set goal means on_personalized_goal,
+    // never default_finished_no_goal.
+    expect(
+      phase({ lifeCompassState: 'set', dayInJourney: 500, totalDays: 90 }),
+    ).toBe('on_personalized_goal');
+  });
+
+  it('past target_date is ignored when life_compass is not_set', () => {
+    // No goal → the target_date is irrelevant; day-vs-total decides.
+    const r = resolveJourneyPlanPhase({
+      dayInJourney: 10, totalDays: 90, lifeCompassState: 'not_set', targetDate: '2020-01-01', now,
+    });
+    expect(r.plan_phase).toBe('default_active');
+    // helper still reports the raw past-ness, but it does not change phase.
+    expect(r.target_date_in_past).toBe(true);
+  });
+
+  it('end-to-end with resolveLifeCompassState: real goal text → on_personalized_goal', () => {
+    const state = resolveLifeCompassState({ primaryGoal: 'Lose 5kg' });
+    expect(phase({ lifeCompassState: state })).toBe('on_personalized_goal');
   });
 });


### PR DESCRIPTION
## R1 slice 2 — additive to slice 1

This is the **next R1 slice** of the unified awareness context, built in the same pure / no-IO / behavior-preserving style as slice 1 (`resolveSpokenFirstName`).

### Existing exports are UNCHANGED
`resolveSpokenFirstName`, `ResolveSpokenFirstNameInput`, `ResolvedFirstName`, `FirstNameSource`, and the `UnifiedAwarenessContext` interface are untouched. The parallel "35-day" program consumes these read-only — nothing it depends on changed signature or behavior. All additions are appended below the slice-1 code.

### New resolvers (`services/gateway/src/services/awareness-unified-context.ts`)
Per the §1.4 `UnifiedAwarenessContext` interface (spec line 86):

- **`resolveLifeCompassState({ primaryGoal, setAt, hasActiveRow }) → 'set' | 'not_set'`** — the one canonical "is there a goal?" rule. `hasActiveRow === false` hard-overrides to `not_set`; otherwise `set` iff non-empty `primaryGoal`, a parseable `setAt`, or `hasActiveRow === true`.
- **`resolveJourneyPlanPhase({ dayInJourney, totalDays, lifeCompassState, targetDate, now }) → { plan_phase, target_date_in_past }`** — the canonical **4-way** discriminator with strict precedence:
  1. set + target_date in past → `goal_completed`
  2. set (no/future target_date) → `on_personalized_goal`
  3. not_set + day > total_days → `default_finished_no_goal`
  4. not_set + day ≤ total_days → `default_active`
  Boundary: `day == total_days` is still `default_active`. `target_date` uses end-of-day UTC so a goal due *today* is not yet completed (mirrors the live `days_past_deadline` cutoff).
- **`isTargetDateInPast(targetDate, now)`** — exported helper for the exact deadline semantics.

Pure functions only — callers pass raw values in; the divergent precedence is unified in one tested place.

### Tests (`test/services/awareness-unified-context.test.ts`)
Extended to **34 cases** (8 slice-1, all still green + 26 new) covering every branch and boundary:
- life_compass: goal text / set_at / hasActiveRow true/false/null, whitespace-only goal, unparseable set_at.
- target_date: past / future / today / null / unparseable, date-only vs full ISO.
- plan_phase: `day == total_days` boundary, `day == total_days + 1`, set overrides day count, past target_date ignored when not_set, end-to-end with `resolveLifeCompassState`.

`npx jest awareness-unified-context` → **34 passed**. Gateway build green (local TS 5.9.3, matching CI).

### Call-site migration — deferred (TODO left, NOT a no-op)
The live `plan_phase` derivation lives in `new-day-overview-payload.ts` and is **3-way** — it folds a past `target_date` into `on_personalized_goal` plus a separate `days_past_deadline`. Migrating it onto the canonical 4-way resolver would promote past-target goals to `goal_completed`, **changing behavior**, so per the slice constraints it was NOT migrated. A `TODO(R1 slice)` comment was left in `live-session-controller.ts` documenting the deferral until the R7 goal-completion provider consumes the 4th phase. No characterization change.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_