### PR TITLE
VTID-03264: ORB Fix-5 HOTFIX — journey-guide cta type guide_step→explain (provider errored every session)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
@@ -122,7 +122,15 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
         kind: 'wake_brief',
         priority: JOURNEY_GUIDE_PRIORITY,
         userFacingLine: stepDef.execute_prompt,
-        cta: { type: 'guide_step', payload: { step_key: step.key, route: step.navigation_route } },
+        // VTID-03264 (Fix-5 hotfix): MUST be a KNOWN_CTA_TYPES value or
+        // validateContinuationCandidate rejects the candidate (the provider
+        // then errors out and never wins — which is exactly what happened with
+        // the invented 'guide_step' type: journey_guide errored every session
+        // and Teacher (priority 85) led turn 1). 'explain' carries no required
+        // fields; the actual lead-the-step behavior comes from userFacingLine +
+        // the bundled GUIDE-MODE block, not this cta. step_key/route ride along
+        // in payload for the client/telemetry.
+        cta: { type: 'explain', payload: { step_key: step.key, route: step.navigation_route } },
         evidence: [
           { kind: 'source:journey_guide', detail: step.key },
           { kind: 'journey_step_tier', detail: String(step.tier) },

--- a/services/gateway/test/services/assistant-continuation/providers/journey-guide.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/journey-guide.test.ts
@@ -13,6 +13,7 @@ import {
   JOURNEY_GUIDE_PROVIDER_KEY,
   JOURNEY_GUIDE_EXTRA_KEY,
 } from '../../../../src/services/assistant-continuation/providers/journey-guide';
+import { validateContinuationCandidate } from '../../../../src/services/assistant-continuation/types';
 
 // The provider reaches the journey-foundation modules via dynamic import().
 const mockBuildSnapshot = jest.fn();
@@ -143,6 +144,22 @@ describe('VTID-03257 makeJourneyGuideProvider', () => {
     const r = await p.produce(makeCtx());
     expect((r as any).candidate.priority).toBeGreaterThan(90);
     expect((r as any).candidate.priority).toBeGreaterThan(85);
+  });
+
+  // VTID-03264 (Fix-5 regression lock): the produced candidate MUST pass the
+  // ranker's invariant validator. Fix-1 shipped with cta.type='guide_step'
+  // (not in KNOWN_CTA_TYPES) so validateContinuationCandidate rejected it and
+  // the provider errored on EVERY production session — Teacher led turn 1 and
+  // the journey never drove the conversation. This test runs the SAME validator
+  // the ranker runs, so an invalid candidate can never pass CI green again.
+  it('produces a candidate that passes validateContinuationCandidate (the ranker invariant)', async () => {
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockGetStepDef.mockReturnValue(STEP_DEF);
+    const p = makeJourneyGuideProvider();
+    const r = await p.produce(makeCtx());
+    expect(r.status).toBe('returned');
+    const verdict = validateContinuationCandidate((r as any).candidate);
+    expect(verdict).toEqual({ ok: true });
   });
 
   it('suppresses when the step has no definition (defensive)', async () => {


### PR DESCRIPTION
## VTID-03264 — HOTFIX: the journey-guide never actually won turn 1

**Reported:** on the live Fix-1..4 build, Vitana still asks Teacher questions; the journey never leads.

**Root cause (from production `[wake-decision]` logs, every session):**
```
{"key":"journey_guide","status":"errored",
 "reason":"invariant_violation: unknown_cta_type (guide_step)"}
```
Fix-1 built the candidate with `cta.type='guide_step'`, which is **not** in `KNOWN_CTA_TYPES`. The ranker runs `validateContinuationCandidate` on every candidate → rejects it → provider marked **errored** → never wins → `feature_discovery_teacher` (priority 85) led turn 1. The journey checklist never drove the conversation in production — even though Fix-1's unit tests were green, because they asserted `produce()`'s output but **never ran the invariant validator the ranker applies.**

**Fix:** `cta.type` `'guide_step'` → `'explain'` (a valid type, no required fields). Lead-the-step behavior comes from `userFacingLine` + the bundled GUIDE-MODE block, not the cta; `step_key`/`route` still ride in `payload`.

**Regression lock:** the journey-guide suite now runs the **same** `validateContinuationCandidate` the ranker runs and asserts `{ok:true}`. With the old `'guide_step'` this test fails — so an invalid candidate can never pass CI green again.

12/12 journey-guide tests green. `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)