### PR TITLE
feat(orb): R6 first-time-welcome + R7 goal-completion-inquiry providers (BOOTSTRAP-ORB-R6R7-PROVIDERS)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/first-time-welcome/content.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/first-time-welcome/content.ts
@@ -1,0 +1,71 @@
+/**
+ * R6 (BOOTSTRAP-ORB-R6R7-PROVIDERS) — First-time-welcome spoken content.
+ *
+ * The one-time self-introduction Vitana speaks on the user's very first
+ * orb session. A ~4–5 sentence script that:
+ *   1. Names herself + her role ("your longevity companion").
+ *   2. Frames the relationship ("together, one step at a time").
+ *   3. Names the 90-day default starter plan.
+ *   4. Invites the user's first goal.
+ *
+ * DE is the default community locale, so the German script is a REAL,
+ * native translation — not a machine gloss. EN is the second authored
+ * locale. Lang fallback chain: requested lang → 'en'.
+ *
+ * Content is kept here (not in `orb/live/instruction/*`) so the provider
+ * owns its own copy, matching the new-day-return / Teacher pattern where
+ * user-facing text lives beside the provider, not in the prompt assembler.
+ */
+
+export interface FirstTimeWelcomeRenderArgs {
+  lang: string;
+  firstName: string | null;
+}
+
+/**
+ * Per-locale scripts. Each entry has a `{name}` placeholder used only in
+ * the withName variant. Both variants are full 4–5 sentence scripts that
+ * stand alone as a spoken Say-exactly opener.
+ */
+const WELCOME_SCRIPTS: Record<
+  string,
+  { withName: string; withoutName: string }
+> = {
+  de: {
+    withName:
+      'Hallo {name}, und herzlich willkommen. Ich bin Vitana, deine Langlebigkeits-Begleiterin. ' +
+      'Gemeinsam setzen wir dein erstes Ziel und wachsen Schritt für Schritt in die Plattform hinein — ' +
+      'ganz in deinem Tempo, ohne Eile. Den Anfang macht dein 90-Tage-Starterplan, der dir den Einstieg ganz natürlich erleichtert. ' +
+      'Erzähl mir zum Start: Was möchtest du als Erstes für dich erreichen?',
+    withoutName:
+      'Herzlich willkommen. Ich bin Vitana, deine Langlebigkeits-Begleiterin. ' +
+      'Gemeinsam setzen wir dein erstes Ziel und wachsen Schritt für Schritt in die Plattform hinein — ' +
+      'ganz in deinem Tempo, ohne Eile. Den Anfang macht dein 90-Tage-Starterplan, der dir den Einstieg ganz natürlich erleichtert. ' +
+      'Erzähl mir zum Start: Was möchtest du als Erstes für dich erreichen?',
+  },
+  en: {
+    withName:
+      'Hello {name}, and a warm welcome. I am Vitana, your longevity companion. ' +
+      'Together we will set your first goal and grow into the platform one step at a time — ' +
+      'at your own pace, with no rush. We will begin with your 90-day starter plan, which eases you in naturally. ' +
+      'To get us started, tell me: what is the first thing you would like to achieve for yourself?',
+    withoutName:
+      'A warm welcome. I am Vitana, your longevity companion. ' +
+      'Together we will set your first goal and grow into the platform one step at a time — ' +
+      'at your own pace, with no rush. We will begin with your 90-day starter plan, which eases you in naturally. ' +
+      'To get us started, tell me: what is the first thing you would like to achieve for yourself?',
+  },
+};
+
+/** Locales that ship a real authored welcome. Exported for tests. */
+export const FIRST_TIME_WELCOME_LOCALES = Object.keys(WELCOME_SCRIPTS);
+
+/**
+ * Render the first-time-welcome spoken line. Pure. Exported for tests.
+ * Falls back to EN for unknown locales; substitutes firstName when known.
+ */
+export function renderFirstTimeWelcomeLine(args: FirstTimeWelcomeRenderArgs): string {
+  const script = WELCOME_SCRIPTS[args.lang] ?? WELCOME_SCRIPTS.en;
+  const template = args.firstName ? script.withName : script.withoutName;
+  return args.firstName ? template.replace('{name}', args.firstName) : template;
+}

