### PR TITLE
fix(i18n): localize Priority-of-the-Day banner copy (VTID-01947)

### DIFF
--- a/services/gateway/src/i18n/catalog.ts
+++ b/services/gateway/src/i18n/catalog.ts
@@ -70,7 +70,30 @@ export type GatewayI18nKey =
   | 'notif.category.community.live_rooms.label'
   | 'notif.category.community.live_rooms.desc'
   | 'notif.category.community.connections_social.label'
-  | 'notif.category.community.connections_social.desc';
+  | 'notif.category.community.connections_social.desc'
+  // Priority of the Day banner (VTID-01947) — awareness-driven Home card +
+  // morning-brief fallback body. Emitted by the gateway as a full sentence,
+  // so it must be localized server-side (the frontend renders it verbatim).
+  | 'priority.absence_streak.named'
+  | 'priority.absence_streak'
+  | 'priority.absence.named.day'
+  | 'priority.absence.named.days'
+  | 'priority.absence.day'
+  | 'priority.absence.days'
+  | 'priority.overdue.one'
+  | 'priority.overdue.many'
+  | 'priority.goal_prosperity_idle'
+  | 'priority.welcome_wave'
+  | 'priority.welcome_generic'
+  | 'priority.open_recs.one'
+  | 'priority.open_recs.many'
+  | 'priority.journey_day'
+  | 'priority.greeting.morning.named'
+  | 'priority.greeting.morning'
+  | 'priority.greeting.afternoon.named'
+  | 'priority.greeting.afternoon'
+  | 'priority.greeting.evening.named'
+  | 'priority.greeting.evening';
 
 type LocaleCatalog = Record<GatewayI18nKey, string>;
 
