### PR TITLE
fix(finetune): avoid gated voice-router base model

### DIFF
--- a/.github/workflows/CRON-FINETUNE-TRAINER.yml
+++ b/.github/workflows/CRON-FINETUNE-TRAINER.yml
@@ -88,5 +88,5 @@ jobs:
         working-directory: services/gateway
         env:
           FINETUNE_DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
-          FINETUNE_BASE_MODEL_OVERRIDE: ${{ inputs.base_model_override || '' }}
+          FINETUNE_BASE_MODEL_OVERRIDE: ${{ inputs.base_model_override || (inputs.synthetic_bootstrap == 'true' && matrix.target == 'voice-tool-router' && 'Qwen/Qwen2.5-0.5B-Instruct') || '' }}
         run: npx tsx scripts/finetune/submit-job.ts ${{ matrix.target }}

--- a/services/gateway/scripts/finetune/submit-job-lib.ts
+++ b/services/gateway/scripts/finetune/submit-job-lib.ts
@@ -38,11 +38,33 @@ interface BuildJobConfigInput {
   trainerPackageUri: string;
 }
 
+export const DEFAULT_SYNTHETIC_SMOKE_BASE_MODEL = 'Qwen/Qwen2.5-0.5B-Instruct';
+
+const KNOWN_GATED_MODEL_PREFIXES = [
+  'google/gemma-',
+  'meta-llama/',
+];
+
 export function buildTrainerPackageUri(config: FinetuneConfig): string {
   // VTID-03244: bumped to 0.1.1 — drops torch from install_requires so it
   // doesn't shadow the container's pre-installed PyTorch (root cause of
   // CustomJob 3154255301083922432 failure 2026-06-01).
   return `${config.vertex_custom_job.output_uri_prefix}trainer/finetune-trainer-0.1.1.tar.gz`;
+}
+
+export function isKnownGatedBaseModel(baseModel: string): boolean {
+  return KNOWN_GATED_MODEL_PREFIXES.some((prefix) => baseModel.startsWith(prefix));
+}
+
+export function assertBaseModelSubmitSafe(config: FinetuneConfig): void {
+  if (!isKnownGatedBaseModel(config.base_model)) return;
+  if (process.env.FINETUNE_ALLOW_GATED_BASE_MODEL === '1') return;
+
+  throw new Error(
+    `Base model ${config.base_model} is a known gated Hugging Face repo. ` +
+    'Vertex workers cannot access it without an HF-authenticated trainer path, so this job would fail at from_pretrained(). ' +
+    `Use an ungated override such as ${DEFAULT_SYNTHETIC_SMOKE_BASE_MODEL}, or implement the gated-model HF token path first.`,
+  );
 }
 
 export function buildTrainingArgs(config: FinetuneConfig, outputUri: string): string[] {

--- a/services/gateway/scripts/finetune/submit-job.ts
+++ b/services/gateway/scripts/finetune/submit-job.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 import {
   assertDatasetReady,
+  assertBaseModelSubmitSafe,
   assertGcsObjectExists,
   buildJobConfig,
   buildTrainerPackageUri,
@@ -74,6 +75,8 @@ async function main(): Promise<void> {
   console.log(`[submit-job] trainer_package: ${trainerPackageUri}`);
   console.log(`[submit-job] config file: ${tmpConfigPath}`);
   console.log(`[submit-job] command: gcloud ${args.join(' ')}`);
+
+  assertBaseModelSubmitSafe(cfg);
 
   if (DRY_RUN) {
     console.log('[submit-job] dry run — not invoking gcloud');

--- a/services/gateway/scripts/finetune/voice-tool-router/config.yaml
+++ b/services/gateway/scripts/finetune/voice-tool-router/config.yaml
@@ -1,9 +1,11 @@
 # Voice tool router fine-tune config — Phase 1 W1 (VTID-03179 FINETUNES)
 # Trained first in W1 (per the 40-day plan); ~$4k Vertex AI Custom Training.
-# Output: HF-format LoRA adapter merged with Gemma-2 2B base for shadow eval.
+# Output: HF-format LoRA adapter. Keep the default base model ungated so
+# unattended weekly Vertex jobs do not fail before training starts. Gated
+# Gemma runs require a separate HF-authenticated trainer path.
 
 target: voice-tool-router
-base_model: google/gemma-2-2b-it
+base_model: Qwen/Qwen2.5-1.5B-Instruct
 adapter_method: lora
 lora_r: 16
 lora_alpha: 32

--- a/services/gateway/test/finetune-submit-job-lib.test.ts
+++ b/services/gateway/test/finetune-submit-job-lib.test.ts
@@ -3,6 +3,8 @@ import {
   buildTrainerPackageUri,
   buildTrainingArgs,
   countDatasetRowsFromJsonl,
+  assertBaseModelSubmitSafe,
+  isKnownGatedBaseModel,
   type FinetuneConfig,
 } from '../scripts/finetune/submit-job-lib';
 
@@ -69,6 +71,16 @@ describe('finetune submit job config', () => {
       'gs://vitana-artifacts-staging/finetune-runs/voice-tool-router/trainer/finetune-trainer-0.1.1.tar.gz',
     ]);
     expect(jobConfig.workerPoolSpecs[0].pythonPackageSpec.pythonModule).toBe('finetune.train');
+  });
+
+  test('detects gated Hugging Face base models before submitting Vertex jobs', () => {
+    expect(isKnownGatedBaseModel('google/gemma-2-2b-it')).toBe(true);
+    expect(isKnownGatedBaseModel('Qwen/Qwen2.5-1.5B-Instruct')).toBe(false);
+
+    expect(() => assertBaseModelSubmitSafe({
+      ...config,
+      base_model: 'google/gemma-2-2b-it',
+    })).toThrow(/known gated Hugging Face repo/);
   });
 });
 


### PR DESCRIPTION
## Summary
- switch voice-tool-router default base model from gated Gemma to ungated Qwen 2.5 1.5B so unattended Vertex jobs can actually start training
- make synthetic smoke dispatch automatically use the smaller ungated Qwen 2.5 0.5B model when no manual override is provided
- add a submit-time guard that fails fast for known gated Hugging Face repos instead of creating doomed Vertex CustomJobs

## Why
Latest Vertex job `7697243833007865856` failed before training because `google/gemma-2-2b-it` is gated and the Vertex worker cannot access it:

`OSError: You are trying to access a gated repo ... google/gemma-2-2b-it ... 401 Client Error`

## Verification
- `npm test -- --runInBand test/finetune-submit-job-lib.test.ts`
- `FINETUNE_DRY_RUN=1 npx tsx scripts/finetune/submit-job.ts voice-tool-router`
- `FINETUNE_DRY_RUN=1 FINETUNE_BASE_MODEL_OVERRIDE=google/gemma-2-2b-it npx tsx scripts/finetune/submit-job.ts voice-tool-router` fails before submit with the gated-model guard

## Rollout
After merge, dispatch:

```powershell
gh workflow run CRON-FINETUNE-TRAINER.yml `
  --repo exafyltd/vitana-platform `
  --ref main `
  -f target=voice-tool-router `
  -f dry_run=false `
  -f synthetic_bootstrap=true `
  -f base_model_override=
```