### PR TITLE
feat(memory): BOOTSTRAP-ORB-PHASEB-RELEVANCE — relevance-ranked memory retrieval (OFF by default)

### DIFF
--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -67,6 +67,11 @@ import { isTier0RedisEnabled } from './system-controls-service';
 import { auditMemoryRead } from './memory-audit';
 // VTID-02000: Marketplace context primitive
 import { getUserHealthContext } from './user-health-context';
+// Phase B (ORB Memory Resilience): relevance-ranked memory selection, gated
+// OFF-by-default behind FEATURE_BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL_ENV with a
+// FEATURE_VOICE_RANKING_SHADOW_ENV shadow-compare log. See memory-ranker.ts.
+import { isFeatureLive } from './feature-flags';
+import { rankMemoryHits, shadowCompareHits } from './memory-hit-ranking';
 
 // =============================================================================
 // Identity Core — fact keys that are ALWAYS loaded regardless of limits
@@ -998,6 +1003,54 @@ export async function buildContextPack(
     memoryHits.sort((a, b) => b.relevance_score - a.relevance_score);
     memoryHits = memoryHits.slice(0, CONTEXT_PACK_CONFIG.MAX_MEMORY_HITS);
     hitCounts.memory_garden = memoryHits.length;
+  }
+
+  // ===========================================================================
+  // Phase B (ORB Memory Resilience): relevance-ranked memory selection.
+  //
+  // At this point `memoryHits` is the NAIVE selection: merged, relevance_score
+  // desc, sliced to MAX_MEMORY_HITS. Phase B replaces "first N by relevance_score"
+  // with a relevance-RANKED top-N (importance + recency + optional similarity)
+  // so the content that survives the cap is the most useful.
+  //
+  // Behavior-safe:
+  //   - When neither flag is live, this block is a no-op — `memoryHits` ships
+  //     byte-for-byte as the naive path produced it.
+  //   - VOICE_RANKING_SHADOW: compute the ranked set, log a structured
+  //     [memory.retrieval.shadow] comparison, but ship the naive set unchanged.
+  //   - BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL: ship the ranked set (same budget).
+  // Both flags default OFF (FEATURE_<NAME>_ENV unset → 'off').
+  // ===========================================================================
+  const rankedRetrievalLive = isFeatureLive('BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL');
+  const rankingShadowLive = isFeatureLive('VOICE_RANKING_SHADOW');
+  if (rankedRetrievalLive || rankingShadowLive) {
+    const rankInputs = {
+      hits: memoryHits,
+      topK: CONTEXT_PACK_CONFIG.MAX_MEMORY_HITS,
+      now: new Date(),
+      // MemoryHit carries no embedding column today, so similarity degrades to 0
+      // and ranking reduces to importance + recency. Seam left open for later.
+      intentEmbedding: undefined as number[] | undefined,
+    };
+    if (rankingShadowLive) {
+      const { ranked, comparison } = shadowCompareHits(memoryHits, rankInputs);
+      // Structured shadow log: old order vs new order, char totals, overlap.
+      console.log(
+        `[memory.retrieval.shadow] ${JSON.stringify({
+          user_id: input.lens.user_id ?? null,
+          query: input.query,
+          applied: rankedRetrievalLive ? 'ranked' : 'naive',
+          ...comparison,
+        })}`,
+      );
+      if (rankedRetrievalLive) {
+        memoryHits = ranked;
+        hitCounts.memory_garden = memoryHits.length;
+      }
+    } else if (rankedRetrievalLive) {
+      memoryHits = rankMemoryHits(rankInputs);
+      hitCounts.memory_garden = memoryHits.length;
+    }
   }
 
   // VTID-01230: Session buffer — inject recent turns from Tier 0

