### PR TITLE
feat(shopping-agent): Phase 2 — standing budget + reorder (VTID-03260)

### DIFF
--- a/services/gateway/src/routes/shopping-agent.ts
+++ b/services/gateway/src/routes/shopping-agent.ts
@@ -33,6 +33,11 @@ import { getSupabase } from '../lib/supabase';
 import { authorizeCommunityCaller, emitCartEvent } from './universal-cart';
 import { getUserHealthContext } from '../services/user-health-context';
 import { runPropose, type AnnotatedPick, type InsertPickFn } from '../services/shopping-agent/agent-core';
+import { getMonthlySpend } from '../services/budget/spend-service';
+import { buildReorderPicks } from '../services/shopping-agent/reorder-core';
+
+/** Default currency fallback (matches the rest of the gateway's commerce code). */
+const DEFAULT_CURRENCY = 'EUR';
 
 export const VTID = 'VTID-03260';
 
@@ -51,6 +56,16 @@ const ProposeBody = z.object({
 function clampMaxItems(raw: number | undefined): number {
   if (raw === undefined || !Number.isFinite(raw)) return 4;
   return Math.max(1, Math.min(6, Math.floor(raw)));
+}
+
+const ReorderBody = z.object({
+  max_items: z.number().int().optional(),
+});
+
+/** Clamp reorder max_items to 1..10, default 6. */
+function clampReorderMaxItems(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw)) return 6;
+  return Math.max(1, Math.min(10, Math.floor(raw)));
 }
 
 function isNoRowsError(error: any): boolean {
@@ -99,6 +114,12 @@ router.post('/propose', async (req: Request, res: Response) => {
 
   // Read-only product search uses the service-role client (same as discover-search).
   const searchClient = getSupabase();
+
+  // Phase 2: standing month-to-date CONVERTED spend (per the user's currency) so
+  // the near/over monthly-cap advisory reflects total projected spend. READ-ONLY;
+  // advisory only — never blocks the proposal.
+  const proposeCurrency = ctx.currency ?? DEFAULT_CURRENCY;
+  const monthlySpendCents = await getMonthlySpend(searchClient, id.user_id, proposeCurrency);
 
   // Cart writes use the RLS-scoped user client (owner isolation enforced by RLS).
   const userClient = createUserSupabaseClient(id.token);
@@ -172,6 +193,7 @@ router.post('/propose', async (req: Request, res: Response) => {
     supabase: searchClient,
     insertPick,
     runId,
+    monthly_spend_cents: monthlySpendCents,
   });
 
   // Fail loud when no LLM provider is configured/reachable. NEVER fabricate picks.
@@ -187,6 +209,142 @@ router.post('/propose', async (req: Request, res: Response) => {
     run_id: result.run_id,
     proposed: result.proposed ?? [],
     advisory: result.advisory ?? [],
+  });
+});
+
+/**
+ * POST /reorder — build reorder picks from the caller's past purchases and write
+ * them into the active cart via the SAME insertPick path /propose uses, tagged
+ * metadata.origin='reorder'. NEVER checks out, never charges. Out-of-stock /
+ * inactive SKUs are dropped (buildReorderPicks), and CURRENT price/currency is
+ * re-snapshotted at proposal time.
+ */
+router.post('/reorder', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  // impact-allow-no-oasis: each reordered item emits an item.added cart event to
+  // universal_cart_events via emitCartEvent (the end-user commerce sink), not
+  // oasis_events. oasis_events is the VTID lifecycle/governance log (CLAUDE.md
+  // §6), not a commerce ledger — identical to the /propose slice's handler. No
+  // state transition here belongs in OASIS; this endpoint only fills a cart and
+  // never charges.
+
+  const parsed = ReorderBody.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: 'invalid_request',
+      detail: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+    });
+  }
+  const maxItems = clampReorderMaxItems(parsed.data.max_items);
+
+  // Brain: carries past_purchases (converted product_orders, newest-first).
+  const ctx = await getUserHealthContext(id.user_id);
+
+  // Read-only product hydrate uses the service-role client (same as /propose).
+  const searchClient = getSupabase();
+
+  // Cart writes use the RLS-scoped user client (owner isolation enforced by RLS).
+  const userClient = createUserSupabaseClient(id.token);
+
+  const cartResolution = await resolveActiveCartId(userClient, id.user_id, id.tenant_id);
+  if (!cartResolution.ok) {
+    return res.status(500).json({ ok: false, error: cartResolution.error });
+  }
+  const cartId = cartResolution.cartId;
+
+  const runId = randomUUID();
+  const proposedAt = new Date().toISOString();
+
+  // Build reorder picks (dedupe → hydrate → drop non-in-stock/inactive → re-snapshot).
+  const picks = await buildReorderPicks(searchClient, ctx, maxItems);
+
+  if (picks.length === 0) {
+    return res.status(200).json({
+      ok: true,
+      run_id: runId,
+      proposed: [],
+      advisory: ['no_reorderable_items'],
+    });
+  }
+
+  // SAME insert path as /propose: one universal_cart_items row per pick, with the
+  // agent metadata blob (origin='reorder') + price lock + source_surface 'autopilot'.
+  const proposed: Array<{
+    item_id: string;
+    product_id: string;
+    title: string;
+    rationale: string;
+    safety_flags: string[];
+    confidence: number;
+  }> = [];
+
+  for (const pick of picks) {
+    const insertPayload: Record<string, unknown> = {
+      cart_id: cartId,
+      item_type: pick.item_type,
+      product_id: pick.product_id,
+      quantity: 1,
+      status: 'active',
+      source_surface: 'autopilot',
+      metadata: {
+        origin: 'reorder',
+        rationale: pick.rationale,
+        safety_flags: pick.safety_flags,
+        confidence: pick.confidence,
+        run_id: runId,
+        proposed_at: proposedAt,
+        previously_purchased_at: pick.previously_purchased_at,
+      },
+    };
+    // Price lock: snapshot CURRENT unit price + currency at proposal time.
+    if (pick.unit_price_cents_snapshot !== null) insertPayload.unit_price_cents_snapshot = pick.unit_price_cents_snapshot;
+    if (pick.currency_snapshot !== null) insertPayload.currency_snapshot = pick.currency_snapshot;
+
+    const inserted = await userClient
+      .from('universal_cart_items')
+      .insert(insertPayload)
+      .select('id')
+      .single();
+
+    if (inserted.error || !inserted.data) {
+      console.error(`[${VTID}] reorder insert failed for product ${pick.product_id}: ${inserted.error?.message}`);
+      continue; // best-effort: a single failed insert must not sink the whole run
+    }
+
+    const itemId = inserted.data.id as string;
+
+    // Audit: same item.added event the cart emits on a manual add.
+    await emitCartEvent({
+      cart_id: cartId,
+      user_id: id.user_id,
+      event_type: 'item.added',
+      event_payload: {
+        cart_item_id: itemId,
+        product_id: pick.product_id,
+        quantity_before: 0,
+        quantity_after: 1,
+        source_surface: 'autopilot',
+      },
+    });
+
+    proposed.push({
+      item_id: itemId,
+      product_id: pick.product_id,
+      title: pick.title,
+      rationale: pick.rationale,
+      safety_flags: pick.safety_flags,
+      confidence: pick.confidence,
+    });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    run_id: runId,
+    proposed,
+    advisory: [],
   });
 });
 

