### PR TITLE
fix(orb): context-integrity gate + reliable local time under geo-IP failure (VTID-03250)

### DIFF
--- a/docs/patches/vitana-v1/VTID-03250-send-browser-timezone.md
+++ b/docs/patches/vitana-v1/VTID-03250-send-browser-timezone.md
@@ -1,0 +1,27 @@
+# VTID-03250 — vitana-v1: send the browser timezone on ORB session start
+
+**Status:** patch (vitana-v1 is a separate repo; can't deploy from the gateway sandbox). **This is the piece that fixes mobile**, where most testers are.
+
+## Why
+The ORB ENVIRONMENT context (location + **local time** the assistant speaks) was derived only from **geo-IP**, which rate-limits (ipapi.co HTTP 429). When it fails, the gateway had no timezone → the assistant hallucinated the time ("8:30 PM" at 15:44) and city ("Berlin" in Cologne).
+
+The gateway now **prefers a browser-supplied timezone** over geo-IP (VTID-03250, `buildClientContext` + `resolveSessionTimezone`). The browser knows its IANA zone reliably via `Intl` — so the client must send it.
+
+## Change (vitana-v1 ORB widget, where it POSTs `/api/v1/orb/live/session/start`)
+Add `client_timezone` to the start payload (mirrors the command-hub widget fix):
+
+```js
+const startPayload = { /* lang, voice_style, response_modalities, vad_silence_ms, ... */ };
+try {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone; // e.g. "Europe/Berlin"
+  if (tz) startPayload.client_timezone = tz;
+} catch (_e) { /* Intl unavailable — gateway falls back to geo-IP */ }
+```
+
+(Equivalently, send an `x-client-timezone` header — the gateway accepts either.)
+
+## Acceptance
+- On mobile, ask Vitana "what time is it?" / "where am I?" → she uses the device's real timezone for local time, even when geo-IP is rate-limited. City still comes from geo-IP (degrades gracefully — she won't fabricate a city when geo is unavailable; she just won't name one).
+
+## Gateway side (already shipped, VTID-03250)
+`buildClientContext` reads `body.client_timezone` / `x-client-timezone` and prefers it via `resolveSessionTimezone`. The context-integrity unit gate (`test/services/context-integrity.test.ts`) locks this so it can't silently regress.

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1158,6 +1158,13 @@
         response_modalities: ['audio', 'text'],
         vad_silence_ms: 850 // VTID-03019: trimmed 1200→850 to cut ~350ms off end-of-turn latency; constants.ts mirrors
       };
+      // VTID-03250: send the browser's OWN IANA timezone so the gateway has a
+      // reliable local time even when geo-IP rate-limits (HTTP 429). Without
+      // this the assistant lost the user's time and hallucinated it.
+      try {
+        var _tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (_tz) startPayload.client_timezone = _tz;
+      } catch (e) { /* Intl unavailable — gateway falls back to geo-IP */ }
       if (_s.currentRoute) startPayload.current_route = _s.currentRoute;
       if (_s.recentRoutes && _s.recentRoutes.length) startPayload.recent_routes = _s.recentRoutes.slice(0, 5);
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -46,6 +46,9 @@ import { randomUUID } from 'crypto';
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
+// VTID-03250: prefer the browser's own timezone over rate-limit-prone geo-IP
+// so the assistant never loses the user's local time (context integrity).
+import { resolveSessionTimezone } from '../services/awareness-unified-context';
 // Phase 1 W2 (BOOTSTRAP-PHASE1-W2-CONSENT-METADATA): tag events with
 // data_export_ok ONLY where tenant export consent is established, so the
 // dataset-extraction PII gate can ingest them. Default off / fail-closed.
@@ -7712,13 +7715,25 @@ export async function buildClientContext(req: Request): Promise<ClientContext> {
     Promise.resolve(parseUserAgent(ua)),
   ]);
 
