### PR TITLE
perf(orb-voice): speculative persona-voice resolve on turn-0 path (BOOTSTRAP-VOICE-LATENCY-SPECULATION)

### DIFF
--- a/services/gateway/src/orb/live/voice-speculation.ts
+++ b/services/gateway/src/orb/live/voice-speculation.ts
@@ -1,0 +1,205 @@
+/**
+ * Voice establishment speculation — Phase 1 W2
+ * (BOOTSTRAP-VOICE-LATENCY-SPECULATION, follows VTID-03181 VOICE-LAT).
+ *
+ * GOAL: cut the turn-0 (click → first greeting audio) latency on the ORB voice
+ * path by running a deterministic, side-effect-free establishment step
+ * SPECULATIVELY in parallel with the upstream WS handshake instead of serially
+ * after it.
+ *
+ * The step we speculate is the persona-voice resolution. Today it runs inside
+ * `buildOrbVertexSetupEnvelope` — i.e. AFTER `upstream_connected` AND AFTER
+ * `await contextReadyPromise` (the `context_awaited` mark). On a cold persona
+ * registry cache it is a DB/registry round-trip sitting squarely on the
+ * critical path between `context_awaited` and `setup_sent`, blocking the setup
+ * envelope (and therefore the greeting / first audio).
+ *
+ * The resolved voice does NOT depend on the WS handshake or on the context
+ * build — only on (persona, tenant) which are known the instant we decide to
+ * connect. So we can resolve it speculatively at connect-START, overlapping it
+ * with the handshake + context build. By the time the envelope builder runs,
+ * the answer is already in hand and the lookup is removed from the hot path.
+ *
+ * SAFETY / NO-OP CONTRACT:
+ *   - Gated behind FEATURE_VOICE_SPECULATION_ENV (default 'off').
+ *   - When OFF, `beginVoiceSpeculation` returns null and the caller takes the
+ *     EXACT pre-existing inline path — byte-for-byte identical wire payload.
+ *   - The speculated resolver and the inline fallback call the SAME registry
+ *     functions with the SAME arguments, so the resolved value is identical;
+ *     speculation only changes WHEN the lookup runs, never WHAT it returns.
+ *   - The resolver is read-only (registry lookup) and its rejection is
+ *     swallowed → the caller falls back to the inline lookup. Speculation can
+ *     only ever SAVE latency or be a no-op; it can never change output or fail
+ *     the connect.
+ *
+ * MEASUREMENT:
+ *   - `consumeSpeculatedVoice` records the speculative resolve time and emits
+ *     `voice.latency.measured` (surface 'voice', phase-style payload) carrying
+ *     speculative_ms vs an inline baseline estimate, so the win is provable in
+ *     shadow BEFORE the flag is flipped to live behaviour.
+ */
+
+import { emitOasisEvent } from '../../services/oasis-event-service';
+import { isFeatureLive } from '../../services/feature-flags';
+
+export const VOICE_SPECULATION_FEATURE = 'VOICE_SPECULATION';
+export const VOICE_SPECULATION_VTID = 'BOOTSTRAP-VOICE-LATENCY-SPECULATION';
+
+/** Resolves a persona's voice id. Same shape as the inline registry calls. */
+export type VoiceResolver = () => Promise<string | undefined>;
+
+export interface VoiceSpeculationInput {
+  session_id: string;
+  actor_id?: string;
+  /** Active persona key (receptionist by default). */
+  persona: string;
+  /** Tenant scope, if the session carries one (drives tenant-aware lookup). */
+  tenant_id?: string | null;
+  /** Provider/model hint for the telemetry payload. */
+  provider?: string;
+}
+
+/** Opaque handle returned by `beginVoiceSpeculation`; passed to `consumeSpeculatedVoice`. */
+export interface VoiceSpeculationHandle {
+  readonly session_id: string;
+  readonly persona: string;
+  readonly tenant_id?: string | null;
+  readonly actor_id?: string;
+  readonly provider?: string;
+  /** Epoch ms the speculative resolve was kicked off. */
+  readonly started_ms: number;
+  /** In-flight (or settled) speculative resolution. Never rejects. */
+  readonly promise: Promise<string | undefined>;
+}
+
+/**
+ * Decide whether to speculate. Pure guard so it is unit-testable without
+ * touching the registry or the clock.
+ *
+ * We only speculate when:
+ *   - the feature is live on this environment, AND
+ *   - we actually have a persona key to resolve.
+ * The (persona, tenant) inputs are the sole determinants of the resolved
+ * voice, so this guard guarantees the speculated value can equal the inline
+ * value.
+ */
+export function shouldSpeculateVoice(
+  input: Pick<VoiceSpeculationInput, 'persona'>,
+  featureLive: boolean,
+): boolean {
+  if (!featureLive) return false;
+  if (!input.persona || input.persona.trim() === '') return false;
+  return true;
+}
+
+/**
+ * Compute the latency delta attributable to speculation. Pure arithmetic,
+ * clamped to non-negative so a noisy clock never reports a "negative win".
+ *
+ *   saved = inlineBaseline - speculative-residual-on-hot-path
+ *
+ * When the speculative resolve has already settled by the time the envelope
+ * builder consumes it (the common, happy case), the residual on the hot path
+ * is ~0, so the saved time equals the inline baseline. When it has NOT settled
+ * yet, the caller awaits it; the residual is whatever was left, and the saved
+ * time is the difference.
+ */
+export function computeSpeculationSavingsMs(
+  inlineBaselineMs: number,
+  speculativeResidualMs: number,
+): number {
+  const saved = inlineBaselineMs - speculativeResidualMs;
+  return saved > 0 ? Math.round(saved) : 0;
+}
+
+/**
+ * Begin resolving the persona voice speculatively. Call this at connect-START
+ * (alongside / before the WS handshake). Returns null when speculation is OFF
+ * or ineligible — in that case the caller MUST take its existing inline path,
+ * unchanged.
+ *
+ * The returned promise NEVER rejects: a resolver failure resolves to undefined
+ * so the consumer falls back to the inline lookup transparently.
+ */
+export function beginVoiceSpeculation(
+  input: VoiceSpeculationInput,
+  resolver: VoiceResolver,
+  now: () => number = Date.now,
+): VoiceSpeculationHandle | null {
+  if (!shouldSpeculateVoice(input, isFeatureLive(VOICE_SPECULATION_FEATURE))) {
+    return null;
+  }
+
+  const started_ms = now();
+  // Kick the resolver off immediately; isolate its rejection so it can never
+  // surface on the connect path.
+  const promise = Promise.resolve()
+    .then(resolver)
+    .catch(() => undefined);
+
+  return {
+    session_id: input.session_id,
+    persona: input.persona,
+    tenant_id: input.tenant_id,
+    actor_id: input.actor_id,
+    provider: input.provider,
+    started_ms,
+    promise,
+  };
+}
+
+/**
+ * Consume a speculative resolution at the point the envelope builder needs the
+ * voice. Awaits the (already in-flight) speculative resolve, measures how much
+ * of it was hidden behind the handshake/context build, and emits a
+ * `voice.latency.measured` comparison so the win is shadow-measurable.
+ *
+ * Returns the resolved voice id (or undefined → caller falls back to the
+ * language-default voice exactly as the inline path does). The byte value
+ * returned here is identical to what the inline lookup would have produced.
+ *
+ * @param handle           handle from `beginVoiceSpeculation` (null → no-op, returns undefined)
+ * @param inlineBaselineMs caller's measured/typical inline lookup cost, used as
+ *                         the baseline for the savings comparison.
+ */
+export async function consumeSpeculatedVoice(
+  handle: VoiceSpeculationHandle | null,
+  inlineBaselineMs: number,
+  now: () => number = Date.now,
+): Promise<string | undefined> {
+  if (!handle) return undefined;
+
+  const awaitStart = now();
+  const voice = await handle.promise;
+  const residualMs = now() - awaitStart; // hot-path time NOT hidden by overlap
+  const totalSpeculativeMs = now() - handle.started_ms;
+  const savedMs = computeSpeculationSavingsMs(inlineBaselineMs, residualMs);
+
+  // Fire-and-forget; telemetry must never affect the connect path.
+  void emitOasisEvent({
+    vtid: VOICE_SPECULATION_VTID,
+    type: 'voice.latency.measured',
+    source: 'gateway/voice-speculation',
+    status: 'success',
+    message: `voice-speculation saved ~${savedMs}ms (residual ${residualMs}ms vs baseline ${inlineBaselineMs}ms)`,
+    actor_id: handle.actor_id,
+    payload: {
+      session_id: handle.session_id,
+      surface: 'voice',
+      turn: 0,
+      provider: handle.provider,
+      speculation: true,
+      step: 'persona_voice_resolve',
+      persona: handle.persona,
+      tenant_scoped: !!handle.tenant_id,
+      resolved: voice !== undefined,
+      // Comparison the win is judged on:
+      inline_baseline_ms: inlineBaselineMs,
+      speculative_total_ms: totalSpeculativeMs,
+      speculative_residual_ms: residualMs,
+      saved_ms: savedMs,
+    },
+  }).catch(() => { /* never break the connect on telemetry */ });
+
+  return voice;
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -62,6 +62,13 @@ import {
 // Phase 1 W2 (BOOTSTRAP-PHASE1-W2-VOICE-LATENCY-WIRE): the LatencyTracker class +
 // LatencyPhase are also used directly to instrument the voice WS/SSE turn timeline.
 import { withLatencyTracker, LatencyTracker, type LatencyPhase } from '../orb/live/latency-tracker';
+// BOOTSTRAP-VOICE-LATENCY-SPECULATION: speculative persona-voice resolution to
+// remove the registry round-trip from the turn-0 critical path. Flag-gated
+// (FEATURE_VOICE_SPECULATION), default OFF → no-op (see voice-speculation.ts).
+import { beginVoiceSpeculation, consumeSpeculatedVoice } from '../orb/live/voice-speculation';
+// Conservative typical inline persona-voice registry-lookup cost (warm cache),
+// used only as the baseline for the speculation-savings telemetry.
+const INLINE_VOICE_LOOKUP_BASELINE_MS = 8;
 // Phase 1 W2 (BOOTSTRAP-PHASE1-W2-SHADOW-RUNTIME-WIRE): shadow-compare the
 // voice tool-routing decision against a candidate model. No-op (candidate never
 // invoked) when FEATURE_SHADOW_TOOL_ROUTER_ENV is off.
@@ -5849,6 +5856,37 @@ async function connectToLiveAPI(
   // path. Error/close handlers continue to register on the raw socket
   // returned by `vertex.getSocket()`, preserving the transparent-reconnect
   // path and all VTID-02637 connection-issue dedupe behavior.
+  // BOOTSTRAP-VOICE-LATENCY-SPECULATION: begin resolving the persona voice
+  // SPECULATIVELY here, at connect-START, so the registry round-trip overlaps
+  // the upstream WS handshake + context build instead of running serially
+  // inside buildOrbVertexSetupEnvelope (between context_awaited and setup_sent).
+  // The (persona, tenant) inputs are known now and fully determine the voice,
+  // so the speculated value is identical to the inline lookup. Returns null
+  // when FEATURE_VOICE_SPECULATION is off → the envelope builder takes its
+  // exact pre-existing inline path (byte-for-byte unchanged). See
+  // orb/live/voice-speculation.ts for the safety/no-op contract.
+  const _specPersona = (session as any).activePersona || RECEPTIONIST_PERSONA_KEY;
+  const _specTenantId = session.identity?.tenant_id;
+  const voiceSpeculation = beginVoiceSpeculation(
+    {
+      session_id: session.sessionId,
+      actor_id: session.identity?.user_id,
+      persona: _specPersona,
+      tenant_id: _specTenantId,
+      provider: `vertex/${VERTEX_LIVE_MODEL}`,
+    },
+    // Same registry calls, same arguments as the inline path below. Returns
+    // undefined on empty/failed lookup so the consumer falls back inline.
+    async () => {
+      if ((session as any).personaVoiceOverride) {
+        return (session as any).personaVoiceOverride as string;
+      }
+      return _specTenantId
+        ? await registryGetPersonaVoiceForTenant(_specPersona, _specTenantId)
+        : await registryGetPersonaVoice(_specPersona);
+    },
+  );
+
   return new Promise<WebSocket>(async (resolve, reject) => {
     const vertex = new VertexLiveClient();
 
@@ -5909,15 +5947,29 @@ async function connectToLiveAPI(
       const _persona = (session as any).activePersona || RECEPTIONIST_PERSONA_KEY;
       let _personaVoice = (session as any).personaVoiceOverride;
       if (!_personaVoice) {
-        try {
-          // VTID-02653: tenant-aware lookup when session has tenant context.
-          const _setupTenantId = session.identity?.tenant_id;
-          const fromRegistry = _setupTenantId
-            ? await registryGetPersonaVoiceForTenant(_persona, _setupTenantId)
-            : await registryGetPersonaVoice(_persona);
-          if (fromRegistry) _personaVoice = fromRegistry;
-        } catch (e) {
-          console.warn(`[VTID-02651] persona registry lookup failed for ${_persona}:`, e);
+        // BOOTSTRAP-VOICE-LATENCY-SPECULATION: when the flag is ON, the persona
+        // voice was resolved speculatively at connect-start (overlapping the
+        // handshake). Consume it here — already settled in the common case so
+        // this is ~0ms on the hot path instead of a serial registry round-trip.
+        // Returns undefined when the flag is OFF (handle is null) → we fall
+        // through to the EXACT pre-existing inline lookup below, unchanged.
+        // INLINE_VOICE_LOOKUP_BASELINE_MS: a conservative typical cost for the
+        // inline registry round-trip on a warm cache; used only as the baseline
+        // for the savings telemetry, never to gate behaviour.
+        const _speculated = await consumeSpeculatedVoice(voiceSpeculation, INLINE_VOICE_LOOKUP_BASELINE_MS);
+        if (_speculated) {
+          _personaVoice = _speculated;
+        } else {
+          try {
+            // VTID-02653: tenant-aware lookup when session has tenant context.
+            const _setupTenantId = session.identity?.tenant_id;
+            const fromRegistry = _setupTenantId
+              ? await registryGetPersonaVoiceForTenant(_persona, _setupTenantId)
+              : await registryGetPersonaVoice(_persona);
+            if (fromRegistry) _personaVoice = fromRegistry;
+          } catch (e) {
+            console.warn(`[VTID-02651] persona registry lookup failed for ${_persona}:`, e);
+          }
         }
       }
       _personaVoice = _personaVoice || getLiveApiVoice(session.lang);

--- a/services/gateway/test/orb/voice-speculation.test.ts
+++ b/services/gateway/test/orb/voice-speculation.test.ts
@@ -1,0 +1,209 @@
+/**
+ * BOOTSTRAP-VOICE-LATENCY-SPECULATION — voice establishment speculation.
+ *
+ * Covers the pure timing/guard logic and the flag-OFF no-op contract for the
+ * speculative persona-voice resolver (orb/live/voice-speculation.ts). The
+ * speculation moves the persona-voice registry lookup off the turn-0 critical
+ * path by running it in parallel with the upstream WS handshake.
+ *
+ * Contract under test:
+ *   - shouldSpeculateVoice: pure guard (feature live + persona present).
+ *   - computeSpeculationSavingsMs: pure, non-negative clamped arithmetic.
+ *   - beginVoiceSpeculation: null when OFF (caller takes inline path); a
+ *     non-rejecting handle when ON.
+ *   - consumeSpeculatedVoice: null handle → undefined (inline fallback);
+ *     resolves to the speculated value and emits a comparison telemetry.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import {
+  shouldSpeculateVoice,
+  computeSpeculationSavingsMs,
+  beginVoiceSpeculation,
+  consumeSpeculatedVoice,
+  VOICE_SPECULATION_FEATURE,
+  VOICE_SPECULATION_VTID,
+} from '../../src/orb/live/voice-speculation';
+import { isFeatureLive } from '../../src/services/feature-flags';
+import { emitOasisEvent } from '../../src/services/oasis-event-service';
+
+jest.mock('../../src/services/feature-flags', () => ({
+  isFeatureLive: jest.fn(),
+}));
+jest.mock('../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+const mockIsFeatureLive = isFeatureLive as jest.MockedFunction<typeof isFeatureLive>;
+const mockEmit = emitOasisEvent as jest.MockedFunction<typeof emitOasisEvent>;
+
+beforeEach(() => {
+  mockIsFeatureLive.mockReset();
+  mockEmit.mockReset();
+  mockEmit.mockResolvedValue({ ok: true } as any);
+});
+
+describe('shouldSpeculateVoice — pure guard', () => {
+  test('false when feature not live, even with a persona', () => {
+    expect(shouldSpeculateVoice({ persona: 'vitana' }, false)).toBe(false);
+  });
+
+  test('false when persona is empty/blank, even when feature live', () => {
+    expect(shouldSpeculateVoice({ persona: '' }, true)).toBe(false);
+    expect(shouldSpeculateVoice({ persona: '   ' }, true)).toBe(false);
+  });
+
+  test('true only when feature live AND persona present', () => {
+    expect(shouldSpeculateVoice({ persona: 'vitana' }, true)).toBe(true);
+  });
+});
+
+describe('computeSpeculationSavingsMs — pure arithmetic', () => {
+  test('saved = baseline - residual when positive', () => {
+    expect(computeSpeculationSavingsMs(10, 2)).toBe(8);
+  });
+
+  test('clamps to 0 when residual exceeds baseline (no negative win)', () => {
+    expect(computeSpeculationSavingsMs(5, 20)).toBe(0);
+  });
+
+  test('0 when residual equals baseline', () => {
+    expect(computeSpeculationSavingsMs(7, 7)).toBe(0);
+  });
+
+  test('rounds fractional savings', () => {
+    expect(computeSpeculationSavingsMs(10.7, 2.1)).toBe(9); // 8.6 → 9
+  });
+});
+
+describe('beginVoiceSpeculation — flag OFF (no-op)', () => {
+  test('returns null when feature is off, resolver never invoked', () => {
+    mockIsFeatureLive.mockReturnValue(false);
+    const resolver = jest.fn().mockResolvedValue('VoiceX');
+    const handle = beginVoiceSpeculation(
+      { session_id: 's1', persona: 'vitana' },
+      resolver,
+    );
+    expect(handle).toBeNull();
+    expect(resolver).not.toHaveBeenCalled();
+    expect(mockIsFeatureLive).toHaveBeenCalledWith(VOICE_SPECULATION_FEATURE);
+  });
+
+  test('returns null when persona missing even if flag on', () => {
+    mockIsFeatureLive.mockReturnValue(true);
+    const resolver = jest.fn();
+    const handle = beginVoiceSpeculation(
+      { session_id: 's1', persona: '' },
+      resolver,
+    );
+    expect(handle).toBeNull();
+    expect(resolver).not.toHaveBeenCalled();
+  });
+});
+
+describe('beginVoiceSpeculation — flag ON', () => {
+  test('returns a handle and kicks the resolver off immediately', async () => {
+    mockIsFeatureLive.mockReturnValue(true);
+    const resolver = jest.fn().mockResolvedValue('Aoede');
+    const handle = beginVoiceSpeculation(
+      { session_id: 's1', persona: 'vitana', tenant_id: 't1', provider: 'vertex/m' },
+      resolver,
+    );
+    expect(handle).not.toBeNull();
+    // Resolver is kicked off via a microtask (Promise.resolve().then) so its
+    // rejection is isolated; it has run by the time the handle promise settles.
+    await expect(handle!.promise).resolves.toBe('Aoede');
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
+
+  test('handle promise never rejects — resolver failure becomes undefined', async () => {
+    mockIsFeatureLive.mockReturnValue(true);
+    const resolver = jest.fn().mockRejectedValue(new Error('registry down'));
+    const handle = beginVoiceSpeculation(
+      { session_id: 's1', persona: 'vitana' },
+      resolver,
+    );
+    await expect(handle!.promise).resolves.toBeUndefined();
+  });
+});
+
+describe('consumeSpeculatedVoice', () => {
+  test('null handle → undefined (inline fallback), no telemetry', async () => {
+    const voice = await consumeSpeculatedVoice(null, 8);
+    expect(voice).toBeUndefined();
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  test('returns the speculated voice and emits a comparison telemetry', async () => {
+    mockIsFeatureLive.mockReturnValue(true);
+    const resolver = jest.fn().mockResolvedValue('Puck');
+    const handle = beginVoiceSpeculation(
+      { session_id: 's9', persona: 'vitana', tenant_id: 't1', provider: 'vertex/gemini', actor_id: 'u1' },
+      resolver,
+    );
+    const voice = await consumeSpeculatedVoice(handle, 8);
+    expect(voice).toBe('Puck');
+
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    const evt = mockEmit.mock.calls[0][0];
+    expect(evt.vtid).toBe(VOICE_SPECULATION_VTID);
+    expect(evt.type).toBe('voice.latency.measured');
+    expect(evt.actor_id).toBe('u1');
+    const p = evt.payload as Record<string, unknown>;
+    expect(p.speculation).toBe(true);
+    expect(p.step).toBe('persona_voice_resolve');
+    expect(p.surface).toBe('voice');
+    expect(p.turn).toBe(0);
+    expect(p.resolved).toBe(true);
+    expect(p.inline_baseline_ms).toBe(8);
+    expect(typeof p.saved_ms).toBe('number');
+    expect(p.tenant_scoped).toBe(true);
+  });
+
+  test('uses an injectable clock so the savings are deterministic', async () => {
+    mockIsFeatureLive.mockReturnValue(true);
+    // Resolver already settled before consume is called.
+    const resolver = jest.fn().mockResolvedValue('Charon');
+
+    // Clock: begin@1000; consume awaits an already-resolved promise so the
+    // residual window collapses to a single tick. Sequence: started_ms=1000,
+    // awaitStart=1000, after-await=1000, total=1000 → residual 0, saved=baseline.
+    let t = 1000;
+    const clock = () => t;
+    const handle = beginVoiceSpeculation(
+      { session_id: 's-clock', persona: 'vitana' },
+      resolver,
+      clock,
+    );
+    const voice = await consumeSpeculatedVoice(handle, 12, clock);
+    expect(voice).toBe('Charon');
+    const p = mockEmit.mock.calls[0][0].payload as Record<string, unknown>;
+    expect(p.speculative_residual_ms).toBe(0);
+    expect(p.saved_ms).toBe(12); // full baseline hidden behind overlap
+  });
+
+  test('resolved=false telemetry when the speculative lookup returned nothing', async () => {
+    mockIsFeatureLive.mockReturnValue(true);
+    const resolver = jest.fn().mockResolvedValue(undefined);
+    const handle = beginVoiceSpeculation(
+      { session_id: 's-empty', persona: 'vitana' },
+      resolver,
+    );
+    const voice = await consumeSpeculatedVoice(handle, 8);
+    expect(voice).toBeUndefined(); // caller falls back to inline lookup
+    const p = mockEmit.mock.calls[0][0].payload as Record<string, unknown>;
+    expect(p.resolved).toBe(false);
+  });
+
+  test('telemetry failure never throws on the consume path', async () => {
+    mockIsFeatureLive.mockReturnValue(true);
+    mockEmit.mockRejectedValue(new Error('oasis down'));
+    const resolver = jest.fn().mockResolvedValue('Kore');
+    const handle = beginVoiceSpeculation(
+      { session_id: 's-telemfail', persona: 'vitana' },
+      resolver,
+    );
+    await expect(consumeSpeculatedVoice(handle, 8)).resolves.toBe('Kore');
+  });
+});


### PR DESCRIPTION
## Voice Latency + Speculation lane (W2)

Behind-a-flag speculative-execution optimization on the ORB voice turn-0 path, proven by the existing `voice.latency.measured` telemetry. **OFF by default, shadow-measurable.**

### The latency-dominant step
The turn-0 critical path (click → first greeting audio) is instrumented by the establishment `LatencyTracker`: `upstream_connected → context_awaited → setup_sent → greeting_sent`. The Google access token is already cached + prewarmed (VTID-01219), and the context build already overlaps the WS handshake (`contextReadyPromise`). The remaining serial step on the hot path is the **persona-voice registry lookup** inside `buildOrbVertexSetupEnvelope` — it runs *after* `context_awaited` and blocks the setup envelope (a DB/registry round-trip on a cold cache) before `setup_sent`.

### The speculation
The resolved voice depends only on `(persona, tenant)` — known the instant we decide to connect, independent of the handshake and context build. So we resolve it **speculatively at connect-start**, in parallel with the handshake, and consume the result when the envelope is built (~0ms on the hot path in the common case).

### Safety / no-op contract
- Gated behind `FEATURE_VOICE_SPECULATION` (default `off`).
- **OFF**: `beginVoiceSpeculation` returns `null`, the resolver never runs, and the envelope builder takes the **exact pre-existing inline lookup** — byte-for-byte identical wire payload.
- **ON**: the speculated resolver calls the *same* registry functions with the *same* arguments, so the value is identical; only *when* it runs changes. The resolver is read-only and non-rejecting; on miss/failure the consumer falls back to the inline lookup.

### Measurement
`consumeSpeculatedVoice` emits `voice.latency.measured` with a `speculative_residual_ms` vs `inline_baseline_ms` comparison (`saved_ms`), so the win is provable in shadow before the flag is flipped.

### Files
- `services/gateway/src/orb/live/voice-speculation.ts` (new) — flag-gated speculation runtime + pure guard/timing helpers.
- `services/gateway/src/routes/orb-live.ts` — begin speculation at connect-start; consume in the envelope builder with inline fallback. **Minimal hub touch** (the hub file `live-session-controller.ts`/`live-system-instruction.ts` are NOT touched — note for coordinator merge-sequencing).
- `services/gateway/test/orb/voice-speculation.test.ts` (new) — 16 cases: pure guard, savings arithmetic, flag-OFF no-op, non-rejecting resolver, telemetry shape (deterministic injectable clock).

### Verification
- `tsc --noEmit`: clean.
- New suite: 16/16 pass.
- Existing establishment-latency characterization contract: 5/5 pass (phase ordering preserved).
- `persona-registry` + all `test/orb` suites: 68 suites / 977 tests green.

No deploy. Draft for coordinator review + merge-sequencing.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_