### PR TITLE
feat(orb): R4 graduated-user Teacher track — deepening refresh + graceful pause (BOOTSTRAP-ORB-R4-GRADUATED-TEACHER)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/teacher/feature-discovery-teacher.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/feature-discovery-teacher.ts
@@ -93,6 +93,40 @@ const DEFAULT_PRIORITY = 85;
 const DEFAULT_LOOKBACK_INTRODUCED_DAYS = 7;
 const MAX_DISMISS_BEFORE_PERMANENT = 3;
 
+// ---------------------------------------------------------------------------
+// R4 (BOOTSTRAP-ORB-R4-GRADUATED-TEACHER) — graduated-user Teacher track.
+//
+// When the linear curriculum is EXHAUSTED (every enabled capability is
+// introduced/tried/completed/mastered within its cooldown → pickCapability
+// returns null) the Teacher used to suppress and fall through to the bare
+// voice-wake-brief. R4 makes it RE-ENGAGE:
+//   1. DEEPENING REFRESH — re-introduce a `tried` capability with next-level
+//      framing IF its refresh schedule is due (per-user × capability,
+//      90-day default cadence, tracked in teacher_capability_refresh_schedule).
+//   2. GRACEFUL PAUSE — if nothing is refresh-eligible, speak ONE gentle line
+//      then stay silent on subsequent same-day opens.
+// ---------------------------------------------------------------------------
+
+/** Default cadence (days) between deepening refreshes of the same capability. */
+export const TEACHER_REFRESH_INTERVAL_DAYS = 90;
+
+/** Reserved capability_key for the graceful-pause same-day silence sentinel. */
+export const GRACEFUL_PAUSE_KEY = '__graceful_pause__' as const;
+
+/** A row from teacher_capability_refresh_schedule for one (user, capability). */
+export interface RefreshScheduleRow {
+  capability_key: string;
+  /** ISO 8601 — refresh/pause allowed again on or after this instant. */
+  next_refresh_ok_at: string;
+  refresh_count?: number | null;
+}
+
+export interface PickedRefresh {
+  row: CapabilityCatalogRow;
+  /** How many times this capability has already been refreshed (0 = first). */
+  refreshCount: number;
+}
+
 export interface TeacherInputs {
   /** Supabase service-role client. Required — DB-backed selection. */
   supabase: SupabaseClient;
@@ -120,6 +154,13 @@ export interface TeacherInputs {
   /** ISO 8601 server-side now. Used for the introduced-within-N-days
    *  filter so a candidate isn't re-introduced too soon. */
   nowIso?: string;
+  /**
+   * R4: minutes offset from UTC for the user's local timezone (e.g. +120 for
+   * CEST). Used ONLY to compute "start of next local day" for the graceful-pause
+   * sentinel so the pause line repeats at most once per local day. Defaults to 0
+   * (UTC) when unknown — a safe fallback (pause may reset at UTC midnight).
+   */
+  tzOffsetMinutes?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -275,6 +316,167 @@ export function renderTeacherLine(args: {
 }
 
 // ---------------------------------------------------------------------------
+// R4 — graduated-track pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * R4 deepening-refresh picker (deterministic, pure).
+ *
+ * Runs ONLY when the linear `pickCapability` returned null (curriculum
+ * exhausted). Selects ONE `tried` capability whose deepening refresh is due:
+ *   1. Capability must be enabled AND its ledger state must be exactly `tried`
+ *      (the user engaged once but hasn't completed/mastered — the right
+ *      surface for a "let's go deeper" re-introduction). completed/mastered
+ *      are intentionally terminal and never re-offered.
+ *   2. Refresh is "due" when there is NO schedule row for it (never refreshed)
+ *      OR the row's `next_refresh_ok_at` is <= now.
+ *   3. Among due candidates, prefer the one refreshed longest ago (oldest
+ *      next_refresh_ok_at first; never-refreshed rows sort first), then
+ *      pedagogical_order asc, then capability_key alphabetical.
+ *
+ * Returns null when nothing is refresh-eligible → caller falls to graceful pause.
+ */
+export function pickRefreshCapability(
+  catalog: CapabilityCatalogRow[],
+  ledger: AwarenessLedgerRow[],
+  schedule: RefreshScheduleRow[],
+  nowIso: string,
+): PickedRefresh | null {
+  const nowMs = Date.parse(nowIso);
+  if (!Number.isFinite(nowMs)) return null;
+
+  const ledgerByKey = new Map<string, AwarenessLedgerRow>();
+  for (const row of ledger) ledgerByKey.set(row.capability_key, row);
+
+  const schedByKey = new Map<string, RefreshScheduleRow>();
+  for (const row of schedule) schedByKey.set(row.capability_key, row);
+
+  interface Cand {
+    row: CapabilityCatalogRow;
+    refreshCount: number;
+    /** Sort key: ms of next_refresh_ok_at; -Infinity when never refreshed. */
+    nextOkMs: number;
+  }
+  const eligible: Cand[] = [];
+  for (const cap of catalog) {
+    if (!cap.enabled) continue;
+    const lr = ledgerByKey.get(cap.capability_key);
+    // Only `tried` capabilities are deepening-refresh candidates.
+    if (!lr || lr.awareness_state !== 'tried') continue;
+
+    const sched = schedByKey.get(cap.capability_key);
+    let nextOkMs = -Infinity;
+    if (sched) {
+      const parsed = Date.parse(sched.next_refresh_ok_at);
+      if (Number.isFinite(parsed)) {
+        if (parsed > nowMs) continue; // not due yet
+        nextOkMs = parsed;
+      }
+    }
+    eligible.push({
+      row: cap,
+      refreshCount: sched?.refresh_count ?? 0,
+      nextOkMs,
+    });
+  }
+
+  if (eligible.length === 0) return null;
+
+  eligible.sort((a, b) => {
+    // Oldest-due / never-refreshed first.
+    if (a.nextOkMs !== b.nextOkMs) return a.nextOkMs - b.nextOkMs;
+    const aOrder = typeof a.row.pedagogical_order === 'number' ? a.row.pedagogical_order : Number.POSITIVE_INFINITY;
+    const bOrder = typeof b.row.pedagogical_order === 'number' ? b.row.pedagogical_order : Number.POSITIVE_INFINITY;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    return a.row.capability_key.localeCompare(b.row.capability_key);
+  });
+
+  const top = eligible[0];
+  return { row: top.row, refreshCount: top.refreshCount };
+}
+
+/**
+ * Decide whether the graceful-pause line may be SPOKEN this open.
+ *
+ * The pause line fires at most once per local day. The same-day silence is
+ * enforced by a `__graceful_pause__` sentinel row whose `next_refresh_ok_at`
+ * is the start of the next local day. So:
+ *   - no sentinel row, OR sentinel due (next_refresh_ok_at <= now) → SPEAK.
+ *   - sentinel still in the future (already spoke today) → STAY SILENT.
+ */
+export function gracefulPauseAllowed(
+  schedule: RefreshScheduleRow[],
+  nowIso: string,
+): boolean {
+  const nowMs = Date.parse(nowIso);
+  if (!Number.isFinite(nowMs)) return false;
+  const sentinel = schedule.find((s) => s.capability_key === GRACEFUL_PAUSE_KEY);
+  if (!sentinel) return true;
+  const okMs = Date.parse(sentinel.next_refresh_ok_at);
+  if (!Number.isFinite(okMs)) return true;
+  return okMs <= nowMs;
+}
+
+/** Start of the user's NEXT local day, as an ISO instant, given an offset in
+ *  minutes from UTC (e.g. +120 for CEST). Used to stamp the pause sentinel so
+ *  the line can fire again tomorrow but stays silent for the rest of today. */
+export function startOfNextLocalDayIso(nowIso: string, tzOffsetMinutes = 0): string {
+  const nowMs = Date.parse(nowIso);
+  if (!Number.isFinite(nowMs)) return nowIso;
+  const offsetMs = tzOffsetMinutes * 60 * 1000;
+  const local = new Date(nowMs + offsetMs);
+  // Compute next local midnight in UTC terms.
+  const y = local.getUTCFullYear();
+  const m = local.getUTCMonth();
+  const d = local.getUTCDate();
+  const nextLocalMidnightUtcMs = Date.UTC(y, m, d + 1, 0, 0, 0, 0) - offsetMs;
+  return new Date(nextLocalMidnightUtcMs).toISOString();
+}
+
+/** Now + 90 days (default refresh cadence), as ISO. */
+export function nextRefreshOkIso(
+  nowIso: string,
+  intervalDays = TEACHER_REFRESH_INTERVAL_DAYS,
+): string {
+  const nowMs = Date.parse(nowIso);
+  if (!Number.isFinite(nowMs)) return nowIso;
+  return new Date(nowMs + intervalDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * Deepening-refresh invitation clause — language-aware, next-level framing.
+ * Escalates wording by refreshCount so a second refresh doesn't repeat the
+ * first verbatim. Names the capability so the user knows what's being revisited.
+ */
+export function renderRefreshInvitation(args: {
+  lang: string;
+  displayName: string;
+  refreshCount: number;
+}): string {
+  const de = args.lang.toLowerCase().startsWith('de');
+  const name = args.displayName;
+  if (args.refreshCount >= 1) {
+    return de
+      ? `Lass uns bei ${name} noch eine Stufe tiefer gehen — darf ich dir fortgeschrittene Wege zeigen?`
+      : `Let's take ${name} one level deeper — may I show you some advanced ways to use it?`;
+  }
+  return de
+    ? `Erinnerst du dich an ${name}? Lass uns das nochmal aufgreifen — darf ich dir zeigen, was du als Nächstes damit machen kannst?`
+    : `Remember ${name}? Let's revisit it — may I show you what you can do next with it?`;
+}
+
+/**
+ * The graceful-pause line (operator-fixed copy, per R4 strategy). Spoken once
+ * per local day when there is nothing new to teach and nothing to refresh.
+ */
+export function renderGracefulPauseLine(lang: string): string {
+  const de = lang.toLowerCase().startsWith('de');
+  return de
+    ? 'Du hast das meiste von dem, was Vitana zu bieten hat, schon erkundet. Ich melde mich, sobald es Neues gibt. Soll ich kurz zusammenfassen, was du diesen Monat gelernt hast?'
+    : "You've explored most of what Vitana offers. I'll surface new things as they ship. Want me to summarize what you've learned this month?";
+}
+
+// ---------------------------------------------------------------------------
 // Provider factory
 // ---------------------------------------------------------------------------
 
@@ -401,12 +603,22 @@ export function makeFeatureDiscoveryTeacherProvider(
       const nowIso = inputs.nowIso ?? new Date().toISOString();
       const picked = pickCapability(catalog, ledger, nowIso);
       if (!picked) {
-        return {
-          providerKey: TEACHER_PROVIDER_KEY,
-          status: 'suppressed',
-          latencyMs: Math.max(0, now() - t0),
-          reason: 'all_capabilities_known_or_dismissed',
-        };
+        // R4 (BOOTSTRAP-ORB-R4-GRADUATED-TEACHER): the linear curriculum is
+        // exhausted. Instead of suppressing → falling to the bare wake-brief,
+        // re-engage: attempt a deepening refresh, else a once-per-day graceful
+        // pause. Bundled/atomic like the R3 design — the candidate carries its
+        // content (or the provider errors/suppresses cleanly).
+        return await produceGraduatedTrack({
+          inputs,
+          catalog,
+          ledger,
+          nowIso,
+          priority,
+          newId,
+          now,
+          rng,
+          t0,
+        });
       }
 
       // ---- Render the two-clause line ----
@@ -579,6 +791,225 @@ function readInputs(ctx: ContinuationDecisionContext): TeacherInputs | null {
         ? obj.skipReason
         : null,
     nowIso: typeof obj.nowIso === 'string' && obj.nowIso ? obj.nowIso : undefined,
+    tzOffsetMinutes:
+      typeof obj.tzOffsetMinutes === 'number' && Number.isFinite(obj.tzOffsetMinutes)
+        ? obj.tzOffsetMinutes
+        : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// R4 — graduated-track producer (curriculum exhausted → refresh OR pause)
+// ---------------------------------------------------------------------------
+
+interface GraduatedTrackArgs {
+  inputs: TeacherInputs;
+  catalog: CapabilityCatalogRow[];
+  ledger: AwarenessLedgerRow[];
+  nowIso: string;
+  priority: number;
+  newId: () => string;
+  now: () => number;
+  rng: () => number;
+  t0: number;
+}
+
+/**
+ * R4: the linear curriculum is exhausted. Re-engage instead of suppressing.
+ *
+ *   1. Fetch the per-user refresh schedule.
+ *   2. DEEPENING REFRESH — if a `tried` capability is refresh-due, re-introduce
+ *      it with next-level framing. Resolve its Teacher Mode content atomically
+ *      (same R3 contract: null/throw → errored, never fire empty). Record the
+ *      refresh (advances the 90-day cadence). Returns a bundled candidate.
+ *   3. GRACEFUL PAUSE — else, if the once-per-day pause is allowed, speak the
+ *      fixed pause line and stamp the same-day silence sentinel. Returns a
+ *      content-free `check_in` candidate.
+ *   4. If the pause already fired today → suppress cleanly (silent).
+ *
+ * Schedule writes are best-effort (fire-and-forget on the RPC): a write failure
+ * must NOT block the spoken turn. We await the RPC but swallow its error.
+ */
+async function produceGraduatedTrack(
+  args: GraduatedTrackArgs,
+): Promise<ProviderResult> {
+  const { inputs, catalog, ledger, nowIso, priority, newId, now, rng, t0 } = args;
+
+  // ---- Fetch the refresh schedule (degrade to empty on error) ----
+  let schedule: RefreshScheduleRow[] = [];
+  try {
+    const sched = await inputs.supabase
+      .from('teacher_capability_refresh_schedule')
+      .select('capability_key, next_refresh_ok_at, refresh_count')
+      .eq('tenant_id', inputs.tenantId)
+      .eq('user_id', inputs.userId);
+    if (!sched.error && Array.isArray(sched.data)) {
+      schedule = sched.data as RefreshScheduleRow[];
+    }
+  } catch {
+    // Missing table / RLS / transient error → treat as no schedule. Every
+    // `tried` capability is then refresh-due (never-refreshed sorts first).
+    schedule = [];
+  }
+
+  // ---- 1. DEEPENING REFRESH ----
+  const refresh = pickRefreshCapability(catalog, ledger, schedule, nowIso);
+  if (refresh) {
+    // Atomic content resolution — identical R3 contract.
+    let teacherMode: TeacherModeContent | null = null;
+    try {
+      const { resolveTeacherModeContent } = await import(
+        '../../../../orb/teacher/teacher-content-resolver'
+      );
+      teacherMode = await resolveTeacherModeContent({
+        supabase: inputs.supabase,
+        tenantId: inputs.tenantId,
+        userId: inputs.userId,
+        activeCapabilityKey: refresh.row.capability_key,
+        lang: inputs.lang,
+        nowIso: inputs.nowIso ?? undefined,
+      });
+    } catch (err) {
+      return {
+        providerKey: TEACHER_PROVIDER_KEY,
+        status: 'errored',
+        latencyMs: Math.max(0, now() - t0),
+        reason: `teacher_refresh_content_resolution_failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      };
+    }
+    if (!teacherMode || !teacherMode.active_capability_key) {
+      return {
+        providerKey: TEACHER_PROVIDER_KEY,
+        status: 'errored',
+        latencyMs: Math.max(0, now() - t0),
+        reason: 'teacher_refresh_content_resolution_failed',
+      };
+    }
+
+    // Greeting clause reuses the name-aware pool; invitation uses the
+    // deepening framing instead of the abstract "may I show you something".
+    const greetingPick = pickTeacherGreetingMeta({
+      lang: inputs.lang,
+      firstName: inputs.firstName ?? null,
+      rng,
+      greetingPolicy: inputs.greetingPolicy,
+    });
+    const invitation = renderRefreshInvitation({
+      lang: inputs.lang,
+      displayName: refresh.row.display_name,
+      refreshCount: refresh.refreshCount,
+    });
+    const userFacingLine = renderTeacherLine({
+      greeting: greetingPick.text,
+      invitation,
+    });
+
+    console.log(
+      `[BOOTSTRAP-ORB-R4 TEACHER-REFRESH] tenant=${inputs.tenantId} user=${inputs.userId.slice(0, 8)} `
+      + `lang=${inputs.lang} capability=${refresh.row.capability_key} refresh_count=${refresh.refreshCount} `
+      + `rendered="${userFacingLine.replace(/"/g, '\\"').slice(0, 240)}"`,
+    );
+
+    // Record the refresh (advance the 90-day cadence). Best-effort.
+    try {
+      await inputs.supabase.rpc('record_teacher_refresh', {
+        p_tenant_id: inputs.tenantId,
+        p_user_id: inputs.userId,
+        p_capability_key: refresh.row.capability_key,
+        p_next_ok_at: nextRefreshOkIso(nowIso),
+        p_is_refresh: true,
+      });
+    } catch {
+      // Schedule write failure must not block the spoken turn.
+    }
+
+    const candidate: TeacherContinuation = {
+      id: `teacher-refresh-${newId()}`,
+      surface: 'orb_wake',
+      kind: 'feature_discovery',
+      priority,
+      userFacingLine,
+      teacherMode,
+      cta: {
+        type: 'offer_demo',
+        payload: {
+          capability_key: refresh.row.capability_key,
+          manual_path: refresh.row.manual_path ?? null,
+          display_name: refresh.row.display_name,
+          refresh: true,
+          refresh_count: refresh.refreshCount,
+        },
+      },
+      evidence: [
+        { kind: 'capability:refresh_eligible', detail: refresh.row.capability_key },
+        { kind: 'refresh_count', detail: String(refresh.refreshCount) },
+        { kind: 'graduated_track', detail: 'deepening_refresh' },
+      ],
+      dedupeKey: `teacher:refresh:${refresh.row.capability_key}`,
+      privacyMode: 'safe_to_speak',
+    };
+    return {
+      providerKey: TEACHER_PROVIDER_KEY,
+      status: 'returned',
+      latencyMs: Math.max(0, now() - t0),
+      candidate,
+    };
+  }
+
+  // ---- 2. GRACEFUL PAUSE (once per local day) ----
+  if (!gracefulPauseAllowed(schedule, nowIso)) {
+    // Already spoke the pause line today → stay silent on this same-day open.
+    return {
+      providerKey: TEACHER_PROVIDER_KEY,
+      status: 'suppressed',
+      latencyMs: Math.max(0, now() - t0),
+      reason: 'graceful_pause_already_spoken_today',
+    };
+  }
+
+  const pauseLine = renderGracefulPauseLine(inputs.lang);
+  console.log(
+    `[BOOTSTRAP-ORB-R4 TEACHER-PAUSE] tenant=${inputs.tenantId} user=${inputs.userId.slice(0, 8)} `
+    + `lang=${inputs.lang} rendered="${pauseLine.replace(/"/g, '\\"').slice(0, 240)}"`,
+  );
+
+  // Stamp the same-day silence sentinel: next allowed at start of next local day.
+  try {
+    await inputs.supabase.rpc('record_teacher_refresh', {
+      p_tenant_id: inputs.tenantId,
+      p_user_id: inputs.userId,
+      p_capability_key: GRACEFUL_PAUSE_KEY,
+      p_next_ok_at: startOfNextLocalDayIso(nowIso, inputs.tzOffsetMinutes ?? 0),
+      p_is_refresh: false,
+    });
+  } catch {
+    // Best-effort — a write failure means the pause might repeat; acceptable.
+  }
+
+  const candidate: AssistantContinuation = {
+    id: `teacher-pause-${newId()}`,
+    surface: 'orb_wake',
+    kind: 'check_in',
+    priority,
+    userFacingLine: pauseLine,
+    cta: {
+      type: 'explain',
+      payload: { graceful_pause: true, offer: 'summarize_month' },
+    },
+    evidence: [
+      { kind: 'graduated_track', detail: 'graceful_pause' },
+      { kind: 'catalog_size', detail: String(catalog.length) },
+    ],
+    dedupeKey: 'teacher:graceful_pause',
+    privacyMode: 'safe_to_speak',
+  };
+  return {
+    providerKey: TEACHER_PROVIDER_KEY,
+    status: 'returned',
+    latencyMs: Math.max(0, now() - t0),
+    candidate,
   };
 }
 

--- a/services/gateway/test/services/assistant-continuation/providers/teacher/feature-discovery-teacher.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/teacher/feature-discovery-teacher.test.ts
@@ -8,8 +8,18 @@ import {
   renderTeacherLine,
   TEACHER_EXTRA_KEY,
   TEACHER_PROVIDER_KEY,
+  // R4 (BOOTSTRAP-ORB-R4-GRADUATED-TEACHER) graduated-track exports.
+  pickRefreshCapability,
+  gracefulPauseAllowed,
+  startOfNextLocalDayIso,
+  nextRefreshOkIso,
+  renderRefreshInvitation,
+  renderGracefulPauseLine,
+  GRACEFUL_PAUSE_KEY,
+  TEACHER_REFRESH_INTERVAL_DAYS,
   type CapabilityCatalogRow,
   type AwarenessLedgerRow,
+  type RefreshScheduleRow,
 } from '../../../../../src/services/assistant-continuation/providers/teacher/feature-discovery-teacher';
 import type { ContinuationDecisionContext } from '../../../../../src/services/assistant-continuation/types';
 
@@ -484,14 +494,21 @@ describe('VTID-03093 — provider produce()', () => {
     expect(r.candidate.dedupeKey).toBe('teacher:life_compass');
   });
 
-  test('all capabilities mastered → suppressed:all_known_or_dismissed', async () => {
+  // R4 (BOOTSTRAP-ORB-R4-GRADUATED-TEACHER): an all-mastered user no longer
+  // SUPPRESSES — the linear pick returns null, the graduated track runs, and
+  // (with no `tried` capability to refresh and no pause sentinel yet) it speaks
+  // the graceful-pause line once. This test previously asserted suppression;
+  // R4 deliberately changes that contract. See the "graduated track" suite for
+  // the refresh/pause/silent matrix.
+  test('all capabilities mastered → graceful-pause fires (R4 re-engage, no suppress)', async () => {
     const provider = makeFeatureDiscoveryTeacherProvider({ rng: () => 0 });
     const r = await provider.produce(
       ctxWith({
         [TEACHER_EXTRA_KEY]: {
-          supabase: fakeSb({
+          supabase: fakeSbGraduated({
             catalog: [cat({ capability_key: 'a' })],
             ledger: [lr({ capability_key: 'a', awareness_state: 'mastered' })],
+            schedule: [],
           }),
           tenantId: 't1',
           userId: 'u1',
@@ -501,9 +518,10 @@ describe('VTID-03093 — provider produce()', () => {
         },
       }),
     );
-    expect(r.status).toBe('suppressed');
-    if (r.status === 'suppressed') {
-      expect(r.reason).toBe('all_capabilities_known_or_dismissed');
+    expect(r.status).toBe('returned');
+    if (r.status === 'returned') {
+      expect(r.candidate.kind).toBe('check_in');
+      expect(r.candidate.dedupeKey).toBe('teacher:graceful_pause');
     }
   });
 
@@ -550,5 +568,397 @@ describe('VTID-03093 — provider produce()', () => {
         expect(r.candidate.userFacingLine.toLowerCase()).not.toContain('how can i help');
       }
     }
+  });
+});
+
+// ===========================================================================
+// R4 (BOOTSTRAP-ORB-R4-GRADUATED-TEACHER) — graduated-user Teacher track.
+//
+// When the linear curriculum is exhausted (Dragan1: every enabled capability
+// tried/completed/introduced within cooldown → pickCapability returns null),
+// the Teacher must RE-ENGAGE instead of suppressing:
+//   1. deepening refresh of a `tried` capability when refresh-due, ELSE
+//   2. graceful-pause line once per local day, ELSE
+//   3. silent on subsequent same-day opens.
+// ===========================================================================
+
+const REFRESH_INTERVAL_MS = TEACHER_REFRESH_INTERVAL_DAYS * DAY_MS;
+
+function sched(over: Partial<RefreshScheduleRow> = {}): RefreshScheduleRow {
+  return {
+    capability_key: 'life_compass',
+    next_refresh_ok_at: NOW_ISO,
+    refresh_count: 0,
+    ...over,
+  };
+}
+
+describe('R4 — pickRefreshCapability (pure)', () => {
+  test('a `tried` capability with NO schedule row is refresh-eligible', () => {
+    const catalog = [cat({ capability_key: 'life_compass' })];
+    const ledger = [lr({ capability_key: 'life_compass', awareness_state: 'tried' })];
+    const picked = pickRefreshCapability(catalog, ledger, [], NOW_ISO);
+    expect(picked?.row.capability_key).toBe('life_compass');
+    expect(picked?.refreshCount).toBe(0);
+  });
+
+  test('completed / mastered / introduced are NOT refresh candidates', () => {
+    const catalog = [
+      cat({ capability_key: 'a' }),
+      cat({ capability_key: 'b' }),
+      cat({ capability_key: 'c' }),
+    ];
+    const ledger = [
+      lr({ capability_key: 'a', awareness_state: 'completed' }),
+      lr({ capability_key: 'b', awareness_state: 'mastered' }),
+      lr({ capability_key: 'c', awareness_state: 'introduced' }),
+    ];
+    expect(pickRefreshCapability(catalog, ledger, [], NOW_ISO)).toBeNull();
+  });
+
+  test('refresh NOT due yet (next_refresh_ok_at in the future) → filtered out', () => {
+    const catalog = [cat({ capability_key: 'life_compass' })];
+    const ledger = [lr({ capability_key: 'life_compass', awareness_state: 'tried' })];
+    const schedule = [
+      sched({
+        capability_key: 'life_compass',
+        next_refresh_ok_at: new Date(NOW_MS + 10 * DAY_MS).toISOString(),
+      }),
+    ];
+    expect(pickRefreshCapability(catalog, ledger, schedule, NOW_ISO)).toBeNull();
+  });
+
+  test('refresh due (next_refresh_ok_at in the past) → eligible, carries refresh_count', () => {
+    const catalog = [cat({ capability_key: 'life_compass' })];
+    const ledger = [lr({ capability_key: 'life_compass', awareness_state: 'tried' })];
+    const schedule = [
+      sched({
+        capability_key: 'life_compass',
+        next_refresh_ok_at: new Date(NOW_MS - 1 * DAY_MS).toISOString(),
+        refresh_count: 2,
+      }),
+    ];
+    const picked = pickRefreshCapability(catalog, ledger, schedule, NOW_ISO);
+    expect(picked?.row.capability_key).toBe('life_compass');
+    expect(picked?.refreshCount).toBe(2);
+  });
+
+  test('never-refreshed sorts before a due-refreshed one', () => {
+    const catalog = [
+      cat({ capability_key: 'never', pedagogical_order: 99 }),
+      cat({ capability_key: 'dueonce', pedagogical_order: 1 }),
+    ];
+    const ledger = [
+      lr({ capability_key: 'never', awareness_state: 'tried' }),
+      lr({ capability_key: 'dueonce', awareness_state: 'tried' }),
+    ];
+    const schedule = [
+      sched({
+        capability_key: 'dueonce',
+        next_refresh_ok_at: new Date(NOW_MS - 1 * DAY_MS).toISOString(),
+      }),
+    ];
+    // 'never' has nextOkMs=-Infinity → sorts first despite higher ped order.
+    const picked = pickRefreshCapability(catalog, ledger, schedule, NOW_ISO);
+    expect(picked?.row.capability_key).toBe('never');
+  });
+});
+
+describe('R4 — pause + schedule pure helpers', () => {
+  test('gracefulPauseAllowed: no sentinel → allowed', () => {
+    expect(gracefulPauseAllowed([], NOW_ISO)).toBe(true);
+  });
+
+  test('gracefulPauseAllowed: sentinel in the future → NOT allowed (already spoke today)', () => {
+    const schedule = [
+      sched({
+        capability_key: GRACEFUL_PAUSE_KEY,
+        next_refresh_ok_at: new Date(NOW_MS + 6 * 60 * 60 * 1000).toISOString(),
+      }),
+    ];
+    expect(gracefulPauseAllowed(schedule, NOW_ISO)).toBe(false);
+  });
+
+  test('gracefulPauseAllowed: sentinel due (past) → allowed again', () => {
+    const schedule = [
+      sched({
+        capability_key: GRACEFUL_PAUSE_KEY,
+        next_refresh_ok_at: new Date(NOW_MS - 60 * 1000).toISOString(),
+      }),
+    ];
+    expect(gracefulPauseAllowed(schedule, NOW_ISO)).toBe(true);
+  });
+
+  test('startOfNextLocalDayIso (UTC) is the next midnight after now', () => {
+    // NOW_ISO = 2026-05-19T08:00:00Z → next UTC midnight = 2026-05-20T00:00:00Z
+    expect(startOfNextLocalDayIso(NOW_ISO, 0)).toBe('2026-05-20T00:00:00.000Z');
+  });
+
+  test('startOfNextLocalDayIso honors a +120min (CEST) offset', () => {
+    // Local time is 10:00 CEST on the 19th → next local midnight = 2026-05-20
+    // 00:00 local = 2026-05-19T22:00:00Z.
+    expect(startOfNextLocalDayIso(NOW_ISO, 120)).toBe('2026-05-19T22:00:00.000Z');
+  });
+
+  test('nextRefreshOkIso defaults to now + 90 days', () => {
+    expect(nextRefreshOkIso(NOW_ISO)).toBe(
+      new Date(NOW_MS + REFRESH_INTERVAL_MS).toISOString(),
+    );
+  });
+
+  test('renderRefreshInvitation names the capability (first refresh)', () => {
+    const en = renderRefreshInvitation({ lang: 'en', displayName: 'Life Compass', refreshCount: 0 });
+    expect(en).toContain('Life Compass');
+    expect(en.toLowerCase()).toContain('revisit');
+    const de = renderRefreshInvitation({ lang: 'de', displayName: 'Life Compass', refreshCount: 0 });
+    expect(de).toContain('Life Compass');
+  });
+
+  test('renderRefreshInvitation escalates framing on a repeat refresh', () => {
+    const first = renderRefreshInvitation({ lang: 'en', displayName: 'X', refreshCount: 0 });
+    const second = renderRefreshInvitation({ lang: 'en', displayName: 'X', refreshCount: 1 });
+    expect(second).not.toBe(first);
+    expect(second.toLowerCase()).toContain('deeper');
+  });
+
+  test('renderGracefulPauseLine is the operator-fixed copy', () => {
+    expect(renderGracefulPauseLine('en')).toBe(
+      "You've explored most of what Vitana offers. I'll surface new things as they ship. Want me to summarize what you've learned this month?",
+    );
+    expect(renderGracefulPauseLine('de')).toContain('Vitana');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Graduated-track mock: supports the schedule SELECT + captures rpc() calls.
+// ---------------------------------------------------------------------------
+
+interface RpcCall {
+  fn: string;
+  args: Record<string, unknown>;
+}
+
+function fakeSbGraduated(opts: {
+  catalog: CapabilityCatalogRow[];
+  ledger: AwarenessLedgerRow[];
+  schedule?: RefreshScheduleRow[];
+  scheduleError?: { message: string } | null;
+  rpcCalls?: RpcCall[];
+}): import('@supabase/supabase-js').SupabaseClient {
+  return {
+    from: (table: string) => ({
+      select: () => ({
+        eq: () => {
+          if (table === 'system_capabilities') {
+            return Promise.resolve({ data: opts.catalog, error: null });
+          }
+          // user_capability_awareness + teacher_capability_refresh_schedule
+          // both use .eq().eq().
+          return {
+            eq: () => {
+              if (table === 'teacher_capability_refresh_schedule') {
+                return Promise.resolve({
+                  data: opts.schedule ?? [],
+                  error: opts.scheduleError ?? null,
+                });
+              }
+              return Promise.resolve({ data: opts.ledger, error: null });
+            },
+          };
+        },
+      }),
+    }),
+    rpc: async (fn: string, args: Record<string, unknown>) => {
+      opts.rpcCalls?.push({ fn, args });
+      return { data: null, error: null };
+    },
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+describe('R4 — provider produce() graduated track', () => {
+  beforeEach(() => {
+    mockResolveTeacherMode.mockReset();
+    mockResolveTeacherMode.mockResolvedValue(makeTeacherMode());
+  });
+
+  // Dragan1 case: linear curriculum exhausted (the one capability is `tried`),
+  // refresh is due (no schedule row) → deepening refresh FIRES.
+  test('exhausted curriculum + refresh due → deepening refresh fires (bundled content)', async () => {
+    mockResolveTeacherMode.mockResolvedValue(
+      makeTeacherMode({ active_capability_key: 'life_compass' }),
+    );
+    const rpcCalls: RpcCall[] = [];
+    const provider = makeFeatureDiscoveryTeacherProvider({ newId: () => 'rid', rng: () => 0 });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSbGraduated({
+            catalog: [cat({ capability_key: 'life_compass', display_name: 'Life Compass' })],
+            ledger: [lr({ capability_key: 'life_compass', awareness_state: 'tried' })],
+            schedule: [],
+            rpcCalls,
+          }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'en',
+          firstName: 'Dragan',
+          greetingPolicy: 'warm_return',
+          nowIso: NOW_ISO,
+        },
+      }),
+    );
+    expect(r.status).toBe('returned');
+    if (r.status !== 'returned') return;
+    expect(r.candidate.id).toBe('teacher-refresh-rid');
+    expect(r.candidate.kind).toBe('feature_discovery');
+    expect(r.candidate.dedupeKey).toBe('teacher:refresh:life_compass');
+    // next-level framing names the capability.
+    expect(r.candidate.userFacingLine).toContain('Life Compass');
+    // bundled teacherMode (R3 atomicity preserved for the refresh path).
+    const tm = (r.candidate as { teacherMode?: TeacherModeContent }).teacherMode;
+    expect(tm?.active_capability_key).toBe('life_compass');
+    // schedule advanced by 90 days via the RPC.
+    const refreshRpc = rpcCalls.find((c) => c.args.p_capability_key === 'life_compass');
+    expect(refreshRpc?.fn).toBe('record_teacher_refresh');
+    expect(refreshRpc?.args.p_is_refresh).toBe(true);
+    expect(refreshRpc?.args.p_next_ok_at).toBe(nextRefreshOkIso(NOW_ISO));
+  });
+
+  // Nothing refresh-eligible (the tried capability was refreshed recently) →
+  // graceful-pause line, ONCE, and stamps the same-day silence sentinel.
+  test('nothing refresh-eligible → graceful-pause line fires once + stamps sentinel', async () => {
+    const rpcCalls: RpcCall[] = [];
+    const provider = makeFeatureDiscoveryTeacherProvider({ newId: () => 'pid', rng: () => 0 });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSbGraduated({
+            catalog: [cat({ capability_key: 'life_compass' })],
+            ledger: [lr({ capability_key: 'life_compass', awareness_state: 'tried' })],
+            // refresh NOT due → no refresh candidate.
+            schedule: [
+              sched({
+                capability_key: 'life_compass',
+                next_refresh_ok_at: new Date(NOW_MS + 30 * DAY_MS).toISOString(),
+              }),
+            ],
+            rpcCalls,
+          }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'en',
+          greetingPolicy: 'warm_return',
+          nowIso: NOW_ISO,
+          tzOffsetMinutes: 0,
+        },
+      }),
+    );
+    expect(r.status).toBe('returned');
+    if (r.status !== 'returned') return;
+    expect(r.candidate.id).toBe('teacher-pause-pid');
+    expect(r.candidate.kind).toBe('check_in');
+    expect(r.candidate.dedupeKey).toBe('teacher:graceful_pause');
+    expect(r.candidate.userFacingLine).toBe(renderGracefulPauseLine('en'));
+    // resolver NOT called on the pause path (no capability to teach).
+    expect(mockResolveTeacherMode).not.toHaveBeenCalled();
+    // sentinel stamped for next local day, NOT a refresh.
+    const pauseRpc = rpcCalls.find((c) => c.args.p_capability_key === GRACEFUL_PAUSE_KEY);
+    expect(pauseRpc?.fn).toBe('record_teacher_refresh');
+    expect(pauseRpc?.args.p_is_refresh).toBe(false);
+    expect(pauseRpc?.args.p_next_ok_at).toBe(startOfNextLocalDayIso(NOW_ISO, 0));
+  });
+
+  // Same-day reopen after the pause already fired → silent (no second pause).
+  test('graceful-pause already spoken today → suppressed (silent)', async () => {
+    const provider = makeFeatureDiscoveryTeacherProvider({ rng: () => 0 });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSbGraduated({
+            catalog: [cat({ capability_key: 'life_compass' })],
+            ledger: [lr({ capability_key: 'life_compass', awareness_state: 'completed' })],
+            schedule: [
+              // pause sentinel already set for later today.
+              sched({
+                capability_key: GRACEFUL_PAUSE_KEY,
+                next_refresh_ok_at: new Date(NOW_MS + 8 * 60 * 60 * 1000).toISOString(),
+              }),
+            ],
+          }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'en',
+          greetingPolicy: 'warm_return',
+          nowIso: NOW_ISO,
+        },
+      }),
+    );
+    expect(r.status).toBe('suppressed');
+    if (r.status === 'suppressed') {
+      expect(r.reason).toBe('graceful_pause_already_spoken_today');
+    }
+  });
+
+  // Refresh content resolution failure must NOT fire an empty Teacher — R3
+  // atomicity contract carries into the graduated track.
+  test('refresh content resolution null → errored (Teacher does not fire empty)', async () => {
+    mockResolveTeacherMode.mockResolvedValue(null);
+    const provider = makeFeatureDiscoveryTeacherProvider({ rng: () => 0 });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSbGraduated({
+            catalog: [cat({ capability_key: 'life_compass' })],
+            ledger: [lr({ capability_key: 'life_compass', awareness_state: 'tried' })],
+            schedule: [],
+          }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'en',
+          greetingPolicy: 'warm_return',
+          nowIso: NOW_ISO,
+        },
+      }),
+    );
+    expect(r.status).toBe('errored');
+    if (r.status === 'errored') {
+      expect(r.reason).toMatch(/teacher_refresh_content_resolution_failed/);
+    }
+  });
+
+  // NON-exhausted case: an unknown capability is still eligible → the NORMAL
+  // Teacher path runs, NOT the graduated track. No regression.
+  test('non-exhausted curriculum → normal Teacher path (no graduated track)', async () => {
+    const rpcCalls: RpcCall[] = [];
+    const provider = makeFeatureDiscoveryTeacherProvider({ newId: () => 'nid', rng: () => 0 });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSbGraduated({
+            catalog: [
+              cat({ capability_key: 'life_compass' }),
+              // 'vitana_index' is unknown (never introduced) → normal pick.
+              cat({ capability_key: 'vitana_index', display_name: 'Vitana Index' }),
+            ],
+            ledger: [lr({ capability_key: 'life_compass', awareness_state: 'tried' })],
+            schedule: [],
+            rpcCalls,
+          }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'en',
+          firstName: 'Dragan',
+          greetingPolicy: 'fresh_intro',
+          nowIso: NOW_ISO,
+        },
+      }),
+    );
+    expect(r.status).toBe('returned');
+    if (r.status !== 'returned') return;
+    // Normal path id prefix (not -refresh- / -pause-), normal dedupe key.
+    expect(r.candidate.id).toBe('teacher-nid');
+    expect(r.candidate.dedupeKey).toBe('teacher:vitana_index');
+    // No refresh/pause RPC was issued on the normal path.
+    expect(rpcCalls.length).toBe(0);
   });
 });

