### PR TITLE
VTID-03259: ORB Fix-3 — single-opener arbiter (strip V2 STEP-1 leak)

### DIFF
--- a/services/gateway/src/orb/live/instruction/brain-opener-sentinels.ts
+++ b/services/gateway/src/orb/live/instruction/brain-opener-sentinels.ts
@@ -1,0 +1,19 @@
+/**
+ * VTID-03259 (Fix-3) — brain-opener region sentinels.
+ *
+ * vitana-brain's PROACTIVE INITIATIVE OFFER (V2) block is a single string that
+ * contains NESTED `=== … ===` subsections (STEP 1 — YOUR VERY FIRST UTTERANCE,
+ * ON NO, ON HARDER REFUSAL). The heading-based stripBrainOpenerSections() regex
+ * stops at the first nested `===`, so STEP 1 — a competing "speak this verbatim
+ * first utterance" directive — used to SURVIVE the strip and fight the
+ * wake-brief / journey-guide override for control of turn 1. That was the
+ * single-opener "mixing".
+ *
+ * Wrapping the whole V2 block in these opaque sentinels lets the stripper
+ * remove the entire region as one unit, regardless of how many `===`
+ * subsections it contains. Shared here so producer (vitana-brain) and consumer
+ * (live-system-instruction) agree on the exact markers without a circular
+ * import.
+ */
+export const BRAIN_OPENER_V2_START = '<<BRAIN_OPENER_V2_START>>';
+export const BRAIN_OPENER_V2_END = '<<BRAIN_OPENER_V2_END>>';

