### PR TITLE
feat(autopilot): on-demand regeneration when the queue empties (VTID-03301)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -1,0 +1,11 @@
+# Gateway service — example environment configuration.
+# Required vars (SUPABASE_URL, SUPABASE_SERVICE_ROLE, PORT, etc.) are injected by
+# the deploy workflow / Cloud Run env. This file documents OPTIONAL operator
+# knobs with sensible code-side defaults, so they are discoverable and bindable.
+
+# Autopilot on-demand regeneration (VTID-03301).
+# Cooldown/debounce window (ms) that suppresses a fresh community recommendation
+# batch when one was generated within the window — prevents back-to-back
+# completes (or a double-tapped force-refresh) from double-generating.
+# Optional: defaults to 180000 (3 minutes) at the call site when unset.
+AUTOPILOT_REGEN_COOLDOWN_MS=180000

--- a/services/gateway/src/routes/autopilot-recommendations.ts
+++ b/services/gateway/src/routes/autopilot-recommendations.ts
@@ -23,7 +23,7 @@
 import { Router, Request, Response } from 'express';
 import { createHash } from 'crypto';
 import { emitOasisEvent } from '../services/oasis-event-service';
-import { generateRecommendations, generatePersonalRecommendations, SourceType } from '../services/recommendation-engine';
+import { generateRecommendations, generatePersonalRecommendations, regenerateCommunityRecommendations, SourceType } from '../services/recommendation-engine';
 import { notifyUserAsync } from '../services/notification-service';
 import { DEFAULT_WAVE_CONFIG, buildTemplateToWaveMap } from '../services/wave-defaults';
 import { derivePillarImpact } from '../services/recommendation-engine/pillar-impact';
