### PR TITLE
fix(orb): emit voice-tool-routing signal on orb.turn.responded (BOOTSTRAP-VOICE-DATASET-EMITTER)

### DIFF
--- a/docs/patches/orb-agent/BOOTSTRAP-VOICE-DATASET-EMITTER.md
+++ b/docs/patches/orb-agent/BOOTSTRAP-VOICE-DATASET-EMITTER.md
@@ -1,0 +1,140 @@
+# BOOTSTRAP-VOICE-DATASET-EMITTER — LiveKit (orb-agent) parity patch
+
+**Status:** Patch spec (session.py is out of the gateway sandbox — apply in the
+`orb-agent` deploy).
+
+## Why
+
+The Phase-1 voice-tool-routing dataset extractor
+(`services/gateway/scripts/datasets/voice-tool-routing.ts`) reads from
+`oasis_events` where `topic = orb.turn.responded` and projects the tool-routing
+signal off the event `metadata` column:
+
+```ts
+const toolName  = meta.tool_name ?? meta.tool_call?.name;
+const userInput = meta.transcript ?? meta.input_text;
+tool_arguments  = meta.tool_call?.arguments ?? null;
+// PII gate (lib.ts): topic NOT LIKE 'safety.guardrail.%' AND metadata->>data_export_ok = true
+```
+
+The Vertex path (`orb-live.ts`) is now fixed: `emitOrbTurnResponded` emits these
+exact fields, consent-gated (`buildOrbTurnRespondedPayload`).
+
+**The LiveKit agent (`session.py`) does not emit `orb.turn.responded` at all** —
+it only emits `vtid.live.session.start/stop`, `vtid.live.stall_detected`,
+`livekit.tool.executed`, and the latency events. So LiveKit voice turns
+contribute ZERO rows to the dataset. This patch closes that gap with the same
+field shape + consent gate as the Vertex emitter, so the two providers reach
+extractor parity.
+
+## Field contract (must match the Vertex emitter exactly)
+
+Top-level keys on the emitted event `payload` (the gateway maps the whole
+payload into `oasis_events.metadata`):
+
+| field | when | source |
+|-------|------|--------|
+| `orb_session_id`, `conversation_id`, `reply_length`, `reply_preview`, `provider`, `metadata:{mode:'orb_voice'}` | always | envelope (non-PII) |
+| `data_export_ok: true` | consent established | tenant policy |
+| `tool_name`, `tool_dispatched: true` | consent ✓ AND not guardrail AND a tool was chosen | last tool call |
+| `tool_call: { name, arguments? }` | same | last tool call |
+| `transcript`, `input_text` | consent ✓ AND not guardrail | raw user STT for the turn |
+
+**PII rule:** `transcript` / `input_text` / tool fields are attached **only**
+when (a) export consent is established for the tenant AND (b) the turn is not
+under a `safety.guardrail.*` exclusion. Otherwise emit the envelope only.
+
+## Patch for `services/agents/orb-agent/src/orb_agent/session.py`
+
+### 1. Add the topic constant (oasis.py)
+
+```python
+# services/agents/orb-agent/src/orb_agent/oasis.py — alongside TOPIC_TOOL_EXECUTED
+TOPIC_TURN_RESPONDED = "orb.turn.responded"  # voice-tool-routing dataset source
+```
+
+### 2. Resolve export consent agent-side (fail-closed, cached)
+
+Mirror `services/gateway/src/services/data-export-consent.ts`: read
+`tenant_settings.feature_flags.data_export_ok` for the session tenant. Strictly
+`True` ⇒ consented; missing row / flag / error ⇒ not consented. Cache 5 min.
+
+```python
+async def _export_consent_ok(gw, tenant_id: str | None) -> bool:
+    if not tenant_id:
+        return False
+    # GET tenant_settings?tenant_id=eq.{tenant_id}&select=feature_flags
+    # return flags.get("data_export_ok") is True; any error -> False
+    ...
+```
+
+### 3. Track the dispatched tool per turn
+
+In the `@function_tool` dispatch path (where `livekit.tool.executed` is already
+emitted), record the chosen tool + args on the turn state:
+
+```python
+turn_state["tool_name"] = tool_name
+turn_state["tool_arguments"] = tool_args or None  # dict
+```
+
+Capture the user STT text already available in `_on_user_transcribed`
+(`turn_state["user_text"] = t` — the same `transcript`/`text` field it reads for
+`user_text_len`).
+
+### 4. Emit `orb.turn.responded` on agent reply completion
+
+Hook the agent-speech-finished event (the `speech_created` / agent_state→idle
+transition that closes the turn). Build the payload with the consent gate:
+
+```python
+async def _emit_turn_responded(reply_text: str) -> None:
+    consented = await _export_consent_ok(gw, identity.tenant_id)
+    guardrail = bool(turn_state.get("guardrail_excluded"))
+    payload: dict[str, Any] = {
+        "orb_session_id": orb_session_id,
+        "conversation_id": turn_state.get("conversation_id") or orb_session_id,
+        "reply_length": len(reply_text),
+        "reply_preview": reply_text[:140],
+        "provider": "livekit",
+        "metadata": {"mode": "orb_voice"},
+    }
+    if consented:
+        payload["data_export_ok"] = True
+    if consented and not guardrail:
+        user_input = turn_state.get("user_text") or ""
+        tool_name = turn_state.get("tool_name")
+        if tool_name:
+            payload["tool_name"] = tool_name
+            payload["tool_dispatched"] = True
+            tc: dict[str, Any] = {"name": tool_name}
+            if turn_state.get("tool_arguments"):
+                tc["arguments"] = turn_state["tool_arguments"]
+            payload["tool_call"] = tc
+        if user_input:
+            payload["transcript"] = user_input
+            payload["input_text"] = user_input
+    if reply_text:
+        await oasis.emit(topic=TOPIC_TURN_RESPONDED, payload=payload)
+    # clear per-turn signal so it doesn't leak into the next turn
+    turn_state.pop("tool_name", None)
+    turn_state.pop("tool_arguments", None)
+    turn_state.pop("user_text", None)
+```
+
+Skip the greeting turn (no user input), same as the Vertex path.
+
+## Verification
+
+After deploy, a consented LiveKit voice turn that dispatches a tool should land
+an `orb.turn.responded` event whose `metadata` carries `tool_name`,
+`tool_call`, `transcript`, `input_text`, and `data_export_ok=true`. Run the
+preview:
+
+```bash
+DATASET_DRY_RUN=1 npx tsx services/gateway/scripts/datasets/voice-tool-routing.ts
+```
+
+Expect `rows_after_dedup > 0` once consented rows exist from either provider.
+A non-consented turn must show the envelope only (no `transcript` / `tool_name`)
+and be filtered out by the SQL PII gate.

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -53,6 +53,10 @@ import { resolveSessionTimezone } from '../services/awareness-unified-context';
 // data_export_ok ONLY where tenant export consent is established, so the
 // dataset-extraction PII gate can ingest them. Default off / fail-closed.
 import { dataExportConsentTag } from '../services/data-export-consent';
