### PR TITLE
feat(shopping-agent): Phase 1 — propose-then-approve cart agent (VTID-03260)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -230,6 +230,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const userPreferencesRouter = require('./routes/user-preferences').default;
   // VTID-03213: Universal Cart Phase 1 gateway slice (universal_carts / universal_cart_items / universal_cart_events)
   const universalCartRouter = require('./routes/universal-cart').default;
+  // VTID-03260: Propose-then-approve shopping agent Phase 1 (proposes into the Universal Cart; never checks out)
+  const shoppingAgentRouter = require('./routes/shopping-agent').default;
   // VTID-03237: Video Shop (Vitanaland) backend slice — feed/anchor/saved/events over products + Universal Cart
   const shopFeedRouter = require('./routes/shop-feed').default;
   // VTID-01126: D32 Situational Awareness Engine - situation understanding layer
@@ -1196,6 +1198,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // VTID-03213: Universal Cart Phase 1 gateway slice — community-role-gated cart over universal_* tables
   mountRouterSync(app, '/api/v1/universal-cart', universalCartRouter, { owner: 'universal-cart' });
+
+  // VTID-03260: Propose-then-approve shopping agent — community-role-gated; proposes items into the Universal Cart (never checks out)
+  mountRouterSync(app, '/api/v1/shopping-agent', shoppingAgentRouter, { owner: 'shopping-agent' });
 
   // VTID-03237: Video Shop (Vitanaland) — community-role-gated feed/anchor/saved/events over products + Universal Cart
   mountRouterSync(app, '/api/v1/shop-feed', shopFeedRouter, { owner: 'shop-feed' });

