### PR TITLE
feat(autopilot): flag-gated calendar-prep recommendation analyzer (BOOTSTRAP-AUTOPILOT-EXPANSION)

### DIFF
--- a/services/gateway/src/services/recommendation-engine/analyzers/calendar-prep-analyzer.ts
+++ b/services/gateway/src/services/recommendation-engine/analyzers/calendar-prep-analyzer.ts
@@ -1,0 +1,290 @@
+/**
+ * BOOTSTRAP-AUTOPILOT-EXPANSION: Calendar Prep Analyzer — flag-gated, OFF by default.
+ *
+ * A new, additive signal source for the Autopilot recommendation engine. It
+ * broadens coverage to the calendar surface: when a user has an upcoming
+ * wellness-pillar `calendar_events` row happening soon (e.g. a workout or sleep
+ * block) but has NOT scheduled a short supporting "prep" block before it, the
+ * analyzer surfaces a low-risk nudge to add one. This lets Autopilot help users
+ * follow through on plans they already made, instead of only reacting to past
+ * signals (codebase/oasis/health) or biometrics (wearable).
+ *
+ * Gated behind FEATURE_AUTOPILOT_CALENDAR_PREP_ENV (see services/feature-flags.ts).
+ * When OFF (default), the generator never imports/runs this analyzer, so there
+ * is zero behavior change. The classification logic is pure (no DB, no I/O) and
+ * fully unit-tested; the DB fetch is a thin wrapper around it.
+ *
+ * Contract parity with wearable-analyzer.ts:
+ *   - exports an `analyze...` async fn returning { ok, signals, summary, error? }
+ *   - exports a `generate...Fingerprint` fn for daily-bucketed dedup
+ *   - signals are per-user, downstream converted into a GeneratedRecommendation
+ */
+
+import { createHash } from 'crypto';
+import { getSupabase } from '../../../lib/supabase';
+
+const LOG_PREFIX = '[BOOTSTRAP-AUTOPILOT-EXPANSION:CalendarPrep]';
+
+/** Canonical wellness pillars (mirrors calendar_events.pillar CHECK constraint). */
+export type WellnessPillar = 'nutrition' | 'hydration' | 'exercise' | 'sleep' | 'mental';
+
+/** Minimal projection of a calendar_events row this analyzer reasons over. */
+export interface CalendarEventRow {
+  id: string;
+  user_id: string;
+  tenant_id: string | null;
+  /** ISO timestamp. */
+  start_time: string;
+  /** Typed pillar column (nullable — legacy rows have no pillar). */
+  pillar: WellnessPillar | null;
+  event_type: string | null;
+  status: string | null;
+  /** 'autopilot' for events Autopilot itself created; used to detect existing prep. */
+  source_type: string | null;
+}
+
+export interface CalendarPrepSignal {
+  user_id: string;
+  tenant_id: string | null;
+  pillar: WellnessPillar;
+  /** id of the upcoming event that triggered this prep nudge. */
+  target_event_id: string;
+  severity: 'low' | 'medium' | 'high';
+  confidence: number; // 0..1
+  /** Hours until the target event starts (rounded, for transparency). */
+  hours_until: number;
+  summary: string; // human-readable for the autopilot card / voice
+}
+
+export interface CalendarPrepAnalysisResult {
+  ok: boolean;
+  signals: CalendarPrepSignal[];
+  summary: {
+    events_analyzed: number;
+    users_with_signals: number;
+    signals_generated: number;
+    duration_ms: number;
+  };
+  error?: string;
+}
+
+export interface CalendarPrepConfig {
+  /** Only consider events starting within this many hours from `now`. */
+  lookahead_hours: number;
+  /** A prep block this many minutes before counts as "already prepared". */
+  prep_window_minutes: number;
+  /** Events sooner than this are "imminent" → higher severity. */
+  imminent_hours: number;
+}
+
+export const DEFAULT_CALENDAR_PREP_CONFIG: CalendarPrepConfig = {
+  lookahead_hours: 48,
+  prep_window_minutes: 120,
+  imminent_hours: 6,
+};
+
+/**
+ * Per-pillar copy for the nudge. Kept here (pure data) so tests can assert the
+ * mapping without spinning up the LLM or DB. source_ref downstream is keyed by
+ * pillar so the existing COMMUNITY_ACTIONS `pillar_template_*` entries can map
+ * the activation to a schedulable wellness block.
+ */
+const PILLAR_PREP_COPY: Record<WellnessPillar, string> = {
+  nutrition: 'plan a quick balanced meal so you are fuelled going in',
+  hydration: 'set a hydration reminder beforehand',
+  exercise: 'block 10 minutes to warm up and get your gear ready',
+  sleep: 'add a wind-down block so the sleep window actually sticks',
+  mental: 'add a short breathing or grounding moment to arrive centred',
+};
+
+/**
+ * PURE: decide whether a single upcoming event needs a prep nudge.
+ *
+ * Rules (all pure, deterministic — no clock reads beyond the injected `now`):
+ *   1. Event must have a recognised wellness `pillar` and not be cancelled.
+ *   2. Event must start in the future, within `lookahead_hours`.
+ *   3. There must be NO existing event for the same user/pillar starting in the
+ *      `prep_window_minutes` before it (that would already be the prep block).
+ *   4. Severity: high if imminent (< imminent_hours) AND today; medium if
+ *      imminent; otherwise low. Confidence scales inversely with lead time.
+ *
+ * Returns null when no nudge is warranted.
+ */
+export function classifyCalendarPrep(
+  target: CalendarEventRow,
+  sameUserPillarEvents: CalendarEventRow[],
+  now: Date,
+  config: CalendarPrepConfig = DEFAULT_CALENDAR_PREP_CONFIG,
+): CalendarPrepSignal | null {
+  if (!target.pillar) return null;
+  if (target.status === 'cancelled') return null;
+
+  const startMs = Date.parse(target.start_time);
+  if (Number.isNaN(startMs)) return null;
+
+  const nowMs = now.getTime();
+  const deltaMs = startMs - nowMs;
+  if (deltaMs <= 0) return null; // already started / past
+
+  const hoursUntil = deltaMs / (1000 * 60 * 60);
+  if (hoursUntil > config.lookahead_hours) return null;
+
+  // Already prepared? Any other (non-cancelled) event for the same pillar that
+  // starts within the prep window before the target counts as a prep block.
+  const prepWindowMs = config.prep_window_minutes * 60 * 1000;
+  const alreadyPrepared = sameUserPillarEvents.some((e) => {
+    if (e.id === target.id) return false;
+    if (e.status === 'cancelled') return false;
+    if (e.pillar !== target.pillar) return false;
+    const eStart = Date.parse(e.start_time);
+    if (Number.isNaN(eStart)) return false;
+    // Prep block must start strictly before the target, no earlier than the window.
+    return eStart < startMs && startMs - eStart <= prepWindowMs;
+  });
+  if (alreadyPrepared) return null;
+
+  const imminent = hoursUntil <= config.imminent_hours;
+  const sameDay = new Date(startMs).toISOString().slice(0, 10) === now.toISOString().slice(0, 10);
+  const severity: CalendarPrepSignal['severity'] = imminent && sameDay ? 'high' : imminent ? 'medium' : 'low';
+
+  // Confidence: more lead time = lower confidence the nudge is timely.
+  // Clamped to [0.4, 0.9]. Imminent same-day events are most actionable.
+  const leadFactor = 1 - Math.min(hoursUntil / config.lookahead_hours, 1);
+  const confidence = Math.round((0.4 + leadFactor * 0.5) * 100) / 100;
+
+  const roundedHours = Math.max(1, Math.round(hoursUntil));
+  const when = roundedHours <= 1 ? 'within the hour' : `in about ${roundedHours}h`;
+  const prepCopy = PILLAR_PREP_COPY[target.pillar];
+
+  return {
+    user_id: target.user_id,
+    tenant_id: target.tenant_id,
+    pillar: target.pillar,
+    target_event_id: target.id,
+    severity,
+    confidence,
+    hours_until: roundedHours,
+    summary: `You have a ${target.pillar} block ${when} with nothing lined up before it — ${prepCopy}.`,
+  };
+}
+
+/**
+ * PURE: classify a whole batch of events for many users. Groups by user+pillar
+ * internally so the "already prepared" check only ever sees that user's events.
+ * Emits at most one signal per (user, pillar) — the soonest qualifying event —
+ * to avoid flooding the queue.
+ */
+export function classifyCalendarPrepBatch(
+  events: CalendarEventRow[],
+  now: Date,
+  config: CalendarPrepConfig = DEFAULT_CALENDAR_PREP_CONFIG,
+): CalendarPrepSignal[] {
+  // Index events by user for the prep-window lookup.
+  const byUser = new Map<string, CalendarEventRow[]>();
+  for (const e of events) {
+    const list = byUser.get(e.user_id) ?? [];
+    list.push(e);
+    byUser.set(e.user_id, list);
+  }
+
+  const out: CalendarPrepSignal[] = [];
+  for (const [, userEvents] of byUser) {
+    // Soonest-first so the per-(user,pillar) dedup keeps the most urgent.
+    const sorted = [...userEvents].sort(
+      (a, b) => Date.parse(a.start_time) - Date.parse(b.start_time),
+    );
+    const seenPillars = new Set<WellnessPillar>();
+    for (const ev of sorted) {
+      if (ev.pillar && seenPillars.has(ev.pillar)) continue;
+      const sig = classifyCalendarPrep(ev, userEvents, now, config);
+      if (sig) {
+        out.push(sig);
+        seenPillars.add(sig.pillar);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * DB wrapper. Fetches upcoming wellness-pillar events and delegates to the pure
+ * batch classifier. Never throws — returns { ok:false } on infra failure so the
+ * generator's per-source try/catch records an error without aborting siblings.
+ */
+export async function analyzeCalendarPrep(
+  opts: { user_ids?: string[]; limit?: number; now?: Date; config?: Partial<CalendarPrepConfig> } = {},
+): Promise<CalendarPrepAnalysisResult> {
+  const startTime = Date.now();
+  const now = opts.now ?? new Date();
+  const config: CalendarPrepConfig = { ...DEFAULT_CALENDAR_PREP_CONFIG, ...opts.config };
+
+  const supabase = getSupabase();
+  if (!supabase) {
+    return {
+      ok: false,
+      signals: [],
+      summary: { events_analyzed: 0, users_with_signals: 0, signals_generated: 0, duration_ms: 0 },
+      error: 'Supabase unavailable',
+    };
+  }
+
+  const horizon = new Date(now.getTime() + config.lookahead_hours * 60 * 60 * 1000).toISOString();
+
+  let query = supabase
+    .from('calendar_events')
+    .select('id,user_id,tenant_id,start_time,pillar,event_type,status,source_type')
+    .not('pillar', 'is', null)
+    .neq('status', 'cancelled')
+    .gte('start_time', now.toISOString())
+    .lte('start_time', horizon)
+    .order('start_time', { ascending: true })
+    .limit(opts.limit ?? 1000);
+  if (opts.user_ids?.length) {
+    query = query.in('user_id', opts.user_ids);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    return {
+      ok: false,
+      signals: [],
+      summary: {
+        events_analyzed: 0,
+        users_with_signals: 0,
+        signals_generated: 0,
+        duration_ms: Date.now() - startTime,
+      },
+      error: error.message,
+    };
+  }
+
+  const rows = (data ?? []) as CalendarEventRow[];
+  const signals = classifyCalendarPrepBatch(rows, now, config);
+  const usersWithSignals = new Set(signals.map((s) => s.user_id)).size;
+
+  const duration = Date.now() - startTime;
+  console.log(
+    `${LOG_PREFIX} analyzed ${rows.length} upcoming events, generated ${signals.length} signals in ${duration}ms`,
+  );
+
+  return {
+    ok: true,
+    signals,
+    summary: {
+      events_analyzed: rows.length,
+      users_with_signals: usersWithSignals,
+      signals_generated: signals.length,
+      duration_ms: duration,
+    },
+  };
+}
+
+/**
+ * Daily-bucketed fingerprint so a user gets at most one prep nudge per pillar
+ * per day, mirroring the wearable analyzer's dedup strategy.
+ */
+export function generateCalendarPrepFingerprint(signal: CalendarPrepSignal): string {
+  const day = new Date().toISOString().slice(0, 10);
+  const data = `calendar_prep:${signal.user_id}:${signal.pillar}:${day}`;
+  return createHash('sha256').update(data).digest('hex').substring(0, 16);
+}

--- a/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
+++ b/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
@@ -65,6 +65,13 @@ import {
   WearableSignal,
   generateWearableFingerprint,
 } from './analyzers/wearable-analyzer';
+// BOOTSTRAP-AUTOPILOT-EXPANSION: calendar prep analyzer (flag-gated, OFF by default).
+import {
+  analyzeCalendarPrep,
+  CalendarPrepSignal,
+  generateCalendarPrepFingerprint,
+} from './analyzers/calendar-prep-analyzer';
+import { isFeatureLive } from '../feature-flags';
 // VTID-03140 (Phase C.6): per-signal-type impact maps live in
 // `decision_policy` now; this module owns the typed lookups.
 import {
@@ -82,7 +89,7 @@ const LOG_PREFIX = '[VTID-01185:Generator]';
 // Types
 // =============================================================================
 
-export type SourceType = 'codebase' | 'oasis' | 'health' | 'roadmap' | 'llm' | 'behavior' | 'community' | 'marketplace' | 'wearable';
+export type SourceType = 'codebase' | 'oasis' | 'health' | 'roadmap' | 'llm' | 'behavior' | 'community' | 'marketplace' | 'wearable' | 'calendar_prep';
 
 export interface GeneratedRecommendation {
   title: string;
@@ -322,6 +329,35 @@ function convertWearableSignal(signal: WearableSignal): GeneratedRecommendation 
     source_type: 'wearable',
     source_ref: `wearable:${signal.condition_key}:${signal.user_id}`,
     fingerprint: generateWearableFingerprint(signal),
+    suggested_files: [],
+    suggested_endpoints: [],
+    suggested_tests: [],
+    user_id: signal.user_id,
+  };
+}
+
+/**
+ * BOOTSTRAP-AUTOPILOT-EXPANSION: map a calendar-prep signal into a community
+ * recommendation. source_ref reuses the existing `pillar_template_<pillar>`
+ * keys so COMMUNITY_ACTIONS already knows how to schedule a wellness prep block
+ * on activation — no new action wiring required.
+ */
+function convertCalendarPrepSignal(signal: CalendarPrepSignal): GeneratedRecommendation {
+  const severityToImpact: Record<CalendarPrepSignal['severity'], number> = {
+    low: 45,
+    medium: 60,
+    high: 72,
+  };
+  return {
+    title: signal.summary.substring(0, 100),
+    summary: signal.summary,
+    domain: 'health',
+    impact_score: severityToImpact[signal.severity],
+    effort_score: 2,
+    risk_level: 'low',
+    source_type: 'calendar_prep',
+    source_ref: `pillar_template_${signal.pillar}`,
+    fingerprint: generateCalendarPrepFingerprint(signal),
     suggested_files: [],
     suggested_endpoints: [],
     suggested_tests: [],
@@ -605,6 +641,32 @@ export async function generateRecommendations(
             }
           } catch (err) {
             errors.push({ source: 'wearable', error: String(err) });
+          }
+        })()
+      );
+    }
+
+    // BOOTSTRAP-AUTOPILOT-EXPANSION: Calendar Prep analyzer.
+    // Double-gated: must be in the requested sources AND the feature flag must
+    // be live (FEATURE_AUTOPILOT_CALENDAR_PREP_ENV). Default = OFF, and
+    // 'calendar_prep' is not in DEFAULT_CONFIG.sources, so there is no behavior
+    // change unless an operator both requests the source and flips the flag.
+    if (fullConfig.sources.includes('calendar_prep') && isFeatureLive('AUTOPILOT_CALENDAR_PREP')) {
+      analyzerPromises.push(
+        (async () => {
+          try {
+            const result = await analyzeCalendarPrep({});
+            analysisSummary.calendar_prep = result.summary;
+            if (result.ok) {
+              const cap = Math.ceil(fullConfig.limit / 2);
+              for (const signal of result.signals.slice(0, cap)) {
+                recommendations.push(convertCalendarPrepSignal(signal));
+              }
+            } else {
+              errors.push({ source: 'calendar_prep', error: result.error || 'Unknown error' });
+            }
+          } catch (err) {
+            errors.push({ source: 'calendar_prep', error: String(err) });
           }
         })()
       );

--- a/services/gateway/test/services/recommendation-engine/analyzers/calendar-prep-analyzer.test.ts
+++ b/services/gateway/test/services/recommendation-engine/analyzers/calendar-prep-analyzer.test.ts
@@ -1,0 +1,222 @@
+/**
+ * BOOTSTRAP-AUTOPILOT-EXPANSION: unit tests for the calendar-prep analyzer.
+ *
+ * Covers the PURE rule layer (classifyCalendarPrep / classifyCalendarPrepBatch):
+ * no DB, no clock — `now` is always injected so assertions are deterministic.
+ */
+
+import {
+  classifyCalendarPrep,
+  classifyCalendarPrepBatch,
+  generateCalendarPrepFingerprint,
+  DEFAULT_CALENDAR_PREP_CONFIG,
+  CalendarEventRow,
+  CalendarPrepSignal,
+  WellnessPillar,
+} from '../../../../src/services/recommendation-engine/analyzers/calendar-prep-analyzer';
+
+const NOW = new Date('2026-06-02T09:00:00.000Z');
+
+function ev(over: Partial<CalendarEventRow> = {}): CalendarEventRow {
+  return {
+    id: over.id ?? 'evt-1',
+    user_id: over.user_id ?? 'user-1',
+    tenant_id: 'tenant_id' in over ? over.tenant_id! : 'tenant-1',
+    // default: 3h from NOW → within lookahead, imminent, same day
+    start_time: over.start_time ?? '2026-06-02T12:00:00.000Z',
+    // Respect an explicit `pillar: null` (don't coerce via ??).
+    pillar: 'pillar' in over ? over.pillar! : 'exercise',
+    event_type: over.event_type ?? 'workout',
+    status: over.status ?? 'confirmed',
+    source_type: over.source_type ?? 'user',
+  };
+}
+
+describe('classifyCalendarPrep (pure single-event rules)', () => {
+  it('emits a signal for an upcoming wellness-pillar event with no prep block', () => {
+    const target = ev();
+    const sig = classifyCalendarPrep(target, [target], NOW);
+    expect(sig).not.toBeNull();
+    expect(sig!.pillar).toBe('exercise');
+    expect(sig!.user_id).toBe('user-1');
+    expect(sig!.target_event_id).toBe('evt-1');
+    expect(sig!.hours_until).toBe(3);
+    expect(sig!.summary).toContain('exercise');
+  });
+
+  it('returns null when the event has no pillar', () => {
+    const target = ev({ pillar: null });
+    expect(classifyCalendarPrep(target, [target], NOW)).toBeNull();
+  });
+
+  it('returns null for cancelled events', () => {
+    const target = ev({ status: 'cancelled' });
+    expect(classifyCalendarPrep(target, [target], NOW)).toBeNull();
+  });
+
+  it('returns null for events already in the past', () => {
+    const target = ev({ start_time: '2026-06-02T08:00:00.000Z' }); // 1h before NOW
+    expect(classifyCalendarPrep(target, [target], NOW)).toBeNull();
+  });
+
+  it('returns null for events beyond the lookahead horizon', () => {
+    // 60h out, lookahead default is 48h
+    const target = ev({ start_time: '2026-06-04T21:00:00.000Z' });
+    expect(classifyCalendarPrep(target, [target], NOW)).toBeNull();
+  });
+
+  it('returns null when a prep block already exists within the prep window', () => {
+    const target = ev({ id: 'evt-target', start_time: '2026-06-02T12:00:00.000Z' });
+    const prep = ev({
+      id: 'evt-prep',
+      pillar: 'exercise',
+      start_time: '2026-06-02T11:00:00.000Z', // 1h before target, inside 120-min window
+    });
+    expect(classifyCalendarPrep(target, [target, prep], NOW)).toBeNull();
+  });
+
+  it('still emits when the only nearby block is a DIFFERENT pillar', () => {
+    const target = ev({ id: 'evt-target', pillar: 'exercise', start_time: '2026-06-02T12:00:00.000Z' });
+    const otherPillar = ev({
+      id: 'evt-other',
+      pillar: 'sleep',
+      start_time: '2026-06-02T11:00:00.000Z',
+    });
+    const sig = classifyCalendarPrep(target, [target, otherPillar], NOW);
+    expect(sig).not.toBeNull();
+    expect(sig!.pillar).toBe('exercise');
+  });
+
+  it('still emits when the nearby same-pillar block is OUTSIDE the prep window', () => {
+    const target = ev({ id: 'evt-target', start_time: '2026-06-02T12:00:00.000Z' });
+    const tooEarly = ev({
+      id: 'evt-early',
+      pillar: 'exercise',
+      start_time: '2026-06-02T09:30:00.000Z', // 2.5h before target, outside 120-min window
+    });
+    expect(classifyCalendarPrep(target, [target, tooEarly], NOW)).not.toBeNull();
+  });
+
+  it('ignores a cancelled prep block (does not count as prepared)', () => {
+    const target = ev({ id: 'evt-target', start_time: '2026-06-02T12:00:00.000Z' });
+    const cancelledPrep = ev({
+      id: 'evt-prep',
+      pillar: 'exercise',
+      start_time: '2026-06-02T11:00:00.000Z',
+      status: 'cancelled',
+    });
+    expect(classifyCalendarPrep(target, [target, cancelledPrep], NOW)).not.toBeNull();
+  });
+
+  describe('severity ladder', () => {
+    it('high for imminent same-day events', () => {
+      const target = ev({ start_time: '2026-06-02T12:00:00.000Z' }); // 3h, same day
+      expect(classifyCalendarPrep(target, [target], NOW)!.severity).toBe('high');
+    });
+
+    it('medium for imminent but next-day events', () => {
+      // imminent_hours default = 6. Pick an event ~5h out that crosses midnight.
+      const lateNow = new Date('2026-06-02T21:00:00.000Z');
+      const target = ev({ start_time: '2026-06-03T01:00:00.000Z' }); // 4h out, next day
+      expect(classifyCalendarPrep(target, [target], lateNow)!.severity).toBe('medium');
+    });
+
+    it('low for events further out than the imminent window', () => {
+      const target = ev({ start_time: '2026-06-03T20:00:00.000Z' }); // ~35h out
+      expect(classifyCalendarPrep(target, [target], NOW)!.severity).toBe('low');
+    });
+  });
+
+  it('confidence is higher for sooner events and clamped to [0.4, 0.9]', () => {
+    const soon = ev({ start_time: '2026-06-02T10:00:00.000Z' }); // 1h
+    const far = ev({ start_time: '2026-06-04T08:00:00.000Z' }); // ~47h
+    const soonSig = classifyCalendarPrep(soon, [soon], NOW)!;
+    const farSig = classifyCalendarPrep(far, [far], NOW)!;
+    expect(soonSig.confidence).toBeGreaterThan(farSig.confidence);
+    expect(soonSig.confidence).toBeLessThanOrEqual(0.9);
+    expect(farSig.confidence).toBeGreaterThanOrEqual(0.4);
+  });
+
+  it('honours a custom config', () => {
+    // Tighten lookahead to 1h — a 3h-out event should now be skipped.
+    const target = ev({ start_time: '2026-06-02T12:00:00.000Z' });
+    expect(
+      classifyCalendarPrep(target, [target], NOW, { ...DEFAULT_CALENDAR_PREP_CONFIG, lookahead_hours: 1 }),
+    ).toBeNull();
+  });
+});
+
+describe('classifyCalendarPrepBatch (pure multi-user rules)', () => {
+  it('emits at most one signal per (user, pillar), keeping the soonest', () => {
+    const early = ev({ id: 'e1', user_id: 'u1', pillar: 'exercise', start_time: '2026-06-02T11:00:00.000Z' });
+    const later = ev({ id: 'e2', user_id: 'u1', pillar: 'exercise', start_time: '2026-06-02T18:00:00.000Z' });
+    const out = classifyCalendarPrepBatch([later, early], NOW);
+    const exercise = out.filter((s) => s.user_id === 'u1' && s.pillar === 'exercise');
+    expect(exercise).toHaveLength(1);
+    expect(exercise[0].target_event_id).toBe('e1'); // the soonest
+  });
+
+  it('emits separate signals for different pillars of the same user', () => {
+    const exercise = ev({ id: 'e1', user_id: 'u1', pillar: 'exercise', start_time: '2026-06-02T12:00:00.000Z' });
+    const sleep = ev({ id: 'e2', user_id: 'u1', pillar: 'sleep', start_time: '2026-06-02T22:00:00.000Z' });
+    const out = classifyCalendarPrepBatch([exercise, sleep], NOW);
+    const pillars = out.filter((s) => s.user_id === 'u1').map((s) => s.pillar).sort();
+    expect(pillars).toEqual<WellnessPillar[]>(['exercise', 'sleep']);
+  });
+
+  it('keeps users isolated — u2\'s prep block only suppresses u2\'s own target, not u1\'s', () => {
+    // u1: a lone unprepared target → must yield a signal targeting evt-a.
+    const u1target = ev({ id: 'a', user_id: 'u1', pillar: 'exercise', start_time: '2026-06-02T12:00:00.000Z' });
+    // u2: same 12:00 target, but with an 11:00 prep block before it. The 12:00
+    // target (evt-b) is suppressed; the 11:00 prep (evt-c) is itself the soonest
+    // unprepared exercise block for u2, so u2 gets exactly one signal — for evt-c.
+    const u2target = ev({ id: 'b', user_id: 'u2', pillar: 'exercise', start_time: '2026-06-02T12:00:00.000Z' });
+    const u2prep = ev({ id: 'c', user_id: 'u2', pillar: 'exercise', start_time: '2026-06-02T11:00:00.000Z' });
+
+    const out = classifyCalendarPrepBatch([u1target, u2target, u2prep], NOW);
+    const targets = out.map((s) => s.target_event_id).sort();
+
+    // u1 keeps its signal (evt-a); u2's 12:00 target (evt-b) is suppressed by its
+    // own prep; u2 instead surfaces the earliest unprepared block (evt-c).
+    expect(targets).toEqual(['a', 'c']);
+    expect(targets).not.toContain('b');
+  });
+
+  it('returns an empty array when nothing qualifies', () => {
+    const past = ev({ start_time: '2026-06-01T12:00:00.000Z' });
+    expect(classifyCalendarPrepBatch([past], NOW)).toEqual([]);
+  });
+});
+
+describe('generateCalendarPrepFingerprint', () => {
+  const base: CalendarPrepSignal = {
+    user_id: 'u1',
+    tenant_id: 't1',
+    pillar: 'exercise',
+    target_event_id: 'e1',
+    severity: 'high',
+    confidence: 0.8,
+    hours_until: 3,
+    summary: 'x',
+  };
+
+  it('is stable for the same user+pillar (daily bucket)', () => {
+    expect(generateCalendarPrepFingerprint(base)).toBe(generateCalendarPrepFingerprint(base));
+  });
+
+  it('differs by pillar', () => {
+    expect(generateCalendarPrepFingerprint(base)).not.toBe(
+      generateCalendarPrepFingerprint({ ...base, pillar: 'sleep' }),
+    );
+  });
+
+  it('differs by user', () => {
+    expect(generateCalendarPrepFingerprint(base)).not.toBe(
+      generateCalendarPrepFingerprint({ ...base, user_id: 'u2' }),
+    );
+  });
+
+  it('is a 16-char hex string', () => {
+    expect(generateCalendarPrepFingerprint(base)).toMatch(/^[0-9a-f]{16}$/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **one new, additive Autopilot signal source** — the **calendar-prep analyzer** — that broadens what Autopilot can proactively surface, without rebuilding the existing recommendation engine.

It surfaces a low-risk nudge when a user has an upcoming wellness-pillar `calendar_events` row happening soon (e.g. a workout or sleep block) but has **not** scheduled a short supporting "prep" block before it. This extends Autopilot from purely reactive signals (codebase / OASIS / health / biometrics) to **helping users follow through on plans they already made**.

## What changed

- **New analyzer** `services/gateway/src/services/recommendation-engine/analyzers/calendar-prep-analyzer.ts`
  - Pure, deterministic classification (`classifyCalendarPrep` / `classifyCalendarPrepBatch`) — `now` is injected, no clock or DB reads — plus a thin DB-fetch wrapper (`analyzeCalendarPrep`).
  - Mirrors the `wearable-analyzer` contract: `analyze...` returns `{ ok, signals, summary, error? }`; `generate...Fingerprint` for daily-bucketed dedup (≤ 1 nudge per user/pillar/day).
- **Wiring** in `recommendation-generator.ts`
  - New `SourceType` `'calendar_prep'`, a `convertCalendarPrepSignal` mapper, and a flag-gated analyzer block.
  - `source_ref` reuses the existing `pillar_template_<pillar>` `COMMUNITY_ACTIONS` keys, so activation already knows how to schedule a wellness prep block — no new action wiring or executor changes.
- **Tests** `test/services/recommendation-engine/analyzers/calendar-prep-analyzer.test.ts` — 22 unit tests over the pure rule logic, all green.

## Off by default — zero behavior change

Double-gated:

```ts
if (fullConfig.sources.includes('calendar_prep') && isFeatureLive('AUTOPILOT_CALENDAR_PREP')) { ... }
```

- `FEATURE_AUTOPILOT_CALENDAR_PREP_ENV` is **unset = off** (`services/feature-flags.ts` convention).
- `'calendar_prep'` is **not** in `DEFAULT_CONFIG.sources`.

So with no env change, the analyzer never runs — no new recommendations, no extra queries.

## Scope / constraints

- Stayed in the recommendation-engine zone. No backlog-cleanup files, no executor allowlists touched.
- No new table (reuses existing `calendar_events` columns). No migration needed.
- No deploy / prod-write performed.

## Tests

```
Test Suites: 1 passed, 1 total
Tests:       22 passed, 22 total
```

`tsc --noEmit` reports only the pre-existing `moduleResolution=node10` deprecation (present on `main`, tsconfig untouched); no new type errors.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_