### PR TITLE
VTID-03257: ORB Fix-1 — Journey Foundation checklist leads turn 1 (no "what do you want")

### DIFF
--- a/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
+++ b/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
@@ -1,0 +1,58 @@
+/**
+ * VTID-03257 (Fix-1) — GUIDE MODE system-instruction block.
+ *
+ * Renders the behavioral contract that turns Vitana from a passive assistant
+ * into a proactive, hand-holding journey guide for users still on the Journey
+ * Foundation. Bundled onto the journey-guide candidate and injected for the
+ * whole session (turns 2+), the way Teacher Mode is.
+ */
+
+import type { JourneyGuideContent } from '../../../services/assistant-continuation/providers/journey-guide';
+
+export function buildJourneyGuideBlock(guide: JourneyGuideContent, lang: string): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+
+  // The doing-verb differs slightly for a teacher-type (walk-through) vs an
+  // action-type (do-it-together) step, but the contract is identical.
+  const stepLine = guide.execute_prompt;
+
+  if (isDe) {
+    return [
+      '',
+      '## GUIDE-MODUS — du FÜHRST diese Person durch ihre Reise, Schritt für Schritt',
+      '',
+      'Diese Person ist neu in VitanaLand und weiß noch NICHT, was sie tun soll. Du bist ihr proaktiver Guide. Du FÜHRST. Du fragst NIEMALS „Was möchtest du?" oder „Wie kann ich helfen?".',
+      '',
+      `AKTUELLER SCHRITT: ${guide.step_title}`,
+      `Warum jetzt wichtig: ${guide.benefit}`,
+      `Führe so: ${stepLine}`,
+      '',
+      'Regeln für diese ganze Session:',
+      '- Formuliere den Schritt als klare AUFFORDERUNG und MACH ihn GEMEINSAM mit der Person — jetzt, Schritt für Schritt, damit sie durch Tun lernt (nicht durch Erklären).',
+      '- NUR DIESEN EINEN Schritt. Spring nicht voraus.',
+      '- Stelle NIEMALS offene „Was möchtest du / Wie kann ich helfen"-Fragen. Wenn die Person unsicher ist, führe sie durch den aktuellen Schritt.',
+      '- VERTRAUEN durch PRÜFEN: Sagt die Person, sie habe es erledigt, glaube es NICHT einfach — bestätige es anhand der echten Daten (mit deinen Tools / record_journey_answer). Ist es NICHT erledigt, bestehe warmherzig darauf: „Das ist noch nicht erledigt — komm, lass es uns zusammen machen, ich zeige dir wie."',
+      '- Wenn der Schritt WIRKLICH abgeschlossen ist, freu dich kurz mit ihr und sag, dass es nächstes Mal weitergeht.',
+      '',
+    ].join('\n');
+  }
+
+  return [
+    '',
+    '## GUIDE MODE — you LEAD this person through their journey, one step at a time',
+    '',
+    'This person is new to VitanaLand and does NOT yet know what to do. You are their proactive guide. You LEAD. You NEVER ask "What do you want?" or "How can I help?".',
+    '',
+    `CURRENT STEP: ${guide.step_title}`,
+    `Why it matters now: ${guide.benefit}`,
+    `Lead with this: ${stepLine}`,
+    '',
+    'Rules for this whole session:',
+    '- State the step as a clear DIRECTIVE and DO it TOGETHER with the person — right now, step by step, so they learn by doing (not by explanation).',
+    '- ONLY this one step. Do not jump ahead.',
+    '- NEVER ask open-ended "what do you want / how can I help". If they are unsure, lead them through the current step.',
+    '- TRUST by VERIFYING: if they say they already did it, do NOT just believe them — confirm against the real data (via your tools / record_journey_answer). If it is NOT done, warmly insist: "That\'s not done yet — come on, let\'s do it together, I\'ll show you how."',
+    '- When the step is GENUINELY complete, briefly celebrate the win with them and say you\'ll continue next time.',
+    '',
+  ].join('\n');
+}

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1225,6 +1225,22 @@ export async function handleLiveSessionStart(
           `[VTID-03218] Teacher Mode content (bundled on candidate) for ${sessionId}: capability=${bundledTeacherMode.active_capability_key} manual_chars=${bundledTeacherMode.active_manual_content.length} remaining=${bundledTeacherMode.remaining_capabilities.length}`,
         );
       }
