### PR TITLE
feat(datasets): read-only PREVIEW mode for dataset extraction (BOOTSTRAP-DATASET-READINESS)

### DIFF
--- a/.github/workflows/CRON-DATASET-EXTRACTION.yml
+++ b/.github/workflows/CRON-DATASET-EXTRACTION.yml
@@ -14,7 +14,16 @@ name: Cron Dataset Extraction
 # roles/storage.objectCreator on gs://vitana-artifacts-staging/ (existing
 # Phase 0 grant).
 #
-# Manual run: workflow_dispatch with optional dry_run + max_rows inputs.
+# Manual run: workflow_dispatch with optional preview + dry_run + max_rows inputs.
+#
+# Phase 1 W2 readiness (BOOTSTRAP-DATASET-READINESS): the `preview` input
+# (default true on manual runs) runs the SAME consent-gated query + the SAME
+# row projection but COUNTS + SAMPLES the projected rows instead of writing the
+# dataset. It lets an operator confirm "X rows would extract" before AND
+# immediately after flipping prod tenant consent
+# (tenant_settings.feature_flags.data_export_ok) — without writing any data and
+# without needing consent first. Preview only applies to manual (workflow_dispatch)
+# runs; the scheduled cron always runs the real extraction unchanged.
 
 on:
   schedule:
@@ -23,8 +32,14 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
+      preview:
+        description: 'PREVIEW only — count + sample projected rows, write NOTHING (no JSONL/GCS/events). Default true.'
+        required: false
+        default: 'true'
+        type: choice
+        options: [ 'true', 'false' ]
       dry_run:
-        description: 'Skip GCS upload + event emit (for testing)'
+        description: 'Skip GCS upload + event emit (still writes local JSONL). Ignored when preview=true.'
         required: false
         default: 'false'
         type: choice
@@ -94,6 +109,10 @@ jobs:
         working-directory: services/gateway
         env:
           DATASET_GCS_BUCKET: ${{ env.GCS_BUCKET }}
+          # Preview is a manual-only, read-only readiness check. On the scheduled
+          # cron `github.event_name` is 'schedule' so DATASET_PREVIEW is forced to
+          # '0' — the real extraction path is never altered by this input.
+          DATASET_PREVIEW: ${{ github.event_name == 'workflow_dispatch' && inputs.preview == 'true' && '1' || '0' }}
           DATASET_DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
           DATASET_MAX_ROWS: ${{ inputs.max_rows || '50000' }}
           DATASET_DAYS_BACK: ${{ inputs.days_back || '30' }}

--- a/services/gateway/.env.template
+++ b/services/gateway/.env.template
@@ -69,3 +69,14 @@ AUTOPILOT_RETRY_CONFIDENCE_THRESHOLD=0.3
 AUTOPILOT_RETRY_CONFIDENCE_CI=0.25
 AUTOPILOT_RETRY_CONFIDENCE_DEPLOY=0.35
 AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION=0.5
+
+# Dataset extraction — PREVIEW mode (scripts/datasets/*, CRON-DATASET-EXTRACTION).
+# These ONLY affect the read-only readiness preview; they do NOT influence the
+# real extractor (which is governed by DATASET_DRY_RUN / DATASET_MAX_ROWS /
+# DATASET_DAYS_BACK in the cron workflow). All optional — code falls back to the
+# defaults below if unset, so they are intentionally unbound in deploy config.
+#
+#   DATASET_PREVIEW           unset  set to '1' to run the read-only preview (writes nothing)
+#   DATASET_PREVIEW_SAMPLES   5      how many sample rows the preview surfaces (preview only)
+# DATASET_PREVIEW=1
+# DATASET_PREVIEW_SAMPLES=5

--- a/services/gateway/scripts/datasets/intent-kind.ts
+++ b/services/gateway/scripts/datasets/intent-kind.ts
@@ -9,20 +9,30 @@
  * metadata.intent_kind).
  *
  * Run: `npx tsx services/gateway/scripts/datasets/intent-kind.ts`
+ * Env: optional DATASET_PREVIEW=1 to count + sample projected rows WITHOUT
+ *      writing any dataset (Phase 1 W2 readiness — BOOTSTRAP-DATASET-READINESS).
  */
 
 import {
+  PREVIEW_MODE,
   dedupeBySourceId,
   defaultSinceIso,
   emitExtractionEvent,
   generateRunId,
   queryOasisEvents,
+  summarizePreview,
   uploadToGcs,
   writeJsonl,
 } from './lib';
-import type { DatasetExtractionRun, DatasetRow } from './types';
+import type {
+  DatasetExtractionPreview,
+  DatasetExtractionRun,
+  DatasetRow,
+  OasisEventRow,
+} from './types';
 
 const TARGET = 'intent-kind' as const;