--- a/services/gateway/src/routes/universal-cart.ts
+++ b/services/gateway/src/routes/universal-cart.ts
@@ -37,8 +37,15 @@ import { z } from 'zod';
 import { createUserSupabaseClient } from '../lib/supabase-user';
 import { getSupabase } from '../lib/supabase';
 import { checkoutUniversalCart, CHECKOUT_ERROR_STATUS } from '../services/checkout/checkout-service';
+import { getMonthlySpend } from '../services/budget/spend-service';
 
 export const VTID = 'VTID-03213';
+
+/** Default currency fallback (matches the rest of the gateway's commerce code). */
+const DEFAULT_CURRENCY = 'EUR';
+
+/** Near-cap advisory ratio — projected spend within 15% of the cap → 'near'. */
+const NEAR_CAP_RATIO = 0.85;
 
 // =============================================================================
 // Constants — keep in sync with supabase/migrations/20260605000000_VTID_03186_universal_cart_schema.sql
@@ -425,6 +432,119 @@ router.get('/', async (req: Request, res: Response) => {
   }
 
   return res.status(200).json({ ok: true, cart: cartRes.data, items: itemsRes.data ?? [] });
+});
+
+/**
+ * GET /budget — VTID-03260 (Phase 2) standing-budget read.
+ *
+ * Read-only budget summary for the caller, in their currency_preference (per
+ * currency, never mixed). ADVISORY ONLY: never blocks or charges anything.
+ *
+ * Response:
+ *   { ok, monthly_cap_cents, spent_this_month_cents, cart_active_subtotal_cents,
+ *     currency, status: 'under'|'near'|'over' }
+ *
+ * status: null/0 cap → 'under'. Else projected = spent + cart subtotal;
+ *   'over' if projected > cap; 'near' if projected >= 0.85*cap; else 'under'.
+ */
+router.get('/budget', async (req: Request, res: Response) => {
+  const id = await authorizeCommunityCaller(req, res);
+  if (!id) return;
+
+  const svc = getSupabase();
+
+  // Currency + monthly cap from the user's profile/limitations (service-role read,
+  // consistent with the spend read). currency_preference falls back to the same
+  // default the rest of the commerce code uses.
+  let currency = DEFAULT_CURRENCY;
+  let monthly_cap_cents: number | null = null;
+
+  if (svc) {
+    const userRow = await svc
+      .from('app_users')
+      .select('currency_preference')
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    if (!userRow.error && userRow.data?.currency_preference) {
+      currency = userRow.data.currency_preference as string;
+    }
+
+    const limRow = await svc
+      .from('user_limitations')
+      .select('budget_monthly_cap_cents')
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    if (!limRow.error && limRow.data) {
+      monthly_cap_cents = (limRow.data.budget_monthly_cap_cents as number | null) ?? null;
+    }
+  }
+
+  // Month-to-date CONVERTED spend in this currency.
+  const spent_this_month_cents = await getMonthlySpend(svc, id.user_id, currency);
+
+  // Active-cart subtotal = sum(coalesce(unit_price_cents_snapshot,0) * quantity)
+  // over the caller's active cart items. RLS-scoped user client.
+  const userClient = createUserSupabaseClient(id.token);
+  let cart_active_subtotal_cents = 0;
+
+  const cartRes = await userClient
+    .from('universal_carts')
+    .select('id')
+    .eq('user_id', id.user_id)
+    .eq('status', 'active')
+    .maybeSingle();
+
+  if (cartRes.error && !isNoRowsError(cartRes.error)) {
+    return res.status(500).json({
+      ok: false,
+      error: 'cart_lookup_failed',
+      detail: cartRes.error.message,
+    });
+  }
+
+  if (cartRes.data?.id) {
+    const itemsRes = await userClient
+      .from('universal_cart_items')
+      .select('unit_price_cents_snapshot, quantity')
+      .eq('cart_id', cartRes.data.id)
+      .eq('status', 'active');
+
+    if (itemsRes.error) {
+      return res.status(500).json({
+        ok: false,
+        error: 'cart_items_lookup_failed',
+        detail: itemsRes.error.message,
+      });
+    }
+
+    for (const row of (itemsRes.data ?? []) as Array<{ unit_price_cents_snapshot: number | null; quantity: number | null }>) {
+      const unit = Number(row?.unit_price_cents_snapshot ?? 0);
+      const qty = Number(row?.quantity ?? 0);
+      if (Number.isFinite(unit) && Number.isFinite(qty)) {
+        cart_active_subtotal_cents += unit * qty;
+      }
+    }
+  }
+
+  // Status (ADVISORY ONLY).
+  let status: 'under' | 'near' | 'over' = 'under';
+  if (monthly_cap_cents && monthly_cap_cents > 0) {
+    const projected = spent_this_month_cents + cart_active_subtotal_cents;
+    if (projected > monthly_cap_cents) {
+      status = 'over';
+    } else if (projected >= monthly_cap_cents * NEAR_CAP_RATIO) {
+      status = 'near';
+    }
+  }
+
+  return res.status(200).json({
+    ok: true,
+    monthly_cap_cents,
+    spent_this_month_cents,
+    cart_active_subtotal_cents,
+    currency,
+    status,
+  });
 });
 
 /**

--- a/services/gateway/src/services/budget/spend-service.ts
+++ b/services/gateway/src/services/budget/spend-service.ts
@@ -1,0 +1,61 @@
+/**
+ * VTID-03260 — Phase 2 standing-budget read primitive.
+ *
+ * `getMonthlySpend()` sums the caller's CONVERTED first-party spend for the
+ * current calendar month, in ONE currency. It is a pure, service-role READ:
+ *
+ *   sum(product_orders.amount_cents)
+ *     WHERE user_id = <caller>
+ *       AND currency = <currency>          -- per-currency only, never mixed
+ *       AND state    = 'converted'         -- realized spend only (no pending/refunded/cancelled)
+ *       AND purchased_at >= date_trunc('month', now())
+ *
+ * Money invariant: this module NEVER writes, charges, debits a wallet, or
+ * checks out. It only reads product_orders so the budget endpoint + the
+ * shopping-agent advisory can reason about standing spend. The cap itself is
+ * ADVISORY — nothing here blocks a purchase.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const VTID = 'VTID-03260';
+
+/** Start-of-current-month in UTC as an ISO string (mirror of date_trunc('month', now())). */
+export function startOfMonthIso(now: Date = new Date()): string {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0)).toISOString();
+}
+
+/**
+ * Sum CONVERTED first-party spend for the caller in the current month, in the
+ * given currency. Returns 0 on any error / missing client (degrade gracefully —
+ * an advisory budget surface must never throw the caller's request).
+ */
+export async function getMonthlySpend(
+  supabase: SupabaseClient | null,
+  userId: string,
+  currency: string
+): Promise<number> {
+  if (!supabase) return 0;
+
+  const monthStart = startOfMonthIso();
+
+  const { data, error } = await supabase
+    .from('product_orders')
+    .select('amount_cents')
+    .eq('user_id', userId)
+    .eq('currency', currency)
+    .eq('state', 'converted')
+    .gte('purchased_at', monthStart);
+
+  if (error) {
+    console.error(`[${VTID}] getMonthlySpend failed for user ${userId}:`, error.message);
+    return 0;
+  }
+
+  let total = 0;
+  for (const row of (data ?? []) as Array<{ amount_cents: number | null }>) {
+    const cents = Number(row?.amount_cents ?? 0);
+    if (Number.isFinite(cents)) total += cents;
+  }
+  return total;
+}