--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -996,12 +996,26 @@ export async function buildContextPack(
 
   // Merge structured facts + diary hits into memory hits (prepend - higher priority)
   // VTID-01224-FIX: Include diary entries so search_memory tool can find diary data
+  //
+  // Phase B (Finding 2): keep an UNSLICED candidate pool. The naive path slices
+  // to MAX_MEMORY_HITS here by relevance_score; the ranked path must instead get
+  // to choose its top-N from the FULL merged pool, so a high-importance/recent
+  // candidate sitting just below the old relevance_score cutoff can still be
+  // selected. We compute the naive result exactly as before (byte-for-byte for
+  // the flag-OFF path) AND retain the unsliced pool for the ranker.
   const mergeItems = [...structuredFacts, ...diaryHits];
+  // `memoryPool` is the full, unsliced candidate set in relevance_score order
+  // when merges happened, or the raw fetch result otherwise (mirrors the
+  // original control flow where the merge block was skipped with no merges).
+  let memoryPool: MemoryHit[] = memoryHits;
   if (mergeItems.length > 0) {
-    memoryHits = [...mergeItems, ...memoryHits];
-    // Re-sort by relevance and enforce limit
-    memoryHits.sort((a, b) => b.relevance_score - a.relevance_score);
-    memoryHits = memoryHits.slice(0, CONTEXT_PACK_CONFIG.MAX_MEMORY_HITS);
+    memoryPool = [...mergeItems, ...memoryHits];
+    // Re-sort by relevance (full pool, NO slice — slice deferred to the naive
+    // computation below so the ranker can see every candidate).
+    memoryPool.sort((a, b) => b.relevance_score - a.relevance_score);
+    // Naive selection: relevance_score desc, sliced to the budget. This is the
+    // exact output the old code produced and what ships when both flags are OFF.
+    memoryHits = memoryPool.slice(0, CONTEXT_PACK_CONFIG.MAX_MEMORY_HITS);
     hitCounts.memory_garden = memoryHits.length;
   }
 
@@ -1012,6 +1026,12 @@ export async function buildContextPack(
   // desc, sliced to MAX_MEMORY_HITS. Phase B replaces "first N by relevance_score"
   // with a relevance-RANKED top-N (importance + recency + optional similarity)
   // so the content that survives the cap is the most useful.
+  //
+  // Finding 2: the ranker is fed the UNSLICED `memoryPool`, not the naive
+  // (already-sliced) `memoryHits`. This lets ranking SELECT the true top-N by
+  // the new formula from the full candidate set instead of merely REORDERING
+  // the naive survivors. `topK` still caps the output at MAX_MEMORY_HITS, so the
+  // size budget is unchanged.
   //
   // Behavior-safe:
   //   - When neither flag is live, this block is a no-op — `memoryHits` ships
@@ -1025,7 +1045,8 @@ export async function buildContextPack(
   const rankingShadowLive = isFeatureLive('VOICE_RANKING_SHADOW');
   if (rankedRetrievalLive || rankingShadowLive) {
     const rankInputs = {
-      hits: memoryHits,
+      // UNSLICED pool: ranker selects top-`topK` from every candidate.
+      hits: memoryPool,
       topK: CONTEXT_PACK_CONFIG.MAX_MEMORY_HITS,
       now: new Date(),
       // MemoryHit carries no embedding column today, so similarity degrades to 0
@@ -1033,6 +1054,9 @@ export async function buildContextPack(
       intentEmbedding: undefined as number[] | undefined,
     };
     if (rankingShadowLive) {
+      // Shadow compares the NAIVE sliced set (what ships when flag is off)
+      // against the ranked set, so the diff reflects exactly what flipping the
+      // flag would change.
       const { ranked, comparison } = shadowCompareHits(memoryHits, rankInputs);
       // Structured shadow log: old order vs new order, char totals, overlap.
       console.log(

--- a/services/gateway/src/services/memory-hit-ranking.ts
+++ b/services/gateway/src/services/memory-hit-ranking.ts
@@ -35,9 +35,12 @@ export function hitToCandidate(
   embeddingOf?: (hit: MemoryHit) => number[] | undefined,
 ): MemoryCandidate {
   const rawImportance = typeof hit.importance === 'number' ? hit.importance : 0;
-  // MemoryHit importance is 0..100; clamp01 in the ranker handles the >1 → 1
-  // case, but normalize here so 30 ranks as 0.30 rather than saturating to 1.
-  const importance = rawImportance > 1 ? rawImportance / 100 : rawImportance;
+  // MemoryHit importance is ALWAYS on a 0..100 scale (routes/memory.ts validates
+  // 1..100; the mapper defaults to 30). Normalize the WHOLE range by /100 so a
+  // stored importance of 1 maps to 0.01 — NOT 1.0. Special-casing ">1 looks
+  // already normalized" was wrong: it let the lowest-importance memories (1)
+  // score as MAXIMALLY important and push genuinely important hits out.
+  const importance = Math.max(0, Math.min(1, rawImportance / 100));
   return {
     id: hit.id,
     content: hit.content ?? '',

--- a/services/gateway/src/services/memory-hit-ranking.ts
+++ b/services/gateway/src/services/memory-hit-ranking.ts
@@ -1,0 +1,106 @@
+/**
+ * Memory-hit relevance selection — Phase B wiring (ORB Memory Resilience).
+ *
+ * The pure relevance math lives in `memory-ranker.ts` (importance + recency +
+ * optional embedding similarity). This sibling adapts the context-pack-builder's
+ * `MemoryHit[]` to that pure ranker, applies the SAME size budget the naive path
+ * uses, and produces a shadow comparison so naive-vs-ranked can be evaluated on
+ * prod traffic before the feature flag is flipped.
+ *
+ * Pure + dependency-free (no Supabase, no fetch, no env reads, no clock except the
+ * injected `now`). Gating on the OFF-by-default flag happens in the caller; this
+ * module only computes selections so it can be exhaustively unit-tested.
+ *
+ * Design constraints honored here:
+ *   - The output is a re-ordered + truncated subset of the SAME `MemoryHit`
+ *     objects passed in (identity-preserving — no field rewrites).
+ *   - `MemoryHit.importance` is on a 0..100 scale (e.g. 30, or
+ *     round(confidence*100)); the pure ranker expects 0..1, so we normalize.
+ *   - `MemoryHit` carries no embedding column today, so similarity degrades to
+ *     0 and ranking reduces to importance+recency. The seam is left open: if an
+ *     embedding ever lands on the hit, pass it through `embeddingOf`.
+ */
+
+import type { MemoryHit } from '../types/conversation';
+import {
+  rankMemory,
+  compareSelections,
+  type MemoryCandidate,
+  type ShadowComparison,
+} from './memory-ranker';
+
+/** Map a MemoryHit (importance 0..100) to a pure-ranker candidate (importance 0..1). */
+export function hitToCandidate(
+  hit: MemoryHit,
+  embeddingOf?: (hit: MemoryHit) => number[] | undefined,
+): MemoryCandidate {
+  const rawImportance = typeof hit.importance === 'number' ? hit.importance : 0;
+  // MemoryHit importance is 0..100; clamp01 in the ranker handles the >1 → 1
+  // case, but normalize here so 30 ranks as 0.30 rather than saturating to 1.
+  const importance = rawImportance > 1 ? rawImportance / 100 : rawImportance;
+  return {
+    id: hit.id,
+    content: hit.content ?? '',
+    importance,
+    occurred_at: hit.occurred_at,
+    embedding: embeddingOf?.(hit),
+  };
+}
+
+export interface RankHitsInputs {
+  hits: MemoryHit[];
+  /** Size budget — same cap the naive path enforces (MAX_MEMORY_HITS). */
+  topK: number;
+  now: Date;
+  /** Optional intent/query embedding for the similarity term. */
+  intentEmbedding?: number[];
+  /** Optional accessor for a per-hit embedding (none today). */
+  embeddingOf?: (hit: MemoryHit) => number[] | undefined;
+}
+
+/**
+ * Relevance-rank `MemoryHit[]` and return the top-`topK` as the SAME hit objects
+ * in ranked order. Pure; stable for tied scores (preserves input order).
+ */
+export function rankMemoryHits(inputs: RankHitsInputs): MemoryHit[] {
+  const { hits, topK, now, intentEmbedding, embeddingOf } = inputs;
+  if (topK <= 0 || hits.length === 0) return [];
+  // Build candidates keyed by index so we can map the ranked candidates back to
+  // the original MemoryHit objects without mutating or re-deriving them. The
+  // index prefix also keeps hits that share an id distinct during ranking.
+  const candidates = hits.map((h, i) => ({
+    ...hitToCandidate(h, embeddingOf),
+    id: `${i}::${h.id}`,
+  }));
+  const ranked = rankMemory({ candidates, intentEmbedding, now, topK });
+  return ranked.map((c) => hits[Number((c.id as string).split('::')[0])]);
+}
+
+export interface ShadowResult {
+  ranked: MemoryHit[];
+  comparison: ShadowComparison;
+}
+
+/**
+ * Compute the ranked selection under the SAME budget and diff it against the
+ * naive selection for the shadow harness.
+ *
+ * `naiveOrdered` should be the hits in the order the naive path would keep them
+ * (already relevance-sorted + sliced by the caller) so the comparison reflects
+ * exactly what ships when the flag is off.
+ */
+export function shadowCompareHits(
+  naiveOrdered: MemoryHit[],
+  inputs: RankHitsInputs,
+): ShadowResult {
+  const ranked = rankMemoryHits(inputs);
+  const toCmp = (hs: MemoryHit[]): MemoryCandidate[] =>
+    hs.map((h) => ({
+      id: h.id,
+      content: h.content ?? '',
+      importance: h.importance,
+      occurred_at: h.occurred_at,
+    }));
+  const comparison = compareSelections(toCmp(naiveOrdered), toCmp(ranked));
+  return { ranked, comparison };
+}

--- a/services/gateway/test/services/memory-hit-ranking.test.ts
+++ b/services/gateway/test/services/memory-hit-ranking.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Phase B wiring tests — memory-hit-ranking.ts (ORB Memory Resilience).
+ *
+ * The pure relevance math is covered by memory-ranker.test.ts. These tests
+ * cover the MemoryHit ↔ ranker adapter that context-pack-builder uses:
+ *   - importance normalization (0..100 → 0..1)
+ *   - identity-preserving subset (same hit objects, re-ordered)
+ *   - budget (topK) respected
+ *   - shadow comparison shape (old order vs new order)
+ */
+
+import {
+  hitToCandidate,
+  rankMemoryHits,
+  shadowCompareHits,
+} from '../../src/services/memory-hit-ranking';
+import type { MemoryHit } from '../../src/types/conversation';
+import { isFeatureLive } from '../../src/services/feature-flags';
+
+const NOW = new Date('2026-05-30T12:00:00Z');
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
+
+function hit(over: Partial<MemoryHit> & { id: string }): MemoryHit {
+  return {
+    category_key: 'conversation',
+    content: 'x'.repeat(40),
+    importance: 50, // 0..100 scale
+    occurred_at: daysAgo(1),
+    relevance_score: 0.5,
+    source: 'memory_items',
+    ...over,
+  };
+}
+
+describe('Phase B feature flags default OFF (byte-for-byte no-op when unset)', () => {
+  const RANKED = 'FEATURE_BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL_ENV';
+  const SHADOW = 'FEATURE_VOICE_RANKING_SHADOW_ENV';
+  const saved = { ranked: process.env[RANKED], shadow: process.env[SHADOW] };
+  afterEach(() => {
+    if (saved.ranked === undefined) delete process.env[RANKED];
+    else process.env[RANKED] = saved.ranked;
+    if (saved.shadow === undefined) delete process.env[SHADOW];
+    else process.env[SHADOW] = saved.shadow;
+  });
+
+  it('both Phase B flags resolve OFF when env vars are unset', () => {
+    delete process.env[RANKED];
+    delete process.env[SHADOW];
+    expect(isFeatureLive('BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL')).toBe(false);
+    expect(isFeatureLive('VOICE_RANKING_SHADOW')).toBe(false);
+  });
+
+  it('ranked flag activates on staging+prod, stays off for unrecognized values', () => {
+    process.env[RANKED] = 'garbage-value';
+    expect(isFeatureLive('BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL')).toBe(false);
+    process.env[RANKED] = 'staging+prod';
+    expect(isFeatureLive('BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL')).toBe(true);
+  });
+});
+
+describe('hitToCandidate', () => {
+  it('normalizes 0..100 importance to 0..1', () => {
+    expect(hitToCandidate(hit({ id: 'a', importance: 30 })).importance).toBeCloseTo(0.3, 5);
+    expect(hitToCandidate(hit({ id: 'b', importance: 100 })).importance).toBeCloseTo(1, 5);
+  });
+  it('leaves already-normalized 0..1 importance untouched', () => {
+    expect(hitToCandidate(hit({ id: 'c', importance: 0.4 })).importance).toBeCloseTo(0.4, 5);
+  });
+  it('carries id, content and occurred_at through; embedding from accessor', () => {
+    const h = hit({ id: 'd', content: 'hello', occurred_at: daysAgo(3) });
+    const c = hitToCandidate(h, () => [1, 2, 3]);
+    expect(c).toMatchObject({ id: 'd', content: 'hello', occurred_at: daysAgo(3) });
+    expect(c.embedding).toEqual([1, 2, 3]);
+  });
+});
+
+describe('rankMemoryHits', () => {
+  it('returns the SAME hit objects, re-ordered (identity preserved)', () => {
+    const a = hit({ id: 'a', importance: 10, occurred_at: daysAgo(2) });
+    const b = hit({ id: 'b', importance: 90, occurred_at: daysAgo(2) });
+    const out = rankMemoryHits({ hits: [a, b], topK: 2, now: NOW });
+    expect(out[0]).toBe(b); // higher importance ranks first (same reference)
+    expect(out[1]).toBe(a);
+  });
+
+  it('respects the topK budget', () => {
+    const hits = Array.from({ length: 30 }, (_, i) => hit({ id: String(i) }));
+    expect(rankMemoryHits({ hits, topK: 25, now: NOW })).toHaveLength(25);
+  });
+
+  it('ranks recent over stale at equal importance', () => {
+    const recent = hit({ id: 'recent', importance: 50, occurred_at: daysAgo(1) });
+    const stale = hit({ id: 'stale', importance: 50, occurred_at: daysAgo(300) });
+    const out = rankMemoryHits({ hits: [stale, recent], topK: 1, now: NOW });
+    expect(out[0].id).toBe('recent');
+  });
+
+  it('keeps the most useful subset under a tight cap (heavy-user drop)', () => {
+    const hits = [
+      hit({ id: 'old-trivial', importance: 5, occurred_at: daysAgo(200) }),
+      hit({ id: 'recent-important', importance: 95, occurred_at: daysAgo(1) }),
+      hit({ id: 'mid', importance: 50, occurred_at: daysAgo(15) }),
+    ];
+    const out = rankMemoryHits({ hits, topK: 2, now: NOW });
+    expect(out.map((h) => h.id)).toEqual(['recent-important', 'mid']);
+  });
+
+  it('handles duplicate ids without collapsing them', () => {
+    const a = hit({ id: 'dup', importance: 90, occurred_at: daysAgo(1) });
+    const b = hit({ id: 'dup', importance: 10, occurred_at: daysAgo(1) });
+    const out = rankMemoryHits({ hits: [a, b], topK: 2, now: NOW });
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe(a);
+  });
+
+  it('empty input and non-positive topK return empty', () => {
+    expect(rankMemoryHits({ hits: [], topK: 5, now: NOW })).toEqual([]);
+    expect(rankMemoryHits({ hits: [hit({ id: 'a' })], topK: 0, now: NOW })).toEqual([]);
+  });
+});
+
+describe('shadowCompareHits (shadow harness)', () => {
+  it('returns a ranked selection plus a comparison of old vs new order', () => {
+    const naive = [
+      hit({ id: 'a', content: 'aa', importance: 50, occurred_at: daysAgo(200) }),
+      hit({ id: 'b', content: 'bbb', importance: 50, occurred_at: daysAgo(1) }),
+    ];
+    const { ranked, comparison } = shadowCompareHits(naive, {
+      hits: naive,
+      topK: 2,
+      now: NOW,
+    });
+    // ranked re-orders by relevance (recent 'b' first)
+    expect(ranked.map((h) => h.id)).toEqual(['b', 'a']);
+    expect(comparison.naive_selection_ids).toEqual(['a', 'b']);
+    expect(comparison.ranked_selection_ids).toEqual(['b', 'a']);
+    expect(comparison.naive_chars).toBe(5);
+    expect(comparison.ranked_chars).toBe(5);
+    expect(comparison.overlap_pct).toBe(100); // same set, different order
+  });
+
+  it('reports reduced overlap when ranking drops a naive pick under a tighter cap', () => {
+    const hits = [
+      hit({ id: 'old', content: 'oo', importance: 10, occurred_at: daysAgo(300) }),
+      hit({ id: 'fresh', content: 'ff', importance: 90, occurred_at: daysAgo(1) }),
+    ];
+    // naive keeps both (cap 2); ranked under cap 1 keeps only 'fresh'
+    const { ranked, comparison } = shadowCompareHits(hits, { hits, topK: 1, now: NOW });
+    expect(ranked.map((h) => h.id)).toEqual(['fresh']);
+    expect(comparison.ranked_selection_ids).toEqual(['fresh']);
+    expect(comparison.overlap_pct).toBe(100); // fresh is in the naive set
+  });
+});

--- a/services/gateway/test/services/memory-hit-ranking.test.ts
+++ b/services/gateway/test/services/memory-hit-ranking.test.ts
@@ -19,6 +19,8 @@ import { isFeatureLive } from '../../src/services/feature-flags';
 
 const NOW = new Date('2026-05-30T12:00:00Z');
 const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
+// Mirrors CONTEXT_PACK_CONFIG.MAX_MEMORY_HITS used as the ranker budget (topK).
+const CONTEXT_PACK_MAX = 25;
 
 function hit(over: Partial<MemoryHit> & { id: string }): MemoryHit {
   return {
@@ -59,12 +61,24 @@ describe('Phase B feature flags default OFF (byte-for-byte no-op when unset)', (
 });
 
 describe('hitToCandidate', () => {
-  it('normalizes 0..100 importance to 0..1', () => {
+  it('normalizes 0..100 importance to 0..1 by dividing the WHOLE range by 100', () => {
     expect(hitToCandidate(hit({ id: 'a', importance: 30 })).importance).toBeCloseTo(0.3, 5);
     expect(hitToCandidate(hit({ id: 'b', importance: 100 })).importance).toBeCloseTo(1, 5);
   });
-  it('leaves already-normalized 0..1 importance untouched', () => {
-    expect(hitToCandidate(hit({ id: 'c', importance: 0.4 })).importance).toBeCloseTo(0.4, 5);
+  it('Finding 1: lowest stored importance 1 normalizes to ~0.01 (NOT 1.0)', () => {
+    // routes/memory.ts validates importance 1..100. A stored `1` is the LOWEST
+    // importance and must map to 0.01 — special-casing ">1 looks normalized" let
+    // it score as MAXIMALLY important and push genuine hits out.
+    expect(hitToCandidate(hit({ id: 'c', importance: 1 })).importance).toBeCloseTo(0.01, 5);
+  });
+  it('clamps to [0,1]: out-of-range values are bounded', () => {
+    expect(hitToCandidate(hit({ id: 'lo', importance: -5 })).importance).toBe(0);
+    expect(hitToCandidate(hit({ id: 'hi', importance: 150 })).importance).toBe(1);
+  });
+  it('a high importance (90) outranks the lowest (1) after normalization', () => {
+    const low = hitToCandidate(hit({ id: 'low', importance: 1 }));
+    const high = hitToCandidate(hit({ id: 'high', importance: 90 }));
+    expect(high.importance).toBeGreaterThan(low.importance);
   });
   it('carries id, content and occurred_at through; embedding from accessor', () => {
     const h = hit({ id: 'd', content: 'hello', occurred_at: daysAgo(3) });
@@ -116,6 +130,53 @@ describe('rankMemoryHits', () => {
   it('empty input and non-positive topK return empty', () => {
     expect(rankMemoryHits({ hits: [], topK: 5, now: NOW })).toEqual([]);
     expect(rankMemoryHits({ hits: [hit({ id: 'a' })], topK: 0, now: NOW })).toEqual([]);
+  });
+});
+
+describe('Finding 2: ranker selects top-N from the UNSLICED candidate pool', () => {
+  // Models the context-pack-builder contract: the naive path sorts the full
+  // pool by relevance_score then slices to the budget. A high-importance/recent
+  // candidate sitting JUST BELOW the old relevance_score cutoff would be dropped
+  // by the naive slice — but the ranker, fed the unsliced pool, must be able to
+  // SELECT it (not merely reorder the naive survivors).
+  const BUDGET = 2;
+
+  // Full candidate pool (what the builder keeps unsliced). `cand` has a LOW
+  // relevance_score (below the cutoff) but the HIGHEST importance + freshest
+  // recency — the new formula should select it.
+  const pool: MemoryHit[] = [
+    hit({ id: 'rel-hi-1', relevance_score: 0.95, importance: 20, occurred_at: daysAgo(120) }),
+    hit({ id: 'rel-hi-2', relevance_score: 0.90, importance: 20, occurred_at: daysAgo(120) }),
+    hit({ id: 'cand', relevance_score: 0.10, importance: 100, occurred_at: daysAgo(1) }),
+  ];
+
+  // Naive selection = relevance_score desc, sliced to BUDGET (drops 'cand').
+  const naive = [...pool]
+    .sort((a, b) => b.relevance_score - a.relevance_score)
+    .slice(0, BUDGET);
+
+  it('naive slice (relevance_score) would DROP the high-importance candidate', () => {
+    expect(naive.map((h) => h.id)).toEqual(['rel-hi-1', 'rel-hi-2']);
+    expect(naive.map((h) => h.id)).not.toContain('cand');
+  });
+
+  it('ranking the UNSLICED pool SELECTS the high-importance candidate', () => {
+    const ranked = rankMemoryHits({ hits: pool, topK: BUDGET, now: NOW });
+    expect(ranked.map((h) => h.id)).toContain('cand'); // could never happen if fed naive survivors
+    expect(ranked).toHaveLength(BUDGET); // budget still respected
+  });
+
+  it('ranking the naive survivors could NEVER surface the candidate (the bug)', () => {
+    // Feeding the ranker the already-sliced naive set only reorders survivors.
+    const ranked = rankMemoryHits({ hits: naive, topK: BUDGET, now: NOW });
+    expect(ranked.map((h) => h.id)).not.toContain('cand');
+  });
+
+  it('respects the budget even with a large unsliced pool', () => {
+    const big = Array.from({ length: 50 }, (_, i) =>
+      hit({ id: `m${i}`, relevance_score: Math.random(), importance: (i % 100) + 1 }),
+    );
+    expect(rankMemoryHits({ hits: big, topK: CONTEXT_PACK_MAX, now: NOW })).toHaveLength(CONTEXT_PACK_MAX);
   });
 });
 


### PR DESCRIPTION
## Summary

Phase B of ORB Memory Resilience (plan §4.B). When assembling the memory context, rank candidate memory hits by **relevance** to the session rather than `relevance_score` alone, and keep the top-ranked within the existing size budget — so the most useful memories survive truncation. Fully behavior-safe: gated behind an OFF-by-default flag, with a shadow comparison log so it can be evaluated before being switched on.

## Ranking approach

The pure relevance math already lives in `services/gateway/src/services/memory-ranker.ts` (landed in PR #2411): `score = 0.4·importance + 0.4·recency + 0.2·similarity`, where recency is `exp(-ageDays/30)` and similarity is cosine over an optional intent/candidate embedding (degrades to importance+recency when embeddings are absent). Pure, stable on ties, exhaustively unit-tested.

This PR adds the **wiring**:

- **New sibling module `memory-hit-ranking.ts`** — adapts the context-pack-builder's `MemoryHit[]` to the pure ranker. It normalizes `MemoryHit.importance` (0..100 scale, e.g. `30`, `round(confidence*100)`) to the ranker's 0..1, preserves hit **identity** (returns the same hit objects, re-ordered — no field rewrites), keeps duplicate-id hits distinct, and enforces the same `MAX_MEMORY_HITS` budget the naive path uses. Pure + dependency-free.
- **Wired into `context-pack-builder.ts`** at the memory-selection site (right after the existing merge → `relevance_score` desc → slice). At that point `memoryHits` is the naive selection; the new block optionally replaces it with the ranked selection.

## OFF-by-default flag

- `FEATURE_BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL_ENV` (unset → `off`, via the existing `isFeatureLive` convention). When off, `memoryHits` ships **byte-for-byte** as the naive path produced it — the entire Phase B block is skipped.
- `FEATURE_VOICE_RANKING_SHADOW_ENV` — shadow mode: compute the ranked set, emit the comparison log, but still ship the naive set unchanged.

Both default OFF. Rollback = flip the env var back, no redeploy.

## Shadow log (plan §4.B.4 shadow harness)

When `VOICE_RANKING_SHADOW` is live, a structured log compares old order vs new order without changing behavior:

```
[memory.retrieval.shadow] {"user_id":...,"query":...,"applied":"naive",
  "naive_selection_ids":[...], "ranked_selection_ids":[...],
  "naive_chars":N, "ranked_chars":M, "overlap_pct":X}
```

This lets naive-vs-ranked be evaluated on prod traffic before the ranked flag is flipped on (canary `dragan1` first, per the plan).

## What it does NOT do

- Does not change the pure ranker (already on `main`).
- Does not touch `orb-live.ts`, the hub files, `orb-livekit.ts`, `vertex-live-client.ts`, or `awareness-unified-context.ts`.
- Does not introduce an embedding column on `MemoryHit` — similarity degrades to 0 today; the seam (`embeddingOf`) is left open for a later pass.

## Vertex parity ✓ / LiveKit parity ✓

Memory retrieval / context-pack assembly is **shared upstream of both providers** — `context-pack-builder.ts` feeds the system instruction regardless of whether the session is served by Vertex or the LiveKit agent. The flag and shadow log apply identically to both paths; no provider-specific code is touched.

## Test summary

- `npm run build` (gateway): green, 0 TS errors.
- `npx jest test/services/memory-hit-ranking.test.ts test/services/memory-ranker.test.ts`: **41 tests pass**.
  - wiring (`memory-hit-ranking.test.ts`, 13): importance normalization, identity-preserving subset, budget (topK) respected, ranking order (recency/importance), duplicate-id handling, shadow comparison shape, **both flags default OFF**.
  - pure ranker (`memory-ranker.test.ts`, 28): pre-existing, still green.
- `npx jest test/services/context-pack` (regression): **29 tests pass**, no regression at the selection site.

No `--no-verify` used. The pre-commit TS hook initially flagged the pre-existing `moduleResolution` deprecation present on `origin/main` (global tsc 6.x vs pinned 5.x); resolved by `npm install` to the pinned TypeScript 5.9.3, after which the hook passed cleanly.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_