--- a/supabase/migrations/20260607010000_BOOTSTRAP_ORB_R4_teacher_capability_refresh_schedule.sql
+++ b/supabase/migrations/20260607010000_BOOTSTRAP_ORB_R4_teacher_capability_refresh_schedule.sql
@@ -1,0 +1,146 @@
+-- BOOTSTRAP-ORB-R4-GRADUATED-TEACHER — graduated-user Teacher track schedule.
+--
+-- Phase R4 of the ORB R0–R9 reconciliation
+-- (docs/superpowers/plans/2026-05-30-vitana-assistant-original-plan-reconciliation.md).
+--
+-- PROBLEM (Dragan1 case): once a user has worked through the linear
+-- curriculum — every enabled capability is introduced / tried / completed /
+-- mastered within its cooldown window — `pickCapability` returns null and the
+-- Teacher SUPPRESSES, falling through to the bare voice-wake-brief. The
+-- graduated user gets nothing new from the Teacher ever again.
+--
+-- R4 makes the Teacher RE-ENGAGE instead of suppressing:
+--   1. DEEPENING REFRESH — re-introduce a `tried` capability with next-level
+--      framing IF its refresh schedule is due. Gated by this table:
+--      per (user_id × capability_key) "next refresh ok at", 90-day default.
+--   2. GRACEFUL PAUSE — if nothing is refresh-eligible, speak ONE gentle line
+--      ("You've explored most of what Vitana offers…") then stay silent on
+--      subsequent same-day opens. The same-day silence is enforced by stamping
+--      a `__graceful_pause__` sentinel row in this table (next_refresh_ok_at =
+--      start of next local day) — no separate table needed.
+--
+-- This is a migration FILE only. It is NOT executed from the sandbox. Apply via
+-- the normal Supabase migration flow.
+
+-- ---------------------------------------------------------------
+-- teacher_capability_refresh_schedule — per (user, capability) refresh gate
+-- ---------------------------------------------------------------
+-- A row's presence means "this capability has been refreshed (or pause-stamped)
+-- for this user; do not refresh again until next_refresh_ok_at". Absence means
+-- "never refreshed → eligible the moment the capability becomes `tried`".
+--
+-- The graceful-pause sentinel uses the reserved capability_key
+-- '__graceful_pause__' (no real capability has a key starting with '__'), so it
+-- shares the same table + (user_id, capability_key) primary key without a
+-- second relation.
+
+CREATE TABLE IF NOT EXISTS teacher_capability_refresh_schedule (
+  tenant_id            UUID NOT NULL,
+  user_id              UUID NOT NULL,
+  -- Real capability_key (soft-linked to system_capabilities) OR the reserved
+  -- '__graceful_pause__' sentinel. We do NOT add a hard FK so the sentinel row
+  -- and capabilities removed from the catalog don't cascade-delete the gate.
+  capability_key       TEXT NOT NULL,
+  -- The Teacher may re-introduce this capability with deepening framing on or
+  -- after this instant. 90-day default cadence from the last refresh.
+  next_refresh_ok_at   TIMESTAMPTZ NOT NULL,
+  -- How many times this capability has been deepening-refreshed for this user.
+  -- Drives escalating framing ("revisit" -> "go deeper") and lets operators see
+  -- who has fully graduated.
+  refresh_count        INT NOT NULL DEFAULT 0,
+  -- Last time a refresh actually fired (NULL for a pure pause-sentinel row).
+  last_refreshed_at    TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (tenant_id, user_id, capability_key)
+);
+
+-- The provider reads "all schedule rows for this user" on every graduated-track
+-- evaluation, exactly like it reads the awareness ledger.
+CREATE INDEX IF NOT EXISTS teacher_capability_refresh_schedule_user_idx
+  ON teacher_capability_refresh_schedule (tenant_id, user_id);
+
+-- Operators: who is due for a refresh right now.
+CREATE INDEX IF NOT EXISTS teacher_capability_refresh_schedule_due_idx
+  ON teacher_capability_refresh_schedule (next_refresh_ok_at);
+
+CREATE OR REPLACE FUNCTION teacher_capability_refresh_schedule_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS teacher_capability_refresh_schedule_updated_at_trigger
+  ON teacher_capability_refresh_schedule;
+CREATE TRIGGER teacher_capability_refresh_schedule_updated_at_trigger
+  BEFORE UPDATE ON teacher_capability_refresh_schedule
+  FOR EACH ROW
+  EXECUTE FUNCTION teacher_capability_refresh_schedule_touch_updated_at();
+
+-- RLS: owning user reads their own rows; service role (gateway) bypasses RLS
+-- for the writes. Matches orb_session_state / user_capability_awareness.
+ALTER TABLE teacher_capability_refresh_schedule ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'teacher_capability_refresh_schedule'
+      AND policyname = 'teacher_capability_refresh_schedule_owner_read'
+  ) THEN
+    CREATE POLICY teacher_capability_refresh_schedule_owner_read
+      ON teacher_capability_refresh_schedule
+      FOR SELECT
+      TO authenticated
+      USING (user_id = auth.uid());
+  END IF;
+END$$;
+
+-- ---------------------------------------------------------------
+-- record_teacher_refresh() — idempotent upsert the provider calls after a
+-- refresh OR a graceful-pause stamp fires. Single round-trip, advances the
+-- 90-day (default) cadence, increments refresh_count for real refreshes.
+-- ---------------------------------------------------------------
+-- p_capability_key:  real capability_key OR '__graceful_pause__'
+-- p_next_ok_at:      when the next refresh / pause-reset is allowed. For a
+--                    deepening refresh the caller passes now + 90d; for a
+--                    graceful-pause sentinel it passes the start of the user's
+--                    next local day (so the pause line repeats at most once/day).
+-- p_is_refresh:      true for a real deepening refresh (bumps refresh_count +
+--                    last_refreshed_at); false for a pure pause-sentinel stamp.
+
+CREATE OR REPLACE FUNCTION record_teacher_refresh(
+  p_tenant_id      UUID,
+  p_user_id        UUID,
+  p_capability_key TEXT,
+  p_next_ok_at     TIMESTAMPTZ,
+  p_is_refresh     BOOLEAN DEFAULT true
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO teacher_capability_refresh_schedule AS s (
+    tenant_id, user_id, capability_key,
+    next_refresh_ok_at, refresh_count, last_refreshed_at
+  ) VALUES (
+    p_tenant_id, p_user_id, p_capability_key,
+    p_next_ok_at,
+    CASE WHEN p_is_refresh THEN 1 ELSE 0 END,
+    CASE WHEN p_is_refresh THEN now() ELSE NULL END
+  )
+  ON CONFLICT (tenant_id, user_id, capability_key) DO UPDATE
+  SET next_refresh_ok_at = EXCLUDED.next_refresh_ok_at,
+      refresh_count = s.refresh_count + (CASE WHEN p_is_refresh THEN 1 ELSE 0 END),
+      last_refreshed_at = CASE WHEN p_is_refresh THEN now() ELSE s.last_refreshed_at END,
+      updated_at = now();
+END;
+$$;
+
+COMMENT ON TABLE teacher_capability_refresh_schedule IS
+  'BOOTSTRAP-ORB-R4: per (user, capability) deepening-refresh gate for the graduated-user Teacher track. capability_key=__graceful_pause__ is the reserved same-day pause sentinel. 90-day default cadence.';
+COMMENT ON FUNCTION record_teacher_refresh IS
+  'BOOTSTRAP-ORB-R4: idempotent upsert advancing the refresh/pause cadence. p_is_refresh=false stamps a pause sentinel without bumping refresh_count.';

--- a/supabase/migrations/20260607010000_BOOTSTRAP_ORB_R4_teacher_capability_refresh_schedule.sql
+++ b/supabase/migrations/20260607010000_BOOTSTRAP_ORB_R4_teacher_capability_refresh_schedule.sql
@@ -140,6 +140,18 @@ BEGIN
 END;
 $$;
 
+-- Lock down the SECURITY DEFINER write RPC. By default Postgres grants EXECUTE
+-- to PUBLIC, which would let any authenticated/anon client call
+-- /rpc/record_teacher_refresh with an arbitrary p_tenant_id/p_user_id and upsert
+-- ANOTHER user's schedule rows (push deepening refreshes / pause sentinel into the
+-- future), bypassing the table's owner-read-only RLS. Service-role only — the
+-- gateway must use the admin Supabase client. Matches
+-- scheduler_vitana_index_compute_daily / health_compute_vitana_index_for_user.
+REVOKE ALL ON FUNCTION record_teacher_refresh(UUID, UUID, TEXT, TIMESTAMPTZ, BOOLEAN) FROM PUBLIC;
+REVOKE ALL ON FUNCTION record_teacher_refresh(UUID, UUID, TEXT, TIMESTAMPTZ, BOOLEAN) FROM authenticated;
+REVOKE ALL ON FUNCTION record_teacher_refresh(UUID, UUID, TEXT, TIMESTAMPTZ, BOOLEAN) FROM anon;
+GRANT EXECUTE ON FUNCTION record_teacher_refresh(UUID, UUID, TEXT, TIMESTAMPTZ, BOOLEAN) TO service_role;
+
 COMMENT ON TABLE teacher_capability_refresh_schedule IS
   'BOOTSTRAP-ORB-R4: per (user, capability) deepening-refresh gate for the graduated-user Teacher track. capability_key=__graceful_pause__ is the reserved same-day pause sentinel. 90-day default cadence.';
 COMMENT ON FUNCTION record_teacher_refresh IS