+
+      // VTID-03257 (Fix-1): when the journey-guide won, bundle its GUIDE-MODE
+      // content onto the session so the envelope injects the lead-the-journey
+      // block (proactive, one-step, do-it-together, verify-on-claim, never
+      // "what do you want"). Mirrors the Teacher bundling above.
+      const bundledJourneyGuide = (picked as {
+        journeyGuide?:
+          | import('../../../services/assistant-continuation/providers/journey-guide').JourneyGuideContent
+          | null;
+      }).journeyGuide ?? null;
+      if (bundledJourneyGuide) {
+        (session as any).journeyGuideContent = bundledJourneyGuide;
+        console.log(
+          `[VTID-03257] Journey guide leading for ${sessionId}: step=${bundledJourneyGuide.step_key} (${bundledJourneyGuide.step_type}) title="${bundledJourneyGuide.step_title}"`,
+        );
+      }
     }
   } catch (e) {
     console.warn(

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5209,6 +5209,40 @@ async function executeLiveApiToolInner(
         };
       }
 
+      case 'record_journey_answer': {
+        // VTID-03257 (Fix-1): Vertex parity for the journey-answer tool.
+        // record_journey_answer was added to ORB_TOOL_REGISTRY by VTID-03255
+        // (so LiveKit's tools.py wrapper can call it) but never got a Vertex
+        // case — so on Vertex it fell through to `Unknown tool`. The GUIDE-MODE
+        // block (buildJourneyGuideBlock) instructs the model to VERIFY a
+        // completion claim via record_journey_answer, so it MUST work on both
+        // transports. Delegate to the shared dispatcher (lifted pattern).
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'Service unavailable — Supabase creds not configured' };
+        }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          'record_journey_answer',
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+            session_id: session.sessionId,
+            thread_id: session.thread_id || session.sessionId,
+            turn_number: session.turn_count,
+            session_started_iso: session.createdAt.toISOString(),
+            lang: session.lang ?? null,
+          },
+          supabase,
+        );
+      }
+
       default: {
         // BOOTSTRAP-ADMIN-DD: route admin voice tools through their handlers.
         // The handlers re-check role server-side, so a community session that

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1307,6 +1307,8 @@ export { buildLiveApiTools } from '../orb/live/tools/live-tool-catalog';
 // content resolver succeeded. Drives multi-turn teaching via prompt +
 // tools rather than a TS-side state machine.
 import { buildTeacherModeBlock } from '../orb/teacher/teacher-mode-prompt';
+// VTID-03257 (Fix-1): GUIDE MODE block — Vitana leads the Foundation checklist.
+import { buildJourneyGuideBlock } from '../orb/live/instruction/journey-guide-prompt';
 // A6.2 (orb-live-refactor): SessionContext + SessionMutator + first
 // lifted navigator handler. orb-live.ts keeps compat shims that build
 // the typed views and forward to handlers under orb/live/tools/handlers/.
@@ -6133,6 +6135,16 @@ async function connectToLiveAPI(
                                   lang: session.lang,
                                   firstName: (session as any).teacherModeFirstName ?? null,
                                 })
+                              : '')
+                          // VTID-03257 (Fix-1): GUIDE MODE — when the journey
+                          // guide won turn 1, inject the lead-the-journey block
+                          // so the whole session is hand-held through the
+                          // current Foundation step (no "what do you want?").
+                          + ((session as any).journeyGuideContent
+                              ? buildJourneyGuideBlock(
+                                  (session as any).journeyGuideContent,
+                                  session.lang,
+                                )
                               : ''),
                         session.active_role,
                         session.conversationSummary,

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -75,6 +75,8 @@ import { buildLiveSystemInstruction } from '../orb/live/instruction/live-system-
 // Python agent's session.say(user_facing_line) is the single source of truth
 // for the LiveKit first turn; the LLM must stay silent until the user replies.
 import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../orb/live/instruction/wake-brief-marker';
