### PR TITLE
test(orb): R5 regression lock for re-applied plan_phase + i18n-llm-locale (BOOTSTRAP-ORB-R5-REAPPLY)

### DIFF
--- a/services/gateway/test/i18n/llm-locale.test.ts
+++ b/services/gateway/test/i18n/llm-locale.test.ts
@@ -1,0 +1,79 @@
+/**
+ * BOOTSTRAP-i18n-llm-locale — gateway LLM locale-injection tests.
+ *
+ * Re-applied under BOOTSTRAP-ORB-R5-REAPPLY (Phase R5). The original change
+ * (PR #2392, sha 8e7570e3) was reverted on 2026-05-29 on a MISDIAGNOSIS — the
+ * real cause was the R0 Vertex instruction-size bug (diagnosed + fixed in a
+ * separate lane). The behavior is back on main; these tests lock the locale
+ * helper so the "German users get English LLM output" gap cannot silently
+ * reopen.
+ *
+ * Note: this helper PREPENDS a short "LANGUAGE: Respond ONLY in {X}" directive
+ * to the system prompt for user-facing LLM callers. It is NOT applied to the
+ * voice system instruction (orb-live / orb-livekit already enforce language)
+ * nor to admin/dev paths (English by design per CLAUDE.md §13b) — so it does
+ * not contribute to the R0 aggregate-instruction overflow.
+ */
+
+import {
+  buildLocalizedSystemPrompt,
+  buildLocalizedSystemPromptForLang,
+} from '../../src/i18n/llm-locale';
+
+const BASE = 'You are an expert health coach. Answer the question.';
+
+describe('buildLocalizedSystemPrompt', () => {
+  it('returns the base prompt unchanged when locale is null/undefined (English-by-design paths)', () => {
+    expect(buildLocalizedSystemPrompt(BASE, null)).toBe(BASE);
+    expect(buildLocalizedSystemPrompt(BASE, undefined)).toBe(BASE);
+  });
+
+  it('German: forces German output, du-form register, and the compound-word rule', () => {
+    const out = buildLocalizedSystemPrompt(BASE, 'de');
+    expect(out).toContain('LANGUAGE: Respond ONLY in German (Deutsch).');
+    expect(out).toContain('du-form');
+    expect(out).toContain('22 characters'); // compound-word rule is DE-only
+    // The base prompt is preserved at the end.
+    expect(out.endsWith(BASE)).toBe(true);
+  });
+
+  it('Spanish: forces Spanish + tú-form, and does NOT inject the German compound rule', () => {
+    const out = buildLocalizedSystemPrompt(BASE, 'es');
+    expect(out).toContain('Respond ONLY in Spanish (Español).');
+    expect(out).toContain('tú-form');
+    expect(out).not.toContain('22 characters');
+  });
+
+  it('Serbian: forces Serbian + ti-form register', () => {
+    const out = buildLocalizedSystemPrompt(BASE, 'sr');
+    expect(out).toContain('Respond ONLY in Serbian (Srpski).');
+    expect(out).toContain('ti-form');
+  });
+
+  it('English: forces English output but has no register/compound hint', () => {
+    const out = buildLocalizedSystemPrompt(BASE, 'en');
+    expect(out).toContain('Respond ONLY in English.');
+    expect(out).not.toContain('du-form');
+    expect(out).not.toContain('22 characters');
+  });
+
+  it('keeps brand names untranslated (does not constrain Vitana/MAXINA/OASIS)', () => {
+    const out = buildLocalizedSystemPrompt(BASE, 'de');
+    expect(out).toContain('Vitana, MAXINA, OASIS');
+  });
+});
+
+describe('buildLocalizedSystemPromptForLang (short-code convenience)', () => {
+  it('normalizes BCP-47-ish prefixes (de-DE, en-US, …) to the supported set', () => {
+    expect(buildLocalizedSystemPromptForLang(BASE, 'de-DE')).toContain('German (Deutsch)');
+    expect(buildLocalizedSystemPromptForLang(BASE, 'en-US')).toContain('English');
+    expect(buildLocalizedSystemPromptForLang(BASE, 'sr-RS')).toContain('Serbian (Srpski)');
+    expect(buildLocalizedSystemPromptForLang(BASE, 'es-419')).toContain('Spanish (Español)');
+  });
+
+  it('passes through unchanged for null / empty / unsupported languages', () => {
+    expect(buildLocalizedSystemPromptForLang(BASE, null)).toBe(BASE);
+    expect(buildLocalizedSystemPromptForLang(BASE, '')).toBe(BASE);
+    expect(buildLocalizedSystemPromptForLang(BASE, 'fr')).toBe(BASE);
+  });
+});