+const SOURCE_QUERY = 'topic=eq.autopilot.intent.created';
 const DAYS_BACK = Number(process.env.DATASET_DAYS_BACK || 30);
 const LIMIT = Number(process.env.DATASET_MAX_ROWS || 50_000);
 const DRY_RUN = process.env.DATASET_DRY_RUN === '1';
@@ -44,21 +54,11 @@ interface IntentMetadata {
   [k: string]: unknown;
 }
 
-async function extract(): Promise<DatasetExtractionRun> {
-  const startedAt = new Date().toISOString();
-  const runId = generateRunId(TARGET);
-  const since = defaultSinceIso(DAYS_BACK);
-
-  console.log(`[${TARGET}] querying oasis_events since ${since} (limit=${LIMIT})`);
-
-  const events = await queryOasisEvents(
-    'topic=eq.autopilot.intent.created',
-    since,
-    LIMIT,
-  );
-
-  console.log(`[${TARGET}] fetched ${events.length} candidate events`);
-
+/**
+ * Pure projection: oasis_events rows → dataset rows. Single source of truth so
+ * the preview path counts EXACTLY what the real extractor would write.
+ */
+export function projectRows(events: OasisEventRow[]): DatasetRow[] {
   const rows: DatasetRow[] = [];
   for (const e of events) {
     const meta = (e.metadata ?? {}) as IntentMetadata;
@@ -76,6 +76,34 @@ async function extract(): Promise<DatasetExtractionRun> {
       },
     });
   }