+// VTID-03257 (Fix-1) — GUIDE-MODE block for LiveKit parity (turns 2+).
+import { buildJourneyGuideBlock } from '../orb/live/instruction/journey-guide-prompt';
 import {
   optionalAuth,
   requireAuthWithTenant,
@@ -1809,10 +1811,19 @@ first turn only. Subsequent turns follow the normal conversation flow.`;
         const vitanaBehavioralRule = buildPersonaBehavioralRule('vitana');
         // Marker at the HEAD so capBootstrapContext (head-preserving) can never
         // trim it away, regardless of bootstrap size.
+        // VTID-03257 (Fix-1): LiveKit parity — when the journey guide won, the
+        // GUIDE-MODE block must govern turns 2+ here too (the directive opener
+        // itself is spoken by the agent via wake_brief_decision.user_facing_line).
+        const journeyGuide = (picked as {
+          journeyGuide?:
+            | import('../services/assistant-continuation/providers/journey-guide').JourneyGuideContent
+            | null;
+        }).journeyGuide ?? null;
         const augmentedContext =
           `${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}\n\n` +
           (bootstrapContext ? `${bootstrapContext}\n\n` : '') +
-          `${vitanaBehavioralRule}`;
+          `${vitanaBehavioralRule}` +
+          (journeyGuide ? buildJourneyGuideBlock(journeyGuide, lang) : '');
         const voiceStyle =
           (voiceConfig as { voice_style?: string } | null)?.voice_style?.trim() ||
           'friendly, calm, empathetic';

--- a/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
@@ -1,0 +1,139 @@
+/**
+ * VTID-03257 (Fix-1) — Journey Guide provider.
+ *
+ * THE PRODUCT CONTRACT: for users who are still on the onboarding journey
+ * (not yet graduated from the Journey Foundation), Vitana is a PROACTIVE,
+ * hand-holding guide — NOT a passive assistant. She drives the Foundation
+ * checklist ONE step at a time, states the step as a DIRECTIVE (never "what do
+ * you want?"), does the task WITH the user, and verifies completion against
+ * real data before advancing.
+ *
+ * This provider makes that real at turn 1. It outranks new_day_return (90) and
+ * Teacher (85) so the journey leads; it SUPPRESSES once the user has graduated,
+ * handing the floor back to the normal ladder. The directive line is the
+ * step's own `execute_prompt`; a GUIDE-MODE block (bundled on the candidate)
+ * governs turns 2+.
+ */
+
+import type {
+  AssistantContinuation,
+  ContinuationDecisionContext,
+  ContinuationProvider,
+  ProviderResult,
+} from '../types';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { JourneyFoundationSnapshot } from '../../journey-foundation/types';
+
+export const JOURNEY_GUIDE_PROVIDER_KEY = 'journey_guide';
+export const JOURNEY_GUIDE_EXTRA_KEY = 'journey_guide';
+
+// Above new_day_return (90) + Teacher (85): the checklist leads. Below
+// first_time_welcome (95, the one-time intro) + goal_completion (92).
+const JOURNEY_GUIDE_PRIORITY = 91;
+
+/** Bundled GUIDE-MODE content the controller reads off the winning candidate. */
+export interface JourneyGuideContent {
+  step_key: string;
+  step_title: string;
+  /** The step's directive execute_prompt (what Vitana leads with). */
+  execute_prompt: string;
+  /** One-line "why this matters now". */
+  benefit: string;
+  /** action = do-it-together task; teacher = walk-through explanation. */
+  step_type: string;
+  navigation_route: string | null;
+}
+
+interface JourneyGuideInputs {
+  supabase: SupabaseClient;
+  userId: string;
+  isReconnect?: boolean;
+}
+
+function readInputs(ctx: ContinuationDecisionContext): JourneyGuideInputs | null {
+  const raw = ctx.extra?.[JOURNEY_GUIDE_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  if (!obj.supabase || typeof obj.userId !== 'string' || !obj.userId) return null;
+  return {
+    supabase: obj.supabase as SupabaseClient,
+    userId: obj.userId,
+    isReconnect: obj.isReconnect === true,
+  };
+}
+
+export function makeJourneyGuideProvider(): ContinuationProvider {
+  return {
+    key: JOURNEY_GUIDE_PROVIDER_KEY,
+    surfaces: ['orb_wake'],
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return { providerKey: JOURNEY_GUIDE_PROVIDER_KEY, status: 'skipped', latencyMs: 0, reason: 'no_journey_guide_inputs' };
+      }
+      // Transparent reconnect: the previous turn is still alive — don't open.
+      if (inputs.isReconnect) {
+        return { providerKey: JOURNEY_GUIDE_PROVIDER_KEY, status: 'suppressed', latencyMs: 0, reason: 'forced_skip_reconnect' };
+      }
+
+      let snapshot: JourneyFoundationSnapshot;
+      let stepDef: { execute_prompt: string; benefit: string } | undefined;
+      try {
+        const [{ buildJourneyFoundationSnapshot }, { getStepDef }] = await Promise.all([
+          import('../../journey-foundation/journey-foundation-state'),
+          import('../../journey-foundation/foundation-steps'),
+        ]);
+        snapshot = await buildJourneyFoundationSnapshot(inputs.supabase, inputs.userId);
+        const key = snapshot.current_next_step?.key;
+        stepDef = key ? getStepDef(key) : undefined;
+      } catch (err) {
+        return {
+          providerKey: JOURNEY_GUIDE_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: 0,
+          reason: `journey_guide_snapshot_failed: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+
+      // Graduated → the journey is done; hand the floor to the normal ladder.
+      if (snapshot.graduated) {
+        return { providerKey: JOURNEY_GUIDE_PROVIDER_KEY, status: 'suppressed', latencyMs: 0, reason: 'journey_graduated' };
+      }
+      const step = snapshot.current_next_step;
+      if (!step || !stepDef) {
+        return { providerKey: JOURNEY_GUIDE_PROVIDER_KEY, status: 'suppressed', latencyMs: 0, reason: 'no_next_step' };
+      }
+
+      const guide: JourneyGuideContent = {
+        step_key: step.key,
+        step_title: step.title,
+        execute_prompt: stepDef.execute_prompt,
+        benefit: stepDef.benefit,
+        step_type: step.type,
+        navigation_route: step.navigation_route,
+      };
+
+      // The spoken opener IS the step's directive — Vitana leads, never asks
+      // "what do you want?". The GUIDE-MODE block (bundled below) governs the
+      // rest of the session.
+      const candidate = {
+        id: `journey-guide-${step.key}`,
+        surface: 'orb_wake',
+        kind: 'wake_brief',
+        priority: JOURNEY_GUIDE_PRIORITY,
+        userFacingLine: stepDef.execute_prompt,
+        cta: { type: 'guide_step', payload: { step_key: step.key, route: step.navigation_route } },
+        evidence: [
+          { kind: 'source:journey_guide', detail: step.key },
+          { kind: 'journey_step_tier', detail: String(step.tier) },
+        ],
+        dedupeKey: `journey_guide:${step.key}`,
+        privacyMode: 'safe_to_speak',
+        // Bundled — controller reads candidate.journeyGuide (cast), like teacherMode.
+        journeyGuide: guide,
+      } as unknown as AssistantContinuation;
+
+      return { providerKey: JOURNEY_GUIDE_PROVIDER_KEY, status: 'returned', latencyMs: 0, candidate };
+    },
+  };
+}

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -81,6 +81,13 @@ import {
   GOAL_COMPLETION_EXTRA_KEY,
   GOAL_COMPLETION_PROVIDER_KEY,
 } from './assistant-continuation/providers/goal-completion-inquiry';
