### PR TITLE
feat(orb): de-stub match-journey context from journey + Vitana Index (BOOTSTRAP-MATCHMAKING-INDEX)

### DIFF
--- a/services/gateway/.env.template
+++ b/services/gateway/.env.template
@@ -83,3 +83,6 @@ AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION=0.5
 
 # Context contract — gate for assertContextContract; OFF by default; dev/validation only.
 # FEATURE_CONTEXT_CONTRACT_ASSERT=false
+
+# BOOTSTRAP-MATCHMAKING-INDEX: gate match-journey context derivation; OFF→historical {journeyStage:'none'} stub; dev/validation only
+# FEATURE_MATCH_JOURNEY_CONTEXT=false

--- a/services/gateway/src/orb/context/providers/match-journey-context-provider.ts
+++ b/services/gateway/src/orb/context/providers/match-journey-context-provider.ts
@@ -22,6 +22,11 @@
  */
 
 import type { ClientContextEnvelope } from '../client-context-envelope';
+import {
+  defaultMatchJourneyFetcher,
+  type MatchJourneyFetcher,
+} from './match-journey-fetcher';
+import { deriveMatchJourneyContext } from './match-journey-derivation';
 
 // ---------------------------------------------------------------------------
 // Output type — the distilled match-journey snapshot.
@@ -110,6 +115,25 @@ export interface MatchJourneyContextProviderInput {
   userId: string | null;
   tenantId: string | null;
   envelope: ClientContextEnvelope | null;
+  /**
+   * BOOTSTRAP-MATCHMAKING-INDEX — injected fetcher (defaults to the
+   * Supabase-backed one). Exists for tests; production omits it.
+   */
+  fetcher?: MatchJourneyFetcher;
+  /** Injected clock for deterministic derivation in tests. */
+  nowMs?: number;
+}
+
+/** The stub the provider returns when the feature flag is OFF. */
+const STUB_CONTEXT: MatchJourneyContext = { journeyStage: 'none' };
+
+/**
+ * Feature flag — default OFF. When unset/anything-but-'true' the
+ * provider returns the historical `{ journeyStage: 'none' }` stub, so
+ * the change is fully additive and reversible at runtime.
+ */
+export function isMatchJourneyContextEnabled(): boolean {
+  return process.env.FEATURE_MATCH_JOURNEY_CONTEXT === 'true';
 }
 
 // ---------------------------------------------------------------------------
