### PR TITLE
feat(autopilot): backlog cleanup apply tool — dry-run-by-default archiver (BOOTSTRAP-AUTOPILOT-BACKLOG-CLEANUP)

### DIFF
--- a/docs/cleanup/autopilot-backlog-cleanup-report.md
+++ b/docs/cleanup/autopilot-backlog-cleanup-report.md
@@ -1,0 +1,100 @@
+# Autopilot Backlog Cleanup Report
+
+**Lane:** Autopilot Backlog Cleanup (`BOOTSTRAP-AUTOPILOT-BACKLOG-CLEANUP`)
+**Date:** 2026-06-02
+**Apply tool:** `services/gateway/scripts/autopilot/backlog-cleanup-apply.ts`
+**Classification source (reused, not re-derived):** `services/gateway/scripts/autopilot/backlog-conversion-classifier.ts` (VTID-03232)
+
+## Summary
+
+The dev-autopilot `vtid_ledger` backlog has **21 stale/blocked rows**. The
+existing W3-C1 conversion classifier already produced the authoritative
+verdict (see `docs/PHASE-1-W3-C1-ACCEPTANCE.md`):
+
+| Action | Count | This lane's behaviour |
+|---|---:|---|
+| `archive_stale_noise` | 10 | **ARCHIVE** (status=cancelled, is_terminal=true, terminal_outcome=cancelled) |
+| `leave_in_operator_review` | 10 | **UNTOUCHED** |
+| `needs_human_spec` | 1 | **UNTOUCHED** (human-spec item — VTID-01227) |
+| `convert_to_dev_autopilot` | 0 | n/a (none convertible) |
+
+The backlog is structurally **non-fuel** for Phase 1. The cleanup tool's only
+job is to safely archive the 10 stale-noise rows so the operator's queue is no
+longer cluttered, while leaving everything that needs human judgement intact.
+
+## What would be archived (10 rows)
+
+All 10 are `>30d` stale AND not Phase 1 relevant (product-side bug reports /
+feature requests that don't intersect the latency/voice/cache/eval/ci/aws/dataset
+bands). The classifier reason for each is `age <N>d > 30 AND no Phase 1
+relevance — archive`. Top 3 (per the W3-C1 acceptance doc):
+
+- **VTID-01869** (age≈69d) — "Gateway: Feature Request: Support attaching screenshots to ..."
+- **VTID-01881** (age≈60d) — "Gateway: Fix chat history issues: older messages loading ..."
+- **VTID-01882** (age≈60d) — "Gateway: Fix the bug in the 'Search tasks' input field"
+
+(The exact live set of 10 is resolved at run time from prod `vtid_ledger` via
+the classifier — the apply tool never hardcodes VTIDs.)
+
+### Archive semantics
+
+Archive is a **status transition, never a delete**:
+
+- `status` → `cancelled` (the documented terminal "did not / will not run" enum value in CLAUDE.md §3)
+- `is_terminal` → `true`
+- `terminal_outcome` → `cancelled`
+- `metadata.archived` → `{ by, action: "archive_stale_noise", reason, archived_at }` (merged into existing metadata; existing provenance preserved)
+
+The PATCH is scoped to `vtid=eq.<id>` **and** `is_terminal=eq.false`, so it is
+idempotent and can never re-terminalize an already-terminal row or touch a
+sibling. No row is ever deleted.
+
+## What is left untouched
+
+### 10 operator-review rows (`leave_in_operator_review`)
+Rows with no clear next step, or business/legal/prod-mutation signals. These
+stay in the operator queue for human triage. The cleanup tool never modifies
+them.
+
+### 1 human-spec item (`needs_human_spec`)
+- **VTID-01227** — "01228 - UNIFIED VITANA AUTH & Orb auth"
+  - phase1 band: `voice`
+  - classifier reason: Phase 1 relevant (voice) but lacks a file/surface hint
+  - This is a sweeping unified-auth + ORB-auth migration. It is correctly
+    **not** auto-convertible and **not** archived — it needs a human-authored
+    spec before any execution. Left exactly as-is.
+
+## Safety guarantees of the apply tool
+
+1. **DRY-RUN by default.** Writes nothing unless invoked with `--execute --confirm=archive-stale`.
+2. **Archives only `archive_stale_noise`.** It reads the classifier's
+   `archive_candidates` list verbatim; `leave_in_operator_review`,
+   `needs_human_spec`, and `convert_to_dev_autopilot` rows are never written.
+3. **Never deletes.** Archive is a status/terminal transition only.
+4. **Never modifies executor allowlists.** The tool only PATCHes the targeted
+   `vtid_ledger` rows; it does not touch `autopilot-executable-source-types.ts`
+   or the drain-plan `EXECUTABLE_ALLOWLIST`.
+5. **Reuses existing classification.** No keyword bands, action ladder, or
+   staleness thresholds are re-derived — it imports `generate()` from the
+   shipped classifier.
+
+## Usage
+
+```bash
+# Dry run (default) — prints the plan + per-row reasons, writes nothing
+npx tsx services/gateway/scripts/autopilot/backlog-cleanup-apply.ts
+
+# Apply (operator only) — archives ONLY the 10 archive_stale_noise rows
+npx tsx services/gateway/scripts/autopilot/backlog-cleanup-apply.ts \
+  --execute --confirm=archive-stale
+```
+
+Env required: `PROD_SUPABASE_URL`, `PROD_SUPABASE_SERVICE_ROLE`.
+Optional: `REPORT_MARKDOWN_PATH` (writes a Markdown run summary).
+
+## Status
+
+- Tool written, type-checks clean, gateway build green (`tsc` exit 0).
+- **No `--execute` run performed from this lane** — dry-run / artifact only.
+- Recommended operator action: review this report, then run the apply tool
+  with `--execute --confirm=archive-stale` to archive the 10 stale-noise rows.