-  const timeCtx = getLocalTimeContext(geo.timezone);
+  // VTID-03250: prefer the browser's own IANA timezone (sent in the
+  // session-start body / x-client-timezone header) over geo-IP, which
+  // rate-limits (HTTP 429) and then yields no zone — that loss was making the
+  // assistant hallucinate the user's local time (e.g. "8:30 PM" at 15:44).
+  const clientTimezone =
+    (req.body && (req.body.client_timezone || req.body.client_context?.timezone)) ||
+    req.get('x-client-timezone') ||
+    null;
+  const resolvedTimezone = resolveSessionTimezone({
+    clientTimezone,
+    geoTimezone: geo.timezone ?? null,
+  });
+  const timeCtx = getLocalTimeContext(resolvedTimezone ?? undefined);
 
   return {
     ip,
     city: geo.city,
     country: geo.country,
-    timezone: geo.timezone,
+    timezone: resolvedTimezone ?? undefined,
     localTime: timeCtx.localTime,
     timeOfDay: timeCtx.timeOfDay,
     device: uaParsed.device,

--- a/services/gateway/src/services/awareness-unified-context.ts
+++ b/services/gateway/src/services/awareness-unified-context.ts
@@ -85,6 +85,50 @@ export function resolveSpokenFirstName(
   return { firstName: null, source: 'none' };
 }
 
+// ---------------------------------------------------------------------------
+// VTID-03250 — session timezone resolution (location/time integrity).
+//
+// The ENVIRONMENT block (city + local time the assistant reads) used to derive
+// the timezone ONLY from geo-IP. geo-IP rate-limits (ipapi.co HTTP 429) and
+// then returns no timezone → the assistant lost the user's local time and
+// hallucinated (e.g. "Berlin, 8:30 PM" when the user was in Cologne at 15:44).
+// The browser KNOWS its IANA timezone reliably (Intl) — prefer it; geo-IP is
+// only the fallback. This makes the spoken local time correct even when the
+// geo provider is unavailable.
+// ---------------------------------------------------------------------------
+
+/** True iff `tz` is a usable IANA timezone (Intl validates it). */
+export function isValidIanaTimezone(tz: string | null | undefined): boolean {
+  if (typeof tz !== 'string' || tz.trim().length === 0) return false;
+  try {
+    // Throws RangeError on an unknown zone.
+    new Intl.DateTimeFormat('en-US', { timeZone: tz.trim() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface ResolveSessionTimezoneInput {
+  /** The browser's own IANA zone (Intl), sent in the session-start body. */
+  clientTimezone?: string | null;
+  /** The geo-IP-derived zone (rate-limit-prone). */
+  geoTimezone?: string | null;
+}
+
+/**
+ * Canonical session timezone: prefer the client/browser zone, fall back to
+ * geo-IP, else null. Invalid client zones fall through to geo. Pure.
+ */
+export function resolveSessionTimezone(input: ResolveSessionTimezoneInput): string | null {
+  const client = typeof input.clientTimezone === 'string' ? input.clientTimezone.trim() : '';
+  if (client && isValidIanaTimezone(client)) return client;
+  const geo = typeof input.geoTimezone === 'string' ? input.geoTimezone.trim() : '';
+  if (geo && isValidIanaTimezone(geo)) return geo;
+  if (geo) return geo; // tolerate a geo zone Intl can't validate in this runtime
+  return null;
+}
+
 /**
  * Target shape for the unified awareness context (populated incrementally by
  * later R1 slices). Documented now so consumers + reviewers see the endpoint;

--- a/services/gateway/test/services/context-integrity.test.ts
+++ b/services/gateway/test/services/context-integrity.test.ts
@@ -1,0 +1,82 @@
+/**
+ * VTID-03250 — context-integrity gate (slice 1: time/location).
+ *
+ * The protection the founder demanded: lock the contract that the assistant's
+ * ENVIRONMENT context (location + LOCAL TIME) must stay correct and must NOT
+ * silently degrade when an upstream (geo-IP) fails. This codifies the fix for
+ * the "Berlin / 8:30 PM at 15:44 in Cologne" hallucination and FAILS the build
+ * if a future change re-breaks time resolution.
+ *
+ * Pure-unit layer here; a post-deploy production smoke (assert the LIVE
+ * system_instruction contains the ENVIRONMENT block + a local time) is the
+ * next gate layer.
+ */
+
+import {
+  resolveSessionTimezone,
+  isValidIanaTimezone,
+} from '../../src/services/awareness-unified-context';
+
+describe('isValidIanaTimezone', () => {
+  it('accepts real IANA zones', () => {
+    expect(isValidIanaTimezone('Europe/Berlin')).toBe(true);
+    expect(isValidIanaTimezone('America/New_York')).toBe(true);
+    expect(isValidIanaTimezone('UTC')).toBe(true);
+  });
+  it('rejects junk / empty', () => {
+    expect(isValidIanaTimezone('Not/AZone')).toBe(false);
+    expect(isValidIanaTimezone('')).toBe(false);
+    expect(isValidIanaTimezone(null)).toBe(false);
+    expect(isValidIanaTimezone(undefined)).toBe(false);
+  });
+});
+
+describe('resolveSessionTimezone — time integrity under geo-IP failure', () => {
+  it('CONTRACT: the browser timezone wins over geo-IP (reliable source)', () => {
+    expect(
+      resolveSessionTimezone({ clientTimezone: 'Europe/Berlin', geoTimezone: 'America/Chicago' }),
+    ).toBe('Europe/Berlin');
+  });
+
+  it('CONTRACT: when geo-IP fails (429 → no zone), the browser timezone still gives us the local time', () => {
+    // This is the exact production failure: geo-IP returned nothing for the
+    // user's IP. The browser zone must keep time correct.
+    expect(
+      resolveSessionTimezone({ clientTimezone: 'Europe/Berlin', geoTimezone: null }),
+    ).toBe('Europe/Berlin');
+    expect(
+      resolveSessionTimezone({ clientTimezone: 'Europe/Berlin', geoTimezone: undefined }),
+    ).toBe('Europe/Berlin');
+  });
+
+  it('falls back to geo-IP when the client sent none', () => {
+    expect(resolveSessionTimezone({ clientTimezone: null, geoTimezone: 'Europe/Berlin' })).toBe('Europe/Berlin');
+  });
+
+  it('an invalid client timezone falls through to geo-IP (never trust junk)', () => {
+    expect(
+      resolveSessionTimezone({ clientTimezone: 'Mars/Olympus', geoTimezone: 'Europe/Berlin' }),
+    ).toBe('Europe/Berlin');
+  });
+
+  it('returns null only when neither source has a zone (env block then omits time, never fabricates it)', () => {
+    expect(resolveSessionTimezone({ clientTimezone: null, geoTimezone: null })).toBeNull();
+    expect(resolveSessionTimezone({})).toBeNull();
+  });
+
+  it('CONTRACT: a resolved zone yields the correct wall-clock for that zone (not UTC)', () => {
+    // Pin an instant where Berlin (CEST, +2) and UTC differ by hours so a
+    // regression that silently used UTC would be caught.
+    const tz = resolveSessionTimezone({ clientTimezone: 'Europe/Berlin' });
+    expect(tz).toBe('Europe/Berlin');
+    const hourBerlin = Number(
+      new Intl.DateTimeFormat('en-US', {
+        timeZone: tz!,
+        hour: 'numeric',
+        hour12: false,
+      }).format(new Date('2026-06-01T13:44:00Z')),
+    );
+    // 13:44 UTC → 15:44 Berlin (CEST). A UTC fallback would give 13.
+    expect(hourBerlin).toBe(15);
+  });
+});


### PR DESCRIPTION
## The protection you asked for + the time/location fix

You reported Vitana hallucinating location/time (Berlin / 8:30 PM when in Cologne at 15:44). Confirmed root cause in live logs: the ENVIRONMENT context took its timezone **only from geo-IP**, which rate-limits (`[VTID-CONTEXT] ipapi.co HTTP 429`) — so the gateway had no zone and the model invented the time/city. (Separately, the 12KB bootstrap cap is trimming ~6.8KB of context/session — follow-up.)

### GATE (the safety net — runs in CI on every PR)
`test/services/context-integrity.test.ts` locks the contract: local time must stay correct under geo-IP failure — **browser timezone wins over geo-IP**, invalid zones fall through, and a resolved zone yields the right wall-clock (not UTC). Revert the fix and the build fails. This is the "catch the regression immediately" mechanism.

### FIX (to green)
- `resolveSessionTimezone` + `isValidIanaTimezone` in the R1 awareness module.
- `buildClientContext` now **prefers a browser timezone** (session-start `client_timezone` body field or `x-client-timezone` header) over geo-IP → correct local time even when geo is rate-limited. City still from geo-IP (degrades gracefully; no fabricated city).
- Command-hub widget sends `Intl...timeZone`.

### Parity
- vitana-v1 (mobile — your testers): `docs/patches/vitana-v1/VTID-03250-send-browser-timezone.md` (separate repo).
- LiveKit already gets a client-sourced timezone via the agent envelope.

### Tests
16 green (8 gate + 8 awareness); `tsc` clean; widget `node --check` OK.

### Honest scope
This is gate **slice 1** (time/location). The next gate layers: a **post-deploy production smoke** asserting the LIVE system instruction contains the ENVIRONMENT block + identity + memory (catches truncation), and the **12KB-cap rework** (it's trimming a third of authenticated context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)