### PR TITLE
fix(gateway): mobile-aware nav catalog for reminders + archived

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -1146,6 +1146,10 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
   {
     screen_id: 'INBOX.REMINDERS',
     route: '/inbox/reminder',
+    // BOOTSTRAP-MOBILE-NAV-CONTAINMENT: same surface as REMINDERS.OVERVIEW — on
+    // mobile open the Calendar popup's Reminders tab in place rather than landing
+    // on the desktop /reminders full page.
+    mobile_route: '/reminders?open=calendar&tab=reminders',
     category: 'inbox',
     access: 'authenticated',
     anonymous_safe: false,
@@ -1300,6 +1304,10 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
   },
   {
     screen_id: 'INBOX.ARCHIVED', route: '/inbox/archived', category: 'inbox',
+    // BOOTSTRAP-MOBILE-NAV-CONTAINMENT: desktop-only master/detail layout (two
+    // fixed-width w-80 panes side by side); no mobile rendering exists. Gate it so
+    // the ORB never route-changes a mobile user here — it stays in voice instead.
+    viewport_only: 'desktop',
     access: 'authenticated', anonymous_safe: false,
     i18n: {
       en: { title: 'Archived Messages', description: 'Messages you have archived.', when_to_visit: 'When the user asks for archived messages, old messages, or messages they saved or dismissed.' },
@@ -1712,6 +1720,12 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
   // ── REMINDERS / MESSAGES / DAILY DIARY ──────────────────────────────────
   {
     screen_id: 'REMINDERS.OVERVIEW', route: '/reminders', category: 'inbox',
+    // BOOTSTRAP-MOBILE-NAV-CONTAINMENT: the /reminders page is a desktop full-list
+    // view; on mobile the reminders surface is the Calendar popup's Reminders tab.
+    // Emit the overlay marker so the ORB opens the popup in place instead of
+    // route-changing to a dead-end full page. The frontend intercepts ?open=calendar
+    // and dispatches `calendar:open` (with tab=reminders) without navigating.
+    mobile_route: '/reminders?open=calendar&tab=reminders',
     access: 'authenticated', anonymous_safe: false,
     aliases: ['reminders', 'reminder-list', 'all-reminders', 'meine-erinnerungen'],
     i18n: {


### PR DESCRIPTION
## Problem

The ORB Navigator redirected mobile users to desktop-only screens because the navigation-catalog's mobile fields (`mobile_route`, `viewport_only`, VTID-02789) were almost entirely unused. Example: "show my reminders" → `/reminders` desktop full-list page on mobile.

## Changes (`services/gateway/src/lib/navigation-catalog.ts`)
- **`REMINDERS.OVERVIEW`** (`/reminders`) and **`INBOX.REMINDERS`** (`/inbox/reminder`): add `mobile_route: '/reminders?open=calendar&tab=reminders'`. On mobile the navigator emits the overlay marker; the frontend opens the Calendar popup on the Reminders tab **in place** (no route change) instead of landing on the desktop page.
- **`INBOX.ARCHIVED`** (`/inbox/archived`): `viewport_only: 'desktop'`. Its fixed two-pane `w-80` master/detail layout has no mobile rendering, so the navigator now stays in voice on mobile (`wrong_viewport`) rather than route-changing there.

The navigator already honors these fields in `tool_navigate_to_screen` (`orb-tools-shared.ts`); `mobile_route` query strings pass through untouched (only `:param` substitution + `entry_kind:'overlay'` marker-append run).

## Verification
- `navigation-catalog.ts` type-checks clean (data-only edit using existing optional fields).
- Frontend (`vitana-v1`, same branch) converts `?open=calendar` → `calendar:open` overlay event and mounts the listener on mobile.

> Pairs with `vitana-v1` PR (same branch): mobile overlay listener + ORB viewport net + mobile screen inventory.

https://claude.ai/code/session_018wL56QkgMNJBTk8t9DpeXb

---
_Generated by [Claude Code](https://claude.ai/code/session_018wL56QkgMNJBTk8t9DpeXb)_