--- a/services/gateway/scripts/autopilot/backlog-cleanup-apply.ts
+++ b/services/gateway/scripts/autopilot/backlog-cleanup-apply.ts
@@ -1,0 +1,303 @@
+/**
+ * Backlog cleanup APPLY — Phase 1 W3 "Autopilot Backlog Cleanup" lane
+ * (BOOTSTRAP-AUTOPILOT-BACKLOG-CLEANUP).
+ *
+ * Safely ARCHIVES the dev-autopilot backlog rows that the existing
+ * conversion classifier (scripts/autopilot/backlog-conversion-classifier.ts,
+ * VTID-03232) already labelled `archive_stale_noise` — and ONLY those rows.
+ *
+ * This script reuses the classifier verbatim. It does NOT re-derive any
+ * classification logic, keyword bands, or action ladder. It calls the
+ * exported `generate()` and acts on the classifier's verdict.
+ *
+ * Scope (what it touches):
+ *   - rows classified `archive_stale_noise`      → ARCHIVE
+ *   - rows classified `leave_in_operator_review` → UNTOUCHED
+ *   - rows classified `needs_human_spec`         → UNTOUCHED (human-spec item,
+ *                                                   e.g. VTID-01227 auth/ORB)
+ *   - rows classified `convert_to_dev_autopilot` → UNTOUCHED (operator-driven
+ *                                                   conversion via convert-row)
+ *
+ * Archive semantics (matches the vtid_ledger status enum in CLAUDE.md:
+ *   scheduled, in_progress, completed, pending, blocked, cancelled):
+ *   - status            = 'cancelled'   (the terminal "did not / will not run" enum value)
+ *   - is_terminal       = true
+ *   - terminal_outcome  = 'cancelled'   (mirrors the documented terminal_outcome enum)
+ *   - metadata.archived = { by, reason, action, archived_at }
+ *
+ * NEVER deletes a row. NEVER modifies executor allowlists. NEVER converts.
+ *
+ * DRY-RUN BY DEFAULT. Refuses to write unless BOTH:
+ *   --execute
+ *   --confirm=archive-stale
+ *
+ * Env:
+ *   PROD_SUPABASE_URL            (required — read + write)
+ *   PROD_SUPABASE_SERVICE_ROLE   (required — read + write)
+ *   REPORT_MARKDOWN_PATH         (optional — writes a Markdown summary)
+ *
+ * Usage:
+ *   # Dry run (default) — prints the plan, writes nothing
+ *   npx tsx services/gateway/scripts/autopilot/backlog-cleanup-apply.ts
+ *
+ *   # Apply (operator only) — archives ONLY the archive_stale_noise rows
+ *   npx tsx services/gateway/scripts/autopilot/backlog-cleanup-apply.ts \
+ *     --execute --confirm=archive-stale
+ */
+
+import { promises as fs } from 'fs';
+import { generate, type Classification, type ConversionPlan } from './backlog-conversion-classifier';
+
+const PROD_SUPABASE_URL = process.env.PROD_SUPABASE_URL;
+const PROD_SUPABASE_KEY = process.env.PROD_SUPABASE_SERVICE_ROLE;
+const REPORT_MARKDOWN_PATH = process.env.REPORT_MARKDOWN_PATH;
+
+const SOURCE_SCRIPT = 'scripts/autopilot/backlog-cleanup-apply.ts';
+const ARCHIVE_STATUS = 'cancelled' as const;
+const ARCHIVE_TERMINAL_OUTCOME = 'cancelled' as const;
+const CONFIRM_TOKEN = 'archive-stale';
+
+interface Args {
+  execute: boolean;
+  confirm?: string;
+}
+
+interface ArchiveResult {
+  vtid: string;
+  ok: boolean;
+  error?: string;
+}
+
+interface CleanupSummary {
+  generated_at: string;
+  mode: 'dry_run' | 'executed';
+  total_scanned: number;
+  to_archive: Classification[];
+  needs_human_spec: Classification[];
+  convert_candidates: Classification[];
+  left_in_operator_review_count: number;
+  archive_results: ArchiveResult[];
+  notes: string[];
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = { execute: false };
+  for (const a of argv.slice(2)) {
+    if (a === '--execute') out.execute = true;
+    else if (a.startsWith('--confirm=')) out.confirm = a.slice('--confirm='.length);
+  }
+  return out;
+}
+
+/**
+ * Archive ONE row via a defensive PATCH. The PATCH is scoped to the exact vtid
+ * AND requires is_terminal=false in the filter, so we can never re-terminalize
+ * an already-terminal row or accidentally touch a sibling. No DELETE, ever.
+ *
+ * metadata is JSONB; we read the current value first and merge the archive
+ * marker into it so existing provenance is preserved.
+ */
+async function archiveRow(c: Classification): Promise<ArchiveResult> {
+  if (!PROD_SUPABASE_URL || !PROD_SUPABASE_KEY) {
+    return { vtid: c.vtid, ok: false, error: 'PROD_SUPABASE_URL / PROD_SUPABASE_SERVICE_ROLE required' };
+  }
+
+  let existingMeta: Record<string, unknown> = {};
+  try {
+    const readResp = await fetch(
+      `${PROD_SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${encodeURIComponent(c.vtid)}&select=metadata&limit=1`,
+      { headers: { apikey: PROD_SUPABASE_KEY, Authorization: `Bearer ${PROD_SUPABASE_KEY}` } },
+    );
+    if (readResp.ok) {
+      const rows = (await readResp.json()) as Array<{ metadata: Record<string, unknown> | null }>;
+      existingMeta = rows[0]?.metadata ?? {};
+    }
+  } catch {
+    existingMeta = {};
+  }
+
+  const body = {
+    status: ARCHIVE_STATUS,
+    is_terminal: true,
+    terminal_outcome: ARCHIVE_TERMINAL_OUTCOME,
+    metadata: {
+      ...existingMeta,
+      archived: {
+        by: SOURCE_SCRIPT,
+        action: 'archive_stale_noise',
+        reason: c.reasons.join('; '),
+        archived_at: new Date().toISOString(),
+      },
+    },
+  };
+
+  const url = `${PROD_SUPABASE_URL}/rest/v1/vtid_ledger`
+    + `?vtid=eq.${encodeURIComponent(c.vtid)}`
+    + '&is_terminal=eq.false';
+
+  try {
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        apikey: PROD_SUPABASE_KEY,
+        Authorization: `Bearer ${PROD_SUPABASE_KEY}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      return { vtid: c.vtid, ok: false, error: `${resp.status} ${await resp.text()}` };
+    }
+    const updated = (await resp.json()) as unknown[];
+    if (updated.length === 0) {
+      // Filter matched nothing — row was already terminal (idempotent no-op).
+      return { vtid: c.vtid, ok: true, error: 'already_terminal_no_op' };
+    }
+    return { vtid: c.vtid, ok: true };
+  } catch (err) {
+    return { vtid: c.vtid, ok: false, error: String(err) };
+  }
+}
+
+async function run(args: Args): Promise<CleanupSummary> {
+  // Reuse the classifier verbatim — single source of truth for classification.
+  const plan: ConversionPlan = await generate();
+
+  // generate() truncates each bucket to top 10 for the report. The documented
+  // backlog is exactly 10 archive candidates / 10 operator-review / 1 human-spec
+  // / 0 convertible, so the truncation is a non-issue here. We re-classify
+  // nothing; we act ONLY on the classifier's archive_candidates list.
+  const to_archive = plan.archive_candidates;
+  const needs_human_spec = plan.human_spec_candidates;
+  const convert_candidates = plan.top_convertible;
+
+  const notes: string[] = [];
+  notes.push(`Classifier verdict: total_blocked=${plan.total_blocked}, `
+    + `archive_stale_noise=${plan.by_action.archive_stale_noise}, `
+    + `needs_human_spec=${plan.by_action.needs_human_spec}, `
+    + `leave_in_operator_review=${plan.by_action.leave_in_operator_review}, `
+    + `convert_to_dev_autopilot=${plan.by_action.convert_to_dev_autopilot}.`);
+  notes.push('This script archives ONLY archive_stale_noise rows. '
+    + 'leave_in_operator_review and needs_human_spec rows are untouched.');
+  notes.push('Archive = status=cancelled + is_terminal=true + terminal_outcome=cancelled. '
+    + 'No row is ever deleted. No executor allowlist is ever modified.');
+  if (plan.by_action.needs_human_spec > 0) {
+    notes.push(`Human-spec item(s) (${needs_human_spec.map((c) => c.vtid).join(', ') || 'see classifier'}) `
+      + 'are LEFT for human spec — e.g. VTID-01227 (unified auth / ORB auth).');
+  }
+
+  const archive_results: ArchiveResult[] = [];
+
+  if (!args.execute) {
+    notes.push('DRY RUN — no writes performed. Re-run with --execute --confirm=archive-stale to apply.');
+    return {
+      generated_at: new Date().toISOString(),
+      mode: 'dry_run',
+      total_scanned: plan.total_blocked,
+      to_archive,
+      needs_human_spec,
+      convert_candidates,
+      left_in_operator_review_count: plan.by_action.leave_in_operator_review,
+      archive_results,
+      notes,
+    };
+  }
+
+  if (args.confirm !== CONFIRM_TOKEN) {
+    throw new Error(`--execute requires --confirm=${CONFIRM_TOKEN}`);
+  }
+
+  // Execute path: archive each archive_stale_noise row, one PATCH at a time.
+  for (const c of to_archive) {
+    const result = await archiveRow(c);
+    archive_results.push(result);
+    console.error(`[backlog-cleanup-apply] ${result.ok ? 'archived' : 'FAILED'} ${c.vtid}${result.error ? ` (${result.error})` : ''}`);
+  }
+  notes.push(`EXECUTED: ${archive_results.filter((r) => r.ok).length}/${archive_results.length} rows archived.`);
+
+  return {
+    generated_at: new Date().toISOString(),
+    mode: 'executed',
+    total_scanned: plan.total_blocked,
+    to_archive,
+    needs_human_spec,
+    convert_candidates,
+    left_in_operator_review_count: plan.by_action.leave_in_operator_review,
+    archive_results,
+    notes,
+  };
+}
+
+function renderMarkdown(summary: CleanupSummary): string {
+  const lines: string[] = [];
+  lines.push('# Autopilot backlog cleanup summary');
+  lines.push('');
+  lines.push(`- Generated: ${summary.generated_at}`);
+  lines.push(`- Mode: **${summary.mode}**`);
+  lines.push(`- Total backlog rows scanned: ${summary.total_scanned}`);
+  lines.push(`- Rows to archive: ${summary.to_archive.length}`);
+  lines.push(`- Rows left for human spec: ${summary.needs_human_spec.length}`);
+  lines.push(`- Rows left in operator review: ${summary.left_in_operator_review_count}`);
+  lines.push(`- Convert candidates (untouched, operator-driven): ${summary.convert_candidates.length}`);
+  lines.push('');
+
+  lines.push('## Would archive (archive_stale_noise)');
+  lines.push('');
+  if (summary.to_archive.length === 0) {
+    lines.push('(none)');
+  } else {
+    for (const c of summary.to_archive) {
+      lines.push(`- **${c.vtid}** — ${c.title} (age=${c.age_days}d)`);
+      for (const r of c.reasons) lines.push(`  - ${r}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Left for human spec (needs_human_spec) — UNTOUCHED');
+  lines.push('');
+  if (summary.needs_human_spec.length === 0) {
+    lines.push('(none)');
+  } else {
+    for (const c of summary.needs_human_spec) {
+      lines.push(`- **${c.vtid}** — ${c.title}`);
+      lines.push(`  - phase1: ${c.phase1_buckets.join(',') || '(none)'}`);
+      for (const r of c.reasons) lines.push(`  - ${r}`);
+    }
+  }
+  lines.push('');
+
+  if (summary.mode === 'executed') {
+    lines.push('## Archive results');
+    lines.push('');
+    for (const r of summary.archive_results) {
+      lines.push(`- ${r.ok ? 'OK' : 'FAILED'} \`${r.vtid}\`${r.error ? ` — ${r.error}` : ''}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Notes');
+  lines.push('');
+  for (const n of summary.notes) lines.push(`- ${n}`);
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  const summary = await run(args);
+  console.log(JSON.stringify(summary, null, 2));
+  if (REPORT_MARKDOWN_PATH) {
+    await fs.writeFile(REPORT_MARKDOWN_PATH, renderMarkdown(summary), 'utf-8');
+    console.error(`[backlog-cleanup-apply] markdown written: ${REPORT_MARKDOWN_PATH}`);
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[backlog-cleanup-apply] FAILED:', err);
+    process.exit(1);
+  });
+}
+
+export { run, renderMarkdown, archiveRow };
+export type { CleanupSummary, ArchiveResult };


### PR DESCRIPTION
## Autopilot Backlog Cleanup lane

Produces the **safe APPLY tool** for the dev-autopilot `vtid_ledger` backlog. The existing W3-C1 classifier (VTID-03232) already produced the authoritative verdict on the 21 stale/blocked rows; this lane acts on it without re-deriving anything.

### What's added
- `services/gateway/scripts/autopilot/backlog-cleanup-apply.ts` — **DRY-RUN by default**, requires `--execute --confirm=archive-stale` to write.
- `docs/cleanup/autopilot-backlog-cleanup-report.md` — what would be archived, what's left, the human-spec item.

### Behaviour
| Classifier action | Count | This tool |
|---|---:|---|
| `archive_stale_noise` | 10 | **ARCHIVE** → status=cancelled, is_terminal=true, terminal_outcome=cancelled |
| `leave_in_operator_review` | 10 | UNTOUCHED |
| `needs_human_spec` | 1 | UNTOUCHED (VTID-01227 unified auth / ORB auth) |
| `convert_to_dev_autopilot` | 0 | n/a |

### Safety guarantees
- Reuses `generate()` from `backlog-conversion-classifier.ts` verbatim — no classification logic, keyword bands, or staleness thresholds re-derived.
- **Never deletes** a row — archive is a status/terminal transition only, matching the documented `vtid_ledger` enum.
- PATCH scoped to `vtid=eq.<id>` AND `is_terminal=eq.false` → idempotent, can't re-terminalize or touch siblings; merges an `archived` marker into existing `metadata` (preserves provenance).
- **Never modifies executor allowlists.**
- DRY-RUN by default; no `--execute` run was performed from this lane.

### Verification
- `tsc` type-check of the new script: clean.
- Gateway full build (`tsc`): exit 0.
- Pre-commit hook passed (no `--no-verify` needed).
- No prod write performed — artifact / dry-run only.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_