--- a/services/gateway/src/services/shopping-agent/agent-core.ts
+++ b/services/gateway/src/services/shopping-agent/agent-core.ts
@@ -111,6 +111,12 @@ export interface RunProposeArgs {
   insertPick: InsertPickFn;
   /** Stable run id (uuid) tying every proposed item together. */
   runId: string;
+  /**
+   * Phase 2 — standing month-to-date CONVERTED spend (in ctx.currency), used to
+   * compute the near/over monthly-cap advisories against (spend + proposed
+   * subtotal). ADVISORY ONLY; defaults to 0 for back-compatibility.
+   */
+  monthly_spend_cents?: number;
 }
 
 // =============================================================================
@@ -440,6 +446,7 @@ const NEAR_CAP_RATIO = 0.85;
 
 export async function runPropose(args: RunProposeArgs): Promise<ProposeResult> {
   const { prompt, maxItems, ctx, supabase, insertPick, runId } = args;
+  const monthlySpendCents = args.monthly_spend_cents ?? 0;
   const advisory: string[] = [];
 
   // Brain empty / stale → advisory (still degrade gracefully).
@@ -487,10 +494,15 @@ export async function runPropose(args: RunProposeArgs): Promise<ProposeResult> {
   const top = candidates.slice(0, maxItems);
   const annotated = top.map((p) => annotatePick(p, ctx));
 
-  // Advisory: near monthly cap (ADVISORY ONLY — never enforced in the money path).
+  // Advisory: monthly-cap proximity (ADVISORY ONLY — never enforced in the money
+  // path). Phase 2: compare standing month-to-date spend PLUS this run's proposed
+  // subtotal against the cap, so the advisory reflects total projected spend.
   if (ctx.budget_monthly_cap_cents && ctx.budget_monthly_cap_cents > 0) {
     const subtotal = annotated.reduce((sum, a) => sum + (a.unit_price_cents_snapshot ?? 0), 0);
-    if (subtotal >= ctx.budget_monthly_cap_cents * NEAR_CAP_RATIO) {
+    const projected = monthlySpendCents + subtotal;
+    if (projected > ctx.budget_monthly_cap_cents) {
+      advisory.push('over_monthly_cap');
+    } else if (projected >= ctx.budget_monthly_cap_cents * NEAR_CAP_RATIO) {
       advisory.push('near_monthly_cap');
     }
   }

--- a/services/gateway/src/services/shopping-agent/reorder-core.ts
+++ b/services/gateway/src/services/shopping-agent/reorder-core.ts
@@ -1,0 +1,123 @@
+/**
+ * VTID-03260 — Phase 2 reorder core.
+ *
+ * `buildReorderPicks()` turns the caller's past_purchases (from the health
+ * context brain) into AnnotatedPicks suitable for the SAME insertPick path the
+ * /propose handler uses. It:
+ *
+ *   1. dedupes past_purchases by product_id (keeping the most-recent purchase),
+ *   2. hydrates each product_id from `products`,
+ *   3. DROPS any product that is not (is_active && availability='in_stock') — so
+ *      a reordered line survives the checkout re-validation gate downstream,
+ *   4. re-snapshots the CURRENT price_cents + currency (never reuses the old
+ *      snapshot),
+ *   5. derives item_type via deriveItemType,
+ *   6. attaches a short neutral rationale + empty safety_flags (unless the
+ *      product carries safety_notes).
+ *
+ * Money invariant: this module READS products and product-purchase history. It
+ * NEVER checks out, charges, debits a wallet, or writes product_orders. The
+ * picks it returns are proposals — the route inserts them as universal_cart_items.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { UserHealthContext } from '../user-health-context';
+import { deriveItemType, type AnnotatedPick } from './agent-core';
+
+export const VTID = 'VTID-03260';
+
+/** Columns we hydrate for a reorder candidate. */
+const REORDER_PRODUCT_COLUMNS =
+  'id, title, category, price_cents, currency, safety_notes, is_active, availability';
+
+interface ReorderProductRow {
+  id: string;
+  title: string | null;
+  category: string | null;
+  price_cents: number | null;
+  currency: string | null;
+  safety_notes: string | null;
+  is_active: boolean | null;
+  availability: string | null;
+}
+
+/**
+ * One reorder pick carries the same AnnotatedPick shape as a /propose pick,
+ * plus the previously_purchased_at the route stamps into metadata.
+ */
+export interface ReorderPick extends AnnotatedPick {
+  previously_purchased_at: string;
+}
+
+/**
+ * Build reorder picks from the caller's past_purchases. Returns at most
+ * `maxItems` picks, in most-recently-purchased-first order. Out-of-stock /
+ * inactive SKUs are dropped so the reordered lines stay purchasable.
+ */
+export async function buildReorderPicks(
+  supabase: SupabaseClient | null,
+  ctx: UserHealthContext,
+  maxItems: number
+): Promise<ReorderPick[]> {
+  if (!supabase) return [];
+
+  // 1. Dedupe by product_id, keeping the most-recent purchased_at. past_purchases
+  //    arrives newest-first (product_orders ordered purchased_at DESC), so the
+  //    first occurrence wins.
+  const firstSeen = new Map<string, string>(); // product_id -> purchased_at
+  const order: string[] = [];
+  for (const p of ctx.past_purchases) {
+    if (!p.product_id) continue;
+    if (firstSeen.has(p.product_id)) continue;
+    firstSeen.set(p.product_id, p.purchased_at);
+    order.push(p.product_id);
+  }
+  if (order.length === 0) return [];
+
+  // 2. Hydrate from products (single batched read).
+  const { data, error } = await supabase
+    .from('products')
+    .select(REORDER_PRODUCT_COLUMNS)
+    .in('id', order);
+
+  if (error) {
+    console.error(`[${VTID}] buildReorderPicks product hydrate failed:`, error.message);
+    return [];
+  }
+
+  const byId = new Map<string, ReorderProductRow>();
+  for (const row of (data ?? []) as ReorderProductRow[]) {
+    if (row?.id) byId.set(row.id, row);
+  }
+
+  // 3. Walk in purchase-recency order, drop non-in-stock/inactive, build picks.
+  const picks: ReorderPick[] = [];
+  for (const productId of order) {
+    if (picks.length >= maxItems) break;
+    const row = byId.get(productId);
+    if (!row) continue;
+    // DROP anything not currently purchasable so reordered lines survive checkout
+    // re-validation.
+    if (row.is_active !== true || row.availability !== 'in_stock') continue;
+
+    const safetyFlags: string[] = [];
+    if (row.safety_notes && row.safety_notes.trim()) safetyFlags.push('has_safety_notes');
+
+    picks.push({
+      product_id: row.id,
+      title: row.title ?? 'Product',
+      // Neutral server-side rationale key-ish text; the FE localizes via origin.
+      rationale: 'Previously purchased — reorder',
+      safety_flags: safetyFlags,
+      // Reorders are high-confidence by definition (the user already bought it).
+      confidence: 0.9,
+      item_type: deriveItemType(row.category),
+      // 4. Re-snapshot CURRENT price + currency (never reuse the old snapshot).
+      unit_price_cents_snapshot: row.price_cents ?? null,
+      currency_snapshot: row.currency ?? null,
+      previously_purchased_at: firstSeen.get(productId)!,
+    });
+  }
+
+  return picks;
+}

--- a/services/gateway/test/services/spend-service.test.ts
+++ b/services/gateway/test/services/spend-service.test.ts
@@ -1,0 +1,92 @@
+/**
+ * VTID-03260 — Phase 2 getMonthlySpend() unit tests.
+ *
+ * getMonthlySpend sums product_orders.amount_cents for ONE user, in ONE
+ * currency, restricted to state='converted' and the current calendar month.
+ * These tests assert:
+ *   - it scopes the query with eq(user_id), eq(currency), eq(state,'converted'),
+ *     gte(purchased_at, start-of-month) — so refunded/cancelled rows, prior
+ *     months, and other currencies are excluded at the source;
+ *   - it sums only what the (already-scoped) query returns;
+ *   - it degrades to 0 on error / null client.
+ */
+
+import { getMonthlySpend, startOfMonthIso } from '../../src/services/budget/spend-service';
+
+type Filter = { op: string; args: any[] };
+
+/** Recording mock: captures every filter applied, returns the seeded rows. */
+function makeRecordingClient(rows: any[] | null, error: any = null) {
+  const filters: Filter[] = [];
+  const builder: any = {
+    from: (...a: any[]) => { filters.push({ op: 'from', args: a }); return builder; },
+    select: (...a: any[]) => { filters.push({ op: 'select', args: a }); return builder; },
+    eq: (...a: any[]) => { filters.push({ op: 'eq', args: a }); return builder; },
+    gte: (...a: any[]) => { filters.push({ op: 'gte', args: a }); return builder; },
+    then: (resolve: any) => Promise.resolve({ data: rows, error }).then(resolve),
+  };
+  return { client: builder as any, filters };
+}
+
+const USER = '11111111-1111-4000-a000-000000000a01';
+
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+beforeEach(() => consoleErrorSpy.mockClear());
+
+describe('VTID-03260 getMonthlySpend — query scoping', () => {
+  test('applies user_id, currency, state=converted, and current-month gte filters', async () => {
+    const { client, filters } = makeRecordingClient([{ amount_cents: 1000 }, { amount_cents: 500 }]);
+    const total = await getMonthlySpend(client, USER, 'EUR');
+
+    expect(total).toBe(1500);
+
+    expect(filters.some((f) => f.op === 'from' && f.args[0] === 'product_orders')).toBe(true);
+    expect(filters.some((f) => f.op === 'eq' && f.args[0] === 'user_id' && f.args[1] === USER)).toBe(true);
+    expect(filters.some((f) => f.op === 'eq' && f.args[0] === 'currency' && f.args[1] === 'EUR')).toBe(true);
+    // EXCLUDES refunded/cancelled/pending/chargeback — only 'converted' is summed.
+    expect(filters.some((f) => f.op === 'eq' && f.args[0] === 'state' && f.args[1] === 'converted')).toBe(true);
+    // EXCLUDES prior months via gte(purchased_at, start-of-month).
+    const gte = filters.find((f) => f.op === 'gte' && f.args[0] === 'purchased_at');
+    expect(gte).toBeDefined();
+    expect(gte!.args[1]).toBe(startOfMonthIso());
+  });
+
+  test('per-currency only — a USD query carries currency=USD (never mixes)', async () => {
+    const { client, filters } = makeRecordingClient([{ amount_cents: 2500 }]);
+    const total = await getMonthlySpend(client, USER, 'USD');
+    expect(total).toBe(2500);
+    expect(filters.some((f) => f.op === 'eq' && f.args[0] === 'currency' && f.args[1] === 'USD')).toBe(true);
+    expect(filters.some((f) => f.op === 'eq' && f.args[0] === 'currency' && f.args[1] === 'EUR')).toBe(false);
+  });
+
+  test('sums only the rows the scoped query returns', async () => {
+    const { client } = makeRecordingClient([
+      { amount_cents: 100 },
+      { amount_cents: 250 },
+      { amount_cents: null }, // tolerated → treated as 0
+    ]);
+    expect(await getMonthlySpend(client, USER, 'EUR')).toBe(350);
+  });
+
+  test('empty result → 0', async () => {
+    const { client } = makeRecordingClient([]);
+    expect(await getMonthlySpend(client, USER, 'EUR')).toBe(0);
+  });
+
+  test('query error → 0 (advisory read must not throw)', async () => {
+    const { client } = makeRecordingClient(null, { message: 'boom' });
+    expect(await getMonthlySpend(client, USER, 'EUR')).toBe(0);
+  });
+
+  test('null client → 0', async () => {
+    expect(await getMonthlySpend(null, USER, 'EUR')).toBe(0);
+  });
+});
+
+describe('VTID-03260 startOfMonthIso', () => {
+  test('returns the first instant of the current UTC month', () => {
+    const fixed = new Date(Date.UTC(2026, 5, 17, 13, 45, 0)); // 2026-06-17
+    expect(startOfMonthIso(fixed)).toBe('2026-06-01T00:00:00.000Z');
+  });
+});

--- a/services/gateway/test/shopping-agent.test.ts
+++ b/services/gateway/test/shopping-agent.test.ts
@@ -314,6 +314,8 @@ describe(`${'VTID-03260'} request validation`, () => {
 describe(`${'VTID-03260'} (e) llm_unavailable`, () => {
   test('router failure → 502 llm_unavailable, no fabricated picks, no cart writes', async () => {
     seedAuth({ role: 'community' });
+    // getMonthlySpend product_orders read (runs before cart resolution)
+    mockSupabase.__seed({ data: [], error: null });
     // cart resolution: existing active cart
     mockSupabase.__seed({ data: { id: CART_A }, error: null });
     mockCallViaRouter.mockResolvedValue({ ok: false, error: 'Provider has no credentials configured' });
@@ -337,6 +339,8 @@ describe(`${'VTID-03260'} (e) llm_unavailable`, () => {
 describe(`${'VTID-03260'} (a) safety invariant + (c) proposal shape`, () => {
   test('allergen-conflicting product is filtered out and never proposed; safe product is', async () => {
     seedAuth({ role: 'community' });
+    // getMonthlySpend product_orders read (runs before cart resolution)
+    mockSupabase.__seed({ data: [], error: null });
     // cart resolution → existing active cart
     mockSupabase.__seed({ data: { id: CART_A }, error: null });
     seedPlannerOk();
@@ -398,8 +402,10 @@ describe(`${'VTID-03260'} (a) safety invariant + (c) proposal shape`, () => {
 // =============================================================================
 
 describe(`${'VTID-03260'} (d) no checkout/charge path`, () => {
-  test('propose never touches checkout/product_orders/wallet tables', async () => {
+  test('propose never touches checkout/charge tables (product_orders is READ-only for budget)', async () => {
     seedAuth({ role: 'community' });
+    // getMonthlySpend product_orders read (runs before cart resolution)
+    mockSupabase.__seed({ data: [], error: null });
     mockSupabase.__seed({ data: { id: CART_A }, error: null });
     seedPlannerOk();
     mockSupabase.__seed({ data: [SAFE_ROW], error: null });
@@ -412,12 +418,14 @@ describe(`${'VTID-03260'} (d) no checkout/charge path`, () => {
       .send({ prompt: 'help me sleep' });
 
     expect(res.status).toBe(200);
-    // Money-path tables must never be touched.
-    expect(mockSupabase.__sawFrom('product_orders')).toBe(false);
+    // Charge/checkout tables must never be touched at all.
     expect(mockSupabase.__sawFrom('checkout_sessions')).toBe(false);
     expect(mockSupabase.__sawFrom('user_wallets')).toBe(false);
     expect(mockSupabase.__sawFrom('wallet_ledger_entries')).toBe(false);
-    // Only the proposal write surface (universal_cart_items) is used.
+    // Phase 2: product_orders may be READ for the standing-spend advisory, but
+    // NEVER written (no insert/update) — proposing is not charging.
+    expect(mockSupabase.__insertsFor('product_orders')).toHaveLength(0);
+    // Only the proposal write surface (universal_cart_items) is written.
     expect(mockSupabase.__sawFrom('universal_cart_items')).toBe(true);
   });
 });
@@ -430,6 +438,8 @@ describe(`${'VTID-03260'} (f) empty brain`, () => {
   test('empty/stale brain → advisory no_health_profile, still proposes', async () => {
     seedAuth({ role: 'community' });
     mockGetUserHealthContext.mockResolvedValue(emptyCtx());
+    // getMonthlySpend product_orders read (runs before cart resolution)
+    mockSupabase.__seed({ data: [], error: null });
     mockSupabase.__seed({ data: { id: CART_A }, error: null });
     seedPlannerOk();
     mockSupabase.__seed({ data: [SAFE_ROW], error: null });
@@ -449,6 +459,8 @@ describe(`${'VTID-03260'} (f) empty brain`, () => {
 
   test('LLM ok but zero candidates pass filters → 200 proposed:[] with explanatory advisory', async () => {
     seedAuth({ role: 'community' });
+    // getMonthlySpend product_orders read (runs before cart resolution)
+    mockSupabase.__seed({ data: [], error: null });
     mockSupabase.__seed({ data: { id: CART_A }, error: null });
     seedPlannerOk();
     // search returns only the allergen product → filtered to empty.
@@ -463,5 +475,212 @@ describe(`${'VTID-03260'} (f) empty brain`, () => {
     expect(res.body.proposed).toEqual([]);
     expect(res.body.advisory).toContain('no_candidates_passed_filters');
     expect(mockSupabase.__insertsFor('universal_cart_items')).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// Phase 2 — over_monthly_cap advisory (spend + subtotal > cap)
+// =============================================================================
+
+describe(`${'VTID-03260'} Phase 2 over_monthly_cap advisory`, () => {
+  test('standing spend + proposed subtotal over cap → advisory over_monthly_cap', async () => {
+    // cap = 5000; one SAFE pick at 1999; standing month-to-date spend = 4000.
+    // projected = 4000 + 1999 = 5999 > 5000 → over_monthly_cap.
+    seedAuth({ role: 'community' });
+    mockGetUserHealthContext.mockResolvedValue(makeCtx({ budget_monthly_cap_cents: 5000 }));
+    // getMonthlySpend product_orders read (runs BEFORE cart resolution) → 4000 converted
+    mockSupabase.__seed({ data: [{ amount_cents: 4000 }], error: null });
+    // cart resolution → existing active cart
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    seedPlannerOk();
+    mockSupabase.__seed({ data: [SAFE_ROW], error: null });
+    mockSupabase.__seed({ data: { id: ITEM_1 }, error: null });
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'help me sleep' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.advisory).toContain('over_monthly_cap');
+    expect(res.body.advisory).not.toContain('near_monthly_cap');
+  });
+
+  test('low standing spend + small subtotal under cap → no cap advisory', async () => {
+    seedAuth({ role: 'community' });
+    mockGetUserHealthContext.mockResolvedValue(makeCtx({ budget_monthly_cap_cents: 100000 }));
+    mockSupabase.__seed({ data: [{ amount_cents: 1000 }], error: null }); // tiny standing spend (read first)
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    seedPlannerOk();
+    mockSupabase.__seed({ data: [SAFE_ROW], error: null });
+    mockSupabase.__seed({ data: { id: ITEM_1 }, error: null });
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/propose')
+      .set('Authorization', BEARER_A)
+      .send({ prompt: 'help me sleep' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.advisory).not.toContain('over_monthly_cap');
+    expect(res.body.advisory).not.toContain('near_monthly_cap');
+  });
+});
+
+// =============================================================================
+// Phase 2 — POST /reorder
+// =============================================================================
+
+const REORDER_PRODUCT_1 = '88888888-8888-4000-f000-000000000f08';
+const REORDER_PRODUCT_2 = '99999999-9999-4000-f000-000000000f09';
+
+/** An in-stock active product row (reorder hydrate shape). */
+const IN_STOCK_ROW = {
+  id: REORDER_PRODUCT_1,
+  title: 'Vitamin D3',
+  category: 'supplement',
+  price_cents: 1299,
+  currency: 'EUR',
+  safety_notes: null,
+  is_active: true,
+  availability: 'in_stock',
+};
+
+/** An out-of-stock product row — must be dropped. */
+const OUT_OF_STOCK_ROW = {
+  id: REORDER_PRODUCT_2,
+  title: 'Discontinued Blend',
+  category: 'partner_product',
+  price_cents: 999,
+  currency: 'EUR',
+  safety_notes: null,
+  is_active: true,
+  availability: 'out_of_stock',
+};
+
+function ctxWithPastPurchases(productIds: string[]): UserHealthContext {
+  return makeCtx({
+    past_purchases: productIds.map((pid, i) => ({
+      product_id: pid,
+      purchased_at: `2026-0${i + 1}-15T00:00:00.000Z`,
+      reordered: false,
+    })),
+  });
+}
+
+describe(`${'VTID-03260'} Phase 2 reorder role gating`, () => {
+  test('POST /reorder without Bearer → 401', async () => {
+    const res = await request(buildApp()).post('/api/v1/shopping-agent/reorder').send({});
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  test('POST /reorder with role=admin → 403 cart_unavailable_for_role', async () => {
+    seedAuth({ role: 'admin' });
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/reorder')
+      .set('Authorization', BEARER_A)
+      .send({});
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cart_unavailable_for_role');
+  });
+});
+
+describe(`${'VTID-03260'} Phase 2 reorder behavior`, () => {
+  test('empty past purchases → proposed:[] + advisory no_reorderable_items, no inserts', async () => {
+    seedAuth({ role: 'community' });
+    mockGetUserHealthContext.mockResolvedValue(makeCtx({ past_purchases: [] }));
+    // cart resolution → existing active cart
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/reorder')
+      .set('Authorization', BEARER_A)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.proposed).toEqual([]);
+    expect(res.body.advisory).toContain('no_reorderable_items');
+    expect(mockSupabase.__insertsFor('universal_cart_items')).toHaveLength(0);
+  });
+
+  test('drops out-of-stock/inactive products, writes origin=reorder with re-snapshotted price', async () => {
+    seedAuth({ role: 'community' });
+    mockGetUserHealthContext.mockResolvedValue(
+      ctxWithPastPurchases([REORDER_PRODUCT_1, REORDER_PRODUCT_2])
+    );
+    // cart resolution → existing active cart
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    // products hydrate (.in) → one in-stock, one out-of-stock
+    mockSupabase.__seed({ data: [IN_STOCK_ROW, OUT_OF_STOCK_ROW], error: null });
+    // insert of the single in-stock pick
+    mockSupabase.__seed({ data: { id: ITEM_1 }, error: null });
+    // item.added event insert (best-effort)
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/reorder')
+      .set('Authorization', BEARER_A)
+      .send({ max_items: 6 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.run_id).toBe('string');
+
+    // Only the in-stock product is reordered; the out-of-stock SKU is dropped.
+    const proposedIds = res.body.proposed.map((p: any) => p.product_id);
+    expect(proposedIds).toEqual([REORDER_PRODUCT_1]);
+
+    const itemInserts = mockSupabase.__insertsFor('universal_cart_items');
+    expect(itemInserts).toHaveLength(1);
+    expect(itemInserts[0].product_id).toBe(REORDER_PRODUCT_1);
+    expect(itemInserts[0].source_surface).toBe('autopilot');
+    expect(itemInserts[0].metadata.origin).toBe('reorder');
+    expect(itemInserts[0].metadata.run_id).toBe(res.body.run_id);
+    expect(typeof itemInserts[0].metadata.proposed_at).toBe('string');
+    expect(itemInserts[0].metadata.previously_purchased_at).toBe('2026-01-15T00:00:00.000Z');
+    // Re-snapshotted CURRENT price + currency.
+    expect(itemInserts[0].unit_price_cents_snapshot).toBe(1299);
+    expect(itemInserts[0].currency_snapshot).toBe('EUR');
+  });
+
+  test('all past purchases out-of-stock → proposed:[] + no_reorderable_items', async () => {
+    seedAuth({ role: 'community' });
+    mockGetUserHealthContext.mockResolvedValue(ctxWithPastPurchases([REORDER_PRODUCT_2]));
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    mockSupabase.__seed({ data: [OUT_OF_STOCK_ROW], error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/reorder')
+      .set('Authorization', BEARER_A)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.proposed).toEqual([]);
+    expect(res.body.advisory).toContain('no_reorderable_items');
+    expect(mockSupabase.__insertsFor('universal_cart_items')).toHaveLength(0);
+  });
+
+  test('reorder never touches checkout/charge tables', async () => {
+    seedAuth({ role: 'community' });
+    mockGetUserHealthContext.mockResolvedValue(ctxWithPastPurchases([REORDER_PRODUCT_1]));
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    mockSupabase.__seed({ data: [IN_STOCK_ROW], error: null });
+    mockSupabase.__seed({ data: { id: ITEM_1 }, error: null });
+    mockSupabase.__seed({ data: null, error: null });
+
+    const res = await request(buildApp())
+      .post('/api/v1/shopping-agent/reorder')
+      .set('Authorization', BEARER_A)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockSupabase.__sawFrom('product_orders')).toBe(false);
+    expect(mockSupabase.__sawFrom('checkout_sessions')).toBe(false);
+    expect(mockSupabase.__sawFrom('user_wallets')).toBe(false);
+    expect(mockSupabase.__sawFrom('wallet_ledger_entries')).toBe(false);
+    // Only the proposal write surface is used.
+    expect(mockSupabase.__sawFrom('universal_cart_items')).toBe(true);
   });
 });

--- a/services/gateway/test/universal-cart.test.ts
+++ b/services/gateway/test/universal-cart.test.ts
@@ -716,6 +716,150 @@ describe(`${'VTID-03213'} §4 item mutation + §5 event emission`, () => {
 });
 
 // =============================================================================
+// VTID-03260 Phase 2 — GET /budget
+// =============================================================================
+
+describe(`${'VTID-03260'} GET /budget`, () => {
+  test('401 without Bearer', async () => {
+    const res = await request(buildApp()).get('/api/v1/universal-cart/budget');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  test('403 cart_unavailable_for_role for non-community', async () => {
+    seedAuth({ role: 'admin' });
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/budget')
+      .set('Authorization', BEARER_A);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cart_unavailable_for_role');
+  });
+
+  /** Seed the budget reads in handler order: app_users, user_limitations,
+   * product_orders (getMonthlySpend), universal_carts, universal_cart_items. */
+  function seedBudget(opts: {
+    currency?: string;
+    capCents?: number | null;
+    spendRows?: Array<{ amount_cents: number }>;
+    cartId?: string | null;
+    itemRows?: Array<{ unit_price_cents_snapshot: number | null; quantity: number | null }>;
+  }) {
+    mockSupabase.__seed({ data: { currency_preference: opts.currency ?? 'EUR' }, error: null });
+    mockSupabase.__seed({ data: { budget_monthly_cap_cents: opts.capCents ?? null }, error: null });
+    mockSupabase.__seed({ data: opts.spendRows ?? [], error: null });
+    mockSupabase.__seed({ data: opts.cartId ? { id: opts.cartId } : null, error: null });
+    if (opts.cartId) {
+      mockSupabase.__seed({ data: opts.itemRows ?? [], error: null });
+    }
+  }
+
+  test('status under — null cap → always under', async () => {
+    seedAuth({ role: 'community' });
+    seedBudget({
+      capCents: null,
+      spendRows: [{ amount_cents: 99999 }],
+      cartId: CART_A,
+      itemRows: [{ unit_price_cents_snapshot: 5000, quantity: 2 }],
+    });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/budget')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.monthly_cap_cents).toBeNull();
+    expect(res.body.spent_this_month_cents).toBe(99999);
+    expect(res.body.cart_active_subtotal_cents).toBe(10000); // 5000 * 2
+    expect(res.body.currency).toBe('EUR');
+    expect(res.body.status).toBe('under'); // null cap → under regardless
+  });
+
+  test('status under — projected well below cap', async () => {
+    seedAuth({ role: 'community' });
+    seedBudget({
+      capCents: 100000,
+      spendRows: [{ amount_cents: 1000 }],
+      cartId: CART_A,
+      itemRows: [{ unit_price_cents_snapshot: 2000, quantity: 1 }],
+    });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/budget')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('under'); // projected 3000 < 0.85*100000
+  });
+
+  test('status near — projected >= 0.85*cap but <= cap', async () => {
+    seedAuth({ role: 'community' });
+    // cap=10000; spend=8000; cart subtotal=1000 → projected=9000 = 0.9*cap → near
+    seedBudget({
+      capCents: 10000,
+      spendRows: [{ amount_cents: 8000 }],
+      cartId: CART_A,
+      itemRows: [{ unit_price_cents_snapshot: 1000, quantity: 1 }],
+    });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/budget')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('near');
+  });
+
+  test('status over — projected > cap', async () => {
+    seedAuth({ role: 'community' });
+    // cap=10000; spend=9000; cart subtotal=2000 → projected=11000 > cap → over
+    seedBudget({
+      capCents: 10000,
+      spendRows: [{ amount_cents: 9000 }],
+      cartId: CART_A,
+      itemRows: [{ unit_price_cents_snapshot: 2000, quantity: 1 }],
+    });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/budget')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('over');
+  });
+
+  test('no active cart → subtotal 0', async () => {
+    seedAuth({ role: 'community' });
+    seedBudget({
+      capCents: 10000,
+      spendRows: [{ amount_cents: 5000 }],
+      cartId: null,
+    });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/budget')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cart_active_subtotal_cents).toBe(0);
+    expect(res.body.spent_this_month_cents).toBe(5000);
+    expect(res.body.status).toBe('under'); // 5000 < 0.85*10000
+  });
+
+  test('currency follows currency_preference (USD)', async () => {
+    seedAuth({ role: 'community' });
+    seedBudget({ currency: 'USD', capCents: null, cartId: null });
+
+    const res = await request(buildApp())
+      .get('/api/v1/universal-cart/budget')
+      .set('Authorization', BEARER_A);
+
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('USD');
+  });
+});
+
+// =============================================================================
 // §2  Owner isolation
 // =============================================================================
 


### PR DESCRIPTION
## Phase 2 (gateway) — standing budget + reorder

> Stacked on **Phase 1** (#2534) so this diff shows only Phase 2. Rebase onto `main` after #2534 merges.

Budget awareness + one-tap reorder, **all propose-then-approve**. **No DB migration.** Nothing charges or checks out — every write is a `universal_cart_items` insert (a proposal); `product_orders` is read-only.

### Endpoints / services
- **`getMonthlySpend(supabase, userId, currency)`** — service-role READ summing `product_orders.amount_cents` WHERE `state='converted'` AND `currency=<currency>` AND `purchased_at >= date_trunc('month', now())`. Per-currency only (never mixes); degrades to 0 on error.
- **`GET /api/v1/universal-cart/budget`** → `{ monthly_cap_cents, spent_this_month_cents, cart_active_subtotal_cents, currency, status }`. `status`: null/0 cap → `under`; projected = spent + active-cart subtotal; `over` if > cap, `near` if ≥ 0.85·cap, else `under`. Advisory only — never blocks checkout.
- **`POST /api/v1/shopping-agent/reorder`** — community-gated; reuses `resolveActiveCartId` + the insert/`emitCartEvent` path with `metadata.origin='reorder'`. `buildReorderPicks` dedupes past purchases, **drops any SKU not `is_active && in_stock`** and **re-snapshots current price** so reorders survive checkout re-validation. Empty/none-in-stock → `proposed:[]` + `['no_reorderable_items']`.
- **`/propose`** now threads month-to-date spend into the cap advisory; `agent-core` compares `(monthly_spend + proposed_subtotal)` vs cap → `over_monthly_cap` / `near_monthly_cap` (advisory only, back-compatible).

### Safety / governance
- **No autonomous charge, by construction** — no imports of checkout-service / wallet debit / `/universal-cart/checkout`; `product_orders` is read-only (budget). Confirmed in code + tests.
- **Budget is advisory** — status & advisories never block checkout.
- Reuses the community role gate; reuses Phase 1's `// impact-allow-no-oasis` convention. No new env/secret/cron in this MVP (the recurring re-propose scheduler is a deliberately-deferred, env-gated follow-up).

### Tests
**73 passing across 3 suites** (`universal-cart` 46/46): spend-service query scoping (excludes refunded/cancelled/prior-month/other-currency), `/budget` thresholds, `/reorder` (role gate, drops out-of-stock, `origin='reorder'`, no checkout/charge tables touched, empty → `no_reorderable_items`), `over_monthly_cap` advisory. `tsc --noEmit` clean.

### Paired with
Frontend PR in `vitana-v1` (budget meter + reorder UI). VTID-03260. Draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCKVrJGmWJpz2T9psbTX61)_