### PR TITLE
fix(commerce): open cart/agent/shop to all authenticated users (VTID-03260)

### DIFF
--- a/services/gateway/src/routes/shop-feed.ts
+++ b/services/gateway/src/routes/shop-feed.ts
@@ -31,11 +31,10 @@ import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { createUserSupabaseClient } from '../lib/supabase-user';
 import { getSupabase } from '../lib/supabase';
-import { getBearerToken, getUserContext, getActiveRole } from './universal-cart';
+import { getBearerToken, getUserContext } from './universal-cart';
 
 export const VTID = 'VTID-03237';
 
-const COMMUNITY_ROLE = 'community';
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
 
@@ -77,11 +76,9 @@ async function authorizeCommunityCaller(
     res.status(401).json({ ok: false, error: 'UNAUTHENTICATED', detail: ctx.error });
     return null;
   }
-  const role = await getActiveRole(ctx.user_id, ctx.tenant_id);
-  if (role !== COMMUNITY_ROLE) {
-    res.status(403).json({ ok: false, error: 'shop_unavailable_for_role', role });
-    return null;
-  }
+  // Mobile-app audience is entirely community users — the video shop is open to
+  // every authenticated caller. Do NOT gate on active_role (it is null/unset for
+  // app users and was blocking everyone). Authenticate only.
   return { token, user_id: ctx.user_id, tenant_id: ctx.tenant_id };
 }
 

--- a/services/gateway/src/routes/universal-cart.ts
+++ b/services/gateway/src/routes/universal-cart.ts
@@ -18,8 +18,10 @@
  *   - No checkout, no Stripe, no wallet waterfall, no autopilot bridge, no matchmaking.
  *
  * Access control:
- *   - Community-role-only. Non-community sessions get HTTP 403 with `error: 'cart_unavailable_for_role'`.
- *   - Role is read from `user_tenants.active_role` via the service-role client.
+ *   - Authenticated-user-only (any role). The mobile app's entire audience is
+ *     community users, so commerce is open to every signed-in caller; we do NOT
+ *     gate on `active_role` (doing so blocked every user whose active_role was
+ *     null/unset). 401 only when the bearer token is missing/invalid.
  *   - Cart + cart_items mutations use the user-JWT-scoped client so RLS enforces owner isolation.
  *   - cart_events INSERTs use the service-role client (RLS blocks `authenticated` writes; audit
  *     emission is the gateway's responsibility).
@@ -79,8 +81,6 @@ const ALLOWED_EVENT_PAYLOAD_KEYS = new Set([
 
 /** Soft cap on event-payload string fields to prevent accidental PII leakage via metadata blob. */
 const EVENT_PAYLOAD_STRING_MAX = 200;
-
-const COMMUNITY_ROLE = 'community';
 
 const router = Router();
 
@@ -154,19 +154,9 @@ export async function getActiveRole(
 }
 
 /**
- * Standardized 403 response for non-community sessions.
- */
-function denyForRole(res: Response, callerRole: string | null): Response {
-  return res.status(403).json({
-    ok: false,
-    error: 'cart_unavailable_for_role',
-    role: callerRole, // for client-side diagnostics; not PII
-  });
-}
-
-/**
- * Combined auth + role gate. Returns the resolved identity on success, or sends
- * a 401/403 response and returns null so callers can early-exit.
+ * Auth gate. Returns the resolved identity for any authenticated caller, or
+ * sends a 401 and returns null so callers can early-exit. Intentionally does
+ * NOT gate on role — see the "Access control" note in the file header.
  */
 export async function authorizeCommunityCaller(
   req: Request,
@@ -182,11 +172,11 @@ export async function authorizeCommunityCaller(
     res.status(401).json({ ok: false, error: 'UNAUTHENTICATED', detail: ctx.error });
     return null;
   }
-  const role = await getActiveRole(ctx.user_id, ctx.tenant_id);
-  if (role !== COMMUNITY_ROLE) {
-    denyForRole(res, role);
-    return null;
-  }
+  // The mobile app has a single audience — every user IS a community user —
+  // so commerce must be available to any authenticated caller. The previous
+  // `active_role === 'community'` wall blocked everyone whose user_tenants
+  // active_role wasn't exactly that string (null/unset for app users), which
+  // broke the cart for all of them. Authenticate only; never gate on role.
   return { token, user_id: ctx.user_id, tenant_id: ctx.tenant_id };
 }
 

--- a/services/gateway/test/shopping-agent.test.ts
+++ b/services/gateway/test/shopping-agent.test.ts
@@ -5,7 +5,8 @@
  *   (a) hard-filtered products NEVER appear in proposals — the agent selects
  *       only through the limitations-filtered search path, so an allergen/
  *       contraindication/medication-conflicting product cannot be proposed.
- *   (b) role gate returns the cart's 403 cart_unavailable_for_role on non-community.
+ *   (b) auth gate: 401 when unauthenticated; ANY authenticated caller is allowed
+ *       (commerce is no longer role-gated — the community-role wall was removed).
  *   (c) metadata shape { origin:'agent', ... } + source_surface 'autopilot' on inserts.
  *   (d) NO checkout/charge side effect — never touches checkout/product_orders/wallet.
  *   (e) llm_unavailable → HTTP 502 (router mocked to fail).
@@ -136,17 +137,18 @@ const ALLERGEN_PRODUCT = '77777777-7777-4000-f000-000000000f02';
 
 const BEARER_A = 'Bearer fake-jwt-user-a';
 
-/** Seed me_context + active_role lookups (mirrors universal-cart.test.ts seedAuth). */
-function seedAuth(opts: { user_id?: string; tenant_id?: string | null; role: string | null }) {
+/**
+ * Seed the me_context auth lookup (mirrors universal-cart.test.ts seedAuth).
+ *
+ * The shared commerce gate (`authorizeCommunityCaller`) is AUTH-ONLY now — it no
+ * longer queries `user_tenants.active_role` — so we seed ONLY the me_context
+ * response. `role` is accepted for call-site compatibility but ignored.
+ */
+function seedAuth(opts: { user_id?: string; tenant_id?: string | null; role?: string | null }) {
   mockSupabase.__seed({
     data: { user_id: opts.user_id ?? USER_A, tenant_id: opts.tenant_id === undefined ? TENANT_1 : opts.tenant_id },
     error: null,
   });
-  if (opts.role !== null && opts.tenant_id !== null) {
-    mockSupabase.__seed({ data: { active_role: opts.role }, error: null });
-  } else if (opts.tenant_id !== null) {
-    mockSupabase.__seed({ data: null, error: null });
-  }
 }
 
 /** A populated brain with a peanut allergy (used to prove hard-filter). */
@@ -247,7 +249,7 @@ beforeEach(() => {
 // (b) Role gate
 // =============================================================================
 
-describe(`${'VTID-03260'} (b) role gating`, () => {
+describe(`${'VTID-03260'} (b) auth gating`, () => {
   test('GET /health is open', async () => {
     const res = await request(buildApp()).get('/api/v1/shopping-agent/health');
     expect(res.status).toBe(200);
@@ -260,25 +262,51 @@ describe(`${'VTID-03260'} (b) role gating`, () => {
     expect(res.body.error).toBe('UNAUTHENTICATED');
   });
 
-  test('POST /propose with role=admin → 403 cart_unavailable_for_role', async () => {
+  test('POST /propose with role=admin is NOT role-blocked (commerce is open to any authed caller)', async () => {
+    // The community-role wall was removed: an 'admin' caller must proceed through
+    // the gate. Seed the standard success path (same as the (a) proposal test).
     seedAuth({ role: 'admin' });
+    // getMonthlySpend product_orders read (runs before cart resolution)
+    mockSupabase.__seed({ data: [], error: null });
+    // cart resolution → existing active cart
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    seedPlannerOk();
+    // products search → one safe row
+    mockSupabase.__seed({ data: [SAFE_ROW], error: null });
+    // insert of the safe pick
+    mockSupabase.__seed({ data: { id: ITEM_1 }, error: null });
+    // item.added event insert (best-effort)
+    mockSupabase.__seed({ data: null, error: null });
+
     const res = await request(buildApp())
       .post('/api/v1/shopping-agent/propose')
       .set('Authorization', BEARER_A)
       .send({ prompt: 'sleep help' });
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe('cart_unavailable_for_role');
-    expect(res.body.role).toBe('admin');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.error).not.toBe('cart_unavailable_for_role');
   });
 
-  test('POST /propose with no active_role → 403', async () => {
+  test('POST /propose with no active_role is NOT role-blocked (proceeds)', async () => {
     seedAuth({ role: null });
+    // getMonthlySpend product_orders read (runs before cart resolution)
+    mockSupabase.__seed({ data: [], error: null });
+    // cart resolution → existing active cart
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+    seedPlannerOk();
+    mockSupabase.__seed({ data: [SAFE_ROW], error: null });
+    mockSupabase.__seed({ data: { id: ITEM_1 }, error: null });
+    mockSupabase.__seed({ data: null, error: null });
+
     const res = await request(buildApp())
       .post('/api/v1/shopping-agent/propose')
       .set('Authorization', BEARER_A)
       .send({ prompt: 'sleep help' });
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe('cart_unavailable_for_role');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.error).not.toBe('cart_unavailable_for_role');
   });
 });
 
@@ -569,21 +597,30 @@ function ctxWithPastPurchases(productIds: string[]): UserHealthContext {
   });
 }
 
-describe(`${'VTID-03260'} Phase 2 reorder role gating`, () => {
+describe(`${'VTID-03260'} Phase 2 reorder auth gating`, () => {
   test('POST /reorder without Bearer → 401', async () => {
     const res = await request(buildApp()).post('/api/v1/shopping-agent/reorder').send({});
     expect(res.status).toBe(401);
     expect(res.body.error).toBe('UNAUTHENTICATED');
   });
 
-  test('POST /reorder with role=admin → 403 cart_unavailable_for_role', async () => {
+  test('POST /reorder with role=admin is NOT role-blocked (proceeds)', async () => {
+    // No community-role wall anymore. An 'admin' caller with no reorderable
+    // history simply proceeds and gets the standard empty-history advisory.
     seedAuth({ role: 'admin' });
+    mockGetUserHealthContext.mockResolvedValue(makeCtx({ past_purchases: [] }));
+    // cart resolution → existing active cart
+    mockSupabase.__seed({ data: { id: CART_A }, error: null });
+
     const res = await request(buildApp())
       .post('/api/v1/shopping-agent/reorder')
       .set('Authorization', BEARER_A)
       .send({});
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe('cart_unavailable_for_role');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.error).not.toBe('cart_unavailable_for_role');
+    expect(res.body.advisory).toContain('no_reorderable_items');
   });
 });
 

--- a/services/gateway/test/universal-cart.test.ts
+++ b/services/gateway/test/universal-cart.test.ts
@@ -2,7 +2,7 @@
  * VTID-03213 — Universal Cart gateway slice tests.
  *
  * Coverage:
- *   §1  Role gating          — 401 unauthenticated, 403 cart_unavailable_for_role for non-community.
+ *   §1  Auth gating          — 401 unauthenticated; commerce is open to ANY authenticated caller (no role gate).
  *   §2  Owner isolation      — RLS-blank reads surface as 404, gateway never trusts cross-user inputs.
  *   §3  Active-cart behavior — POST / get-or-create idempotency; emits cart.created only on actual create.
  *   §4  Item mutation        — add (insert), add (quantity bump), patch quantity, soft-remove, complete (idempotent).
@@ -136,21 +136,21 @@ const PRODUCT_B = '77777777-7777-4000-f000-000000000f02';
 const BEARER_A = 'Bearer fake-jwt-user-a';
 const BEARER_B = 'Bearer fake-jwt-user-b';
 
-/** Seed the me_context + active_role lookups for a given user / role. */
-function seedAuth(opts: { user_id?: string; tenant_id?: string | null; role: string | null }) {
-  // me_context RPC
+/**
+ * Seed the me_context auth lookup for a given user.
+ *
+ * The commerce gate is AUTH-ONLY now: `authorizeCommunityCaller` no longer
+ * queries `user_tenants.active_role`, so we seed ONLY the me_context response.
+ * The `role` field is accepted for call-site compatibility but ignored — it no
+ * longer affects anything. (Seeding a phantom active_role response here would be
+ * wrongly consumed by the handler's first real query and misalign every test.)
+ */
+function seedAuth(opts: { user_id?: string; tenant_id?: string | null; role?: string | null }) {
+  // me_context RPC — the only auth lookup the gate performs.
   mockSupabase.__seed({
     data: { user_id: opts.user_id ?? USER_A, tenant_id: opts.tenant_id === undefined ? TENANT_1 : opts.tenant_id },
     error: null,
   });
-  // user_tenants.active_role lookup
-  if (opts.role !== null && opts.tenant_id !== null) {
-    mockSupabase.__seed({ data: { active_role: opts.role }, error: null });
-  } else if (opts.tenant_id !== null) {
-    // explicit no-row → maybeSingle returns data: null
-    mockSupabase.__seed({ data: null, error: null });
-  }
-  // If tenant_id is null, getActiveRole short-circuits without querying — no seed needed.
 }
 
 beforeEach(() => {
@@ -216,10 +216,10 @@ describe(`${'VTID-03213'} §6 getBearerToken`, () => {
 });
 
 // =============================================================================
-// §1  Role gating
+// §1  Auth gating (open to any authenticated user — commerce is NOT role-gated)
 // =============================================================================
 
-describe(`${'VTID-03213'} §1 role gating`, () => {
+describe(`${'VTID-03213'} §1 auth gating`, () => {
   test('GET /health is open (no auth required)', async () => {
     const res = await request(buildApp()).get('/api/v1/universal-cart/health');
     expect(res.status).toBe(200);
@@ -241,42 +241,79 @@ describe(`${'VTID-03213'} §1 role gating`, () => {
     expect(res.body.error).toBe('UNAUTHENTICATED');
   });
 
-  test('POST / with role=admin → 403 cart_unavailable_for_role', async () => {
+  test('POST / with role=admin is allowed (commerce is not role-gated) → 201', async () => {
+    // The hotfix removed the community-role wall: ANY authenticated caller may
+    // use the cart. Prove an 'admin' caller is allowed through to create a cart.
     seedAuth({ role: 'admin' });
+    // universal_carts SELECT → no existing
+    mockSupabase.__seed({ data: null, error: null });
+    // universal_carts INSERT → returns new cart
+    mockSupabase.__seed({
+      data: { id: CART_A, user_id: USER_A, status: 'active', tenant_id: TENANT_1 },
+      error: null,
+    });
+    // universal_cart_events INSERT (audit)
+    mockSupabase.__seed({ data: null, error: null });
+
     const res = await request(buildApp())
       .post('/api/v1/universal-cart')
       .set('Authorization', BEARER_A);
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe('cart_unavailable_for_role');
-    expect(res.body.role).toBe('admin');
+
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.created).toBe(true);
+    expect(res.body.error).toBeUndefined();
   });
 
-  test('POST / with role=developer → 403', async () => {
+  test('POST / with role=developer is allowed → existing cart returned (200)', async () => {
     seedAuth({ role: 'developer' });
+    // universal_carts SELECT → existing active cart
+    mockSupabase.__seed({
+      data: { id: CART_A, user_id: USER_A, status: 'active' },
+      error: null,
+    });
+
     const res = await request(buildApp())
       .post('/api/v1/universal-cart')
       .set('Authorization', BEARER_A);
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe('cart_unavailable_for_role');
+
+    expect(res.status).toBe(200);
+    expect(res.body.created).toBe(false);
+    expect(res.body.error).toBeUndefined();
   });
 
-  test('POST / with no active_role row → 403', async () => {
+  test('POST / with no active_role is still allowed (existing-cart path) → 200', async () => {
+    // Users whose active_role is null/unset were the ones the old gate broke;
+    // they must now be allowed through.
     seedAuth({ role: null });
+    // universal_carts SELECT → existing active cart
+    mockSupabase.__seed({
+      data: { id: CART_A, user_id: USER_A, status: 'active' },
+      error: null,
+    });
+
     const res = await request(buildApp())
       .post('/api/v1/universal-cart')
       .set('Authorization', BEARER_A);
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe('cart_unavailable_for_role');
-    expect(res.body.role).toBeNull();
+
+    expect(res.status).toBe(200);
+    expect(res.body.created).toBe(false);
+    expect(res.body.cart.id).toBe(CART_A);
+    expect(res.body.error).toBeUndefined();
   });
 
-  test('GET / requires same gate (sanity)', async () => {
+  test('GET / is open to any authenticated caller (no role gate)', async () => {
     seedAuth({ role: 'admin' });
+    // universal_carts SELECT → no cart
+    mockSupabase.__seed({ data: null, error: null });
+
     const res = await request(buildApp())
       .get('/api/v1/universal-cart')
       .set('Authorization', BEARER_A);
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe('cart_unavailable_for_role');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.error).toBeUndefined();
   });
 });
 
@@ -726,13 +763,16 @@ describe(`${'VTID-03260'} GET /budget`, () => {
     expect(res.body.error).toBe('UNAUTHENTICATED');
   });
 
-  test('403 cart_unavailable_for_role for non-community', async () => {
+  test('non-community role (admin) is allowed — budget is not role-gated', async () => {
     seedAuth({ role: 'admin' });
+    // Budget reads: app_users, user_limitations, product_orders (spend), carts.
+    seedBudget({ capCents: null, cartId: null });
     const res = await request(buildApp())
       .get('/api/v1/universal-cart/budget')
       .set('Authorization', BEARER_A);
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe('cart_unavailable_for_role');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.error).toBeUndefined();
   });
 
   /** Seed the budget reads in handler order: app_users, user_limitations,


### PR DESCRIPTION
## Hotfix — commerce was role-gated to death on mobile

The mobile app has a single audience (every user **is** a community user), but the universal-cart gate (`authorizeCommunityCaller`) and the video-shop gate hard-required `user_tenants.active_role === 'community'` and 403'd everyone else. For app users `active_role` is null/unset → **this blocked every user**: the sidebar cart link, the agent, budget, reorder, and the video shop all returned `cart_unavailable_for_role` / `shop_unavailable_for_role`. Phase 0 made it worse by redirecting the previously-**open** `/cart` into the gated cart.

### Fix
Both gates are now **auth-only** — any authenticated caller is allowed (401 only on missing/invalid bearer token). No role lookup, no role 403. RLS still enforces per-user owner isolation on cart writes. Removed the dead `COMMUNITY_ROLE`/`denyForRole` (cart) and `COMMUNITY_ROLE`/`getActiveRole` import (shop-feed).

**Frontend needs no change** — its `roleBlocked` screen is derived from the 403 and simply goes dormant once the gateway stops sending it.

### Tests
`seedAuth` no longer seeds the now-unused `active_role` lookup (FIFO mock realignment); the former role-403 tests are **converted** (not deleted) into allowed-through tests. **universal-cart 46/46, shopping-agent 20/20**, `tsc --noEmit` clean.

VTID-03260.

https://claude.ai/code/session_01NCKVrJGmWJpz2T9psbTX61

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCKVrJGmWJpz2T9psbTX61)_