+// VTID-03257 (Fix-1): journey-guide — for non-graduated users the Foundation
+// checklist LEADS turn-1 (priority 91, above new-day-return + Teacher).
+import {
+  makeJourneyGuideProvider,
+  JOURNEY_GUIDE_EXTRA_KEY,
+  JOURNEY_GUIDE_PROVIDER_KEY,
+} from './assistant-continuation/providers/journey-guide';
 // VTID-03061 (B0d-real Xf.1): auto-emit OASIS next_action.suggested/
 // .suppressed events when a wake-brief decision lands. Fire-and-forget;
 // never blocks the voice path.
@@ -147,6 +154,13 @@ export function ensureWakeBriefProviderRegistered(): void {
   // completed and otherwise yields to new-day-return / Teacher / wake-brief.
   if (!defaultProviderRegistry.get(GOAL_COMPLETION_PROVIDER_KEY)) {
     defaultProviderRegistry.register(makeGoalCompletionInquiryProvider());
+  }
+  // VTID-03257 (Fix-1): journey-guide at priority 91 — for users still on the
+  // Journey Foundation (not graduated), the checklist LEADS the conversation
+  // (above new_day_return 90 + Teacher 85). Suppresses cleanly when graduated
+  // or no next step, so it never blocks the returning-user providers.
+  if (!defaultProviderRegistry.get(JOURNEY_GUIDE_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeJourneyGuideProvider());
   }
   _registered = true;
 }
