### PR TITLE
test(orb): context-integrity gate — guard the ENVIRONMENT block (VTID-03252)

### DIFF
--- a/services/gateway/src/orb/live/instruction/client-context-format.ts
+++ b/services/gateway/src/orb/live/instruction/client-context-format.ts
@@ -1,0 +1,25 @@
+/**
+ * VTID-03252 — ENVIRONMENT context formatter (extracted for testability).
+ *
+ * Builds the "ENVIRONMENT CONTEXT" block the assistant reads for the user's
+ * location + LOCAL TIME. Extracted out of the 13k-line orb-live route so the
+ * context-integrity gate can assert its contract directly: it must surface
+ * location + local time when known, must NEVER fabricate a city, and must
+ * always carry a UTC anchor so the model can compute any timezone. Pure.
+ */
+
+import type { ClientContext } from '../types';
+
+export function formatClientContextForInstruction(ctx: ClientContext): string {
+  const parts: string[] = [];
+  if (ctx.city && ctx.country) parts.push(`User location: ${ctx.city}, ${ctx.country}`);
+  else if (ctx.country) parts.push(`User location: ${ctx.country}`);
+  if (ctx.timezone) parts.push(`Timezone: ${ctx.timezone}`);
+  if (ctx.localTime) parts.push(`Local time: ${ctx.localTime}`);
+  // Always include UTC reference so the model can accurately calculate any timezone
+  parts.push(`Current UTC time: ${new Date().toISOString()}`);
+  if (ctx.device) parts.push(`Device: ${ctx.device}`);
+  if (ctx.os) parts.push(`OS: ${ctx.os}`);
+  if (parts.length === 0) return '';
+  return `\nENVIRONMENT CONTEXT:\n${parts.join('\n')}\nWhen asked about the time in any city or timezone, calculate from the UTC time above — do NOT guess UTC offsets from memory, as DST rules change. Use this context naturally — e.g. time-appropriate greetings, location-relevant suggestions.`;
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -76,6 +76,8 @@ import { decideWakeBriefForSession } from '../services/wake-brief-wiring';
 // distills. NO raw rows cross this boundary.
 import { compileAssistantDecisionContext } from '../orb/context/compile-assistant-decision-context';
 import { renderDecisionContract } from '../orb/live/instruction/decision-contract-renderer';
+// VTID-03252: ENVIRONMENT block formatter, extracted for testability.
+import { formatClientContextForInstruction } from '../orb/live/instruction/client-context-format';
 // BOOTSTRAP-VOICE-DEMO: real heartbeats from voice call sites so the agents
 // dashboard reflects live usage instead of fake startup status.
 import { recordAgentHeartbeat } from './agents-registry';
@@ -5590,23 +5592,11 @@ backend when you say the appropriate goodbye per the sections above — just spe
 naturally, never call a tool.`;
 }
 
-/**
- * VTID-CONTEXT: Format client context into a context section for the system instruction.
- * Used for both anonymous and authenticated sessions.
- */
-export function formatClientContextForInstruction(ctx: ClientContext): string {
-  const parts: string[] = [];
-  if (ctx.city && ctx.country) parts.push(`User location: ${ctx.city}, ${ctx.country}`);
-  else if (ctx.country) parts.push(`User location: ${ctx.country}`);
-  if (ctx.timezone) parts.push(`Timezone: ${ctx.timezone}`);
-  if (ctx.localTime) parts.push(`Local time: ${ctx.localTime}`);
-  // Always include UTC reference so the model can accurately calculate any timezone
-  parts.push(`Current UTC time: ${new Date().toISOString()}`);
-  if (ctx.device) parts.push(`Device: ${ctx.device}`);
-  if (ctx.os) parts.push(`OS: ${ctx.os}`);
-  if (parts.length === 0) return '';
-  return `\nENVIRONMENT CONTEXT:\n${parts.join('\n')}\nWhen asked about the time in any city or timezone, calculate from the UTC time above — do NOT guess UTC offsets from memory, as DST rules change. Use this context naturally — e.g. time-appropriate greetings, location-relevant suggestions.`;
-}
+// VTID-03252: formatClientContextForInstruction was extracted to
+// orb/live/instruction/client-context-format.ts (imported at the top of this
+// file) so the context-integrity gate can unit-test the ENVIRONMENT block
+// contract. Re-exported here so existing importers (orb-livekit) keep working.
+export { formatClientContextForInstruction };
 
 /**
  * VTID-01219: Connect to Vertex AI Live API WebSocket

--- a/services/gateway/test/orb/live/instruction/client-context-format.test.ts
+++ b/services/gateway/test/orb/live/instruction/client-context-format.test.ts
@@ -1,0 +1,58 @@
+/**
+ * VTID-03252 — ENVIRONMENT block contract (context-integrity gate).
+ *
+ * Guards the block the assistant reads for the user's location + LOCAL TIME.
+ * These contracts fail the build if a change re-breaks env context (the
+ * "Berlin / 8:30 PM in Cologne" class of bug).
+ */
+
+import { formatClientContextForInstruction } from '../../../../src/orb/live/instruction/client-context-format';
+import type { ClientContext } from '../../../../src/orb/live/types';
+
+function ctx(over: Partial<ClientContext> = {}): ClientContext {
+  return { ...over } as ClientContext;
+}
+
+describe('formatClientContextForInstruction — ENVIRONMENT block contract', () => {
+  it('surfaces location + timezone + local time when all are known', () => {
+    const out = formatClientContextForInstruction(
+      ctx({ city: 'Cologne', country: 'Germany', timezone: 'Europe/Berlin', localTime: 'Monday afternoon, 15:44' }),
+    );
+    expect(out).toContain('ENVIRONMENT CONTEXT');
+    expect(out).toContain('User location: Cologne, Germany');
+    expect(out).toContain('Timezone: Europe/Berlin');
+    expect(out).toContain('Local time: Monday afternoon, 15:44');
+  });
+
+  it('CONTRACT: always carries a UTC anchor so the model can compute any timezone', () => {
+    const out = formatClientContextForInstruction(ctx({ timezone: 'Europe/Berlin' }));
+    expect(out).toMatch(/Current UTC time: \d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('CONTRACT: NEVER fabricates a city/location when geo is unavailable', () => {
+    // geo-IP failed → no city/country. The block must NOT invent a location.
+    const out = formatClientContextForInstruction(ctx({ timezone: 'Europe/Berlin', localTime: 'Monday afternoon, 15:44' }));
+    expect(out).not.toContain('User location:');
+    // ...but local time (from the browser TZ) is still present — time integrity.
+    expect(out).toContain('Local time: Monday afternoon, 15:44');
+    expect(out).toContain('Timezone: Europe/Berlin');
+  });
+
+  it('CONTRACT: when even the timezone is unknown, omits Timezone/Local time (no guessing) but keeps the UTC anchor', () => {
+    const out = formatClientContextForInstruction(ctx({}));
+    expect(out).not.toContain('Timezone:');
+    expect(out).not.toContain('Local time:');
+    expect(out).toContain('Current UTC time:');
+  });
+
+  it('country-only location renders without a city', () => {
+    const out = formatClientContextForInstruction(ctx({ country: 'Germany' }));
+    expect(out).toContain('User location: Germany');
+  });
+
+  it('instructs the model to compute time from UTC, never guess offsets (DST safety)', () => {
+    const out = formatClientContextForInstruction(ctx({ timezone: 'Europe/Berlin' }));
+    expect(out.toLowerCase()).toContain('calculate from the utc time');
+    expect(out.toLowerCase()).toContain('do not guess');
+  });
+});


### PR DESCRIPTION
Strengthens regression protection: extracts the ENV-block formatter (location + local time) into a testable module (re-exported from orb-live; orb-livekit unchanged) and locks its contract in CI — surfaces location/timezone/local-time when known, always carries a UTC anchor, never fabricates a city when geo is unavailable, keeps local time (browser TZ) even when geo-IP failed, compute-from-UTC never guess (DST). Runs on every PR. Pure extraction, zero behavior change. tsc + 6 gate tests green. (Authenticated live post-deploy smoke = follow-up.)