@@ -138,7 +162,28 @@ export interface MatchJourneyContextProviderInput {
  * will need awaits for memory-broker reads.
  */
 export async function compileMatchJourneyContext(
-  _input: MatchJourneyContextProviderInput,
+  input: MatchJourneyContextProviderInput,
 ): Promise<MatchJourneyContext> {
-  return { journeyStage: 'none' };
+  // Flag OFF (default) → historical stub. Fully additive.
+  if (!isMatchJourneyContextEnabled()) return STUB_CONTEXT;
+
+  // Need an authenticated user + tenant to anchor on real journey/Index
+  // state. Without them there is nothing to derive — degrade to the stub.
+  if (!input.userId || !input.tenantId) return STUB_CONTEXT;
+
+  const fetcher = input.fetcher ?? defaultMatchJourneyFetcher;
+  try {
+    const fetched = await fetcher.fetch({
+      userId: input.userId,
+      tenantId: input.tenantId,
+    });
+    return deriveMatchJourneyContext({
+      latestMatch: fetched.latestMatch,
+      indexScoreTotal: fetched.indexScoreTotal,
+      nowMs: input.nowMs,
+    });
+  } catch {
+    // Fail safe — never break context compilation over match-journey.
+    return STUB_CONTEXT;
+  }
 }

--- a/services/gateway/src/orb/context/providers/match-journey-derivation.ts
+++ b/services/gateway/src/orb/context/providers/match-journey-derivation.ts
@@ -14,11 +14,22 @@
  *   - NO OASIS topic literals (the grep guard at
  *     scripts/ci/match-journey-topics-guard.mjs enforces this).
  *
- * Stage mapping (intent_matches.state → journeyStage):
+ * Stage mapping (intent_matches.state → journeyStage). The fetcher
+ * always reads the user as side A (filters on `vitana_id_a`), so the
+ * "other side" is always B. This mirrors the canonical classifier in
+ * `services/.../next-action/sources/match-activity-plan.ts`:
  *   - no match rows at all           → 'browsing'
- *   - latest state = 'suggested'     → 'pre_interest'
- *   - latest state = 'accepted'      → 'mutual_match'
- *   - latest state = 'dismissed'     → 'browsing' (back to the pool)
+ *   - 'new'                          → 'pre_interest' (fresh, show interest)
+ *   - 'responded_by_b'               → 'pre_interest' (B replied → our turn
+ *                                       to decide, pendingUserDecision=reply)
+ *   - 'responded_by_a'               → 'interest_sent' (we replied, waiting
+ *                                       on the other side — not our turn)
+ *   - 'mutual_interest'              → 'mutual_match' (both engaged)
+ *   - 'declined'                     → 'browsing' (back to the pool)
+ *   Legacy states (kept for back-compat):
+ *   - 'suggested'                    → 'pre_interest'
+ *   - 'accepted'                     → 'mutual_match'
+ *   - 'dismissed'                    → 'browsing'
  *
  * Vitana Index tier anchors the *confidence* of the recommended next
  * move and surfaces a low-momentum warning so matchmaking can lean on
@@ -29,8 +40,27 @@ import type { MatchJourneyContext } from './match-journey-context-provider';
 import type { VitanaIndexTier } from '../../../services/journey-stage/types';
 import { tierFromScore } from '../../../services/journey-stage/compile-journey-stage-context';
 
-/** Canonical match lifecycle states (intent_matches.match_state enum). */
-export type MatchLifecycleState = 'suggested' | 'accepted' | 'dismissed';
+/**
+ * Canonical match lifecycle states (intent_matches.state enum).
+ *
+ * The real `intent_matches` rows use the `new` / `responded_by_a` /
+ * `responded_by_b` / `mutual_interest` / `declined` set (see
+ * `match-activity-plan.ts` + `orb-tools-shared.ts`). The earlier
+ * `suggested` / `accepted` / `dismissed` triple never existed in the
+ * table; it is retained only as a legacy alias so any historical caller
+ * keeps deriving a sensible stage instead of collapsing to 'browsing'.
+ */
+export type MatchLifecycleState =
+  // Real states (intent_matches.state)
+  | 'new'
+  | 'responded_by_a'
+  | 'responded_by_b'
+  | 'mutual_interest'
+  | 'declined'
+  // Legacy aliases (back-compat only)
+  | 'suggested'
+  | 'accepted'
+  | 'dismissed';
 
 /**
  * Distilled latest-match observation. The fetcher reduces the raw
@@ -64,8 +94,23 @@ const SILENCE_WARN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
  * strings collapse to null so the derivation degrades to 'browsing'
  * rather than emitting an invalid stage.
  */
+const KNOWN_STATES: ReadonlySet<MatchLifecycleState> = new Set<MatchLifecycleState>([
+  // Real intent_matches.state values.
+  'new',
+  'responded_by_a',
+  'responded_by_b',
+  'mutual_interest',
+  'declined',
+  // Legacy aliases.
+  'suggested',
+  'accepted',
+  'dismissed',
+]);
+
 export function normaliseMatchState(raw: unknown): MatchLifecycleState | null {
-  if (raw === 'suggested' || raw === 'accepted' || raw === 'dismissed') return raw;
+  if (typeof raw === 'string' && KNOWN_STATES.has(raw as MatchLifecycleState)) {
+    return raw as MatchLifecycleState;
+  }
   return null;
 }
 
@@ -84,15 +129,9 @@ export function deriveMatchJourneyContext(
   const state = latest?.state ?? null;
 
   // ----- Stage from match lifecycle -----
-  let journeyStage: MatchJourneyContext['journeyStage'];
-  if (!latest || state === null || state === 'dismissed') {
-    journeyStage = 'browsing';
-  } else if (state === 'suggested') {
-    journeyStage = 'pre_interest';
-  } else {
-    // state === 'accepted'
-    journeyStage = 'mutual_match';
-  }
+  // The fetcher always reads the user as side A (filters on vitana_id_a),
+  // so "the other side" is always B. Mirrors match-activity-plan.ts.
+  const journeyStage: MatchJourneyContext['journeyStage'] = stageForState(state);
 
   const ctx: MatchJourneyContext = { journeyStage };
 
@@ -108,15 +147,28 @@ export function deriveMatchJourneyContext(
     ctx.silenceDuration = silence;
   }
 
-  // ----- Pending decision + recommended next move (stage-driven) -----
+  // ----- Pending decision + recommended next move (state-driven) -----
+  // We key off the raw state (not just the stage) so 'new' vs.
+  // 'responded_by_b' produce the right pending decision even though both
+  // map to the 'pre_interest' stage.
   switch (journeyStage) {
     case 'pre_interest':
-      ctx.pendingUserDecision = 'show_interest';
+      // 'responded_by_b' = the other side replied and it's our turn to
+      // respond; 'new'/'suggested' = a fresh match awaiting first interest.
+      if (state === 'responded_by_b') {
+        ctx.pendingUserDecision = 'reply_to_match';
+      } else {
+        ctx.pendingUserDecision = 'show_interest';
+      }
       ctx.recommendedNextMove = 'ask_should_i_show_interest';
       break;
     case 'mutual_match':
       ctx.pendingUserDecision = 'send_opener';
       ctx.recommendedNextMove = 'stage_opener';
+      break;
+    case 'interest_sent':
+      // We've responded ('responded_by_a'); the ball is in the other
+      // side's court, so there is no pending decision for this user yet.
       break;
     case 'browsing':
     default:
@@ -142,6 +194,33 @@ export function deriveMatchJourneyContext(
   if (warnings.length > 0) ctx.warnings = warnings;
 
   return ctx;
+}
+
+/**
+ * Map a (normalised) lifecycle state to a journey stage, from the
+ * user-as-side-A perspective the fetcher always uses. No match row, an
+ * unknown state, or a declined/dismissed match all fall back to the
+ * browsing pool. Mirrors classifyStage() in match-activity-plan.ts.
+ */
+function stageForState(
+  state: MatchLifecycleState | null,
+): MatchJourneyContext['journeyStage'] {
+  switch (state) {
+    case 'mutual_interest':
+    case 'accepted': // legacy alias
+      return 'mutual_match';
+    case 'new':
+    case 'responded_by_b': // other side replied → our turn to decide
+    case 'suggested': // legacy alias
+      return 'pre_interest';
+    case 'responded_by_a': // we replied → waiting on the other side
+      return 'interest_sent';
+    case 'declined':
+    case 'dismissed': // legacy alias
+    case null:
+    default:
+      return 'browsing';
+  }
 }
 
 /** Foundation/building tiers (and unknown) signal a user still warming up. */

--- a/services/gateway/src/orb/context/providers/match-journey-derivation.ts
+++ b/services/gateway/src/orb/context/providers/match-journey-derivation.ts
@@ -1,0 +1,156 @@
+/**
+ * BOOTSTRAP-MATCHMAKING-INDEX — pure match-journey derivation.
+ *
+ * De-stubs the match-journey context provider by deriving a real
+ * `MatchJourneyContext` from the user's latest matchmaking state and
+ * their Vitana Index tier. This module is intentionally PURE — no IO,
+ * no clock side-effects (now is injected), no Supabase. The thin
+ * fetcher (`match-journey-fetcher.ts`) feeds distilled rows in; this
+ * function maps them to the distilled snapshot the compiler consumes.
+ *
+ * Hard guardrails (preserved from the seam):
+ *   - NO raw match rows / chat text / profile payloads escape — only
+ *     the distilled `MatchJourneyContext` fields are produced here.
+ *   - NO OASIS topic literals (the grep guard at
+ *     scripts/ci/match-journey-topics-guard.mjs enforces this).
+ *
+ * Stage mapping (intent_matches.state → journeyStage):
+ *   - no match rows at all           → 'browsing'
+ *   - latest state = 'suggested'     → 'pre_interest'
+ *   - latest state = 'accepted'      → 'mutual_match'
+ *   - latest state = 'dismissed'     → 'browsing' (back to the pool)
+ *
+ * Vitana Index tier anchors the *confidence* of the recommended next
+ * move and surfaces a low-momentum warning so matchmaking can lean on
+ * the user's real journey/Index state rather than a hardcoded 'none'.
+ */
+
+import type { MatchJourneyContext } from './match-journey-context-provider';
+import type { VitanaIndexTier } from '../../../services/journey-stage/types';
+import { tierFromScore } from '../../../services/journey-stage/compile-journey-stage-context';
+
+/** Canonical match lifecycle states (intent_matches.match_state enum). */
+export type MatchLifecycleState = 'suggested' | 'accepted' | 'dismissed';
+
+/**
+ * Distilled latest-match observation. The fetcher reduces the raw
+ * intent_matches row to exactly these fields — nothing raw crosses in.
+ */
+export interface LatestMatchObservation {
+  matchId: string | null;
+  intentId: string | null;
+  /** Normalised lifecycle state, or null when the row had an unknown state. */
+  state: MatchLifecycleState | null;
+  /** ISO timestamp of the most recent state change / row update. */
+  stateChangedAt: string | null;
+}
+
+export interface DeriveMatchJourneyInput {
+  /**
+   * The most-recent match row for the user, or null when the user has
+   * no matches yet (→ 'browsing').
+   */
+  latestMatch: LatestMatchObservation | null;
+  /** Latest Vitana Index total score, or null when no history exists. */
+  indexScoreTotal: number | null;
+  /** Injected for testability. Production passes Date.now(). */
+  nowMs?: number;
+}
+
+const SILENCE_WARN_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+
+/**
+ * Map a raw state string to the canonical lifecycle enum. Unknown
+ * strings collapse to null so the derivation degrades to 'browsing'
+ * rather than emitting an invalid stage.
+ */
+export function normaliseMatchState(raw: unknown): MatchLifecycleState | null {
+  if (raw === 'suggested' || raw === 'accepted' || raw === 'dismissed') return raw;
+  return null;
+}
+
+/**
+ * Pure derivation: latest match state + Vitana Index tier → distilled
+ * `MatchJourneyContext`. Never returns 'none' — that sentinel is
+ * reserved for the flag-OFF stub path in the provider.
+ */
+export function deriveMatchJourneyContext(
+  input: DeriveMatchJourneyInput,
+): MatchJourneyContext {
+  const now = input.nowMs ?? Date.now();
+  const tier = tierFromScore(input.indexScoreTotal);
+
+  const latest = input.latestMatch;
+  const state = latest?.state ?? null;
+
+  // ----- Stage from match lifecycle -----
+  let journeyStage: MatchJourneyContext['journeyStage'];
+  if (!latest || state === null || state === 'dismissed') {
+    journeyStage = 'browsing';
+  } else if (state === 'suggested') {
+    journeyStage = 'pre_interest';
+  } else {
+    // state === 'accepted'
+    journeyStage = 'mutual_match';
+  }
+
+  const ctx: MatchJourneyContext = { journeyStage };
+
+  // ----- Identifiers (distilled, never raw rows) -----
+  if (latest?.matchId) ctx.matchId = latest.matchId;
+  if (latest?.intentId) ctx.intentId = latest.intentId;
+
+  // ----- Event recency + silence -----
+  const lastMs = parseIsoMs(latest?.stateChangedAt ?? null);
+  if (latest?.stateChangedAt && lastMs !== null) {
+    ctx.lastMatchEventAt = latest.stateChangedAt;
+    const silence = Math.max(0, now - lastMs);
+    ctx.silenceDuration = silence;
+  }
+
+  // ----- Pending decision + recommended next move (stage-driven) -----
+  switch (journeyStage) {
+    case 'pre_interest':
+      ctx.pendingUserDecision = 'show_interest';
+      ctx.recommendedNextMove = 'ask_should_i_show_interest';
+      break;
+    case 'mutual_match':
+      ctx.pendingUserDecision = 'send_opener';
+      ctx.recommendedNextMove = 'stage_opener';
+      break;
+    case 'browsing':
+    default:
+      // No pending decision while browsing the pool.
+      break;
+  }
+
+  // ----- Vitana-Index anchored warnings -----
+  const warnings: string[] = [];
+  if (isLowMomentumTier(tier)) {
+    // The matchmaker can use this to soften pressure / favour
+    // confidence-building suggestions for users early in their journey.
+    warnings.push(`vitana_index_tier:${tier}`);
+  }
+  if (
+    journeyStage === 'mutual_match' &&
+    ctx.silenceDuration !== undefined &&
+    ctx.silenceDuration >= SILENCE_WARN_MS
+  ) {
+    warnings.push('match_silence');
+    ctx.recommendedNextMove = 'nudge_reply';
+  }
+  if (warnings.length > 0) ctx.warnings = warnings;
+
+  return ctx;
+}
+
+/** Foundation/building tiers (and unknown) signal a user still warming up. */
+function isLowMomentumTier(tier: VitanaIndexTier): boolean {
+  return tier === 'foundation' || tier === 'building' || tier === 'unknown';
+}
+
+function parseIsoMs(iso: string | null): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? t : null;
+}

--- a/services/gateway/src/orb/context/providers/match-journey-fetcher.ts
+++ b/services/gateway/src/orb/context/providers/match-journey-fetcher.ts
@@ -1,0 +1,148 @@
+/**
+ * BOOTSTRAP-MATCHMAKING-INDEX — thin match-journey fetcher.
+ *
+ * Read-only. Reduces authoritative rows to the distilled shapes the
+ * pure derivation (`match-journey-derivation.ts`) consumes. NO raw
+ * rows / chat text / profile payloads escape this module.
+ *
+ * Sources (all already populated by other code paths):
+ *   profiles            — user_id → vitana_id (same join the matchmaker uses)
+ *   intent_matches      — latest match lifecycle state (vitana_id_a side)
+ *   vitana_index_scores — latest Index total (via the B4 fetcher)
+ *
+ * Failure policy: every read degrades to a null/empty result with a
+ * reason rather than throwing — the provider can still produce a
+ * useful context (or fall back to the stub) from partial data.
+ */
+
+import { getSupabase } from '../../../lib/supabase';
+import {
+  defaultJourneyStageFetcher,
+  type JourneyStageFetcher,
+} from '../../../services/journey-stage/journey-stage-fetcher';
+import {
+  normaliseMatchState,
+  type LatestMatchObservation,
+} from './match-journey-derivation';
+
+export interface MatchJourneyFetchResult {
+  latestMatch: LatestMatchObservation | null;
+  indexScoreTotal: number | null;
+  sourceHealth: {
+    profiles: { ok: boolean; reason?: string };
+    intent_matches: { ok: boolean; reason?: string };
+    vitana_index_scores: { ok: boolean; reason?: string };
+  };
+}
+
+export interface MatchJourneyFetcher {
+  fetch(args: {
+    userId: string;
+    tenantId: string;
+  }): Promise<MatchJourneyFetchResult>;
+}
+
+export interface SupabaseMatchJourneyFetcherOptions {
+  getDb?: typeof getSupabase;
+  /** Reused for the Index history read; defaults to the B4 fetcher. */
+  journeyStageFetcher?: JourneyStageFetcher;
+}
+
+export function createSupabaseMatchJourneyFetcher(
+  opts: SupabaseMatchJourneyFetcherOptions = {},
+): MatchJourneyFetcher {
+  const getDb = opts.getDb ?? getSupabase;
+  const indexFetcher = opts.journeyStageFetcher ?? defaultJourneyStageFetcher;
+
+  return {
+    async fetch(args) {
+      const sb = getDb();
+      const health: MatchJourneyFetchResult['sourceHealth'] = {
+        profiles: { ok: false, reason: 'supabase_unconfigured' },
+        intent_matches: { ok: false, reason: 'supabase_unconfigured' },
+        vitana_index_scores: { ok: false, reason: 'supabase_unconfigured' },
+      };
+
+      // ----- Vitana Index (reuse B4 fetcher) -----
+      let indexScoreTotal: number | null = null;
+      try {
+        const idx = await indexFetcher.fetchVitanaIndexHistory({
+          tenantId: args.tenantId,
+          userId: args.userId,
+          limit: 1,
+        });
+        if (idx.ok) {
+          health.vitana_index_scores = { ok: true };
+          indexScoreTotal = idx.rows.length > 0 ? idx.rows[0].score_total : null;
+        } else {
+          health.vitana_index_scores = { ok: false, reason: idx.reason ?? 'unknown_failure' };
+        }
+      } catch (e) {
+        health.vitana_index_scores = { ok: false, reason: (e as Error).message };
+      }
+
+      if (!sb) {
+        return { latestMatch: null, indexScoreTotal, sourceHealth: health };
+      }
+
+      // ----- user_id → vitana_id (same join the matchmaker uses) -----
+      let vitanaId: string | null = null;
+      try {
+        const { data, error } = await sb
+          .from('profiles')
+          .select('vitana_id')
+          .eq('user_id', args.userId)
+          .maybeSingle();
+        if (error) {
+          health.profiles = { ok: false, reason: error.message };
+        } else {
+          health.profiles = { ok: true };
+          vitanaId = (data as { vitana_id?: string } | null)?.vitana_id ?? null;
+        }
+      } catch (e) {
+        health.profiles = { ok: false, reason: (e as Error).message };
+      }
+
+      // ----- Latest match row (distilled) -----
+      let latestMatch: LatestMatchObservation | null = null;
+      if (!vitanaId) {
+        // No vitana_id → user is not in the match pool yet; treat as
+        // "no matches" but mark the source healthy (it's not a failure).
+        health.intent_matches = { ok: true };
+      } else {
+        try {
+          const { data, error } = await sb
+            .from('intent_matches')
+            .select('match_id, intent_a_id, state, state_changed_at, created_at')
+            .eq('vitana_id_a', vitanaId)
+            .order('state_changed_at', { ascending: false, nullsFirst: false })
+            .order('created_at', { ascending: false })
+            .limit(1)
+            .maybeSingle();
+          if (error) {
+            health.intent_matches = { ok: false, reason: error.message };
+          } else {
+            health.intent_matches = { ok: true };
+            if (data) {
+              const row = data as Record<string, unknown>;
+              latestMatch = {
+                matchId: row.match_id ? String(row.match_id) : null,
+                intentId: row.intent_a_id ? String(row.intent_a_id) : null,
+                state: normaliseMatchState(row.state),
+                stateChangedAt:
+                  (row.state_changed_at ? String(row.state_changed_at) : null) ??
+                  (row.created_at ? String(row.created_at) : null),
+              };
+            }
+          }
+        } catch (e) {
+          health.intent_matches = { ok: false, reason: (e as Error).message };
+        }
+      }
+
+      return { latestMatch, indexScoreTotal, sourceHealth: health };
+    },
+  };
+}
+
+export const defaultMatchJourneyFetcher = createSupabaseMatchJourneyFetcher();

--- a/services/gateway/test/orb/context/match-journey-derivation.test.ts
+++ b/services/gateway/test/orb/context/match-journey-derivation.test.ts
@@ -1,0 +1,201 @@
+/**
+ * BOOTSTRAP-MATCHMAKING-INDEX — match-journey derivation + flag tests.
+ *
+ * Covers:
+ *   1. Pure derivation (deriveMatchJourneyContext) — stage mapping from
+ *      latest match state, Index-tier anchoring, silence warning.
+ *   2. Provider flag behaviour — FEATURE_MATCH_JOURNEY_CONTEXT OFF (the
+ *      default) returns the historical { journeyStage: 'none' } stub.
+ */
+
+import {
+  deriveMatchJourneyContext,
+  normaliseMatchState,
+} from '../../../src/orb/context/providers/match-journey-derivation';
+import {
+  compileMatchJourneyContext,
+  type MatchJourneyContextProviderInput,
+} from '../../../src/orb/context/providers/match-journey-context-provider';
+import type { MatchJourneyFetcher } from '../../../src/orb/context/providers/match-journey-fetcher';
+
+const FIXED_NOW = Date.UTC(2026, 4, 11, 18, 30, 0);
+
+describe('BOOTSTRAP-MATCHMAKING-INDEX — deriveMatchJourneyContext (pure)', () => {
+  it('no match rows → browsing, no pending decision', () => {
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: null,
+      indexScoreTotal: 350, // momentum tier — no low-momentum warning
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('browsing');
+    expect(ctx.pendingUserDecision).toBeUndefined();
+    expect(ctx.recommendedNextMove).toBeUndefined();
+    expect(ctx.warnings).toBeUndefined();
+  });
+
+  it('latest state suggested → pre_interest with show_interest decision', () => {
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: {
+        matchId: 'm1',
+        intentId: 'i1',
+        state: 'suggested',
+        stateChangedAt: '2026-05-11T18:00:00Z',
+      },
+      indexScoreTotal: 500, // resonance — no low-momentum warning
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('pre_interest');
+    expect(ctx.matchId).toBe('m1');
+    expect(ctx.intentId).toBe('i1');
+    expect(ctx.pendingUserDecision).toBe('show_interest');
+    expect(ctx.recommendedNextMove).toBe('ask_should_i_show_interest');
+    expect(ctx.lastMatchEventAt).toBe('2026-05-11T18:00:00Z');
+    expect(ctx.silenceDuration).toBe(FIXED_NOW - Date.parse('2026-05-11T18:00:00Z'));
+  });
+
+  it('latest state accepted → mutual_match with send_opener', () => {
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: {
+        matchId: 'm2',
+        intentId: 'i2',
+        state: 'accepted',
+        stateChangedAt: '2026-05-11T17:00:00Z',
+      },
+      indexScoreTotal: 600,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('mutual_match');
+    expect(ctx.pendingUserDecision).toBe('send_opener');
+    expect(ctx.recommendedNextMove).toBe('stage_opener');
+  });
+
+  it('latest state dismissed → browsing (back to pool)', () => {
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: {
+        matchId: 'm3',
+        intentId: 'i3',
+        state: 'dismissed',
+        stateChangedAt: '2026-05-10T10:00:00Z',
+      },
+      indexScoreTotal: 700,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('browsing');
+    expect(ctx.pendingUserDecision).toBeUndefined();
+  });
+
+  it('low Index tier (foundation) surfaces a vitana_index_tier warning', () => {
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: { matchId: 'm', intentId: 'i', state: 'suggested', stateChangedAt: null },
+      indexScoreTotal: 50, // foundation
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.warnings).toContain('vitana_index_tier:foundation');
+  });
+
+  it('null Index score → unknown tier → low-momentum warning', () => {
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: null,
+      indexScoreTotal: null,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.warnings).toContain('vitana_index_tier:unknown');
+  });
+
+  it('mutual_match with >3d silence flips next move to nudge_reply + match_silence warning', () => {
+    const fourDaysAgo = new Date(FIXED_NOW - 4 * 24 * 60 * 60 * 1000).toISOString();
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: { matchId: 'm', intentId: 'i', state: 'accepted', stateChangedAt: fourDaysAgo },
+      indexScoreTotal: 600, // resonance — only the silence warning expected
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('mutual_match');
+    expect(ctx.recommendedNextMove).toBe('nudge_reply');
+    expect(ctx.warnings).toContain('match_silence');
+  });
+
+  it('unknown raw state collapses to browsing', () => {
+    expect(normaliseMatchState('weird')).toBeNull();
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: { matchId: 'm', intentId: 'i', state: normaliseMatchState('weird'), stateChangedAt: null },
+      indexScoreTotal: 500,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('browsing');
+  });
+
+  it('never emits the "none" sentinel — that is reserved for the flag-OFF stub', () => {
+    const states: Array<'suggested' | 'accepted' | 'dismissed'> = ['suggested', 'accepted', 'dismissed'];
+    for (const s of states) {
+      const ctx = deriveMatchJourneyContext({
+        latestMatch: { matchId: 'm', intentId: 'i', state: s, stateChangedAt: null },
+        indexScoreTotal: 400,
+        nowMs: FIXED_NOW,
+      });
+      expect(ctx.journeyStage).not.toBe('none');
+    }
+  });
+});
+
+describe('BOOTSTRAP-MATCHMAKING-INDEX — compileMatchJourneyContext flag gate', () => {
+  const ORIGINAL = process.env.FEATURE_MATCH_JOURNEY_CONTEXT;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.FEATURE_MATCH_JOURNEY_CONTEXT;
+    else process.env.FEATURE_MATCH_JOURNEY_CONTEXT = ORIGINAL;
+  });
+
+  const baseInput: MatchJourneyContextProviderInput = {
+    userId: 'user-1',
+    tenantId: 'tenant-1',
+    envelope: null,
+    nowMs: FIXED_NOW,
+  };
+
+  // A fetcher that, if ever called, would yield a non-'none' stage. Lets
+  // us prove the flag-OFF path never touches the fetcher.
+  const liveFetcher: MatchJourneyFetcher = {
+    fetch: jest.fn().mockResolvedValue({
+      latestMatch: { matchId: 'm', intentId: 'i', state: 'suggested', stateChangedAt: null },
+      indexScoreTotal: 400,
+      sourceHealth: {
+        profiles: { ok: true },
+        intent_matches: { ok: true },
+        vitana_index_scores: { ok: true },
+      },
+    }),
+  };
+
+  it('flag OFF (unset) → returns the { journeyStage: "none" } stub and does not call the fetcher', async () => {
+    delete process.env.FEATURE_MATCH_JOURNEY_CONTEXT;
+    (liveFetcher.fetch as jest.Mock).mockClear();
+    const ctx = await compileMatchJourneyContext({ ...baseInput, fetcher: liveFetcher });
+    expect(ctx).toEqual({ journeyStage: 'none' });
+    expect(liveFetcher.fetch).not.toHaveBeenCalled();
+  });
+
+  it('flag set to non-"true" → still the stub', async () => {
+    process.env.FEATURE_MATCH_JOURNEY_CONTEXT = '1';
+    const ctx = await compileMatchJourneyContext({ ...baseInput, fetcher: liveFetcher });
+    expect(ctx.journeyStage).toBe('none');
+  });
+
+  it('flag ON → derives real stage from fetched state', async () => {
+    process.env.FEATURE_MATCH_JOURNEY_CONTEXT = 'true';
+    const ctx = await compileMatchJourneyContext({ ...baseInput, fetcher: liveFetcher });
+    expect(ctx.journeyStage).toBe('pre_interest');
+    expect(ctx.pendingUserDecision).toBe('show_interest');
+  });
+
+  it('flag ON but missing userId → stub (nothing to anchor on)', async () => {
+    process.env.FEATURE_MATCH_JOURNEY_CONTEXT = 'true';
+    const ctx = await compileMatchJourneyContext({ ...baseInput, userId: null, fetcher: liveFetcher });
+    expect(ctx.journeyStage).toBe('none');
+  });
+
+  it('flag ON but fetcher throws → fail-safe stub', async () => {
+    process.env.FEATURE_MATCH_JOURNEY_CONTEXT = 'true';
+    const throwing: MatchJourneyFetcher = { fetch: jest.fn().mockRejectedValue(new Error('boom')) };
+    const ctx = await compileMatchJourneyContext({ ...baseInput, fetcher: throwing });
+    expect(ctx.journeyStage).toBe('none');
+  });
+});

