### PR TITLE
chore(gateway): trigger governed deploy for cart agent (VTID-03260)

### DIFF
--- a/services/gateway/src/routes/shopping-agent.ts
+++ b/services/gateway/src/routes/shopping-agent.ts
@@ -408,3 +408,5 @@ async function resolveActiveCartId(
 }
 
 export default router;
+
+// Deploy marker: governed redeploy for VTID-03260 (universal cart agent phases 0-2).


### PR DESCRIPTION
Triggers a governed gateway redeploy now that `VTID-03260` is registered in the OASIS ledger, so the EXEC-DEPLOY **VTID-0542 orphan-deploy gate** passes and the already-merged phases 0–2 gateway endpoints (`/api/v1/shopping-agent/propose`, `/reorder`, `/api/v1/universal-cart/budget`) deploy to Cloud Run.

Change is a single deploy-marker comment on `shopping-agent.ts` (under `services/gateway/**`, so AUTO-DEPLOY fires; build-safe). VTID-03260.

https://claude.ai/code/session_01NCKVrJGmWJpz2T9psbTX61

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCKVrJGmWJpz2T9psbTX61)_