--- a/services/gateway/test/services/assistant-continuation/providers/new-day-overview-plan-phase.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/new-day-overview-plan-phase.test.ts
@@ -1,0 +1,148 @@
+/**
+ * VTID-03184 — endless-journey plan_phase branching characterization tests.
+ *
+ * Re-applied under BOOTSTRAP-ORB-R5-REAPPLY (Phase R5). The original change
+ * (PR #2390, sha 6f37bcdd) was reverted on 2026-05-29 on a MISDIAGNOSIS — the
+ * real cause was the R0 Vertex instruction-size bug (diagnosed + fixed in a
+ * separate lane). The behavior is back on main; these tests lock it so it
+ * cannot silently regress / be re-reverted again.
+ *
+ * The journey is endless. The default 90-day plan is scaffolding for users
+ * WITHOUT a personalized goal — not a universal cap. `buildNewDayOverviewBlock`
+ * must branch its JOURNEY CONTEXT framing + COVERAGE CHECKLIST on
+ * `journey.plan_phase`:
+ *
+ *   - default_active            → "Tag X von Y" + wave framing kept.
+ *   - default_finished_no_goal  → starter-plan-complete → invite first goal.
+ *   - on_personalized_goal      → DROP "X von 90"; anchor on the goal arc.
+ */
+
+import { buildNewDayOverviewBlock } from '../../../../src/services/assistant-continuation/providers/new-day-overview-prompt';
+import type { OverviewPayload, JourneyPlanPhase } from '../../../../src/services/assistant-continuation/providers/new-day-overview-payload';
+
+type Journey = NonNullable<OverviewPayload['journey']>;
+
+function makePayload(journey: OverviewPayload['journey']): OverviewPayload {
+  return {
+    journey,
+    vitana_index: {
+      state: 'not_set_up',
+      today: null,
+      tier: null,
+      tier_framing: null,
+      trend_7d: null,
+      weakest_pillar: null,
+      strongest_pillar: null,
+      balance_label: null,
+      pillars: null,
+      projected_day_90: null,
+      projected_day_90_tier: null,
+    },
+    life_compass: {
+      state: 'not_set',
+      primary_goal: null,
+      category: null,
+      target_date: null,
+      target_value: null,
+      target_unit: null,
+      starting_value: null,
+      set_at: null,
+      days_to_deadline: null,
+      goal_progress_pct: null,
+    },
+    calendar_today: { count: 0, next: null },
+    calendar_passed: { count: 0, most_recent: null },
+    autopilot: { state: 'none_yet', today_checkpoint: null, this_week: [], pending_total: 0 },
+    matches_unread: 0,
+    messages_unread: 0,
+    reminders_today: { count: 0, next: null },
+    diary_last_7d: 0,
+    last_session_date_user_tz: '2026-05-31',
+  };
+}
+
+const baseJourney: Journey = {
+  plan_phase: 'default_active',
+  day_in_journey: 23,
+  is_first_session: false,
+  plan_type: 'default',
+  default_plan_total_days: 90,
+  current_wave: {
+    name: 'Exploration',
+    description: 'Getting to know the platform',
+    day_in_wave: 3,
+    days_to_next_wave: 7,
+  },
+  current_goal_day: null,
+  days_past_deadline: null,
+  previous_goals_count: 0,
+};
+
+function buildFor(journey: Journey): string {
+  return buildNewDayOverviewBlock({
+    payload: makePayload(journey),
+    lang: 'de',
+    firstName: 'Anna',
+    localHour: 9,
+    timezone: 'Europe/Berlin',
+  });
+}
+
+describe('VTID-03184 plan_phase branching — buildNewDayOverviewBlock', () => {
+  it('default_active: keeps the "Tag X von Y" starter-plan + wave framing', () => {
+    const block = buildFor({ ...baseJourney, plan_phase: 'default_active' });
+    expect(block).toContain("plan_phase='default_active'");
+    // Starter-plan day-of-total framing with the wave named.
+    expect(block).toContain('Day 23 of 90 in the starter plan');
+    expect(block).toContain('"Exploration" phase');
+  });
+
+  it('default_finished_no_goal: invites the first personalized goal, no "X of Y" cap', () => {
+    const block = buildFor({
+      ...baseJourney,
+      plan_phase: 'default_finished_no_goal',
+      day_in_journey: 152, // past the 90-day default — the bug case ("Day 152 of 90")
+      current_wave: null,
+    });
+    expect(block).toContain("plan_phase='default_finished_no_goal'");
+    expect(block).toContain('completed the 90-day starter plan');
+    expect(block).toContain('NOT set a personalized goal');
+    // The endless-journey contract: never frame the finished default as a dead end.
+    expect(block).not.toContain('Day 152 of 90');
+  });
+
+  it('on_personalized_goal: drops the 90-day frame and anchors on the goal arc', () => {
+    const block = buildFor({
+      ...baseJourney,
+      plan_phase: 'on_personalized_goal',
+      day_in_journey: 132,
+      default_plan_total_days: null,
+      current_wave: null,
+      current_goal_day: 40,
+      previous_goals_count: 1,
+    });
+    expect(block).toContain("plan_phase='on_personalized_goal'");
+    expect(block).toContain('Day 132 with Vitana');
+    // previous_goals_count=1 → this is goal number 2 in the arc.
+    expect(block).toContain('This is goal number 2 in the user arc.');
+    expect(block).toContain('Day 40 on this goal.');
+    // The hard rule: no scaffolding "Tag X von 90" framing on a personalized goal.
+    expect(block).toContain('DO NOT use "Tag X von 90" framing.');
+  });
+
+  it('on_personalized_goal: surfaces a past deadline gently (never as failure)', () => {
+    const block = buildFor({
+      ...baseJourney,
+      plan_phase: 'on_personalized_goal',
+      day_in_journey: 200,
+      default_plan_total_days: null,
+      current_wave: null,
+      current_goal_day: 95,
+      days_past_deadline: 12,
+      previous_goals_count: 0,
+    });
+    expect(block).toContain('Target date passed 12 days ago');
+    expect(block).toContain('never as failure');
+    expect(block).toContain('This is the first personalized goal for this user.');
+  });
+});


