### PR TITLE
feat(evidence): phase-evidence digest + MIRROR-ARTIFACTS-S3 preflight (BOOTSTRAP-EVIDENCE-ARTIFACTS)

### DIFF
--- a/.github/workflows/MIRROR-ARTIFACTS-S3.yml
+++ b/.github/workflows/MIRROR-ARTIFACTS-S3.yml
@@ -13,6 +13,12 @@ name: Mirror Artifacts to S3 (dormant)
 # artifacts — eval-coverage reports and dataset manifests — so the GCS -> S3
 # wiring proves itself end-to-end before any weights exist (W3 Bedrock work).
 # Setup / secrets: scripts/aws/README.md.
+#
+# BOOTSTRAP-EVIDENCE-ARTIFACTS: the `preflight` job below runs on EVERY
+# schedule regardless of AWS secrets (gated only on the existing GCP WIF). It
+# enumerates the GCS source side with the SAME globs the mirror uses and
+# reports exactly WHAT would mirror — read-only, no AWS calls. This keeps the
+# dormant mirror code-ready and inspectable before AWS is provisioned.
 
 on:
   schedule:
@@ -50,6 +56,62 @@ jobs:
             echo 'aws_ready=false' >> "$GITHUB_OUTPUT"
             echo "AWS_BUCKET / AWS_ROLE_ARN not configured; skipping (this is expected pre-W3)"
           fi
+
+  # BOOTSTRAP-EVIDENCE-ARTIFACTS — preflight / dry-run. Runs on EVERY schedule
+  # regardless of AWS secrets (gated only on GCP WIF, which already exists), so
+  # the GCS source side of the mirror is always inspectable. Reports exactly
+  # WHAT would mirror without ever touching AWS — code-ready proof the mirror
+  # has real sources to carry the moment AWS lands.
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Enumerate what WOULD mirror (read-only, no AWS)
+        env:
+          STAGING_BUCKET: ${{ env.STAGING_BUCKET }}
+          # Empty when secret unset — preflight renders a placeholder S3 dest.
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+          PREFLIGHT_MARKDOWN_PATH: /tmp/mirror-preflight.md
+        run: |
+          set -euo pipefail
+          npx -y tsx scripts/aws/mirror-preflight.ts > /tmp/mirror-preflight.json
+          echo "Would-mirror count: $(python3 -c "import json;print(json.load(open('/tmp/mirror-preflight.json'))['would_mirror_count'])")"
+
+      - name: Append preflight summary
+        if: always()
+        run: |
+          if [ -f /tmp/mirror-preflight.md ]; then
+            cat /tmp/mirror-preflight.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## MIRROR-ARTIFACTS-S3 preflight'                >> "$GITHUB_STEP_SUMMARY"
+            echo ''                                                >> "$GITHUB_STEP_SUMMARY"
+            echo 'Preflight did not produce Markdown — see logs.'  >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload preflight artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mirror-preflight-${{ github.run_id }}
+          path: |
+            /tmp/mirror-preflight.json
+            /tmp/mirror-preflight.md
+          if-no-files-found: warn
+          retention-days: 90
 
   mirror:
     needs: guard

