### PR TITLE
feat(finetune): Vertex CustomJob training-status monitor (BOOTSTRAP-TRAINING-OPS-MONITOR)

### DIFF
--- a/.github/workflows/CRON-FINETUNE-STATUS.yml
+++ b/.github/workflows/CRON-FINETUNE-STATUS.yml
@@ -1,0 +1,102 @@
+name: Cron Finetune Status
+
+# BOOTSTRAP-TRAINING-OPS-MONITOR — Training Ops monitor for the Vertex
+# fine-tune pipeline. The submit path (CRON-FINETUNE-TRAINER.yml) is
+# fire-and-forget and does NOT wait for the job to finish; runs have sat in
+# JOB_STATE_PENDING unnoticed because L4 GPU quota pressure keeps them QUEUED
+# (Google credits only begin once a job STARTS). This workflow polls the latest
+# CustomJob for a target, classifies its state (PENDING / RUNNING / SUCCEEDED /
+# FAILED + explicit quota-wait detection), writes a status summary artifact +
+# step summary, and optionally emits an OASIS finetune.job.status event.
+#
+# READ-ONLY: it only runs `gcloud ai custom-jobs list` / `describe`. It never
+# creates, cancels, or mutates a job. Builds ON TOP of the accelerator/region
+# overrides added in PR #2515 (the quota-wait verdict points the operator at
+# those inputs).
+
+on:
+  schedule:
+    # Twice daily on weekdays (08:00 + 16:00 UTC) so a stuck-PENDING training
+    # run is noticed within hours, not next Monday.
+    - cron: '0 8,16 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Which fine-tune to monitor'
+        required: true
+        default: 'voice-tool-router'
+        type: choice
+        options: [ voice-tool-router, intent-kind, pillar-classifier ]
+      job_id:
+        description: 'Optional explicit CustomJob numeric id (blank = latest by display-name prefix)'
+        required: false
+        default: ''
+        type: string
+      region_override:
+        description: 'Optional region to query (blank = target config.yaml default, us-central1)'
+        required: false
+        default: ''
+        type: string
+      emit_oasis_event:
+        description: 'Emit OASIS finetune.job.status event to staging'
+        required: false
+        default: 'true'
+        type: choice
+        options: [ 'true', 'false' ]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cron-finetune-status-${{ inputs.target || 'voice-tool-router' }}
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: lovable-vitana-vers1
+  GCP_REGION: us-central1
+
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        target: ${{ inputs.target && fromJSON(format('[{0}]', toJSON(inputs.target))) || fromJSON('["voice-tool-router"]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/gateway/package-lock.json
+      - working-directory: services/gateway
+        run: npm ci --no-audit --no-fund
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Monitor ${{ matrix.target }} CustomJob status
+        working-directory: services/gateway
+        env:
+          GCP_PROJECT: ${{ env.GCP_PROJECT }}
+          FINETUNE_JOB_ID: ${{ inputs.job_id || '' }}
+          FINETUNE_REGION: ${{ inputs.region_override || '' }}
+          FINETUNE_STATUS_OUT: /tmp/finetune-status-${{ matrix.target }}.md
+          STAGING_SUPABASE_URL: ${{ (inputs.emit_oasis_event != 'false') && secrets.STAGING_SUPABASE_URL || '' }}
+          STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ (inputs.emit_oasis_event != 'false') && secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY || '' }}
+        run: npx tsx scripts/finetune/status-monitor.ts ${{ matrix.target }}
+
+      - name: Upload status summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: finetune-status-${{ matrix.target }}-${{ github.run_id }}
+          path: /tmp/finetune-status-${{ matrix.target }}.md
+          if-no-files-found: warn
+          retention-days: 30

--- a/services/gateway/scripts/finetune/status-monitor-lib.ts
+++ b/services/gateway/scripts/finetune/status-monitor-lib.ts
@@ -1,0 +1,203 @@
+/**
+ * Vertex CustomJob status classifier — Training Ops monitor
+ * (BOOTSTRAP-TRAINING-OPS-MONITOR).
+ *
+ * Pure, side-effect-free classification of a Vertex AI CustomJob describe
+ * payload into an operator-facing verdict. Lives separately from the runner
+ * (status-monitor.ts) so it can be unit-tested without invoking gcloud.
+ *
+ * WHY THIS EXISTS: the submit pipeline (submit-job.ts / CRON-FINETUNE-TRAINER)
+ * is fire-and-forget — it does NOT wait for the job to finish. Jobs have sat in
+ * JOB_STATE_PENDING unnoticed because L4 GPU quota pressure in us-central1 keeps
+ * the run QUEUED (Google credits only start once the job STARTS). This module
+ * turns the raw Vertex state into a verdict that surfaces that quota-wait case
+ * explicitly so an operator can re-submit to a region with quota (the
+ * accelerator/region overrides added in PR #2515).
+ *
+ * Read-only: this never mutates the job. The runner only ever calls
+ * `gcloud ai custom-jobs describe` / `list`.
+ */
+
+/** Verdict bucket the operator acts on. */
+export type FinetuneVerdict =
+  | 'PENDING' // accepted, not yet running (may be quota-waiting — see quotaWait)
+  | 'RUNNING' // actively training
+  | 'SUCCEEDED' // finished OK; weights should be in the output prefix
+  | 'FAILED' // failed / cancelled / expired — needs attention
+  | 'UNKNOWN'; // no job found or unrecognised state
+
+/** Subset of `gcloud ai custom-jobs describe` fields we classify on. */
+export interface VertexJobDescribe {
+  name?: string; // full resource path (projects/.../customJobs/<id>)
+  displayName?: string;
+  state?: string; // e.g. JOB_STATE_PENDING, JOB_STATE_RUNNING
+  createTime?: string;
+  startTime?: string; // ONLY set once the job actually starts running
+  endTime?: string;
+  error?: { code?: number; message?: string } | null;
+}
+
+export interface FinetuneStatusReport {
+  jobId: string | null;
+  displayName: string | null;
+  state: string;
+  verdict: FinetuneVerdict;
+  /** True when the job is PENDING and almost certainly blocked on GPU quota. */
+  quotaWait: boolean;
+  /** True for any verdict that warrants an operator looking now. */
+  needsAttention: boolean;
+  /** Minutes since createTime (null if unknown). Used for stuck-pending detection. */
+  ageMinutes: number | null;
+  /** Human-readable one-liner. */
+  summary: string;
+  errorMessage: string | null;
+}
+
+/**
+ * A PENDING job older than this (and never started) is treated as a
+ * quota-wait — surfaced so the operator re-submits to a region with capacity.
+ */
+export const STUCK_PENDING_THRESHOLD_MINUTES = 30;
+
+const RUNNING_STATES = new Set(['JOB_STATE_RUNNING']);
+const SUCCEEDED_STATES = new Set(['JOB_STATE_SUCCEEDED']);
+const FAILED_STATES = new Set([
+  'JOB_STATE_FAILED',
+  'JOB_STATE_CANCELLED',
+  'JOB_STATE_CANCELLING',
+  'JOB_STATE_EXPIRED',
+]);
+const PENDING_STATES = new Set([
+  'JOB_STATE_QUEUED',
+  'JOB_STATE_PENDING',
+  'JOB_STATE_UPDATING',
+]);
+
+/** Extract the numeric job id from a full Vertex resource name. */
+export function extractJobId(name?: string | null): string | null {
+  if (!name) return null;
+  const m = name.match(/customJobs\/(\d+)/);
+  if (m) return m[1];
+  // Already a bare numeric id?
+  if (/^\d+$/.test(name)) return name;
+  return null;
+}
+
+export function mapStateToVerdict(state: string | undefined | null): FinetuneVerdict {
+  if (!state) return 'UNKNOWN';
+  if (RUNNING_STATES.has(state)) return 'RUNNING';
+  if (SUCCEEDED_STATES.has(state)) return 'SUCCEEDED';
+  if (FAILED_STATES.has(state)) return 'FAILED';
+  if (PENDING_STATES.has(state)) return 'PENDING';
+  return 'UNKNOWN';
+}
+
+function diffMinutes(fromIso?: string, nowMs?: number): number | null {
+  if (!fromIso) return null;
+  const t = Date.parse(fromIso);
+  if (Number.isNaN(t)) return null;
+  const now = nowMs ?? Date.now();
+  return Math.max(0, Math.round((now - t) / 60000));
+}
+
+/**
+ * Detect the L4-quota-wait case: a job that Vertex ACCEPTED (pending/queued)
+ * but never STARTED, and has been waiting past the stuck threshold. There is
+ * no explicit "waiting on quota" field in describe output for a queued
+ * CustomJob, so we infer it: state is pending AND startTime is unset AND it's
+ * been queued longer than STUCK_PENDING_THRESHOLD_MINUTES.
+ */
+export function isQuotaWait(job: VertexJobDescribe, nowMs?: number): boolean {
+  const verdict = mapStateToVerdict(job.state);
+  if (verdict !== 'PENDING') return false;
+  if (job.startTime) return false; // it started -> not stuck queued
+  const age = diffMinutes(job.createTime, nowMs);
+  if (age === null) return false;
+  return age >= STUCK_PENDING_THRESHOLD_MINUTES;
+}
+
+/** Classify a single describe payload into the operator-facing report. */
+export function classifyJob(job: VertexJobDescribe, nowMs?: number): FinetuneStatusReport {
+  const jobId = extractJobId(job.name);
+  const state = job.state ?? 'UNKNOWN';
+  const verdict = mapStateToVerdict(state);
+  const quotaWait = isQuotaWait(job, nowMs);
+  const ageMinutes = diffMinutes(job.createTime, nowMs);
+  const errorMessage = job.error?.message ?? null;
+
+  // FAILED always needs attention; a quota-stuck PENDING does too (operator
+  // should re-submit to a region with quota). Plain RUNNING/PENDING/SUCCEEDED
+  // do not.
+  const needsAttention = verdict === 'FAILED' || quotaWait || verdict === 'UNKNOWN';
+
+  let summary: string;
+  switch (verdict) {
+    case 'RUNNING':
+      summary = `Job ${jobId ?? '?'} is RUNNING${
+        ageMinutes !== null ? ` (queued+running ${ageMinutes}m)` : ''
+      }.`;
+      break;
+    case 'SUCCEEDED':
+      summary = `Job ${jobId ?? '?'} SUCCEEDED — weights should be in the output prefix.`;
+      break;
+    case 'FAILED':
+      summary = `Job ${jobId ?? '?'} ${state}${errorMessage ? `: ${errorMessage}` : ''}.`;
+      break;
+    case 'PENDING':
+      summary = quotaWait
+        ? `Job ${jobId ?? '?'} stuck PENDING for ${ageMinutes}m and never started — likely GPU quota wait. ` +
+          'Re-submit to a region with capacity (accelerator/region overrides).'
+        : `Job ${jobId ?? '?'} is PENDING${
+            ageMinutes !== null ? ` (${ageMinutes}m)` : ''
+          } — accepted, not yet started.`;
+      break;
+    default:
+      summary = jobId
+        ? `Job ${jobId} has unrecognised state ${state}.`
+        : 'No matching CustomJob found.';
+  }
+
+  return {
+    jobId,
+    displayName: job.displayName ?? null,
+    state,
+    verdict,
+    quotaWait,
+    needsAttention,
+    ageMinutes,
+    summary,
+    errorMessage,
+  };
+}
+
+/**
+ * Pick the latest job from a `gcloud ai custom-jobs list` array by createTime
+ * (descending). Used to find the most recent voice-tool-router run. Returns
+ * null for an empty list.
+ */
+export function pickLatestJob(jobs: VertexJobDescribe[]): VertexJobDescribe | null {
+  if (!jobs.length) return null;
+  return [...jobs].sort((a, b) => {
+    const ta = Date.parse(a.createTime ?? '') || 0;
+    const tb = Date.parse(b.createTime ?? '') || 0;
+    return tb - ta;
+  })[0];
+}
+
+/** Map a verdict onto an OASIS event status field. */
+export function verdictToEventStatus(
+  verdict: FinetuneVerdict,
+): 'success' | 'warning' | 'error' | 'info' {
+  switch (verdict) {
+    case 'SUCCEEDED':
+      return 'success';
+    case 'FAILED':
+      return 'error';
+    case 'PENDING':
+      return 'warning'; // includes quota-wait
+    case 'RUNNING':
+      return 'info';
+    default:
+      return 'warning';
+  }
+}

--- a/services/gateway/scripts/finetune/status-monitor.ts
+++ b/services/gateway/scripts/finetune/status-monitor.ts
@@ -1,0 +1,220 @@
+/**
+ * Vertex CustomJob status monitor runner — Training Ops
+ * (BOOTSTRAP-TRAINING-OPS-MONITOR).
+ *
+ * Read-only monitor for the fine-tune pipeline. The submit path
+ * (submit-job.ts / CRON-FINETUNE-TRAINER.yml) is fire-and-forget; this script
+ * answers "what is the latest <target> job actually doing right now?" by:
+ *   1. `gcloud ai custom-jobs list` to find the latest run for the target's
+ *      display-name prefix (or describing an explicit FINETUNE_JOB_ID).
+ *   2. `gcloud ai custom-jobs describe` for the full state/timestamps/error.
+ *   3. classifyJob() (pure, in status-monitor-lib.ts) -> verdict + quota-wait.
+ *   4. Writes a Markdown summary to docs/ (and the GitHub step summary when
+ *      run in CI) and optionally emits an OASIS `finetune.job.status` event.
+ *
+ * This NEVER creates, cancels, or mutates a job — describe/list only.
+ *
+ * Run: `npx tsx scripts/finetune/status-monitor.ts <target>`
+ *      target: voice-tool-router | intent-kind | pillar-classifier
+ *
+ * Env:
+ *   GCP_PROJECT (default lovable-vitana-vers1)
+ *   FINETUNE_REGION  — override region to query (default: target config.yaml)
+ *   FINETUNE_JOB_ID  — describe this exact numeric job id instead of listing
+ *   FINETUNE_STATUS_OUT — output Markdown path (default docs/finetune-status-<target>.md)
+ *   STAGING_SUPABASE_URL / STAGING_SUPABASE_SERVICE_ROLE_KEY — if both set,
+ *     emit an OASIS finetune.job.status event to staging oasis_events.
+ *   GITHUB_STEP_SUMMARY — when set (CI), the summary is appended there too.
+ */
+
+import { execSync } from 'child_process';
+import { promises as fs } from 'fs';
+import path from 'path';
+import {
+  classifyJob,
+  pickLatestJob,
+  verdictToEventStatus,
+  type FinetuneStatusReport,
+  type VertexJobDescribe,
+} from './status-monitor-lib';
+
+const TARGET = process.argv[2];
+const VALID_TARGETS = new Set(['voice-tool-router', 'intent-kind', 'pillar-classifier']);
+const GCP_PROJECT = process.env.GCP_PROJECT || 'lovable-vitana-vers1';
+const JOB_ID = (process.env.FINETUNE_JOB_ID || '').trim();
+const REGION_OVERRIDE = (process.env.FINETUNE_REGION || '').trim();
+const STAGING_URL = process.env.STAGING_SUPABASE_URL;
+const STAGING_KEY = process.env.STAGING_SUPABASE_SERVICE_ROLE_KEY;
+
+if (!TARGET || !VALID_TARGETS.has(TARGET)) {
+  console.error(`Usage: tsx status-monitor.ts <target>\n  target: ${[...VALID_TARGETS].join(' | ')}`);
+  process.exit(2);
+}
+
+interface TargetConfig {
+  region: string;
+  displayNamePrefix: string;
+}
+
+async function loadTargetConfig(): Promise<TargetConfig> {
+  const configPath = path.join(__dirname, TARGET, 'config.yaml');
+  const raw = await fs.readFile(configPath, 'utf-8');
+  const jsYaml = await import('js-yaml');
+  const cfg = jsYaml.load(raw) as {
+    vertex_custom_job: { region: string; display_name_prefix: string };
+  };
+  return {
+    region: REGION_OVERRIDE || cfg.vertex_custom_job.region,
+    displayNamePrefix: cfg.vertex_custom_job.display_name_prefix,
+  };
+}
+
+const DESCRIBE_FORMAT = 'json(name,displayName,state,createTime,startTime,endTime,error)';
+
+function describeJob(jobId: string, region: string): VertexJobDescribe {
+  const out = execSync(
+    `gcloud ai custom-jobs describe ${shellQuote(jobId)} ` +
+      `--project=${shellQuote(GCP_PROJECT)} --region=${shellQuote(region)} ` +
+      `--format=${shellQuote(DESCRIBE_FORMAT)}`,
+    { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  return JSON.parse(out) as VertexJobDescribe;
+}
+
+function listJobsForPrefix(prefix: string, region: string): VertexJobDescribe[] {
+  // `list` does not server-side filter on a displayName prefix reliably across
+  // gcloud versions, so we pull recent jobs and filter client-side.
+  const out = execSync(
+    `gcloud ai custom-jobs list ` +
+      `--project=${shellQuote(GCP_PROJECT)} --region=${shellQuote(region)} ` +
+      `--sort-by=~createTime --limit=50 ` +
+      `--format=${shellQuote(DESCRIBE_FORMAT.replace('json(', 'json('))}`,
+    { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  const all = (JSON.parse(out || '[]') as VertexJobDescribe[]) || [];
+  return all.filter((j) => (j.displayName || '').startsWith(prefix));
+}
+
+function renderMarkdown(report: FinetuneStatusReport, region: string): string {
+  const stamp = new Date().toISOString();
+  return [
+    `# Fine-tune status — ${TARGET}`,
+    '',
+    `_Generated ${stamp} (BOOTSTRAP-TRAINING-OPS-MONITOR, read-only)_`,
+    '',
+    '| Field | Value |',
+    '| --- | --- |',
+    `| Target | \`${TARGET}\` |`,
+    `| Region | \`${region}\` |`,
+    `| Job ID | ${report.jobId ? `\`${report.jobId}\`` : '_(none found)_'} |`,
+    `| Display name | ${report.displayName ? `\`${report.displayName}\`` : '—'} |`,
+    `| State | \`${report.state}\` |`,
+    `| Verdict | **${report.verdict}** |`,
+    `| Quota wait | ${report.quotaWait ? '⚠️ YES' : 'no'} |`,
+    `| Needs attention | ${report.needsAttention ? 'YES' : 'no'} |`,
+    `| Age (min) | ${report.ageMinutes ?? '—'} |`,
+    `| Error | ${report.errorMessage ? `\`${report.errorMessage}\`` : '—'} |`,
+    '',
+    `> ${report.summary}`,
+    '',
+    report.quotaWait
+      ? '**Action:** the job was accepted but never started — almost certainly GPU ' +
+        'quota pressure (Google credits only begin once a job STARTS). Re-submit via ' +
+        'CRON-FINETUNE-TRAINER with `region_override` / `accelerator_type_override` ' +
+        '(PR #2515) to capacity that has quota.'
+      : '',
+    '',
+  ].join('\n');
+}
+
+async function emitOasisEvent(report: FinetuneStatusReport, region: string): Promise<void> {
+  if (!STAGING_URL || !STAGING_KEY) {
+    console.log('[status-monitor] STAGING_SUPABASE_* not set — skipping OASIS event emit');
+    return;
+  }
+  const body = {
+    vtid: 'VTID-03179',
+    topic: 'finetune.job.status',
+    service: 'gateway/finetune-status-monitor',
+    role: 'CICD',
+    model: 'finetune-status-monitor',
+    status: verdictToEventStatus(report.verdict),
+    message: report.summary,
+    metadata: {
+      env: 'staging',
+      target: TARGET,
+      region,
+      job_id: report.jobId,
+      display_name: report.displayName,
+      state: report.state,
+      verdict: report.verdict,
+      quota_wait: report.quotaWait,
+      needs_attention: report.needsAttention,
+      age_minutes: report.ageMinutes,
+      error_message: report.errorMessage,
+    },
+  };
+  try {
+    await fetch(`${STAGING_URL}/rest/v1/oasis_events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: STAGING_KEY,
+        Authorization: `Bearer ${STAGING_KEY}`,
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(body),
+    });
+    console.log('[status-monitor] emitted OASIS finetune.job.status event');
+  } catch (err) {
+    console.error('[status-monitor] OASIS event emit failed:', err);
+  }
+}
+
+async function main(): Promise<void> {
+  const { region, displayNamePrefix } = await loadTargetConfig();
+  console.log(`[status-monitor] target=${TARGET} region=${region} prefix=${displayNamePrefix}`);
+
+  let job: VertexJobDescribe | null = null;
+  try {
+    if (JOB_ID) {
+      console.log(`[status-monitor] describing explicit job ${JOB_ID}`);
+      job = describeJob(JOB_ID, region);
+    } else {
+      const jobs = listJobsForPrefix(displayNamePrefix, region);
+      console.log(`[status-monitor] found ${jobs.length} job(s) matching prefix`);
+      job = pickLatestJob(jobs);
+    }
+  } catch (err) {
+    console.error('[status-monitor] gcloud query failed:', err);
+    // Still emit an UNKNOWN report so the operator sees the monitor ran.
+    job = null;
+  }
+
+  const report = classifyJob(job ?? {}, Date.now());
+  console.log(`[status-monitor] verdict=${report.verdict} quotaWait=${report.quotaWait}`);
+  console.log(`[status-monitor] ${report.summary}`);
+
+  const md = renderMarkdown(report, region);
+  const outPath = process.env.FINETUNE_STATUS_OUT
+    ? path.resolve(process.env.FINETUNE_STATUS_OUT)
+    : path.join(__dirname, '..', '..', '..', '..', 'docs', `finetune-status-${TARGET}.md`);
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  await fs.writeFile(outPath, md, 'utf-8');
+  console.log(`[status-monitor] wrote status summary -> ${outPath}`);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, `\n${md}\n`, 'utf-8');
+  }
+
+  await emitOasisEvent(report, region);
+
+  // Machine-readable line for downstream tooling / log scraping.
+  console.log(`[status-monitor] result ${JSON.stringify(report)}`);
+}
+
+function shellQuote(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+main();

--- a/services/gateway/test/finetune-status-monitor-lib.test.ts
+++ b/services/gateway/test/finetune-status-monitor-lib.test.ts
@@ -1,0 +1,180 @@
+import {
+  classifyJob,
+  extractJobId,
+  isQuotaWait,
+  mapStateToVerdict,
+  pickLatestJob,
+  verdictToEventStatus,
+  STUCK_PENDING_THRESHOLD_MINUTES,
+  type VertexJobDescribe,
+} from '../scripts/finetune/status-monitor-lib';
+
+const NOW = Date.parse('2026-06-02T12:00:00Z');
+const minsAgo = (m: number) => new Date(NOW - m * 60_000).toISOString();
+
+describe('mapStateToVerdict', () => {
+  test('maps Vertex job states to verdict buckets', () => {
+    expect(mapStateToVerdict('JOB_STATE_RUNNING')).toBe('RUNNING');
+    expect(mapStateToVerdict('JOB_STATE_SUCCEEDED')).toBe('SUCCEEDED');
+    expect(mapStateToVerdict('JOB_STATE_FAILED')).toBe('FAILED');
+    expect(mapStateToVerdict('JOB_STATE_CANCELLED')).toBe('FAILED');
+    expect(mapStateToVerdict('JOB_STATE_EXPIRED')).toBe('FAILED');
+    expect(mapStateToVerdict('JOB_STATE_PENDING')).toBe('PENDING');
+    expect(mapStateToVerdict('JOB_STATE_QUEUED')).toBe('PENDING');
+  });
+
+  test('returns UNKNOWN for missing or unrecognised states', () => {
+    expect(mapStateToVerdict(undefined)).toBe('UNKNOWN');
+    expect(mapStateToVerdict('')).toBe('UNKNOWN');
+    expect(mapStateToVerdict('JOB_STATE_SOMETHING_NEW')).toBe('UNKNOWN');
+  });
+});
+
+describe('extractJobId', () => {
+  test('pulls the numeric id from a full resource name', () => {
+    expect(
+      extractJobId('projects/123/locations/us-central1/customJobs/3154255301083922432'),
+    ).toBe('3154255301083922432');
+  });
+  test('accepts a bare numeric id and rejects junk', () => {
+    expect(extractJobId('3154255301083922432')).toBe('3154255301083922432');
+    expect(extractJobId('not-a-job')).toBeNull();
+    expect(extractJobId(undefined)).toBeNull();
+  });
+});
+
+describe('isQuotaWait (L4 quota-wait detection)', () => {
+  test('flags a long-pending job that never started', () => {
+    const job: VertexJobDescribe = {
+      state: 'JOB_STATE_PENDING',
+      createTime: minsAgo(STUCK_PENDING_THRESHOLD_MINUTES + 5),
+      // startTime intentionally absent — Vertex queued it but never started
+    };
+    expect(isQuotaWait(job, NOW)).toBe(true);
+  });
+
+  test('does NOT flag a freshly-pending job under the threshold', () => {
+    const job: VertexJobDescribe = {
+      state: 'JOB_STATE_PENDING',
+      createTime: minsAgo(STUCK_PENDING_THRESHOLD_MINUTES - 5),
+    };
+    expect(isQuotaWait(job, NOW)).toBe(false);
+  });
+
+  test('does NOT flag a job that has already started running', () => {
+    const job: VertexJobDescribe = {
+      state: 'JOB_STATE_RUNNING',
+      createTime: minsAgo(120),
+      startTime: minsAgo(60),
+    };
+    expect(isQuotaWait(job, NOW)).toBe(false);
+  });
+
+  test('does NOT flag a pending job that recorded a startTime', () => {
+    const job: VertexJobDescribe = {
+      state: 'JOB_STATE_PENDING',
+      createTime: minsAgo(120),
+      startTime: minsAgo(90),
+    };
+    expect(isQuotaWait(job, NOW)).toBe(false);
+  });
+});
+
+describe('classifyJob', () => {
+  test('RUNNING job: not quota-wait, no attention needed', () => {
+    const r = classifyJob(
+      {
+        name: 'projects/1/locations/us-central1/customJobs/999',
+        displayName: 'voice-tool-router-ft-2026',
+        state: 'JOB_STATE_RUNNING',
+        createTime: minsAgo(40),
+        startTime: minsAgo(10),
+      },
+      NOW,
+    );
+    expect(r.verdict).toBe('RUNNING');
+    expect(r.quotaWait).toBe(false);
+    expect(r.needsAttention).toBe(false);
+    expect(r.jobId).toBe('999');
+  });
+
+  test('SUCCEEDED job: success, no attention needed', () => {
+    const r = classifyJob({ name: 'x/customJobs/1', state: 'JOB_STATE_SUCCEEDED' }, NOW);
+    expect(r.verdict).toBe('SUCCEEDED');
+    expect(r.needsAttention).toBe(false);
+    expect(r.summary).toMatch(/SUCCEEDED/);
+  });
+
+  test('FAILED job: surfaces error message and needs attention', () => {
+    const r = classifyJob(
+      {
+        name: 'x/customJobs/2',
+        state: 'JOB_STATE_FAILED',
+        error: { code: 9, message: 'torch shadowed the container PyTorch' },
+      },
+      NOW,
+    );
+    expect(r.verdict).toBe('FAILED');
+    expect(r.needsAttention).toBe(true);
+    expect(r.errorMessage).toMatch(/torch shadowed/);
+    expect(r.summary).toMatch(/torch shadowed/);
+  });
+
+  test('stuck PENDING job: quota-wait verdict needs attention and names the fix', () => {
+    const r = classifyJob(
+      {
+        name: 'x/customJobs/3',
+        state: 'JOB_STATE_PENDING',
+        createTime: minsAgo(STUCK_PENDING_THRESHOLD_MINUTES + 60),
+      },
+      NOW,
+    );
+    expect(r.verdict).toBe('PENDING');
+    expect(r.quotaWait).toBe(true);
+    expect(r.needsAttention).toBe(true);
+    expect(r.summary).toMatch(/quota/i);
+  });
+
+  test('fresh PENDING job: not quota-wait, no attention needed', () => {
+    const r = classifyJob(
+      { name: 'x/customJobs/4', state: 'JOB_STATE_PENDING', createTime: minsAgo(2) },
+      NOW,
+    );
+    expect(r.verdict).toBe('PENDING');
+    expect(r.quotaWait).toBe(false);
+    expect(r.needsAttention).toBe(false);
+  });
+
+  test('empty describe (no job found): UNKNOWN and needs attention', () => {
+    const r = classifyJob({}, NOW);
+    expect(r.verdict).toBe('UNKNOWN');
+    expect(r.jobId).toBeNull();
+    expect(r.needsAttention).toBe(true);
+    expect(r.summary).toMatch(/No matching CustomJob/);
+  });
+});
+
+describe('pickLatestJob', () => {
+  test('returns the most recent job by createTime', () => {
+    const jobs: VertexJobDescribe[] = [
+      { name: 'x/customJobs/old', createTime: minsAgo(500) },
+      { name: 'x/customJobs/new', createTime: minsAgo(10) },
+      { name: 'x/customJobs/mid', createTime: minsAgo(100) },
+    ];
+    expect(pickLatestJob(jobs)?.name).toBe('x/customJobs/new');
+  });
+
+  test('returns null for an empty list', () => {
+    expect(pickLatestJob([])).toBeNull();
+  });
+});
+
+describe('verdictToEventStatus', () => {
+  test('maps verdicts onto OASIS event status values', () => {
+    expect(verdictToEventStatus('SUCCEEDED')).toBe('success');
+    expect(verdictToEventStatus('FAILED')).toBe('error');
+    expect(verdictToEventStatus('PENDING')).toBe('warning');
+    expect(verdictToEventStatus('RUNNING')).toBe('info');
+    expect(verdictToEventStatus('UNKNOWN')).toBe('warning');
+  });
+});


### PR DESCRIPTION
## Training Ops — Vertex CustomJob status monitor

The submit pipeline (`CRON-FINETUNE-TRAINER.yml` / `submit-job.ts`) is fire-and-forget — it never waits for a job to finish. Runs have sat in `JOB_STATE_PENDING` unnoticed because L4 GPU quota pressure in `us-central1` keeps them QUEUED (Google credits only begin once a job STARTS).

This adds a **read-only** status monitor that answers "what is the latest fine-tune job actually doing right now?".

### What's added
- **`scripts/finetune/status-monitor-lib.ts`** — pure, side-effect-free classifier: maps Vertex state → verdict (`PENDING` / `RUNNING` / `SUCCEEDED` / `FAILED` / `UNKNOWN`), with explicit **L4 quota-wait detection** (PENDING + never-started + queued past a 30 min threshold → `quotaWait=true`). Also `pickLatestJob`, `extractJobId`, `verdictToEventStatus`.
- **`scripts/finetune/status-monitor.ts`** — runner: `gcloud ai custom-jobs list`/`describe` (read-only) for the latest job by display-name prefix (or an explicit `FINETUNE_JOB_ID`), classifies it, writes a Markdown status summary + GitHub step summary, and optionally emits an OASIS `finetune.job.status` event to staging.
- **`.github/workflows/CRON-FINETUNE-STATUS.yml`** — scheduled (weekdays 08:00/16:00 UTC) + `workflow_dispatch`. Reuses the WIF auth + `gcloud` pattern from `DESCRIBE-VERTEX-CUSTOMJOB.yml`/`CRON-FINETUNE-TRAINER.yml`. Uploads the status summary as an artifact.
- **`test/finetune-status-monitor-lib.test.ts`** — 17 unit tests for the classification logic.

### Builds on PR #2515 (does not touch it)
When a job is quota-stuck, the verdict/summary points the operator at the accelerator/region overrides added in #2515 — re-submit to a region with capacity. The submit-job override logic is only read, never modified.

### Safety
Read-only against Vertex: only `list` / `describe`. Never creates, cancels, or mutates a job. The workflow was NOT run/dispatched.

### Verification
- `npx jest test/finetune-status-monitor-lib.test.ts` → 17/17 pass
- Existing `test/finetune-submit-job-lib.test.ts` → 5/5 still pass
- `tsc --noEmit` clean on the new scripts
- Workflow YAML parses

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_