### PR DESCRIPTION
## Phase R5 — Re-apply the two misdiagnosis reverts

**Marker:** `BOOTSTRAP-ORB-R5-REAPPLY` (also references `VTID-03184`)

This is Phase R5 of the ORB R0–R9 reconciliation
(`docs/superpowers/plans/2026-05-30-vitana-assistant-original-plan-reconciliation.md`,
§3 Phase R5 + §4 RESTORE list).

### The two changes to restore
| Change | Original PR | Original sha |
|---|---|---|
| VTID-03184 — endless-journey `plan_phase` branching (new-day-overview) | #2390 | `6f37bcdd` |
| BOOTSTRAP-i18n-llm-locale — gateway LLM callers respect user locale | #2392 | `8e7570e3` |

### What was re-applied + method

**Both changes are ALREADY present on `main` — verified byte-identical to the originals — so the re-apply itself is a no-op.** A prior session already re-landed them via PRs **#2400** (`3a7ff981`) and **#2401** (`282f5525`) after the misdiagnosis. Evidence:

- Originals `6f37bcdd` / `8e7570e3`: **not** ancestors of `origin/main` (they were the reverted commits).
- Re-applies `3a7ff981` / `282f5525`: **on** `origin/main`.
- Misdiagnosis reverts `bb1b8fe3` (undoes #2390) / `5329f3ae` (undoes #2392): **NOT on main** — they live only on side branches, never merged.
- File-level diff of every touched file vs the original commit's resulting tree: **IDENTICAL** for all 7 files
  (`new-day-overview-payload.ts`, `new-day-overview-prompt.ts`, `i18n/llm-locale.ts`, `context-pack-builder.ts`, `guide/session-summaries.ts`, `knowledge-hub.ts`, `orb-tools-shared.ts`).

So per the R5 instruction *"verify the change isn't already present on main (if it is, note that and skip)"* — the production behavior is restored and needs no code change.

**What WAS missing:** neither the originals, the reverts, nor the re-applies ever shipped a single test. The re-applied behavior was completely uncovered, which is exactly how it got silently reverted in the first place. This PR adds the regression lock:

- `test/services/assistant-continuation/providers/new-day-overview-plan-phase.test.ts` (4 tests) — characterizes `buildNewDayOverviewBlock` branching on `journey.plan_phase`:
  - `default_active` → keeps "Day X of Y" + wave framing.
  - `default_finished_no_goal` → "completed the starter plan" + invite first goal, never the bug-case "Day 152 of 90".
  - `on_personalized_goal` → drops the 90-day frame, anchors on the goal arc (`This is goal number N`, `Day X on this goal`, `DO NOT use "Tag X von 90" framing`), surfaces a past deadline gently (never as failure).
- `test/i18n/llm-locale.test.ts` (8 tests) — characterizes `buildLocalizedSystemPrompt` / `buildLocalizedSystemPromptForLang`: DE du-form + 22-char compound rule, ES tú, SR ti, EN no register hint, brand names (Vitana/MAXINA/OASIS) untranslated, null/empty/unsupported pass-through, BCP-47 short-code normalization.

### Why this is safe now (R0 fixed)

The 2026-05-29 reverts blamed Vertex breakage on memory/instruction size. The **real** cause is the R0 Vertex aggregate-instruction-size overflow bug, diagnosed + fixed in a **separate lane**. R5 is safe **because R0 is fixed**:

- **plan_phase branching** only reshapes the `new-day-overview` payload/prompt builder — no growth of the hub system-instruction.
- **i18n-llm-locale** only PREPENDS a short `LANGUAGE: Respond ONLY in {X}` directive to **user-facing LLM callers** (knowledge-hub, session-summaries, explain-feature). It is explicitly NOT applied to the voice system instruction (`orb-live` / `orb-livekit` already enforce language via their explicit lang param) nor to admin/dev paths — so it does not contribute to the R0 aggregate-instruction overflow.

### Parity

**Vertex parity ✓ / LiveKit parity ✓** — both touched zones are transport-agnostic: the new-day-overview payload/prompt builder and the locale helper produce identical output regardless of transport. The added tests exercise the pure builders directly, so they assert the same behavior both providers consume.

### Hub-file touch

**None.** Neither original commit nor this test PR touches the hub files (`live-system-instruction.ts`, `live-session-controller.ts`) or `orb-live.ts` / `vertex-live-client.ts` / `awareness-unified-context.ts`. No merge-sequencing dependency for the coordinator.

### Build + test

- `cd services/gateway && npm run build` → **green** (exit 0).
- `npx jest` (new files) → **12/12 pass**.
- `npx jest test/services/assistant-continuation` (touched-area regression) → **464/464 pass**.
- No `--no-verify` used — `npm install` resolved the pre-existing global-TS `moduleResolution` deprecation locally, so the pre-commit hook passed clean.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_