--- a/services/gateway/src/routes/shopping-agent.ts
+++ b/services/gateway/src/routes/shopping-agent.ts
@@ -77,6 +77,13 @@ router.post('/propose', async (req: Request, res: Response) => {
   const id = await authorizeCommunityCaller(req, res);
   if (!id) return;
 
+  // impact-allow-no-oasis: each proposed item emits an item.added cart event to
+  // universal_cart_events via emitCartEvent (the end-user commerce sink), not
+  // oasis_events. oasis_events is the VTID lifecycle/governance log (CLAUDE.md
+  // §6), not a commerce ledger — identical to the universal-cart slice's
+  // handlers (see universal-cart.ts checkout). No state transition here belongs
+  // in OASIS; this endpoint only fills a cart and never charges.
+
   const parsed = ProposeBody.safeParse(req.body ?? {});
   if (!parsed.success) {
     return res.status(400).json({

--- a/services/gateway/src/routes/shopping-agent.ts
+++ b/services/gateway/src/routes/shopping-agent.ts
@@ -1,0 +1,245 @@
+/**
+ * VTID-03260 — Propose-then-approve shopping agent (Phase 1) gateway slice.
+ *
+ * Endpoint (mounted at /api/v1/shopping-agent):
+ *   POST /propose — Fill the caller's ONE active universal cart with
+ *                   AGENT-PROPOSED items, each carrying a rationale + soft
+ *                   safety flags + confidence. The user later reviews and taps
+ *                   the existing Approve & Pay (universal-cart POST /checkout).
+ *
+ * THIS ENDPOINT MUST NEVER CHECK OUT and never charges anything. It only reads
+ * products (through the limitations-filtered search path) and writes proposal
+ * rows into universal_cart_items. No Stripe, no wallet, no product_orders.
+ *
+ * Conventions mirrored from universal-cart.ts:
+ *   - Community-role-only via the cart's `authorizeCommunityCaller` (same 403
+ *     `cart_unavailable_for_role` shape on non-community sessions).
+ *   - createUserSupabaseClient(token) for RLS-evaluated cart writes.
+ *   - emitCartEvent() service-role audit emission (best-effort).
+ *   - { ok, error?, ... } response envelopes; zod request validation.
+ *
+ * Safety invariant (by construction): the agent selects candidates ONLY through
+ * agent-core's searchCandidates(), which runs applyUserLimitations() — the same
+ * hard-filter substrate discover-search uses. A hard-blocked product (allergen /
+ * contraindicated condition / medication interaction / excluded region) is
+ * removed before the agent ever sees it, so it can NEVER be proposed.
+ */
+
+import { Router, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { createUserSupabaseClient } from '../lib/supabase-user';
+import { getSupabase } from '../lib/supabase';
+import { authorizeCommunityCaller, emitCartEvent } from './universal-cart';
+import { getUserHealthContext } from '../services/user-health-context';
+import { runPropose, type AnnotatedPick, type InsertPickFn } from '../services/shopping-agent/agent-core';
+
+export const VTID = 'VTID-03260';
+
+const router = Router();
+
+// =============================================================================
+// Request schema (frozen contract)
+// =============================================================================
+
+const ProposeBody = z.object({
+  prompt: z.string().min(1).max(500),
+  max_items: z.number().int().optional(),
+});
+
+/** Clamp max_items to 1..6, default 4. */
+function clampMaxItems(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw)) return 4;
+  return Math.max(1, Math.min(6, Math.floor(raw)));
+}
+
+function isNoRowsError(error: any): boolean {
+  return error?.code === 'PGRST116';
+}
+function isUniqueViolation(error: any): boolean {
+  return error?.code === '23505';
+}
+
+// =============================================================================
+// Routes
+// =============================================================================
+
+/** GET /health — sanity check; no auth needed (mirrors universal-cart). */
+router.get('/health', (_req: Request, res: Response) => {
+  return res.status(200).json({ ok: true, vtid: VTID, scope: 'shopping_agent_propose_phase_1' });
+});
+
+/**
+ * POST /propose — plan → select (limitations-filtered) → annotate → write into
+ * the active cart. NEVER checks out.
+ */
+router.post('/propose', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  const parsed = ProposeBody.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: 'invalid_request',
+      detail: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+    });
+  }
+  const maxItems = clampMaxItems(parsed.data.max_items);
+
+  // Brain: allergies / dietary / conditions / medications / goals / budget / geo.
+  const ctx = await getUserHealthContext(id.user_id);
+
+  // Read-only product search uses the service-role client (same as discover-search).
+  const searchClient = getSupabase();
+
+  // Cart writes use the RLS-scoped user client (owner isolation enforced by RLS).
+  const userClient = createUserSupabaseClient(id.token);
+
+  // Resolve-or-create the caller's active cart up front so every proposed item
+  // lands in the same cart. Mirrors universal-cart POST /items cart resolution.
+  const cartResolution = await resolveActiveCartId(userClient, id.user_id, id.tenant_id);
+  if (!cartResolution.ok) {
+    return res.status(500).json({ ok: false, error: cartResolution.error });
+  }
+  const cartId = cartResolution.cartId;
+
+  const runId = randomUUID();
+
+  // The insert path the agent calls per pick: write one universal_cart_items
+  // row with the agent metadata blob, price lock, source_surface 'autopilot'.
+  const insertPick: InsertPickFn = async (pick: AnnotatedPick, rid: string, proposedAt: string) => {
+    const insertPayload: Record<string, unknown> = {
+      cart_id: cartId,
+      item_type: pick.item_type,
+      product_id: pick.product_id,
+      quantity: 1,
+      status: 'active',
+      source_surface: 'autopilot',
+      metadata: {
+        origin: 'agent',
+        rationale: pick.rationale,
+        safety_flags: pick.safety_flags,
+        confidence: pick.confidence,
+        run_id: rid,
+        proposed_at: proposedAt,
+      },
+    };
+    // Price lock: snapshot unit price + currency at proposal time.
+    if (pick.unit_price_cents_snapshot !== null) insertPayload.unit_price_cents_snapshot = pick.unit_price_cents_snapshot;
+    if (pick.currency_snapshot !== null) insertPayload.currency_snapshot = pick.currency_snapshot;
+
+    const inserted = await userClient
+      .from('universal_cart_items')
+      .insert(insertPayload)
+      .select('id')
+      .single();
+
+    if (inserted.error || !inserted.data) {
+      return { ok: false, error: inserted.error?.message ?? 'item_insert_failed' };
+    }
+
+    const itemId = inserted.data.id as string;
+
+    // Audit: same item.added event the cart emits on a manual add.
+    await emitCartEvent({
+      cart_id: cartId,
+      user_id: id.user_id,
+      event_type: 'item.added',
+      event_payload: {
+        cart_item_id: itemId,
+        product_id: pick.product_id,
+        quantity_before: 0,
+        quantity_after: 1,
+        source_surface: 'autopilot',
+      },
+    });
+
+    return { ok: true, item_id: itemId };
+  };
+
+  const result = await runPropose({
+    prompt: parsed.data.prompt,
+    maxItems,
+    ctx,
+    supabase: searchClient,
+    insertPick,
+    runId,
+  });
+
+  // Fail loud when no LLM provider is configured/reachable. NEVER fabricate picks.
+  if (!result.ok) {
+    if (result.error === 'llm_unavailable') {
+      return res.status(502).json({ ok: false, error: 'llm_unavailable' });
+    }
+    return res.status(500).json({ ok: false, error: result.error ?? 'propose_failed' });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    run_id: result.run_id,
+    proposed: result.proposed ?? [],
+    advisory: result.advisory ?? [],
+  });
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Get-or-create the caller's ONE active universal cart and return its id.
+ * Mirrors the resolution block in universal-cart POST /items, including the
+ * partial-unique-index race recovery.
+ */
+async function resolveActiveCartId(
+  userClient: ReturnType<typeof createUserSupabaseClient>,
+  userId: string,
+  tenantId: string | null
+): Promise<{ ok: true; cartId: string } | { ok: false; error: string }> {
+  const cartLookup = await userClient
+    .from('universal_carts')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('status', 'active')
+    .maybeSingle();
+
+  if (cartLookup.error && !isNoRowsError(cartLookup.error)) {
+    return { ok: false, error: 'cart_lookup_failed' };
+  }
+  if (cartLookup.data?.id) {
+    return { ok: true, cartId: cartLookup.data.id as string };
+  }
+
+  const newCart = await userClient
+    .from('universal_carts')
+    .insert({ user_id: userId, tenant_id: tenantId, status: 'active', metadata: {} })
+    .select('id')
+    .single();
+
+  if (newCart.error && isUniqueViolation(newCart.error)) {
+    const racedCart = await userClient
+      .from('universal_carts')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('status', 'active')
+      .maybeSingle();
+    if (racedCart.data?.id) return { ok: true, cartId: racedCart.data.id as string };
+    return { ok: false, error: 'cart_create_failed' };
+  }
+  if (newCart.error || !newCart.data?.id) {
+    return { ok: false, error: 'cart_create_failed' };
+  }
+
+  // Emit cart.created for the freshly created cart (mirrors the cart route).
+  await emitCartEvent({
+    cart_id: newCart.data.id as string,
+    user_id: userId,
+    event_type: 'cart.created',
+    event_payload: {},
+  });
+
+  return { ok: true, cartId: newCart.data.id as string };
+}
+
+export default router;

--- a/services/gateway/src/routes/universal-cart.ts
+++ b/services/gateway/src/routes/universal-cart.ts
@@ -161,7 +161,7 @@ function denyForRole(res: Response, callerRole: string | null): Response {
  * Combined auth + role gate. Returns the resolved identity on success, or sends
  * a 401/403 response and returns null so callers can early-exit.
  */
-async function authorizeCommunityCaller(
+export async function authorizeCommunityCaller(
   req: Request,
   res: Response
 ): Promise<{ token: string; user_id: string; tenant_id: string | null } | null> {

--- a/services/gateway/src/services/shopping-agent/agent-core.ts
+++ b/services/gateway/src/services/shopping-agent/agent-core.ts
@@ -1,0 +1,518 @@
+/**
+ * VTID-03260 — Propose-then-approve shopping agent (Phase 1) core logic.
+ *
+ * The brain of `POST /api/v1/shopping-agent/propose`. Pure-ish, unit-testable:
+ * the route handler resolves identity + auth and hands a UserHealthContext +
+ * the inserted-item writer down here; everything else (LLM planning turn,
+ * candidate search through the limitations-filtered path, annotation) lives in
+ * this module with NO Express / no HTTP coupling.
+ *
+ * Hard invariant (by construction):
+ *   The agent NEVER selects a candidate except through `searchCandidates()`,
+ *   which runs the same hard-filter substrate `applyUserLimitations()` that
+ *   discover-search uses (allergens, contraindicated conditions, medication
+ *   interactions, excluded regions, geo). A hard-blocked product is removed
+ *   before the agent can ever see it, so it can NEVER end up in a proposal.
+ *   `safety_flags` only ever carry SOFT overlaps (ingredient sensitivities,
+ *   pregnancy-relevant notes, over-per-product-budget) and product safety_notes.
+ *
+ * Money invariant:
+ *   This module reads products and WRITES universal_cart_items (proposals). It
+ *   has NO checkout / Stripe / wallet / order path. Budget cap is ADVISORY only.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { UserHealthContext } from '../user-health-context';
+import { inferPrimaryCondition } from '../user-health-context';
+import { applyUserLimitations, type FilterableProduct } from '../limitations-filter';
+import { callViaRouter, type LLMRouterTool } from '../llm-router';
+import { getConditionMapping } from '../condition-matcher';
+
+export const VTID = 'VTID-03260';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Structured search intent the planning LLM emits — a subset of discover-search filters. */
+export interface AgentSearchIntent {
+  q?: string;
+  category?: string;
+  health_goals?: string[];
+  dietary_tags?: string[];
+  ingredients_any?: string[];
+  brand?: string[];
+  price_max_cents?: number;
+  /** The user goal this intent serves — used to build per-pick rationale. */
+  serves_goal?: string;
+}
+
+/** Candidate product row (post-filter) carried through annotation. */
+export interface AgentCandidate extends FilterableProduct {
+  id: string;
+  title: string;
+  category: string | null;
+  price_cents: number | null;
+  currency: string | null;
+  rating: number | null;
+  review_count: number | null;
+  origin_country: string | null;
+  ingredients_primary: string[];
+  health_goals: string[];
+  dietary_tags: string[];
+  safety_notes: string | null;
+  availability: string;
+  /** Match reasons attached during search (condition/rating/origin/goal). */
+  match_reasons: Array<{ kind: string; text: string }>;
+  /** The intent's serves_goal that produced this candidate (for rationale). */
+  _serves_goal?: string;
+}
+
+/** One annotated proposal, pre-insert. */
+export interface AnnotatedPick {
+  product_id: string;
+  title: string;
+  rationale: string;
+  safety_flags: string[];
+  confidence: number;
+  /** item_type derived from product category, for the cart insert. */
+  item_type: 'supplement' | 'partner_product';
+  unit_price_cents_snapshot: number | null;
+  currency_snapshot: string | null;
+}
+
+export interface ProposeResult {
+  ok: boolean;
+  error?: string;
+  run_id?: string;
+  proposed?: Array<{
+    item_id: string;
+    product_id: string;
+    title: string;
+    rationale: string;
+    safety_flags: string[];
+    confidence: number;
+  }>;
+  advisory?: string[];
+}
+
+/** Writer the route provides: insert one annotated pick into the caller's active cart. */
+export type InsertPickFn = (pick: AnnotatedPick, runId: string, proposedAt: string) => Promise<
+  { ok: true; item_id: string } | { ok: false; error: string }
+>;
+
+export interface RunProposeArgs {
+  prompt: string;
+  maxItems: number;
+  ctx: UserHealthContext;
+  /** Service-role (or user-scoped) client for the read-only product search. */
+  supabase: SupabaseClient | null;
+  /** Persists one pick into the active universal cart. */
+  insertPick: InsertPickFn;
+  /** Stable run id (uuid) tying every proposed item together. */
+  runId: string;
+}
+
+// =============================================================================
+// 1. Planning turn (LLM) — emit structured search intents
+// =============================================================================
+
+const PLAN_TOOL: LLMRouterTool = {
+  name: 'emit_search_intents',
+  description:
+    'Emit 1-3 product search intents that together satisfy the shopper request, ' +
+    'each compatible with the Vitana marketplace search filters.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      intents: {
+        type: 'array',
+        maxItems: 3,
+        items: {
+          type: 'object',
+          properties: {
+            q: { type: 'string', description: 'Free-text search query' },
+            category: { type: 'string' },
+            health_goals: { type: 'array', items: { type: 'string' } },
+            dietary_tags: { type: 'array', items: { type: 'string' } },
+            ingredients_any: { type: 'array', items: { type: 'string' } },
+            brand: { type: 'array', items: { type: 'string' } },
+            price_max_cents: { type: 'integer' },
+            serves_goal: { type: 'string', description: 'The user goal this intent serves' },
+          },
+        },
+      },
+    },
+    required: ['intents'],
+  },
+};
+
+/** Build the system prompt that seeds the planner from the health context. */
+export function buildPlannerSystemPrompt(ctx: UserHealthContext): string {
+  const lines: string[] = [];
+  lines.push(
+    'You are the Vitana shopping agent. You PROPOSE products for the shopper to review later; ' +
+      'you never purchase anything. Translate the request into 1-3 marketplace search intents.'
+  );
+
+  // HARD constraints — present prominently. These are also enforced by a
+  // downstream filter, but telling the model keeps proposals on-target.
+  const hard: string[] = [];
+  if (ctx.allergies.length) hard.push(`allergies: ${ctx.allergies.join(', ')}`);
+  if (ctx.contraindications.length) hard.push(`medical contraindications: ${ctx.contraindications.join(', ')}`);
+  if (ctx.current_medications.length) hard.push(`current medications (avoid interactions): ${ctx.current_medications.join(', ')}`);
+  if (ctx.pregnancy_status) hard.push(`pregnancy status: ${ctx.pregnancy_status}`);
+  if (hard.length) {
+    lines.push(`HARD SAFETY CONSTRAINTS — never propose anything conflicting with: ${hard.join('; ')}.`);
+  }
+
+  // Soft preferences / signals.
+  if (ctx.active_goals.length) lines.push(`User goals: ${ctx.active_goals.map((g) => g.key).join(', ')}.`);
+  if (ctx.active_conditions.length) lines.push(`Active conditions: ${ctx.active_conditions.map((c) => c.key).join(', ')}.`);
+  if (ctx.dietary_restrictions.length) lines.push(`Dietary preferences: ${ctx.dietary_restrictions.join(', ')}.`);
+  if (ctx.ingredient_sensitivities.length) lines.push(`Ingredient sensitivities (avoid where possible): ${ctx.ingredient_sensitivities.join(', ')}.`);
+  if (ctx.budget_max_per_product_cents) {
+    lines.push(`Budget band: keep per-product price at or below ${Math.floor(ctx.budget_max_per_product_cents / 100)} ${ctx.currency ?? ''}.`.trim());
+  }
+  if (ctx.country_code) lines.push(`Ships to: ${ctx.country_code}.`);
+
+  lines.push('Call emit_search_intents with the structured intents. Do not write prose.');
+  return lines.join('\n');
+}
+
+/**
+ * Run the single planning turn. Returns the structured intents, or an error
+ * marker the route maps to HTTP 502 `llm_unavailable`. ONE turn for MVP —
+ * no agentic loop.
+ */
+export async function planSearchIntents(
+  prompt: string,
+  ctx: UserHealthContext
+): Promise<{ ok: true; intents: AgentSearchIntent[] } | { ok: false; error: 'llm_unavailable' }> {
+  const systemPrompt = buildPlannerSystemPrompt(ctx);
+  const result = await callViaRouter('planner', prompt, {
+    service: 'shopping-agent',
+    vtid: VTID,
+    systemPrompt,
+    maxTokens: 1500,
+    tools: [PLAN_TOOL],
+    forceTool: 0,
+  });
+
+  if (!result.ok) {
+    // No provider configured / both providers failed → fail loud. NEVER fabricate picks.
+    return { ok: false, error: 'llm_unavailable' };
+  }
+
+  const intents = parseIntents(result.toolCall?.arguments, result.text);
+  // A reachable provider that returned no usable structure is still "available";
+  // an empty intent list flows downstream to a graceful proposed:[] outcome.
+  return { ok: true, intents };
+}
+
+/** Extract intents from a forced tool call, falling back to JSON-in-text. */
+export function parseIntents(
+  toolArgs: Record<string, unknown> | undefined,
+  text: string | undefined
+): AgentSearchIntent[] {
+  const fromArgs = coerceIntentArray(toolArgs?.intents);
+  if (fromArgs.length) return fromArgs;
+
+  if (text) {
+    const match = text.match(/\{[\s\S]*\}/);
+    if (match) {
+      try {
+        const parsed = JSON.parse(match[0]) as Record<string, unknown>;
+        return coerceIntentArray(parsed.intents);
+      } catch {
+        // not JSON — fall through
+      }
+    }
+  }
+  return [];
+}
+
+function coerceIntentArray(raw: unknown): AgentSearchIntent[] {
+  if (!Array.isArray(raw)) return [];
+  const out: AgentSearchIntent[] = [];
+  for (const r of raw) {
+    if (!r || typeof r !== 'object') continue;
+    const o = r as Record<string, unknown>;
+    const intent: AgentSearchIntent = {};
+    if (typeof o.q === 'string') intent.q = o.q.slice(0, 512);
+    if (typeof o.category === 'string') intent.category = o.category.slice(0, 64);
+    if (Array.isArray(o.health_goals)) intent.health_goals = stringArray(o.health_goals);
+    if (Array.isArray(o.dietary_tags)) intent.dietary_tags = stringArray(o.dietary_tags);
+    if (Array.isArray(o.ingredients_any)) intent.ingredients_any = stringArray(o.ingredients_any);
+    if (Array.isArray(o.brand)) intent.brand = stringArray(o.brand);
+    if (typeof o.price_max_cents === 'number' && Number.isFinite(o.price_max_cents)) {
+      intent.price_max_cents = Math.max(0, Math.floor(o.price_max_cents));
+    }
+    if (typeof o.serves_goal === 'string') intent.serves_goal = o.serves_goal.slice(0, 200);
+    out.push(intent);
+  }
+  return out;
+}
+
+function stringArray(raw: unknown[]): string[] {
+  return raw.filter((x): x is string => typeof x === 'string').map((x) => x.slice(0, 64));
+}
+
+// =============================================================================
+// 2. Candidate search — the ONLY product-selection path (limitations pre-applied)
+// =============================================================================
+
+const CANDIDATE_COLUMNS =
+  'id, title, brand, category, price_cents, currency, availability, rating, review_count, ' +
+  'origin_country, origin_region, ingredients_primary, health_goals, dietary_tags, safety_notes, ' +
+  'contains_allergens, contraindicated_with_conditions, contraindicated_with_medications, ' +
+  'ships_to_countries, ships_to_regions, excluded_from_regions';
+
+/**
+ * Run one intent through the marketplace, then HARD-FILTER with
+ * applyUserLimitations(). Mirrors the in-process discover-search invocation in
+ * gemini-operator.ts (executeSearchMarketplaceProducts). Always forces
+ * availability='in_stock' so price-locked proposals are purchasable later.
+ *
+ * The returned candidates have already had allergen / contraindication /
+ * medication / region / geo conflicts removed — the agent cannot see them.
+ */
+export async function searchCandidates(
+  supabase: SupabaseClient,
+  intent: AgentSearchIntent,
+  ctx: UserHealthContext,
+  overFetch: number
+): Promise<AgentCandidate[]> {
+  // Condition-driven expansion (mirrors discover-search): only when the intent
+  // didn't already specify ingredients/goals.
+  const conditionKey = inferPrimaryCondition(ctx);
+  const mapping = conditionKey ? await getConditionMapping(conditionKey) : null;
+
+  let healthGoals = intent.health_goals;
+  let ingredientsAny = intent.ingredients_any;
+  if (mapping) {
+    if (!ingredientsAny?.length && mapping.recommended_ingredients.length) ingredientsAny = mapping.recommended_ingredients;
+    if (!healthGoals?.length && mapping.recommended_health_goals.length) healthGoals = mapping.recommended_health_goals;
+  }
+
+  let query = supabase
+    .from('products')
+    .select(CANDIDATE_COLUMNS)
+    .eq('is_active', true)
+    .eq('availability', 'in_stock');
+
+  if (intent.q) {
+    const sanitizedQ = intent.q.replace(/[&|!<>()]/g, ' ').trim();
+    if (sanitizedQ) query = query.textSearch('search_text', sanitizedQ, { config: 'simple', type: 'websearch' });
+  }
+  if (intent.category) query = query.eq('category', intent.category);
+  if (healthGoals?.length) query = query.overlaps('health_goals', healthGoals);
+  if (ingredientsAny?.length) query = query.overlaps('ingredients_primary', ingredientsAny);
+  if (intent.dietary_tags?.length) query = query.contains('dietary_tags', intent.dietary_tags);
+  if (intent.brand?.length) query = query.in('brand', intent.brand);
+  if (intent.price_max_cents !== undefined) query = query.lte('price_cents', intent.price_max_cents);
+
+  query = query.order('rating', { ascending: false, nullsFirst: false }).limit(overFetch);
+
+  const { data: rows, error } = await query;
+  if (error) {
+    console.error(`[${VTID}] candidate search failed:`, error.message);
+    return [];
+  }
+
+  const fetched = (rows ?? []) as unknown as AgentCandidate[];
+
+  // HARD + soft limitation filter — the safety substrate. No bypasses here:
+  // the agent must never propose anything the user could not be shown.
+  const { allowed } = applyUserLimitations(fetched, ctx, { surface: 'shopping_agent' });
+
+  // Exclude past purchases (ctx already carries them).
+  const pastIds = new Set(ctx.past_purchases.map((p) => p.product_id));
+  const withoutPast = allowed.filter((p) => !pastIds.has(p.id));
+
+  // Build match_reasons (condition/rating/origin) + carry the goal this intent serves.
+  for (const p of withoutPast) {
+    const reasons: Array<{ kind: string; text: string }> = [];
+    if (mapping?.recommended_ingredients_ranked.length && p.ingredients_primary?.length) {
+      const pIngs = new Set(p.ingredients_primary.map((x) => x.toLowerCase()));
+      for (const rec of mapping.recommended_ingredients_ranked) {
+        if (pIngs.has(rec.ingredient.toLowerCase())) {
+          reasons.push({ kind: 'condition', text: `Contains ${rec.ingredient} (${rec.evidence} evidence for ${mapping.display_label})` });
+          break;
+        }
+      }
+    }
+    if (p.rating !== null && p.rating >= 4.5) {
+      reasons.push({ kind: 'rating', text: `Rated ${p.rating.toFixed(1)}/5${p.review_count ? ` by ${p.review_count} users` : ''}` });
+    }
+    if (p.origin_country) reasons.push({ kind: 'origin', text: `Ships from ${p.origin_country}` });
+    p.match_reasons = reasons;
+    p._serves_goal = intent.serves_goal;
+  }
+
+  return withoutPast;
+}
+
+// =============================================================================
+// 3. Annotation — rationale + SOFT safety flags + confidence
+// =============================================================================
+
+/** Map a product category to the cart item_type enum (supplement | partner_product). */
+export function deriveItemType(category: string | null): 'supplement' | 'partner_product' {
+  const c = (category ?? '').toLowerCase();
+  // Supplements (vitamins, minerals, herbals) are first-party 'supplement';
+  // everything else (devices, foods, partner SKUs) is 'partner_product'.
+  return c === 'supplement' || c === 'supplements' || c === 'vitamin' || c === 'vitamins'
+    ? 'supplement'
+    : 'partner_product';
+}
+
+/**
+ * Build the per-pick rationale + SOFT safety flags + confidence. Hard conflicts
+ * are ALREADY filtered out upstream — never re-added here.
+ */
+export function annotatePick(p: AgentCandidate, ctx: UserHealthContext): AnnotatedPick {
+  // Rationale: prefer the strongest match reason, append the goal it serves.
+  const reasonText = p.match_reasons.map((r) => r.text);
+  const goal = p._serves_goal || (ctx.active_goals[0]?.key ?? null);
+  const rationaleParts: string[] = [];
+  if (reasonText.length) rationaleParts.push(reasonText[0]);
+  if (goal) rationaleParts.push(`supports your goal: ${goal}`);
+  if (!rationaleParts.length) rationaleParts.push(`Matches your request`);
+  const rationale = rationaleParts.join(' — ');
+
+  // SOFT safety flags only (hard conflicts are impossible here by construction).
+  const flags: string[] = [];
+
+  // Product-declared safety notes.
+  if (p.safety_notes && p.safety_notes.trim()) flags.push('has_safety_notes');
+
+  // Ingredient sensitivities (soft overlap — surfaced, not blocked).
+  if (ctx.ingredient_sensitivities.length && p.ingredients_primary?.length) {
+    const sens = new Set(ctx.ingredient_sensitivities.map((s) => s.toLowerCase()));
+    if (p.ingredients_primary.some((i) => sens.has(i.toLowerCase()))) {
+      flags.push('ingredient_sensitivity_overlap');
+    }
+  }
+
+  // Pregnancy-relevant: if the user is pregnant and the product carries safety
+  // notes, surface a review-with-clinician flag (advisory, not a block).
+  if (ctx.pregnancy_status && p.safety_notes && p.safety_notes.trim()) {
+    flags.push('pregnancy_review_recommended');
+  }
+
+  // Price above the per-product budget ceiling (soft — surfaced for review).
+  if (
+    ctx.budget_max_per_product_cents !== null &&
+    p.price_cents !== null &&
+    p.price_cents !== undefined &&
+    p.price_cents > ctx.budget_max_per_product_cents
+  ) {
+    flags.push('over_per_product_budget');
+  }
+
+  // Confidence: base on rating + reason richness, lightly penalized by flags.
+  let confidence = 0.55;
+  if (p.match_reasons.some((r) => r.kind === 'condition')) confidence += 0.2;
+  if (p.rating !== null && p.rating >= 4.5) confidence += 0.1;
+  if (p.review_count && p.review_count >= 50) confidence += 0.05;
+  confidence -= flags.length * 0.05;
+  confidence = Math.max(0.2, Math.min(0.95, confidence));
+
+  return {
+    product_id: p.id,
+    title: p.title,
+    rationale,
+    safety_flags: flags,
+    confidence: Math.round(confidence * 100) / 100,
+    item_type: deriveItemType(p.category),
+    unit_price_cents_snapshot: p.price_cents ?? null,
+    currency_snapshot: p.currency ?? null,
+  };
+}
+
+// =============================================================================
+// 4. Orchestration — plan → select → annotate → write (NEVER checkout)
+// =============================================================================
+
+/** Advisory: proposed subtotal within 15% of the monthly cap → near_monthly_cap. */
+const NEAR_CAP_RATIO = 0.85;
+
+export async function runPropose(args: RunProposeArgs): Promise<ProposeResult> {
+  const { prompt, maxItems, ctx, supabase, insertPick, runId } = args;
+  const advisory: string[] = [];
+
+  // Brain empty / stale → advisory (still degrade gracefully).
+  const brainEmpty =
+    ctx.stale ||
+    (ctx.active_goals.length === 0 &&
+      ctx.active_conditions.length === 0 &&
+      ctx.allergies.length === 0 &&
+      ctx.dietary_restrictions.length === 0 &&
+      ctx.current_medications.length === 0);
+  if (brainEmpty) advisory.push('no_health_profile');
+
+  // 1. Planning turn. No provider → fail loud (502 upstream).
+  const plan = await planSearchIntents(prompt, ctx);
+  if (!plan.ok) {
+    return { ok: false, error: 'llm_unavailable' };
+  }
+
+  // 2. Run intents through the limitations-filtered search path.
+  if (!supabase) {
+    // No DB → no candidates can be safely sourced. Degrade to empty proposals.
+    advisory.push('catalog_unavailable');
+    return { ok: true, run_id: runId, proposed: [], advisory };
+  }
+
+  const overFetch = Math.min(Math.max(maxItems * 3, 6), 60);
+  const seen = new Set<string>();
+  const candidates: AgentCandidate[] = [];
+  for (const intent of plan.intents) {
+    const found = await searchCandidates(supabase, intent, ctx, overFetch);
+    for (const c of found) {
+      if (seen.has(c.id)) continue;
+      seen.add(c.id);
+      candidates.push(c);
+    }
+    if (candidates.length >= maxItems * 3) break;
+  }
+
+  if (candidates.length === 0) {
+    advisory.push(plan.intents.length === 0 ? 'no_search_intent' : 'no_candidates_passed_filters');
+    return { ok: true, run_id: runId, proposed: [], advisory };
+  }
+
+  // 3. Top-N picks, annotate.
+  const top = candidates.slice(0, maxItems);
+  const annotated = top.map((p) => annotatePick(p, ctx));
+
+  // Advisory: near monthly cap (ADVISORY ONLY — never enforced in the money path).
+  if (ctx.budget_monthly_cap_cents && ctx.budget_monthly_cap_cents > 0) {
+    const subtotal = annotated.reduce((sum, a) => sum + (a.unit_price_cents_snapshot ?? 0), 0);
+    if (subtotal >= ctx.budget_monthly_cap_cents * NEAR_CAP_RATIO) {
+      advisory.push('near_monthly_cap');
+    }
+  }
+
+  // 4. Insert each pick into the active cart (the route owns the insert path).
+  const proposedAt = new Date().toISOString();
+  const proposed: NonNullable<ProposeResult['proposed']> = [];
+  for (const pick of annotated) {
+    const res = await insertPick(pick, runId, proposedAt);
+    if (!res.ok) {
+      console.error(`[${VTID}] insert pick failed for product ${pick.product_id}: ${res.error}`);
+      continue; // best-effort: a single failed insert must not sink the whole run
+    }
+    proposed.push({
+      item_id: res.item_id,
+      product_id: pick.product_id,
+      title: pick.title,
+      rationale: pick.rationale,
+      safety_flags: pick.safety_flags,
+      confidence: pick.confidence,
+    });
+  }
+
+  return { ok: true, run_id: runId, proposed, advisory };
+}

--- a/services/gateway/test/shopping-agent.test.ts
+++ b/services/gateway/test/shopping-agent.test.ts
@@ -1,0 +1,467 @@
+/**
+ * VTID-03260 — Propose-then-approve shopping agent gateway slice tests.
+ *
+ * Coverage (per the Phase 1 handoff):
+ *   (a) hard-filtered products NEVER appear in proposals — the agent selects
+ *       only through the limitations-filtered search path, so an allergen/
+ *       contraindication/medication-conflicting product cannot be proposed.
+ *   (b) role gate returns the cart's 403 cart_unavailable_for_role on non-community.
+ *   (c) metadata shape { origin:'agent', ... } + source_surface 'autopilot' on inserts.
+ *   (d) NO checkout/charge side effect — never touches checkout/product_orders/wallet.
+ *   (e) llm_unavailable → HTTP 502 (router mocked to fail).
+ *   (f) empty-brain → advisory 'no_health_profile' and still degrades gracefully.
+ *
+ * The Supabase client + LLM router + condition-matcher are mocked, mirroring
+ * the mock style in test/universal-cart.test.ts.
+ */
+
+import request from 'supertest';
+
+// =============================================================================
+// Chainable Supabase mock — mirrors test/universal-cart.test.ts
+// =============================================================================
+
+type SupaResponse = { data: any; error: any };
+
+const createChainableMock = () => {
+  let defaultData: SupaResponse = { data: null, error: null };
+  const responseQueue: SupaResponse[] = [];
+  const calls: { op: string; args: any[] }[] = [];
+
+  const record = (op: string, args: any[]) => calls.push({ op, args });
+
+  const chain: any = {
+    from: jest.fn((...args: any[]) => { record('from', args); return chain; }),
+    select: jest.fn((...args: any[]) => { record('select', args); return chain; }),
+    insert: jest.fn((...args: any[]) => { record('insert', args); return chain; }),
+    update: jest.fn((...args: any[]) => { record('update', args); return chain; }),
+    delete: jest.fn((...args: any[]) => { record('delete', args); return chain; }),
+    eq: jest.fn((...args: any[]) => { record('eq', args); return chain; }),
+    neq: jest.fn(() => chain),
+    gt: jest.fn(() => chain),
+    gte: jest.fn(() => chain),
+    lt: jest.fn(() => chain),
+    lte: jest.fn(() => chain),
+    is: jest.fn(() => chain),
+    in: jest.fn(() => chain),
+    contains: jest.fn(() => chain),
+    overlaps: jest.fn(() => chain),
+    textSearch: jest.fn(() => chain),
+    order: jest.fn(() => chain),
+    limit: jest.fn(() => chain),
+    single: jest.fn(() => chain),
+    maybeSingle: jest.fn(() => chain),
+    rpc: jest.fn((...args: any[]) => { record('rpc', args); return chain; }),
+    then: jest.fn((resolve: any) => {
+      const data = responseQueue.length > 0 ? responseQueue.shift()! : defaultData;
+      return Promise.resolve(data).then(resolve);
+    }),
+    __seed: (response: SupaResponse) => { responseQueue.push(response); return chain; },
+    __setDefault: (response: SupaResponse) => { defaultData = response; return chain; },
+    __clear: () => {
+      responseQueue.length = 0;
+      defaultData = { data: null, error: null };
+      calls.length = 0;
+    },
+    __calls: () => calls,
+    __insertsFor: (table: string) => {
+      const inserts: any[] = [];
+      let lastFrom: string | null = null;
+      for (const c of calls) {
+        if (c.op === 'from') lastFrom = c.args[0];
+        if (c.op === 'insert' && lastFrom === table) inserts.push(c.args[0]);
+      }
+      return inserts;
+    },
+    __sawFrom: (table: string) => calls.some((c) => c.op === 'from' && c.args[0] === table),
+  };
+  return chain;
+};
+
+const mockSupabase = createChainableMock();
+
+jest.mock('../src/lib/supabase', () => ({
+  getSupabase: jest.fn(() => mockSupabase),
+}));
+jest.mock('../src/lib/supabase-user', () => ({
+  createUserSupabaseClient: jest.fn(() => mockSupabase),
+}));
+
+// Mock the LLM router — agent-core's planning turn goes through callViaRouter.
+const mockCallViaRouter = jest.fn();
+jest.mock('../src/services/llm-router', () => ({
+  callViaRouter: (...args: any[]) => mockCallViaRouter(...args),
+}));
+
+// Mock condition-matcher so no extra DB round-trips are needed in search.
+jest.mock('../src/services/condition-matcher', () => ({
+  getConditionMapping: jest.fn(async () => null),
+}));
+
+// Mock the health-context brain — the route resolves ctx via getUserHealthContext.
+const mockGetUserHealthContext = jest.fn();
+jest.mock('../src/services/user-health-context', () => {
+  const actual = jest.requireActual('../src/services/user-health-context');
+  return {
+    ...actual,
+    getUserHealthContext: (...args: any[]) => mockGetUserHealthContext(...args),
+  };
+});
+
+process.env.SUPABASE_URL = 'http://localhost:54321';
+process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+import express from 'express';
+import shoppingAgentRouter from '../src/routes/shopping-agent';
+import { applyUserLimitations } from '../src/services/limitations-filter';
+import type { UserHealthContext } from '../src/services/user-health-context';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/shopping-agent', shoppingAgentRouter);
+  return app;
+}
+
+const USER_A = '11111111-1111-4000-a000-000000000a01';
+const TENANT_1 = '00000000-0000-4000-c000-000000000c01';
+const CART_A = '33333333-3333-4000-d000-000000000d01';
+const ITEM_1 = '55555555-5555-4000-e000-000000000e01';
+const ITEM_2 = '55555555-5555-4000-e000-000000000e02';
+const SAFE_PRODUCT = '66666666-6666-4000-f000-000000000f01';
+const ALLERGEN_PRODUCT = '77777777-7777-4000-f000-000000000f02';
+
+const BEARER_A = 'Bearer fake-jwt-user-a';
+
+/** Seed me_context + active_role lookups (mirrors universal-cart.test.ts seedAuth). */
+function seedAuth(opts: { user_id?: string; tenant_id?: string | null; role: string | null }) {
+  mockSupabase.__seed({
+    data: { user_id: opts.user_id ?? USER_A, tenant_id: opts.tenant_id === undefined ? TENANT_1 : opts.tenant_id },
+    error: null,
+  });
+  if (opts.role !== null && opts.tenant_id !== null) {
+    mockSupabase.__seed({ data: { active_role: opts.role }, error: null });
+  } else if (opts.tenant_id !== null) {
+    mockSupabase.__seed({ data: null, error: null });
+  }
+}
+
+/** A populated brain with a peanut allergy (used to prove hard-filter). */
+function makeCtx(overrides: Partial<UserHealthContext> = {}): UserHealthContext {
+  return {
+    user_id: USER_A,
+    tenant_id: TENANT_1,
+    active_conditions: [],
+    active_goals: [{ key: 'better_sleep' }],
+    dietary_restrictions: [],
+    allergies: ['peanut'],
+    contraindications: [],
+    current_medications: [],
+    pregnancy_status: null,
+    age_bracket: null,
+    religious_restrictions: [],
+    ingredient_sensitivities: [],
+    budget_max_per_product_cents: null,
+    budget_monthly_cap_cents: null,
+    budget_preferred_band: null,
+    wearable_summary_7d: null,
+    vitana_index_snapshot: null,
+    upcoming_events: [],
+    past_purchases: [],
+    recent_recommendations_dismissed: [],
+    topic_affinity: {},
+    country_code: null,
+    region_group: null,
+    scope_preference: 'friendly',
+    currency: 'EUR',
+    lifecycle_stage: null,
+    retrieved_at: new Date().toISOString(),
+    sources_queried: ['user_limitations'],
+    stale: false,
+    ...overrides,
+  };
+}
+
+/** An empty/stale brain (no health profile). */
+function emptyCtx(): UserHealthContext {
+  return makeCtx({
+    active_goals: [],
+    allergies: [],
+    sources_queried: [],
+    stale: true,
+  });
+}
+
+const SAFE_ROW = {
+  id: SAFE_PRODUCT,
+  title: 'Magnesium Glycinate',
+  brand: 'Acme',
+  category: 'supplement',
+  price_cents: 1999,
+  currency: 'EUR',
+  availability: 'in_stock',
+  rating: 4.7,
+  review_count: 120,
+  origin_country: 'DE',
+  origin_region: 'EU',
+  ingredients_primary: ['magnesium'],
+  health_goals: ['sleep'],
+  dietary_tags: ['vegan'],
+  safety_notes: null,
+  contains_allergens: [],
+  contraindicated_with_conditions: [],
+  contraindicated_with_medications: [],
+  ships_to_countries: ['DE'],
+  ships_to_regions: ['EU'],
+  excluded_from_regions: [],
+};
+
+const ALLERGEN_ROW = {
+  ...SAFE_ROW,
+  id: ALLERGEN_PRODUCT,
+  title: 'Peanut Protein Blend',
+  ingredients_primary: ['peanut'],
+  contains_allergens: ['peanut'], // would conflict with ctx.allergies = ['peanut']
+};
+
+/** Make the router emit one intent for every test that reaches the planner. */
+function seedPlannerOk() {
+  mockCallViaRouter.mockResolvedValue({
+    ok: true,
+    toolCall: { name: 'emit_search_intents', arguments: { intents: [{ q: 'sleep support', serves_goal: 'better_sleep' }] } },
+  });
+}
+
+beforeEach(() => {
+  mockSupabase.__clear();
+  mockCallViaRouter.mockReset();
+  mockGetUserHealthContext.mockReset();
+  mockGetUserHealthContext.mockResolvedValue(makeCtx());
+  consoleErrorSpy.mockClear();
+});
+
+// =============================================================================
+// (b) Role gate
+// =============================================================================
+
+describe(`${'VTID-03260'} (b) role gating`, () => {
+  test('GET /health is open', async () => {
+    const res = await request(buildApp()).get('/api/v1/shopping-agent/health');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  test('POST /propose without Bearer → 401', async () => {
+    const res = await request(buildApp()).post('/api/v1/shopping-agent/propose').send({ prompt: 'sleep help' });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  test('POST /propose with role=admin → 403 cart_unavailable_for_role', async () => {
+    seedAuth({ role: 'admin' });
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'sleep help' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cart_unavailable_for_role');
+    expect(res.body.role).toBe('admin');
+  });
+
+  test('POST /propose with no active_role → 403', async () => {
+    seedAuth({ role: null });
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'sleep help' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cart_unavailable_for_role');
+  });
+});
+
+// =============================================================================
+// Request validation
+// =============================================================================
+
+describe(`${'VTID-03260'} request validation`, () => {
+  test('400 on empty prompt', async () => {
+    seedAuth({ role: 'community' });
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: '' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+  });
+
+  test('400 on prompt over 500 chars', async () => {
+    seedAuth({ role: 'community' });
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'x'.repeat(501) });
+    expect(res.status).toBe(400);
+  });
+});
+
+// =============================================================================
+// (e) llm_unavailable → 502
+// =============================================================================
+
+describe(`${'VTID-03260'} (e) llm_unavailable`, () => {
+  test('router failure → 502 llm_unavailable, no fabricated picks, no cart writes', async () => {
+    seedAuth({ role: 'community' });
+    // cart resolution: existing active cart
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    mockCallViaRouter.mockResolvedValue({ ok: false, error: 'Provider has no credentials configured' });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'help me sleep' });
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({ ok: false, error: 'llm_unavailable' });
+    // NEVER fabricated picks → zero item inserts.
+    expect(mockSupabase.__insertsFor('universal_cart_items')).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// (a) Hard-filtered products NEVER appear + (c) metadata/source_surface
+// =============================================================================
+
+describe(`${'VTID-03260'} (a) safety invariant + (c) proposal shape`, () => {
+  test('allergen-conflicting product is filtered out and never proposed; safe product is', async () => {
+    seedAuth({ role: 'community' });
+    // cart resolution → existing active cart
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    seedPlannerOk();
+    // products search returns BOTH a safe row and an allergen-conflicting row.
+    mockSupabase.__seed({ data: [SAFE_ROW, ALLERGEN_ROW], error: null });
+    // insert of the (only) safe pick → returns its row id
+    mockSupabase.__seed({ data: { id: ITEM_1 }, error: null });
+    // item.added event insert (best-effort)
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'help me sleep', max_items: 4 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.run_id).toBe('string');
+
+    // The allergen product must NOT be in proposals.
+    const proposedProductIds = res.body.proposed.map((p: any) => p.product_id);
+    expect(proposedProductIds).toContain(SAFE_PRODUCT);
+    expect(proposedProductIds).not.toContain(ALLERGEN_PRODUCT);
+
+    // Exactly one item inserted (the safe one).
+    const itemInserts = mockSupabase.__insertsFor('universal_cart_items');
+    expect(itemInserts).toHaveLength(1);
+    expect(itemInserts[0].product_id).toBe(SAFE_PRODUCT);
+    // (c) source_surface autopilot + agent metadata blob + price lock.
+    expect(itemInserts[0].source_surface).toBe('autopilot');
+    expect(itemInserts[0].metadata.origin).toBe('agent');
+    expect(itemInserts[0].metadata.run_id).toBe(res.body.run_id);
+    expect(Array.isArray(itemInserts[0].metadata.safety_flags)).toBe(true);
+    expect(typeof itemInserts[0].metadata.confidence).toBe('number');
+    expect(typeof itemInserts[0].metadata.proposed_at).toBe('string');
+    expect(itemInserts[0].unit_price_cents_snapshot).toBe(1999);
+    expect(itemInserts[0].currency_snapshot).toBe('EUR');
+    expect(itemInserts[0].item_type).toBe('supplement');
+
+    // The proposal echoes rationale + safety_flags + confidence.
+    const safePick = res.body.proposed.find((p: any) => p.product_id === SAFE_PRODUCT);
+    expect(safePick.item_id).toBe(ITEM_1);
+    expect(typeof safePick.rationale).toBe('string');
+    expect(Array.isArray(safePick.safety_flags)).toBe(true);
+    expect(typeof safePick.confidence).toBe('number');
+  });
+
+  test('applyUserLimitations directly drops the allergen product (substrate guarantee)', () => {
+    const ctx = makeCtx(); // allergies = ['peanut']
+    const { allowed } = applyUserLimitations([SAFE_ROW as any, ALLERGEN_ROW as any], ctx, { surface: 'shopping_agent' });
+    const ids = allowed.map((p) => p.id);
+    expect(ids).toContain(SAFE_PRODUCT);
+    expect(ids).not.toContain(ALLERGEN_PRODUCT);
+  });
+});
+
+// =============================================================================
+// (d) NO checkout / charge side effect
+// =============================================================================
+
+describe(`${'VTID-03260'} (d) no checkout/charge path`, () => {
+  test('propose never touches checkout/product_orders/wallet tables', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    seedPlannerOk();
+    mockSupabase.__seed({ data: [SAFE_ROW], error: null });
+    mockSupabase.__seed({ data: { id: ITEM_1 }, error: null });
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'help me sleep' });
+
+    expect(res.status).toBe(200);
+    // Money-path tables must never be touched.
+    expect(mockSupabase.__sawFrom('product_orders')).toBe(false);
+    expect(mockSupabase.__sawFrom('checkout_sessions')).toBe(false);
+    expect(mockSupabase.__sawFrom('user_wallets')).toBe(false);
+    expect(mockSupabase.__sawFrom('wallet_ledger_entries')).toBe(false);
+    // Only the proposal write surface (universal_cart_items) is used.
+    expect(mockSupabase.__sawFrom('universal_cart_items')).toBe(true);
+  });
+});
+
+// =============================================================================
+// (f) Empty brain → advisory no_health_profile, graceful degrade
+// =============================================================================
+
+describe(`${'VTID-03260'} (f) empty brain`, () => {
+  test('empty/stale brain → advisory no_health_profile, still proposes', async () => {
+    seedAuth({ role: 'community' });
+    mockGetUserHealthContext.mockResolvedValue(emptyCtx());
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    seedPlannerOk();
+    mockSupabase.__seed({ data: [SAFE_ROW], error: null });
+    mockSupabase.__seed({ data: { id: ITEM_1 }, error: null });
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'help me sleep' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.advisory).toContain('no_health_profile');
+    // Degrades gracefully — still returns a proposal for the safe product.
+    expect(res.body.proposed.map((p: any) => p.product_id)).toContain(SAFE_PRODUCT);
+  });
+
+  test('LLM ok but zero candidates pass filters → 200 proposed:[] with explanatory advisory', async () => {
+    seedAuth({ role: 'community' });
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    seedPlannerOk();
+    // search returns only the allergen product → filtered to empty.
+    mockSupabase.__seed({ data: [ALLERGEN_ROW], error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'peanut protein' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.proposed).toEqual([]);
+    expect(res.body.advisory).toContain('no_candidates_passed_filters');
+    expect(mockSupabase.__insertsFor('universal_cart_items')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Phase 1 (gateway) — propose-then-approve shopping agent

The app's **first real agent**. A new endpoint fills the user's **one** universal cart with agent-proposed items, each carrying a rationale + soft safety flags. The user always reviews and taps the existing **Approve & Pay** (universal-cart checkout). **This endpoint never checks out and never charges.** Built entirely on existing plumbing — no new AI stack, no new secret.

### Endpoint
`POST /api/v1/shopping-agent/propose` (+ `/health`), community-only via the cart's `authorizeCommunityCaller` (identical 403).
- Request `{ prompt, max_items? }` → Success `{ ok, run_id, proposed[], advisory[] }`.
- Writes each pick into the caller's active cart as a `universal_cart_items` row: `source_surface:'autopilot'`, `metadata {origin:'agent', rationale, safety_flags, confidence, run_id, proposed_at}`, price-locked (`unit_price_cents_snapshot` + `currency_snapshot`).

### Reused, not rebuilt
- **The brain** — `getUserHealthContext()` (allergies, dietary, contraindications, medications, conditions, goals, budget).
- **Candidate search** — the same `applyUserLimitations()` hard-filter substrate as discover-search.
- **LLM** — `llm-router` (Anthropic / Gemini; keys already configured).

### The two invariants (verified in code + tests)
- **Safety by construction** — the agent's *only* selection path is `searchCandidates()`, which does `in_stock` + `applyUserLimitations()` (strips allergen / contraindication / medication / geo conflicts) before returning. A hard-blocked product can never be proposed. `safety_flags` only ever carry *soft* signals.
- **No money path** — zero imports of checkout/Stripe/wallet/`product_orders`; tests assert those tables are never touched. Budget cap is advisory-only.
- **Fail-loud** — no LLM provider reachable → **502 `llm_unavailable`**, never fabricated picks.

### Tests
`test/shopping-agent.test.ts` — **12 passing** (allergen never proposed, role gate, metadata/source_surface shape, no checkout/charge side-effects, `llm_unavailable` 502, empty-brain advisory). `test/universal-cart.test.ts` regression — **38/38 still green**. `tsc --noEmit` clean.

> Note: `npm run lint` cannot run in this package (no ESLint config exists repo-wide — pre-existing); 0 new issues introduced.

### Paired with
Frontend PR in `vitana-v1` (the "Vitana schlägt vor" UI). VTID-03260. Draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCKVrJGmWJpz2T9psbTX61)_