### PR TITLE
VTID-03262: ORB Fix-4 — reconcile the two journey models into one coherent "where am I"

### DIFF
--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -541,11 +541,37 @@ export async function buildProactiveGuideBlock(input: {
   // VTID-02019: pass the user's tz through so HH:MM in the awareness block
   // renders local. If the surface didn't supply one, awareness resolves to
   // Europe/Berlin (system default).
+  // VTID-03262 (Fix-4): fetch the unified awareness AND the Journey Foundation
+  // signal in PARALLEL (no added latency). The Foundation signal lets
+  // buildAwarenessBlock render ONE coherent "where am I" — Foundation-primary
+  // until graduation, 90-day wave arc after — instead of two competing
+  // journey narratives. Best-effort: a Foundation read failure just falls back
+  // to the legacy wave line.
   let awareness: UserAwareness | null = null;
-  try {
-    awareness = await getAwarenessContext(input.user_id, input.tenant_id, input.user_timezone);
-  } catch (err: any) {
-    console.warn(`${LOG_PREFIX} getAwarenessContext failed:`, err?.message);
+  let foundationSignal: FoundationAwarenessSignal | null = null;
+  const [awarenessRes, foundationRes] = await Promise.allSettled([
+    getAwarenessContext(input.user_id, input.tenant_id, input.user_timezone),
+    (async (): Promise<FoundationAwarenessSignal | null> => {
+      const sb = getSupabase();
+      if (!sb) return null;
+      const { buildJourneyFoundationSnapshot } = await import('./journey-foundation/journey-foundation-state');
+      const snap = await buildJourneyFoundationSnapshot(sb, input.user_id);
+      return {
+        on_foundation: snap.foundation_steps.length > 0,
+        graduated: snap.graduated,
+        next_step_title: snap.current_next_step?.title ?? null,
+      };
+    })(),
+  ]);
+  if (awarenessRes.status === 'fulfilled') {
+    awareness = awarenessRes.value;
+  } else {
+    console.warn(`${LOG_PREFIX} getAwarenessContext failed:`, awarenessRes.reason?.message);
+  }
+  if (foundationRes.status === 'fulfilled') {
+    foundationSignal = foundationRes.value;
+  } else {
+    console.warn(`${LOG_PREFIX} journey-foundation signal failed:`, foundationRes.reason?.message);
   }
 
   // VTID-01931 Phase B: Read companion config from voice_live personality.
@@ -631,7 +657,7 @@ export async function buildProactiveGuideBlock(input: {
   const introductionMode = awareness?.tenure.stage === 'day0';
 
   // Awareness block — single source of truth for "who is on the line right now"
-  const awarenessBlock = buildAwarenessBlock(awareness);
+  const awarenessBlock = buildAwarenessBlock(awareness, foundationSignal);
 
   // Always include the rules — even with no candidate today, the LLM still
   // needs to know how to honor dismissals if the user volunteers one.
@@ -1104,10 +1130,26 @@ ${BRAIN_OPENER_V2_END}`;
 
 
 /**
+ * VTID-03262 (Fix-4): compact Journey Foundation signal used to reconcile the
+ * two journey models into one coherent "where am I" in the awareness block.
+ */
+export interface FoundationAwarenessSignal {
+  /** A user_journey_foundation row exists (the user is in the onboarding arc). */
+  on_foundation: boolean;
+  /** All required Foundation steps satisfied. */
+  graduated: boolean;
+  /** Title of the current next Foundation step (for the awareness line). */
+  next_step_title: string | null;
+}
+
+/**
  * Build the awareness summary block for the system prompt.
  * Returns empty string when no awareness available.
  */
-function buildAwarenessBlock(awareness: UserAwareness | null): string {
+export function buildAwarenessBlock(
+  awareness: UserAwareness | null,
+  foundation?: FoundationAwarenessSignal | null,
+): string {
   if (!awareness) return '';
 
   const lines: string[] = ['=== USER AWARENESS (right now) ==='];
@@ -1129,15 +1171,30 @@ function buildAwarenessBlock(awareness: UserAwareness | null): string {
     }
   }
 
-  // Journey + active wave
-  if (awareness.journey.is_past_90_day) {
-    lines.push(`Journey: past the initial 90-day plan (day ${awareness.journey.day_in_journey}). No active wave.`);
+  // Journey — VTID-03262 (Fix-4): reconcile the TWO journey models into ONE
+  // coherent "where am I". There is exactly ONE day-counter (day_in_journey,
+  // days since signup). There are two arcs: the Journey Foundation onboarding
+  // checklist (user_journey_foundation — the immediate "where am I" UNTIL
+  // graduation) and the 90-day wave plan (user_journey — the longer arc).
+  // Pre-graduation the Foundation is primary and the wave plan is explicitly
+  // demoted to background so Vitana never narrates two competing "where you
+  // are" stories (that was the mixing). Post-graduation the wave plan leads.
+  const dayN = awareness.journey.day_in_journey;
+  if (foundation && foundation.on_foundation && !foundation.graduated) {
+    const stepBit = foundation.next_step_title
+      ? ` Current step: "${foundation.next_step_title}".`
+      : '';
+    lines.push(
+      `Journey (day ${dayN}): the user is still completing the JOURNEY FOUNDATION onboarding checklist (not yet graduated) — this is their "where am I" RIGHT NOW.${stepBit} The journey-guide leads the next Foundation step; do NOT narrate a separate "day N of 90 / wave" plan as their current focus — the 90-day wave arc only becomes primary after they graduate the Foundation.`,
+    );
+  } else if (awareness.journey.is_past_90_day) {
+    lines.push(`Journey: past the initial 90-day plan (day ${dayN}). No active wave.`);
   } else if (awareness.journey.current_wave) {
     lines.push(
-      `Journey: day ${awareness.journey.day_in_journey} of 90, currently in wave "${awareness.journey.current_wave.name}" — ${awareness.journey.current_wave.description}`,
+      `Journey: day ${dayN} of 90, currently in wave "${awareness.journey.current_wave.name}" — ${awareness.journey.current_wave.description}`,
     );
   } else {
-    lines.push(`Journey: day ${awareness.journey.day_in_journey}, between waves.`);
+    lines.push(`Journey: day ${dayN}, between waves.`);
   }
 
   // Active goal

--- a/services/gateway/test/services/vitana-brain-awareness-reconcile.test.ts
+++ b/services/gateway/test/services/vitana-brain-awareness-reconcile.test.ts
@@ -1,0 +1,70 @@
+/**
+ * VTID-03262 (Fix-4) — buildAwarenessBlock journey reconciliation.
+ *
+ * One day-counter, one "where am I". Pre-graduation the Journey Foundation
+ * onboarding checklist is the user's current "where am I" and the 90-day wave
+ * plan is explicitly demoted to background (so Vitana never narrates two
+ * competing journey stories). Post-graduation the 90-day wave arc leads.
+ * Without a Foundation signal the legacy wave line is preserved (back-compat).
+ */
+
+import { buildAwarenessBlock } from '../../src/services/vitana-brain';
+import type { FoundationAwarenessSignal } from '../../src/services/vitana-brain';
+import type { UserAwareness } from '../../src/services/guide/types';
+
+function makeAwareness(overrides: Partial<UserAwareness> = {}): UserAwareness {
+  return {
+    tenure: { stage: 'day1', days_since_signup: 3, active_usage_days: 2, registered_at: '2026-05-30T10:00:00Z' },
+    journey: { current_wave: { id: 'w1', name: 'Momentum', description: 'build the habit' }, day_in_journey: 3, is_past_90_day: false },
+    goal: null,
+    community_signals: { diary_streak_days: 0, connection_count: 0, group_count: 0, pending_match_count: 0, memory_goals: [], memory_interests: [] },
+    recent_activity: { open_autopilot_recs: 0, activated_recs_last_7d: 0, dismissed_recs_last_7d: 0, overdue_calendar_count: 0, upcoming_calendar_24h_count: 0 },
+    last_interaction: null,
+    feature_introductions: [],
+    prior_session_themes: [],
+    user_timezone: 'Europe/Berlin',
+    sessions_today: null,
+    last_session_yesterday: null,
+    ...overrides,
+  } as unknown as UserAwareness;
+}
+
+const onFoundation: FoundationAwarenessSignal = {
+  on_foundation: true,
+  graduated: false,
+  next_step_title: 'Set your Life Compass',
+};
+
+describe('VTID-03262 — journey-model reconciliation in buildAwarenessBlock', () => {
+  it('pre-graduation: Foundation is the "where am I"; the 90-day wave is demoted (not narrated as current focus)', () => {
+    const out = buildAwarenessBlock(makeAwareness(), onFoundation);
+    expect(out).toMatch(/JOURNEY FOUNDATION onboarding checklist \(not yet graduated\)/);
+    expect(out).toContain('Set your Life Compass');
+    // The competing "day N of 90 / wave" current-focus narrative must be gone.
+    expect(out).not.toMatch(/day 3 of 90, currently in wave/);
+    expect(out).not.toContain('Momentum — build the habit');
+  });
+
+  it('exactly one day-counter is surfaced (day_in_journey), no second number', () => {
+    const out = buildAwarenessBlock(makeAwareness({ journey: { current_wave: null, day_in_journey: 12, is_past_90_day: false } }), onFoundation);
+    const dayMentions = (out.match(/\bday 12\b/gi) || []).length;
+    expect(dayMentions).toBe(1);
+  });
+
+  it('post-graduation: the 90-day wave arc leads again', () => {
+    const out = buildAwarenessBlock(makeAwareness(), { on_foundation: true, graduated: true, next_step_title: null });
+    expect(out).toMatch(/day 3 of 90, currently in wave "Momentum"/);
+    expect(out).not.toMatch(/JOURNEY FOUNDATION onboarding checklist/);
+  });
+
+  it('no Foundation signal: legacy wave line preserved (back-compat)', () => {
+    const out = buildAwarenessBlock(makeAwareness());
+    expect(out).toMatch(/day 3 of 90, currently in wave "Momentum"/);
+    expect(out).not.toMatch(/JOURNEY FOUNDATION onboarding checklist/);
+  });
+
+  it('on_foundation=false (e.g. no foundation row): legacy wave line preserved', () => {
+    const out = buildAwarenessBlock(makeAwareness(), { on_foundation: false, graduated: false, next_step_title: null });
+    expect(out).toMatch(/day 3 of 90, currently in wave/);
+  });
+});


### PR DESCRIPTION
## VTID-03262 — ORB Fix-4: one coherent "where am I"

Two parallel journey models both claimed to describe where the user is: the **90-day wave plan** (`user_journey`: "day N of 90, wave X") and the **Journey Foundation** checklist (`user_journey_foundation`: current step + graduated). The brain awareness block narrated the 90-day wave as the current focus while the journey-guide (Fix-1) led the Foundation step — two competing "where am I" stories. That was the journey-model mixing.

### Fix (brain awareness layer)
`buildProactiveGuideBlock` fetches the Foundation snapshot **in parallel** with awareness (community-only, best-effort — no greeting-latency regression) and passes a compact `FoundationAwarenessSignal` to `buildAwarenessBlock`. The journey line becomes ONE coherent picture:
- **One day-counter** (`day_in_journey`) — unchanged single source.
- **Pre-graduation**: Foundation checklist is the "where am I" right now; the 90-day wave is explicitly demoted to background ("do NOT narrate a separate day-N-of-90/wave plan as current focus").
- **Post-graduation**: 90-day wave arc leads again (legacy).
- **No Foundation signal / no row**: legacy wave line preserved (back-compat).

### Tests
New `vitana-brain-awareness-reconcile` suite — 5 cases (pre/post graduation, single day-counter, back-compat ×2). `npm run build` green.

Note: also restored the shopping-agent feature's `VTID-03260` constant after an accidental local sed touch (no functional change; those files are byte-identical to main in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)