### PR TITLE
ci(finetune): operator-configurable accelerator/machine/region for Vertex custom-job (BOOTSTRAP-FT-QUOTA-FALLBACK)

### DIFF
--- a/.github/workflows/CRON-FINETUNE-TRAINER.yml
+++ b/.github/workflows/CRON-FINETUNE-TRAINER.yml
@@ -35,6 +35,35 @@ on:
         required: false
         default: ''
         type: string
+      # BOOTSTRAP-FT-QUOTA-FALLBACK: accelerator/machine/region overrides.
+      # The default L4 in us-central1 has been stuck JOB_STATE_PENDING because of L4
+      # GPU quota pressure — the queued run never STARTS (and Google credits only
+      # begin once it starts). These inputs let an operator re-submit to capacity
+      # that has quota WITHOUT editing code. Leave blank to keep config.yaml defaults
+      # (NVIDIA_L4 / g2-standard-8 / us-central1).
+      #
+      # Known-good fallback combos (pick accelerator + matching machine + region):
+      #   * A100 in us-central1:  accelerator=NVIDIA_TESLA_A100  machine=a2-highgpu-1g
+      #   * L4 in us-east1:       accelerator=NVIDIA_L4          machine=g2-standard-8  region=us-east1
+      #   * L4 in europe-west4:   accelerator=NVIDIA_L4          machine=g2-standard-8  region=europe-west4
+      # COST NOTE: A100 costs materially MORE per GPU-hour than L4. Prefer moving the
+      # SAME L4 to a region with quota first; only escalate to A100 if no L4 region has
+      # capacity. This is opt-in and never the default — choose consciously.
+      accelerator_type_override:
+        description: 'Override accelerator (blank=NVIDIA_L4 default; A100=NVIDIA_TESLA_A100, pricier)'
+        required: false
+        default: ''
+        type: string
+      machine_type_override:
+        description: 'Override machine type (blank=g2-standard-8 default; A100 needs a2-highgpu-1g)'
+        required: false
+        default: ''
+        type: string
+      region_override:
+        description: 'Override region (blank=us-central1 default; e.g. us-east1 / europe-west4 for L4 quota)'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -89,4 +118,8 @@ jobs:
         env:
           FINETUNE_DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
           FINETUNE_BASE_MODEL_OVERRIDE: ${{ inputs.base_model_override || (inputs.synthetic_bootstrap == 'true' && matrix.target == 'voice-tool-router' && 'Qwen/Qwen2.5-0.5B-Instruct') || '' }}
+          # BOOTSTRAP-FT-QUOTA-FALLBACK: blank => submit-job.ts keeps config.yaml defaults.
+          FINETUNE_ACCELERATOR_TYPE: ${{ inputs.accelerator_type_override || '' }}
+          FINETUNE_MACHINE_TYPE: ${{ inputs.machine_type_override || '' }}
+          FINETUNE_REGION: ${{ inputs.region_override || '' }}
         run: npx tsx scripts/finetune/submit-job.ts ${{ matrix.target }}

--- a/services/gateway/scripts/finetune/submit-job.ts
+++ b/services/gateway/scripts/finetune/submit-job.ts
@@ -12,6 +12,15 @@
  *   GCP_PROJECT (default lovable-vitana-vers1)
  *   GCP_REGION  (default us-central1)
  *   FINETUNE_DRY_RUN=1 — print the gcloud command without invoking
+ *
+ *   Quota / accelerator fallback (BOOTSTRAP-FT-QUOTA-FALLBACK) — all optional,
+ *   default to the values in the target config.yaml when unset/empty:
+ *   FINETUNE_ACCELERATOR_TYPE — e.g. NVIDIA_TESLA_A100 (default: config, NVIDIA_L4)
+ *   FINETUNE_MACHINE_TYPE     — e.g. a2-highgpu-1g     (default: config, g2-standard-8)
+ *   FINETUNE_REGION           — e.g. us-east1          (default: config, us-central1)
+ *   These let an operator re-submit to an accelerator+region that currently has
+ *   quota when L4/us-central1 is stuck JOB_STATE_PENDING — WITHOUT editing code.
+ *   NOTE: A100 costs materially more per GPU-hour than L4. Choose consciously.
  */
 
 import { execSync } from 'child_process';