### PR DESCRIPTION
## Phase R4 — Graduated-User Teacher Track

When a user (e.g. **dragan1**) exhausts the linear curriculum — every enabled capability is `introduced`/`tried`/`completed`/`mastered` within its cooldown, so `pickCapability` returns null — the Teacher used to suppress and fall through to the bare `voice-wake-brief`. R4 makes it **re-engage** instead.

### Strategy (operator-decided default)

When the standard eligible list is empty, the Teacher attempts, in order:

1. **Deepening refresh** — re-introduce a `tried` capability with next-level framing IF its refresh schedule is due. Gated by the new `teacher_capability_refresh_schedule` table (per `user_id × capability_key`, "next refresh ok at", **90-day default** cadence). Only `tried` capabilities qualify (`completed`/`mastered` stay terminal). Resolved **atomically** like the R3 design: Teacher Mode content is resolved inside `produce()`, and `null`/throw → `status:'errored'` so the ranker falls through — the refresh **never fires empty**. On fire it records the refresh via `record_teacher_refresh()` RPC (advances the cadence by 90 days, increments `refresh_count` for escalating framing).

2. **Graceful pause** — if nothing is refresh-eligible, speak the operator-fixed line **once per local day**:
   > "You've explored most of what Vitana offers. I'll surface new things as they ship. Want me to summarize what you've learned this month?"

   then stay silent on subsequent same-day opens. Same-day silence is enforced by stamping a reserved `__graceful_pause__` sentinel row with `next_refresh_ok_at = start of next local day` (honors a `tzOffsetMinutes`).