+import {
+  buildOrbTurnRespondedPayload,
+  type OrbTurnToolSignal,
+} from './orb-turn-event-payload';
 // VTID-03177 (PROFILE): per-turn latency telemetry. The middleware is a no-op
 // when FEATURE_LATENCY_TELEMETRY_ENV is off; safe to wire on every route.
 // Phase 1 W2 (BOOTSTRAP-PHASE1-W2-VOICE-LATENCY-WIRE): the LatencyTracker class +
@@ -908,6 +912,11 @@ export interface GeminiLiveSession {
   // VTID-01225-THROTTLE: Buffer for accumulating user input transcription.
   // Written to memory_items once per turn_complete instead of per-fragment.
   inputTranscriptBuffer: string;
+  // BOOTSTRAP-VOICE-DATASET-EMITTER: tool/function the model selected on the
+  // current turn (set in executeLiveApiTool). Read once at turn_complete to
+  // carry the voice-tool-routing signal into the orb.turn.responded event,
+  // then cleared. Undefined when the turn dispatched no tool.
+  pendingTurnToolSignal?: { toolName: string; toolArguments?: Record<string, unknown> };
   // VTID-STREAM-KEEPALIVE: Interval handle for upstream Vertex WS ping
   upstreamPingInterval?: ReturnType<typeof setInterval>;
   // VTID-STREAM-SILENCE: Interval handle for sending silence audio to Vertex
@@ -2093,6 +2102,14 @@ async function executeLiveApiTool(
   const startTime = Date.now();
   // Phase 1 W2: mark the tool boundary on the active voice turn (no-op off-flag).
   markVoiceLatency(session, 'tool_dispatch', { tool: toolName });
+  // BOOTSTRAP-VOICE-DATASET-EMITTER: record the tool the model chose for this
+  // turn so emitOrbTurnResponded can carry the voice-tool-routing signal. This
+  // is just an in-memory note on the session — consent gating happens at emit
+  // time (buildOrbTurnRespondedPayload), so recording here leaks nothing.
+  session.pendingTurnToolSignal = {
+    toolName,
+    ...(args && Object.keys(args).length > 0 ? { toolArguments: args } : {}),
+  };
   // Phase 1 W2: shadow-compare the tool-routing decision. Primary = the tool
   // Vertex already chose (toolName); candidate = the W2 stub (echoes it until a
   // fine-tune is served). Fire-and-forget — never blocks or alters execution,
@@ -7473,8 +7490,15 @@ async function emitOrbTurnResponded(
   conversationId: string,
   replyText: string,
   provider: string,
-  userId?: string
+  userId?: string,
+  // BOOTSTRAP-VOICE-DATASET-EMITTER: tool-routing signal for the voice-tool-routing
+  // dataset extractor. Carried into the event metadata ONLY when export consent is
+  // established AND the turn is not guardrail-excluded (PII gate in
+  // buildOrbTurnRespondedPayload). When omitted, the emitter behaves exactly as
+  // before (envelope-only).
+  opts?: { toolSignal?: OrbTurnToolSignal; guardrailExcluded?: boolean }
 ): Promise<void> {
+  const consentTag = await dataExportConsentTag({ userId });
   await emitOasisEvent({
     vtid: 'VTID-0135',
     type: 'orb.turn.responded',
@@ -7482,15 +7506,15 @@ async function emitOrbTurnResponded(
     status: 'success',
     message: `ORB turn responded via ${provider}`,
     ...(userId && { actor_id: userId, surface: 'orb' as const }),
-    payload: {
-      orb_session_id: orbSessionId,
-      conversation_id: conversationId,
-      reply_length: replyText.length,
-      reply_preview: replyText.slice(0, 140),
+    payload: buildOrbTurnRespondedPayload({
+      orbSessionId,
+      conversationId,
+      replyText,
       provider,
-      metadata: { mode: 'orb_voice' },
-      ...(await dataExportConsentTag({ userId }))
-    }
+      consentTag,
+      toolSignal: opts?.toolSignal,
+      guardrailExcluded: opts?.guardrailExcluded,
+    }),
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.turn.responded:', err.message));
 }
 
@@ -12668,13 +12692,45 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
       },
       // Turn complete handler - forward to WS client so it knows when response ends
       () => {
+        const isGreetingTurn = liveSession.greetingSent && liveSession.turn_count === (liveSession.greetingTurnIndex ?? 0) + 1;
         if (clientWs.readyState === WebSocket.OPEN) {
-          const isGreetingTurn = liveSession.greetingSent && liveSession.turn_count === (liveSession.greetingTurnIndex ?? 0) + 1;
           sendWsMessage(clientWs, {
             type: 'turn_complete',
             is_greeting: isGreetingTurn
           });
           console.log(`[VTID-VOICE-INIT] Forwarded turn_complete to WS client ${sessionId} (isGreeting=${isGreetingTurn})`);
+        }
+        // BOOTSTRAP-VOICE-DATASET-EMITTER: emit orb.turn.responded with the
+        // voice-tool-routing signal so the dataset extractor sees real rows.
+        // Skip greeting turns (no user input). The transcript/tool fields are
+        // attached ONLY under export consent + no guardrail (gating lives in
+        // buildOrbTurnRespondedPayload); the consent read is cached per-tenant.
+        const toolSignal = liveSession.pendingTurnToolSignal;
+        liveSession.pendingTurnToolSignal = undefined;
+        if (!isGreetingTurn) {
+          const replyText = liveSession.outputTranscriptBuffer || '';
+          const userInput = liveSession.inputTranscriptBuffer || '';
+          if (replyText.length > 0) {
+            void emitOrbTurnResponded(
+              liveSession.sessionId,
+              liveSession.conversation_id || liveSession.sessionId,
+              replyText,
+              'vertex',
+              liveSession.identity?.user_id,
+              {
+                toolSignal: toolSignal
+                  ? {
+                      toolName: toolSignal.toolName,
+                      inputText: userInput,
+                      toolCall: {
+                        name: toolSignal.toolName,
+                        ...(toolSignal.toolArguments ? { arguments: toolSignal.toolArguments } : {}),
+                      },
+                    }
+                  : { inputText: userInput },
+              },
+            );
+          }
         }
       },
       // Interrupted handler - forward to WS client so it can clear audio queue

--- a/services/gateway/src/routes/orb-turn-event-payload.ts
+++ b/services/gateway/src/routes/orb-turn-event-payload.ts
@@ -1,0 +1,132 @@
+/**
+ * orb.turn.responded payload assembly — BOOTSTRAP-VOICE-DATASET-EMITTER.
+ *
+ * The Phase 1 voice-tool-routing dataset extractor
+ * (services/gateway/scripts/datasets/voice-tool-routing.ts) projects the
+ * tool-routing signal off the emitted event's `metadata` column:
+ *
+ *   const toolName  = meta.tool_name ?? meta.tool_call?.name;
+ *   const userInput = meta.transcript ?? meta.input_text;
+ *   tool_arguments  = meta.tool_call?.arguments ?? null;
+ *
+ * The W1/W2 emitter only ever carried { reply_preview, provider, mode, ... } —
+ * NONE of tool_name / tool_call / transcript / input_text — so every candidate
+ * row failed the `if (!toolName || !userInput) continue;` guard and the cron
+ * extracted ZERO real rows even after consent. This module closes the wire by
+ * aligning the emitter's payload to the extractor's projection.
+ *
+ * `emitOasisEvent` maps the WHOLE event `payload` into the oasis_events
+ * `metadata` column (oasis-event-service.ts: `metadata: { ...callerMetadata }`),
+ * so these fields must live at the TOP LEVEL of the payload — not nested under
+ * the legacy `payload.metadata: { mode }` object the extractor never reads.
+ *
+ * PII / consent contract (hard rule — see data-export-consent.ts + PII_FILTER.md):
+ * `transcript` / `input_text` are RAW user content and the tool-routing signal
+ * is derived telemetry. They are included ONLY when the turn is export-eligible:
+ *   1. export consent is established for the surface — i.e. the spread consent
+ *      tag carries `data_export_ok: true` (same flag the SQL PII gate filters on)
+ *   AND
+ *   2. the turn is NOT under a `safety.guardrail.*` exclusion.
+ * When either condition fails, the tool-routing/transcript fields are omitted
+ * entirely; only the non-PII envelope (reply_preview length, provider, mode)
+ * is emitted. Fail-closed by construction — no broadening for non-consented
+ * users.
+ */
+
+/** The tool-routing signal the extractor needs, captured for the finalized turn. */
+export interface OrbTurnToolSignal {
+  /** The tool/function name Vertex selected for this turn (extractor: tool_name). */
+  toolName?: string | null;
+  /** Raw user input transcript for the turn (extractor: transcript / input_text). */
+  inputText?: string | null;
+  /** Structured tool_call — extractor reads .name and .arguments as fallbacks. */
+  toolCall?: { name?: string; arguments?: Record<string, unknown> } | null;
+}
+
+export interface BuildOrbTurnPayloadInput {
+  orbSessionId: string;
+  conversationId: string;
+  replyText: string;
+  provider: string;
+  /** Spread result of `dataExportConsentTag(...)` — `{ data_export_ok: true }` or `{}`. */
+  consentTag: { data_export_ok?: true } | Record<string, never>;
+  /** Tool-routing signal for the turn (optional — many turns dispatch no tool). */
+  toolSignal?: OrbTurnToolSignal;
+  /**
+   * True when the turn was caught by a `safety.guardrail.*` exclusion. When set,
+   * the raw transcript / tool-routing fields are withheld even if consent holds.
+   */
+  guardrailExcluded?: boolean;
+}
+
+/**
+ * Build the `orb.turn.responded` event payload.
+ *
+ * Always-present envelope (non-PII, no regression to existing consumers):
+ *   orb_session_id, conversation_id, reply_length, reply_preview, provider,
+ *   metadata:{ mode }, and the spread consent tag.
+ *
+ * Export-eligible-only (consent established AND not guardrail-excluded), aligned
+ * to the extractor's field names so real signal flows:
+ *   tool_name, tool_call, transcript, input_text.
+ */
+export function buildOrbTurnRespondedPayload(
+  input: BuildOrbTurnPayloadInput,
+): Record<string, unknown> {
+  const {
+    orbSessionId,
+    conversationId,
+    replyText,
+    provider,
+    consentTag,
+    toolSignal,
+    guardrailExcluded,
+  } = input;
+
+  // Existing fields preserved verbatim — other consumers depend on these.
+  const payload: Record<string, unknown> = {
+    orb_session_id: orbSessionId,
+    conversation_id: conversationId,
+    reply_length: replyText.length,
+    reply_preview: replyText.slice(0, 140),
+    provider,
+    metadata: { mode: 'orb_voice' },
+    ...consentTag,
+  };
+
+  // PII gate: only attach raw transcript + tool-routing signal when the turn is
+  // export-eligible. data_export_ok must be strictly true AND no guardrail.
+  const exportEligible = consentTag.data_export_ok === true && !guardrailExcluded;
+  if (!exportEligible || !toolSignal) return payload;
+
+  const toolName = toolSignal.toolName ?? toolSignal.toolCall?.name ?? undefined;
+  const inputText =
+    typeof toolSignal.inputText === 'string' && toolSignal.inputText.length > 0
+      ? toolSignal.inputText
+      : undefined;
+
+  // tool_name: top-level key the extractor reads first.
+  if (toolName) {
+    payload.tool_name = toolName;
+    payload.tool_dispatched = true;
+  }
+
+  // tool_call: structured fallback the extractor reads (.name / .arguments).
+  if (toolSignal.toolCall && (toolSignal.toolCall.name || toolSignal.toolCall.arguments)) {
+    payload.tool_call = {
+      ...(toolSignal.toolCall.name ? { name: toolSignal.toolCall.name } : {}),
+      ...(toolSignal.toolCall.arguments ? { arguments: toolSignal.toolCall.arguments } : {}),
+    };
+  } else if (toolName) {
+    // Always give the extractor a tool_call.name fallback when a tool was chosen.
+    payload.tool_call = { name: toolName };
+  }
+
+  // transcript + input_text: raw user content, only here under consent.
+  if (inputText) {
+    payload.transcript = inputText;
+    payload.input_text = inputText;
+  }
+
+  return payload;
+}

--- a/services/gateway/test/orb-turn-event-payload.test.ts
+++ b/services/gateway/test/orb-turn-event-payload.test.ts
@@ -1,0 +1,156 @@
+/**
+ * BOOTSTRAP-VOICE-DATASET-EMITTER — orb.turn.responded payload assembly tests.
+ *
+ * Proves the contract the voice-tool-routing dataset extractor
+ * (services/gateway/scripts/datasets/voice-tool-routing.ts) depends on:
+ *   - WHEN export consent is established AND the turn is not guardrail-excluded,
+ *     the emitted payload (→ oasis_events.metadata) carries the extractor's
+ *     projected fields: tool_name, tool_call{name,arguments}, transcript,
+ *     input_text.
+ *   - WHEN consent is absent, or the turn is guardrail-excluded, those raw /
+ *     tool-routing fields are OMITTED entirely (PII fail-closed), while the
+ *     non-PII envelope (reply_preview, provider, mode) is preserved.
+ *
+ * These mirror the extractor's exact projection so a green test here means a
+ * non-zero extraction downstream.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import {
+  buildOrbTurnRespondedPayload,
+  type BuildOrbTurnPayloadInput,
+} from '../src/routes/orb-turn-event-payload';
+
+const BASE: Omit<BuildOrbTurnPayloadInput, 'consentTag'> = {
+  orbSessionId: 'orb-abc',
+  conversationId: 'conv-xyz',
+  replyText: 'Sure — I have opened your calendar for tomorrow.',
+  provider: 'vertex',
+  toolSignal: {
+    toolName: 'create_calendar_event',
+    inputText: 'book me a dentist appointment tomorrow at 9',
+    toolCall: {
+      name: 'create_calendar_event',
+      arguments: { title: 'Dentist', when: 'tomorrow 09:00' },
+    },
+  },
+};
+
+/** Mirrors the extractor's projection in voice-tool-routing.ts. */
+function extractorProjection(meta: Record<string, unknown>) {
+  const tc = meta.tool_call as { name?: string; arguments?: unknown } | undefined;
+  const toolName = (meta.tool_name as string | undefined) ?? tc?.name;
+  const userInput = (meta.transcript as string | undefined) ?? (meta.input_text as string | undefined);
+  return { toolName, userInput, toolArguments: tc?.arguments ?? null };
+}
+
+describe('buildOrbTurnRespondedPayload — consented turn', () => {
+  const payload = buildOrbTurnRespondedPayload({
+    ...BASE,
+    consentTag: { data_export_ok: true },
+  });
+
+  test('carries the extractor-aligned tool + transcript fields', () => {
+    expect(payload.tool_name).toBe('create_calendar_event');
+    expect(payload.tool_dispatched).toBe(true);
+    expect(payload.transcript).toBe('book me a dentist appointment tomorrow at 9');
+    expect(payload.input_text).toBe('book me a dentist appointment tomorrow at 9');
+    expect(payload.tool_call).toEqual({
+      name: 'create_calendar_event',
+      arguments: { title: 'Dentist', when: 'tomorrow 09:00' },
+    });
+  });
+
+  test('the extractor would derive a real (user_input, tool_chosen) row', () => {
+    const proj = extractorProjection(payload);
+    expect(proj.toolName).toBe('create_calendar_event');
+    expect(proj.userInput).toBe('book me a dentist appointment tomorrow at 9');
+    expect(proj.toolArguments).toEqual({ title: 'Dentist', when: 'tomorrow 09:00' });
+  });
+
+  test('preserves the existing envelope (no regression)', () => {
+    expect(payload.orb_session_id).toBe('orb-abc');
+    expect(payload.conversation_id).toBe('conv-xyz');
+    expect(payload.reply_preview).toBe('Sure — I have opened your calendar for tomorrow.');
+    expect(payload.provider).toBe('vertex');
+    expect(payload.metadata).toEqual({ mode: 'orb_voice' });
+    expect(payload.data_export_ok).toBe(true);
+  });
+});
+
+describe('buildOrbTurnRespondedPayload — NOT consented', () => {
+  const payload = buildOrbTurnRespondedPayload({
+    ...BASE,
+    consentTag: {}, // dataExportConsentTag returned no flag
+  });
+
+  test('omits all raw / tool-routing fields', () => {
+    expect(payload.tool_name).toBeUndefined();
+    expect(payload.tool_call).toBeUndefined();
+    expect(payload.transcript).toBeUndefined();
+    expect(payload.input_text).toBeUndefined();
+    expect(payload.tool_dispatched).toBeUndefined();
+    expect('data_export_ok' in payload).toBe(false);
+  });
+
+  test('the extractor would skip this row (no toolName/userInput)', () => {
+    const proj = extractorProjection(payload);
+    expect(proj.toolName).toBeUndefined();
+    expect(proj.userInput).toBeUndefined();
+  });
+
+  test('still emits the non-PII envelope', () => {
+    expect(payload.reply_preview).toBe('Sure — I have opened your calendar for tomorrow.');
+    expect(payload.provider).toBe('vertex');
+    expect(payload.metadata).toEqual({ mode: 'orb_voice' });
+  });
+});
+
+describe('buildOrbTurnRespondedPayload — guardrail-excluded turn', () => {
+  test('withholds raw fields even when consent is present', () => {
+    const payload = buildOrbTurnRespondedPayload({
+      ...BASE,
+      consentTag: { data_export_ok: true },
+      guardrailExcluded: true,
+    });
+    expect(payload.tool_name).toBeUndefined();
+    expect(payload.transcript).toBeUndefined();
+    expect(payload.input_text).toBeUndefined();
+    expect(payload.tool_call).toBeUndefined();
+    // consent flag itself is still recorded; only the PII content is withheld.
+    expect(payload.data_export_ok).toBe(true);
+    expect(payload.reply_preview).toBe('Sure — I have opened your calendar for tomorrow.');
+  });
+});
+
+describe('buildOrbTurnRespondedPayload — tool_call.name fallback', () => {
+  test('uses tool_call.name when toolName is absent (extractor fallback path)', () => {
+    const payload = buildOrbTurnRespondedPayload({
+      ...BASE,
+      consentTag: { data_export_ok: true },
+      toolSignal: {
+        inputText: 'what is on my calendar',
+        toolCall: { name: 'search_calendar' },
+      },
+    });
+    expect(payload.tool_name).toBe('search_calendar');
+    expect(payload.tool_call).toEqual({ name: 'search_calendar' });
+    expect(extractorProjection(payload).toolName).toBe('search_calendar');
+  });
+});
+
+describe('buildOrbTurnRespondedPayload — consented turn with NO tool dispatched', () => {
+  test('emits transcript but no tool fields (extractor skips: no toolName)', () => {
+    const payload = buildOrbTurnRespondedPayload({
+      ...BASE,
+      consentTag: { data_export_ok: true },
+      toolSignal: { inputText: 'just chatting, thanks' },
+    });
+    expect(payload.transcript).toBe('just chatting, thanks');
+    expect(payload.input_text).toBe('just chatting, thanks');
+    expect(payload.tool_name).toBeUndefined();
+    expect(payload.tool_call).toBeUndefined();
+    expect(extractorProjection(payload).toolName).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Verified mismatch (extractor vs emitter)

PR #2516's preview lane found the voice-tool-router fine-tune would extract **ZERO** real rows even after consent. Confirmed before changing anything:

**Extractor** — `services/gateway/scripts/datasets/voice-tool-routing.ts:60-72` projects off the event `metadata` column:
```ts
const toolName  = meta.tool_name ?? meta.tool_call?.name;     // metadata.tool_name / tool_call.name
const userInput = meta.transcript ?? meta.input_text;          // metadata.transcript / input_text
tool_arguments  = meta.tool_call?.arguments ?? null;
if (!toolName || !userInput || typeof userInput !== 'string') continue;
```
PII gate (`scripts/datasets/lib.ts:52-53`): `topic NOT LIKE 'safety.guardrail.%'` **AND** `metadata->>data_export_ok = true`.

**Emitter** — `services/gateway/src/routes/orb-live.ts` `emitOrbTurnResponded` (pre-fix payload) carried only:
```ts
{ orb_session_id, conversation_id, reply_length, reply_preview, provider,
  metadata: { mode: 'orb_voice' }, ...dataExportConsentTag(...) }
```
`emitOasisEvent` (`services/gateway/src/services/oasis-event-service.ts:61-78`) maps the **whole payload → `oasis_events.metadata`**. So the extractor read `metadata.tool_name` / `metadata.transcript` / `metadata.tool_call` — **none of which the emitter ever set** (and the only `metadata.*` present was the nested `metadata.metadata.mode`, which the extractor doesn't read). Every candidate row hit `continue` ⇒ 0 rows. **Mismatch confirmed real.**

Additional finding: `emitOrbTurnResponded` had **no call site** in the live path, and the LiveKit agent (`session.py`) never emits `orb.turn.responded` at all — so neither provider produced rows.

## Fix (emitter aligned to extractor, under strict consent/PII)

- New `services/gateway/src/routes/orb-turn-event-payload.ts` — `buildOrbTurnRespondedPayload()` emits the extractor-aligned **top-level** fields `tool_name`, `tool_dispatched`, `tool_call{name,arguments}`, `transcript`, `input_text`.
- **Consent/PII gate:** raw transcript + tool-routing fields are attached **only when** `data_export_ok === true` (same flag the SQL PII gate filters on) **AND** the turn is **not** guardrail-excluded. Otherwise the envelope-only payload is emitted. Fail-closed — no broadening for non-consented users. `reply_preview` and all existing fields preserved (no regression).
- `emitOrbTurnResponded` now takes the tool signal + guardrail flag and is **wired into the Vertex live `turn_complete` handler**, reading the per-turn dispatched tool (`session.pendingTurnToolSignal`, captured in `executeLiveApiTool`) and the user STT buffer. Greeting turns skipped.

## Parity

- **Vertex parity ✓** — `orb-live.ts` emits the consent-gated fields on every non-greeting turn.
- **LiveKit parity ✓** — `session.py` is out of the gateway sandbox; the equivalent emit (same field shape + agent-side consent read) is specced in `docs/patches/orb-agent/BOOTSTRAP-VOICE-DATASET-EMITTER.md`.

## Tests

`services/gateway/test/orb-turn-event-payload.test.ts` (new, 9 cases) proves, mirroring the extractor's exact projection:
- consented turn → `tool_name` / `tool_call` / `transcript` / `input_text` present; extractor derives a real `(user_input, tool_chosen)` row.
- not consented → all raw/tool fields omitted; extractor skips.
- guardrail-excluded (consent present) → raw fields withheld, `data_export_ok` flag still recorded.
- `tool_call.name` fallback + consented-but-no-tool cases.

Build: `npm run build` green (after `npm install` for local TS — global TS hit the pre-existing `moduleResolution=node10` deprecation). Touched jest green: new suite 9/9, `data-export-consent` 7/7, synthetic + shadow 6/6, 3 orb-live characterization suites 33/33. Pre-commit hook passed (no `--no-verify`).

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_