### PR TITLE
feat(gateway): surface partner_age on enriched matches

### DIFF
--- a/services/gateway/src/services/intent-match-enrich.ts
+++ b/services/gateway/src/services/intent-match-enrich.ts
@@ -30,6 +30,24 @@ function normalizeGender(raw: unknown): 'male' | 'female' | null {
   return null;
 }
 
+/**
+ * Whole-years age from a `date_of_birth` value (DATE column → 'YYYY-MM-DD'
+ * string, or a Date). Returns null for missing/invalid/future dates and
+ * clamps to a sane 13–120 band so a typo'd birth year never surfaces a
+ * nonsense age on the card or skews the age filter.
+ */
+function computeAge(dob: unknown): number | null {
+  if (dob == null) return null;
+  const birth = dob instanceof Date ? dob : new Date(String(dob));
+  if (Number.isNaN(birth.getTime())) return null;
+  const now = new Date();
+  let age = now.getFullYear() - birth.getFullYear();
+  const m = now.getMonth() - birth.getMonth();
+  if (m < 0 || (m === 0 && now.getDate() < birth.getDate())) age -= 1;
+  if (age < 13 || age > 120) return null;
+  return age;
+}
+
 function pickCounterpartyVid(
   match: RedactedMatch,
   readerOwnsA: boolean,
@@ -127,12 +145,13 @@ export async function enrichMatchesWithCounterpartyProfiles(
     full_name: string | null;
     avatar_url: string | null;
     gender: string | null;
+    date_of_birth: string | null;
   };
   const profileByVid = new Map<string, ProfileRow>();
   if (counterpartyVids.size > 0) {
     const { data: profiles } = await supabase
       .from('profiles')
-      .select('user_id, vitana_id, display_name, full_name, avatar_url, gender')
+      .select('user_id, vitana_id, display_name, full_name, avatar_url, gender, date_of_birth')
       .in('vitana_id', Array.from(counterpartyVids));
     for (const p of (profiles ?? []) as ProfileRow[]) {
       if (p.vitana_id) profileByVid.set(p.vitana_id, p);
@@ -162,6 +181,7 @@ export async function enrichMatchesWithCounterpartyProfiles(
         partner_display_name: null,
         partner_avatar_url: null,
         partner_gender: null,
+        partner_age: null,
         ...EMPTY_COUNTERPARTY_INTENT_FIELDS,
       };
     }
@@ -185,6 +205,7 @@ export async function enrichMatchesWithCounterpartyProfiles(
         partner_display_name: null,
         partner_avatar_url: null,
         partner_gender: null,
+        partner_age: null,
         ...intentFields,
       };
     }
@@ -195,6 +216,7 @@ export async function enrichMatchesWithCounterpartyProfiles(
         partner_display_name: null,
         partner_avatar_url: null,
         partner_gender: null,
+        partner_age: null,
         ...intentFields,
       };
     }
@@ -207,6 +229,7 @@ export async function enrichMatchesWithCounterpartyProfiles(
         partner_display_name: null,
         partner_avatar_url: null,
         partner_gender: null,
+        partner_age: null,
         ...intentFields,
       };
     }
@@ -215,6 +238,7 @@ export async function enrichMatchesWithCounterpartyProfiles(
       partner_display_name: profile.display_name ?? profile.full_name ?? null,
       partner_avatar_url: profile.avatar_url ?? null,
       partner_gender: normalizeGender(profile.gender),
+      partner_age: computeAge(profile.date_of_birth),
       ...intentFields,
     };
   });

--- a/services/gateway/src/services/intent-mutual-reveal.ts
+++ b/services/gateway/src/services/intent-mutual-reveal.ts
@@ -40,6 +40,10 @@ export interface RedactedMatch extends Omit<MatchRow, 'vitana_id_a' | 'vitana_id
   partner_display_name?: string | null;
   partner_avatar_url?: string | null;
   partner_gender?: 'male' | 'female' | null;
+  // E6 follow-up — counterparty age in whole years, derived from
+  // profiles.date_of_birth. null when redacted, hidden, unset, or invalid.
+  // Lets the Find-a-Match age-range filter operate on real data.
+  partner_age?: number | null;
   // BOOTSTRAP-INTENT-COVER-GEN — landscape cover photo for the
   // counterparty's intent. User-uploaded or auto-generated.
   partner_match_cover_url?: string | null;


### PR DESCRIPTION
## What
Derives the counterparty's **age in whole years** from `profiles.date_of_birth` and sets `partner_age` on each enriched match in `intent-match-enrich.ts`.

This is the backend half of the Find a Match filter work in **exafyltd/vitana-v1#639**. Until now the age-range slider applied defensively because no age field ever reached the client — this makes it real.

## Behaviour (mirrors `partner_gender`)
`partner_age` is `null` when:
- the match is redacted (partner_seek pre-reveal),
- the counterparty is hidden (`global_community_profiles.is_visible = false`),
- DOB is unset, or
- DOB is invalid / in the future / outside a sane **13–120** band (so a typo'd birth year never surfaces a nonsense age or skews the filter).

Otherwise it's the computed age. The match route already returns the enriched object verbatim (`matches: enriched`), so no DTO/whitelist change is needed.

## Changes
- `services/gateway/src/services/intent-match-enrich.ts` — add `date_of_birth` to the profile select, a clamped `computeAge()` helper, and set `partner_age` in every assembly branch.
- `services/gateway/src/services/intent-mutual-reveal.ts` — add `partner_age?: number | null` to `RedactedMatch`.

## Not in this PR (tracked separately)
- **Presence** (`partner_last_active_at`) — no presence/last-active column exists in the schema; needs a presence source.
- **Distance** (`partner_distance_km`) — profiles carry only free-text location, no coordinates; needs geocoding.

See the tracking issue for both.

## Verification
- `tsc --noEmit` clean for both changed files.

https://claude.ai/code/session_01CMUFCGG2JJzG4HetADvV6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMUFCGG2JJzG4HetADvV6U)_