@@ -30,6 +39,12 @@ import {
 const TARGET = process.argv[2];
 const DRY_RUN = process.env.FINETUNE_DRY_RUN === '1';
 const BASE_MODEL_OVERRIDE = process.env.FINETUNE_BASE_MODEL_OVERRIDE;
+// BOOTSTRAP-FT-QUOTA-FALLBACK: optional accelerator/machine/region overrides so an
+// operator can re-submit to capacity that has quota when the default (L4/us-central1)
+// is stuck JOB_STATE_PENDING. Empty/unset => keep the config.yaml default.
+const ACCELERATOR_TYPE_OVERRIDE = (process.env.FINETUNE_ACCELERATOR_TYPE || '').trim();
+const MACHINE_TYPE_OVERRIDE = (process.env.FINETUNE_MACHINE_TYPE || '').trim();
+const REGION_OVERRIDE = (process.env.FINETUNE_REGION || '').trim();
 const VALID_TARGETS = new Set(['voice-tool-router', 'intent-kind', 'pillar-classifier']);
 
 if (!TARGET || !VALID_TARGETS.has(TARGET)) {
@@ -50,6 +65,21 @@ async function main(): Promise<void> {
   if (BASE_MODEL_OVERRIDE) {
     console.log(`[submit-job] overriding base_model ${cfg.base_model} -> ${BASE_MODEL_OVERRIDE}`);
     cfg.base_model = BASE_MODEL_OVERRIDE;
+  }
+
+  // BOOTSTRAP-FT-QUOTA-FALLBACK: apply opt-in accelerator/machine/region overrides.
+  // Defaults are unchanged (L4 / g2-standard-8 / us-central1) — only env-set values move.
+  if (REGION_OVERRIDE) {
+    console.log(`[submit-job] overriding region ${cfg.vertex_custom_job.region} -> ${REGION_OVERRIDE}`);
+    cfg.vertex_custom_job.region = REGION_OVERRIDE;
+  }
+  if (ACCELERATOR_TYPE_OVERRIDE) {
+    console.log(`[submit-job] overriding accelerator_type ${cfg.vertex_custom_job.worker_pool.accelerator_type} -> ${ACCELERATOR_TYPE_OVERRIDE}`);
+    cfg.vertex_custom_job.worker_pool.accelerator_type = ACCELERATOR_TYPE_OVERRIDE;
+  }
+  if (MACHINE_TYPE_OVERRIDE) {
+    console.log(`[submit-job] overriding machine_type ${cfg.vertex_custom_job.worker_pool.machine_type} -> ${MACHINE_TYPE_OVERRIDE}`);
+    cfg.vertex_custom_job.worker_pool.machine_type = MACHINE_TYPE_OVERRIDE;
   }
 
   const runId = `${cfg.vertex_custom_job.display_name_prefix}-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}-${randomUUID().slice(0, 8)}`;
@@ -74,6 +104,14 @@ async function main(): Promise<void> {
   console.log(`[submit-job] output_uri: ${outputUri}`);
   console.log(`[submit-job] trainer_package: ${trainerPackageUri}`);
   console.log(`[submit-job] config file: ${tmpConfigPath}`);
+  // BOOTSTRAP-FT-QUOTA-FALLBACK: print the resolved worker-pool-spec so the operator
+  // can confirm accelerator/machine/region (and quota target) BEFORE the job is created.
+  const wp = cfg.vertex_custom_job.worker_pool;
+  console.log(
+    `[submit-job] resolved worker-pool-spec: region=${cfg.vertex_custom_job.region} ` +
+    `accelerator=${wp.accelerator_type} x${wp.accelerator_count} ` +
+    `machine=${wp.machine_type} replicas=${wp.replica_count}`,
+  );
   console.log(`[submit-job] command: gcloud ${args.join(' ')}`);
 
   assertBaseModelSubmitSafe(cfg);


### PR DESCRIPTION
## Problem

The `voice-tool-router` Vertex AI CustomJob has been stuck `JOB_STATE_PENDING` because of **L4 GPU quota pressure in `us-central1`**. Submission itself works (IAM is granted), but the queued/next training run never actually **STARTS** — and Google credits only begin once a job starts. Today the accelerator (`NVIDIA_L4`), machine type (`g2-standard-8`), and region (`us-central1`) are hardcoded in `scripts/finetune/voice-tool-router/config.yaml`, so re-targeting capacity that has quota required a code edit.

## What's now configurable

`CRON-FINETUNE-TRAINER.yml` gains three optional `workflow_dispatch` inputs, threaded through to `submit-job.ts` as env overrides that are applied on top of `config.yaml` before the worker-pool-spec is built:

| Input | Env var | Blank default |
|-------|---------|---------------|
| `accelerator_type_override` | `FINETUNE_ACCELERATOR_TYPE` | `NVIDIA_L4` |
| `machine_type_override` | `FINETUNE_MACHINE_TYPE` | `g2-standard-8` |
| `region_override` | `FINETUNE_REGION` | `us-central1` |

An operator can now re-submit to capacity that has quota (e.g. A100 in `us-central1`, or L4 in `us-east1`/`europe-west4`) **without editing code**. Blank inputs keep the config.yaml defaults.

`submit-job.ts` also logs a **resolved worker-pool-spec** line before submission (works in dry-run too), so the operator can confirm exactly what will run:

```
[submit-job] resolved worker-pool-spec: region=us-central1 accelerator=NVIDIA_TESLA_A100 x1 machine=a2-highgpu-1g replicas=1
```

Documented known-good fallback combos in the workflow:
- **A100 in us-central1**: accelerator `NVIDIA_TESLA_A100` + machine `a2-highgpu-1g`
- **L4 in us-east1**: accelerator `NVIDIA_L4` + machine `g2-standard-8` + region `us-east1`
- **L4 in europe-west4**: same, region `europe-west4`

## Cost note

**A100 costs materially MORE per GPU-hour than L4.** The workflow comment directs the operator to prefer moving the *same L4* to a region with quota first, and only escalate to A100 if no L4 region has capacity. This is opt-in and **never the default** — choose consciously.

## Defaults unchanged

L4 / `g2-standard-8` / `us-central1` remain the defaults for both the weekly cron and a no-input manual dispatch. Verified via dry-run: with no overrides the resolved spec is `accelerator=NVIDIA_L4 machine=g2-standard-8 region=us-central1` and no override log lines appear.

## Verification

- Dry-run with A100 overrides → applies and logs the new spec.
- Dry-run with no overrides → keeps L4/us-central1.
- No job submitted, no workflow run, no deploy — code/config change only. Draft PR.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_