--- a/.github/workflows/PHASE-EVIDENCE-DIGEST.yml
+++ b/.github/workflows/PHASE-EVIDENCE-DIGEST.yml
@@ -1,0 +1,159 @@
+name: Phase Evidence Digest
+
+# BOOTSTRAP-EVIDENCE-ARTIFACTS — consolidated phase-evidence generator.
+#
+# Rolls the four standing Phase 1 evidence sources into ONE dated digest
+# artifact for the operator's daily rhythm:
+#   1. Phase gate status      (reuses eval/phase-gate-status-report.ts)
+#   2. Shadow comparison      (reuses eval/shadow-comparison-report.ts)
+#   3. Canary readiness       (reuses eval/canary-readiness-report.ts)
+#   4. Dataset preview counts (reuses datasets/*.ts in DATASET_PREVIEW mode)
+#
+# Read-only across the board — same read paths the underlying reports use.
+# Emits NO oasis_events, writes NO GCS/JSONL, flips NO state, performs NO
+# deploy. Output is a GitHub artifact + step summary (same pattern as the
+# three reports it aggregates). No auto-commit to the repo.
+
+on:
+  schedule:
+    # Daily at 09:00 UTC — 15 min after CANARY-READINESS-REPORT (08:45 UTC)
+    # so the canary verdict it reads is the freshest one. The chain is:
+    #   08:15 shadow-comparison → 08:30 phase-gate → 08:45 canary → 09:00 digest
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Fine-tune target for the canary section'
+        required: false
+        default: 'voice-tool-router'
+        type: choice
+        options: [ voice-tool-router, intent-kind, pillar-classifier ]
+      dataset_preview:
+        description: 'Run the read-only dataset preview section (needs prod Supabase creds)'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: phase-evidence-digest
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: lovable-vitana-vers1
+  STAGING_GATEWAY_URL: https://gateway-staging-q74ibpv6ia-uc.a.run.app
+  PROD_GATEWAY_URL: https://gateway.vitanaland.com
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/gateway/package-lock.json
+
+      - name: Install gateway deps
+        working-directory: services/gateway
+        run: npm ci --no-audit --no-fund
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Resolve prod Supabase creds (existing W1 grants on WIF SA)
+        run: |
+          set -euo pipefail
+          PROD_URL=$(gcloud secrets versions access latest --secret=SUPABASE_URL --project="${GCP_PROJECT}" 2>/dev/null || echo '')
+          PROD_KEY=$(gcloud secrets versions access latest --secret=SUPABASE_SERVICE_ROLE --project="${GCP_PROJECT}" 2>/dev/null || echo '')
+          if [ -z "$PROD_URL" ] || [ -z "$PROD_KEY" ]; then
+            echo "::warning::Could not resolve prod Supabase creds — prod-backed sections degrade to unavailable (digest still produced)."
+          else
+            echo "::add-mask::$PROD_URL"
+            echo "::add-mask::$PROD_KEY"
+          fi
+          {
+            echo "PROD_SUPABASE_URL=$PROD_URL"
+            echo "PROD_SUPABASE_SERVICE_ROLE=$PROD_KEY"
+            echo "SUPABASE_URL=$PROD_URL"
+            echo "SUPABASE_SERVICE_ROLE=$PROD_KEY"
+          } >> "$GITHUB_ENV"
+
+      - name: Probe Vertex IAM (parity with phase-gate report)
+        run: |
+          set +e
+          gcloud ai custom-jobs list \
+            --region=us-central1 --project="${GCP_PROJECT}" --limit=1 \
+            > /tmp/vertex-probe.txt 2>&1
+          RC=$?
+          if [ $RC -eq 0 ]; then
+            echo "VERTEX_IAM_CHECK_RESULT=ok" >> "$GITHUB_ENV"
+          elif grep -qiE "permission|denied|403|aiplatform|forbidden|insufficient|customjobs|role/iam" /tmp/vertex-probe.txt; then
+            echo "VERTEX_IAM_CHECK_RESULT=denied" >> "$GITHUB_ENV"
+          else
+            echo "VERTEX_IAM_CHECK_RESULT=skipped" >> "$GITHUB_ENV"
+          fi
+
+      - name: Report AWS mirror secret presence (read-only)
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          if [ -z "${AWS_BUCKET:-}" ] || [ -z "${AWS_ROLE_ARN:-}" ]; then
+            echo "AWS_SMOKE_RESULT=not_configured" >> "$GITHUB_ENV"
+            echo "AWS_BUCKET="   >> "$GITHUB_ENV"
+            echo "AWS_ROLE_ARN=" >> "$GITHUB_ENV"
+          else
+            echo "AWS_SMOKE_RESULT=skipped" >> "$GITHUB_ENV"
+            echo "AWS_BUCKET=$AWS_BUCKET"     >> "$GITHUB_ENV"
+            echo "AWS_ROLE_ARN=$AWS_ROLE_ARN" >> "$GITHUB_ENV"
+          fi
+
+      - name: Generate phase evidence digest
+        working-directory: services/gateway
+        env:
+          GATEWAY_SERVICE_TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}
+          FEATURE_TARGET: ${{ inputs.target || 'voice-tool-router' }}
+          DATASET_PREVIEW_ENABLED: ${{ (inputs.dataset_preview == false) && '0' || '1' }}
+          DIGEST_JSON_PATH: /tmp/phase-evidence-digest.json
+          DIGEST_MARKDOWN_PATH: /tmp/phase-evidence-digest.md
+        run: |
+          set -euo pipefail
+          npx tsx scripts/eval/phase-evidence-digest.ts > /tmp/phase-evidence-digest.stdout.json
+          echo "JSON written: $(wc -c < /tmp/phase-evidence-digest.json) bytes"
+          echo "Markdown written: $(wc -c < /tmp/phase-evidence-digest.md 2>/dev/null || echo 0) bytes"
+          # Surface the headline in the run log without opening the artifact.
+          HEADLINE=$(python3 -c "import json;print(json.load(open('/tmp/phase-evidence-digest.json'))['headline'])")
+          echo "Headline: $HEADLINE"
+
+      - name: Append summary
+        if: always()
+        run: |
+          if [ -f /tmp/phase-evidence-digest.md ]; then
+            cat /tmp/phase-evidence-digest.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## Phase evidence digest'                    >> "$GITHUB_STEP_SUMMARY"
+            echo ''                                             >> "$GITHUB_STEP_SUMMARY"
+            echo 'Digest script did not produce Markdown — see logs.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase-evidence-digest-${{ github.run_id }}
+          path: |
+            /tmp/phase-evidence-digest.json
+            /tmp/phase-evidence-digest.md
+          if-no-files-found: warn
+          retention-days: 90