--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -45,6 +45,10 @@ import {
 // boundary. The function is pure (lang → string), so the round-trip is
 // safe.
 import { buildNavigatorPolicySection } from '../../../routes/orb-live';
+import {
+  BRAIN_OPENER_V2_START,
+  BRAIN_OPENER_V2_END,
+} from './brain-opener-sentinels';
 // L2.2b.6 (VTID-03010): tool-catalog renderer. Embeds the tool catalog into
 // the prompt as a prose block so the LiveKit path (where the Python
 // livekit-plugins-google plugin does NOT fully serialize @function_tool
@@ -205,12 +209,26 @@ export function describeRoute(route: string | undefined | null, lang: string): {
  */
 export function stripBrainOpenerSections(bootstrap: string): string {
   if (!bootstrap) return bootstrap;
+  let out = bootstrap;
+  // VTID-03259 (Fix-3): remove the sentinel-delimited V2 proactive-initiative
+  // region FIRST, as one opaque unit. The V2 block contains nested `=== … ===`
+  // subsections (STEP 1 — YOUR VERY FIRST UTTERANCE, ON NO, ON HARDER REFUSAL);
+  // the heading-based strip below stops at the first nested `===`, so STEP 1's
+  // competing "speak this verbatim" directive used to survive and fight the
+  // wake-brief / journey-guide override. Stripping the sentinel region kills it
+  // regardless of nesting. (Belt-and-suspenders: the heading list still runs in
+  // case an older brain build emitted the block without sentinels.)
+  const sentinelPattern = new RegExp(
+    `${BRAIN_OPENER_V2_START}[\\s\\S]*?${BRAIN_OPENER_V2_END}`,
+    'g',
+  );
+  out = out.replace(sentinelPattern, '');
   const SECTIONS = [
     'OPENING SHAPE MATRIX (TENURE × LAST_INTERACTION)',
     'PROACTIVE OPENER CANDIDATE — YOUR FIRST UTTERANCE MUST BUILD AROUND THIS',
     'PROACTIVE INITIATIVE OFFER (V2 — HIGHEST-PRIORITY OPENER FOR THIS SESSION)',
+    'STEP 1 — YOUR VERY FIRST UTTERANCE (sanctioned, do NOT paraphrase)',
   ];
-  let out = bootstrap;
   for (const heading of SECTIONS) {
     const safe = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const pattern = new RegExp(

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -43,6 +43,12 @@ import { getSupabase } from '../lib/supabase';
 import { getSystemControl } from './system-controls-service';
 // VTID-01952 Phase 0 — Identity Lock guardrail block (canonical name/DOB/etc from app_users)
 import { buildIdentityGuardrailBlock } from './identity-guardrail-block';
+// VTID-03259 (Fix-3): sentinels wrapping the V2 proactive-initiative block so
+// the live-instruction stripper removes it as one unit when an override wins.
+import {
+  BRAIN_OPENER_V2_START,
+  BRAIN_OPENER_V2_END,
+} from '../orb/live/instruction/brain-opener-sentinels';
 import {
   pickOpenerCandidate,
   getAwarenessContext,
@@ -1045,8 +1051,13 @@ async function buildProactiveInitiativeOffer(
      Splice tool-result fields ({index_delta}, {pillar_value}, etc.)
      naturally where the template uses them.`;
 
+  // VTID-03259 (Fix-3): wrap the whole V2 block (incl. nested STEP 1 / ON NO /
+  // ON HARDER REFUSAL subsections) in opaque sentinels so the live-instruction
+  // stripper can remove it as ONE unit when a wake-brief / journey-guide
+  // override owns turn 1 — otherwise STEP 1's "speak this verbatim" directive
+  // survives the heading-based strip and competes with the override.
   return `
-
+${BRAIN_OPENER_V2_START}
 === PROACTIVE INITIATIVE OFFER (V2 — HIGHEST-PRIORITY OPENER FOR THIS SESSION) ===
 
 This block OVERRIDES the PROACTIVE OPENER CANDIDATE block above and
@@ -1087,7 +1098,8 @@ ${afterConsentBlock}
 
 Once you have offered this initiative in this session, do NOT re-offer
 it. If the user wants to talk about something else first, give them the
-floor — you can come back to the initiative naturally if it fits.`;
+floor — you can come back to the initiative naturally if it fits.
+${BRAIN_OPENER_V2_END}`;
 }
 
 

--- a/services/gateway/test/orb/live/instruction/strip-brain-opener-sections.test.ts
+++ b/services/gateway/test/orb/live/instruction/strip-brain-opener-sections.test.ts
@@ -122,3 +122,75 @@ keep
     expect(second).toBe(first);
   });
 });
+
+describe('VTID-03259 (Fix-3) — V2 sentinel region (nested STEP 1) is fully stripped', () => {
+  // The realistic V2 block: nested === subsections (STEP 1 / ON NO / ON HARDER
+  // REFUSAL) inside one sentinel-wrapped region. Pre-fix, the heading regex
+  // stopped at STEP 1, so its competing "speak this verbatim" first utterance
+  // SURVIVED and fought the wake-brief/journey-guide override. The sentinel
+  // strip must remove the whole region — STEP 1 included.
+  const v2Block = `
+<<BRAIN_OPENER_V2_START>>
+=== PROACTIVE INITIATIVE OFFER (V2 — HIGHEST-PRIORITY OPENER FOR THIS SESSION) ===
+
+Initiative key: log_meal
+
+=== STEP 1 — YOUR VERY FIRST UTTERANCE (sanctioned, do NOT paraphrase) ===
+
+  "Let's log your breakfast — ready?"
+
+=== ON NO (any decline) ===
+  Call pause_proactive_guidance.
+
+=== ON HARDER REFUSAL ("not today") ===
+  Call pause_proactive_guidance scope=all.
+<<BRAIN_OPENER_V2_END>>`;
+
+  test('removes the entire V2 region including the nested STEP 1 verbatim line', () => {
+    const input = `
+## USER CONTEXT PROFILE
+Dragan, day0.
+${v2Block}
+
+=== ACTIVITY 14D ===
+keep me
+`.trim();
+    const out = stripBrainOpenerSections(input);
+    // The competing first-utterance MUST be gone.
+    expect(out).not.toContain('STEP 1 — YOUR VERY FIRST UTTERANCE');
+    expect(out).not.toContain("Let's log your breakfast");
+    expect(out).not.toContain('PROACTIVE INITIATIVE OFFER');
+    expect(out).not.toContain('ON HARDER REFUSAL');
+    expect(out).not.toContain('BRAIN_OPENER_V2');
+    // Non-opener grounding survives.
+    expect(out).toContain('USER CONTEXT PROFILE');
+    expect(out).toContain('ACTIVITY 14D');
+    expect(out).toContain('keep me');
+  });
+
+  test('belt-and-suspenders: STEP 1 heading is stripped even without sentinels (older brain build)', () => {
+    const input = `
+HEADER
+=== PROACTIVE INITIATIVE OFFER (V2 — HIGHEST-PRIORITY OPENER FOR THIS SESSION) ===
+Initiative key: log_meal
+=== STEP 1 — YOUR VERY FIRST UTTERANCE (sanctioned, do NOT paraphrase) ===
+  "Verbatim opener here"
+=== ACTIVITY 14D ===
+keep me
+`.trim();
+    const out = stripBrainOpenerSections(input);
+    expect(out).not.toContain('STEP 1 — YOUR VERY FIRST UTTERANCE');
+    expect(out).not.toContain('Verbatim opener here');
+    expect(out).not.toContain('PROACTIVE INITIATIVE OFFER');
+    expect(out).toContain('ACTIVITY 14D');
+    expect(out).toContain('keep me');
+  });
+
+  test('no override (sentinels present, no nested leak): idempotent + clean', () => {
+    const out1 = stripBrainOpenerSections(`x\n${v2Block}\n=== KEEP ===\ny`);
+    const out2 = stripBrainOpenerSections(out1);
+    expect(out2).toBe(out1);
+    expect(out1).not.toMatch(/\n{3,}/);
+    expect(out1).toContain('KEEP');
+  });
+});


### PR DESCRIPTION
## VTID-03259 — ORB Fix-3: one opener owns turn 1

The provider ranker already picks ONE wake-brief winner, and VTID-03097 strips vitana-brain's opener sections when an override is active. But the strip was **heading-based**, and the brain's `PROACTIVE INITIATIVE OFFER (V2)` block is one string with **nested** `=== … ===` subsections (`STEP 1 — YOUR VERY FIRST UTTERANCE`, `ON NO`, `ON HARDER REFUSAL`). The regex stopped at the first nested `===`, so **`STEP 1` — a competing "speak this verbatim first utterance" — survived the strip** and fought the wake-brief / journey-guide (Fix-1) override. That was the real "two voices on turn 1" mixing.

### Fix
- Wrap the whole V2 block in opaque sentinels (`<<BRAIN_OPENER_V2_START/END>>`, shared module so producer + consumer agree).
- `stripBrainOpenerSections` removes the delimited region as **one unit** — immune to nested `===`.
- Belt-and-suspenders: `STEP 1` heading added to the heading list too (older brain build w/o sentinels still cleaned).
- Runs in the shared `buildLiveSystemInstruction` → **Vertex + LiveKit** identical.

Result: when journey-guide (or any wake-brief) wins, exactly **one** opener reaches Gemini — the override.

### Tests
Strip suite extended with the realistic nested-V2 shape (STEP 1 fully removed) + belt-and-suspenders + idempotence; both first-turn single-source suites still green (**23 tests**). `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)