@@ -99,6 +99,69 @@ function annotateWithPillarImpact<T extends { contribution_vector?: unknown }>(r
 const router = Router();
 
 const LOG_PREFIX = '[VTID-01180]';
+
+/**
+ * Build the full community recommendation rows for an API response body
+ * (dedup → retired-action filter → wave/horizon enrichment → pillar_impact).
+ * Mirrors the GET / handler's community enrichment. The GET / handler remains
+ * the canonical "which recs does this user see" surface and the FE refetches it
+ * after a forced /generate, so this is a convenience projection for the
+ * /generate response (VTID-03301). Defined after COMMUNITY_ACTIONS so the
+ * retired-action filter can reference it.
+ */
+async function buildCommunityRecsResponse(
+  userId: string,
+  statuses: string[],
+  limit: number,
+): Promise<Array<Record<string, any>>> {
+  const fetchLimit = Math.max((limit + 1) * 4, 80);
+  const result = await queryRecommendationsByRole('community', userId, statuses, fetchLimit, 0);
+  let recommendations = result.ok ? (result.data || []) : [];
+
+  // Dedup by source_ref then title, preferring 'new' status (same rules as GET /).
+  const seen = new Map<string, any>();
+  for (const rec of recommendations) {
+    const k = rec.source_ref || rec.title;
+    const ex = seen.get(k);
+    if (!ex) seen.set(k, rec);
+    else if (rec.status === 'new' && ex.status !== 'new') seen.set(k, rec);
+  }
+  const seenTitles = new Set<string>();
+  recommendations = [];
+  for (const rec of seen.values()) {
+    if (seenTitles.has(rec.title)) continue;
+    seenTitles.add(rec.title);
+    recommendations.push(rec);
+  }
+
+  // Retired-action filter: only keep refs that map to a real community action.
+  recommendations = recommendations.filter((rec) => !rec.source_ref || COMMUNITY_ACTIONS[rec.source_ref]);
+
+  // Wave/horizon enrichment (mirrors GET /).
+  const templateToWave = buildTemplateToWaveMap();
+  for (const rec of recommendations) {
+    if (rec.source_ref) {
+      const waveId = templateToWave.get(rec.source_ref);
+      if (waveId) {
+        rec.wave_id = waveId;
+        rec.wave_order = DEFAULT_WAVE_CONFIG.find((w) => w.id === waveId)?.order ?? 99;
+      }
+    }
+    if (!rec.wave_id) {
+      rec.wave_id = 'wave-1';
+      rec.wave_order = 1;
+    }
+    const waveDef = DEFAULT_WAVE_CONFIG.find((w) => w.id === rec.wave_id);
+    const startDay = waveDef?.timeline.start_day ?? 0;
+    rec.horizon =
+      startDay <= 0  ? 'today'    :
+      startDay <= 3  ? 'next3'    :
+      startDay <= 7  ? 'thisWeek' :
+      startDay <= 30 ? 'month'    : 'future';
+  }
+
+  return annotateWithPillarImpact(recommendations).slice(0, limit);
+}
 
 // =============================================================================
 // Community Action Map — signal_type → action for community user activation
@@ -1527,6 +1590,8 @@ router.post('/:id/reject', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const { reason } = req.body;
+    const userId = getUserId(req);
+    const role = getActiveRole(req);
 
     if (!id) {
       return res.status(400).json({ ok: false, error: 'Recommendation ID required' });
@@ -1546,6 +1611,16 @@ router.post('/:id/reject', async (req: Request, res: Response) => {
     const response = result.data;
     if (!response?.ok) {
       return res.status(400).json({ ok: false, error: response?.error || 'Failed to reject' });
+    }
+
+    // VTID-03301: dismissing the last rec also empties the queue — kick the
+    // same guarded regeneration the /complete path uses. Community only;
+    // fire-and-forget so reject stays fast.
+    if (role === 'community' && userId) {
+      regenerateCommunityRecommendations(userId, {
+        requireEmptyQueue: true,
+        trigger_type: 'auto_replenish',
+      }).catch((e: any) => console.warn(`${LOG_PREFIX} post-reject regen error (non-fatal): ${e?.message}`));
     }
 
     return res.status(200).json({
@@ -1636,6 +1711,49 @@ router.post('/generate', async (req: Request, res: Response) => {
 
   try {
     const userId = getUserId(req);
+    const role = getActiveRole(req);
+
+    // =========================================================================
+    // VTID-03301: Community on-demand regeneration.
+    // POST /recommendations/generate?role=community
+    //   → 200 { ok, generated, recommendations }            (fresh batch)
+    //   → 200 { ok, generated: 0, reason }                  (guard fired)
+    // Same guards as the queue-empty auto-trigger; the cooldown makes a
+    // double-tap idempotent so a force-refresh can't double-generate.
+    // =========================================================================
+    if (role === 'community') {
+      if (!userId) {
+        return res.status(401).json({ ok: false, error: 'User ID required' });
+      }
+      const tenantId = req.get('X-Vitana-Tenant') || undefined;
+      const regen = await regenerateCommunityRecommendations(userId, {
+        trigger_type: 'manual',
+        tenantId,
+      });
+      if (!regen.ok) {
+        return res.status(500).json({ ok: false, error: regen.error || 'Generation failed' });
+      }
+      if (regen.generated === 0) {
+        return res.status(200).json({
+          ok: true,
+          generated: 0,
+          reason: regen.reason || 'no_signals',
+          recommendations: [],
+          vtid: 'VTID-03301',
+          timestamp: new Date().toISOString(),
+        });
+      }
+      const recommendations = await buildCommunityRecsResponse(userId, ['new', 'activated'], 20);
+      return res.status(200).json({
+        ok: true,
+        generated: regen.generated,
+        recommendations,
+        run_id: regen.run_id,
+        vtid: 'VTID-03301',
+        timestamp: new Date().toISOString(),
+      });
+    }
+
     const {
       sources = ['codebase', 'oasis', 'health', 'roadmap'],
       limit = 20,
@@ -2051,6 +2169,17 @@ router.post('/:id/complete', async (req: Request, res: Response) => {
         }
       }
     }
+
+    // VTID-03301: queue-empty → regenerate immediately. Fire-and-forget so
+    // Complete returns fast; the guard re-checks the active (new + activated)
+    // count and only generates when it has actually hit 0 (and honors the
+    // daily cap / cooldown / consent / enabled gates). The FE's poll/refetch
+    // surfaces the fresh batch.
+    regenerateCommunityRecommendations(userId, {
+      requireEmptyQueue: true,
+      tenantId: tenantRow?.tenant_id || undefined,
+      trigger_type: 'auto_replenish',
+    }).catch((e: any) => console.warn(`${LOG_PREFIX} post-complete regen error (non-fatal): ${e?.message}`));
 
     return res.status(200).json({
       ok: true,

--- a/services/gateway/src/services/recommendation-engine/community-regeneration.ts
+++ b/services/gateway/src/services/recommendation-engine/community-regeneration.ts
@@ -1,0 +1,219 @@
+/**
+ * Community Autopilot — On-Demand Regeneration (VTID-03301)
+ *
+ * Guarded, reusable service that refills a community user's Autopilot queue the
+ * moment it empties (after complete/reject), plus an explicit force path for the
+ * frontend / testing (POST /generate?role=community). It wraps
+ * generatePersonalRecommendations with the guards that make "immediate"
+ * regeneration safe instead of a runaway complete→generate→complete loop:
+ *
+ *   enabled → consent → per-user lock → cooldown → daily cap → generate
+ *
+ * Product decisions (locked):
+ *   1. Honor the daily cap. When hit, return generated:0 + reason:'daily_cap'
+ *      so the UI can show "all caught up for today" instead of looping forever.
+ *   2. Trigger BOTH automatically on queue-empty AND via the explicit endpoint;
+ *      the cooldown makes a double-tap idempotent.
+ *
+ * i18n note (CLAUDE.md §13b): the community generation path is template-based —
+ * it runs the community / Life Compass / index-gap analyzers and does NOT call
+ * an LLM — so the llm-locale injection rule does not apply here. If a future
+ * LLM analyzer is added to this path, inject getUserLocale +
+ * buildLocalizedSystemPrompt at that call site so DE users don't get English.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { generatePersonalRecommendations, type GenerationConfig } from './recommendation-generator';
+
+const LOG_PREFIX = '[VTID-03301]';
+
+/** Why a regeneration produced no new recommendations. */
+export type RegenerationReason = 'daily_cap' | 'disabled' | 'cooldown' | 'no_signals' | 'not_empty';
+
+export interface CommunityRegenResult {
+  ok: boolean;
+  generated: number;
+  reason?: RegenerationReason;
+  run_id?: string;
+  error?: string;
+}
+
+export interface RegenerateOpts {
+  /**
+   * Auto-trigger sets this true: only regenerate when the user's active
+   * (new + activated) queue has actually hit 0. The explicit /generate endpoint
+   * leaves it false (force-refresh), relying on the cooldown for idempotency.
+   */
+  requireEmptyQueue?: boolean;
+  /** Pre-resolved primary tenant id — saves a lookup when the caller has it. */
+  tenantId?: string;
+  /** Provenance recorded on the generation run. */
+  trigger_type?: GenerationConfig['trigger_type'];
+}
+
+/**
+ * Cooldown/debounce window. A batch created within this window suppresses a
+ * fresh generation, so back-to-back completes (or a double-tapped force button)
+ * can't double-generate. Overridable via env for testing.
+ */
+const COOLDOWN_MS = Number(process.env.AUTOPILOT_REGEN_COOLDOWN_MS) || 3 * 60 * 1000;
+
+/**
+ * Per-instance lock: serializes concurrent regenerations for the same user so
+ * two completes landing in the same process don't both generate. The DB-level
+ * cooldown above is the cross-instance backstop.
+ */
+const inFlight = new Set<string>();
+
+/**
+ * Best-effort per-user AI-data consent check. There is no dedicated Autopilot
+ * consent store today (ai_consent_log is for external AI providers), so the
+ * tenant `enabled` flag is the authoritative enable gate. This adds a
+ * forward-compatible per-user opt-out: a memory_facts row with
+ * fact_key='autopilot_opt_out' whose value is truthy suppresses regeneration.
+ * Defaults to allowed (returns false) when no opt-out is recorded or on error.
+ */
+async function hasAutopilotOptOut(supa: SupabaseClient, userId: string): Promise<boolean> {
+  try {
+    const { data } = await supa
+      .from('memory_facts')
+      .select('fact_value')
+      .eq('user_id', userId)
+      .eq('fact_key', 'autopilot_opt_out')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const v = (data as { fact_value?: string | null } | null)?.fact_value;
+    return typeof v === 'string' && ['true', '1', 'yes'].includes(v.trim().toLowerCase());
+  } catch {
+    // Never block regeneration on a consent-store read error.
+    return false;
+  }
+}
+
+/**
+ * Guarded on-demand regeneration for a community user. Never throws — returns a
+ * structured result the route maps to HTTP and the auto-trigger fires-and-forgets.
+ */
+export async function regenerateCommunityRecommendations(
+  userId: string,
+  opts: RegenerateOpts = {},
+): Promise<CommunityRegenResult> {
+  if (!userId) return { ok: false, generated: 0, error: 'userId required' };
+
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return { ok: false, generated: 0, error: 'Supabase not configured' };
+
+  // Per-instance lock: a concurrent complete/reject for the same user is
+  // already generating — treat as cooldown so we never double-generate.
+  if (inFlight.has(userId)) {
+    console.log(`${LOG_PREFIX} regen skipped (in-flight lock) for ${userId.slice(0, 8)}`);
+    return { ok: true, generated: 0, reason: 'cooldown' };
+  }
+  inFlight.add(userId);
+
+  try {
+    const { createClient } = await import('@supabase/supabase-js');
+    const supa = createClient(url, key);
+
+    // Resolve primary tenant.
+    let tenantId = opts.tenantId;
+    if (!tenantId) {
+      const { data: tenantRow } = await supa
+        .from('user_tenants')
+        .select('tenant_id')
+        .eq('user_id', userId)
+        .eq('is_primary', true)
+        .maybeSingle();
+      tenantId = (tenantRow as { tenant_id?: string } | null)?.tenant_id || undefined;
+    }
+    if (!tenantId) {
+      console.warn(`${LOG_PREFIX} no primary tenant for ${userId.slice(0, 8)} — skipping regen`);
+      return { ok: true, generated: 0, reason: 'disabled' };
+    }
+
+    // Guard: tenant Autopilot enabled (this is also the AI-data enable gate).
+    const { data: settings } = await supa
+      .from('tenant_autopilot_settings')
+      .select('enabled, max_recommendations_per_day')
+      .eq('tenant_id', tenantId)
+      .maybeSingle();
+    if (settings && (settings as { enabled?: boolean }).enabled === false) {
+      console.log(`${LOG_PREFIX} Autopilot disabled for tenant ${tenantId} — skipping regen`);
+      return { ok: true, generated: 0, reason: 'disabled' };
+    }
+    const dailyCap = (settings as { max_recommendations_per_day?: number } | null)?.max_recommendations_per_day ?? 20;
+
+    // Guard: per-user AI-data consent.
+    if (await hasAutopilotOptOut(supa, userId)) {
+      console.log(`${LOG_PREFIX} user ${userId.slice(0, 8)} opted out of Autopilot — skipping regen`);
+      return { ok: true, generated: 0, reason: 'disabled' };
+    }
+
+    // Guard: queue must be empty for the auto-trigger (new + activated == 0).
+    if (opts.requireEmptyQueue) {
+      const { count: activeCount } = await supa
+        .from('autopilot_recommendations')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .in('status', ['new', 'activated']);
+      if ((activeCount ?? 0) > 0) {
+        return { ok: true, generated: 0, reason: 'not_empty' };
+      }
+    }
+
+    // Guard: cooldown/debounce — skip if a batch was created very recently.
+    const since = new Date(Date.now() - COOLDOWN_MS).toISOString();
+    const { count: recentCount } = await supa
+      .from('autopilot_recommendations')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .gte('created_at', since);
+    if ((recentCount ?? 0) > 0) {
+      console.log(
+        `${LOG_PREFIX} cooldown active for ${userId.slice(0, 8)} ` +
+        `(${recentCount} rec(s) in last ${Math.round(COOLDOWN_MS / 1000)}s)`,
+      );
+      return { ok: true, generated: 0, reason: 'cooldown' };
+    }
+
+    // Guard: daily cap — honor max_recommendations_per_day. Locked decision:
+    // show "all caught up for today" rather than regenerate past the cap.
+    const startOfDay = new Date();
+    startOfDay.setUTCHours(0, 0, 0, 0);
+    const { count: todayCount } = await supa
+      .from('autopilot_recommendations')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .gte('created_at', startOfDay.toISOString());
+    if ((todayCount ?? 0) >= dailyCap) {
+      console.log(`${LOG_PREFIX} daily cap reached for ${userId.slice(0, 8)} (${todayCount}/${dailyCap})`);
+      return { ok: true, generated: 0, reason: 'daily_cap' };
+    }
+
+    // All guards passed → generate.
+    const result = await generatePersonalRecommendations(userId, tenantId, {
+      trigger_type: opts.trigger_type || 'auto_replenish',
+    });
+    if (!result.ok) {
+      return {
+        ok: false,
+        generated: 0,
+        run_id: result.run_id,
+        error: result.errors[0]?.error || 'generation failed',
+      };
+    }
+    if (result.generated === 0) {
+      // Generation ran but every candidate was a live duplicate / no fresh signals.
+      return { ok: true, generated: 0, run_id: result.run_id, reason: 'no_signals' };
+    }
+    console.log(`${LOG_PREFIX} regenerated ${result.generated} rec(s) for ${userId.slice(0, 8)}`);
+    return { ok: true, generated: result.generated, run_id: result.run_id };
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} regen failed (non-fatal) for ${userId.slice(0, 8)}: ${err?.message}`);
+    return { ok: false, generated: 0, error: err?.message || String(err) };
+  } finally {
+    inFlight.delete(userId);
+  }
+}

--- a/services/gateway/src/services/recommendation-engine/index.ts
+++ b/services/gateway/src/services/recommendation-engine/index.ts
@@ -24,5 +24,6 @@
 
 export * from './analyzers';
 export * from './recommendation-generator';
+export * from './community-regeneration';
 export * from './scheduler';
 export * from './autonomous-engine';

--- a/services/gateway/test/services/recommendation-engine/community-regeneration.test.ts
+++ b/services/gateway/test/services/recommendation-engine/community-regeneration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the community on-demand regeneration guards — VTID-03301.
+ *
+ * Verifies the guard chain that makes "regenerate the moment the queue empties"
+ * safe instead of a runaway loop:
+ *   enabled → consent → (empty queue) → cooldown → daily cap → generate.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { regenerateCommunityRecommendations } from '../../../src/services/recommendation-engine/community-regeneration';
+import { generatePersonalRecommendations } from '../../../src/services/recommendation-engine/recommendation-generator';
+
+jest.mock('@supabase/supabase-js');
+jest.mock('../../../src/services/recommendation-engine/recommendation-generator', () => ({
+  generatePersonalRecommendations: jest.fn(),
+}));
+
+const mockCreateClient = createClient as jest.Mock;
+const mockGenerate = generatePersonalRecommendations as jest.Mock;
+
+/**
+ * Build a chainable supabase mock. `maybeSingle()` resolves per-table; the
+ * count queries on autopilot_recommendations are awaited directly (the builder
+ * is thenable) and consume `counts` in call order:
+ *   requireEmptyQueue=true  → [activeQueue, cooldownWindow, today]
+ *   requireEmptyQueue=false → [cooldownWindow, today]
+ */
+function makeSupabase(opts: {
+  tenant?: { tenant_id: string } | null;
+  settings?: { enabled?: boolean; max_recommendations_per_day?: number } | null;
+  optOut?: { fact_value: string } | null;
+  counts?: number[];
+}) {
+  let countIdx = 0;
+  const builder: any = {};
+  builder.from = jest.fn((t: string) => { builder._table = t; return builder; });
+  builder.select = jest.fn(() => builder);
+  builder.eq = jest.fn(() => builder);
+  builder.in = jest.fn(() => builder);
+  builder.gte = jest.fn(() => builder);
+  builder.order = jest.fn(() => builder);
+  builder.limit = jest.fn(() => builder);
+  builder.maybeSingle = jest.fn(async () => {
+    if (builder._table === 'user_tenants') return { data: opts.tenant ?? null };
+    if (builder._table === 'tenant_autopilot_settings') return { data: opts.settings ?? null };
+    if (builder._table === 'memory_facts') return { data: opts.optOut ?? null };
+    return { data: null };
+  });
+  // Thenable: resolves count queries against autopilot_recommendations.
+  builder.then = (resolve: any) => {
+    const c = opts.counts?.[countIdx++] ?? 0;
+    return Promise.resolve({ count: c, data: [] }).then(resolve);
+  };
+  return builder;
+}
+
+const USER = 'a27552a3-0257-4305-8ed0-351a80fd3701';
+const TENANT = { tenant_id: 'tenant-1' };
+
+describe('regenerateCommunityRecommendations — guards', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...OLD_ENV, SUPABASE_URL: 'https://x.supabase.co', SUPABASE_SERVICE_ROLE: 'svc' };
+    mockGenerate.mockResolvedValue({ ok: true, generated: 4, run_id: 'run-1', errors: [] });
+  });
+
+  afterAll(() => { process.env = OLD_ENV; });
+
+  it('skips when Autopilot is disabled for the tenant', async () => {
+    mockCreateClient.mockReturnValue(makeSupabase({ tenant: TENANT, settings: { enabled: false } }));
+    const res = await regenerateCommunityRecommendations(USER, { tenantId: TENANT.tenant_id });
+    expect(res).toMatchObject({ ok: true, generated: 0, reason: 'disabled' });
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('skips when the user has opted out (consent)', async () => {
+    mockCreateClient.mockReturnValue(
+      makeSupabase({ tenant: TENANT, settings: { enabled: true }, optOut: { fact_value: 'true' } }),
+    );
+    const res = await regenerateCommunityRecommendations(USER, { tenantId: TENANT.tenant_id });
+    expect(res).toMatchObject({ ok: true, generated: 0, reason: 'disabled' });
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('reports not_empty when the active queue is not empty (auto-trigger)', async () => {
+    mockCreateClient.mockReturnValue(
+      makeSupabase({ tenant: TENANT, settings: { enabled: true }, counts: [2] }),
+    );
+    const res = await regenerateCommunityRecommendations(USER, {
+      tenantId: TENANT.tenant_id,
+      requireEmptyQueue: true,
+    });
+    expect(res).toMatchObject({ ok: true, generated: 0, reason: 'not_empty' });
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('debounces via cooldown when a batch was created recently', async () => {
+    mockCreateClient.mockReturnValue(
+      makeSupabase({ tenant: TENANT, settings: { enabled: true }, counts: [3 /* cooldown window */] }),
+    );
+    const res = await regenerateCommunityRecommendations(USER, { tenantId: TENANT.tenant_id });
+    expect(res).toMatchObject({ ok: true, generated: 0, reason: 'cooldown' });
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('honors the daily cap (all caught up for today)', async () => {
+    mockCreateClient.mockReturnValue(
+      makeSupabase({
+        tenant: TENANT,
+        settings: { enabled: true, max_recommendations_per_day: 5 },
+        counts: [0 /* cooldown */, 5 /* today >= cap */],
+      }),
+    );
+    const res = await regenerateCommunityRecommendations(USER, { tenantId: TENANT.tenant_id });
+    expect(res).toMatchObject({ ok: true, generated: 0, reason: 'daily_cap' });
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('generates when all guards pass', async () => {
+    mockCreateClient.mockReturnValue(
+      makeSupabase({
+        tenant: TENANT,
+        settings: { enabled: true, max_recommendations_per_day: 20 },
+        counts: [0 /* queue */, 0 /* cooldown */, 0 /* today */],
+      }),
+    );
+    const res = await regenerateCommunityRecommendations(USER, {
+      tenantId: TENANT.tenant_id,
+      requireEmptyQueue: true,
+    });
+    expect(res).toMatchObject({ ok: true, generated: 4, run_id: 'run-1' });
+    expect(mockGenerate).toHaveBeenCalledWith(USER, TENANT.tenant_id, { trigger_type: 'auto_replenish' });
+  });
+
+  it('reports no_signals when generation produced nothing fresh', async () => {
+    mockGenerate.mockResolvedValue({ ok: true, generated: 0, run_id: 'run-2', errors: [] });
+    mockCreateClient.mockReturnValue(
+      makeSupabase({ tenant: TENANT, settings: { enabled: true }, counts: [0, 0] }),
+    );
+    const res = await regenerateCommunityRecommendations(USER, { tenantId: TENANT.tenant_id });
+    expect(res).toMatchObject({ ok: true, generated: 0, reason: 'no_signals' });
+  });
+
+  it('skips when no primary tenant can be resolved', async () => {
+    mockCreateClient.mockReturnValue(makeSupabase({ tenant: null }));
+    const res = await regenerateCommunityRecommendations(USER);
+    expect(res).toMatchObject({ ok: true, generated: 0, reason: 'disabled' });
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What & why

Implements the missing **backend regeneration** piece of Autopilot on-demand regeneration. After a community user completes/clears all their active Autopilot recommendations, Autopilot now **immediately** produces a new set instead of waiting for the next cron. (The card-preview + click-to-overview FE piece already shipped in vitana-v1 #624; the small FE resurfacing change is deferred per the spec.)

## Locked product decisions
- **Daily cap:** honor `max_recommendations_per_day`; when hit, return `generated: 0, reason: "daily_cap"` so the UI shows "all caught up for today" (prevents complete→generate→complete runaway loops).
- **Trigger style:** **both** — auto on queue-empty *and* an explicit endpoint for force-refresh/testing.

## Changes

**New service — `services/gateway/src/services/recommendation-engine/community-regeneration.ts`**
`regenerateCommunityRecommendations(userId, opts)` wraps the existing `generatePersonalRecommendations` with the guard chain that makes "immediate" safe:

```
enabled → consent → (empty queue) → cooldown/debounce + per-user lock → daily cap → generate
```

- **Daily cap** — counts today's rows vs `tenant_autopilot_settings.max_recommendations_per_day` (default 20).
- **Cooldown** — DB-backed debounce (`AUTOPILOT_REGEN_COOLDOWN_MS`, default 3 min) + per-instance in-flight lock to serialize concurrent completes.
- **Enabled / consent** — skips when the tenant has Autopilot disabled, or the user has a `memory_facts` `autopilot_opt_out` fact. (`tenant_autopilot_settings.enabled` is the authoritative gate; `ai_consent_log` is for external AI providers, not this.)
- Never throws — returns a structured `{ ok, generated, reason?, run_id? }`.

**Triggers — `services/gateway/src/routes/autopilot-recommendations.ts`**
- `POST /:id/complete` and `POST /:id/reject` now **fire-and-forget** regeneration with `requireEmptyQueue: true` after the write, so clearing the last rec immediately refills the queue. Fast return; the guard re-checks the active (`new + activated`) count and only generates when it actually hit 0.
- `POST /recommendations/generate?role=community` (new community branch on the existing route) →
  - `200 { ok: true, generated, recommendations: [...] }`, or
  - `200 { ok: true, generated: 0, reason: "daily_cap" | "disabled" | "cooldown" | "no_signals" }`.
  Idempotent under the cooldown so a double-tap can't double-generate. The dev/admin `/generate` path (codebase/oasis/health/roadmap) is unchanged.

The recommendation **row shape** the FE consumes is unchanged. The community generation path is template-based (community / Life Compass / index-gap analyzers — **no LLM**), so the i18n llm-locale rule does not apply; this is documented inline for any future LLM analyzer added to the path.

## Notes / scope
- The pre-existing auto-replenish in the **activate** path (fires when the last `new` rec is activated) is intentionally left as-is to limit regression surface; the new complete/reject triggers and the endpoint are additive.

## Testing
- `typecheck`: clean (0 errors).
- New unit tests (`community-regeneration.test.ts`, 8 cases): `disabled`, consent opt-out, `not_empty`, `cooldown`, `daily_cap`, success, `no_signals`, missing-tenant — all pass.
- Existing autopilot/recommendation tests still green.
- Suggested e2e against a running gateway: complete all → `GET /recommendations?status=new,activated` returns a fresh set; a second immediate completion within the cooldown does **not** double-generate; cap reached → `generated: 0, reason: "daily_cap"`.

https://claude.ai/code/session_01WZpTHzLK7EqBrWm2savZ63

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZpTHzLK7EqBrWm2savZ63)_