--- a/docs/evidence/README.md
+++ b/docs/evidence/README.md
@@ -1,0 +1,50 @@
+# Phase evidence digests
+
+Consolidated, dated roll-ups of the standing Phase 1 evidence sources —
+one artifact per day for the operator's daily rhythm.
+
+**BOOTSTRAP-EVIDENCE-ARTIFACTS** — read-only. The digest emits no
+`oasis_events`, writes no GCS/JSONL, flips no state, performs no deploy. It
+only aggregates the output of reports that already exist.
+
+## What it rolls up
+
+| Source | Reused from | What it contributes |
+|---|---|---|
+| Phase gate status | `services/gateway/scripts/eval/phase-gate-status-report.ts` (`generate()`) | Which of the 5 operator-side gates are open/blocked/unknown + first blocker |
+| Shadow comparison | `services/gateway/scripts/eval/shadow-comparison-report.ts` (`fetchReport()`) | Per-feature shadow rollup (agreement, candidate p95, error rate) over the window |
+| Canary readiness | `services/gateway/scripts/eval/canary-readiness-report.ts` (`generate()`) | `READY_FOR_CANARY` / `NOT_READY` verdict + per-rule reasons |
+| Dataset preview counts | `services/gateway/scripts/datasets/*.ts` in `DATASET_PREVIEW` mode | Rows that WOULD extract per target (read-only projection, nothing written) |
+
+The digest never duplicates the underlying logic — it imports each report's
+exported generator and aggregates. If any one source is unavailable (missing
+creds/token, network blip), that section degrades to `unavailable` and the
+rest of the digest still renders.
+
+## How it runs
+
+`.github/workflows/PHASE-EVIDENCE-DIGEST.yml` — daily at 09:00 UTC, 15 min
+after the canary-readiness report (08:45 UTC) so the verdict it reads is the
+freshest one. The chain is:
+
+```
+08:15 shadow-comparison → 08:30 phase-gate → 08:45 canary → 09:00 digest
+```
+
+The workflow uploads `phase-evidence-digest.{json,md}` as a 90-day artifact
+and appends the Markdown to the run's step summary (same pattern as the three
+reports it aggregates). It does NOT auto-commit digests into this directory.
+
+## Run it locally
+
+```bash
+cd services/gateway
+GATEWAY_SERVICE_TOKEN=<token> \
+PROD_SUPABASE_URL=<url> PROD_SUPABASE_SERVICE_ROLE=<key> \
+DATASET_PREVIEW_ENABLED=1 \
+DIGEST_MARKDOWN_PATH=/tmp/digest.md DIGEST_JSON_PATH=/tmp/digest.json \
+  npx tsx scripts/eval/phase-evidence-digest.ts > /tmp/digest.stdout.json
+```
+
+With no creds, each prod-backed section reports `unavailable` and the digest
+still produces — the unattended-daily contract.

