### PR TITLE
feat(intelligence): role-based tool/source policy enforcer (shadow) (BOOTSTRAP-ROLE-AUTH-ENFORCER)

### DIFF
--- a/services/gateway/src/services/intelligence/role-policy-enforcer.ts
+++ b/services/gateway/src/services/intelligence/role-policy-enforcer.ts
@@ -1,0 +1,211 @@
+/**
+ * Role policy enforcer — Phase 1 W3-E1 (BOOTSTRAP-ROLE-AUTH-ENFORCER).
+ *
+ * Runtime ENFORCEMENT layer on top of the assistant role registry
+ * (VTID-03240). Given the active assistant role and a requested
+ * tool/source, it validates the request against the registry's
+ * closed-world (deny-by-default) policy and returns an allow/deny
+ * decision WITH a machine-readable reason.
+ *
+ * This module does NOT define policy — it only reads the registry's
+ * `isToolAllowed` / `isContextSourceAllowed` helpers and wraps them with
+ * reasons + a feature gate. The registry remains the single source of
+ * truth; do NOT relax any allowlist here.
+ *
+ * ── Gating semantics ───────────────────────────────────────────────
+ * Gated by FEATURE_ROLE_POLICY_ENFORCE_ENV (off | staging-only |
+ * staging+prod), default off — same flag pattern as the W3 shadow.
+ *
+ *   - Flag OFF (default):   `enforced=false`. Callers MUST treat every
+ *                           decision as advisory — LOG the violation
+ *                           (shadow), never block. `assertToolAllowed`
+ *                           still returns the correct allow/deny verdict
+ *                           so callers can record it.
+ *   - Flag ON:              `enforced=true`. Callers SHOULD block on a
+ *                           deny verdict.
+ *
+ * The enforcer NEVER throws and NEVER blocks on its own; it returns a
+ * decision. The decision to block lives with the caller (so a single
+ * misbehaving call site can never hard-fail every assistant turn). The
+ * `enforced` field tells the caller whether the flag is live.
+ */
+
+import { isFeatureLive } from '../feature-flags';
+import {
+  type AssistantRoleProfile,
+  getRoleProfile,
+  isContextSourceAllowed,
+  isToolAllowed,
+} from './assistant-role-registry';
+
+export const FEATURE_NAME = 'ROLE_POLICY_ENFORCE';
+
+/** Why a request was allowed or denied. Machine-readable for telemetry. */
+export type RolePolicyReason =
+  | 'allowed'
+  | 'denied_by_policy' // closed-world default OR explicit denylist hit
+  | 'unknown_role'; // active_role did not resolve to a profile
+
+export interface RolePolicyDecision {
+  /** True iff the requested tool/source passes the role's policy. */
+  allowed: boolean;
+  /** Machine-readable reason for the verdict. */
+  reason: RolePolicyReason;
+  /**
+   * True iff FEATURE_ROLE_POLICY_ENFORCE is live in this environment.
+   * When false, callers MUST treat `allowed=false` as advisory (log
+   * only, do NOT block). When true, callers SHOULD block on deny.
+   */
+  enforced: boolean;
+  /** The resolved role (canonical) or the raw input if unrecognized. */
+  role: string | null;
+  /** The tool/source name that was evaluated. */
+  target: string;
+  /** 'tool' | 'source' — what kind of target was checked. */
+  kind: 'tool' | 'source';
+  /** Human-readable one-liner for logs. */
+  message: string;
+}
+
+/**
+ * True iff the enforcer is live in this environment. When false, callers
+ * run in shadow mode (log violations, never block).
+ */
+export function isEnforcementLive(): boolean {
+  return isFeatureLive(FEATURE_NAME);
+}
+
+function denyMessage(kind: 'tool' | 'source', target: string, role: string | null): string {
+  return `role '${role ?? '(null)'}' is NOT permitted ${kind} '${target}' (deny-by-default closed-world policy)`;
+}
+
+function allowMessage(kind: 'tool' | 'source', target: string, role: string | null): string {
+  return `role '${role ?? '(null)'}' permitted ${kind} '${target}'`;
+}
+
+function decide(
+  kind: 'tool' | 'source',
+  role: string | null | undefined,
+  target: string,
+  check: (profile: AssistantRoleProfile, target: string) => boolean,
+): RolePolicyDecision {
+  const enforced = isEnforcementLive();
+  const profile = getRoleProfile(role);
+
+  // Unknown role → deny-by-default (closed world). An unrecognized role
+  // never gets a tool/source.
+  if (!profile) {
+    return {
+      allowed: false,
+      reason: 'unknown_role',
+      enforced,
+      role: role ?? null,
+      target,
+      kind,
+      message: `unrecognized role '${role ?? '(null)'}' — denying ${kind} '${target}' by default`,
+    };
+  }
+
+  const allowed = check(profile, target);
+  return {
+    allowed,
+    reason: allowed ? 'allowed' : 'denied_by_policy',
+    enforced,
+    role: profile.role,
+    target,
+    kind,
+    message: allowed
+      ? allowMessage(kind, target, profile.role)
+      : denyMessage(kind, target, profile.role),
+  };
+}
+
+/**
+ * Validate that `role` is permitted to dispatch `toolName` under the
+ * registry's closed-world policy. Returns a decision; never throws,
+ * never blocks. Caller inspects `enforced` to decide whether to block.
+ */
+export function assertToolAllowed(
+  role: string | null | undefined,
+  toolName: string,
+): RolePolicyDecision {
+  return decide('tool', role, toolName, isToolAllowed);
+}
+
+/**
+ * Validate that `role` is permitted to consult context-source `source`
+ * under the registry's closed-world policy. Returns a decision; never
+ * throws, never blocks.
+ */
+export function assertSourceAllowed(
+  role: string | null | undefined,
+  source: string,
+): RolePolicyDecision {
+  return decide('source', role, source, isContextSourceAllowed);
+}
+
+export interface ShadowLogContext {
+  /** Surface that requested the tool/source (orb-live, /orb/tool, etc). */
+  surface?: string;
+  /** Correlation id (session / request) for cockpit drill-down. */
+  session_id?: string;
+  /** Optional actor id. */
+  actor_id?: string;
+}
+
+/**
+ * Shadow-log a denied decision. Safe to call from hot paths. In shadow
+ * mode (flag off) this records the violation that WOULD have been
+ * blocked; with the flag on the caller is expected to block, and this
+ * log records that it was an enforced block. No-op for `allowed`
+ * decisions.
+ *
+ * Uses console.warn (structured prefix) so it shows in Cloud Run logs
+ * without coupling the enforcer to the OASIS event pipeline — the W3
+ * shadow already emits the structured OASIS telemetry for the full
+ * context-pack view.
+ */
+export function logPolicyViolation(
+  decision: RolePolicyDecision,
+  ctx: ShadowLogContext = {},
+): void {
+  if (decision.allowed) return;
+  const mode = decision.enforced ? 'ENFORCED' : 'SHADOW';
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[role-policy-enforcer][${mode}] ${decision.message}` +
+      (ctx.surface ? ` surface=${ctx.surface}` : '') +
+      (ctx.session_id ? ` session=${ctx.session_id}` : '') +
+      (ctx.actor_id ? ` actor=${ctx.actor_id}` : ''),
+  );
+}
+
+/**
+ * Convenience for call sites: check a tool, log on violation, and return
+ * whether the caller SHOULD block. In shadow mode this always returns
+ * false (never block) while still logging the violation. With the flag
+ * on it returns true on a deny verdict.
+ */
+export function shouldBlockTool(
+  role: string | null | undefined,
+  toolName: string,
+  ctx: ShadowLogContext = {},
+): boolean {
+  const decision = assertToolAllowed(role, toolName);
+  logPolicyViolation(decision, ctx);
+  return decision.enforced && !decision.allowed;
+}
+
+/**
+ * Convenience for call sites: check a context source, log on violation,
+ * and return whether the caller SHOULD block.
+ */
+export function shouldBlockSource(
+  role: string | null | undefined,
+  source: string,
+  ctx: ShadowLogContext = {},
+): boolean {
+  const decision = assertSourceAllowed(role, source);
+  logPolicyViolation(decision, ctx);
+  return decision.enforced && !decision.allowed;
+}

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -26,6 +26,7 @@
  */
 
 import { SupabaseClient } from '@supabase/supabase-js';
+import { shouldBlockTool } from './intelligence/role-policy-enforcer';
 import { fetchVitanaIndexForProfiler } from './user-context-profiler';
 import { resolvePillarKey } from '../lib/vitana-pillars';
 import {
@@ -3881,6 +3882,24 @@ export async function dispatchOrbTool(
   if (!handler) {
     return { ok: false, error: `unknown tool: ${name}` };
   }
+
+  // BOOTSTRAP-ROLE-AUTH-ENFORCER — role-policy shadow hook (deny-by-default).
+  //
+  // Non-invasive: with FEATURE_ROLE_POLICY_ENFORCE off (default) this only
+  // LOGS a violation (shadow) and NEVER blocks. With the flag on it would
+  // return a deny result before dispatch.
+  //
+  // INTEGRATION TODO: the ORB tool registry names here (e.g. 'search_memory',
+  // 'play_music') are NOT yet 1:1 with the assistant-role-registry tool
+  // allowlist names (e.g. 'get_recent_memory'). A name-mapping table
+  // (orb-tool-name -> registry-tool-name) must land BEFORE the enforce flag
+  // is flipped to staging+prod, otherwise legitimate tools would be denied.
+  // Until that mapping exists this hook is shadow-only telemetry; do NOT
+  // enable FEATURE_ROLE_POLICY_ENFORCE in prod. See role-policy-enforcer.ts.
+  if (shouldBlockTool(identity.role, name, { surface: 'orb-tool', session_id: identity.session_id ?? undefined, actor_id: identity.user_id })) {
+    return { ok: false, error: `tool '${name}' not permitted for role '${identity.role ?? '(null)'}'` };
+  }
+
   try {
     return await handler(args, identity, sb);
   } catch (e: unknown) {

--- a/services/gateway/test/role-policy-enforcer.test.ts
+++ b/services/gateway/test/role-policy-enforcer.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Role policy enforcer tests — BOOTSTRAP-ROLE-AUTH-ENFORCER.
+ *
+ * Validates the closed-world (deny-by-default) enforcement layer over the
+ * assistant role registry (VTID-03240):
+ *   - Each of the 7 roles ALLOWS every tool in its declared allowlist.
+ *   - Each role DENIES tools that are not in its allowlist (including tools
+ *     that belong to OTHER roles → no cross-role leakage).
+ *   - Explicit denylist patterns are denied.
+ *   - Unknown role → deny-by-default with reason 'unknown_role'.
+ *   - Context-source allow/deny mirror the registry.
+ *   - Shadow vs enforce gating: flag off => enforced=false, never block;
+ *     flag on => enforced=true, block on deny.
+ *
+ * The enforcer must NOT relax the registry — these tests pin that contract.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { isFeatureLive } from '../src/services/feature-flags';
+import {
+  ASSISTANT_ROLES,
+  ROLE_PROFILES,
+  type AssistantRole,
+} from '../src/services/intelligence/assistant-role-registry';
+import {
+  assertSourceAllowed,
+  assertToolAllowed,
+  isEnforcementLive,
+  shouldBlockSource,
+  shouldBlockTool,
+} from '../src/services/intelligence/role-policy-enforcer';
+
+jest.mock('../src/services/feature-flags', () => ({
+  isFeatureLive: jest.fn(),
+}));
+
+const mockIsFeatureLive = isFeatureLive as jest.MockedFunction<typeof isFeatureLive>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: enforcement OFF (shadow mode) unless a test flips it.
+  mockIsFeatureLive.mockReturnValue(false);
+});
+
+describe('assertToolAllowed — per-role allowlist coverage', () => {
+  test('every role allows every tool in its declared allowlist', () => {
+    for (const role of ASSISTANT_ROLES) {
+      const profile = ROLE_PROFILES[role];
+      for (const tool of profile.tool_allowlist) {
+        const d = assertToolAllowed(role, tool);
+        expect({ role, tool, allowed: d.allowed, reason: d.reason }).toEqual({
+          role,
+          tool,
+          allowed: true,
+          reason: 'allowed',
+        });
+      }
+    }
+  });
+
+  test('every role denies a tool that is not in any allowlist', () => {
+    const fabricated = 'totally_made_up_tool_name_xyz';
+    for (const role of ASSISTANT_ROLES) {
+      const d = assertToolAllowed(role, fabricated);
+      expect(d.allowed).toBe(false);
+      expect(d.reason).toBe('denied_by_policy');
+    }
+  });
+});
+
+describe('no cross-role leakage — a role denies tools exclusive to other roles', () => {
+  // For each role, take tools that ANOTHER role allows but this role does
+  // NOT allow, and assert they are denied.
+  test.each([...ASSISTANT_ROLES])('role %s denies other roles\' exclusive tools', (role) => {
+    const ownAllow = new Set(ROLE_PROFILES[role as AssistantRole].tool_allowlist);
+    const otherTools = new Set<string>();
+    for (const other of ASSISTANT_ROLES) {
+      if (other === role) continue;
+      for (const t of ROLE_PROFILES[other].tool_allowlist) {
+        if (!ownAllow.has(t)) otherTools.add(t);
+      }
+    }
+    // Sanity: there should be cross-role-distinct tools to check.
+    expect(otherTools.size).toBeGreaterThan(0);
+    for (const t of otherTools) {
+      const d = assertToolAllowed(role, t);
+      expect({ role, tool: t, allowed: d.allowed }).toEqual({ role, tool: t, allowed: false });
+    }
+  });
+});
+
+describe('explicit denylist patterns are denied', () => {
+  test('community denies admin_*/devops_* prefixed tools', () => {
+    expect(assertToolAllowed('community', 'admin_force_publish').allowed).toBe(false);
+    expect(assertToolAllowed('community', 'devops_drop_table').allowed).toBe(false);
+    expect(assertToolAllowed('community', 'cicd_run_pipeline').allowed).toBe(false);
+  });
+
+  test('developer is explicitly denied community wellness + canary tools', () => {
+    for (const t of ['get_pillar_status', 'find_partner', 'publish_canary', 'promote_canary', 'log_symptom']) {
+      expect(assertToolAllowed('developer', t).allowed).toBe(false);
+    }
+  });
+
+  test('admin denies cicd_force_* even though it is operational', () => {
+    expect(assertToolAllowed('admin', 'cicd_force_merge').allowed).toBe(false);
+    expect(assertToolAllowed('admin', 'devops_drop_secrets').allowed).toBe(false);
+  });
+
+  test('staff denies publish/revert/canary prefixes', () => {
+    for (const t of ['publish_canary', 'revert_deployment', 'canary_promote']) {
+      expect(assertToolAllowed('staff', t).allowed).toBe(false);
+    }
+  });
+});
+
+describe('unknown / null role → deny-by-default', () => {
+  test('unrecognized role denies with reason unknown_role', () => {
+    const d = assertToolAllowed('superuser', 'send_chat_message');
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toBe('unknown_role');
+    expect(d.role).toBe('superuser');
+  });
+
+  test('null role denies with reason unknown_role', () => {
+    const d = assertToolAllowed(null, 'remember');
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toBe('unknown_role');
+    expect(d.role).toBeNull();
+  });
+});
+
+describe('assertSourceAllowed — context-source policy mirrors registry', () => {
+  test('every role allows each source in its allowlist and denies denylist + unknown', () => {
+    for (const role of ASSISTANT_ROLES) {
+      const profile = ROLE_PROFILES[role];
+      for (const src of profile.context_source_allowlist) {
+        expect(assertSourceAllowed(role, src).allowed).toBe(true);
+      }
+      for (const src of profile.context_source_denylist) {
+        expect(assertSourceAllowed(role, src).allowed).toBe(false);
+      }
+      // safety_guardrails must never be allowed for any role.
+      expect(assertSourceAllowed(role, 'safety_guardrails').allowed).toBe(false);
+      // a fabricated source id is denied by default.
+      expect(assertSourceAllowed(role, 'made_up_source_id').allowed).toBe(false);
+    }
+  });
+
+  test('infra denies user memory sources (bounded to infra-only)', () => {
+    expect(assertSourceAllowed('infra', 'memory_facts').allowed).toBe(false);
+    expect(assertSourceAllowed('infra', 'vitana_index').allowed).toBe(false);
+    expect(assertSourceAllowed('infra', 'assistant_state').allowed).toBe(true);
+  });
+});
+
+describe('shadow vs enforce gating', () => {
+  test('flag OFF: enforced=false, shouldBlockTool never blocks even on deny', () => {
+    mockIsFeatureLive.mockReturnValue(false);
+    expect(isEnforcementLive()).toBe(false);
+
+    const denyDecision = assertToolAllowed('community', 'devops_drop_table');
+    expect(denyDecision.allowed).toBe(false);
+    expect(denyDecision.enforced).toBe(false);
+
+    // Shadow mode: never blocks.
+    expect(shouldBlockTool('community', 'devops_drop_table')).toBe(false);
+    expect(shouldBlockSource('infra', 'memory_facts')).toBe(false);
+  });
+
+  test('flag ON: enforced=true, shouldBlockTool blocks on deny but not on allow', () => {
+    mockIsFeatureLive.mockReturnValue(true);
+    expect(isEnforcementLive()).toBe(true);
+
+    // Denied tool → block.
+    expect(shouldBlockTool('community', 'devops_drop_table')).toBe(true);
+    // Allowed tool → no block.
+    expect(shouldBlockTool('community', 'send_chat_message')).toBe(false);
+    // Denied source → block.
+    expect(shouldBlockSource('infra', 'memory_facts')).toBe(true);
+    // Allowed source → no block.
+    expect(shouldBlockSource('community', 'memory_facts')).toBe(false);
+  });
+
+  test('flag ON: unknown role is blocked', () => {
+    mockIsFeatureLive.mockReturnValue(true);
+    expect(shouldBlockTool('superuser', 'send_chat_message')).toBe(true);
+  });
+});
+
+describe('decision shape is stable for telemetry', () => {
+  test('decision carries kind, target, role, message', () => {
+    const d = assertToolAllowed('developer', 'search_codebase');
+    expect(d.kind).toBe('tool');
+    expect(d.target).toBe('search_codebase');
+    expect(d.role).toBe('developer');
+    expect(typeof d.message).toBe('string');
+    expect(d.message.length).toBeGreaterThan(0);
+
+    const s = assertSourceAllowed('developer', 'vitana_index');
+    expect(s.kind).toBe('source');
+    expect(s.allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a runtime **enforcement** layer over the assistant role registry (VTID-03240). Given the active assistant role and a requested tool/source, it validates the request against the registry's closed-world **deny-by-default** policy and returns an allow/deny decision with a machine-readable reason. Additive only — does **not** rebuild the registry, does **not** modify `assistant-role-registry.ts`, and does **not** relax any allowlist.

## What's in this PR

- **NEW `services/gateway/src/services/intelligence/role-policy-enforcer.ts`**
  - `assertToolAllowed(role, toolName)` / `assertSourceAllowed(role, source)` → `RolePolicyDecision` (`allowed`, `reason`, `enforced`, `role`, `target`, `kind`, `message`).
  - Reuses the registry's `isToolAllowed` / `isContextSourceAllowed` helpers — registry stays the single source of truth.
  - Unknown / null role → deny-by-default with reason `unknown_role`.
  - Convenience `shouldBlockTool` / `shouldBlockSource` + `logPolicyViolation` for call sites.
- **Feature gate `FEATURE_ROLE_POLICY_ENFORCE_ENV`** (default `off`), same pattern as the W3 shadow flag.
  - **OFF (default):** `enforced=false` → callers log violations (shadow), never block.
  - **ON:** `enforced=true` → callers block on a deny verdict.
- **Non-invasive shadow hook** at `dispatchOrbTool` in `orb-tools-shared.ts`. With the flag off it only logs; with the flag on it returns a deny result before dispatch.
  - **Documented integration TODO:** the ORB tool registry names (e.g. `search_memory`, `play_music`) are not yet 1:1 with the registry allowlist names (e.g. `get_recent_memory`). A name-mapping table must land before the enforce flag is flipped in prod, otherwise legitimate tools would be denied. Until then the hook is shadow-only telemetry.
- **NEW `services/gateway/test/role-policy-enforcer.test.ts`** — 21 tests:
  - All 7 roles allow every tool in their declared allowlist.
  - No cross-role leakage: each role denies tools exclusive to other roles.
  - Denylist patterns denied; context-source allow/deny mirror; unknown-role deny; shadow-vs-enforce gating.

## Verification

- `tsc --noEmit` (project-local TypeScript): clean.
- `jest role-policy-enforcer`: 21/21 pass.

## Risk

Low. Default-off feature flag; the only production-path change is a shadow hook that logs and (in shadow mode) never blocks. No deploy in this PR.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_