### PR TITLE
test(autopilot): fix stale empty-queue voice assertion (VTID-03245 fallout)

### DIFF
--- a/services/gateway/test/services/autopilot-voice-tools.test.ts
+++ b/services/gateway/test/services/autopilot-voice-tools.test.ts
@@ -36,7 +36,10 @@ describe('summarizeAutopilotForVoice', () => {
     const s = summarizeAutopilotForVoice([]);
     expect(s.count).toBe(0);
     expect(s.ids).toEqual([]);
-    expect(s.spoken).toMatch(/no Autopilot actions/i);
+    // VTID-03245 (#2480) reworded the empty-queue line for offer-integrity:
+    // "You don't have any Autopilot actions prepared yet …". Assert the
+    // "no actions" meaning without pinning the exact marketing copy.
+    expect(s.spoken).toMatch(/don't have any Autopilot actions/i);
   });
 
   it('uses the singular form for exactly one action', () => {


### PR DESCRIPTION
## Fix stale autopilot-voice empty-queue test (unblocks all open PRs)

**Root cause:** #2480 (VTID-03245, "offer-integrity — never speak tool failures as system issues") reworded the empty Autopilot queue voice line in `autopilot-recommendations.ts` to:

> "You don't have any Autopilot actions prepared yet — those build up as you keep using Vitana. …"

…but did not update `autopilot-voice-tools.test.ts`, which still asserts `/no Autopilot actions/i`. That test now fails on `main`, so **"Gateway Service Tests" is red on every open PR**, not just one.

**Fix:** update the regex to `/don't have any Autopilot actions/i` to match the intended phrasing (the impl change is canonical; the test was stale). Verified locally: the suite goes 4/4 green.

Scope: one-line test assertion. No source/behaviour change.

🤖 Draft.

https://claude.ai/code/session_015ksCuqQXUog3KXUhfyvXMY

---
_Generated by [Claude Code](https://claude.ai/code/session_015ksCuqQXUog3KXUhfyvXMY)_