--- a/scripts/aws/mirror-preflight.ts
+++ b/scripts/aws/mirror-preflight.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env -S npx -y tsx
+/**
+ * mirror-preflight.ts — BOOTSTRAP-EVIDENCE-ARTIFACTS.
+ *
+ * Dry-run / preflight for MIRROR-ARTIFACTS-S3.yml. Reports exactly WHAT the
+ * dormant mirror job WOULD copy GCS -> S3, WITHOUT needing the AWS secrets.
+ *
+ * The real mirror job (and the smoke) refuse without AWS_BUCKET / AWS_ROLE_ARN.
+ * That makes the GCS->S3 wiring un-inspectable until an operator provisions
+ * AWS — you can't see whether there's anything to mirror. This preflight
+ * closes that gap: it enumerates the GCS source side ONLY (gsutil ls), using
+ * the SAME source globs the mirror job uses, and prints a manifest of what
+ * would be mirrored plus the S3 destination keys it would write to.
+ *
+ * It NEVER touches AWS, NEVER copies anything, NEVER deletes anything — pure
+ * read-only enumeration of the GCS staging bucket. Safe to run on the daily
+ * schedule alongside the dormant mirror.
+ *
+ * The three source groups mirror the MIRROR-ARTIFACTS-S3.yml job exactly:
+ *   1. per-target current weights:  finetune-current/<target>/weights.tar.gz
+ *   2. eval-coverage reports:       eval-reports/**
+ *   3. dataset manifests:           datasets/<name>/manifest.json
+ *
+ * Output:
+ *   stdout: JSON manifest
+ *   $PREFLIGHT_MARKDOWN_PATH (env, optional): Markdown manifest file
+ *
+ * Env:
+ *   STAGING_BUCKET (default gs://vitana-artifacts-staging)
+ *   AWS_BUCKET     (optional — used only to render the destination S3 keys;
+ *                   when empty, destinations show as s3://<AWS_BUCKET>/... so
+ *                   the manifest is still readable pre-provisioning)
+ */
+import { execFileSync } from 'node:child_process';
+
+const STAGING_BUCKET = process.env.STAGING_BUCKET || 'gs://vitana-artifacts-staging';
+const AWS_BUCKET = process.env.AWS_BUCKET || '';
+const PREFLIGHT_MARKDOWN_PATH = process.env.PREFLIGHT_MARKDOWN_PATH;
+const TARGETS = ['voice-tool-router', 'intent-kind', 'pillar-classifier'] as const;
+
+/** Run gsutil; return stdout lines. Missing path / non-zero exit => []. */
+function gsutilLs(pattern: string): string[] {
+  try {
+    const out = execFileSync('gsutil', ['ls', pattern], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return out.split('\n').map((l) => l.trim()).filter((l) => l.startsWith('gs://'));
+  } catch {
+    // gsutil exits non-zero when the glob matches nothing — that's an
+    // expected "nothing to mirror yet" state, not an error.
+    return [];
+  }
+}
+
+/** Convert a gs:// source URI to the S3 destination the mirror job would use. */
+function s3Dest(gsUri: string, group: 'weights' | 'eval' | 'manifest'): string {
+  const bucket = AWS_BUCKET || '<AWS_BUCKET>';
+  // Mirror job preserves the path under the staging bucket root.
+  const rel = gsUri.replace(`${STAGING_BUCKET}/`, '');
+  switch (group) {
+    case 'weights':
+    case 'eval':
+    case 'manifest':
+      return `s3://${bucket}/${rel}`;
+  }
+}
+
+interface MirrorItem {
+  group: 'weights' | 'eval-reports' | 'dataset-manifests';
+  source: string;
+  destination: string;
+}
+
+interface PreflightManifest {
+  generated_at: string;
+  staging_bucket: string;
+  aws_bucket_set: boolean;
+  would_mirror_count: number;
+  groups: {
+    weights: { target: string; present: boolean; source: string; destination: string }[];
+    eval_reports: { source: string; destination: string }[];
+    dataset_manifests: { name: string; source: string; destination: string }[];
+  };
+  items: MirrorItem[];
+}
+
+function buildManifest(): PreflightManifest {
+  const items: MirrorItem[] = [];
+
+  // 1. Per-target current weights (exact path the mirror job checks).
+  const weights = TARGETS.map((target) => {
+    const src = `${STAGING_BUCKET}/finetune-current/${target}/weights.tar.gz`;
+    const present = gsutilLs(src).length > 0;
+    const dest = s3Dest(src, 'weights');
+    if (present) items.push({ group: 'weights', source: src, destination: dest });
+    return { target, present, source: src, destination: dest };
+  });
+
+  // 2. Eval-coverage reports (rsync of the whole prefix).
+  const evalFiles = gsutilLs(`${STAGING_BUCKET}/eval-reports/**`);
+  const eval_reports = evalFiles.map((src) => {
+    const dest = s3Dest(src, 'eval');
+    items.push({ group: 'eval-reports', source: src, destination: dest });
+    return { source: src, destination: dest };
+  });
+
+  // 3. Dataset manifests (one per dataset dir).
+  const manifestFiles = gsutilLs(`${STAGING_BUCKET}/datasets/*/manifest.json`);
+  const dataset_manifests = manifestFiles.map((src) => {
+    const m = src.match(/\/datasets\/([^/]+)\/manifest\.json$/);
+    const name = m ? m[1] : 'unknown';
+    const dest = s3Dest(src, 'manifest');
+    items.push({ group: 'dataset-manifests', source: src, destination: dest });
+    return { name, source: src, destination: dest };
+  });
+
+  return {
+    generated_at: new Date().toISOString(),
+    staging_bucket: STAGING_BUCKET,
+    aws_bucket_set: AWS_BUCKET.length > 0,
+    would_mirror_count: items.length,
+    groups: { weights, eval_reports, dataset_manifests },
+    items,
+  };
+}
+
+function renderMarkdown(m: PreflightManifest): string {
+  const L: string[] = [];
+  L.push('# MIRROR-ARTIFACTS-S3 preflight (dry-run)');
+  L.push('');
+  L.push(`- Generated: ${m.generated_at}`);
+  L.push(`- Staging bucket: \`${m.staging_bucket}\``);
+  L.push(`- AWS_BUCKET secret set: **${m.aws_bucket_set ? 'YES' : 'NO (destinations shown as placeholder)'}**`);
+  L.push(`- Objects that WOULD mirror: **${m.would_mirror_count}**`);
+  L.push('');
+  L.push('> Read-only GCS enumeration. No AWS calls, no copies, no deletes.');
+  L.push('> Proves the GCS source side of the mirror without the AWS secrets.');
+  L.push('');
+
+  L.push('## Weights (per target)');
+  L.push('');
+  L.push('| Target | Present | Source | Destination |');
+  L.push('| --- | --- | --- | --- |');
+  for (const w of m.groups.weights) {
+    L.push(`| ${w.target} | ${w.present ? 'yes' : 'no'} | \`${w.source}\` | \`${w.destination}\` |`);
+  }
+  L.push('');
+
+  L.push('## Eval-coverage reports');
+  L.push('');
+  if (m.groups.eval_reports.length === 0) {
+    L.push('_None present in GCS yet._');
+  } else {
+    L.push('| Source | Destination |');
+    L.push('| --- | --- |');
+    for (const e of m.groups.eval_reports) {
+      L.push(`| \`${e.source}\` | \`${e.destination}\` |`);
+    }
+  }
+  L.push('');
+
+  L.push('## Dataset manifests');
+  L.push('');
+  if (m.groups.dataset_manifests.length === 0) {
+    L.push('_None present in GCS yet._');
+  } else {
+    L.push('| Dataset | Source | Destination |');
+    L.push('| --- | --- | --- |');
+    for (const d of m.groups.dataset_manifests) {
+      L.push(`| ${d.name} | \`${d.source}\` | \`${d.destination}\` |`);
+    }
+  }
+  L.push('');
+
+  if (m.would_mirror_count === 0) {
+    L.push('> Nothing to mirror yet — expected pre-W3 (no weights, reports, or manifests in staging).');
+    L.push('> Once `STAGE-ARTIFACTS-GCS.yml` and the dataset/eval crons populate these prefixes,');
+    L.push('> this preflight will enumerate them and the dormant mirror will carry them once AWS lands.');
+  }
+  L.push('');
+  return L.join('\n') + '\n';
+}
+
+function main(): void {
+  const manifest = buildManifest();
+  console.log(JSON.stringify(manifest, null, 2));
+  if (PREFLIGHT_MARKDOWN_PATH) {
+    // Synchronous write — small file, keeps this script dep-free.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { writeFileSync } = require('node:fs') as typeof import('node:fs');
+    writeFileSync(PREFLIGHT_MARKDOWN_PATH, renderMarkdown(manifest), 'utf-8');
+    console.error(`[mirror-preflight] markdown written: ${PREFLIGHT_MARKDOWN_PATH}`);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+export { buildManifest, renderMarkdown };
+export type { PreflightManifest, MirrorItem };

--- a/services/gateway/scripts/eval/phase-evidence-digest.ts
+++ b/services/gateway/scripts/eval/phase-evidence-digest.ts
@@ -1,0 +1,329 @@
+/**
+ * Phase evidence digest — BOOTSTRAP-EVIDENCE-ARTIFACTS.
+ *
+ * Rolls the four standing Phase 1 evidence sources into ONE dated digest
+ * artifact for the operator's daily rhythm:
+ *
+ *   1. Phase gate status      (eval/phase-gate-status-report.ts → generate())
+ *   2. Shadow comparison      (eval/shadow-comparison-report.ts → fetchReport())
+ *   3. Canary readiness       (eval/canary-readiness-report.ts → generate())
+ *   4. Dataset preview counts (datasets/*.ts extractors in DATASET_PREVIEW mode)
+ *
+ * The first three are reused as-is via their exported generators, so the
+ * digest never duplicates their logic — it only aggregates. The dataset
+ * preview reuses each target's projection predicate through the extractors'
+ * own preview path.
+ *
+ * READ-ONLY. Calls the same read-only endpoints/queries the underlying
+ * reports already use. Emits NO oasis_events, writes NO GCS/JSONL, flips
+ * NO state. Each sub-report is wrapped so a missing creds/token or a network
+ * blip degrades that one section to "unavailable" instead of failing the
+ * whole digest — the digest is meant to run unattended every day.
+ *
+ * Output:
+ *   stdout: JSON (one digest object)
+ *   $DIGEST_MARKDOWN_PATH (env, optional): Markdown digest file
+ *   $DIGEST_JSON_PATH     (env, optional): JSON digest file
+ *
+ * Env (all optional — each maps to the underlying report's own env):
+ *   STAGING_GATEWAY_URL, PROD_GATEWAY_URL, GATEWAY_SERVICE_TOKEN,
+ *   PROD_SUPABASE_URL, PROD_SUPABASE_SERVICE_ROLE, VERTEX_IAM_CHECK_RESULT,
+ *   AWS_BUCKET, AWS_ROLE_ARN, AWS_SMOKE_RESULT, FINETUNE_STATUS,
+ *   FEATURE_TARGET, WINDOW_HOURS
+ *   DATASET_PREVIEW_ENABLED=1 → run the dataset preview section (default off;
+ *     it queries prod Supabase, so the workflow only enables it when creds
+ *     resolve).
+ */
+
+import { promises as fs } from 'fs';
+import {
+  generate as generatePhaseGate,
+  type PhaseGateReport,
+} from './phase-gate-status-report';
+import {
+  generate as generateCanary,
+  type CanaryReadinessReport,
+} from './canary-readiness-report';
+import { fetchReport as fetchShadowReport } from './shadow-comparison-report';
+
+const DIGEST_MARKDOWN_PATH = process.env.DIGEST_MARKDOWN_PATH;
+const DIGEST_JSON_PATH = process.env.DIGEST_JSON_PATH;
+const DATASET_PREVIEW_ENABLED = process.env.DATASET_PREVIEW_ENABLED === '1';
+
+/** Shadow report shape (mirrors shadow-comparison-report's ReportResponse). */
+interface ShadowReportShape {
+  ok: boolean;
+  env?: string;
+  window_hours?: number;
+  total_events: number;
+  insufficient_data?: boolean;
+  message?: string;
+  features: Array<{
+    feature: string;
+    total_comparisons: number;
+    agreement_rate: number | null;
+    candidate_p95_ms: number;
+    candidate_error_rate: number;
+  }>;
+}
+
+/** Dataset preview shape (mirrors datasets/types.ts DatasetExtractionPreview). */
+interface DatasetPreviewShape {
+  target: string;
+  preview: true;
+  rows_total: number;
+  rows_projected: number;
+  rows_after_dedup: number;
+}
+
+type SectionStatus = 'ok' | 'unavailable';
+
+interface Section<T> {
+  status: SectionStatus;
+  /** Present when status === 'unavailable'. */
+  error?: string;
+  /** Present when status === 'ok'. */
+  data?: T;
+}
+
+interface DatasetPreviewSummary {
+  total_rows_after_dedup: number;
+  per_target: Array<{
+    target: string;
+    rows_total: number;
+    rows_projected: number;
+    rows_after_dedup: number;
+  }>;
+}
+
+interface PhaseEvidenceDigest {
+  generated_at: string;
+  /** One-line operator headline derived from the sub-reports. */
+  headline: string;
+  sections: {
+    phase_gate: Section<PhaseGateReport>;
+    shadow_comparison: Section<ShadowReportShape>;
+    canary_readiness: Section<CanaryReadinessReport>;
+    dataset_preview: Section<DatasetPreviewSummary>;
+  };
+}
+
+/** Run a sub-report generator, degrading any throw to an `unavailable` section. */
+async function section<T>(fn: () => Promise<T>): Promise<Section<T>> {
+  try {
+    return { status: 'ok', data: await fn() };
+  } catch (err) {
+    return { status: 'unavailable', error: (err as Error).message };
+  }
+}
+
+/**
+ * Read-only dataset preview across the three targets. Reuses each extractor's
+ * own preview path by importing them with DATASET_PREVIEW set, so the
+ * projection logic is never duplicated here. Imported dynamically because the
+ * extractors read process.env at module load — we must set the flag first.
+ */
+async function previewDatasets(): Promise<DatasetPreviewSummary> {
+  process.env.DATASET_PREVIEW = '1';
+  const [{ extract: voice }, { extract: intent }, { extract: pillar }] = await Promise.all([
+    import('../datasets/voice-tool-routing'),
+    import('../datasets/intent-kind'),
+    import('../datasets/pillar-classification'),
+  ]);
+  const targets: Array<[string, () => Promise<unknown>]> = [
+    ['voice-tool-routing', voice],
+    ['intent-kind', intent],
+    ['pillar-classification', pillar],
+  ];
+  const per_target: DatasetPreviewSummary['per_target'] = [];
+  let total = 0;
+  for (const [name, fn] of targets) {
+    const p = (await fn()) as DatasetPreviewShape;
+    const after = p.rows_after_dedup ?? 0;
+    total += after;
+    per_target.push({
+      target: name,
+      rows_total: p.rows_total ?? 0,
+      rows_projected: p.rows_projected ?? 0,
+      rows_after_dedup: after,
+    });
+  }
+  return { total_rows_after_dedup: total, per_target };
+}
+
+function buildHeadline(d: PhaseEvidenceDigest['sections']): string {
+  const parts: string[] = [];
+
+  if (d.phase_gate.status === 'ok' && d.phase_gate.data) {
+    const o = d.phase_gate.data.overall;
+    parts.push(
+      `gates ${o.gates_open}/${o.gates_total} open`
+      + (o.first_blocker ? `, first blocker: ${o.first_blocker}` : ', no blockers'),
+    );
+  } else {
+    parts.push('gates unavailable');
+  }
+
+  if (d.canary_readiness.status === 'ok' && d.canary_readiness.data) {
+    parts.push(`canary: ${d.canary_readiness.data.verdict}`);
+  } else {
+    parts.push('canary unavailable');
+  }
+
+  if (d.shadow_comparison.status === 'ok' && d.shadow_comparison.data) {
+    parts.push(`shadow events 24h: ${d.shadow_comparison.data.total_events}`);
+  } else {
+    parts.push('shadow unavailable');
+  }
+
+  if (d.dataset_preview.status === 'ok' && d.dataset_preview.data) {
+    parts.push(`dataset preview rows: ${d.dataset_preview.data.total_rows_after_dedup}`);
+  } else if (DATASET_PREVIEW_ENABLED) {
+    parts.push('dataset preview unavailable');
+  } else {
+    parts.push('dataset preview skipped');
+  }
+
+  return parts.join(' | ');
+}
+
+async function generate(): Promise<PhaseEvidenceDigest> {
+  const [phase_gate, shadow_comparison, canary_readiness] = await Promise.all([
+    section<PhaseGateReport>(() => generatePhaseGate()),
+    section<ShadowReportShape>(async () => (await fetchShadowReport()) as unknown as ShadowReportShape),
+    section<CanaryReadinessReport>(() => generateCanary()),
+  ]);
+
+  const dataset_preview: Section<DatasetPreviewSummary> = DATASET_PREVIEW_ENABLED
+    ? await section<DatasetPreviewSummary>(previewDatasets)
+    : { status: 'unavailable', error: 'dataset preview not enabled (DATASET_PREVIEW_ENABLED!=1)' };
+
+  const sections = { phase_gate, shadow_comparison, canary_readiness, dataset_preview };
+  return {
+    generated_at: new Date().toISOString(),
+    headline: buildHeadline(sections),
+    sections,
+  };
+}
+
+function fmtSectionHeader(name: string, s: Section<unknown>): string {
+  return `### ${name} — ${s.status === 'ok' ? 'OK' : 'UNAVAILABLE'}`;
+}
+
+function renderMarkdown(d: PhaseEvidenceDigest): string {
+  const L: string[] = [];
+  const date = d.generated_at.slice(0, 10);
+  L.push(`# Phase evidence digest — ${date}`);
+  L.push('');
+  L.push(`- Generated: ${d.generated_at}`);
+  L.push(`- Headline: **${d.headline}**`);
+  L.push('');
+  L.push('> Read-only roll-up of the four standing Phase 1 evidence sources.');
+  L.push('> Emits no events, writes no datasets, flips no state.');
+  L.push('');
+
+  // 1. Phase gate
+  L.push(fmtSectionHeader('Phase gate status', d.sections.phase_gate));
+  L.push('');
+  const pg = d.sections.phase_gate;
+  if (pg.status === 'ok' && pg.data) {
+    const o = pg.data.overall;
+    L.push(`- Gates: ${o.gates_open} open / ${o.gates_blocked} blocked / ${o.gates_unknown} unknown`);
+    L.push(`- Ready for W3-B..G wave: **${o.ready_for_w3_b_to_g ? 'YES' : 'NO'}**`);
+    if (o.first_blocker) L.push(`- First blocker: **${o.first_blocker}**`);
+    if (o.blocked_by_priority.length) {
+      L.push(`- Blocked (priority order): ${o.blocked_by_priority.join(' → ')}`);
+    }
+    L.push('');
+    L.push('| Gate | Status | Detail |');
+    L.push('| --- | --- | --- |');
+    for (const g of pg.data.gates) {
+      L.push(`| ${g.name} | ${g.status.toUpperCase()} | ${g.detail.replace(/\|/g, '\\|')} |`);
+    }
+  } else {
+    L.push(`Unavailable: ${pg.error ?? 'unknown error'}`);
+  }
+  L.push('');
+
+  // 2. Shadow comparison
+  L.push(fmtSectionHeader('Shadow comparison', d.sections.shadow_comparison));
+  L.push('');
+  const sh = d.sections.shadow_comparison;
+  if (sh.status === 'ok' && sh.data) {
+    L.push(`- Total comparisons (window): ${sh.data.total_events}`);
+    if (sh.data.insufficient_data) {
+      L.push('- **Insufficient shadow data** — expected until staging voice traffic accumulates.');
+    } else if (sh.data.features.length) {
+      L.push('');
+      L.push('| Feature | n | Agreement | Candidate p95 | Err rate |');
+      L.push('| --- | ---: | ---: | ---: | ---: |');
+      for (const f of sh.data.features) {
+        const ag = f.agreement_rate === null ? '—' : `${(f.agreement_rate * 100).toFixed(1)}%`;
+        L.push(`| \`${f.feature}\` | ${f.total_comparisons} | ${ag} | ${f.candidate_p95_ms.toFixed(0)}ms | ${(f.candidate_error_rate * 100).toFixed(1)}% |`);
+      }
+    }
+  } else {
+    L.push(`Unavailable: ${sh.error ?? 'unknown error'}`);
+  }
+  L.push('');
+
+  // 3. Canary readiness
+  L.push(fmtSectionHeader('Canary readiness', d.sections.canary_readiness));
+  L.push('');
+  const cr = d.sections.canary_readiness;
+  if (cr.status === 'ok' && cr.data) {
+    L.push(`- Target: ${cr.data.target}`);
+    L.push(`- Verdict: **${cr.data.verdict}**`);
+    L.push(`- Next: ${cr.data.next_recommended_action}`);
+    L.push('');
+    for (const r of cr.data.reasons) {
+      L.push(`- **[${r.ok ? 'PASS' : 'FAIL'}] ${r.rule}** — ${r.detail}`);
+    }
+  } else {
+    L.push(`Unavailable: ${cr.error ?? 'unknown error'}`);
+  }
+  L.push('');
+
+  // 4. Dataset preview
+  L.push(fmtSectionHeader('Dataset preview counts', d.sections.dataset_preview));
+  L.push('');
+  const dp = d.sections.dataset_preview;
+  if (dp.status === 'ok' && dp.data) {
+    L.push(`- Total rows that WOULD extract (post-dedup): **${dp.data.total_rows_after_dedup}**`);
+    L.push('');
+    L.push('| Target | rows_total | rows_projected | rows_after_dedup |');
+    L.push('| --- | ---: | ---: | ---: |');
+    for (const t of dp.data.per_target) {
+      L.push(`| ${t.target} | ${t.rows_total} | ${t.rows_projected} | ${t.rows_after_dedup} |`);
+    }
+  } else {
+    L.push(`Unavailable: ${dp.error ?? 'unknown error'}`);
+  }
+  L.push('');
+
+  return L.join('\n') + '\n';
+}
+
+async function main(): Promise<void> {
+  const digest = await generate();
+  const json = JSON.stringify(digest, null, 2);
+  console.log(json);
+  if (DIGEST_JSON_PATH) {
+    await fs.writeFile(DIGEST_JSON_PATH, json + '\n', 'utf-8');
+    console.error(`[phase-evidence-digest] json written: ${DIGEST_JSON_PATH}`);
+  }
+  if (DIGEST_MARKDOWN_PATH) {
+    await fs.writeFile(DIGEST_MARKDOWN_PATH, renderMarkdown(digest), 'utf-8');
+    console.error(`[phase-evidence-digest] markdown written: ${DIGEST_MARKDOWN_PATH}`);
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[phase-evidence-digest] FAILED:', err);
+    process.exit(1);
+  });
+}
+
+export { generate, renderMarkdown };
+export type { PhaseEvidenceDigest };


### PR DESCRIPTION
## Summary

Strengthens the Phase 1 evidence/artifact trail with two read-only additions. Neither writes prod state, emits `oasis_events`, deploys, nor touches AWS. Targets from the Phase-1 record (`docs/PHASE-1-W2-ACCEPTANCE.md`, W3-B0).

### 1. PHASE-EVIDENCE-DIGEST — consolidated daily roll-up

A single dated artifact that rolls up the four standing evidence sources for the operator's daily rhythm:

- `services/gateway/scripts/eval/phase-evidence-digest.ts` — aggregates **phase-gate status** + **shadow comparison** + **canary readiness** + **dataset preview counts**. It reuses each report's exported `generate()`/`fetchReport()` — no logic duplication. Any unavailable source (missing creds/token, network blip) degrades to an `unavailable` section so the digest runs unattended every day.
- `.github/workflows/PHASE-EVIDENCE-DIGEST.yml` — daily at 09:00 UTC (15 min after the 08:45 canary report so the verdict it reads is freshest). Uploads `phase-evidence-digest.{json,md}` as a 90-day artifact and appends the Markdown to the step summary — same pattern as the three reports it aggregates. No auto-commit.
- `docs/evidence/README.md` — documents the format + sources.

Evidence chain: `08:15 shadow → 08:30 phase-gate → 08:45 canary → 09:00 digest`.

### 2. MIRROR-ARTIFACTS-S3 preflight — code-ready the dormant mirror

The mirror + smoke both refuse without `AWS_BUCKET`/`AWS_ROLE_ARN`, so the GCS→S3 wiring was un-inspectable pre-provisioning. This adds a dry-run:

- `scripts/aws/mirror-preflight.ts` — enumerates the GCS source side with the **same globs the mirror job uses** (per-target weights, eval-coverage reports, dataset manifests) and reports exactly WHAT would mirror + the S3 destination keys, without needing AWS secrets. Pure read-only `gsutil ls`; renders an `<AWS_BUCKET>` placeholder when the secret is unset.
- A new `preflight` job on `MIRROR-ARTIFACTS-S3.yml` gated **only on the existing GCP WIF** (not AWS), so the dormant mirror stays inspectable on every schedule.

## Verification

- `npm install` (per pre-commit hook guidance for the global-TS `moduleResolution` deprecation) → `npm run build` (gateway TypeScript) **green**.
- `phase-evidence-digest.ts` type-checks clean under the project's module settings; ran locally — aggregates all four sources, degrades cleanly with no creds.
- `mirror-preflight.ts` ran locally — enumerates the three source groups, renders the "nothing to mirror yet" pre-W3 state correctly.

## Scope / safety

Read-only. No prod writes, no `oasis_events`, no deploy, no AWS calls, no auto-commit. Draft PR.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_