@@ -390,6 +404,14 @@ export async function decideWakeBriefForSession(
         userId: args.userId,
         lang: args.lang,
         firstName: args.firstName ?? null,
+      };
+      // VTID-03257 (Fix-1): journey-guide inputs. Provider suppresses when the
+      // user has graduated the Foundation or has no next step, so passing the
+      // extra always is safe — when active it LEADS (priority 91).
+      extra[JOURNEY_GUIDE_EXTRA_KEY] = {
+        supabase: args.supabase,
+        userId: args.userId,
+        isReconnect: args.isReconnect,
       };
     }
   }

--- a/services/gateway/test/orb/routes/livekit-context-parity.test.ts
+++ b/services/gateway/test/orb/routes/livekit-context-parity.test.ts
@@ -26,11 +26,17 @@ const ORB_LIVEKIT_PATH = path.resolve(
   __dirname,
   '../../../src/routes/orb-livekit.ts',
 );
+const ORB_LIVE_PATH = path.resolve(
+  __dirname,
+  '../../../src/routes/orb-live.ts',
+);
 
 let source: string;
+let vertexSource: string;
 
 beforeAll(() => {
   source = fs.readFileSync(ORB_LIVEKIT_PATH, 'utf8');
+  vertexSource = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
 });
 
 describe('VTID-03036 LiveKit context parity wire-up', () => {
@@ -190,5 +196,46 @@ describe('VTID-03122 Phase E LiveKit context parity — lastSessionInfo + journe
     // failure cannot block the bootstrap response. The Vertex orb-live.ts
     // path is unaffected.
     expect(source).toMatch(/fetchLastSessionInfo failed[\s\S]{0,200}falls back to UNKNOWN/);
+  });
+});
+
+describe('VTID-03257 (Fix-1) GUIDE-MODE cross-provider parity', () => {
+  // The Journey Foundation checklist must LEAD turn 1 on BOTH transports. The
+  // directive opener flows through the shared wake-decision (userFacingLine);
+  // the GUIDE-MODE block (buildJourneyGuideBlock) must be injected into the
+  // system instruction on each provider so turns 2+ keep leading. If one
+  // provider drops the block, the journey-led behavior silently diverges.
+  it('LiveKit imports buildJourneyGuideBlock', () => {
+    expect(source).toMatch(
+      /import\s*{[^}]*\bbuildJourneyGuideBlock\b[^}]*}\s*from\s*['"][^'"]*journey-guide-prompt['"]/,
+    );
+  });
+
+  it('LiveKit injects the GUIDE-MODE block into the augmented system context', () => {
+    // Reads the bundled journeyGuide off the winning candidate and appends the
+    // block to augmentedContext (after the behavioral rule, outside the marker).
+    expect(source).toMatch(/\}\)\.journeyGuide\s*\?\?\s*null/);
+    expect(source).toMatch(/journeyGuide\s*\?\s*buildJourneyGuideBlock\(\s*journeyGuide\s*,\s*lang\s*\)\s*:\s*['"]['"]/);
+  });
+
+  it('Vertex imports buildJourneyGuideBlock', () => {
+    expect(vertexSource).toMatch(
+      /import\s*{[^}]*\bbuildJourneyGuideBlock\b[^}]*}\s*from\s*['"][^'"]*journey-guide-prompt['"]/,
+    );
+  });
+
+  it('Vertex injects the GUIDE-MODE block into the setup envelope', () => {
+    // Consumes session.journeyGuideContent (set by the controller from the
+    // bundled candidate) and appends the block alongside teacherModeContent.
+    expect(vertexSource).toMatch(/journeyGuideContent\s*\?\s*buildJourneyGuideBlock\(/);
+  });
+
+  it('controller bundles picked.journeyGuide onto the session', () => {
+    const controller = fs.readFileSync(
+      path.resolve(__dirname, '../../../src/orb/live/session/live-session-controller.ts'),
+      'utf8',
+    );
+    expect(controller).toMatch(/picked\b[\s\S]{0,200}journeyGuide/);
+    expect(controller).toMatch(/journeyGuideContent\s*=\s*bundledJourneyGuide/);
   });
 });

