### PR TITLE
refactor(orb): R2 delete legacy greeting-policy dead code, move fallback pools to voice-wake-brief (BOOTSTRAP-ORB-R2-GREETING-POLICY)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -23,22 +23,22 @@
 import type { ClientContext } from '../types';
 import { getPersonalityConfigSync } from '../../../services/ai-personality-service';
 import { getAwarenessConfigSync } from '../../../services/awareness-registry';
-import { isFeatureLive } from '../../../services/feature-flags';
 import {
   getContent as getNavContent,
   lookupByRoute as lookupNavByRoute,
 } from '../../../lib/navigation-catalog';
-import { pickShortGapGreetings } from '../../instruction/greeting-pools';
-// VTID-03118 (Phase B.4): bucket thresholds + greeting-bucket prompt
-// fragments come from PolicyResolver instead of inline literals/switch-case
-// lines. Resolver returns byte-identical content for the seeded defaults
-// (Phase B.2 / VTID-03114); the consumer below substitutes
-// {{greeting_time_of_day}} and {{short_gap_phrase_menu}} tokens to
-// reproduce the pre-B.4 output exactly.
+// VTID-03118 (Phase B.4): bucket thresholds come from PolicyResolver instead
+// of inline literals. Resolver returns byte-identical values for the seeded
+// defaults (Phase B.2 / VTID-03114).
+//
+// R2 (BOOTSTRAP-ORB-R2-GREETING-POLICY): the greeting-bucket prompt fragments
+// (RENDER_BLOCK_KEYS) and the short-gap phrase pool (pickShortGapGreetings)
+// are no longer consumed here — the legacy `## GREETING POLICY` fallback stack
+// moved to the voice-wake-brief provider. Only the time-since threshold
+// lookups (POLICY_KEYS) remain.
 import {
   getPolicyResolver,
   POLICY_KEYS,
-  RENDER_BLOCK_KEYS,
 } from '../../../services/decision-contract';
 // A3: buildNavigatorPolicySection stays in orb-live.ts (still consumed by
 // the route handler too); the instruction builder calls it back across the