@@ -129,6 +152,27 @@ const DE: LocaleCatalog = {
   'notif.category.community.live_rooms.desc': 'Live-Raum-Starts, Einladungen, Zusammenfassungen und Aufzeichnungen',
   'notif.category.community.connections_social.label': 'Verbindungen & Soziales',
   'notif.category.community.connections_social.desc': 'Neue Matches, Verbindungen und soziale Aktivität',
+  // Priority of the Day banner (VTID-01947)
+  'priority.absence_streak.named': '{name}, willkommen zurück. Deine Tagebuch-Serie pausierte bei {streak} Tagen – möchtest du sie fortsetzen?',
+  'priority.absence_streak': 'Willkommen zurück. Deine Tagebuch-Serie pausierte bei {streak} Tagen – möchtest du sie fortsetzen?',
+  'priority.absence.named.day': '{name}, es ist {days} Tag her – schön, dass du wieder da bist.',
+  'priority.absence.named.days': '{name}, es sind {days} Tage her – schön, dass du wieder da bist.',
+  'priority.absence.day': 'Es ist {days} Tag her – schön, dass du wieder da bist.',
+  'priority.absence.days': 'Es sind {days} Tage her – schön, dass du wieder da bist.',
+  'priority.overdue.one': '{count} Journey-Aktivität wartet noch von vorhin. Willst du sie jetzt angehen?',
+  'priority.overdue.many': '{count} Journey-Aktivitäten warten noch von vorhin. Willst du eine jetzt angehen?',
+  'priority.goal_prosperity_idle': 'Dein Ziel zielt auf finanzielle Freiheit. Ein Business-Hub-Check-in könnte es heute voranbringen.',
+  'priority.welcome_wave': 'Du bist in „{wave}“ – {description}. Möchtest du eine 2-Minuten-Tour?',
+  'priority.welcome_generic': 'Willkommen auf deiner Longevity-Reise. Lass mich dir zeigen, was wir gemeinsam tun können.',
+  'priority.open_recs.one': '{count} Autopilot-Aktion ist für dich bereit. Einen Blick wert?',
+  'priority.open_recs.many': '{count} Autopilot-Aktionen sind für dich bereit. Einen Blick wert?',
+  'priority.journey_day': 'Tag {day} deiner Reise, in „{wave}“. Bleib dran.',
+  'priority.greeting.morning.named': 'Guten Morgen, {name}. Bereit, wenn du es bist.',
+  'priority.greeting.morning': 'Guten Morgen. Bereit, wenn du es bist.',
+  'priority.greeting.afternoon.named': 'Guten Tag, {name}. Bereit, wenn du es bist.',
+  'priority.greeting.afternoon': 'Guten Tag. Bereit, wenn du es bist.',
+  'priority.greeting.evening.named': 'Guten Abend, {name}. Bereit, wenn du es bist.',
+  'priority.greeting.evening': 'Guten Abend. Bereit, wenn du es bist.',
 };
 
 const EN: LocaleCatalog = {
@@ -186,6 +230,27 @@ const EN: LocaleCatalog = {
   'notif.category.community.live_rooms.desc': 'Live room starting, invites, summaries, and recordings',
   'notif.category.community.connections_social.label': 'Connections & Social',
   'notif.category.community.connections_social.desc': 'New matches, connections, and social activity',
+  // Priority of the Day banner (VTID-01947)
+  'priority.absence_streak.named': '{name}, welcome back. Your diary streak paused at {streak} days — want to pick it up?',
+  'priority.absence_streak': 'Welcome back. Your diary streak paused at {streak} days — want to pick it up?',
+  'priority.absence.named.day': "{name}, it's been {days} day — glad you're back.",
+  'priority.absence.named.days': "{name}, it's been {days} days — glad you're back.",
+  'priority.absence.day': "It's been {days} day — glad you're back.",
+  'priority.absence.days': "It's been {days} days — glad you're back.",
+  'priority.overdue.one': '{count} journey activity is waiting from earlier. Want to tackle it now?',
+  'priority.overdue.many': '{count} journey activities are waiting from earlier. Want to tackle one now?',
+  'priority.goal_prosperity_idle': 'Your goal points at building freedom. One Business Hub check-in could move it today.',
+  'priority.welcome_wave': 'You\'re in "{wave}" — {description}. Want a 2-minute walkthrough?',
+  'priority.welcome_generic': 'Welcome to your longevity journey. Let me show you what we can do together.',
+  'priority.open_recs.one': '{count} Autopilot action ready for you. Worth a look?',
+  'priority.open_recs.many': '{count} Autopilot actions ready for you. Worth a look?',
+  'priority.journey_day': 'Day {day} of your journey, in {wave}. Keep going.',
+  'priority.greeting.morning.named': 'Good morning, {name}. Ready when you are.',
+  'priority.greeting.morning': 'Good morning. Ready when you are.',
+  'priority.greeting.afternoon.named': 'Good afternoon, {name}. Ready when you are.',
+  'priority.greeting.afternoon': 'Good afternoon. Ready when you are.',
+  'priority.greeting.evening.named': 'Good evening, {name}. Ready when you are.',
+  'priority.greeting.evening': 'Good evening. Ready when you are.',
 };
 
 // Draft locales — start as a copy of EN; replace with native strings as they

--- a/services/gateway/src/routes/presence.ts
+++ b/services/gateway/src/routes/presence.ts
@@ -17,6 +17,9 @@ import {
   recordTouch,
 } from '../services/guide';
 import { resolvePriorityMessage } from '../services/guide/priority-rules';
+import { tt, GATEWAY_DEFAULT_LOCALE } from '../i18n/catalog';
+import { getUserLocale } from '../i18n/server-locale';
+import { getSupabase } from '../lib/supabase';
 
 const router = Router();
 
@@ -101,6 +104,12 @@ router.get('/priority', async (req: Request, res: Response) => {
       user_name: identity.user_name,
     });
 
+    // Localize the banner copy server-side: the rule engine returns a catalog
+    // key + params, and the frontend renders the resolved string verbatim.
+    const supa = getSupabase();
+    const locale = supa ? await getUserLocale(supa, identity.user_id) : GATEWAY_DEFAULT_LOCALE;
+    const message = tt(priority.message_key, locale, priority.message_params);
+
     // Fire-and-forget telemetry touch (doesn't count toward daily cap because
     // we bypassed it — but log for dashboard visibility).
     recordTouch({
@@ -113,7 +122,7 @@ router.get('/priority', async (req: Request, res: Response) => {
     return res.json({
       ok: true,
       suppressed: false,
-      message: priority.message,
+      message,
       cta_url: priority.cta_url,
       reason_tag: priority.reason_tag,
       variant: priority.variant,

--- a/services/gateway/src/services/guide/morning-brief-generator.ts
+++ b/services/gateway/src/services/guide/morning-brief-generator.ts
@@ -14,6 +14,8 @@ import { resolvePriorityMessage } from './priority-rules';
 import { canSurfaceProactively } from './presence-pacer';
 import type { NotificationPayload } from '../notification-service';
 import { getSupabase } from '../../lib/supabase';
+import { tt, GATEWAY_DEFAULT_LOCALE } from '../../i18n/catalog';
+import { getUserLocale } from '../../i18n/server-locale';
 import { fetchLifeCompass } from '../user-context-profiler';
 import { tierForScore, projectDay90 } from '../../lib/vitana-pillars';
 import { buildRankerContext, rankBatch } from '../recommendation-engine/ranking/index-pillar-weighter';
@@ -149,7 +151,13 @@ export async function buildMorningBrief(
   if (parts.length > 0) {
     body = parts.join(' · ');
   } else {
-    body = priority.message;
+    // Localize the priority fallback to the user's language (the rule engine
+    // returns a catalog key + params, not a baked English sentence).
+    const supabase = getSupabase();
+    const locale = supabase
+      ? await getUserLocale(supabase, input.user_id)
+      : GATEWAY_DEFAULT_LOCALE;
+    body = tt(priority.message_key, locale, priority.message_params);
   }
   if (body.length > 140) body = body.slice(0, 137) + '…';
 

--- a/services/gateway/src/services/guide/priority-rules.ts
+++ b/services/gateway/src/services/guide/priority-rules.ts
@@ -6,14 +6,23 @@
  * match wins. Falls back to a generic time-of-day message when no
  * awareness-driven rule matches.
  *
- * Consumed by /api/v1/presence/priority endpoint and (future) the
- * WelcomeBackBanner.
+ * The rule engine is locale-agnostic: it returns a catalog key + params
+ * (never a baked English sentence) so the gateway can localize the copy to
+ * each user's language via `tt()`. The frontend renders the resolved
+ * `message` verbatim. See services/gateway/src/i18n/catalog.ts.
+ *
+ * Consumed by /api/v1/presence/priority endpoint and the morning brief
+ * generator.
  */
 
 import type { UserAwareness } from './types';
+import type { GatewayI18nKey } from '../../i18n/catalog';
 
 export interface PriorityMessage {
-  message: string;
+  /** Catalog key resolved against the user's locale by the caller via `tt()`. */
+  message_key: GatewayI18nKey;
+  /** Interpolation params for the catalog string (e.g. {name}, {count}). */
+  message_params?: Record<string, string | number>;
   cta_url: string | null;
   reason_tag: string;
   variant: 'urgent' | 'warm' | 'engage' | 'inform';
@@ -33,6 +42,7 @@ export interface PriorityRulesInput {
 export function resolvePriorityMessage(input: PriorityRulesInput): PriorityMessage {
   const { awareness, user_name } = input;
   const firstName = (user_name || '').split(' ')[0] || '';
+  const named = firstName.length > 0;
 
   // Rule 1 — absence re-engagement (highest priority)
   const motiv = awareness.last_interaction?.motivation_signal;
@@ -41,14 +51,19 @@ export function resolvePriorityMessage(input: PriorityRulesInput): PriorityMessa
     const streak = awareness.community_signals?.diary_streak_days ?? 0;
     if (streak > 0) {
       return {
-        message: `${firstName ? firstName + ', ' : ''}welcome back. Your diary streak paused at ${streak} days — want to pick it up?`,
+        message_key: named ? 'priority.absence_streak.named' : 'priority.absence_streak',
+        message_params: named ? { name: firstName, streak } : { streak },
         cta_url: '/memory?tab=diary',
         reason_tag: `absence:${days}d+streak`,
         variant: 'warm',
       };
     }
+    const oneDay = days === 1;
     return {
-      message: `${firstName ? firstName + ', ' : ''}it's been ${days} day${days === 1 ? '' : 's'} — glad you're back.`,
+      message_key: named
+        ? (oneDay ? 'priority.absence.named.day' : 'priority.absence.named.days')
+        : (oneDay ? 'priority.absence.day' : 'priority.absence.days'),
+      message_params: named ? { name: firstName, days } : { days },
       cta_url: null,
       reason_tag: `absence:${days}d`,
       variant: 'warm',
@@ -59,7 +74,8 @@ export function resolvePriorityMessage(input: PriorityRulesInput): PriorityMessa
   const overdue = awareness.recent_activity?.overdue_calendar_count ?? 0;
   if (overdue > 0) {
     return {
-      message: `${overdue} journey activit${overdue === 1 ? 'y is' : 'ies are'} waiting from earlier. Want to tackle ${overdue === 1 ? 'it' : 'one'} now?`,
+      message_key: overdue === 1 ? 'priority.overdue.one' : 'priority.overdue.many',
+      message_params: { count: overdue },
       cta_url: '/autopilot',
       reason_tag: `overdue:${overdue}`,
       variant: 'urgent',
@@ -72,7 +88,7 @@ export function resolvePriorityMessage(input: PriorityRulesInput): PriorityMessa
     const activated = awareness.recent_activity?.activated_recs_last_7d ?? 0;
     if (activated === 0) {
       return {
-        message: 'Your goal points at building freedom. One Business Hub check-in could move it today.',
+        message_key: 'priority.goal_prosperity_idle',
         cta_url: '/business',
         reason_tag: 'goal:prosperity:idle',
         variant: 'engage',
@@ -85,14 +101,15 @@ export function resolvePriorityMessage(input: PriorityRulesInput): PriorityMessa
     const wave = awareness.journey?.current_wave;
     if (wave) {
       return {
-        message: `You're in "${wave.name}" — ${wave.description}. Want a 2-minute walkthrough?`,
+        message_key: 'priority.welcome_wave',
+        message_params: { wave: wave.name, description: wave.description },
         cta_url: '/autopilot',
         reason_tag: `tenure:${awareness.tenure.stage}:wave:${wave.id}`,
         variant: 'engage',
       };
     }
     return {
-      message: 'Welcome to your longevity journey. Let me show you what we can do together.',
+      message_key: 'priority.welcome_generic',
       cta_url: '/autopilot',
       reason_tag: `tenure:${awareness.tenure.stage}:no_wave`,
       variant: 'engage',
@@ -103,7 +120,8 @@ export function resolvePriorityMessage(input: PriorityRulesInput): PriorityMessa
   const openRecs = awareness.recent_activity?.open_autopilot_recs ?? 0;
   if (openRecs > 0) {
     return {
-      message: `${openRecs} Autopilot action${openRecs === 1 ? '' : 's'} ready for you. Worth a look?`,
+      message_key: openRecs === 1 ? 'priority.open_recs.one' : 'priority.open_recs.many',
+      message_params: { count: openRecs },
       cta_url: '/autopilot',
       reason_tag: `open_recs:${openRecs}`,
       variant: 'inform',
@@ -114,7 +132,8 @@ export function resolvePriorityMessage(input: PriorityRulesInput): PriorityMessa
   const wave = awareness.journey?.current_wave;
   if (wave && awareness.journey?.day_in_journey != null) {
     return {
-      message: `Day ${awareness.journey.day_in_journey} of your journey, in ${wave.name}. Keep going.`,
+      message_key: 'priority.journey_day',
+      message_params: { day: awareness.journey.day_in_journey, wave: wave.name },
       cta_url: '/autopilot',
       reason_tag: `journey:${wave.id}:day${awareness.journey.day_in_journey}`,
       variant: 'inform',
@@ -124,8 +143,12 @@ export function resolvePriorityMessage(input: PriorityRulesInput): PriorityMessa
   // Rule 7 — generic fallback (time-of-day) — matches legacy banner behavior
   const hour = (input.now ?? new Date()).getHours();
   const tod = hour < 12 ? 'morning' : hour < 18 ? 'afternoon' : 'evening';
+  const greetingKey = (
+    named ? `priority.greeting.${tod}.named` : `priority.greeting.${tod}`
+  ) as GatewayI18nKey;
   return {
-    message: `Good ${tod}${firstName ? ', ' + firstName : ''}. Ready when you are.`,
+    message_key: greetingKey,
+    message_params: named ? { name: firstName } : undefined,
     cta_url: null,
     reason_tag: 'fallback:time_of_day',
     variant: 'inform',


### PR DESCRIPTION
## Problem

The Home **"Für dich, jetzt gerade"** Priority-of-the-Day banner showed **English** text to German users (e.g. *"Your goal points at building freedom. One Business Hub check-in could move it today."*), even though the surrounding UI was fully German.

The banner copy is generated by the gateway as a **full sentence** and returned in the `/api/v1/presence/priority` response. The frontend renders `message` verbatim, so it can't translate it — this is exactly the "gateway emits strings directly to users" case covered by the server-side i18n rule (CLAUDE.md §13b).

## Fix

Following the established `tt()` catalog pattern:

1. **`services/guide/priority-rules.ts`** — the rule engine is now locale-agnostic. `resolvePriorityMessage()` returns a `message_key: GatewayI18nKey` + `message_params` instead of a baked English string. Singular/plural and named/unnamed variants are selected by key.
2. **`i18n/catalog.ts`** — added the 20 `priority.*` keys, with **DE (source of truth, du-form)** and **EN** translations. `ES`/`SR` inherit `EN` via spread, per the catalog's draft-locale convention.
3. **`routes/presence.ts`** — resolves the user's locale via `getUserLocale()` and translates with `tt()` before returning `message`. The response shape is unchanged (`message` is just now localized).
4. **`services/guide/morning-brief-generator.ts`** — the priority fallback body is now localized the same way (the brief is a push-notification surface, so it benefits too).

The frontend (`useProactivePriority` → `PriorityOfDayBanner`) needs **no changes** — it still reads `json.message`, which now arrives in the user's language.

## Verification

- `npm run typecheck` (gateway) — **passes clean**.
- Catalog key parity verified: 20 keys present in the type union, DE, and EN (no missing/extra).
- No existing tests reference the changed functions or the old `.message` field.

## Scope note

The morning brief still has a few other hardcoded English fragments (e.g. `"Today's move:"`, `"Aligned with:"`) that predate this change and are a separate surface; left out to keep this PR focused on the reported banner.

https://claude.ai/code/session_01WKBQewY166RgnX4aUB4qhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKBQewY166RgnX4aUB4qhu)_