--- a/services/gateway/test/orb/context/match-journey-derivation.test.ts
+++ b/services/gateway/test/orb/context/match-journey-derivation.test.ts
@@ -84,6 +84,122 @@ describe('BOOTSTRAP-MATCHMAKING-INDEX — deriveMatchJourneyContext (pure)', () 
     expect(ctx.pendingUserDecision).toBeUndefined();
   });
 
+  // ---- Real intent_matches.state values (the bug this PR fixes) ----
+
+  it('real state "new" → pre_interest with show_interest (not browsing)', () => {
+    expect(normaliseMatchState('new')).toBe('new');
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: {
+        matchId: 'm-new',
+        intentId: 'i-new',
+        state: 'new',
+        stateChangedAt: '2026-05-11T18:00:00Z',
+      },
+      indexScoreTotal: 500,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('pre_interest');
+    expect(ctx.pendingUserDecision).toBe('show_interest');
+    expect(ctx.recommendedNextMove).toBe('ask_should_i_show_interest');
+  });
+
+  it('real state "responded_by_b" → pre_interest with reply_to_match (other side replied, our turn)', () => {
+    expect(normaliseMatchState('responded_by_b')).toBe('responded_by_b');
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: {
+        matchId: 'm-rbb',
+        intentId: 'i-rbb',
+        state: 'responded_by_b',
+        stateChangedAt: '2026-05-11T18:00:00Z',
+      },
+      indexScoreTotal: 500,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('pre_interest');
+    expect(ctx.pendingUserDecision).toBe('reply_to_match');
+    expect(ctx.recommendedNextMove).toBe('ask_should_i_show_interest');
+  });
+
+  it('real state "responded_by_a" → interest_sent, no pending decision (waiting on the other side)', () => {
+    expect(normaliseMatchState('responded_by_a')).toBe('responded_by_a');
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: {
+        matchId: 'm-rba',
+        intentId: 'i-rba',
+        state: 'responded_by_a',
+        stateChangedAt: '2026-05-11T18:00:00Z',
+      },
+      indexScoreTotal: 500,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('interest_sent');
+    expect(ctx.pendingUserDecision).toBeUndefined();
+    expect(ctx.recommendedNextMove).toBeUndefined();
+  });
+
+  it('real state "mutual_interest" → mutual_match with send_opener', () => {
+    expect(normaliseMatchState('mutual_interest')).toBe('mutual_interest');
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: {
+        matchId: 'm-mi',
+        intentId: 'i-mi',
+        state: 'mutual_interest',
+        stateChangedAt: '2026-05-11T17:00:00Z',
+      },
+      indexScoreTotal: 600,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('mutual_match');
+    expect(ctx.pendingUserDecision).toBe('send_opener');
+    expect(ctx.recommendedNextMove).toBe('stage_opener');
+  });
+
+  it('real state "declined" → browsing (back to pool)', () => {
+    expect(normaliseMatchState('declined')).toBe('declined');
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: {
+        matchId: 'm-dec',
+        intentId: 'i-dec',
+        state: 'declined',
+        stateChangedAt: '2026-05-10T10:00:00Z',
+      },
+      indexScoreTotal: 700,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('browsing');
+    expect(ctx.pendingUserDecision).toBeUndefined();
+  });
+
+  it('real "mutual_interest" with >3d silence flips next move to nudge_reply + match_silence warning', () => {
+    const fourDaysAgo = new Date(FIXED_NOW - 4 * 24 * 60 * 60 * 1000).toISOString();
+    const ctx = deriveMatchJourneyContext({
+      latestMatch: { matchId: 'm', intentId: 'i', state: 'mutual_interest', stateChangedAt: fourDaysAgo },
+      indexScoreTotal: 600,
+      nowMs: FIXED_NOW,
+    });
+    expect(ctx.journeyStage).toBe('mutual_match');
+    expect(ctx.recommendedNextMove).toBe('nudge_reply');
+    expect(ctx.warnings).toContain('match_silence');
+  });
+
+  it('real states never collapse to "browsing" when actionable (regression guard)', () => {
+    const actionable: Array<'new' | 'responded_by_b' | 'responded_by_a' | 'mutual_interest'> = [
+      'new',
+      'responded_by_b',
+      'responded_by_a',
+      'mutual_interest',
+    ];
+    for (const s of actionable) {
+      const ctx = deriveMatchJourneyContext({
+        latestMatch: { matchId: 'm', intentId: 'i', state: s, stateChangedAt: null },
+        indexScoreTotal: 400,
+        nowMs: FIXED_NOW,
+      });
+      expect(ctx.journeyStage).not.toBe('browsing');
+      expect(ctx.journeyStage).not.toBe('none');
+    }
+  });
+
   it('low Index tier (foundation) surfaces a vitana_index_tier warning', () => {
     const ctx = deriveMatchJourneyContext({
       latestMatch: { matchId: 'm', intentId: 'i', state: 'suggested', stateChangedAt: null },
@@ -125,7 +241,16 @@ describe('BOOTSTRAP-MATCHMAKING-INDEX — deriveMatchJourneyContext (pure)', () 
   });
 
   it('never emits the "none" sentinel — that is reserved for the flag-OFF stub', () => {
-    const states: Array<'suggested' | 'accepted' | 'dismissed'> = ['suggested', 'accepted', 'dismissed'];
+    const states: Array<
+      | 'new'
+      | 'responded_by_a'
+      | 'responded_by_b'
+      | 'mutual_interest'
+      | 'declined'
+      | 'suggested'
+      | 'accepted'
+      | 'dismissed'
+    > = ['new', 'responded_by_a', 'responded_by_b', 'mutual_interest', 'declined', 'suggested', 'accepted', 'dismissed'];
     for (const s of states) {
       const ctx = deriveMatchJourneyContext({
         latestMatch: { matchId: 'm', intentId: 'i', state: s, stateChangedAt: null },
@@ -155,7 +280,7 @@ describe('BOOTSTRAP-MATCHMAKING-INDEX — compileMatchJourneyContext flag gate',
   // us prove the flag-OFF path never touches the fetcher.
   const liveFetcher: MatchJourneyFetcher = {
     fetch: jest.fn().mockResolvedValue({
-      latestMatch: { matchId: 'm', intentId: 'i', state: 'suggested', stateChangedAt: null },
+      latestMatch: { matchId: 'm', intentId: 'i', state: 'new', stateChangedAt: null },
       indexScoreTotal: 400,
       sourceHealth: {
         profiles: { ok: true },


### PR DESCRIPTION
## Summary

De-stubs the match-journey context provider (audit §F: `match-journey-context-provider.ts:140-144` returned a hardcoded `{journeyStage:'none'}`). The provider now derives a real `MatchJourneyContext` anchored on the user's **matchmaking lifecycle state** (`intent_matches`) and their **Vitana Index tier**, so match/recommendation quality keys off real journey state.

Fully **additive + reversible**: gated behind `FEATURE_MATCH_JOURNEY_CONTEXT` (default OFF → returns the historical stub).

## What changed

- **`match-journey-derivation.ts`** (new, pure): maps latest `intent_matches.state` + Vitana Index score → distilled `MatchJourneyContext`.
  - `suggested → pre_interest` (show_interest), `accepted → mutual_match` (send_opener), `dismissed`/none → `browsing`.
  - Low Index tier (foundation/building/unknown, via reused `tierFromScore`) emits a `vitana_index_tier:*` warning so matchmaking can soften pressure for early-journey users.
  - `mutual_match` + >3d silence → flips next move to `nudge_reply` + `match_silence` warning.
  - No IO, injected clock.
- **`match-journey-fetcher.ts`** (new, thin read-only): `profiles → vitana_id` (same join the matchmaker uses), latest `intent_matches` row by `vitana_id_a`, and **reuses the B4 journey-stage fetcher** for the Index score. Degrades per-source, never throws.
- **`match-journey-context-provider.ts`**: flag-gated. OFF / missing user / fetcher error → fail-safe stub.

## Guardrails preserved
- No raw match rows / chat text / profile payloads escape the provider — only distilled fields.
- No OASIS topic literals (the `match-journey-topics-guard` CI script + test stay green).
- Reuses existing resolvers (`tierFromScore`, `defaultJourneyStageFetcher`) — no duplication.
- Did not touch hub files or `orb-live.ts`.

## Tests
`test/orb/context/match-journey-derivation.test.ts` — pure derivation (stage mapping, tier anchoring, silence) + flag-OFF returns stub + flag-ON derivation + fail-safe.

`npx tsc --noEmit` clean. New + `context-compiler` + `match-journey-topics-guard` suites: **32 passed**.

No deploy / prod-write.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_