### PR TITLE
fix(gateway): route diary intents to mobile daily-diary on mobile

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -1003,6 +1003,12 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
   {
     screen_id: 'MEMORY.DIARY',
     route: '/memory/diary',
+    // BOOTSTRAP-MOBILE-NAV-CONTAINMENT: /memory/diary renders the desktop Memory
+    // hub (tabbed Overview/Timeline/Daily-Diary/Recall view) which is a desktop
+    // layout. On mobile the real diary surface is MobileDailyDiary at /daily-diary,
+    // so redirect there — otherwise "open my daily diary" strands mobile users on
+    // the read-only activity-timeline hub.
+    mobile_route: '/daily-diary',
     category: 'memory',
     access: 'authenticated',
     anonymous_safe: false,


### PR DESCRIPTION
## Problem

Follow-up to the mobile nav-containment work (#2497 / vitana-v1 #621). A "show my daily diary" request on mobile lands on the **desktop Memory hub** — the tabbed `Overview / Timeline / Daily Diary / Recall` activity-timeline view — instead of the dedicated mobile diary screen.

## Root cause

`MEMORY.DIARY` (`/memory/diary`) is titled **"Daily Diary"** with aliases `['diary','daily-diary','tagebuch',…]`, so the navigator matches diary intents to it. On mobile `/memory/diary` renders the desktop Memory hub. The real mobile diary is `MobileDailyDiary` at `/daily-diary` (already `viewport_only:'mobile'`). The catalog comment even assumed "open my diary → MEMORY.DIARY is fine" — true on desktop, broken on mobile.

## Fix

Add `mobile_route: '/daily-diary'` to `MEMORY.DIARY`. On mobile the navigator now redirects diary intents to `MobileDailyDiary`; desktop behaviour is unchanged.

## Verification
- Data-only edit on an existing entry using the already-supported `mobile_route` field (same pattern as the merged reminders fix that passed all CI).

> Pairs with vitana-v1 PR (same branch): inventory doc update.

https://claude.ai/code/session_018wL56QkgMNJBTk8t9DpeXb

---
_Generated by [Claude Code](https://claude.ai/code/session_018wL56QkgMNJBTk8t9DpeXb)_