@@ -60,111 +60,15 @@ import {
 
 type TemporalBucket = 'reconnect' | 'recent' | 'same_day' | 'today' | 'yesterday' | 'week' | 'long' | 'first';
 
-// VTID-03118 (Phase B.4): map TemporalBucket → policy_render_block key so
-// the consumer below can fetch the seeded template by enum.
-const BUCKET_TO_BLOCK_KEY: Record<TemporalBucket, string> = {
-  reconnect: RENDER_BLOCK_KEYS.GREETING_BUCKET_RECONNECT,
-  recent: RENDER_BLOCK_KEYS.GREETING_BUCKET_RECENT,
-  same_day: RENDER_BLOCK_KEYS.GREETING_BUCKET_SAME_DAY,
-  today: RENDER_BLOCK_KEYS.GREETING_BUCKET_TODAY,
-  yesterday: RENDER_BLOCK_KEYS.GREETING_BUCKET_YESTERDAY,
-  week: RENDER_BLOCK_KEYS.GREETING_BUCKET_WEEK,
-  long: RENDER_BLOCK_KEYS.GREETING_BUCKET_LONG,
-  first: RENDER_BLOCK_KEYS.GREETING_BUCKET_FIRST,
-};
-
-// VTID-03118 (Phase B.4): safety-net fallbacks. Byte-identical to the
-// Phase B.2 seed content. The resolver returns the DB row in production;
-// these defaults activate only when the seed migration hasn't been run
-// (e.g. early boot in a fresh environment). Placeholder tokens match the
-// seed migration (see supabase/migrations/20260527020000_...).
-const BUCKET_DEFAULT_TEMPLATES: Record<TemporalBucket, string> = {
-  reconnect:
-`- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).
-  • DO NOT speak. DO NOT greet. DO NOT acknowledge any "interruption", "reconnection", "resume", "where were we", "I'm back", "I'm listening", "picking up", or anything similar. Saying any of these creates a perceived apology that the user reads as a bug.
-  • Wait for the user to speak. Your next message must be a direct response to the user's next utterance — nothing else.
-  • If the user says nothing, you say nothing. Silence is correct here.`,
-  recent:
-`- BUCKET = recent (2–15 min since last session).
-  • Do NOT use a formal greeting. NO "Hello <name>!", NO "Hi there!", NO self-introduction. NO user name.
-  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
-{{short_gap_phrase_menu}}
-  • Max ONE short phrase. Warm but direct.`,
-  same_day:
-`- BUCKET = same_day (15 min – 8 h since last session).
-  • Light re-engagement. NOT a formal greeting. No user name. NEVER "Hello <name>!" as if you've never met.
-  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
-{{short_gap_phrase_menu}}
-  • Max ONE short phrase. Warm and direct.`,
-  today:
-`- BUCKET = today (8–24 h since last session — this is a NEW-DAY greeting).
-  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
-  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
-  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
-  • Example follow-up if no candidate exists (pick ONE or skip):
-      "What's on your mind today?"
-      "Where would you like to focus today?"
-  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
-  yesterday:
-`- BUCKET = yesterday (this is a NEW-DAY greeting).
-  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
-  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
-  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
-  • Example follow-up if no candidate exists (pick ONE or skip):
-      "What would you like to explore today?"
-      "Picking up where we left off?"
-  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
-  week:
-`- BUCKET = week (2–7 days since last session — this is a NEW-DAY greeting).
-  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
-  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
-  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
-  • Example follow-up if no candidate exists (pick ONE or skip):
-      "Good to hear from you again — what's been on your mind?"
-      "What would you like to explore today?"
-  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
-  long:
-`- BUCKET = long (> 7 days since last session — this is a NEW-DAY greeting).
-  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
-  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
-  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available — for >7-day absences the candidate should explicitly acknowledge the gap).
-  • Example follow-up if no candidate exists (pick ONE or skip):
-      "It's been a few days — happy you're back. What's been on your mind?"
-      "What would you like to focus on today?"
-  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
-  first:
-`- BUCKET = first (telemetry lookup found no prior session — usually treat as RETURNING with NEW-DAY greeting).
-  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
-  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
-  • EXCEPTION: when the brain context's USER AWARENESS shows tenure.stage="day0", the user is genuinely new. Use the FULL INTRODUCTION shape from the brain context's OPENING SHAPE MATRIX — that overrides this fallback.
-  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
-  • Example follow-up if no candidate exists (pick ONE or skip):
-      "What's on your mind today?"
-      "Where would you like to focus today?"
-  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
-};
-
-// VTID-03118 (Phase B.4): the `{{short_gap_phrase_menu}}` placeholder
-// inside the `recent` and `same_day` templates expands to this multi-line
-// block. Identical line-for-line to the pre-B.4 `appendShortGapPhraseMenu`
-// closure that used to live inside `buildTemporalJourneyContextSection`.
-function expandShortGapPhraseMenu(
-  lang: string,
-  wakeBriefOverrideActive?: boolean,
-): string {
-  if (wakeBriefOverrideActive) {
-    return '  • SHORT-GAP PHRASE LIST SUPPRESSED — a VERTEX WAKE BRIEF override is active later in this prompt. Speak the override line verbatim instead of any phrase here.';
-  }
-  const examples = pickShortGapGreetings(lang, 6);
-  const out: string[] = [
-    '  • Pick ONE of these example phrasings (use them VERBATIM — they are already in the user\'s language; pick a different one than last time):',
-  ];
-  for (const p of examples) {
-    out.push(`      "${p}"`);
-  }
-  out.push('  • Rotate across sessions — the user notices repetition. If the previous session used one of these, pick a different one.');
-  return out.join('\n');
-}
+// R2 (BOOTSTRAP-ORB-R2-GREETING-POLICY): the legacy 8-bucket greeting-policy
+// fallback pools (`BUCKET_TO_BLOCK_KEY`, `BUCKET_DEFAULT_TEMPLATES`,
+// `expandShortGapPhraseMenu`) were removed from this module. The Central
+// Continuation Contract owns the first spoken line in production; the
+// temporal fallback pools now live on the priority-80 voice-wake-brief
+// provider (see WAKE_BRIEF_BUCKET_TEMPLATES / renderWakeBriefFallbackBlock in
+// services/assistant-continuation/providers/voice-wake-brief.ts). `TemporalBucket`
+// is retained here — `describeTimeSince` still classifies session recency for
+// the TEMPORAL AND JOURNEY CONTEXT block and the continuation decider.
 
 // Exported for characterization testing (A0.2, orb-live-refactor).
 // No behavior change — same function, externally addressable so the refactor
@@ -391,141 +295,40 @@ function buildTemporalJourneyContextSection(
     lines.push('- Journey before opening ORB: (no prior screens reported this session)');
   }
 
-  // VTID-03046 step 2: skip the entire greeting-policy stack on LiveKit
-  // (caller passes omitGreetingPolicy=true). The early-return jumps over
-  // the GREETING POLICY block (until ## TONE RULES below), the RECONNECT
-  // FINAL OVERRIDE block, and the HARD ANTI-PATTERNS block — all of which
-  // exist solely to constrain the LLM's FIRST utterance. LiveKit's
-  // pre-rendered session.say() greeting bypasses them entirely.
-  if (omitGreetingPolicy) {
-    lines.push('');
-    lines.push('## TONE RULES (CRITICAL)');
-    lines.push('- Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.');
-    lines.push('- Baseline register: "how can I help", "what\'s on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.');
-    lines.push('- NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.');
-    lines.push('- Even your shortest responses must feel genuinely kind. A single phrase can still be warm.');
-    lines.push('');
-    lines.push('## JOURNEY AWARENESS (CRITICAL — how to answer "where am I?" correctly)');
-    lines.push('- The "Current screen" field above is a SNAPSHOT from session start. It can become stale the moment any navigation happens (including navigation YOU just triggered via navigate_to_screen).');
-    lines.push('- Whenever the user asks any form of "where am I?" / "which screen is this?" / "what page am I on?" / "what am I looking at?" / "wo bin ich?" / "welcher Bildschirm ist das?", you MUST call the `get_current_screen` tool to get the FRESH answer. Never answer from memory or from the snapshot above — always call the tool.');
-    lines.push('- The get_current_screen tool is also the right call for any follow-up like "what is this screen for?" or "what can I do here?" — it returns a short description of the screen in the user\'s language.');
-    lines.push('- If the user asks "where was I before?" or similar, you may list the journey trail above in a natural sentence, OR call get_current_screen which also returns recent_screens.');
-    lines.push('- NEVER tell the user "I don\'t know which screen you\'re on" without calling get_current_screen first. That is always wrong.');
-    lines.push('- NEVER read raw URL paths aloud. Always speak the friendly screen title instead.');
-    return '\n\n' + lines.join('\n');
-  }
-
-  lines.push('');
-  lines.push('## GREETING POLICY — TIME AND JOURNEY AWARE (CRITICAL, overrides generic GREETING RULES above)');
-  lines.push('');
-  lines.push('Pick your opening line based on the bucket below. Follow it literally.');
-  lines.push('');
-  // VTID-01929: When the brain context (appended after this section) contains
-  // a USER AWARENESS block + Proactive Opener Candidate, that block's OPENING
-  // SHAPE MATRIX (tenure × last_interaction) is the authority — IGNORE the
-  // example follow-up phrasings below. The example phrasings are the LEGACY
-  // FALLBACK for sessions where the proactive guide has no candidate to surface.
-  lines.push('PROACTIVE OVERRIDE: If the brain context appended below contains a "PROACTIVE OPENER CANDIDATE" or "USER AWARENESS" block, IGNORE the example follow-up phrasings in this section. Use the OPENING SHAPE MATRIX from the brain context instead. The phrasings below are LEGACY FALLBACKS only.');
-  lines.push('');
-
-  // Map 'night' to 'evening' for greetings ("Good night" is a farewell, not a greeting)
-  const greetingTimeOfDay = timeOfDay === 'night' ? 'evening' : (timeOfDay || 'day');
-
-  const bucket = isReconnect ? 'reconnect' : temporal.bucket;
-  // VTID-03097: caller signals when a wake-brief override block is
-  // active. When yes, the SHORT-GAP GREETING PHRASES pool is
-  // suppressed so Gemini doesn't see two competing "speak this
-  // verbatim" lists.
-  // VTID-GREETING-VARIETY: for short-gap buckets, inject a freshly-shuffled
-  // subset of the language-specific phrase pool so Gemini rotates openers
-  // instead of converging on the same translation every time.
-  // VTID-03118 (Phase B.4): the bucket-to-prompt mapping (8 templates × 8
-  // languages) is the policy_render_block table seeded in Phase B.2. The
-  // resolver returns each bucket's full multi-line template; the consumer
-  // here substitutes the two dynamic tokens that survive into seed text:
+  // R2 (BOOTSTRAP-ORB-R2-GREETING-POLICY): the legacy `## GREETING POLICY`
+  // 8-bucket × multi-language fallback stack has been DELETED from this
+  // builder. It used to render the opening-line policy (bucket templates +
+  // short-gap phrase menu + HARD ANTI-PATTERNS) only on the Vertex path;
+  // LiveKit already omitted it via `omitGreetingPolicy=true`. In production
+  // the Central Continuation Contract (voice-wake-brief / teacher / new-day)
+  // owns the first spoken line, so the legacy block was a soft Vertex/LiveKit
+  // conflict — Vertex rendered dead text the override always superseded while
+  // LiveKit skipped it entirely. The temporal/bucketed fallback pools now
+  // live in the priority-80 `voice-wake-brief` provider (the pure-fallback
+  // producer), so the fallback greeting content still exists where it
+  // belongs.
   //
-  //   {{greeting_time_of_day}}  -> the local `greetingTimeOfDay` value
-  //                                (morning | afternoon | evening | day).
-  //   {{short_gap_phrase_menu}} -> the locale-specific menu produced by
-  //                                `expandShortGapPhraseMenu()` below
-  //                                (1 line under wake-brief override,
-  //                                multiple lines otherwise).
-  //
-  // BUCKET_DEFAULT_TEMPLATES below is byte-identical to the seed content
-  // — it exists ONLY as a safety net for the "resolver cold + cache miss"
-  // case. In production, the resolver returns the DB row.
-  const shortGapPhraseMenu = expandShortGapPhraseMenu(
-    lang,
-    wakeBriefOverrideActive,
-  );
-  const template = getPolicyResolver().getRenderBlock(
-    BUCKET_TO_BLOCK_KEY[bucket],
-    lang,
-    { defaultValue: BUCKET_DEFAULT_TEMPLATES[bucket] },
-  );
-  const rendered = template
-    .replace(/\{\{greeting_time_of_day\}\}/g, greetingTimeOfDay)
-    .replace(/\{\{short_gap_phrase_menu\}\}/g, shortGapPhraseMenu);
-  for (const line of rendered.split('\n')) {
-    lines.push(line);
-  }
-
-  // VTID-02637: wasFailure means the PREVIOUS session ended with no audio
-  // delivered (turn_count=0 or audio_out=0). For 'recent' bucket (true new
-  // user-initiated session 2-15min after a failed one), an apology is the
-  // right behavior. For 'reconnect' bucket (transparent server-side WS
-  // recycle that the user never perceived), an apology is the bug — the
-  // user is still in the same conversation. Restrict the override to
-  // 'recent' only.
-  if (temporal.wasFailure && bucket === 'recent') {
-    lines.push('- OVERRIDE: The previous session FAILED (you did not actually reach the user last time). Acknowledge it warmly and sincerely, e.g. "I\'m so sorry about earlier — I\'m here now. How can I help?" Still ONE short sentence.');
-  }
-
-  // VTID-02637: when this is a transparent reconnect (isReconnect=true) we
-  // also want to suppress the ## TONE RULES baseline phrasings below ("how
-  // can I help", "I am listening", etc.) because they leak into the model's
-  // first utterance after reconnect even when bucket says "stay silent".
-  // Append a final hard override that wins on recency.
-  if (isReconnect) {
-    lines.push('');
-    lines.push('## RECONNECT FINAL OVERRIDE — VTID-02637 (HIGHEST PRIORITY, OVERRIDES EVERYTHING ABOVE)');
-    lines.push('This entire turn is a transparent server-side resume. The user did not perceive any pause.');
-    lines.push('- DO NOT speak first. Output zero audio. Output zero text. Wait for the user to speak.');
-    lines.push('- Even short phrases are forbidden: NO "I\'m here", NO "I\'m listening", NO "I\'m back", NO "go ahead", NO "yes?", NO "mhm", NO "hello again". NONE.');
-    lines.push('- Ignore any "open with one phrase", "baseline register", or "FALLBACK" instructions above. They do NOT apply on reconnect.');
-    lines.push('- The very first audio/text you emit MUST be a direct response to whatever the user says next, with no prefix acknowledgment of any pause or interruption.');
-    lines.push('- If the user says nothing, you say nothing. Silence is the correct behavior here.');
-  }
-
+  // Both transports now render the SAME lean stack below: TONE RULES +
+  // JOURNEY AWARENESS. Reconnect silence is still enforced upstream by the
+  // top-level GREETING RULES (`VTID-02637 RECONNECT SILENCE RULE`) and by
+  // `decideGreetingPolicy()` returning `'skip'` on reconnect — neither
+  // depends on the deleted block. The `omitGreetingPolicy` parameter is now
+  // dead (kept on the signature for caller compatibility; both `true` and
+  // `false` produce identical output) and `bucket`/`greetingTimeOfDay` /
+  // the policy-resolver render call are no longer consumed here.
+  void omitGreetingPolicy;
+  void wakeBriefOverrideActive;
   lines.push('');
   lines.push('## TONE RULES (CRITICAL)');
   lines.push('- Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.');
-  // VTID-01927: When the brain context appends a Proactive Opener Candidate, that candidate's
-  // opening shape OVERRIDES the baseline below. The baseline only applies as a true fallback
-  // when no candidate is provided. The phrase "what can I do for you" was previously here and
-  // overrode the proactive opener — removed as a forbidden opening per the proactive guide rules.
-  lines.push('- Baseline register (FALLBACK ONLY — when no Proactive Opener Candidate is provided): "how can I help", "what\'s on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.');
+  lines.push('- Baseline register: "how can I help", "what\'s on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.');
   lines.push('- NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.');
-  lines.push('- NEVER use two-part sentences in greetings. NO dashes, NO "X — Y" patterns. Each greeting is ONE single direct phrase or sentence.');
   lines.push('- Even your shortest responses must feel genuinely kind. A single phrase can still be warm.');
-
-  lines.push('');
-  lines.push('## HARD ANTI-PATTERNS (NEVER DO THESE)');
-  lines.push('- For SHORT-GAP sessions (reconnect, recent, same_day): NEVER open with "Hello <name>!" or "Hi <name>!" or the user\'s name at all. They were just here — using their name sounds like a goldfish that forgot the last conversation.');
-  lines.push('- For NEW-DAY sessions (today, yesterday, week, long, first): ALWAYS open with "Good [morning/afternoon/evening], [Name]." — this is the ONLY greeting pattern allowed UNLESS the brain context specifies a tenure-aware opening shape (see PROACTIVE OPENER OVERRIDE at the very end of this prompt). Use the user\'s name from memory context. If no name is available, just say "Good [morning/afternoon/evening]."');
-  // VTID-01927: introductions are now allowed for true Day-0 newcomers (tenure.stage='day0')
-  lines.push('- NEVER introduce yourself ("My name is Vitana...", "I\'m Vitana...") on RETURNING-user sessions. EXCEPTION: when the brain context\'s USER AWARENESS shows tenure stage = "day0", you SHOULD deliver a one-time introduction covering mission, capabilities, and agency offer — that user is brand new to Vitanaland and needs orientation.');
-  lines.push('- NEVER recite remembered facts back as a greeting ("Hello Dragan from Vienna, born 1969..."). You KNOW these facts — use them only when relevant.');
-  lines.push('- NEVER ignore the current screen. If you know where the user is, your greeting may reference it but must not read the route path aloud.');
-  // VTID-01927: rephrased to be tenure-aware
-  lines.push('- NEVER deliver a "first impression" platform-introduction on a RETURNING-user session (tenure.stage in day1/day3/day7/day14/day30plus). Returning users already know who you are. ONLY tenure.stage="day0" gets the full introduction shape.');
-  lines.push('- NEVER use two-part compound sentences in greetings. NO "Yes, of course — how can I help?" NO "Happy to help — what\'s on your mind?" Just say the question directly.');
   lines.push('');
   lines.push('## JOURNEY AWARENESS (CRITICAL — how to answer "where am I?" correctly)');
   lines.push('- The "Current screen" field above is a SNAPSHOT from session start. It can become stale the moment any navigation happens (including navigation YOU just triggered via navigate_to_screen).');
   lines.push('- Whenever the user asks any form of "where am I?" / "which screen is this?" / "what page am I on?" / "what am I looking at?" / "wo bin ich?" / "welcher Bildschirm ist das?", you MUST call the `get_current_screen` tool to get the FRESH answer. Never answer from memory or from the snapshot above — always call the tool.');
   lines.push('- The get_current_screen tool is also the right call for any follow-up like "what is this screen for?" or "what can I do here?" — it returns a short description of the screen in the user\'s language.');
-  lines.push('- You already know the screen the user just arrived on if you navigated them via navigate_to_screen on the PREVIOUS turn (the tool result told you the destination title). You may reference that from conversation memory without re-calling get_current_screen, but if in doubt, call the tool — it is cheap.');
   lines.push('- If the user asks "where was I before?" or similar, you may list the journey trail above in a natural sentence, OR call get_current_screen which also returns recent_screens.');
   lines.push('- NEVER tell the user "I don\'t know which screen you\'re on" without calling get_current_screen first. That is always wrong.');
   lines.push('- NEVER read raw URL paths aloud. Always speak the friendly screen title instead.');
@@ -855,30 +658,19 @@ ${trimmedHistory}
   // VTID-NAV-TIMEJOURNEY: Append the temporal + journey context block LAST so
   // its greeting policy overrides the generic GREETING RULES higher up. This
   // is what stops Vitana from saying "Hello <name>!" every single session.
-  // VTID-03097: detect VERTEX WAKE BRIEF override here at the
-  // top-level buildLiveSystemInstruction (which has bootstrapContext)
-  // and pass the boolean down so the temporal section can suppress
-  // the SHORT-GAP GREETING PHRASES pool when needed.
-  const wakeBriefOverrideActive =
-    typeof bootstrapContext === 'string' &&
-    bootstrapContext.includes('<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>');
-  // ORB-CONVERSATION-LATENCY: lean system_instruction experiment (ship-dark,
-  // flag-gated, fully reversible). When FEATURE_LEAN_SYSTEM_INSTRUCTION is live
-  // AND this is a first connect (not a reconnect), drop the ~20-25 KB
-  // greeting-policy stack (GREETING POLICY time-buckets + HARD ANTI-PATTERNS)
-  // from the Vertex prompt — the SAME stack LiveKit already omits in production
-  // via omitGreetingPolicy. The hypothesis under test: Vertex's Gemini still
-  // opens well from TONE RULES + the explicit greeting prompt
-  // (sendGreetingPromptToLiveAPI), trading prompt-ingestion time for a faster
-  // first token. Reconnect ALWAYS keeps the full stack so the RECONNECT FINAL
-  // OVERRIDE (silence-on-transparent-resume) is never dropped. LiveKit callers
-  // already pass omitGreetingPolicy=true, so the flag is a no-op for them.
-  // Flag off (default) => byte-identical to current behavior.
-  const leanGreetingActive =
-    !omitGreetingPolicy &&
-    !isReconnect &&
-    isFeatureLive('LEAN_SYSTEM_INSTRUCTION');
-  const effectiveOmitGreetingPolicy = !!omitGreetingPolicy || leanGreetingActive;
+  // R2 (BOOTSTRAP-ORB-R2-GREETING-POLICY): the legacy greeting-policy stack
+  // that this call used to render (gated by `omitGreetingPolicy` and the
+  // FEATURE_LEAN_SYSTEM_INSTRUCTION experiment) has been deleted from
+  // `buildTemporalJourneyContextSection`. Both transports now emit the same
+  // lean TONE RULES + JOURNEY AWARENESS stack, so:
+  //   - the lean experiment flag (FEATURE_LEAN_SYSTEM_INSTRUCTION) is dead and
+  //     no longer consulted here;
+  //   - the `wakeBriefOverrideActive` signal — which only suppressed the
+  //     deleted SHORT-GAP GREETING PHRASES pool — is no longer needed.
+  // The trailing `omitGreetingPolicy` / `wakeBriefOverrideActive` parameters
+  // are kept on the section signature for caller compatibility but are inert.
+  // (Note: the `<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>` sentinel is still
+  // load-bearing above where it strips competing brain-side opener sections.)
   instruction += buildTemporalJourneyContextSection(
     lang,
     lastSessionInfo,
@@ -886,8 +678,8 @@ ${trimmedHistory}
     recentRoutes,
     !!isReconnect,
     clientContext?.timeOfDay,
-    effectiveOmitGreetingPolicy,
-    wakeBriefOverrideActive,
+    !!omitGreetingPolicy,
+    false,
   );
 
   // BOOTSTRAP-AWARENESS-REGISTRY: gate the override blocks below on admin

--- a/services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts
@@ -44,6 +44,150 @@ import type {
   DecisionPillarMomentum,
   PillarKey,
 } from '../../../orb/context/types';
+import { pickShortGapGreetings } from '../../../orb/instruction/greeting-pools';
+
+// ---------------------------------------------------------------------------
+// Temporal / bucketed fallback pools
+// (R2 — BOOTSTRAP-ORB-R2-GREETING-POLICY)
+// ---------------------------------------------------------------------------
+//
+// These pools were lifted verbatim from the legacy `## GREETING POLICY` stack
+// in `orb/live/instruction/live-system-instruction.ts`. That stack rendered
+// an 8-bucket × multi-language fallback opening policy directly into the
+// Vertex system_instruction, even though the Central Continuation Contract
+// (this provider + teacher + new-day) already owns the first spoken line in
+// production — making it dead text on Vertex and omitted entirely on LiveKit
+// (a soft transport conflict). The fallback content now lives HERE, on the
+// priority-80 pure-fallback producer that owns the temporal fallback pools.
+//
+// The actual per-language greeting STRINGS still live in
+// `orb/instruction/greeting-pools.ts` (`SHORT_GAP_GREETING_PHRASES`, surfaced
+// via `pickShortGapGreetings`); only the bucket templating moved here. No
+// greeting string or language was dropped in the move.
+
+/** Time-since-last-session buckets the legacy stack keyed its templates on. */
+export type WakeBriefTemporalBucket =
+  | 'reconnect'
+  | 'recent'
+  | 'same_day'
+  | 'today'
+  | 'yesterday'
+  | 'week'
+  | 'long'
+  | 'first';
+
+/**
+ * The 8-bucket structural opening templates. Byte-identical to the
+ * `BUCKET_DEFAULT_TEMPLATES` previously inlined in live-system-instruction.ts.
+ * `{{greeting_time_of_day}}` and `{{short_gap_phrase_menu}}` are substituted
+ * by `renderWakeBriefFallbackBlock()` below.
+ */
+export const WAKE_BRIEF_BUCKET_TEMPLATES: Record<WakeBriefTemporalBucket, string> = {
+  reconnect:
+`- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).
+  • DO NOT speak. DO NOT greet. DO NOT acknowledge any "interruption", "reconnection", "resume", "where were we", "I'm back", "I'm listening", "picking up", or anything similar. Saying any of these creates a perceived apology that the user reads as a bug.
+  • Wait for the user to speak. Your next message must be a direct response to the user's next utterance — nothing else.
+  • If the user says nothing, you say nothing. Silence is correct here.`,
+  recent:
+`- BUCKET = recent (2–15 min since last session).
+  • Do NOT use a formal greeting. NO "Hello <name>!", NO "Hi there!", NO self-introduction. NO user name.
+  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
+{{short_gap_phrase_menu}}
+  • Max ONE short phrase. Warm but direct.`,
+  same_day:
+`- BUCKET = same_day (15 min – 8 h since last session).
+  • Light re-engagement. NOT a formal greeting. No user name. NEVER "Hello <name>!" as if you've never met.
+  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
+{{short_gap_phrase_menu}}
+  • Max ONE short phrase. Warm and direct.`,
+  today:
+`- BUCKET = today (8–24 h since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What's on your mind today?"
+      "Where would you like to focus today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  yesterday:
+`- BUCKET = yesterday (this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What would you like to explore today?"
+      "Picking up where we left off?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  week:
+`- BUCKET = week (2–7 days since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "Good to hear from you again — what's been on your mind?"
+      "What would you like to explore today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  long:
+`- BUCKET = long (> 7 days since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available — for >7-day absences the candidate should explicitly acknowledge the gap).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "It's been a few days — happy you're back. What's been on your mind?"
+      "What would you like to focus on today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  first:
+`- BUCKET = first (telemetry lookup found no prior session — usually treat as RETURNING with NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • EXCEPTION: when the brain context's USER AWARENESS shows tenure.stage="day0", the user is genuinely new. Use the FULL INTRODUCTION shape from the brain context's OPENING SHAPE MATRIX — that overrides this fallback.
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What's on your mind today?"
+      "Where would you like to focus today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+};
+
+/**
+ * Expand the `{{short_gap_phrase_menu}}` token. Identical line-for-line to
+ * the `expandShortGapPhraseMenu()` helper that used to live inside
+ * `buildTemporalJourneyContextSection`. Pulls the per-language greeting
+ * strings from the preserved `SHORT_GAP_GREETING_PHRASES` pool.
+ */
+export function expandShortGapPhraseMenu(
+  lang: string,
+  wakeBriefOverrideActive?: boolean,
+): string {
+  if (wakeBriefOverrideActive) {
+    return '  • SHORT-GAP PHRASE LIST SUPPRESSED — a VERTEX WAKE BRIEF override is active later in this prompt. Speak the override line verbatim instead of any phrase here.';
+  }
+  const examples = pickShortGapGreetings(lang, 6);
+  const out: string[] = [
+    '  • Pick ONE of these example phrasings (use them VERBATIM — they are already in the user\'s language; pick a different one than last time):',
+  ];
+  for (const p of examples) {
+    out.push(`      "${p}"`);
+  }
+  out.push('  • Rotate across sessions — the user notices repetition. If the previous session used one of these, pick a different one.');
+  return out.join('\n');
+}
+
+/**
+ * Render the bucket's fallback opening block with the two dynamic tokens
+ * substituted — the no-provider fallback content that used to be inlined in
+ * the Vertex system_instruction. Pure; no IO.
+ */
+export function renderWakeBriefFallbackBlock(
+  bucket: WakeBriefTemporalBucket,
+  lang: string,
+  greetingTimeOfDay: string,
+  wakeBriefOverrideActive?: boolean,
+): string {
+  const menu = expandShortGapPhraseMenu(lang, wakeBriefOverrideActive);
+  return WAKE_BRIEF_BUCKET_TEMPLATES[bucket]
+    .replace(/\{\{greeting_time_of_day\}\}/g, greetingTimeOfDay || 'day')
+    .replace(/\{\{short_gap_phrase_menu\}\}/g, menu);
+}
 
 // ---------------------------------------------------------------------------
 // Inputs the orchestrator caller forwards via ctx.extra.voiceWakeBrief

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -174,43 +174,16 @@ This is real, per-session data. Treat it as ground truth about what the user is 
 - Current screen: "Vitanaland Landing" (route: /)
 - Journey before opening ORB: (no prior screens reported this session)
 
-## GREETING POLICY — TIME AND JOURNEY AWARE (CRITICAL, overrides generic GREETING RULES above)
-
-Pick your opening line based on the bucket below. Follow it literally.
-
-PROACTIVE OVERRIDE: If the brain context appended below contains a "PROACTIVE OPENER CANDIDATE" or "USER AWARENESS" block, IGNORE the example follow-up phrasings in this section. Use the OPENING SHAPE MATRIX from the brain context instead. The phrasings below are LEGACY FALLBACKS only.
-
-- BUCKET = first (telemetry lookup found no prior session — usually treat as RETURNING with NEW-DAY greeting).
-  • ALWAYS open with "Good day, [Name]." using the user's name from memory context.
-  • If no name is available in memory, just say "Good day."
-  • EXCEPTION: when the brain context's USER AWARENESS shows tenure.stage="day0", the user is genuinely new. Use the FULL INTRODUCTION shape from the brain context's OPENING SHAPE MATRIX — that overrides this fallback.
-  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
-  • Example follow-up if no candidate exists (pick ONE or skip):
-      "What's on your mind today?"
-      "Where would you like to focus today?"
-  • Max TWO short sentences total: the time-of-day greeting + optionally one question.
-
 ## TONE RULES (CRITICAL)
 - Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.
-- Baseline register (FALLBACK ONLY — when no Proactive Opener Candidate is provided): "how can I help", "what's on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.
+- Baseline register: "how can I help", "what's on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.
 - NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.
-- NEVER use two-part sentences in greetings. NO dashes, NO "X — Y" patterns. Each greeting is ONE single direct phrase or sentence.
 - Even your shortest responses must feel genuinely kind. A single phrase can still be warm.
-
-## HARD ANTI-PATTERNS (NEVER DO THESE)
-- For SHORT-GAP sessions (reconnect, recent, same_day): NEVER open with "Hello <name>!" or "Hi <name>!" or the user's name at all. They were just here — using their name sounds like a goldfish that forgot the last conversation.
-- For NEW-DAY sessions (today, yesterday, week, long, first): ALWAYS open with "Good [morning/afternoon/evening], [Name]." — this is the ONLY greeting pattern allowed UNLESS the brain context specifies a tenure-aware opening shape (see PROACTIVE OPENER OVERRIDE at the very end of this prompt). Use the user's name from memory context. If no name is available, just say "Good [morning/afternoon/evening]."
-- NEVER introduce yourself ("My name is Vitana...", "I'm Vitana...") on RETURNING-user sessions. EXCEPTION: when the brain context's USER AWARENESS shows tenure stage = "day0", you SHOULD deliver a one-time introduction covering mission, capabilities, and agency offer — that user is brand new to Vitanaland and needs orientation.
-- NEVER recite remembered facts back as a greeting ("Hello Dragan from Vienna, born 1969..."). You KNOW these facts — use them only when relevant.
-- NEVER ignore the current screen. If you know where the user is, your greeting may reference it but must not read the route path aloud.
-- NEVER deliver a "first impression" platform-introduction on a RETURNING-user session (tenure.stage in day1/day3/day7/day14/day30plus). Returning users already know who you are. ONLY tenure.stage="day0" gets the full introduction shape.
-- NEVER use two-part compound sentences in greetings. NO "Yes, of course — how can I help?" NO "Happy to help — what's on your mind?" Just say the question directly.
 
 ## JOURNEY AWARENESS (CRITICAL — how to answer "where am I?" correctly)
 - The "Current screen" field above is a SNAPSHOT from session start. It can become stale the moment any navigation happens (including navigation YOU just triggered via navigate_to_screen).
 - Whenever the user asks any form of "where am I?" / "which screen is this?" / "what page am I on?" / "what am I looking at?" / "wo bin ich?" / "welcher Bildschirm ist das?", you MUST call the \`get_current_screen\` tool to get the FRESH answer. Never answer from memory or from the snapshot above — always call the tool.
 - The get_current_screen tool is also the right call for any follow-up like "what is this screen for?" or "what can I do here?" — it returns a short description of the screen in the user's language.
-- You already know the screen the user just arrived on if you navigated them via navigate_to_screen on the PREVIOUS turn (the tool result told you the destination title). You may reference that from conversation memory without re-calling get_current_screen, but if in doubt, call the tool — it is cheap.
 - If the user asks "where was I before?" or similar, you may list the journey trail above in a natural sentence, OR call get_current_screen which also returns recent_screens.
 - NEVER tell the user "I don't know which screen you're on" without calling get_current_screen first. That is always wrong.
 - NEVER read raw URL paths aloud. Always speak the friendly screen title instead.
@@ -441,43 +414,16 @@ This is real, per-session data. Treat it as ground truth about what the user is 
 - Current screen: "Gesundheit" (route: /health)
 - Journey before opening ORB (newest → oldest): "/diary" → "Wallet"
 
-## GREETING POLICY — TIME AND JOURNEY AWARE (CRITICAL, overrides generic GREETING RULES above)
-
-Pick your opening line based on the bucket below. Follow it literally.
-
-PROACTIVE OVERRIDE: If the brain context appended below contains a "PROACTIVE OPENER CANDIDATE" or "USER AWARENESS" block, IGNORE the example follow-up phrasings in this section. Use the OPENING SHAPE MATRIX from the brain context instead. The phrasings below are LEGACY FALLBACKS only.
-
-- BUCKET = first (telemetry lookup found no prior session — usually treat as RETURNING with NEW-DAY greeting).
-  • ALWAYS open with "Good day, [Name]." using the user's name from memory context.
-  • If no name is available in memory, just say "Good day."
-  • EXCEPTION: when the brain context's USER AWARENESS shows tenure.stage="day0", the user is genuinely new. Use the FULL INTRODUCTION shape from the brain context's OPENING SHAPE MATRIX — that overrides this fallback.
-  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
-  • Example follow-up if no candidate exists (pick ONE or skip):
-      "What's on your mind today?"
-      "Where would you like to focus today?"
-  • Max TWO short sentences total: the time-of-day greeting + optionally one question.
-
 ## TONE RULES (CRITICAL)
 - Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.
-- Baseline register (FALLBACK ONLY — when no Proactive Opener Candidate is provided): "how can I help", "what's on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.
+- Baseline register: "how can I help", "what's on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.
 - NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.
-- NEVER use two-part sentences in greetings. NO dashes, NO "X — Y" patterns. Each greeting is ONE single direct phrase or sentence.
 - Even your shortest responses must feel genuinely kind. A single phrase can still be warm.
-
-## HARD ANTI-PATTERNS (NEVER DO THESE)
-- For SHORT-GAP sessions (reconnect, recent, same_day): NEVER open with "Hello <name>!" or "Hi <name>!" or the user's name at all. They were just here — using their name sounds like a goldfish that forgot the last conversation.
-- For NEW-DAY sessions (today, yesterday, week, long, first): ALWAYS open with "Good [morning/afternoon/evening], [Name]." — this is the ONLY greeting pattern allowed UNLESS the brain context specifies a tenure-aware opening shape (see PROACTIVE OPENER OVERRIDE at the very end of this prompt). Use the user's name from memory context. If no name is available, just say "Good [morning/afternoon/evening]."
-- NEVER introduce yourself ("My name is Vitana...", "I'm Vitana...") on RETURNING-user sessions. EXCEPTION: when the brain context's USER AWARENESS shows tenure stage = "day0", you SHOULD deliver a one-time introduction covering mission, capabilities, and agency offer — that user is brand new to Vitanaland and needs orientation.
-- NEVER recite remembered facts back as a greeting ("Hello Dragan from Vienna, born 1969..."). You KNOW these facts — use them only when relevant.
-- NEVER ignore the current screen. If you know where the user is, your greeting may reference it but must not read the route path aloud.
-- NEVER deliver a "first impression" platform-introduction on a RETURNING-user session (tenure.stage in day1/day3/day7/day14/day30plus). Returning users already know who you are. ONLY tenure.stage="day0" gets the full introduction shape.
-- NEVER use two-part compound sentences in greetings. NO "Yes, of course — how can I help?" NO "Happy to help — what's on your mind?" Just say the question directly.
 
 ## JOURNEY AWARENESS (CRITICAL — how to answer "where am I?" correctly)
 - The "Current screen" field above is a SNAPSHOT from session start. It can become stale the moment any navigation happens (including navigation YOU just triggered via navigate_to_screen).
 - Whenever the user asks any form of "where am I?" / "which screen is this?" / "what page am I on?" / "what am I looking at?" / "wo bin ich?" / "welcher Bildschirm ist das?", you MUST call the \`get_current_screen\` tool to get the FRESH answer. Never answer from memory or from the snapshot above — always call the tool.
 - The get_current_screen tool is also the right call for any follow-up like "what is this screen for?" or "what can I do here?" — it returns a short description of the screen in the user's language.
-- You already know the screen the user just arrived on if you navigated them via navigate_to_screen on the PREVIOUS turn (the tool result told you the destination title). You may reference that from conversation memory without re-calling get_current_screen, but if in doubt, call the tool — it is cheap.
 - If the user asks "where was I before?" or similar, you may list the journey trail above in a natural sentence, OR call get_current_screen which also returns recent_screens.
 - NEVER tell the user "I don't know which screen you're on" without calling get_current_screen first. That is always wrong.
 - NEVER read raw URL paths aloud. Always speak the friendly screen title instead.
@@ -1660,46 +1606,16 @@ This is real, per-session data. Treat it as ground truth about what the user is 
 - Current screen: "Vitanaland Landing" (route: /)
 - Journey before opening ORB (newest → oldest): "/intent" → "/community"
 
-## GREETING POLICY — TIME AND JOURNEY AWARE (CRITICAL, overrides generic GREETING RULES above)
-
-Pick your opening line based on the bucket below. Follow it literally.
-
-PROACTIVE OVERRIDE: If the brain context appended below contains a "PROACTIVE OPENER CANDIDATE" or "USER AWARENESS" block, IGNORE the example follow-up phrasings in this section. Use the OPENING SHAPE MATRIX from the brain context instead. The phrasings below are LEGACY FALLBACKS only.
-
-- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).
-  • DO NOT speak. DO NOT greet. DO NOT acknowledge any "interruption", "reconnection", "resume", "where were we", "I'm back", "I'm listening", "picking up", or anything similar. Saying any of these creates a perceived apology that the user reads as a bug.
-  • Wait for the user to speak. Your next message must be a direct response to the user's next utterance — nothing else.
-  • If the user says nothing, you say nothing. Silence is correct here.
-
-## RECONNECT FINAL OVERRIDE — VTID-02637 (HIGHEST PRIORITY, OVERRIDES EVERYTHING ABOVE)
-This entire turn is a transparent server-side resume. The user did not perceive any pause.
-- DO NOT speak first. Output zero audio. Output zero text. Wait for the user to speak.
-- Even short phrases are forbidden: NO "I'm here", NO "I'm listening", NO "I'm back", NO "go ahead", NO "yes?", NO "mhm", NO "hello again". NONE.
-- Ignore any "open with one phrase", "baseline register", or "FALLBACK" instructions above. They do NOT apply on reconnect.
-- The very first audio/text you emit MUST be a direct response to whatever the user says next, with no prefix acknowledgment of any pause or interruption.
-- If the user says nothing, you say nothing. Silence is the correct behavior here.
-
 ## TONE RULES (CRITICAL)
 - Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.
-- Baseline register (FALLBACK ONLY — when no Proactive Opener Candidate is provided): "how can I help", "what's on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.
+- Baseline register: "how can I help", "what's on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.
 - NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.
-- NEVER use two-part sentences in greetings. NO dashes, NO "X — Y" patterns. Each greeting is ONE single direct phrase or sentence.
 - Even your shortest responses must feel genuinely kind. A single phrase can still be warm.
-
-## HARD ANTI-PATTERNS (NEVER DO THESE)
-- For SHORT-GAP sessions (reconnect, recent, same_day): NEVER open with "Hello <name>!" or "Hi <name>!" or the user's name at all. They were just here — using their name sounds like a goldfish that forgot the last conversation.
-- For NEW-DAY sessions (today, yesterday, week, long, first): ALWAYS open with "Good [morning/afternoon/evening], [Name]." — this is the ONLY greeting pattern allowed UNLESS the brain context specifies a tenure-aware opening shape (see PROACTIVE OPENER OVERRIDE at the very end of this prompt). Use the user's name from memory context. If no name is available, just say "Good [morning/afternoon/evening]."
-- NEVER introduce yourself ("My name is Vitana...", "I'm Vitana...") on RETURNING-user sessions. EXCEPTION: when the brain context's USER AWARENESS shows tenure stage = "day0", you SHOULD deliver a one-time introduction covering mission, capabilities, and agency offer — that user is brand new to Vitanaland and needs orientation.
-- NEVER recite remembered facts back as a greeting ("Hello Dragan from Vienna, born 1969..."). You KNOW these facts — use them only when relevant.
-- NEVER ignore the current screen. If you know where the user is, your greeting may reference it but must not read the route path aloud.
-- NEVER deliver a "first impression" platform-introduction on a RETURNING-user session (tenure.stage in day1/day3/day7/day14/day30plus). Returning users already know who you are. ONLY tenure.stage="day0" gets the full introduction shape.
-- NEVER use two-part compound sentences in greetings. NO "Yes, of course — how can I help?" NO "Happy to help — what's on your mind?" Just say the question directly.
 
 ## JOURNEY AWARENESS (CRITICAL — how to answer "where am I?" correctly)
 - The "Current screen" field above is a SNAPSHOT from session start. It can become stale the moment any navigation happens (including navigation YOU just triggered via navigate_to_screen).
 - Whenever the user asks any form of "where am I?" / "which screen is this?" / "what page am I on?" / "what am I looking at?" / "wo bin ich?" / "welcher Bildschirm ist das?", you MUST call the \`get_current_screen\` tool to get the FRESH answer. Never answer from memory or from the snapshot above — always call the tool.
 - The get_current_screen tool is also the right call for any follow-up like "what is this screen for?" or "what can I do here?" — it returns a short description of the screen in the user's language.
-- You already know the screen the user just arrived on if you navigated them via navigate_to_screen on the PREVIOUS turn (the tool result told you the destination title). You may reference that from conversation memory without re-calling get_current_screen, but if in doubt, call the tool — it is cheap.
 - If the user asks "where was I before?" or similar, you may list the journey trail above in a natural sentence, OR call get_current_screen which also returns recent_screens.
 - NEVER tell the user "I don't know which screen you're on" without calling get_current_screen first. That is always wrong.
 - NEVER read raw URL paths aloud. Always speak the friendly screen title instead.

--- a/services/gateway/test/orb/live/characterization/greeting-block-resolver.test.ts
+++ b/services/gateway/test/orb/live/characterization/greeting-block-resolver.test.ts
@@ -1,20 +1,23 @@
 /**
- * VTID-03118 (Phase B.4) — byte-identical proof for the resolver-backed
- * greeting block.
+ * VTID-03118 (Phase B.4) — greeting-bucket fallback content lock.
  *
- * The Phase B.4 PR removes the inline `switch (bucket)` body that used to
- * push per-bucket greeting policy lines and replaces it with a single
- * `PolicyResolver.getRenderBlock()` call plus two token substitutions.
+ * ORIGINAL PURPOSE: prove that `buildLiveSystemInstruction` rendered the
+ * per-bucket greeting-policy block byte-identically whether the PolicyResolver
+ * returned its seeded content or the consumer fell back to the inline
+ * BUCKET_DEFAULT_TEMPLATES.
  *
- * This test locks the invariant: the output of `buildLiveSystemInstruction`
- * is **byte-identical** whether the resolver returns its seeded content or
- * the consumer falls back to BUCKET_DEFAULT_TEMPLATES. Both code paths must
- * produce the same prompt — that is the whole point of the vertical proof.
+ * R2 (BOOTSTRAP-ORB-R2-GREETING-POLICY): the legacy `## GREETING POLICY` stack
+ * was DELETED from `buildLiveSystemInstruction`. Its temporal/bucketed
+ * fallback pools moved verbatim to the priority-80 voice-wake-brief provider,
+ * which owns the no-provider fallback path in the Central Continuation
+ * Contract. The resolver-vs-defaults parity is no longer relevant (the moved
+ * pools are static constants, not resolver-backed), but the VERBATIM bucket
+ * content + token substitution must still be locked — that is what this test
+ * now does, against the new owner.
  */
 
 // pickShortGapGreetings shuffles its return value, which would make the
-// byte-identical comparison flap. Pin it to a fixed sequence so the two
-// invocations (defaults path vs resolver path) emit the same menu lines.
+// menu-expansion comparison flap. Pin it to a fixed sequence.
 jest.mock('../../../../src/orb/instruction/greeting-pools', () => ({
   pickShortGapGreetings: (_lang: string, _n: number) => [
     'fixed phrase 1',
@@ -26,19 +29,18 @@ jest.mock('../../../../src/orb/instruction/greeting-pools', () => ({
   ],
 }));
 
-import { buildLiveSystemInstruction } from '../../../../src/orb/live/instruction/live-system-instruction';
 import {
-  configurePolicyResolverForTests,
-  __resetPolicyResolverForTests,
-  POLICY_KEYS,
-  RENDER_BLOCK_KEYS,
-} from '../../../../src/services/decision-contract';
+  WAKE_BRIEF_BUCKET_TEMPLATES,
+  renderWakeBriefFallbackBlock,
+  expandShortGapPhraseMenu,
+  type WakeBriefTemporalBucket,
+} from '../../../../src/services/assistant-continuation/providers/voice-wake-brief';
 
-// Same template strings the consumer falls back to when the cache is cold
-// (see BUCKET_DEFAULT_TEMPLATES in live-system-instruction.ts). Duplicating
-// them here is the test contract: if the consumer ever diverges from these,
-// the byte-identical claim fails.
-const TEMPLATES = {
+// The template strings the moved pools must render. Duplicating them here is
+// the test contract: if the provider ever diverges from these verbatim
+// strings, the lock fails. These are byte-identical to the pre-R2
+// BUCKET_DEFAULT_TEMPLATES that used to live in live-system-instruction.ts.
+const TEMPLATES: Record<WakeBriefTemporalBucket, string> = {
   reconnect:
 `- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).
   • DO NOT speak. DO NOT greet. DO NOT acknowledge any "interruption", "reconnection", "resume", "where were we", "I'm back", "I'm listening", "picking up", or anything similar. Saying any of these creates a perceived apology that the user reads as a bug.
@@ -104,136 +106,29 @@ const TEMPLATES = {
   • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
 };
 
-const RECENT_PAST = new Date(Date.now() - 60_000).toISOString();
+const ALL_BUCKETS: WakeBriefTemporalBucket[] = [
+  'reconnect', 'recent', 'same_day', 'today',
+  'yesterday', 'week', 'long', 'first',
+];
 
-type BucketName = 'reconnect' | 'recent' | 'same_day' | 'today' | 'yesterday' | 'week' | 'long' | 'first';
-
-// Map each bucket to a lastSessionInfo timestamp that classifies into that
-// bucket via describeTimeSince().
-function timestampFor(bucket: BucketName): string {
-  const now = Date.now();
-  switch (bucket) {
-    case 'reconnect': return new Date(now - 30000).toISOString();           // < 120s
-    case 'recent':    return new Date(now - 5 * 60000).toISOString();        // 2-15 min
-    case 'same_day':  return new Date(now - 2 * 3600000).toISOString();      // 15 min - 8 h
-    case 'today':     return new Date(now - 10 * 3600000).toISOString();     // 8-24 h
-    case 'yesterday': return new Date(now - 25 * 3600000).toISOString();     // ~1 day
-    case 'week':      return new Date(now - 3 * 86400000).toISOString();    // 2-7 days
-    case 'long':      return new Date(now - 14 * 86400000).toISOString();   // > 7 days
-    case 'first':     return '';                                              // empty → 'first'
-  }
-}
-
-function withResolverFromTable(): void {
-  configurePolicyResolverForTests({
-    decisionPolicy: [
-      {
-        policy_key: POLICY_KEYS.SESSION_RECENCY_RECONNECT_MAX_SECONDS,
-        tenant_id: null, version: 1, value_json: 120,
-        effective_from: RECENT_PAST, effective_until: null,
-      },
-      {
-        policy_key: POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
-        tenant_id: null, version: 1, value_json: 15,
-        effective_from: RECENT_PAST, effective_until: null,
-      },
-      {
-        policy_key: POLICY_KEYS.SESSION_RECENCY_SAME_DAY_MAX_HOURS,
-        tenant_id: null, version: 1, value_json: 8,
-        effective_from: RECENT_PAST, effective_until: null,
-      },
-      {
-        policy_key: POLICY_KEYS.SESSION_RECENCY_TODAY_MAX_HOURS,
-        tenant_id: null, version: 1, value_json: 24,
-        effective_from: RECENT_PAST, effective_until: null,
-      },
-      {
-        policy_key: POLICY_KEYS.SESSION_RECENCY_WEEK_MAX_DAYS,
-        tenant_id: null, version: 1, value_json: 7,
-        effective_from: RECENT_PAST, effective_until: null,
-      },
-    ],
-    policyRenderBlock: [
-      ['reconnect', RENDER_BLOCK_KEYS.GREETING_BUCKET_RECONNECT],
-      ['recent', RENDER_BLOCK_KEYS.GREETING_BUCKET_RECENT],
-      ['same_day', RENDER_BLOCK_KEYS.GREETING_BUCKET_SAME_DAY],
-      ['today', RENDER_BLOCK_KEYS.GREETING_BUCKET_TODAY],
-      ['yesterday', RENDER_BLOCK_KEYS.GREETING_BUCKET_YESTERDAY],
-      ['week', RENDER_BLOCK_KEYS.GREETING_BUCKET_WEEK],
-      ['long', RENDER_BLOCK_KEYS.GREETING_BUCKET_LONG],
-      ['first', RENDER_BLOCK_KEYS.GREETING_BUCKET_FIRST],
-    ].map(([bucket, blockKey]) => ({
-      block_key: blockKey,
-      language: 'en',
-      tenant_id: null,
-      version: 1,
-      content: TEMPLATES[bucket as keyof typeof TEMPLATES],
-      effective_from: RECENT_PAST,
-      effective_until: null,
-    })),
+describe('R2: voice-wake-brief owns the temporal fallback pools (byte-identical to legacy)', () => {
+  it('exposes one template per temporal bucket', () => {
+    for (const bucket of ALL_BUCKETS) {
+      expect(WAKE_BRIEF_BUCKET_TEMPLATES[bucket]).toBe(TEMPLATES[bucket]);
+    }
   });
-}
 
-function callBuilder(timestamp: string): string {
-  return buildLiveSystemInstruction(
-    'en',                       // lang
-    'verbose',                  // voiceStyle
-    undefined,                  // bootstrapContext (no wake-brief override marker)
-    'community',                // activeRole
-    undefined,                  // conversationSummary
-    undefined,                  // conversationHistory
-    false,                      // isReconnect
-    timestamp ? { time: timestamp, wasFailure: false } : null,
-    null,                       // currentRoute
-    null,                       // recentRoutes
-    { timeOfDay: 'evening' } as any, // clientContext — carries timeOfDay
-    null,                       // vitanaId
-    false,                      // omitGreetingPolicy
-  );
-}
-
-beforeEach(() => {
-  __resetPolicyResolverForTests();
-});
-
-afterAll(() => {
-  __resetPolicyResolverForTests();
-});
-
-describe('VTID-03118 — resolver-backed greeting block parity', () => {
-  const buckets: BucketName[] = [
-    'reconnect', 'recent', 'same_day', 'today',
-    'yesterday', 'week', 'long', 'first',
-  ];
-
-  for (const bucket of buckets) {
-    it(`bucket="${bucket}" produces byte-identical output via defaults vs resolver`, () => {
-      const ts = timestampFor(bucket);
-
-      // Path 1: cache empty → defaults.
-      __resetPolicyResolverForTests();
-      const fromDefaults = callBuilder(ts);
-
-      // Path 2: cache primed with the same templates the seed migration loaded.
-      withResolverFromTable();
-      const fromResolver = callBuilder(ts);
-
-      expect(fromResolver).toBe(fromDefaults);
-    });
-  }
-
-  it('today bucket output contains the expected verbatim line for greetingTimeOfDay="evening"', () => {
-    const out = callBuilder(timestampFor('today'));
+  it('today bucket substitutes greetingTimeOfDay verbatim', () => {
+    const out = renderWakeBriefFallbackBlock('today', 'en', 'evening');
     expect(out).toContain(
       '  • ALWAYS open with "Good evening, [Name]." using the user\'s name from memory context.',
     );
     expect(out).toContain('  • If no name is available in memory, just say "Good evening."');
-    // Sanity: the placeholder must NOT survive into the rendered prompt.
     expect(out).not.toContain('{{greeting_time_of_day}}');
   });
 
-  it('reconnect bucket output contains the "do not speak" guardrail verbatim', () => {
-    const out = callBuilder(timestampFor('reconnect'));
+  it('reconnect bucket renders the "do not speak" guardrail verbatim', () => {
+    const out = renderWakeBriefFallbackBlock('reconnect', 'en', 'evening');
     expect(out).toContain(
       '- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).',
     );
@@ -241,27 +136,33 @@ describe('VTID-03118 — resolver-backed greeting block parity', () => {
   });
 
   it('recent bucket expands the short-gap phrase menu (non-wake-brief path)', () => {
-    const out = callBuilder(timestampFor('recent'));
+    const out = renderWakeBriefFallbackBlock('recent', 'en', 'evening');
     expect(out).toContain('  • Pick ONE of these example phrasings (use them VERBATIM');
     expect(out).toContain(
       '  • Rotate across sessions — the user notices repetition. If the previous session used one of these, pick a different one.',
     );
     expect(out).toContain('  • Max ONE short phrase. Warm but direct.');
-    // Placeholder must be fully substituted.
     expect(out).not.toContain('{{short_gap_phrase_menu}}');
   });
 
-  it('describeTimeSince still classifies via the resolver-supplied thresholds', () => {
-    // Prime the cache with the same constants the pre-PR literals used and
-    // verify each timestamp lands in the expected bucket via output markers.
-    withResolverFromTable();
-    expect(callBuilder(timestampFor('reconnect'))).toContain('BUCKET = reconnect');
-    expect(callBuilder(timestampFor('recent'))).toContain('BUCKET = recent');
-    expect(callBuilder(timestampFor('same_day'))).toContain('BUCKET = same_day');
-    expect(callBuilder(timestampFor('today'))).toContain('BUCKET = today');
-    expect(callBuilder(timestampFor('yesterday'))).toContain('BUCKET = yesterday');
-    expect(callBuilder(timestampFor('week'))).toContain('BUCKET = week');
-    expect(callBuilder(timestampFor('long'))).toContain('BUCKET = long');
-    expect(callBuilder(timestampFor('first'))).toContain('BUCKET = first');
+  it('wake-brief override suppresses the short-gap phrase list', () => {
+    const out = renderWakeBriefFallbackBlock('recent', 'en', 'evening', true);
+    expect(out).toContain('SHORT-GAP PHRASE LIST SUPPRESSED');
+    expect(out).not.toContain('Pick ONE of these example phrasings');
+  });
+
+  it('expandShortGapPhraseMenu emits the pinned fixed phrases verbatim', () => {
+    const menu = expandShortGapPhraseMenu('en');
+    expect(menu).toContain('"fixed phrase 1"');
+    expect(menu).toContain('"fixed phrase 6"');
+  });
+
+  it('every bucket renders with no surviving placeholder tokens', () => {
+    for (const bucket of ALL_BUCKETS) {
+      const out = renderWakeBriefFallbackBlock(bucket, 'en', 'morning');
+      expect(out).not.toContain('{{greeting_time_of_day}}');
+      expect(out).not.toContain('{{short_gap_phrase_menu}}');
+      expect(out).toContain(`BUCKET = ${bucket}`);
+    }
   });
 });

--- a/services/gateway/test/orb/live/instruction/lean-system-instruction.test.ts
+++ b/services/gateway/test/orb/live/instruction/lean-system-instruction.test.ts
@@ -1,22 +1,27 @@
 /**
- * ORB-CONVERSATION-LATENCY — lean system_instruction experiment (ship-dark).
+ * ORB-CONVERSATION-LATENCY (updated by R2 — BOOTSTRAP-ORB-R2-GREETING-POLICY).
  *
- * FEATURE_LEAN_SYSTEM_INSTRUCTION, when live, drops the ~20-25 KB greeting-policy
- * stack (## GREETING POLICY time-buckets + ## HARD ANTI-PATTERNS) from the Vertex
- * first-connect prompt — the same stack LiveKit already omits in production via
- * omitGreetingPolicy — trading prompt-ingestion time for a faster first token.
- * It ships dark: default off => byte-identical to today, rollback = flip the env
- * var with no redeploy.
+ * History: FEATURE_LEAN_SYSTEM_INSTRUCTION was a ship-dark experiment that
+ * dropped the legacy `## GREETING POLICY` stack from the Vertex first-connect
+ * prompt — the same stack LiveKit already omitted via omitGreetingPolicy.
  *
- * These are behavioural unit tests (buildLiveSystemInstruction is a pure sync
- * function), so they assert the ACTUAL rendered output, not source structure.
- * They lock four invariants the experiment must never violate:
- *   1. Flag OFF: the full greeting stack is present (no silent behaviour change).
- *   2. Flag ON: the greeting stack is dropped but TONE RULES + JOURNEY AWARENESS
- *      (and the identity lock + LANGUAGE rule) survive.
- *   3. Reconnect is NEVER slimmed — the RECONNECT FINAL OVERRIDE (silence on a
- *      transparent resume) is preserved even with the flag on.
- *   4. LiveKit (omitGreetingPolicy=true) is unaffected by the flag.
+ * R2 made that experiment permanent and unconditional: the legacy greeting-
+ * policy stack (## GREETING POLICY time-buckets + ## HARD ANTI-PATTERNS) is
+ * now DELETED from `live-system-instruction.ts` outright. Its temporal
+ * fallback pools moved to the priority-80 voice-wake-brief provider, which
+ * owns the no-provider fallback path in the Central Continuation Contract.
+ *
+ * Consequence for this file: the flag is now a no-op and both transports
+ * behave identically. These behavioural unit tests (buildLiveSystemInstruction
+ * is a pure sync function) now lock the R2 invariants:
+ *   1. The legacy greeting-policy stack is ABSENT in every state — flag on/off,
+ *      Vertex or LiveKit, first-connect or reconnect.
+ *   2. The lean stack (TONE RULES + JOURNEY AWARENESS) plus the behaviour-
+ *      critical IDENTITY LOCK + LANGUAGE rule always survive.
+ *   3. Reconnect silence is preserved upstream by the top-level GREETING RULES
+ *      (VTID-02637 RECONNECT SILENCE RULE), not by the deleted block.
+ *   4. Vertex and LiveKit render identical output (the soft transport conflict
+ *      is gone), and the lean flag no longer changes the prompt.
  */
 
 import { buildLiveSystemInstruction } from '../../../../src/orb/live/instruction/live-system-instruction';
@@ -25,7 +30,7 @@ const H_GREETING = '## GREETING POLICY';
 const H_ANTIPATTERN = '## HARD ANTI-PATTERNS';
 const H_TONE = '## TONE RULES';
 const H_JOURNEY = '## JOURNEY AWARENESS';
-const H_RECONNECT = '## RECONNECT FINAL OVERRIDE';
+const RECONNECT_SILENCE_RULE = 'VTID-02637 RECONNECT SILENCE RULE';
 const IDENTITY_LOCK = '=== IDENTITY LOCK ===';
 const LANGUAGE_RULE = 'LANGUAGE: Respond ONLY in';
 
@@ -53,7 +58,7 @@ function liveKitConnect(): string {
   );
 }
 
-describe('ORB-CONVERSATION-LATENCY: lean system_instruction flag', () => {
+describe('R2: legacy greeting-policy stack deleted; lean flag is a no-op', () => {
   let prev: string | undefined;
   beforeEach(() => { prev = process.env[FLAG]; });
   afterEach(() => {
@@ -61,67 +66,73 @@ describe('ORB-CONVERSATION-LATENCY: lean system_instruction flag', () => {
     else process.env[FLAG] = prev;
   });
 
-  describe('flag OFF (default — production behaviour today)', () => {
+  describe('flag OFF (default — production behaviour)', () => {
     beforeEach(() => { delete process.env[FLAG]; });
 
-    it('Vertex first-connect renders the FULL greeting-policy stack', () => {
-      const out = vertexFirstConnect();
-      expect(out).toContain(H_GREETING);
-      expect(out).toContain(H_ANTIPATTERN);
-      expect(out).toContain(H_TONE);
-    });
-  });
-
-  describe('flag ON (staging+prod)', () => {
-    beforeEach(() => { process.env[FLAG] = 'staging+prod'; });
-
-    it('Vertex first-connect DROPS the greeting-policy stack', () => {
+    it('Vertex first-connect NO LONGER renders the legacy greeting-policy stack', () => {
       const out = vertexFirstConnect();
       expect(out).not.toContain(H_GREETING);
       expect(out).not.toContain(H_ANTIPATTERN);
-    });
-
-    it('still keeps TONE RULES + JOURNEY AWARENESS (the lean greeting guidance)', () => {
-      const out = vertexFirstConnect();
+      // The lean stack survives.
       expect(out).toContain(H_TONE);
       expect(out).toContain(H_JOURNEY);
     });
 
-    it('still keeps the behaviour-critical IDENTITY LOCK + LANGUAGE rule', () => {
+    it('keeps the behaviour-critical IDENTITY LOCK + LANGUAGE rule', () => {
       const out = vertexFirstConnect();
       expect(out).toContain(IDENTITY_LOCK);
       expect(out).toContain(LANGUAGE_RULE);
     });
+  });
 
-    it('produces a strictly shorter prompt than flag-off (the latency win)', () => {
-      const lean = vertexFirstConnect();
-      delete process.env[FLAG];
-      const full = vertexFirstConnect();
-      expect(lean.length).toBeLessThan(full.length);
+  describe('flag ON (staging+prod) — now a no-op', () => {
+    beforeEach(() => { process.env[FLAG] = 'staging+prod'; });
+
+    it('Vertex first-connect still omits the legacy stack', () => {
+      const out = vertexFirstConnect();
+      expect(out).not.toContain(H_GREETING);
+      expect(out).not.toContain(H_ANTIPATTERN);
+      expect(out).toContain(H_TONE);
+      expect(out).toContain(H_JOURNEY);
     });
 
-    it('NEVER slims a reconnect — RECONNECT FINAL OVERRIDE is preserved', () => {
+    it('produces a prompt byte-identical to flag-off (the flag is dead)', () => {
+      const lean = vertexFirstConnect();
+      delete process.env[FLAG];
+      const off = vertexFirstConnect();
+      expect(lean).toEqual(off);
+    });
+
+    it('reconnect silence is preserved upstream by the top-level GREETING RULES', () => {
       const out = vertexReconnect();
-      expect(out).toContain(H_RECONNECT);
-      // The reconnect path keeps the full temporal stack, so the greeting
-      // section header is still present on reconnect even with the flag on.
-      expect(out).toContain(H_GREETING);
+      // The deleted RECONNECT FINAL OVERRIDE is no longer needed: reconnect
+      // silence is enforced by the top-level GREETING RULES (and by
+      // decideGreetingPolicy() returning 'skip' on reconnect).
+      expect(out).toContain(RECONNECT_SILENCE_RULE);
+      expect(out).not.toContain(H_GREETING);
     });
   });
 
-  describe('LiveKit (omitGreetingPolicy=true) is independent of the flag', () => {
-    it('omits the greeting stack with the flag OFF (unchanged behaviour)', () => {
+  describe('Vertex and LiveKit are now identical (omitGreetingPolicy is dead)', () => {
+    it('both omit the legacy stack and keep the lean stack (flag OFF)', () => {
       delete process.env[FLAG];
-      const out = liveKitConnect();
-      expect(out).not.toContain(H_GREETING);
-      expect(out).toContain(H_TONE);
+      const vertex = vertexFirstConnect();
+      const livekit = liveKitConnect();
+      expect(vertex).not.toContain(H_GREETING);
+      expect(livekit).not.toContain(H_GREETING);
+      expect(vertex).toContain(H_TONE);
+      expect(livekit).toContain(H_TONE);
+      // Block removal makes both transports render byte-identical output.
+      expect(vertex).toEqual(livekit);
     });
 
-    it('still omits the greeting stack with the flag ON (no regression)', () => {
+    it('still identical with the flag ON (no regression)', () => {
       process.env[FLAG] = 'staging+prod';
-      const out = liveKitConnect();
-      expect(out).not.toContain(H_GREETING);
-      expect(out).toContain(H_TONE);
+      const vertex = vertexFirstConnect();
+      const livekit = liveKitConnect();
+      expect(vertex).not.toContain(H_GREETING);
+      expect(livekit).not.toContain(H_GREETING);
+      expect(vertex).toEqual(livekit);
     });
   });
 });


### PR DESCRIPTION
## Phase R2 — Delete the legacy greeting-policy dead code

Phase R2 of the ORB R0–R9 reconciliation (`docs/superpowers/plans/2026-05-30-vitana-assistant-original-plan-reconciliation.md`). Audit §G flagged the `## GREETING POLICY` block as a **soft Vertex/LiveKit conflict**: Vertex rendered it under the override while LiveKit omitted it (`omitGreetingPolicy=true`). In production the Central Continuation Contract (voice-wake-brief / teacher / new-day) already owns the first spoken line, so the block was dead text the override always superseded.

### What was removed
From `services/gateway/src/orb/live/instruction/live-system-instruction.ts`:
- The entire legacy `## GREETING POLICY — TIME AND JOURNEY AWARE` stack + `## HARD ANTI-PATTERNS` block from `buildTemporalJourneyContextSection`.
- The supporting dead constants/helpers: `BUCKET_DEFAULT_TEMPLATES`, `BUCKET_TO_BLOCK_KEY`, `expandShortGapPhraseMenu`, plus the policy-resolver `getRenderBlock` call and the now-unused `RENDER_BLOCK_KEYS` / `pickShortGapGreetings` / `isFeatureLive` imports.
- The dead `FEATURE_LEAN_SYSTEM_INSTRUCTION` lean-flag plumbing (`leanGreetingActive` / `effectiveOmitGreetingPolicy`).

Net: **~320 lines reduced** in that file (559 deletions / 323 insertions across the PR). Both transports now render the identical lean `## TONE RULES` + `## JOURNEY AWARENESS` stack.

### Where the pools moved
Into the priority-80 pure-fallback producer `services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts`:
- `WAKE_BRIEF_BUCKET_TEMPLATES` — the 8-bucket structural templates (byte-identical to the old `BUCKET_DEFAULT_TEMPLATES`).
- `expandShortGapPhraseMenu()` + `renderWakeBriefFallbackBlock()` — the token-substitution + short-gap menu rendering.
- The actual per-language greeting **strings** stay in `orb/instruction/greeting-pools.ts` (`SHORT_GAP_GREETING_PHRASES`, via `pickShortGapGreetings`) — no greeting string or language was dropped.

### omitGreetingPolicy plumbing
With the block gone, `omitGreetingPolicy` and the lean flag are inert — both `true`/`false` produce identical output. Parameters are kept on the signature for caller compatibility (callers in `orb-live.ts` / `orb-livekit.ts` are out of this lane's scope), but the lean computation + `isFeatureLive` import were removed. Reconnect silence is still enforced upstream by the top-level `GREETING RULES` (`VTID-02637 RECONNECT SILENCE RULE`) and by `decideGreetingPolicy()` returning `'skip'` on reconnect — verified the reconnect persona still carries the silence rule and no longer needs the deleted `RECONNECT FINAL OVERRIDE`.

### Characterization — no-diff evidence
- The 3 `system-instruction.characterization` persona snapshots are the **no-provider fallback path** (no `<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>` sentinel). Their **only** diff is removal of the legacy block — the single intended fallback-path diff per the plan. Snapshots regenerated; reviewed line-by-line to confirm nothing else changed.
- The provider-wins path (sessions where a continuation provider returns a candidate) is unchanged — the block was already unreachable/superseded there.
- Retargeted two tests to the new owner / new invariants:
  - `greeting-block-resolver.test.ts` (VTID-03118): now locks the verbatim bucket content + token substitution against `voice-wake-brief`'s moved pools.
  - `lean-system-instruction.test.ts`: now asserts the legacy stack is absent in all states, the lean flag is a no-op, and **Vertex output === LiveKit output**.

### Vertex parity ✓ / LiveKit parity ✓
Block removal makes both transports render byte-identical instruction bodies (asserted in `lean-system-instruction.test.ts`).

### Tests
- `cd services/gateway && npm run build` → green (exit 0).
- `npx jest` touched + characterization: **65 suites / 944 passed** (test/orb), incl. lean + greeting-block-resolver + voice-wake-brief + the regenerated characterization snapshots.

No merge / deploy / prod-write performed.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_