--- a/services/gateway/test/services/assistant-continuation/providers/journey-guide.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/journey-guide.test.ts
@@ -1,0 +1,186 @@
+/**
+ * VTID-03257 (Fix-1) — journey-guide provider tests.
+ *
+ * Locks the product contract: for a non-graduated user, the Journey Foundation
+ * checklist LEADS turn 1 — the directive step line is the spoken opener, the
+ * GUIDE-MODE content is bundled, priority 91 beats new_day_return (90) and
+ * Teacher (85). Suppresses once graduated, on reconnect, and when there is no
+ * next step. Skips on missing inputs.
+ */
+
+import {
+  makeJourneyGuideProvider,
+  JOURNEY_GUIDE_PROVIDER_KEY,
+  JOURNEY_GUIDE_EXTRA_KEY,
+} from '../../../../src/services/assistant-continuation/providers/journey-guide';
+
+// The provider reaches the journey-foundation modules via dynamic import().
+const mockBuildSnapshot = jest.fn();
+const mockGetStepDef = jest.fn();
+
+jest.mock('../../../../src/services/journey-foundation/journey-foundation-state', () => ({
+  buildJourneyFoundationSnapshot: (...args: any[]) => mockBuildSnapshot(...args),
+}));
+jest.mock('../../../../src/services/journey-foundation/foundation-steps', () => ({
+  getStepDef: (...args: any[]) => mockGetStepDef(...args),
+}));
+
+const FAKE_SB = { from: () => ({}) } as any;
+
+function makeCtx(extraOverride: any = {}) {
+  return {
+    surface: 'orb_wake',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    extra: {
+      [JOURNEY_GUIDE_EXTRA_KEY]: {
+        supabase: FAKE_SB,
+        userId: 'u1',
+        isReconnect: false,
+        ...extraOverride,
+      },
+    },
+  } as any;
+}
+
+const NEXT_STEP = {
+  key: 'life_compass',
+  title: 'Set your Life Compass',
+  strand: 'health',
+  type: 'action',
+  tier: 0,
+  status: 'pending',
+  required_for_graduation: true,
+  navigation_route: '/life-compass',
+  benefit: 'Define the one goal your whole journey is built around.',
+};
+
+const STEP_DEF = {
+  benefit: 'Define the one goal your whole journey is built around.',
+  execute_prompt: "Let's set your Life Compass right now — I'll walk you through it.",
+};
+
+beforeEach(() => {
+  mockBuildSnapshot.mockReset();
+  mockGetStepDef.mockReset();
+});
+
+describe('VTID-03257 makeJourneyGuideProvider', () => {
+  it('exposes the correct surface + key', () => {
+    const p = makeJourneyGuideProvider();
+    expect(p.key).toBe(JOURNEY_GUIDE_PROVIDER_KEY);
+    expect(p.surfaces).toEqual(['orb_wake']);
+  });
+
+  it('skips when inputs are missing', async () => {
+    const p = makeJourneyGuideProvider();
+    const r = await p.produce({ surface: 'orb_wake', extra: {} } as any);
+    expect(r.status).toBe('skipped');
+    expect((r as any).reason).toBe('no_journey_guide_inputs');
+  });
+
+  it('suppresses on transparent reconnect', async () => {
+    const p = makeJourneyGuideProvider();
+    const r = await p.produce(makeCtx({ isReconnect: true }));
+    expect(r.status).toBe('suppressed');
+    expect((r as any).reason).toBe('forced_skip_reconnect');
+  });
+
+  it('suppresses once the user has graduated', async () => {
+    mockBuildSnapshot.mockResolvedValue({ graduated: true, current_next_step: null });
+    const p = makeJourneyGuideProvider();
+    const r = await p.produce(makeCtx());
+    expect(r.status).toBe('suppressed');
+    expect((r as any).reason).toBe('journey_graduated');
+  });
+
+  it('suppresses when there is no next step', async () => {
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: null });
+    const p = makeJourneyGuideProvider();
+    const r = await p.produce(makeCtx());
+    expect(r.status).toBe('suppressed');
+    expect((r as any).reason).toBe('no_next_step');
+  });
+
+  it('errors gracefully when the snapshot build throws', async () => {
+    mockBuildSnapshot.mockRejectedValue(new Error('boom'));
+    const p = makeJourneyGuideProvider();
+    const r = await p.produce(makeCtx());
+    expect(r.status).toBe('errored');
+    expect((r as any).reason).toMatch(/journey_guide_snapshot_failed/);
+  });
+
+  it('LEADS turn 1: directive opener + bundled guide, priority 91', async () => {
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockGetStepDef.mockReturnValue(STEP_DEF);
+    const p = makeJourneyGuideProvider();
+    const r = await p.produce(makeCtx());
+    expect(r.status).toBe('returned');
+    const c = (r as any).candidate;
+    expect(c.priority).toBe(91);
+    expect(c.surface).toBe('orb_wake');
+    expect(c.kind).toBe('wake_brief');
+    // The spoken opener IS the step's directive — never "what do you want?".
+    expect(c.userFacingLine).toBe(STEP_DEF.execute_prompt);
+    expect(c.userFacingLine).not.toMatch(/what (do|can) you/i);
+    expect(c.dedupeKey).toBe('journey_guide:life_compass');
+    // GUIDE-MODE content bundled on the candidate for the controller.
+    expect(c.journeyGuide).toMatchObject({
+      step_key: 'life_compass',
+      step_title: 'Set your Life Compass',
+      execute_prompt: STEP_DEF.execute_prompt,
+      benefit: STEP_DEF.benefit,
+      step_type: 'action',
+      navigation_route: '/life-compass',
+    });
+  });
+
+  it('priority beats new_day_return (90) and Teacher (85)', async () => {
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockGetStepDef.mockReturnValue(STEP_DEF);
+    const p = makeJourneyGuideProvider();
+    const r = await p.produce(makeCtx());
+    expect((r as any).candidate.priority).toBeGreaterThan(90);
+    expect((r as any).candidate.priority).toBeGreaterThan(85);
+  });
+
+  it('suppresses when the step has no definition (defensive)', async () => {
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockGetStepDef.mockReturnValue(undefined);
+    const p = makeJourneyGuideProvider();
+    const r = await p.produce(makeCtx());
+    expect(r.status).toBe('suppressed');
+    expect((r as any).reason).toBe('no_next_step');
+  });
+});
+
+describe('VTID-03257 buildJourneyGuideBlock', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { buildJourneyGuideBlock } = require('../../../../src/orb/live/instruction/journey-guide-prompt');
+  const guide = {
+    step_key: 'life_compass',
+    step_title: 'Set your Life Compass',
+    execute_prompt: "Let's set your Life Compass right now.",
+    benefit: 'Define the one goal your whole journey is built around.',
+    step_type: 'action',
+    navigation_route: '/life-compass',
+  };
+
+  it('English block leads, forbids "what do you want", demands verify-on-claim', () => {
+    const block = buildJourneyGuideBlock(guide, 'en');
+    expect(block).toMatch(/GUIDE MODE/);
+    expect(block).toMatch(/you LEAD/);
+    expect(block).toMatch(/Set your Life Compass/);
+    expect(block).toMatch(/NEVER ask/i);
+    expect(block).toMatch(/TRUST by VERIFYING/);
+    expect(block).toMatch(/let's do it together/i);
+  });
+
+  it('German block renders for de lang', () => {
+    const block = buildJourneyGuideBlock(guide, 'de');
+    expect(block).toMatch(/GUIDE-MODUS/);
+    expect(block).toMatch(/du FÜHRST/);
+    expect(block).toMatch(/NIEMALS/);
+  });
+});