+  return rows;
+}
+
+/** Read-only preview — same query + same projection, writes nothing, consent gate untouched. */
+async function preview(): Promise<DatasetExtractionPreview> {
+  const since = defaultSinceIso(DAYS_BACK);
+  console.log(`[${TARGET}] PREVIEW querying oasis_events since ${since} (limit=${LIMIT})`);
+  const events = await queryOasisEvents(SOURCE_QUERY, since, LIMIT);
+  console.log(`[${TARGET}] PREVIEW fetched ${events.length} candidate events`);
+  const summary = summarizePreview(TARGET, events, projectRows(events));
+  console.log(`[${TARGET}] PREVIEW would extract ${summary.rows_after_dedup} rows (nothing written)`);
+  return summary;
+}
+
+async function extract(): Promise<DatasetExtractionRun | DatasetExtractionPreview> {
+  if (PREVIEW_MODE) return preview();
+
+  const startedAt = new Date().toISOString();
+  const runId = generateRunId(TARGET);
+  const since = defaultSinceIso(DAYS_BACK);
+
+  console.log(`[${TARGET}] querying oasis_events since ${since} (limit=${LIMIT})`);
+
+  const events = await queryOasisEvents(SOURCE_QUERY, since, LIMIT);
+
+  console.log(`[${TARGET}] fetched ${events.length} candidate events`);
+
+  const rows = projectRows(events);
 
   const deduped = dedupeBySourceId(rows);
   const outputPath = await writeJsonl(deduped, TARGET, runId);

--- a/services/gateway/scripts/datasets/lib.ts
+++ b/services/gateway/scripts/datasets/lib.ts
@@ -173,8 +173,18 @@ export function generateRunId(target: DatasetTarget): string {
  */
 export const PREVIEW_MODE = process.env.DATASET_PREVIEW === '1';
 
-/** How many sample rows the preview surfaces. Kept small — this is a readiness check, not an export. */
-export const PREVIEW_SAMPLE_LIMIT = Number(process.env.DATASET_PREVIEW_SAMPLES || 5);
+/**
+ * How many sample rows the preview surfaces. Kept small — this is a readiness
+ * check, not an export. Defaults to 5 and is intentionally unbound in any
+ * workflow/deploy config: it ONLY affects preview mode, so a missing env var is
+ * the normal case. Parsed defensively — a non-numeric / empty value falls back
+ * to the default rather than producing NaN (which would silently surface 0 rows).
+ */
+const PREVIEW_SAMPLE_DEFAULT = 5;
+export const PREVIEW_SAMPLE_LIMIT = (() => {
+  const parsed = Number.parseInt(process.env.DATASET_PREVIEW_SAMPLES ?? '5', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : PREVIEW_SAMPLE_DEFAULT;
+})();
 
 /**
  * Pull a tenant identifier out of an event's metadata for preview grouping.

--- a/services/gateway/scripts/datasets/lib.ts
+++ b/services/gateway/scripts/datasets/lib.ts
@@ -14,7 +14,13 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';
-import type { DatasetExtractionRun, DatasetRow, DatasetTarget } from './types';
+import type {
+  DatasetExtractionPreview,
+  DatasetExtractionRun,
+  DatasetRow,
+  DatasetTarget,
+  OasisEventRow,
+} from './types';
 
 const PROD_SUPABASE_URL = process.env.SUPABASE_URL;
 const PROD_SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE;
@@ -37,7 +43,7 @@ export async function queryOasisEvents(
   where: string,
   sinceIso: string,
   limit = 50_000,
-): Promise<Array<{ id: string; created_at: string; topic: string; metadata: Record<string, unknown> | null; message: string | null }>> {
+): Promise<OasisEventRow[]> {
   if (!PROD_SUPABASE_URL || !PROD_SUPABASE_KEY) return [];
 
   // PII guards encoded as PostgREST filters (independent query params,
@@ -63,7 +69,7 @@ export async function queryOasisEvents(
   if (!resp.ok) {
     throw new Error(`oasis_events query failed: ${resp.status} ${await resp.text()}`);
   }
-  return (await resp.json()) as Array<{ id: string; created_at: string; topic: string; metadata: Record<string, unknown> | null; message: string | null }>;
+  return (await resp.json()) as OasisEventRow[];
 }
 
 export async function writeJsonl(rows: DatasetRow[], target: DatasetTarget, runId: string): Promise<string> {
@@ -149,4 +155,79 @@ export function defaultSinceIso(daysBack: number): string {
 export function generateRunId(target: DatasetTarget): string {
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
   return `${target}-${ts}`;
+}
+
+/**
+ * PREVIEW / DRY-RUN mode flag — Phase 1 W2 readiness (BOOTSTRAP-DATASET-READINESS).
+ *
+ * When `DATASET_PREVIEW=1` the extractors run the SAME consent-gated query and
+ * the SAME row projection, then COUNT + SAMPLE the projected rows instead of
+ * writing JSONL / uploading to GCS / emitting the completion event. This is a
+ * strict superset of the legacy `DATASET_DRY_RUN=1` behavior (which still wrote
+ * the local JSONL): preview writes NOTHING.
+ *
+ * This does NOT relax the consent gate. The query in `queryOasisEvents` still
+ * carries `metadata->>data_export_ok=eq.true`, so preview over an unconsented
+ * prod correctly reports 0 — and reports a non-zero, correct count the instant
+ * an operator flips consent, with no data written either way.
+ */
+export const PREVIEW_MODE = process.env.DATASET_PREVIEW === '1';
+
+/** How many sample rows the preview surfaces. Kept small — this is a readiness check, not an export. */
+export const PREVIEW_SAMPLE_LIMIT = Number(process.env.DATASET_PREVIEW_SAMPLES || 5);
+
+/**
+ * Pull a tenant identifier out of an event's metadata for preview grouping.
+ * oasis_events has no top-level tenant_id column (it's a global log), so the
+ * tenant — when present — lives in metadata. We check the common keys the
+ * producing surfaces use; falls back to "unknown" so every projected row is
+ * still counted.
+ */
+export function tenantKeyFromEvent(event: OasisEventRow | undefined): string {
+  const meta = event?.metadata;
+  if (!meta || typeof meta !== 'object') return 'unknown';
+  const m = meta as Record<string, unknown>;
+  const candidate =
+    m.tenant_id ?? m.tenantId ?? m.tenant ?? (m.identity as Record<string, unknown> | undefined)?.tenant_id;
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : 'unknown';
+}
+
+/**
+ * Build a read-only preview summary from the query result and the projected
+ * rows. `events` is the raw consent-gated query output (defines rows_total and
+ * carries metadata for tenant grouping); `projected` is what the target's own
+ * projector produced (i.e. exactly the rows that WOULD be written, pre-dedup).
+ *
+ * Writes nothing. Pure function — unit-testable without prod access.
+ */
+export function summarizePreview(
+  target: DatasetTarget,
+  events: OasisEventRow[],
+  projected: DatasetRow[],
+): DatasetExtractionPreview {
+  const eventById = new Map<string, OasisEventRow>();
+  for (const e of events) eventById.set(e.id, e);
+
+  const byTenant: Record<string, number> = {};
+  const bySource: Record<string, number> = {};
+  for (const row of projected) {
+    const event = eventById.get(row.source_id);
+    const tenant = tenantKeyFromEvent(event);
+    const source = event?.topic ?? 'unknown';
+    byTenant[tenant] = (byTenant[tenant] ?? 0) + 1;
+    bySource[source] = (bySource[source] ?? 0) + 1;
+  }
+
+  const deduped = dedupeBySourceId(projected);
+
+  return {
+    target,
+    preview: true,
+    rows_total: events.length,
+    rows_projected: projected.length,
+    rows_after_dedup: deduped.length,
+    by_tenant: byTenant,
+    by_source: bySource,
+    samples: deduped.slice(0, Math.max(0, PREVIEW_SAMPLE_LIMIT)),
+  };
 }

--- a/services/gateway/scripts/datasets/pillar-classification.ts
+++ b/services/gateway/scripts/datasets/pillar-classification.ts
@@ -11,20 +11,30 @@
  * metadata.vitana_pillars array).
  *
  * Run: `npx tsx services/gateway/scripts/datasets/pillar-classification.ts`
+ * Env: optional DATASET_PREVIEW=1 to count + sample projected rows WITHOUT
+ *      writing any dataset (Phase 1 W2 readiness — BOOTSTRAP-DATASET-READINESS).
  */
 
 import {
+  PREVIEW_MODE,
   dedupeBySourceId,
   defaultSinceIso,
   emitExtractionEvent,
   generateRunId,
   queryOasisEvents,
+  summarizePreview,
   uploadToGcs,
   writeJsonl,
 } from './lib';
-import type { DatasetExtractionRun, DatasetRow } from './types';
+import type {
+  DatasetExtractionPreview,
+  DatasetExtractionRun,
+  DatasetRow,
+  OasisEventRow,
+} from './types';
 
 const TARGET = 'pillar-classification' as const;
+const SOURCE_QUERY = 'topic=in.(memory.write.user_message,memory.write.assistant_message)';
 const DAYS_BACK = Number(process.env.DATASET_DAYS_BACK || 30);
 const LIMIT = Number(process.env.DATASET_MAX_ROWS || 50_000);
 const DRY_RUN = process.env.DATASET_DRY_RUN === '1';
@@ -37,21 +47,11 @@ interface PillarMetadata {
   [k: string]: unknown;
 }
 
-async function extract(): Promise<DatasetExtractionRun> {
-  const startedAt = new Date().toISOString();
-  const runId = generateRunId(TARGET);
-  const since = defaultSinceIso(DAYS_BACK);
-
-  console.log(`[${TARGET}] querying oasis_events since ${since} (limit=${LIMIT})`);
-
-  const events = await queryOasisEvents(
-    'topic=in.(memory.write.user_message,memory.write.assistant_message)',
-    since,
-    LIMIT,
-  );
-
-  console.log(`[${TARGET}] fetched ${events.length} candidate events`);
-
+/**
+ * Pure projection: oasis_events rows → dataset rows. Single source of truth so
+ * the preview path counts EXACTLY what the real extractor would write.
+ */
+export function projectRows(events: OasisEventRow[]): DatasetRow[] {
   const rows: DatasetRow[] = [];
   for (const e of events) {
     const meta = (e.metadata ?? {}) as PillarMetadata;
@@ -68,6 +68,34 @@ async function extract(): Promise<DatasetExtractionRun> {
       },
     });
   }
+  return rows;
+}
+
+/** Read-only preview — same query + same projection, writes nothing, consent gate untouched. */
+async function preview(): Promise<DatasetExtractionPreview> {
+  const since = defaultSinceIso(DAYS_BACK);
+  console.log(`[${TARGET}] PREVIEW querying oasis_events since ${since} (limit=${LIMIT})`);
+  const events = await queryOasisEvents(SOURCE_QUERY, since, LIMIT);
+  console.log(`[${TARGET}] PREVIEW fetched ${events.length} candidate events`);
+  const summary = summarizePreview(TARGET, events, projectRows(events));
+  console.log(`[${TARGET}] PREVIEW would extract ${summary.rows_after_dedup} rows (nothing written)`);
+  return summary;
+}
+
+async function extract(): Promise<DatasetExtractionRun | DatasetExtractionPreview> {
+  if (PREVIEW_MODE) return preview();
+
+  const startedAt = new Date().toISOString();
+  const runId = generateRunId(TARGET);
+  const since = defaultSinceIso(DAYS_BACK);
+
+  console.log(`[${TARGET}] querying oasis_events since ${since} (limit=${LIMIT})`);
+
+  const events = await queryOasisEvents(SOURCE_QUERY, since, LIMIT);
+
+  console.log(`[${TARGET}] fetched ${events.length} candidate events`);
+
+  const rows = projectRows(events);
 
   const deduped = dedupeBySourceId(rows);
   const outputPath = await writeJsonl(deduped, TARGET, runId);

--- a/services/gateway/scripts/datasets/run-all.ts
+++ b/services/gateway/scripts/datasets/run-all.ts
@@ -6,22 +6,30 @@
  * doesn't take the others down.
  *
  * Run: `npx tsx services/gateway/scripts/datasets/run-all.ts`
+ * Env: DATASET_PREVIEW=1 → read-only preview (count + sample projected rows
+ *      per target, write NOTHING). Phase 1 W2 readiness check.
  */
 
 import { extract as extractVoiceToolRouting } from './voice-tool-routing';
 import { extract as extractIntentKind } from './intent-kind';
 import { extract as extractPillarClassification } from './pillar-classification';
-import type { DatasetExtractionRun } from './types';
+import type { DatasetExtractionPreview, DatasetExtractionRun } from './types';
+
+const PREVIEW_MODE = process.env.DATASET_PREVIEW === '1';
 
 interface Result {
   target: string;
   ok: boolean;
-  run?: DatasetExtractionRun;
+  run?: DatasetExtractionRun | DatasetExtractionPreview;
   error?: string;
 }
 
 async function main(): Promise<void> {
   const results: Result[] = [];
+
+  if (PREVIEW_MODE) {
+    console.log('=== DATASET PREVIEW (read-only — no JSONL, no GCS, no events) ===');
+  }
 
   for (const [name, fn] of [
     ['voice-tool-routing', extractVoiceToolRouting],
@@ -39,8 +47,16 @@ async function main(): Promise<void> {
     }
   }
 
-  console.log('\n=== summary ===');
+  console.log(`\n=== ${PREVIEW_MODE ? 'preview ' : ''}summary ===`);
   console.log(JSON.stringify(results, null, 2));
+
+  if (PREVIEW_MODE) {
+    const totalProjected = results.reduce((sum, r) => {
+      const run = r.run as DatasetExtractionPreview | undefined;
+      return sum + (run && 'rows_after_dedup' in run ? run.rows_after_dedup : 0);
+    }, 0);
+    console.log(`\n[preview] total rows that WOULD extract across all targets: ${totalProjected}`);
+  }
 
   const allOk = results.every((r) => r.ok);
   process.exit(allOk ? 0 : 1);

--- a/services/gateway/scripts/datasets/types.ts
+++ b/services/gateway/scripts/datasets/types.ts
@@ -36,3 +36,43 @@ export interface DatasetExtractionRun {
   hf_dataset_id?: string;       // huggingface dataset id if pushed
   dry_run: boolean;
 }
+
+/**
+ * Minimal shape of an oasis_events row as returned by the extraction query.
+ * Shared so the preview summarizer and each extractor's row projector agree
+ * on the input shape without re-declaring it.
+ */
+export interface OasisEventRow {
+  id: string;
+  created_at: string;
+  topic: string;
+  metadata: Record<string, unknown> | null;
+  message: string | null;
+}
+
+/**
+ * Read-only PREVIEW of what a real extraction WOULD produce — Phase 1 W2
+ * readiness (BOOTSTRAP-DATASET-READINESS).
+ *
+ * Runs the SAME consent-gated query and the SAME per-target row projection as
+ * the real extractor, but writes nothing (no JSONL, no GCS upload, no event
+ * emit). Lets an operator confirm "X rows would extract" before and
+ * immediately after flipping `tenant_settings.feature_flags.data_export_ok`,
+ * without producing or persisting a dataset.
+ */
+export interface DatasetExtractionPreview {
+  target: DatasetTarget;
+  preview: true;
+  /** Events returned by the consent-gated query (already post-PII-filter). */
+  rows_total: number;
+  /** Rows that pass this target's projection predicate (would land in JSONL, pre-dedup). */
+  rows_projected: number;
+  /** Rows after dedup-by-source-id — the real JSONL row count that would be written. */
+  rows_after_dedup: number;
+  /** Projected-row counts grouped by metadata.tenant_id ("unknown" when absent). */
+  by_tenant: Record<string, number>;
+  /** Projected-row counts grouped by source event topic. */
+  by_source: Record<string, number>;
+  /** Up to N sample projected rows (same shape that would be written to JSONL). */
+  samples: DatasetRow[];
+}

--- a/services/gateway/scripts/datasets/voice-tool-routing.ts
+++ b/services/gateway/scripts/datasets/voice-tool-routing.ts
@@ -11,21 +11,31 @@
  *
  * Run: `npx tsx services/gateway/scripts/datasets/voice-tool-routing.ts`
  * Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE, optional DATASET_GCS_BUCKET,
- *      optional DATASET_DRY_RUN=1 to skip GCS upload + event emit.
+ *      optional DATASET_DRY_RUN=1 to skip GCS upload + event emit,
+ *      optional DATASET_PREVIEW=1 to count + sample projected rows WITHOUT
+ *      writing any dataset (Phase 1 W2 readiness — BOOTSTRAP-DATASET-READINESS).
  */
 
 import {
+  PREVIEW_MODE,
   dedupeBySourceId,
   defaultSinceIso,
   emitExtractionEvent,
   generateRunId,
   queryOasisEvents,
+  summarizePreview,
   uploadToGcs,
   writeJsonl,
 } from './lib';
-import type { DatasetExtractionRun, DatasetRow } from './types';
+import type {
+  DatasetExtractionPreview,
+  DatasetExtractionRun,
+  DatasetRow,
+  OasisEventRow,
+} from './types';
 
 const TARGET = 'voice-tool-routing' as const;
+const SOURCE_QUERY = 'topic=eq.orb.turn.responded';
 const DAYS_BACK = Number(process.env.DATASET_DAYS_BACK || 30);
 const LIMIT = Number(process.env.DATASET_MAX_ROWS || 50_000);
 const DRY_RUN = process.env.DATASET_DRY_RUN === '1';
@@ -40,21 +50,12 @@ interface ToolResponseMetadata {
   [k: string]: unknown;
 }
 
-async function extract(): Promise<DatasetExtractionRun> {
-  const startedAt = new Date().toISOString();
-  const runId = generateRunId(TARGET);
-  const since = defaultSinceIso(DAYS_BACK);
-
-  console.log(`[${TARGET}] querying oasis_events since ${since} (limit=${LIMIT})`);
-
-  const events = await queryOasisEvents(
-    'topic=eq.orb.turn.responded',
-    since,
-    LIMIT,
-  );
-
-  console.log(`[${TARGET}] fetched ${events.length} candidate events`);
-
+/**
+ * Pure projection: oasis_events rows → dataset rows. Single source of truth for
+ * "which events become training rows", so the preview path counts EXACTLY what
+ * the real extractor would write.
+ */
+export function projectRows(events: OasisEventRow[]): DatasetRow[] {
   const rows: DatasetRow[] = [];
   for (const e of events) {
     const meta = (e.metadata ?? {}) as ToolResponseMetadata;
@@ -72,6 +73,37 @@ async function extract(): Promise<DatasetExtractionRun> {
       },
     });
   }
+  return rows;
+}
+
+/**
+ * Read-only preview — same query + same projection, writes nothing.
+ * Does NOT touch the consent gate (still SQL-filtered to data_export_ok=true).
+ */
+async function preview(): Promise<DatasetExtractionPreview> {
+  const since = defaultSinceIso(DAYS_BACK);
+  console.log(`[${TARGET}] PREVIEW querying oasis_events since ${since} (limit=${LIMIT})`);
+  const events = await queryOasisEvents(SOURCE_QUERY, since, LIMIT);
+  console.log(`[${TARGET}] PREVIEW fetched ${events.length} candidate events`);
+  const summary = summarizePreview(TARGET, events, projectRows(events));
+  console.log(`[${TARGET}] PREVIEW would extract ${summary.rows_after_dedup} rows (nothing written)`);
+  return summary;
+}
+
+async function extract(): Promise<DatasetExtractionRun | DatasetExtractionPreview> {
+  if (PREVIEW_MODE) return preview();
+
+  const startedAt = new Date().toISOString();
+  const runId = generateRunId(TARGET);
+  const since = defaultSinceIso(DAYS_BACK);
+
+  console.log(`[${TARGET}] querying oasis_events since ${since} (limit=${LIMIT})`);
+
+  const events = await queryOasisEvents(SOURCE_QUERY, since, LIMIT);
+
+  console.log(`[${TARGET}] fetched ${events.length} candidate events`);
+
+  const rows = projectRows(events);
 
   const deduped = dedupeBySourceId(rows);
   const outputPath = await writeJsonl(deduped, TARGET, runId);

--- a/services/gateway/test/dataset-extraction-preview.test.ts
+++ b/services/gateway/test/dataset-extraction-preview.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Dataset extraction PREVIEW mode — Phase 1 W2 readiness
+ * (BOOTSTRAP-DATASET-READINESS).
+ *
+ * Verifies the read-only preview path: same projection as the real extractor,
+ * counts/groups/samples the projected rows, and writes NOTHING. These are pure
+ * functions, so no prod access or network is involved.
+ */
+
+import { summarizePreview, tenantKeyFromEvent } from '../scripts/datasets/lib';
+import { projectRows as projectVoice } from '../scripts/datasets/voice-tool-routing';
+import { projectRows as projectIntent } from '../scripts/datasets/intent-kind';
+import { projectRows as projectPillar } from '../scripts/datasets/pillar-classification';
+import type { OasisEventRow } from '../scripts/datasets/types';
+
+function ev(partial: Partial<OasisEventRow> & { id: string }): OasisEventRow {
+  return {
+    created_at: '2026-06-01T00:00:00.000Z',
+    topic: 'orb.turn.responded',
+    metadata: null,
+    message: null,
+    ...partial,
+  };
+}
+
+describe('dataset preview — tenantKeyFromEvent', () => {
+  it('reads metadata.tenant_id', () => {
+    expect(tenantKeyFromEvent(ev({ id: '1', metadata: { tenant_id: 'tenant-a' } }))).toBe('tenant-a');
+  });
+  it('reads nested identity.tenant_id', () => {
+    expect(
+      tenantKeyFromEvent(ev({ id: '1', metadata: { identity: { tenant_id: 'tenant-b' } } })),
+    ).toBe('tenant-b');
+  });
+  it('falls back to "unknown" when absent', () => {
+    expect(tenantKeyFromEvent(ev({ id: '1', metadata: { foo: 'bar' } }))).toBe('unknown');
+    expect(tenantKeyFromEvent(ev({ id: '1', metadata: null }))).toBe('unknown');
+    expect(tenantKeyFromEvent(undefined)).toBe('unknown');
+  });
+});
+
+describe('dataset preview — voice-tool-routing projection', () => {
+  const events: OasisEventRow[] = [
+    ev({
+      id: 'v1',
+      topic: 'orb.turn.responded',
+      metadata: { tenant_id: 'tenant-a', transcript: 'play some jazz', tool_name: 'media.play' },
+    }),
+    ev({
+      id: 'v2',
+      topic: 'orb.turn.responded',
+      metadata: { tenant_id: 'tenant-b', input_text: 'set a timer', tool_call: { name: 'timer.set' } },
+    }),
+    // dropped — no tool
+    ev({ id: 'v3', metadata: { tenant_id: 'tenant-a', transcript: 'hello there' } }),
+    // dropped — input too short
+    ev({ id: 'v4', metadata: { transcript: 'a', tool_name: 'x.y' } }),
+  ];
+
+  it('projects only valid (user_input, tool_chosen) rows', () => {
+    const rows = projectVoice(events);
+    expect(rows.map((r) => r.source_id)).toEqual(['v1', 'v2']);
+    expect(rows[0].payload).toMatchObject({ user_input: 'play some jazz', tool_chosen: 'media.play' });
+  });
+
+  it('summarizePreview counts + groups by tenant and source, writes nothing', () => {
+    const projected = projectVoice(events);
+    const summary = summarizePreview('voice-tool-routing', events, projected);
+    expect(summary.preview).toBe(true);
+    expect(summary.rows_total).toBe(4); // raw query result count
+    expect(summary.rows_projected).toBe(2);
+    expect(summary.rows_after_dedup).toBe(2);
+    expect(summary.by_tenant).toEqual({ 'tenant-a': 1, 'tenant-b': 1 });
+    expect(summary.by_source).toEqual({ 'orb.turn.responded': 2 });
+    expect(summary.samples.length).toBe(2);
+  });
+
+  it('dedupes by source_id in the projected count', () => {
+    const dupes = [events[0], events[0], events[1]];
+    const summary = summarizePreview('voice-tool-routing', dupes, projectVoice(dupes));
+    expect(summary.rows_projected).toBe(3);
+    expect(summary.rows_after_dedup).toBe(2);
+  });
+});
+
+describe('dataset preview — intent-kind projection', () => {
+  it('keeps only valid intent kinds', () => {
+    const events: OasisEventRow[] = [
+      ev({
+        id: 'i1',
+        topic: 'autopilot.intent.created',
+        metadata: { tenant_id: 't1', intent_kind: 'task', detected_text: 'remind me to call mom' },
+      }),
+      // dropped — unknown kind
+      ev({
+        id: 'i2',
+        topic: 'autopilot.intent.created',
+        metadata: { intent_kind: 'nonsense', detected_text: 'something' },
+      }),
+    ];
+    const summary = summarizePreview('intent-kind', events, projectIntent(events));
+    expect(summary.rows_after_dedup).toBe(1);
+    expect(summary.by_source).toEqual({ 'autopilot.intent.created': 1 });
+  });
+});
+
+describe('dataset preview — pillar-classification projection', () => {
+  it('requires non-empty pillars and a long-enough text', () => {
+    const events: OasisEventRow[] = [
+      ev({
+        id: 'p1',
+        topic: 'memory.write.user_message',
+        metadata: { tenant_id: 't9', content: 'I have been sleeping much better lately', vitana_pillars: ['health'] },
+      }),
+      // dropped — no pillars
+      ev({ id: 'p2', topic: 'memory.write.assistant_message', metadata: { content: 'a long enough message here', pillars: [] } }),
+    ];
+    const summary = summarizePreview('pillar-classification', events, projectPillar(events));
+    expect(summary.rows_after_dedup).toBe(1);
+    expect(summary.by_tenant).toEqual({ t9: 1 });
+    expect(summary.samples[0].payload).toMatchObject({ pillars: ['health'] });
+  });
+});
+
+describe('dataset preview — empty input (unconsented prod yields 0)', () => {
+  it('reports zeros and empty groupings without throwing', () => {
+    const summary = summarizePreview('voice-tool-routing', [], []);
+    expect(summary).toMatchObject({
+      rows_total: 0,
+      rows_projected: 0,
+      rows_after_dedup: 0,
+      by_tenant: {},
+      by_source: {},
+      samples: [],
+    });
+  });
+});


### PR DESCRIPTION
## Phase 1 W2 — Dataset extraction readiness (preview only)

Per `docs/PHASE-1-W2-ACCEPTANCE.md` §(B): `CRON-DATASET-EXTRACTION.yml` reads PROD `oasis_events` filtered on `metadata->>data_export_ok=eq.true`. No prod tenant has consented, so it correctly yields 0 rows. The instant an operator flips consent we want to confirm — **without writing data and without needing consent first** — that extraction would produce a non-zero, correct dataset, and verify the projected row count.

This PR adds a **read-only preview** that does exactly that. It does **not** change the consent gate or the real extraction path.

### 1. Dry-run / preview mechanism

- New env flag `DATASET_PREVIEW=1` and a new `workflow_dispatch` input **`preview`** (default `'true'` on manual runs). Preview is gated to `workflow_dispatch` only — the scheduled cron always runs the real extraction (`DATASET_PREVIEW` forced to `'0'` via `github.event_name == 'workflow_dispatch'`).
- In preview mode each extractor runs the **SAME** consent-gated query and the **SAME** per-target row projection, then **counts + samples** the projected rows and reports:
  - `rows_total` (raw consent-gated query result),
  - `rows_projected` (rows that pass the target predicate),
  - `rows_after_dedup` (the real JSONL row count that would be written),
  - `by_tenant` (grouped by `metadata.tenant_id`, `"unknown"` when absent),
  - `by_source` (grouped by event topic),
  - up to 5 sample rows.
  It writes **nothing** — no local JSONL, no GCS upload, no `dataset.extraction.completed` event.
- This is a strict superset of the legacy `DATASET_DRY_RUN=1` (which still wrote local JSONL). `dry_run` is unchanged and is ignored when `preview=true`.
- To guarantee the preview counts *exactly* what the real path would write, each extractor now exposes a pure `projectRows(events)` and the real `extract()` calls it too (single source of truth). `summarizePreview()` in `lib.ts` is a pure, unit-tested function.

**Operator workflow:** run the workflow manually with `preview=true` (the default). Before flipping consent → expect `0`. Flip `tenant_settings.feature_flags.data_export_ok=true` for the consented tenants → re-run preview → see the non-zero `rows_after_dedup` and the per-tenant/per-source breakdown, all without producing or persisting a dataset.

### 2. Query-correctness verification

- **Consent gate — correct.** `queryOasisEvents` carries `metadata->>data_export_ok=eq.true` (PostgREST, AND-ed) plus the `safety.guardrail.*` topic exclusion, matching `PII_FILTER.md`. Unchanged by this PR.
- **`metadata` column mapping — correct.** `emitOasisEvent` writes the caller `payload` into the `oasis_events.metadata` column, so the extractors reading `e.metadata.<field>` are reading the event payload as intended.
- **Tenant grouping — correct/safe.** `oasis_events` has **no top-level `tenant_id` column** (it's a global log; confirmed in `admin-scanners/assistant.ts`). Tenant identity, when present, lives in `metadata`. `tenantKeyFromEvent` reads `metadata.tenant_id` / nested `identity.tenant_id` and falls back to `"unknown"`, so every projected row is still counted.
- **⚠️ Pre-existing field mismatch flagged (not fixed here — out of scope).** The `voice-tool-routing` extractor reads `metadata.tool_name` / `tool_call.name` / `transcript` / `input_text`, but the live `orb.turn.responded` emitter (`orb-live.ts` `emitOrbTurnResponded`) currently emits only `orb_session_id`, `conversation_id`, `reply_length`, `reply_preview`, `provider` (+ consent tag). None of the fields the extractor projects on are present, so even with consent flipped this target would project **0 rows**. The preview surfaces this immediately: an operator would see `rows_total > 0` but `rows_projected = 0`, exposing the gap. Fixing the emitter to include the tool/transcript fields is a separate change (it alters extraction semantics) and is intentionally **not** done here. The `intent-kind` and `pillar-classification` field expectations align with their emitters' payloads.

### 3. Consent gate + real path unchanged

- Consent SQL filter (`metadata->>data_export_ok=eq.true`) untouched.
- The non-preview `extract()` behavior, the scheduled cron, and `DATASET_DRY_RUN` semantics are unchanged.
- No prod read/write performed from this PR; preview is read-only by construction.

### Tests

`services/gateway/test/dataset-extraction-preview.test.ts` — 9 unit tests, all green (pure functions, no network): tenant key resolution, per-target projection predicates, count/group/sample/dedup, and the empty-input (unconsented → 0) case. `finetune-submit-job-lib.test.ts` still green. `npm install` was run first so the pre-commit hook passed (no `--no-verify`).

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_