### PR TITLE
feat(gateway): formalize + validate the context contract (BOOTSTRAP-CONTEXT-CONTRACT)

### DIFF
--- a/services/gateway/.env.template
+++ b/services/gateway/.env.template
@@ -80,3 +80,6 @@ AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION=0.5
 #   DATASET_PREVIEW_SAMPLES   5      how many sample rows the preview surfaces (preview only)
 # DATASET_PREVIEW=1
 # DATASET_PREVIEW_SAMPLES=5
+
+# Context contract — gate for assertContextContract; OFF by default; dev/validation only.
+# FEATURE_CONTEXT_CONTRACT_ASSERT=false

--- a/services/gateway/src/services/context-contract.ts
+++ b/services/gateway/src/services/context-contract.ts
@@ -1,0 +1,405 @@
+/**
+ * BOOTSTRAP-CONTEXT-CONTRACT — formal, validated "context contract".
+ *
+ * The context object that flows from the builder(s) into every prompt
+ * assembler / provider is consumed in many places, each assuming a shape.
+ * Today that shape is enforced only by the hand-written TypeScript interfaces
+ * (`ContextPack` in `types/conversation.ts`, `UnifiedAwarenessContext` in
+ * `awareness-unified-context.ts`). TypeScript checks compile-time call sites
+ * but does NOT validate runtime objects (post-deserialization, post-merge,
+ * cross-service boundaries). This module adds a runtime, Zod-based contract
+ * that asserts those shapes, plus a single `validateContextContract()` entry
+ * point and a dev-only assertion gate.
+ *
+ * ADDITIVE ONLY. This file:
+ *   - does NOT modify `awareness-unified-context.ts` (R1-owned, read-only),
+ *   - does NOT modify `context-pack-builder.ts` or the `ContextPack` interface,
+ *   - is a sibling that mirrors those shapes and is locked by a characterization
+ *     test so any drift in the real interfaces fails loudly here.
+ *
+ * The Zod schemas are the source-of-truth-in-tests; the static checks at the
+ * bottom assert the inferred Zod types stay structurally compatible with the
+ * canonical interfaces (a build-time tripwire if R1 or the builder changes a
+ * field without updating the contract).
+ */
+
+import { z } from 'zod';
+import type {
+  ContextPack,
+  ConversationChannel,
+  RetrievalSource,
+} from '../types/conversation';
+import type {
+  UnifiedAwarenessContext,
+  FirstNameSource,
+} from './awareness-unified-context';
+
+// ---------------------------------------------------------------------------
+// Shared enums (mirror the const tuples in types/conversation.ts +
+// awareness-unified-context.ts). Kept literal so a value drift is caught.
+// ---------------------------------------------------------------------------
+
+const conversationChannelSchema = z.enum([
+  'orb',
+  'operator',
+  'developer_assistant',
+]);
+
+const retrievalSourceSchema = z.enum([
+  'memory_garden',
+  'knowledge_hub',
+  'web_search',
+  'calendar',
+]);
+
+const firstNameSourceSchema = z.enum([
+  'memory_facts',
+  'app_users',
+  'email',
+  'none',
+]);
+
+// A loose Record<RetrievalSource, number> — the builder only ever populates
+// the queried subset, so we validate "string keys → numbers" rather than
+// requiring all four keys to be present.
+const retrievalSourceNumberMap = z.record(z.string(), z.number());
+
+// ---------------------------------------------------------------------------
+// UnifiedAwarenessContext contract (R1 endpoint — read-only target shape).
+// ---------------------------------------------------------------------------
+
+export const unifiedAwarenessContextSchema = z.object({
+  identity: z.object({
+    user_id: z.string().nullable(),
+    tenant_id: z.string().nullable(),
+    first_name: z.string().nullable(),
+    first_name_source: firstNameSourceSchema,
+    display_name: z.string().nullable(),
+    vitana_id: z.string().nullable(),
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// ContextPack contract (context-pack-builder output).
+// ---------------------------------------------------------------------------
+
+const memoryHitSchema = z.object({
+  id: z.string(),
+  category_key: z.string(),
+  content: z.string(),
+  importance: z.number(),
+  occurred_at: z.string(),
+  relevance_score: z.number(),
+  source: z.string(),
+});
+
+const knowledgeHitSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  snippet: z.string(),
+  source_path: z.string(),
+  relevance_score: z.number(),
+});
+
+const webHitSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  snippet: z.string(),
+  url: z.string(),
+  citation: z.string(),
+  relevance_score: z.number(),
+});
+
+const toolHealthStatusSchema = z.object({
+  name: z.string(),
+  available: z.boolean(),
+  latency_ms: z.number().optional(),
+  last_checked: z.string(),
+  error: z.string().optional(),
+});
+
+const activeVtidSchema = z.object({
+  vtid: z.string(),
+  title: z.string(),
+  status: z.string(),
+  priority: z.string().optional(),
+});
+
+const tenantPolicySchema = z.object({
+  policy_id: z.string(),
+  type: z.string(),
+  value: z.unknown(),
+  enforced: z.boolean(),
+});
+
+const uiContextSchema = z.object({
+  surface: conversationChannelSchema,
+  screen: z.string().optional(),
+  selection: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+const calendarEventSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  start_time: z.string(),
+  end_time: z.string().nullable(),
+  event_type: z.string(),
+  status: z.string(),
+});
+
+const retrievalRouterDecisionSchema = z.object({
+  sources_to_query: z.array(retrievalSourceSchema),
+  query_order: z.array(retrievalSourceSchema),
+  limits: retrievalSourceNumberMap,
+  matched_rule: z.string(),
+  decided_at: z.string(),
+  rationale: z.string(),
+});
+
+export const contextPackSchema = z.object({
+  pack_id: z.string(),
+  pack_hash: z.string(),
+  assembled_at: z.string(),
+  assembly_duration_ms: z.number(),
+
+  identity: z.object({
+    tenant_id: z.string(),
+    user_id: z.string(),
+    role: z.string(),
+    display_name: z.string().optional(),
+  }),
+
+  session_state: z.object({
+    thread_id: z.string(),
+    channel: conversationChannelSchema,
+    turn_number: z.number(),
+    conversation_start: z.string(),
+  }),
+
+  memory_hits: z.array(memoryHitSchema),
+  knowledge_hits: z.array(knowledgeHitSchema),
+  web_hits: z.array(webHitSchema),
+  active_vtids: z.array(activeVtidSchema),
+  tenant_policies: z.array(tenantPolicySchema),
+  tool_health: z.array(toolHealthStatusSchema),
+
+  ui_context: uiContextSchema.optional(),
+  relationship_context: z.array(z.string()).optional(),
+
+  calendar_context: z
+    .object({
+      today_events: z.array(calendarEventSchema),
+      upcoming_events: z.array(calendarEventSchema),
+      gaps_today: z.array(
+        z.object({
+          start: z.string(),
+          end: z.string(),
+          duration_minutes: z.number(),
+        }),
+      ),
+      active_role: z.string(),
+      journey_stage: z
+        .object({
+          wave_name: z.string(),
+          day_number: z.number(),
+          total_days: z.number(),
+        })
+        .optional(),
+      patterns: z.array(z.string()),
+    })
+    .optional(),
+
+  session_buffer: z
+    .object({
+      turn_count: z.number(),
+      session_facts_count: z.number(),
+      formatted_context: z.string(),
+    })
+    .optional(),
+
+  oasis_context: z
+    .object({
+      active_tasks: z.array(
+        z.object({
+          vtid: z.string(),
+          title: z.string(),
+          status: z.string(),
+          stage: z.string().optional(),
+        }),
+      ),
+      recent_deploys: z.array(
+        z.object({
+          service: z.string(),
+          status: z.string(),
+          created_at: z.string(),
+        }),
+      ),
+      pending_approvals_count: z.number(),
+      self_healing_alerts: z.number(),
+      recent_recommendations: z.array(
+        z.object({ title: z.string(), status: z.string() }),
+      ),
+    })
+    .optional(),
+
+  marketplace_context: z
+    .object({
+      lifecycle_stage: z
+        .enum(['onboarding', 'early', 'established', 'mature'])
+        .nullable(),
+      region_group: z.string().nullable(),
+      scope_preference: z.enum(['local', 'regional', 'friendly', 'international']),
+      budget_max_per_product_cents: z.number().nullable(),
+      hard_limitations: z.object({
+        allergies: z.array(z.string()),
+        dietary_restrictions: z.array(z.string()),
+        contraindications: z.array(z.string()),
+        current_medications: z.array(z.string()),
+      }),
+      active_conditions: z.array(
+        z.object({ key: z.string(), source: z.string() }),
+      ),
+      recent_purchases_count: z.number(),
+      upcoming_events_hints: z.array(z.string()),
+      marketplace_picks: z.array(
+        z.object({
+          product_id: z.string(),
+          title: z.string(),
+          match_reason: z.string(),
+        }),
+      ),
+      wearable_summary_7d: z
+        .object({
+          sleep_avg_minutes: z.number().nullable().optional(),
+          sleep_deep_pct: z.number().nullable().optional(),
+          hrv_avg_ms: z.number().nullable().optional(),
+          resting_hr: z.number().nullable().optional(),
+          activity_minutes: z.number().nullable().optional(),
+          workout_count: z.number().nullable().optional(),
+        })
+        .nullable()
+        .optional(),
+    })
+    .optional(),
+
+  retrieval_trace: z.object({
+    router_decision: retrievalRouterDecisionSchema,
+    sources_queried: z.array(retrievalSourceSchema),
+    latencies: retrievalSourceNumberMap,
+    hit_counts: retrievalSourceNumberMap,
+  }),
+
+  token_budget: z.object({
+    total_budget: z.number(),
+    used: z.number(),
+    remaining: z.number(),
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Public validator API.
+// ---------------------------------------------------------------------------
+
+export type ContextContractKind = 'context_pack' | 'unified_awareness';
+
+export interface ContextContractResult<T> {
+  ok: boolean;
+  /** The parsed value (typed) when ok === true. */
+  data?: T;
+  /** Flattened human-readable issues when ok === false. */
+  issues?: string[];
+}
+
+function flatten(error: z.ZodError): string[] {
+  return error.issues.map((i) => {
+    const path = i.path.length ? i.path.join('.') : '(root)';
+    return `${path}: ${i.message}`;
+  });
+}
+
+/**
+ * Validate an object against the context contract. Non-throwing — returns a
+ * structured result so callers can log/branch. Use `kind` to pick the schema.
+ *
+ * @example
+ *   const r = validateContextContract(pack, 'context_pack');
+ *   if (!r.ok) logger.warn('context contract drift', r.issues);
+ */
+export function validateContextContract(
+  value: unknown,
+  kind: 'context_pack',
+): ContextContractResult<ContextPack>;
+export function validateContextContract(
+  value: unknown,
+  kind: 'unified_awareness',
+): ContextContractResult<UnifiedAwarenessContext>;
+export function validateContextContract(
+  value: unknown,
+  kind: ContextContractKind,
+): ContextContractResult<ContextPack | UnifiedAwarenessContext> {
+  const schema =
+    kind === 'context_pack' ? contextPackSchema : unifiedAwarenessContextSchema;
+  const parsed = schema.safeParse(value);
+  if (parsed.success) {
+    return {
+      ok: true,
+      data: parsed.data as ContextPack | UnifiedAwarenessContext,
+    };
+  }
+  return { ok: false, issues: flatten(parsed.error) };
+}
+
+/**
+ * Dev-only hard assertion. Gated behind FEATURE_CONTEXT_CONTRACT_ASSERT
+ * (default OFF). When ON, throws on contract violation so drift is caught
+ * immediately in dev/CI; when OFF this is a no-op (zero prod risk).
+ *
+ * Intended (future) wiring: call right after buildContextPack(...) returns,
+ * inside the builder's caller — NOT inside the builder itself (which is
+ * owned by another lane). Left unwired by default.
+ */
+export function assertContextContract(
+  value: unknown,
+  kind: ContextContractKind,
+): void {
+  if (process.env.FEATURE_CONTEXT_CONTRACT_ASSERT !== 'true') return;
+  const result =
+    kind === 'context_pack'
+      ? validateContextContract(value, 'context_pack')
+      : validateContextContract(value, 'unified_awareness');
+  if (!result.ok) {
+    throw new Error(
+      `[context-contract] ${kind} violated the contract:\n  ${(
+        result.issues ?? []
+      ).join('\n  ')}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Static structural tripwires. These never run; they fail `tsc` if the Zod
+// inferred type drifts from the canonical interface (e.g. R1 adds a required
+// identity field, or the builder changes a field type). This is the additive
+// "contract is in sync" guarantee without touching the source interfaces.
+// ---------------------------------------------------------------------------
+
+type InferredUnified = z.infer<typeof unifiedAwarenessContextSchema>;
+type InferredPack = z.infer<typeof contextPackSchema>;
+
+// Assert the Zod schema accepts every canonical value (interface → inferred).
+// If a canonical field can't be assigned into the inferred type, tsc errors.
+const _unifiedForward: (x: UnifiedAwarenessContext) => InferredUnified = (x) => x;
+const _packForward: (x: ContextPack) => InferredPack = (x) => x;
+
+// Enum tripwires: keep literal lists aligned with the source const tuples.
+const _channel: ConversationChannel = 'orb';
+const _source: RetrievalSource = 'memory_garden';
+const _fns: FirstNameSource = 'none';
+
+// Reference the unused bindings so noUnusedLocals (if enabled) stays quiet.
+void _unifiedForward;
+void _packForward;
+void _channel;
+void _source;
+void _fns;

--- a/services/gateway/test/context-contract.test.ts
+++ b/services/gateway/test/context-contract.test.ts
@@ -1,0 +1,258 @@
+/**
+ * BOOTSTRAP-CONTEXT-CONTRACT — characterization test that LOCKS the context
+ * contract.
+ *
+ * It builds representative `ContextPack` and `UnifiedAwarenessContext` objects
+ * (shaped exactly like `context-pack-builder.ts` and the R1 endpoint emit) and
+ * asserts the runtime validator accepts them. Because the fixtures are typed as
+ * the canonical interfaces, any drift in those interfaces breaks compilation
+ * here; any drift in the Zod schema breaks these assertions — so the contract
+ * and the real shapes stay in lockstep without modifying either source file.
+ */
+
+import {
+  validateContextContract,
+  assertContextContract,
+  contextPackSchema,
+  unifiedAwarenessContextSchema,
+} from '../src/services/context-contract';
+import type { ContextPack } from '../src/types/conversation';
+import type { UnifiedAwarenessContext } from '../src/services/awareness-unified-context';
+
+// Minimal-but-complete pack, mirroring the object literal assembled at the end
+// of buildContextPack() (context-pack-builder.ts ~line 1071).
+function makeMinimalPack(): ContextPack {
+  return {
+    pack_id: 'pack_abc123',
+    pack_hash: '0123456789abcdef',
+    assembled_at: new Date().toISOString(),
+    assembly_duration_ms: 42,
+    identity: {
+      tenant_id: '00000000-0000-0000-0000-000000000000',
+      user_id: 'a27552a3-0257-4305-8ed0-351a80fd3701',
+      role: 'community',
+      display_name: 'Dragan',
+    },
+    session_state: {
+      thread_id: '11111111-1111-1111-1111-111111111111',
+      channel: 'orb',
+      turn_number: 1,
+      conversation_start: new Date().toISOString(),
+    },
+    memory_hits: [],
+    knowledge_hits: [],
+    web_hits: [],
+    active_vtids: [],
+    tenant_policies: [],
+    tool_health: [],
+    retrieval_trace: {
+      router_decision: {
+        sources_to_query: ['memory_garden'],
+        query_order: ['memory_garden'],
+        limits: { memory_garden: 8, knowledge_hub: 6, web_search: 4, calendar: 5 },
+        matched_rule: 'personal_history',
+        decided_at: new Date().toISOString(),
+        rationale: 'matched personal_history',
+      },
+      sources_queried: ['memory_garden'],
+      latencies: { memory_garden: 12, knowledge_hub: 0, web_search: 0, calendar: 0 },
+      hit_counts: { memory_garden: 0, knowledge_hub: 0, web_search: 0, calendar: 0 },
+    },
+    token_budget: {
+      total_budget: 8000,
+      used: 120,
+      remaining: 7880,
+    },
+  };
+}
+
+// Fully-populated pack exercising every optional block.
+function makeFullPack(): ContextPack {
+  const base = makeMinimalPack();
+  return {
+    ...base,
+    memory_hits: [
+      {
+        id: 'm1',
+        category_key: 'health_wellness',
+        content: 'Sleeps poorly on Sundays',
+        importance: 0.8,
+        occurred_at: new Date().toISOString(),
+        relevance_score: 0.91,
+        source: 'memory_garden',
+      },
+    ],
+    knowledge_hits: [
+      {
+        id: 'k1',
+        title: 'Sleep hygiene',
+        snippet: 'Keep a consistent schedule',
+        source_path: 'kb/sleep.md',
+        relevance_score: 0.7,
+      },
+    ],
+    web_hits: [
+      {
+        id: 'w1',
+        title: 'CDC sleep',
+        snippet: '7-9 hours',
+        url: 'https://example.com',
+        citation: '[1]',
+        relevance_score: 0.6,
+      },
+    ],
+    active_vtids: [{ vtid: 'VTID-01225', title: 'Memory', status: 'in_progress', priority: 'high' }],
+    tenant_policies: [{ policy_id: 'p1', type: 'pii', value: { redact: true }, enforced: true }],
+    tool_health: [{ name: 'memory_garden', available: true, latency_ms: 12, last_checked: new Date().toISOString() }],
+    ui_context: { surface: 'orb', screen: 'home', metadata: { foo: 'bar' } },
+    relationship_context: ['Fiancee: Ana'],
+    calendar_context: {
+      today_events: [
+        { id: 'e1', title: 'Standup', start_time: '09:00', end_time: '09:15', event_type: 'meeting', status: 'confirmed' },
+      ],
+      upcoming_events: [],
+      gaps_today: [{ start: '10:00', end: '12:00', duration_minutes: 120 }],
+      active_role: 'community',
+      journey_stage: { wave_name: 'Foundation', day_number: 3, total_days: 35 },
+      patterns: ['busy mornings'],
+    },
+    session_buffer: { turn_count: 2, session_facts_count: 1, formatted_context: 'recent turns...' },
+    oasis_context: {
+      active_tasks: [{ vtid: 'VTID-01200', title: 'Worker plane', status: 'in_progress', stage: 'worker' }],
+      recent_deploys: [{ service: 'gateway', status: 'success', created_at: new Date().toISOString() }],
+      pending_approvals_count: 2,
+      self_healing_alerts: 0,
+      recent_recommendations: [{ title: 'Add cache', status: 'open' }],
+    },
+    marketplace_context: {
+      lifecycle_stage: 'early',
+      region_group: 'EU',
+      scope_preference: 'regional',
+      budget_max_per_product_cents: 5000,
+      hard_limitations: {
+        allergies: ['peanuts'],
+        dietary_restrictions: [],
+        contraindications: [],
+        current_medications: [],
+      },
+      active_conditions: [{ key: 'hypertension', source: 'self_reported' }],
+      recent_purchases_count: 3,
+      upcoming_events_hints: ['birthday'],
+      marketplace_picks: [{ product_id: 'prod1', title: 'Magnesium', match_reason: 'sleep support' }],
+      wearable_summary_7d: {
+        sleep_avg_minutes: 420,
+        sleep_deep_pct: 18,
+        hrv_avg_ms: 55,
+        resting_hr: 58,
+        activity_minutes: 200,
+        workout_count: 4,
+      },
+    },
+  };
+}
+
+function makeUnified(): UnifiedAwarenessContext {
+  return {
+    identity: {
+      user_id: 'a27552a3-0257-4305-8ed0-351a80fd3701',
+      tenant_id: '00000000-0000-0000-0000-000000000000',
+      first_name: 'Dragan',
+      first_name_source: 'memory_facts',
+      display_name: 'Dragan Alexander',
+      vitana_id: 'VIT-0001',
+    },
+  };
+}
+
+describe('context-contract: ContextPack', () => {
+  it('accepts a minimal builder-shaped pack', () => {
+    const r = validateContextContract(makeMinimalPack(), 'context_pack');
+    expect(r.ok).toBe(true);
+    expect(r.issues).toBeUndefined();
+    expect(r.data?.pack_id).toBe('pack_abc123');
+  });
+
+  it('accepts a fully-populated pack (all optional blocks present)', () => {
+    const r = validateContextContract(makeFullPack(), 'context_pack');
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects a pack missing a required field', () => {
+    const bad = makeMinimalPack() as Record<string, unknown>;
+    delete bad.token_budget;
+    const r = validateContextContract(bad, 'context_pack');
+    expect(r.ok).toBe(false);
+    expect(r.issues?.some((i) => i.includes('token_budget'))).toBe(true);
+  });
+
+  it('rejects a pack with a wrong-typed field', () => {
+    const bad = { ...makeMinimalPack(), assembly_duration_ms: 'fast' } as unknown;
+    const r = validateContextContract(bad, 'context_pack');
+    expect(r.ok).toBe(false);
+    expect(r.issues?.some((i) => i.includes('assembly_duration_ms'))).toBe(true);
+  });
+
+  it('rejects an unknown channel value', () => {
+    const bad = makeMinimalPack();
+    (bad.session_state as { channel: string }).channel = 'sms';
+    const r = validateContextContract(bad, 'context_pack');
+    expect(r.ok).toBe(false);
+  });
+
+  it('schema is directly usable via safeParse', () => {
+    expect(contextPackSchema.safeParse(makeMinimalPack()).success).toBe(true);
+  });
+});
+
+describe('context-contract: UnifiedAwarenessContext', () => {
+  it('accepts the R1 endpoint shape', () => {
+    const r = validateContextContract(makeUnified(), 'unified_awareness');
+    expect(r.ok).toBe(true);
+    expect(r.data?.identity.first_name).toBe('Dragan');
+  });
+
+  it('accepts null identity fields (pre-resolution)', () => {
+    const u = makeUnified();
+    u.identity.first_name = null;
+    u.identity.first_name_source = 'none';
+    u.identity.vitana_id = null;
+    expect(validateContextContract(u, 'unified_awareness').ok).toBe(true);
+  });
+
+  it('rejects an invalid first_name_source', () => {
+    const bad = makeUnified() as { identity: Record<string, unknown> };
+    bad.identity.first_name_source = 'guess';
+    const r = validateContextContract(bad, 'unified_awareness');
+    expect(r.ok).toBe(false);
+  });
+
+  it('schema is directly usable via safeParse', () => {
+    expect(unifiedAwarenessContextSchema.safeParse(makeUnified()).success).toBe(true);
+  });
+});
+
+describe('context-contract: assertContextContract feature gate', () => {
+  const prev = process.env.FEATURE_CONTEXT_CONTRACT_ASSERT;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.FEATURE_CONTEXT_CONTRACT_ASSERT;
+    else process.env.FEATURE_CONTEXT_CONTRACT_ASSERT = prev;
+  });
+
+  it('is a no-op when flag is OFF (default), even on invalid input', () => {
+    delete process.env.FEATURE_CONTEXT_CONTRACT_ASSERT;
+    expect(() => assertContextContract({ garbage: true }, 'context_pack')).not.toThrow();
+  });
+
+  it('throws on invalid input when flag is ON', () => {
+    process.env.FEATURE_CONTEXT_CONTRACT_ASSERT = 'true';
+    expect(() => assertContextContract({ garbage: true }, 'context_pack')).toThrow(
+      /context-contract/,
+    );
+  });
+
+  it('passes on valid input when flag is ON', () => {
+    process.env.FEATURE_CONTEXT_CONTRACT_ASSERT = 'true';
+    expect(() => assertContextContract(makeMinimalPack(), 'context_pack')).not.toThrow();
+    expect(() => assertContextContract(makeUnified(), 'unified_awareness')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Context Contract lane (BOOTSTRAP-CONTEXT-CONTRACT)

Formalizes and **validates** the "context contract" — the typed, runtime-checked schema the context object must satisfy so every consumer reads a consistent shape — **without rebuilding the builder**. Additive only.

### What this does NOT touch (collision-free with R1 lane)
- `awareness-unified-context.ts` (R1-owned) — read-only
- `context-pack-builder.ts` + the `ContextPack` interface — read-only
- `role-aware-context-pack-shadow.ts`, hub files, `orb-live.ts` — read-only

### New files
- **`services/gateway/src/services/context-contract.ts`**
  - Zod schemas mirroring `ContextPack` (full, all optional blocks) and `UnifiedAwarenessContext`.
  - `validateContextContract(value, kind)` — non-throwing, returns `{ ok, data?, issues? }` (overloaded for `'context_pack'` | `'unified_awareness'`).
  - `assertContextContract(value, kind)` — dev-only hard assertion gated behind **`FEATURE_CONTEXT_CONTRACT_ASSERT`** (default **OFF** = no-op). Left **unwired** (no builder/caller edits).
  - Static structural tripwires that fail `tsc` if the canonical interfaces drift from the schema (contract stays in sync without modifying the source interfaces).
- **`services/gateway/test/context-contract.test.ts`**
  - Characterization test locking the contract against builder-shaped fixtures (minimal + fully-populated + negative cases) and the feature-gate behavior.

### Verification
- `tsc --noEmit` (project-local TS 5.9.3): **green**
- `jest test/context-contract.test.ts`: **13/13 passing**

### Risk
Zero runtime behavior change — nothing imports the new validator yet, and the assertion is gated OFF by default.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_