--- a/services/gateway/src/services/assistant-continuation/providers/first-time-welcome/index.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/first-time-welcome/index.ts
@@ -1,0 +1,233 @@
+/**
+ * R6 (BOOTSTRAP-ORB-R6R7-PROVIDERS) — First-time-welcome continuation provider.
+ *
+ * Fires EXACTLY ONCE per user — on the very first orb session ever, when
+ * `user_journey.is_first_session === true`. Wins priority 95, above every
+ * other turn-1 producer (goal-completion-inquiry 92, new-day-return 90,
+ * Teacher 85, voice-wake-brief 80). This is the one-time onboarding moment:
+ * Vitana introduces herself, names the 90-day default starter plan, and
+ * invites the user to set their first goal.
+ *
+ * Trigger contract (plan §2.2 — "First-ever session"):
+ *   user_journey.is_first_session === true
+ *
+ * NOT triggered:
+ *   - Returning users (is_first_session=false → new-day-return / Teacher /
+ *     wake-brief own those states).
+ *   - Anonymous sessions (no user_id → no identity → wake-brief at 80).
+ *   - Sessions with no supabase client (can't read/flip the flag).
+ *
+ * Side-effect on selection (plan R6): after firing, flips
+ * `is_first_session = false` so the welcome NEVER fires twice. We stamp it
+ * fire-and-forget from inside produce() — same pattern new-day-return uses
+ * for last_session_date. Even if another provider somehow out-ranks this
+ * one in the ranker (none does at 95), stamping is correct: the user HAS
+ * now opened the orb for the first time. The flag is also independently
+ * cleared at session-end by user-journey-service.updateSessionEndState
+ * (clear_first_session) — this is defense-in-depth, not the sole writer.
+ *
+ * Architecture note: returns a server-composed `userFacingLine` for the
+ * wake-brief Say-exactly pattern, identical to voice-wake-brief /
+ * new-day-return. No new prompt block, no system-instruction concat. The
+ * ranker picks this at 95 and the controller speaks the line. Transport-
+ * agnostic: the ranker is shared by Vertex (live-session-controller) and
+ * LiveKit (orb-livekit), so both transports get the welcome for free.
+ */
+
+import { randomUUID } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  ContinuationDecisionContext,
+  ContinuationProvider,
+  ProviderResult,
+  AssistantContinuation,
+} from '../../types';
+import { renderFirstTimeWelcomeLine } from './content';
+
+export const FIRST_TIME_WELCOME_PROVIDER_KEY = 'first_time_welcome' as const;
+export const FIRST_TIME_WELCOME_EXTRA_KEY = 'firstTimeWelcome' as const;
+
+/** Highest turn-1 priority. Above goal-completion-inquiry (92),
+ *  new-day-return (90), Teacher (85), voice-wake-brief (80). The
+ *  first-ever session is the one moment that out-ranks everything. */
+export const FIRST_TIME_WELCOME_PRIORITY = 95;
+
+export interface FirstTimeWelcomeInputs {
+  supabase: SupabaseClient;
+  userId: string;
+  tenantId: string;
+  lang: string;
+  firstName: string | null;
+}
+
+export interface FirstTimeWelcomeProviderOptions {
+  newId?: () => string;
+  now?: () => number;
+  priority?: number;
+}
+
+interface UserJourneyRow {
+  is_first_session: boolean;
+}
+
+function readInputs(ctx: ContinuationDecisionContext): FirstTimeWelcomeInputs | null {
+  const extra = ctx.extra;
+  if (!extra || typeof extra !== 'object') return null;
+  const raw = (extra as Record<string, unknown>)[FIRST_TIME_WELCOME_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.userId !== 'string' || o.userId.length === 0) return null;
+  if (typeof o.tenantId !== 'string' || o.tenantId.length === 0) return null;
+  if (!o.supabase) return null;
+  return {
+    supabase: o.supabase as SupabaseClient,
+    userId: o.userId,
+    tenantId: o.tenantId,
+    lang: typeof o.lang === 'string' && o.lang.length > 0 ? o.lang : 'en',
+    firstName:
+      typeof o.firstName === 'string' && o.firstName.length > 0 ? o.firstName : null,
+  };
+}
+
+/**
+ * Fire-and-forget DB write: flip user_journey.is_first_session to false
+ * so the welcome never fires a second time. Never throws. Logs on failure.
+ */
+async function clearFirstSession(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<void> {
+  try {
+    const { error } = await supabase
+      .from('user_journey')
+      .update({ is_first_session: false })
+      .eq('user_id', userId);
+    if (error) {
+      console.warn(
+        `[R6 first-time-welcome] clearFirstSession failed for ${userId.slice(0, 8)}: ${error.message}`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[R6 first-time-welcome] clearFirstSession threw for ${userId.slice(0, 8)}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+export function makeFirstTimeWelcomeProvider(
+  opts: FirstTimeWelcomeProviderOptions = {},
+): ContinuationProvider {
+  const newId = opts.newId ?? randomUUID;
+  const now = opts.now ?? (() => Date.now());
+  const priority = opts.priority ?? FIRST_TIME_WELCOME_PRIORITY;
+
+  return {
+    key: FIRST_TIME_WELCOME_PROVIDER_KEY,
+    surfaces: ['orb_wake'],
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const t0 = now();
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return {
+          providerKey: FIRST_TIME_WELCOME_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'no_first_time_welcome_inputs',
+        };
+      }
+
+      // ---- DB fetch: user_journey row ----
+      let row: UserJourneyRow | null = null;
+      try {
+        const { data, error } = await inputs.supabase
+          .from('user_journey')
+          .select('is_first_session')
+          .eq('user_id', inputs.userId)
+          .maybeSingle();
+        if (error) {
+          return {
+            providerKey: FIRST_TIME_WELCOME_PROVIDER_KEY,
+            status: 'errored',
+            latencyMs: Math.max(0, now() - t0),
+            reason: `user_journey_fetch_failed: ${error.message}`,
+          };
+        }
+        row = (data ?? null) as UserJourneyRow | null;
+      } catch (err) {
+        return {
+          providerKey: FIRST_TIME_WELCOME_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      // Only fire on the first-ever session. Every other state belongs to
+      // new-day-return / goal-completion-inquiry / Teacher / wake-brief.
+      // No row at all → treat as NOT first-session (a returning user whose
+      // journey row was never written shouldn't get a welcome here).
+      if (!row || row.is_first_session !== true) {
+        return {
+          providerKey: FIRST_TIME_WELCOME_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: row ? 'is_first_session_false' : 'no_user_journey_row',
+        };
+      }
+
+      const line = renderFirstTimeWelcomeLine({
+        lang: inputs.lang,
+        firstName: inputs.firstName,
+      });
+      if (!line || line.trim().length === 0) {
+        return {
+          providerKey: FIRST_TIME_WELCOME_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'renderer_produced_empty_line',
+        };
+      }
+
+      // Fire-and-forget flip so the welcome never repeats. Safe to do
+      // before the candidate is selected — at priority 95 it always wins,
+      // and even if it didn't, the user HAS opened the orb for the first
+      // time, so clearing the flag is correct.
+      void clearFirstSession(inputs.supabase, inputs.userId);
+
+      const candidate: AssistantContinuation = {
+        id: `first-time-welcome-${newId()}`,
+        surface: 'orb_wake',
+        kind: 'wake_brief',
+        priority,
+        userFacingLine: line,
+        // Invites the user to set their first goal — confirming routes
+        // into the Life Compass setup flow. Same flow goal-completion-
+        // inquiry uses on confirmation. The model interprets a "yes" /
+        // a stated goal and proceeds conversationally; the navigate CTA
+        // is the deterministic fallback target.
+        cta: {
+          type: 'navigate',
+          route: '/life-compass',
+          payload: { intent: 'first_goal' },
+        },
+        evidence: [
+          { kind: 'first_time_welcome', detail: 'is_first_session_true' },
+          { kind: 'default_plan', detail: '90_day_starter' },
+        ],
+        // Dedupe: one welcome per user, ever. The is_first_session flip is
+        // the real one-time guard; this key keeps the same logical
+        // continuation stable across re-renders of the same session.
+        dedupeKey: `first-time-welcome:${inputs.userId}`,
+        privacyMode: 'safe_to_speak',
+      };
+
+      return {
+        providerKey: FIRST_TIME_WELCOME_PROVIDER_KEY,
+        status: 'returned',
+        latencyMs: Math.max(0, now() - t0),
+        candidate,
+      };
+    },
+  };
+}

--- a/services/gateway/src/services/assistant-continuation/providers/goal-completion-inquiry/content.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/goal-completion-inquiry/content.ts
@@ -1,0 +1,75 @@
+/**
+ * R7 (BOOTSTRAP-ORB-R6R7-PROVIDERS) — Goal-completion-inquiry spoken content.
+ *
+ * The celebration + invitation Vitana speaks when the user's active Life
+ * Compass goal has reached its target date. A short script that:
+ *   1. Celebrates hitting the target.
+ *   2. Invites the next goal OR a pause — the user's choice.
+ *
+ * DE is the default community locale → real native translation. EN second.
+ * Lang fallback chain: requested lang → 'en'.
+ *
+ * Content lives beside the provider (not in `orb/live/instruction/*`),
+ * matching the new-day-return / Teacher / first-time-welcome pattern.
+ */
+
+export interface GoalCompletionRenderArgs {
+  lang: string;
+  firstName: string | null;
+  /** The completed goal's text, woven in when available. */
+  goalText: string | null;
+}
+
+interface GoalCompletionScript {
+  /** Celebration + invitation, with a `{goal}` clause when goal text is known. */
+  withGoal: string;
+  /** Celebration + invitation without naming the specific goal. */
+  withoutGoal: string;
+}
+
+const GOAL_COMPLETION_SCRIPTS: Record<string, GoalCompletionScript> = {
+  de: {
+    withGoal:
+      'Du hast dein Ziel erreicht — "{goal}". Das ist großartig, herzlichen Glückwunsch! ' +
+      'Möchtest du gleich das nächste Ziel gemeinsam setzen, oder erst einmal kurz durchatmen und den Moment genießen?',
+    withoutGoal:
+      'Du hast dein Ziel erreicht — das ist großartig, herzlichen Glückwunsch! ' +
+      'Möchtest du gleich das nächste Ziel gemeinsam setzen, oder erst einmal kurz durchatmen und den Moment genießen?',
+  },
+  en: {
+    withGoal:
+      'You hit your target — "{goal}". That is huge, congratulations! ' +
+      'Want to set the next one together, or take a moment first and enjoy it?',
+    withoutGoal:
+      'You hit your target — that is huge, congratulations! ' +
+      'Want to set the next one together, or take a moment first and enjoy it?',
+  },
+};
+
+/** Optional leading name clause, locale-aware. */
+function namePrefix(lang: string, firstName: string | null): string {
+  if (!firstName) return '';
+  // Both locales front a short name address; the script itself stays
+  // grammatical without it, so this is purely a warmth add.
+  return lang === 'de' ? `${firstName}, ` : `${firstName}, `;
+}
+
+/** Locales that ship a real authored script. Exported for tests. */
+export const GOAL_COMPLETION_LOCALES = Object.keys(GOAL_COMPLETION_SCRIPTS);
+
+/**
+ * Render the goal-completion-inquiry spoken line. Pure. Exported for tests.
+ * Falls back to EN for unknown locales; weaves goalText + firstName when known.
+ */
+export function renderGoalCompletionLine(args: GoalCompletionRenderArgs): string {
+  const script = GOAL_COMPLETION_SCRIPTS[args.lang] ?? GOAL_COMPLETION_SCRIPTS.en;
+  const goal = args.goalText?.trim();
+  const base = goal
+    ? script.withGoal.replace('{goal}', goal)
+    : script.withoutGoal;
+  const prefix = namePrefix(args.lang, args.firstName);
+  if (!prefix) return base;
+  // Lower-case the first letter of the base so the name prefix reads as a
+  // natural address ("Dragan, you hit your target…").
+  return prefix + base.charAt(0).toLowerCase() + base.slice(1);
+}

--- a/services/gateway/src/services/assistant-continuation/providers/goal-completion-inquiry/index.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/goal-completion-inquiry/index.ts
@@ -1,0 +1,260 @@
+/**
+ * R7 (BOOTSTRAP-ORB-R6R7-PROVIDERS) — Goal-completion-inquiry provider.
+ *
+ * Fires when the user's ACTIVE Life Compass goal has reached its target
+ * date (`life_compass.target_date` in the past). Wins priority 92 — above
+ * new-day-return (90), Teacher (85) and voice-wake-brief (80), below the
+ * first-time-welcome (95). When it fires, Vitana celebrates the user
+ * hitting their target and invites the next goal (or a pause).
+ *
+ * Trigger contract (plan §2.2 — "plan_phase=goal_completed", R7):
+ *   active life_compass row exists AND target_date is in the past
+ *   (compared at END-OF-DAY UTC so a same-day deadline isn't prematurely
+ *   declared "missed" earlier that day).
+ *
+ * One-time per goal: after firing, the candidate carries a dedupeKey keyed
+ * on the life_compass row id, and the side-effect path (R7) moves the old
+ * goal to is_active=false / activates a new one through the existing Life
+ * Compass setup flow ON CONFIRMATION. This provider does NOT mutate the
+ * goal itself — selection stays a pure read + the deactivation happens on
+ * the confirmed handoff (controller wiring, see TODO below) so an
+ * unanswered inquiry doesn't silently retire the user's goal.
+ *
+ * NOT triggered:
+ *   - No active goal / no target_date / target_date still in the future.
+ *   - Anonymous sessions (no user_id).
+ *   - Sessions with no supabase client.
+ *
+ * Autopilot goal-met signal: the plan also allows an Autopilot rule to
+ * signal goal-met independent of the date. That branch is deferred — this
+ * slice implements the deterministic past-target-date path only; the
+ * Autopilot signal will OR in once its rule surface lands.
+ *
+ * Past-date check: implemented inline as an end-of-day-UTC comparison.
+ * TODO(R6/R7 wiring): replace `isTargetDateInPastEndOfDayUtc` with the
+ * canonical `resolveJourneyPlanPhase` / `isTargetDateInPast` from
+ * `awareness-unified-context.ts` once that lands on main — keep the
+ * semantics identical (end-of-day UTC) so behavior does not drift.
+ *
+ * Transport-agnostic: the ranker is shared by Vertex
+ * (live-session-controller) and LiveKit (orb-livekit), so both transports
+ * get the inquiry once registered. No transport-specific code here.
+ */
+
+import { randomUUID } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  ContinuationDecisionContext,
+  ContinuationProvider,
+  ProviderResult,
+  AssistantContinuation,
+} from '../../types';
+import { renderGoalCompletionLine } from './content';
+
+export const GOAL_COMPLETION_PROVIDER_KEY = 'goal_completion_inquiry' as const;
+export const GOAL_COMPLETION_EXTRA_KEY = 'goalCompletionInquiry' as const;
+
+/** Above new-day-return (90), below first-time-welcome (95). A goal that
+ *  just completed is a bigger turn-1 moment than the routine daily
+ *  catch-up, but never out-ranks a brand-new user's onboarding. */
+export const GOAL_COMPLETION_PRIORITY = 92;
+
+export interface GoalCompletionInputs {
+  supabase: SupabaseClient;
+  userId: string;
+  tenantId: string;
+  lang: string;
+  firstName: string | null;
+}
+
+export interface GoalCompletionProviderOptions {
+  newId?: () => string;
+  now?: () => number;
+  priority?: number;
+}
+
+interface LifeCompassRow {
+  id: string;
+  primary_goal: string | null;
+  target_date: string | null;
+  is_active: boolean;
+}
+
+/**
+ * End-of-day-UTC past check. A target_date is "in the past" only once the
+ * ENTIRE calendar day (UTC) of that date has elapsed — so a goal due today
+ * is not prematurely declared complete at 00:01.
+ *
+ * Accepts a YYYY-MM-DD date string OR a full ISO timestamp; both are
+ * normalized to the end of their UTC calendar day (23:59:59.999Z).
+ * Returns false for null / unparseable input (fail-closed: no inquiry).
+ *
+ * TODO(R6/R7 wiring): swap for the canonical `isTargetDateInPast` from
+ * awareness-unified-context.ts once it lands — identical end-of-day-UTC
+ * semantics.
+ */
+export function isTargetDateInPastEndOfDayUtc(
+  targetDate: string | null,
+  now: Date,
+): boolean {
+  if (!targetDate) return false;
+  // Take the date portion (YYYY-MM-DD) regardless of whether a time was
+  // supplied, then anchor to the very end of that UTC day.
+  const datePart = targetDate.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(datePart)) return false;
+  const endOfDayUtcMs = Date.parse(`${datePart}T23:59:59.999Z`);
+  if (!Number.isFinite(endOfDayUtcMs)) return false;
+  return now.getTime() > endOfDayUtcMs;
+}
+
+function readInputs(ctx: ContinuationDecisionContext): GoalCompletionInputs | null {
+  const extra = ctx.extra;
+  if (!extra || typeof extra !== 'object') return null;
+  const raw = (extra as Record<string, unknown>)[GOAL_COMPLETION_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.userId !== 'string' || o.userId.length === 0) return null;
+  if (typeof o.tenantId !== 'string' || o.tenantId.length === 0) return null;
+  if (!o.supabase) return null;
+  return {
+    supabase: o.supabase as SupabaseClient,
+    userId: o.userId,
+    tenantId: o.tenantId,
+    lang: typeof o.lang === 'string' && o.lang.length > 0 ? o.lang : 'en',
+    firstName:
+      typeof o.firstName === 'string' && o.firstName.length > 0 ? o.firstName : null,
+  };
+}
+
+export function makeGoalCompletionInquiryProvider(
+  opts: GoalCompletionProviderOptions = {},
+): ContinuationProvider {
+  const newId = opts.newId ?? randomUUID;
+  const now = opts.now ?? (() => Date.now());
+  const priority = opts.priority ?? GOAL_COMPLETION_PRIORITY;
+
+  return {
+    key: GOAL_COMPLETION_PROVIDER_KEY,
+    surfaces: ['orb_wake'],
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const t0 = now();
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return {
+          providerKey: GOAL_COMPLETION_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'no_goal_completion_inputs',
+        };
+      }
+
+      // ---- DB fetch: active life_compass row ----
+      let row: LifeCompassRow | null = null;
+      try {
+        const { data, error } = await inputs.supabase
+          .from('life_compass')
+          .select('id, primary_goal, target_date, is_active')
+          .eq('user_id', inputs.userId)
+          .eq('is_active', true)
+          .maybeSingle();
+        if (error) {
+          return {
+            providerKey: GOAL_COMPLETION_PROVIDER_KEY,
+            status: 'errored',
+            latencyMs: Math.max(0, now() - t0),
+            reason: `life_compass_fetch_failed: ${error.message}`,
+          };
+        }
+        row = (data ?? null) as LifeCompassRow | null;
+      } catch (err) {
+        return {
+          providerKey: GOAL_COMPLETION_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      // No active goal → nothing to celebrate. Let other providers win.
+      if (!row) {
+        return {
+          providerKey: GOAL_COMPLETION_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'no_active_life_compass',
+        };
+      }
+
+      // No target_date → can't determine completion by date. Suppress.
+      if (!row.target_date) {
+        return {
+          providerKey: GOAL_COMPLETION_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'no_target_date',
+        };
+      }
+
+      // Target date still in the future (or today, not yet elapsed). The
+      // goal isn't complete yet — let new-day-return anchor on it instead.
+      const nowDate = new Date(now());
+      if (!isTargetDateInPastEndOfDayUtc(row.target_date, nowDate)) {
+        return {
+          providerKey: GOAL_COMPLETION_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: `target_date_not_past_${row.target_date}`,
+        };
+      }
+
+      const line = renderGoalCompletionLine({
+        lang: inputs.lang,
+        firstName: inputs.firstName,
+        goalText: row.primary_goal,
+      });
+      if (!line || line.trim().length === 0) {
+        return {
+          providerKey: GOAL_COMPLETION_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'renderer_produced_empty_line',
+        };
+      }
+
+      const candidate: AssistantContinuation = {
+        id: `goal-completion-inquiry-${newId()}`,
+        surface: 'orb_wake',
+        kind: 'check_in',
+        priority,
+        userFacingLine: line,
+        // On confirmation ("yes, let's set the next one") the assistant
+        // routes through the existing Life Compass setup flow, where the
+        // old goal moves to is_active=false and the new goal becomes
+        // active. We do NOT deactivate here — an unanswered inquiry must
+        // not silently retire the user's goal.
+        // TODO(R6/R7 wiring): the controller should, on confirmed handoff,
+        // call the Life Compass setup flow + deactivate row.id.
+        cta: {
+          type: 'navigate',
+          route: '/life-compass',
+          payload: { intent: 'next_goal', completed_life_compass_id: row.id },
+        },
+        evidence: [
+          { kind: 'goal_completed', detail: `life_compass_id=${row.id}` },
+          { kind: 'target_date_past', detail: row.target_date },
+        ],
+        // One inquiry per completed goal. Keyed on the row id so a NEW
+        // active goal (different id) can fire its own inquiry later.
+        dedupeKey: `goal-completion-inquiry:${row.id}`,
+        privacyMode: 'safe_to_speak',
+      };
+
+      return {
+        providerKey: GOAL_COMPLETION_PROVIDER_KEY,
+        status: 'returned',
+        latencyMs: Math.max(0, now() - t0),
+        candidate,
+      };
+    },
+  };
+}

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -63,6 +63,24 @@ import {
   NEW_DAY_RETURN_EXTRA_KEY,
   NEW_DAY_RETURN_PROVIDER_KEY,
 } from './assistant-continuation/providers/new-day-return';
+// R6 (BOOTSTRAP-ORB-R6R7-PROVIDERS): first-time-welcome provider — fires
+// once on the user's first-ever session (is_first_session=true). Priority
+// 95, above every other turn-1 producer. Suppresses cleanly otherwise so
+// it never blocks the daily/Teacher/wake-brief path.
+import {
+  makeFirstTimeWelcomeProvider,
+  FIRST_TIME_WELCOME_EXTRA_KEY,
+  FIRST_TIME_WELCOME_PROVIDER_KEY,
+} from './assistant-continuation/providers/first-time-welcome';
+// R7 (BOOTSTRAP-ORB-R6R7-PROVIDERS): goal-completion-inquiry provider —
+// fires when the active life_compass goal's target_date is in the past
+// (end-of-day UTC). Priority 92, above new-day-return (90). Suppresses
+// cleanly when no active goal / no target_date / target not yet past.
+import {
+  makeGoalCompletionInquiryProvider,
+  GOAL_COMPLETION_EXTRA_KEY,
+  GOAL_COMPLETION_PROVIDER_KEY,
+} from './assistant-continuation/providers/goal-completion-inquiry';
 // VTID-03061 (B0d-real Xf.1): auto-emit OASIS next_action.suggested/
 // .suppressed events when a wake-brief decision lands. Fire-and-forget;
 // never blocks the voice path.
@@ -115,6 +133,20 @@ export function ensureWakeBriefProviderRegistered(): void {
   // never blocks the other providers when the trigger does not apply.
   if (!defaultProviderRegistry.get(NEW_DAY_RETURN_PROVIDER_KEY)) {
     defaultProviderRegistry.register(makeNewDayReturnProvider());
+  }
+  // R6 (BOOTSTRAP-ORB-R6R7-PROVIDERS): first-time-welcome at priority 95.
+  // Suppresses unless user_journey.is_first_session=true, so it only wins
+  // the ranker on the user's first-ever session and never blocks the
+  // returning-user providers otherwise.
+  if (!defaultProviderRegistry.get(FIRST_TIME_WELCOME_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeFirstTimeWelcomeProvider());
+  }
+  // R7 (BOOTSTRAP-ORB-R6R7-PROVIDERS): goal-completion-inquiry at priority
+  // 92. Suppresses unless the active life_compass goal's target_date is in
+  // the past (end-of-day UTC), so it only wins when a goal has actually
+  // completed and otherwise yields to new-day-return / Teacher / wake-brief.
+  if (!defaultProviderRegistry.get(GOAL_COMPLETION_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeGoalCompletionInquiryProvider());
   }
   _registered = true;
 }
@@ -338,6 +370,26 @@ export async function decideWakeBriefForSession(
         lang: args.lang,
         firstName: args.firstName ?? null,
         timezone: args.timezone ?? null,
+      };
+      // R6 (BOOTSTRAP-ORB-R6R7-PROVIDERS): first-time-welcome inputs.
+      // Provider suppresses unless is_first_session=true, so passing the
+      // extra always is safe.
+      extra[FIRST_TIME_WELCOME_EXTRA_KEY] = {
+        supabase: args.supabase,
+        tenantId: args.tenantId,
+        userId: args.userId,
+        lang: args.lang,
+        firstName: args.firstName ?? null,
+      };
+      // R7 (BOOTSTRAP-ORB-R6R7-PROVIDERS): goal-completion-inquiry inputs.
+      // Provider suppresses unless the active goal's target_date is past,
+      // so passing the extra always is safe.
+      extra[GOAL_COMPLETION_EXTRA_KEY] = {
+        supabase: args.supabase,
+        tenantId: args.tenantId,
+        userId: args.userId,
+        lang: args.lang,
+        firstName: args.firstName ?? null,
       };
     }
   }

--- a/services/gateway/test/services/assistant-continuation/providers/first-time-welcome/first-time-welcome.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/first-time-welcome/first-time-welcome.test.ts
@@ -1,0 +1,184 @@
+/**
+ * R6 (BOOTSTRAP-ORB-R6R7-PROVIDERS) — first-time-welcome provider tests.
+ *
+ * Locks the contract:
+ *   - Fires (status=returned, priority 95) when is_first_session=true.
+ *   - Suppresses when is_first_session=false / no row.
+ *   - Skips on missing inputs.
+ *   - Errors on DB error.
+ *   - Flips is_first_session=false fire-and-forget on fire.
+ *   - EN + DE content both present and authored (real DE, not a copy of EN).
+ */
+
+import {
+  makeFirstTimeWelcomeProvider,
+  FIRST_TIME_WELCOME_PROVIDER_KEY,
+  FIRST_TIME_WELCOME_EXTRA_KEY,
+  FIRST_TIME_WELCOME_PRIORITY,
+} from '../../../../../src/services/assistant-continuation/providers/first-time-welcome';
+import {
+  renderFirstTimeWelcomeLine,
+  FIRST_TIME_WELCOME_LOCALES,
+} from '../../../../../src/services/assistant-continuation/providers/first-time-welcome/content';
+
+function makeFakeSupabase(
+  row: { is_first_session: boolean } | null,
+  errorMsg?: string,
+) {
+  const captured: any = { updatePatch: null, queriedTable: null };
+  const sb = {
+    from(table: string) {
+      const builder: any = {
+        select() {
+          return builder;
+        },
+        eq() {
+          return builder;
+        },
+        async maybeSingle() {
+          captured.queriedTable = table;
+          if (errorMsg) return { data: null, error: { message: errorMsg } };
+          return { data: row, error: null };
+        },
+        update(patch: any) {
+          captured.updatePatch = patch;
+          return { eq: () => Promise.resolve({ error: null }) };
+        },
+      };
+      return builder;
+    },
+  } as any;
+  return { sb, captured };
+}
+
+function makeCtx(extraOverride: any = {}, sbOverride?: any) {
+  return {
+    surface: 'orb_wake',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    extra: {
+      [FIRST_TIME_WELCOME_EXTRA_KEY]: {
+        supabase:
+          sbOverride ?? makeFakeSupabase({ is_first_session: true }).sb,
+        userId: 'u1',
+        tenantId: 't1',
+        lang: 'en',
+        firstName: 'Dragan',
+        ...extraOverride,
+      },
+    },
+  } as any;
+}
+
+describe('R6 first-time-welcome content', () => {
+  it('exposes both EN and DE locales', () => {
+    expect(FIRST_TIME_WELCOME_LOCALES).toContain('en');
+    expect(FIRST_TIME_WELCOME_LOCALES).toContain('de');
+  });
+
+  it('renders an EN script naming the 90-day plan and inviting a goal', () => {
+    const line = renderFirstTimeWelcomeLine({ lang: 'en', firstName: null });
+    expect(line).toMatch(/Vitana/);
+    expect(line).toMatch(/longevity companion/i);
+    expect(line).toMatch(/90-day/);
+    expect(line).toMatch(/\?$/); // ends on the first-goal invitation
+  });
+
+  it('renders a REAL German script (not a copy of EN)', () => {
+    const de = renderFirstTimeWelcomeLine({ lang: 'de', firstName: null });
+    const en = renderFirstTimeWelcomeLine({ lang: 'en', firstName: null });
+    expect(de).not.toEqual(en);
+    expect(de).toMatch(/Vitana/);
+    expect(de).toMatch(/Langlebigkeits-Begleiterin/);
+    expect(de).toMatch(/90-Tage-Starterplan/);
+    expect(de).toMatch(/\?$/);
+  });
+
+  it('substitutes firstName when present', () => {
+    const line = renderFirstTimeWelcomeLine({ lang: 'en', firstName: 'Dragan' });
+    expect(line).toMatch(/Dragan/);
+    expect(line).not.toMatch(/\{name\}/);
+  });
+
+  it('falls back to EN for an unknown locale', () => {
+    const unknown = renderFirstTimeWelcomeLine({ lang: 'zz', firstName: null });
+    const en = renderFirstTimeWelcomeLine({ lang: 'en', firstName: null });
+    expect(unknown).toEqual(en);
+  });
+});
+
+describe('R6 first-time-welcome provider', () => {
+  const baseOpts = {
+    newId: () => 'fixed-id',
+    now: () => 1_000,
+  };
+
+  it('has the right key and orb_wake surface', () => {
+    const p = makeFirstTimeWelcomeProvider(baseOpts);
+    expect(p.key).toBe(FIRST_TIME_WELCOME_PROVIDER_KEY);
+    expect(p.surfaces).toEqual(['orb_wake']);
+  });
+
+  it('fires with priority 95 when is_first_session=true', async () => {
+    const { sb } = makeFakeSupabase({ is_first_session: true });
+    const p = makeFirstTimeWelcomeProvider(baseOpts);
+    const res = await p.produce(makeCtx({}, sb));
+    expect(res.status).toBe('returned');
+    expect(res.candidate?.priority).toBe(FIRST_TIME_WELCOME_PRIORITY);
+    expect(res.candidate?.priority).toBe(95);
+    expect(res.candidate?.kind).toBe('wake_brief');
+    expect(res.candidate?.surface).toBe('orb_wake');
+    expect(res.candidate?.userFacingLine).toMatch(/Dragan/);
+    expect(res.candidate?.dedupeKey).toBe('first-time-welcome:u1');
+  });
+
+  it('flips is_first_session=false fire-and-forget when it fires', async () => {
+    const { sb, captured } = makeFakeSupabase({ is_first_session: true });
+    const p = makeFirstTimeWelcomeProvider(baseOpts);
+    await p.produce(makeCtx({}, sb));
+    // microtask drain so the fire-and-forget update lands
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(captured.updatePatch).toEqual({ is_first_session: false });
+  });
+
+  it('suppresses when is_first_session=false', async () => {
+    const { sb } = makeFakeSupabase({ is_first_session: false });
+    const p = makeFirstTimeWelcomeProvider(baseOpts);
+    const res = await p.produce(makeCtx({}, sb));
+    expect(res.status).toBe('suppressed');
+    expect(res.reason).toBe('is_first_session_false');
+  });
+
+  it('suppresses when there is no user_journey row', async () => {
+    const { sb } = makeFakeSupabase(null);
+    const p = makeFirstTimeWelcomeProvider(baseOpts);
+    const res = await p.produce(makeCtx({}, sb));
+    expect(res.status).toBe('suppressed');
+    expect(res.reason).toBe('no_user_journey_row');
+  });
+
+  it('skips when inputs are missing', async () => {
+    const p = makeFirstTimeWelcomeProvider(baseOpts);
+    const res = await p.produce({ surface: 'orb_wake', extra: {} } as any);
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('no_first_time_welcome_inputs');
+  });
+
+  it('errors on a DB error', async () => {
+    const { sb } = makeFakeSupabase(null, 'boom');
+    const p = makeFirstTimeWelcomeProvider(baseOpts);
+    const res = await p.produce(makeCtx({}, sb));
+    expect(res.status).toBe('errored');
+    expect(res.reason).toMatch(/boom/);
+  });
+
+  it('renders the DE line when lang=de and fires', async () => {
+    const { sb } = makeFakeSupabase({ is_first_session: true });
+    const p = makeFirstTimeWelcomeProvider(baseOpts);
+    const res = await p.produce(makeCtx({ lang: 'de', firstName: null }, sb));
+    expect(res.status).toBe('returned');
+    expect(res.candidate?.userFacingLine).toMatch(/Langlebigkeits-Begleiterin/);
+  });
+});

--- a/services/gateway/test/services/assistant-continuation/providers/goal-completion-inquiry/goal-completion-inquiry.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/goal-completion-inquiry/goal-completion-inquiry.test.ts
@@ -1,0 +1,251 @@
+/**
+ * R7 (BOOTSTRAP-ORB-R6R7-PROVIDERS) — goal-completion-inquiry provider tests.
+ *
+ * Locks the contract:
+ *   - Fires (status=returned, priority 92) when the active goal's
+ *     target_date is in the past (end-of-day UTC).
+ *   - Suppresses when no active goal / no target_date / target not yet past.
+ *   - Skips on missing inputs. Errors on DB error.
+ *   - End-of-day-UTC boundary: a goal due today is NOT yet complete.
+ *   - dedupeKey keyed on the life_compass row id (one inquiry per goal).
+ *   - EN + DE content both present and authored (real DE, not a copy of EN).
+ */
+
+import {
+  makeGoalCompletionInquiryProvider,
+  GOAL_COMPLETION_PROVIDER_KEY,
+  GOAL_COMPLETION_EXTRA_KEY,
+  GOAL_COMPLETION_PRIORITY,
+  isTargetDateInPastEndOfDayUtc,
+} from '../../../../../src/services/assistant-continuation/providers/goal-completion-inquiry';
+import {
+  renderGoalCompletionLine,
+  GOAL_COMPLETION_LOCALES,
+} from '../../../../../src/services/assistant-continuation/providers/goal-completion-inquiry/content';
+
+interface CompassRow {
+  id: string;
+  primary_goal: string | null;
+  target_date: string | null;
+  is_active: boolean;
+}
+
+function makeFakeSupabase(row: CompassRow | null, errorMsg?: string) {
+  const captured: any = { queriedTable: null };
+  const sb = {
+    from(table: string) {
+      const builder: any = {
+        select() {
+          return builder;
+        },
+        eq() {
+          return builder;
+        },
+        async maybeSingle() {
+          captured.queriedTable = table;
+          if (errorMsg) return { data: null, error: { message: errorMsg } };
+          return { data: row, error: null };
+        },
+      };
+      return builder;
+    },
+  } as any;
+  return { sb, captured };
+}
+
+// 2026-06-15T10:30Z — used as the fixed "now" for past-date checks.
+const NOW_MS = Date.parse('2026-06-15T10:30:00.000Z');
+
+function makeCtx(extraOverride: any = {}, sbOverride?: any) {
+  return {
+    surface: 'orb_wake',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    extra: {
+      [GOAL_COMPLETION_EXTRA_KEY]: {
+        supabase:
+          sbOverride ??
+          makeFakeSupabase({
+            id: 'lc-1',
+            primary_goal: 'Run a 10k',
+            target_date: '2026-06-01',
+            is_active: true,
+          }).sb,
+        userId: 'u1',
+        tenantId: 't1',
+        lang: 'en',
+        firstName: 'Dragan',
+        ...extraOverride,
+      },
+    },
+  } as any;
+}
+
+describe('R7 isTargetDateInPastEndOfDayUtc', () => {
+  const now = new Date(NOW_MS); // 2026-06-15
+
+  it('returns true for a date strictly before today', () => {
+    expect(isTargetDateInPastEndOfDayUtc('2026-06-01', now)).toBe(true);
+  });
+
+  it('returns false for today (not yet end-of-day past)', () => {
+    expect(isTargetDateInPastEndOfDayUtc('2026-06-15', now)).toBe(false);
+  });
+
+  it('returns false for a future date', () => {
+    expect(isTargetDateInPastEndOfDayUtc('2026-07-01', now)).toBe(false);
+  });
+
+  it('accepts full ISO timestamps (uses date portion)', () => {
+    expect(isTargetDateInPastEndOfDayUtc('2026-06-01T00:00:00.000Z', now)).toBe(true);
+  });
+
+  it('returns false for null / malformed input (fail-closed)', () => {
+    expect(isTargetDateInPastEndOfDayUtc(null, now)).toBe(false);
+    expect(isTargetDateInPastEndOfDayUtc('not-a-date', now)).toBe(false);
+  });
+
+  it('only flips the day AFTER the target — end-of-day boundary', () => {
+    // target = yesterday relative to now; end-of-day yesterday < now → true
+    const justAfterMidnight = new Date(Date.parse('2026-06-16T00:00:01.000Z'));
+    expect(isTargetDateInPastEndOfDayUtc('2026-06-15', justAfterMidnight)).toBe(true);
+    // but at 23:59:59 on the target day itself → still not past
+    const lateSameDay = new Date(Date.parse('2026-06-15T23:59:59.000Z'));
+    expect(isTargetDateInPastEndOfDayUtc('2026-06-15', lateSameDay)).toBe(false);
+  });
+});
+
+describe('R7 goal-completion content', () => {
+  it('exposes both EN and DE locales', () => {
+    expect(GOAL_COMPLETION_LOCALES).toContain('en');
+    expect(GOAL_COMPLETION_LOCALES).toContain('de');
+  });
+
+  it('renders an EN celebration + invitation', () => {
+    const line = renderGoalCompletionLine({ lang: 'en', firstName: null, goalText: null });
+    expect(line).toMatch(/hit your target/i);
+    expect(line).toMatch(/next one together|take a moment/i);
+  });
+
+  it('renders a REAL German script (not a copy of EN)', () => {
+    const de = renderGoalCompletionLine({ lang: 'de', firstName: null, goalText: null });
+    const en = renderGoalCompletionLine({ lang: 'en', firstName: null, goalText: null });
+    expect(de).not.toEqual(en);
+    expect(de).toMatch(/Ziel erreicht/);
+    expect(de).toMatch(/durchatmen|nächste Ziel/);
+  });
+
+  it('weaves the goal text in when present', () => {
+    const line = renderGoalCompletionLine({
+      lang: 'en',
+      firstName: null,
+      goalText: 'Run a 10k',
+    });
+    expect(line).toMatch(/Run a 10k/);
+  });
+
+  it('weaves the firstName in when present', () => {
+    const line = renderGoalCompletionLine({ lang: 'en', firstName: 'Dragan', goalText: null });
+    expect(line).toMatch(/^Dragan,/);
+  });
+
+  it('falls back to EN for an unknown locale', () => {
+    const unknown = renderGoalCompletionLine({ lang: 'zz', firstName: null, goalText: null });
+    const en = renderGoalCompletionLine({ lang: 'en', firstName: null, goalText: null });
+    expect(unknown).toEqual(en);
+  });
+});
+
+describe('R7 goal-completion-inquiry provider', () => {
+  const baseOpts = {
+    newId: () => 'fixed-id',
+    now: () => NOW_MS,
+  };
+
+  it('has the right key and orb_wake surface', () => {
+    const p = makeGoalCompletionInquiryProvider(baseOpts);
+    expect(p.key).toBe(GOAL_COMPLETION_PROVIDER_KEY);
+    expect(p.surfaces).toEqual(['orb_wake']);
+  });
+
+  it('fires with priority 92 when the active goal target_date is past', async () => {
+    const { sb } = makeFakeSupabase({
+      id: 'lc-1',
+      primary_goal: 'Run a 10k',
+      target_date: '2026-06-01',
+      is_active: true,
+    });
+    const p = makeGoalCompletionInquiryProvider(baseOpts);
+    const res = await p.produce(makeCtx({}, sb));
+    expect(res.status).toBe('returned');
+    expect(res.candidate?.priority).toBe(GOAL_COMPLETION_PRIORITY);
+    expect(res.candidate?.priority).toBe(92);
+    expect(res.candidate?.kind).toBe('check_in');
+    expect(res.candidate?.surface).toBe('orb_wake');
+    expect(res.candidate?.userFacingLine).toMatch(/Run a 10k/);
+    expect(res.candidate?.dedupeKey).toBe('goal-completion-inquiry:lc-1');
+  });
+
+  it('suppresses when target_date is not yet past', async () => {
+    const { sb } = makeFakeSupabase({
+      id: 'lc-1',
+      primary_goal: 'Run a 10k',
+      target_date: '2026-07-01',
+      is_active: true,
+    });
+    const p = makeGoalCompletionInquiryProvider(baseOpts);
+    const res = await p.produce(makeCtx({}, sb));
+    expect(res.status).toBe('suppressed');
+    expect(res.reason).toMatch(/target_date_not_past/);
+  });
+
+  it('suppresses when there is no active goal', async () => {
+    const { sb } = makeFakeSupabase(null);
+    const p = makeGoalCompletionInquiryProvider(baseOpts);
+    const res = await p.produce(makeCtx({}, sb));
+    expect(res.status).toBe('suppressed');
+    expect(res.reason).toBe('no_active_life_compass');
+  });
+
+  it('suppresses when the active goal has no target_date', async () => {
+    const { sb } = makeFakeSupabase({
+      id: 'lc-1',
+      primary_goal: 'Run a 10k',
+      target_date: null,
+      is_active: true,
+    });
+    const p = makeGoalCompletionInquiryProvider(baseOpts);
+    const res = await p.produce(makeCtx({}, sb));
+    expect(res.status).toBe('suppressed');
+    expect(res.reason).toBe('no_target_date');
+  });
+
+  it('skips when inputs are missing', async () => {
+    const p = makeGoalCompletionInquiryProvider(baseOpts);
+    const res = await p.produce({ surface: 'orb_wake', extra: {} } as any);
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('no_goal_completion_inputs');
+  });
+
+  it('errors on a DB error', async () => {
+    const { sb } = makeFakeSupabase(null, 'boom');
+    const p = makeGoalCompletionInquiryProvider(baseOpts);
+    const res = await p.produce(makeCtx({}, sb));
+    expect(res.status).toBe('errored');
+    expect(res.reason).toMatch(/boom/);
+  });
+
+  it('renders the DE line when lang=de and fires', async () => {
+    const { sb } = makeFakeSupabase({
+      id: 'lc-1',
+      primary_goal: null,
+      target_date: '2026-06-01',
+      is_active: true,
+    });
+    const p = makeGoalCompletionInquiryProvider(baseOpts);
+    const res = await p.produce(makeCtx({ lang: 'de', firstName: null }, sb));
+    expect(res.status).toBe('returned');
+    expect(res.candidate?.userFacingLine).toMatch(/Ziel erreicht/);
+  });
+});


### PR DESCRIPTION
## ORB R6 + R7 — two new assistant-continuation providers

Implements the two NEW continuation providers from the reconciliation plan (`docs/superpowers/plans/2026-05-30-vitana-assistant-original-plan-reconciliation.md`, phases R6 + R7, §2.2 state table). Both are transport-agnostic `orb_wake` providers that plug into the existing `decide-continuation` ranker (ranks by descending priority), matching the established `new-day-return` provider shape.

### R6 — `first-time-welcome` (priority 95)
- Fires once, when `user_journey.is_first_session === true`. Highest turn-1 priority — wins over goal-completion (92), new-day-return (90), Teacher (85), wake-brief (80).
- After firing, flips `is_first_session = false` (fire-and-forget) so the welcome never repeats. (Defense-in-depth alongside `user-journey-service.updateSessionEndState`'s `clear_first_session`.)
- Suppresses cleanly when `is_first_session=false` / no journey row; skips on missing inputs; errors surfaced as `status:'errored'`.
- CTA: `navigate` to `/life-compass` (`intent: first_goal`).

**EN script:** "A warm welcome. I am Vitana, your longevity companion. Together we will set your first goal and grow into the platform one step at a time — at your own pace, with no rush. We will begin with your 90-day starter plan, which eases you in naturally. To get us started, tell me: what is the first thing you would like to achieve for yourself?"

**DE script (real translation, default community locale):** "Herzlich willkommen. Ich bin Vitana, deine Langlebigkeits-Begleiterin. Gemeinsam setzen wir dein erstes Ziel und wachsen Schritt für Schritt in die Plattform hinein — ganz in deinem Tempo, ohne Eile. Den Anfang macht dein 90-Tage-Starterplan, der dir den Einstieg ganz natürlich erleichtert. Erzähl mir zum Start: Was möchtest du als Erstes für dich erreichen?"

(Both have name-prefixed variants substituting `{name}`.)

### R7 — `goal-completion-inquiry` (priority 92)
- Fires when the active `life_compass.target_date` is in the **past (end-of-day UTC)**. One-time per goal (dedupeKey keyed on the `life_compass` row id).
- Inline `isTargetDateInPastEndOfDayUtc` end-of-day comparison — a goal due *today* is not prematurely "complete". `TODO(R6/R7 wiring)` comment notes it should consume the canonical `resolveJourneyPlanPhase`/`isTargetDateInPast` from `awareness-unified-context.ts` once that lands on main.
- Does NOT mutate the goal in `produce()` — on confirmed handoff the controller routes through the existing Life Compass setup flow (old goal → `is_active=false`, new goal active). CTA: `navigate` to `/life-compass` (`intent: next_goal`, `completed_life_compass_id`). Left as a `TODO(R6/R7 wiring)` to keep the provider self-contained.
- Suppresses when no active goal / no `target_date` / target not yet past; skips/errors handled.

**EN script:** "You hit your target — that is huge, congratulations! Want to set the next one together, or take a moment first and enjoy it?"

**DE script (real translation):** "Du hast dein Ziel erreicht — das ist großartig, herzlichen Glückwunsch! Möchtest du gleich das nächste Ziel gemeinsam setzen, oder erst einmal kurz durchatmen und den Moment genießen?"

(Both weave in the completed goal text + an optional name prefix when known.)

### Registry change (only shared-file touch)
`services/gateway/src/services/wake-brief-wiring.ts` — additive only:
- Imports both providers.
- Registers them in `ensureWakeBriefProviderRegistered()` (idempotent, alongside the existing providers).
- Threads `firstTimeWelcome` + `goalCompletionInquiry` extras in the authed-only block of `decideWakeBriefForSession` (provider suppresses unless its trigger holds, so always-passing the extra is safe).

No edits to `live-system-instruction.ts`, `live-session-controller.ts`, `orb-live.ts`, `orb-livekit.ts`, or `awareness-unified-context.ts`.

### Parity
- **Vertex parity ✓ / LiveKit parity ✓** — these are transport-agnostic providers. The `decide-continuation` ranker is shared by both transports (Vertex `live-session-controller` and LiveKit `orb-livekit`), so registering once in the shared registry means both transports get R6 + R7 with no transport-specific code.

### Files added
- `services/gateway/src/services/assistant-continuation/providers/first-time-welcome/{index,content}.ts`
- `services/gateway/src/services/assistant-continuation/providers/goal-completion-inquiry/{index,content}.ts`
- `services/gateway/test/services/assistant-continuation/providers/first-time-welcome/first-time-welcome.test.ts`
- `services/gateway/test/services/assistant-continuation/providers/goal-completion-inquiry/goal-completion-inquiry.test.ts`

### Tests
- 33 new unit tests pass (provider fires under the right state, suppresses/skips/errors otherwise, priority 95/92 asserted, EN+DE present and DE verified `!= EN`, end-of-day-UTC boundary cases, fire-and-forget flip).
- Full `assistant-continuation` + `wake-brief-wiring` suites green (509 tests, 28 suites).
- `npm run build` green.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_