### PR TITLE
fix(eval): reliable shadow-comparison emit on Cloud Run (BOOTSTRAP-EVAL-SHADOW-EMIT)

### DIFF
--- a/services/gateway/src/routes/admin-staging.ts
+++ b/services/gateway/src/routes/admin-staging.ts
@@ -26,7 +26,7 @@ import { z } from 'zod';
 import { getSupabase } from '../lib/supabase';
 import { isStaging } from '../env';
 import { emitOasisEvent } from '../services/oasis-event-service';
-import { runWithShadow } from '../services/llm-router-shadow';
+import { runWithShadowAwaitable } from '../services/llm-router-shadow';
 
 const router = Router();
 
@@ -443,26 +443,26 @@ router.post(
       const primaryDelay = 80 + hashIdx(`${seed}:p-delay`, i, 100);
       const candidateDelay = 60 + hashIdx(`${seed}:c-delay`, i, 160);
 
-      // VTID-03221 (Phase 1 W3-B1): dual-emit reliability.
+      // BOOTSTRAP-EVAL-SHADOW-EMIT (Phase 1 W3-B2): reliable awaited emit.
       //
       // W3-B0 observed that runWithShadow's `void (async () => {...})()`
       // candidate-await + emit chain doesn't reliably flush on Cloud Run
-      // staging with --min-instances=0. CPU throttling on idle drops the
-      // detached promise before the emit completes; only the explicit
+      // staging with --min-instances=0. CPU is de-allocated / the instance
+      // scales in after the HTTP response is sent, silently dropping the
+      // detached promise before the emit completes — only the explicit
       // rollup event landed (2 events per 2 exerciser dispatches instead
-      // of 30+2).
+      // of 30+2). W3-B1 worked around this with a redundant second
+      // (dual_emit) emit from the exerciser itself.
       //
-      // Fix: still invoke runWithShadow so the wrapper code path is
-      // exercised (it's the real voice-traffic path), but ALSO emit one
-      // awaited per-prompt eval.shadow.compared event from the exerciser
-      // itself. The awaited emit guarantees evidence lands regardless of
-      // detached-promise behavior. Per-prompt event is tagged
-      // metadata.exerciser_via='dual_emit_await' so consumers can tell
-      // it apart from organic events. Real voice traffic doesn't hit
-      // this — active sessions keep CPU allocated, so the IIFE flushes.
+      // Root fix: runWithShadowAwaitable returns the candidate+emit chain as
+      // an awaitable `shadowDone` promise instead of detaching it. We await
+      // it here, inside the request handler, so the SINGLE real
+      // eval.shadow.compared emit lands while the container still has CPU
+      // allocated. No more dual-emit / no duplicate rows. The voice hot path
+      // keeps the fire-and-forget runWithShadow (active session keeps CPU
+      // allocated, so the detached emit flushes there).
 
-      const runStart = Date.now();
-      const result = await runWithShadow({
+      const { result, shadowDone } = await runWithShadowAwaitable({
         feature,
         input: { text: input, exerciser_source: exerciserSource } as Record<string, unknown>,
         primary: async () => {
@@ -479,34 +479,9 @@ router.post(
           session_id: `${sessionPrefix}-${i}`,
         },
       });
-      const wrapperMs = Date.now() - runStart;
-
-      // Awaited per-prompt emit — the guaranteed evidence path.
-      // Shape mirrors runWithShadow's emit payload (services/llm-router-shadow.ts)
-      // so the shadow-comparison report's rollup logic groups it correctly.
-      const agreement = !candidateWillError && primaryTool === candidateTool;
-      await emitOasisEvent({
-        vtid: 'VTID-03221',
-        type: 'eval.shadow.compared',
-        source: 'gateway/admin-staging-exerciser',
-        status: candidateWillError ? 'warning' : 'success',
-        message: candidateWillError
-          ? `exerciser ${feature}: candidate errored (idx=${i})`
-          : `exerciser ${feature}: primary=${primaryTool} candidate=${candidateTool} agree=${agreement}`,
-        payload: {
-          feature,
-          session_id: `${sessionPrefix}-${i}`,
-          primary_key: primaryTool,
-          candidate_key: candidateWillError ? null : candidateTool,
-          agreement: candidateWillError ? null : agreement,
-          primary_ms: primaryDelay,
-          candidate_ms: candidateDelay,
-          candidate_error: candidateWillError ? 'synthetic candidate error (exerciser)' : null,
-          exerciser_source: exerciserSource,
-          exerciser_via: 'dual_emit_await',
-          wrapper_ms: wrapperMs,
-        },
-      });
+      // Await the shadow comparison emit before moving on — this is the
+      // guaranteed evidence path on Cloud Run. shadowDone never rejects.
+      await shadowDone;
 
       emitted++;
       if (primaryTool !== candidateTool) mismatches++;
@@ -531,7 +506,9 @@ router.post(
 
     const wallMs = Date.now() - started;
 
-    void emitOasisEvent({
+    // Await the rollup emit too — same Cloud Run drop risk applies to any
+    // fire-and-forget emit issued just before the response is sent.
+    await emitOasisEvent({
       vtid: 'VTID-03215',
       type: 'eval.shadow.compared',
       source: 'gateway/admin-staging-exerciser',
@@ -549,7 +526,7 @@ router.post(
         wall_ms: wallMs,
         is_exerciser_rollup: true,
       },
-    });
+    }).catch(() => { /* telemetry must not break the exerciser response */ });
 
     res.json({
       ok: true,
@@ -563,7 +540,7 @@ router.post(
       designed_error_count: errors,
       wall_ms: wallMs,
       sample,
-      note: 'Each emitted event is a real eval.shadow.compared row tagged metadata.exerciser_source so downstream consumers can filter.',
+      note: 'Each emitted event is a real eval.shadow.compared row emitted via runWithShadowAwaitable and awaited before response (reliable on Cloud Run). Per-prompt session_id is prefixed "exerciser-staging-" so downstream consumers can identify exerciser-driven rows; the rollup row carries metadata.exerciser_source + is_exerciser_rollup.',
     });
   },
 );

--- a/services/gateway/src/services/llm-router-shadow.ts
+++ b/services/gateway/src/services/llm-router-shadow.ts
@@ -37,70 +37,139 @@ export interface ShadowInvocation<TInput, TOutput> {
 }
 
 /**
- * Runs primary and (if enabled) candidate. Returns primary result.
- * Candidate execution is fire-and-forget.
+ * Result of {@link runWithShadowAwaitable}: the primary result the caller
+ * serves to the user, plus a handle to the shadow comparison work.
+ *
+ * `shadowDone` resolves once the candidate has run and the
+ * `eval.shadow.compared` OASIS event has been emitted (or skipped because the
+ * feature flag is off). It NEVER rejects — shadow telemetry must not be able to
+ * break a caller that awaits it.
  */
-export async function runWithShadow<TInput, TOutput>(
+export interface ShadowRunResult<TOutput> {
+  result: TOutput;
+  shadowDone: Promise<void>;
+}
+
+/**
+ * Runs the candidate model and emits the `eval.shadow.compared` event for one
+ * shadow invocation. Pulled out of {@link runWithShadow} so the chain can be
+ * either detached (fire-and-forget, voice path) or awaited (HTTP request
+ * handlers on Cloud Run, where a detached promise is dropped when the instance
+ * scales in before the response flushes — the W3-B0 root cause).
+ *
+ * Never throws.
+ */
+async function compareAndEmit<TInput, TOutput>(
   inv: ShadowInvocation<TInput, TOutput>,
-): Promise<TOutput> {
+  primaryResult: TOutput,
+  primaryMs: number,
+): Promise<void> {
+  const candidateStart = Date.now();
+  let candidateResult: TOutput | undefined;
+  let candidateError: string | undefined;
+  try {
+    candidateResult = await inv.candidate();
+  } catch (err) {
+    candidateError = err instanceof Error ? err.message : String(err);
+  }
+  const candidateMs = Date.now() - candidateStart;
+
+  const primaryKey = inv.extractKey ? safe(() => inv.extractKey!(primaryResult)) : null;
+  const candidateKey = candidateResult && inv.extractKey
+    ? safe(() => inv.extractKey!(candidateResult!))
+    : null;
+  const agreement = primaryKey != null && candidateKey != null
+    ? primaryKey === candidateKey
+    : null;
+
+  try {
+    await emitOasisEvent({
+      vtid: 'VTID-03179',
+      type: 'eval.shadow.compared',
+      source: 'gateway/llm-router-shadow',
+      status: candidateError ? 'warning' : 'success',
+      message: candidateError
+        ? `shadow ${inv.feature}: candidate errored (${candidateError.slice(0, 80)})`
+        : `shadow ${inv.feature}: primary=${primaryKey} candidate=${candidateKey} agree=${agreement}`,
+      actor_id: inv.context?.actor_id,
+      payload: {
+        feature: inv.feature,
+        session_id: inv.context?.session_id,
+        primary_key: primaryKey,
+        candidate_key: candidateKey,
+        agreement,
+        primary_ms: primaryMs,
+        candidate_ms: candidateMs,
+        candidate_error: candidateError,
+      },
+    });
+  } catch {
+    // Never let shadow telemetry break anything.
+  }
+}
+
+/**
+ * Runs primary and (if enabled) candidate, returning both the primary result
+ * AND an awaitable handle to the shadow comparison work.
+ *
+ * This is the reliable-on-Cloud-Run variant. The candidate + `emitOasisEvent`
+ * chain is NOT detached — the caller gets a `shadowDone` promise it can await
+ * before the request handler returns the HTTP response. On Cloud Run with
+ * `--min-instances=0`, awaiting `shadowDone` guarantees the
+ * `eval.shadow.compared` emit completes while the container still has CPU
+ * allocated (the instance is torn down / CPU-throttled after the response is
+ * sent, which silently drops any still-pending detached promise — the W3-B0
+ * starvation root cause).
+ *
+ * Primary path is unaffected: `result` is the primary output, computed and
+ * available before the candidate even starts. Callers that don't care about
+ * flushing can ignore `shadowDone`. Callers on a request/response boundary
+ * should `await shadowDone` (or hand it to a `waitUntil`-style hook) so the
+ * emit isn't dropped.
+ *
+ * When the feature flag is off, the candidate is never invoked and
+ * `shadowDone` is an already-resolved promise (zero overhead).
+ */
+export async function runWithShadowAwaitable<TInput, TOutput>(
+  inv: ShadowInvocation<TInput, TOutput>,
+): Promise<ShadowRunResult<TOutput>> {
   const enabled = isFeatureLive(FEATURE_NAME);
 
   if (!enabled) {
-    return inv.primary();
+    return { result: await inv.primary(), shadowDone: Promise.resolve() };
   }
 
   const primaryStart = Date.now();
   const primaryResult = await inv.primary();
   const primaryMs = Date.now() - primaryStart;
 
-  // Kick off candidate after primary returns so we never extend user-visible
-  // latency by waiting on the candidate to start.
-  void (async () => {
-    const candidateStart = Date.now();
-    let candidateResult: TOutput | undefined;
-    let candidateError: string | undefined;
-    try {
-      candidateResult = await inv.candidate();
-    } catch (err) {
-      candidateError = err instanceof Error ? err.message : String(err);
-    }
-    const candidateMs = Date.now() - candidateStart;
+  // Start the candidate AFTER primary returns so we never extend user-visible
+  // latency by waiting on the candidate to start. Returning the promise lets
+  // the caller flush it reliably; compareAndEmit never throws so awaiting it
+  // (or detaching it) is always safe.
+  const shadowDone = compareAndEmit(inv, primaryResult, primaryMs);
 
-    const primaryKey = inv.extractKey ? safe(() => inv.extractKey!(primaryResult)) : null;
-    const candidateKey = candidateResult && inv.extractKey
-      ? safe(() => inv.extractKey!(candidateResult!))
-      : null;
-    const agreement = primaryKey != null && candidateKey != null
-      ? primaryKey === candidateKey
-      : null;
+  return { result: primaryResult, shadowDone };
+}
 
-    try {
-      await emitOasisEvent({
-        vtid: 'VTID-03179',
-        type: 'eval.shadow.compared',
-        source: 'gateway/llm-router-shadow',
-        status: candidateError ? 'warning' : 'success',
-        message: candidateError
-          ? `shadow ${inv.feature}: candidate errored (${candidateError.slice(0, 80)})`
-          : `shadow ${inv.feature}: primary=${primaryKey} candidate=${candidateKey} agree=${agreement}`,
-        actor_id: inv.context?.actor_id,
-        payload: {
-          feature: inv.feature,
-          session_id: inv.context?.session_id,
-          primary_key: primaryKey,
-          candidate_key: candidateKey,
-          agreement,
-          primary_ms: primaryMs,
-          candidate_ms: candidateMs,
-          candidate_error: candidateError,
-        },
-      });
-    } catch {
-      // Never let shadow telemetry break anything.
-    }
-  })();
-
-  return primaryResult;
+/**
+ * Runs primary and (if enabled) candidate. Returns primary result.
+ * Candidate execution is fire-and-forget.
+ *
+ * Use this on the voice hot path, where an active WebSocket/SSE session keeps
+ * the container's CPU allocated long enough for the detached emit to flush. For
+ * short-lived HTTP request handlers (e.g. the staging exerciser), prefer
+ * {@link runWithShadowAwaitable} and await `shadowDone` so the emit isn't
+ * dropped when the Cloud Run instance scales in after the response.
+ */
+export async function runWithShadow<TInput, TOutput>(
+  inv: ShadowInvocation<TInput, TOutput>,
+): Promise<TOutput> {
+  const { result, shadowDone } = await runWithShadowAwaitable(inv);
+  // Detached on purpose for the hot path. `shadowDone` never rejects, but
+  // attach a catch anyway so an unhandled rejection can never surface here.
+  void shadowDone.catch(() => {});
+  return result;
 }
 
 function safe<T>(fn: () => T): T | null {

--- a/services/gateway/test/voice-tool-router-shadow.test.ts
+++ b/services/gateway/test/voice-tool-router-shadow.test.ts
@@ -19,7 +19,7 @@ jest.mock('../src/services/feature-flags', () => ({
   isFeatureLive: jest.fn(),
 }));
 
-import { runWithShadow } from '../src/services/llm-router-shadow';
+import { runWithShadow, runWithShadowAwaitable } from '../src/services/llm-router-shadow';
 import { predictVoiceToolRoute } from '../src/services/voice-tool-router-candidate';
 import { emitOasisEvent } from '../src/services/oasis-event-service';
 import { isFeatureLive } from '../src/services/feature-flags';
@@ -109,5 +109,107 @@ describe('runWithShadow — flag ON', () => {
 
     const evt = mockEmit.mock.calls[0][0];
     expect(evt.payload.agreement).toBe(false);
+  });
+});
+
+/**
+ * BOOTSTRAP-EVAL-SHADOW-EMIT — reliable-on-Cloud-Run awaitable variant.
+ *
+ * Root cause (W3-B0): the candidate + emit chain ran inside a detached
+ * `void (async () => {…})()` IIFE. On Cloud Run with --min-instances=0 the
+ * instance's CPU is de-allocated / scaled in right after the HTTP response is
+ * sent, so the still-pending detached promise is dropped and the
+ * eval.shadow.compared event never lands. These tests prove the emit is
+ * awaitable so request handlers can flush it before returning the response.
+ */
+describe('runWithShadowAwaitable — flag ON', () => {
+  test('returns primary immediately; shadowDone resolves after the awaited emit', async () => {
+    mockFlag.mockReturnValue(true);
+    const candidate = jest.fn(async () => 'set_reminder');
+
+    const { result, shadowDone } = await runWithShadowAwaitable<{ t: string }, string>({
+      feature: 'voice-tool-router',
+      input: { t: 'remind me' },
+      primary: async () => 'set_reminder',
+      candidate,
+      extractKey: (t) => t,
+      context: { actor_id: 'u-1', session_id: 's-1' },
+    });
+
+    // Primary path is unaffected — result available before the emit completes.
+    expect(result).toBe('set_reminder');
+
+    // The key guarantee: awaiting shadowDone deterministically flushes the
+    // emit. No setImmediate/flush hack — the caller can rely on this.
+    await shadowDone;
+
+    expect(candidate).toHaveBeenCalledTimes(1);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    const evt = mockEmit.mock.calls[0][0];
+    expect(evt.type).toBe('eval.shadow.compared');
+    expect(evt.payload.primary_key).toBe('set_reminder');
+    expect(evt.payload.candidate_key).toBe('set_reminder');
+    expect(evt.payload.agreement).toBe(true);
+  });
+
+  test('shadowDone never rejects even if the candidate throws', async () => {
+    mockFlag.mockReturnValue(true);
+
+    const { result, shadowDone } = await runWithShadowAwaitable<{ t: string }, string>({
+      feature: 'voice-tool-router',
+      input: { t: 'x' },
+      primary: async () => 'set_reminder',
+      candidate: async () => { throw new Error('candidate boom'); },
+      extractKey: (t) => t,
+    });
+
+    expect(result).toBe('set_reminder');
+    // Must resolve, not reject — awaiting it in a handler must be safe.
+    await expect(shadowDone).resolves.toBeUndefined();
+
+    // Candidate error is still recorded as a warning event.
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    const evt = mockEmit.mock.calls[0][0];
+    expect(evt.status).toBe('warning');
+    expect(evt.payload.candidate_error).toContain('candidate boom');
+    expect(evt.payload.agreement).toBeNull();
+  });
+
+  test('shadowDone never rejects even if emitOasisEvent throws', async () => {
+    mockFlag.mockReturnValue(true);
+    mockEmit.mockRejectedValueOnce(new Error('oasis sink down'));
+
+    const { shadowDone } = await runWithShadowAwaitable<{ t: string }, string>({
+      feature: 'voice-tool-router',
+      input: { t: 'x' },
+      primary: async () => 'set_reminder',
+      candidate: async () => 'set_reminder',
+      extractKey: (t) => t,
+    });
+
+    // Emit failure is swallowed — the awaited chain still resolves cleanly so
+    // it can never break the request handler.
+    await expect(shadowDone).resolves.toBeUndefined();
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runWithShadowAwaitable — flag OFF', () => {
+  test('returns primary, never invokes candidate, shadowDone is a no-op', async () => {
+    mockFlag.mockReturnValue(false);
+    const candidate = jest.fn(async () => 'set_reminder');
+
+    const { result, shadowDone } = await runWithShadowAwaitable<{ t: string }, string>({
+      feature: 'voice-tool-router',
+      input: { t: 'x' },
+      primary: async () => 'search_calendar',
+      candidate,
+      extractKey: (t) => t,
+    });
+    await shadowDone;
+
+    expect(result).toBe('search_calendar');
+    expect(candidate).not.toHaveBeenCalled();
+    expect(mockEmit).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Root cause (W3-B0 §1 — dropped emits)

`runWithShadow` returned the primary result synchronously and ran the candidate model + `eval.shadow.compared` OASIS emit inside a **detached** `void (async () => { … })()` IIFE. On Cloud Run with `--min-instances=0`, the instance's CPU is de-allocated / the instance scales in **right after the HTTP response is sent**. The still-pending detached promise is silently dropped before the emit completes, so the per-iteration `eval.shadow.compared` events never land in `oasis_events`. The staging exerciser observed `total_events: 2` (only the rollups) instead of `30+2` — starving the canary-readiness evidence.

This is a short-HTTP-request worst case; real voice turns run inside an active WebSocket/SSE session that keeps CPU allocated, so the detached emit flushes there.

## The fix

Extract the candidate + emit chain into a non-detached helper and expose a new `runWithShadowAwaitable()` that returns `{ result, shadowDone }`:

- `shadowDone` is an **awaitable** handle to the candidate-run + emit. Request handlers can `await` it before returning the response, guaranteeing the emit completes **while CPU is still allocated**.
- `runWithShadow()` is preserved for the voice hot path — it now delegates to the awaitable variant and detaches `shadowDone` (active session keeps CPU allocated, so the emit flushes).
- The **staging exerciser** (`/eval/exercise-shadow`) now uses `runWithShadowAwaitable` + `await shadowDone`, and awaits the rollup emit before `res.json`. This replaces the W3-B1 `dual_emit` workaround, so there is now **one** real `eval.shadow.compared` row per prompt instead of a duplicate.

## Primary path is unaffected

- `result` is the primary output, computed and returned **before** the candidate even starts — no added user-visible latency.
- `shadowDone` **never rejects**: candidate exceptions and `emitOasisEvent` failures are swallowed inside the chain, so a handler can safely await it without risk of breaking the user-facing response.
- Flag-off path stays zero-overhead (`shadowDone` is an already-resolved promise; candidate never invoked).

## Test summary

Extended `services/gateway/test/voice-tool-router-shadow.test.ts` (8 pass, including the 4 existing):
- `shadowDone` **deterministically flushes** the emit (no `setImmediate` hack) — primary returned immediately, emit observed after `await shadowDone`.
- `shadowDone` resolves (never rejects) when the **candidate throws** — recorded as a `warning` event with `agreement: null`.
- `shadowDone` resolves when **`emitOasisEvent` itself throws** — failure swallowed.
- Flag-off: candidate never invoked, no emit, `shadowDone` is a no-op.

`cd services/gateway && npm run build` → green. Touched jest suite → 8/8 green.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_