The non-exhausted (normal) Teacher path is untouched — the graduated track only runs when `pickCapability` returns null.

### Migration file

`supabase/migrations/20260607010000_BOOTSTRAP_ORB_R4_teacher_capability_refresh_schedule.sql` — **migration FILE only, NOT executed.**
- `teacher_capability_refresh_schedule` table: `(tenant_id, user_id, capability_key)` PK, `next_refresh_ok_at`, `refresh_count`, `last_refreshed_at`, `updated_at` trigger, owner-read RLS (service role writes).
- `record_teacher_refresh(p_tenant_id, p_user_id, p_capability_key, p_next_ok_at, p_is_refresh)` — idempotent upsert advancing the 90-day cadence; `p_is_refresh=false` stamps the graceful-pause sentinel without bumping `refresh_count`.

### Vertex parity ✓ / LiveKit parity ✓

Shared provider → both transports get the same graduated-track candidate through the same `decide-continuation` path. No transport-specific code touched (`live-system-instruction.ts`, `live-session-controller.ts`, `orb-live.ts`, `orb-livekit.ts`, `awareness-unified-context.ts` all untouched).

### Test summary

`feature-discovery-teacher.test.ts` — **46 tests green**, including:
- exhausted curriculum + refresh due → **deepening refresh fires** with bundled `teacherMode` content + 90-day schedule write (the dragan1 case)
- nothing refresh-eligible → **graceful-pause line fires once** + stamps the same-day sentinel (resolver NOT called)
- pause already spoken today → **suppressed (silent)** on the same-day reopen
- refresh content resolution `null`/throw → **errored** (never fires empty — R3 contract carried into R4)
- non-exhausted curriculum → **normal Teacher path unchanged** (no refresh/pause RPC issued) — no regression
- pure-helper coverage for `pickRefreshCapability`, `gracefulPauseAllowed`, `startOfNextLocalDayIso` (incl. +120 CEST offset), `nextRefreshOkIso` (90-day), `renderRefreshInvitation` (naming + escalation), `renderGracefulPauseLine`

Broader: **490 tests green** across `test/services/assistant-continuation` + `test/orb/teacher`. Teacher recovery + wake acceptance suites green.

`cd services/gateway && npm run build` clean (only the pre-existing global-tsconfig `moduleResolution=node10` TS5107 deprecation present on origin/main).

### Out of sandbox (not done)
Migration not run; no merge/deploy/prod-write.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_