### PR DESCRIPTION
## VTID-03257 — ORB Fix-1: the journey LEADS

**The product contract.** For users still on the Journey Foundation (not yet graduated), Vitana is a **proactive, hand-holding guide** — not a passive assistant. She drives the Foundation checklist **one step at a time**, states the step as a **DIRECTIVE** (never "what do you want?" / "how can I help?"), does the task **WITH** the user (learn-by-doing), and **verifies completion against real data** before advancing.

This is the structural fix for the inversion where Journey Foundation was built but never reached turn 1.

### What ships
- **journey-guide provider** (priority **91**): outranks new_day_return (90) and Teacher (85). Suppresses once graduated, on reconnect, and when there is no next step. The spoken opener **is** the step directive execute_prompt.
- **buildJourneyGuideBlock (EN + DE)**: GUIDE-MODE block for turns 2+ — lead with the one step, NEVER ask "what do you want", TRUST by VERIFYING, celebrate genuine wins.
- Registered in the shared wake-decision; controller bundles picked.journeyGuide onto the session.

### Vertex + LiveKit parity
Both transports inject buildJourneyGuideBlock; the directive opener flows through the shared wake-decision userFacingLine. Locked by source-level parity assertions.

### Tests
11 new provider/block tests + 5 cross-provider parity assertions. npm run build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)