### PR TITLE
VTID-03266: ORB Fix-6 — journey-guide opener in user language + whole-session lead (no English, no revert)

### DIFF
--- a/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
+++ b/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
@@ -9,17 +9,115 @@
 
 import type { JourneyGuideContent } from '../../../services/assistant-continuation/providers/journey-guide';
 
+/**
+ * VTID-03266 (Fix-6) — the SPOKEN opener LINE for the journey guide.
+ *
+ * CRITICAL transport constraint: this string becomes the candidate's
+ * `userFacingLine`, and on LiveKit the Python agent plays it via
+ * `session.say(user_facing_line)` LITERALLY — there is NO LLM translation step
+ * (orb-agent/session.py: "session.say() speaks the literal string we pass").
+ * On Vertex it is wrapped by buildVertexWakeBriefBlock as "speak verbatim, do
+ * NOT translate". So the line MUST already be in the session language — we
+ * cannot rely on the model to translate it. That is why the previous approach
+ * (English execute_prompt, or a structured instruction block) produced English
+ * speech for German users / would have made LiveKit read instructions aloud.
+ *
+ * These are short, warm DIRECTIVES (lead + do-it-together), never an open
+ * "what do you want / how can I help". The whole-session ban on passive
+ * openers lives in buildJourneyGuideBlock (injected as system instruction on
+ * BOTH transports), which governs turns 2+.
+ *
+ * de + en today (the platform's active languages; the user base is German).
+ * Other langs fall back to en — a pre-existing limitation of session.say()
+ * across every provider, not specific to the journey guide.
+ */
+const JOURNEY_OPENER_LINES: Record<string, { de: string; en: string }> = {
+  life_compass: {
+    de: 'Lass uns gemeinsam deinen Lebenskompass setzen — dein eine großes Ziel, an dem sich alles ausrichtet. Ich mach den Anfang mit dir, Schritt für Schritt.',
+    en: "Let's set your Life Compass together — the one big goal everything aligns to. I'll get us started, step by step.",
+  },
+  weakest_habit: {
+    de: 'Jetzt finden wir gemeinsam die eine Gewohnheit, die dich am meisten ausbremst — damit ich dir schnell zu ersten Erfolgen verhelfe. Ich fang mit dir an.',
+    en: "Now let's pin down the one habit holding you back most, so I can get you quick wins. I'll start with you.",
+  },
+  reminder: {
+    de: 'Lass uns deine erste Erinnerung gemeinsam einrichten — dein erster kleiner Gewinn. Ich zeig dir genau, wie.',
+    en: "Let's set up your first reminder together — your first quick win. I'll show you exactly how.",
+  },
+  understand_economy: {
+    de: 'Ich zeige dir jetzt, wie die Langlebigkeits-Ökonomie hier funktioniert — und wie sie für dich arbeitet. Lass uns kurz gemeinsam reinschauen.',
+    en: "Let me show you how the longevity economy here works — and how it works for you. Let's take a quick look together.",
+  },
+  profile: {
+    de: 'Lass uns dein Profil gemeinsam vervollständigen — das dauert nur einen Moment, und ich geh es mit dir durch.',
+    en: "Let's complete your profile together — it only takes a moment, and I'll walk you through it.",
+  },
+  diary: {
+    de: 'Lass uns deinen ersten Tagebucheintrag zusammen machen — ich zeig dir, wie einfach das ist.',
+    en: "Let's make your first diary entry together — I'll show you how simple it is.",
+  },
+  vitana_index: {
+    de: 'Lass uns deinen Vitana-Index gemeinsam aufsetzen — deine Startmessung. Ich führe dich durch.',
+    en: "Let's set up your Vitana Index together — your baseline. I'll guide you through it.",
+  },
+  economic_aspiration: {
+    de: 'Jetzt halten wir gemeinsam fest, wie deine Reise dich auch finanziell unterstützen soll. Ich mach den Anfang mit dir.',
+    en: "Now let's capture how your journey should support you financially too. I'll get us started.",
+  },
+  calendar: {
+    de: 'Lass uns deinen ersten Termin gemeinsam in den Kalender setzen — ich zeig dir, wie.',
+    en: "Let's put your first event on the calendar together — I'll show you how.",
+  },
+  autopilot: {
+    de: 'Ich zeige dir jetzt deinen Autopiloten — deinen autonomen Einkommens-Helfer. Lass uns kurz gemeinsam draufschauen.',
+    en: "Let me show you your Autopilot — your autonomous income agent. Let's take a quick look together.",
+  },
+  connect: {
+    de: 'Lass uns dich mit den ersten Menschen hier verbinden — ich mach den ersten Schritt mit dir.',
+    en: "Let's connect you with your first people here — I'll take the first step with you.",
+  },
+  events: {
+    de: 'Lass uns gemeinsam dein erstes Event hier finden — ich zeig dir, wo es losgeht.',
+    en: "Let's find your first event here together — I'll show you where to start.",
+  },
+  marketplace: {
+    de: 'Lass uns gemeinsam den Marktplatz erkunden — ich zeig dir, wie er für dich arbeitet.',
+    en: "Let's explore the Marketplace together — I'll show you how it works for you.",
+  },
+  business_live_media: {
+    de: 'Ich zeige dir jetzt, wie du hier mit Business, Live und Media etwas aufbauen kannst. Lass uns kurz gemeinsam reinschauen.',
+    en: "Let me show you how you can build something here with Business, Live and Media. Let's take a quick look together.",
+  },
+};
+
+/**
+ * The clean, already-localized spoken opener line for a step. Falls back to a
+ * generic lead-in (still a directive, still in-language) for any step key not
+ * in the map, so a new step never silently produces an English/empty opener.
+ */
+export function buildJourneyGuideOpenerLine(stepKey: string, stepTitle: string, lang: string): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  const entry = JOURNEY_OPENER_LINES[stepKey];
+  if (entry) return isDe ? entry.de : entry.en;
+  // Generic directive fallback — still leads, still in-language, names the step.
+  return isDe
+    ? `Lass uns gemeinsam an deinem nächsten Schritt arbeiten: ${stepTitle}. Ich mach den Anfang mit dir.`
+    : `Let's work on your next step together: ${stepTitle}. I'll get us started.`;
+}
+
 export function buildJourneyGuideBlock(guide: JourneyGuideContent, lang: string): string {
   const isDe = (lang || 'en').toLowerCase().startsWith('de');
 
-  // The doing-verb differs slightly for a teacher-type (walk-through) vs an
-  // action-type (do-it-together) step, but the contract is identical.
-  const stepLine = guide.execute_prompt;
+  // VTID-03266 (Fix-6): use the already-localized opener line as the lead, not
+  // the English execute_prompt — otherwise the German block embeds English.
+  const stepLine = buildJourneyGuideOpenerLine(guide.step_key, guide.step_title, lang);
 
   if (isDe) {
     return [
       '',
       '## GUIDE-MODUS — du FÜHRST diese Person durch ihre Reise, Schritt für Schritt',
+      '',
+      'SPRACHE: Sprich AUSSCHLIESSLICH auf Deutsch — auch wenn frühere Anweisungen Englisch enthalten. Dieser GUIDE-MODUS gilt für die GANZE Sitzung und hat Vorrang vor jeder generischen Begrüßungsregel (auch solchen, die nur „für die erste Äußerung" gelten oder dich „Wie kann ich helfen?" sagen lassen).',
       '',
       'Diese Person ist neu in VitanaLand und weiß noch NICHT, was sie tun soll. Du bist ihr proaktiver Guide. Du FÜHRST. Du fragst NIEMALS „Was möchtest du?" oder „Wie kann ich helfen?".',
       '',
@@ -40,6 +138,8 @@ export function buildJourneyGuideBlock(guide: JourneyGuideContent, lang: string)
   return [
     '',
     '## GUIDE MODE — you LEAD this person through their journey, one step at a time',
+    '',
+    'LANGUAGE: speak ONLY in the user\'s language — even if earlier instructions contain English. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting rule (including any that apply "for the first turn only" or tell you to say "How can I help?").',
     '',
     'This person is new to VitanaLand and does NOT yet know what to do. You are their proactive guide. You LEAD. You NEVER ask "What do you want?" or "How can I help?".',
     '',

--- a/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
@@ -48,6 +48,7 @@ interface JourneyGuideInputs {
   supabase: SupabaseClient;
   userId: string;
   isReconnect?: boolean;
+  lang: string;
 }
 
 function readInputs(ctx: ContinuationDecisionContext): JourneyGuideInputs | null {
@@ -59,6 +60,7 @@ function readInputs(ctx: ContinuationDecisionContext): JourneyGuideInputs | null
     supabase: obj.supabase as SupabaseClient,
     userId: obj.userId,
     isReconnect: obj.isReconnect === true,
+    lang: typeof obj.lang === 'string' && obj.lang ? obj.lang : 'en',
   };
 }
 
@@ -113,15 +115,21 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
         navigation_route: step.navigation_route,
       };
 
-      // The spoken opener IS the step's directive — Vitana leads, never asks
-      // "what do you want?". The GUIDE-MODE block (bundled below) governs the
-      // rest of the session.
+      // VTID-03266 (Fix-6): the spoken opener is an ALREADY-LOCALIZED short
+      // directive line — NOT the raw English execute_prompt. On LiveKit the
+      // agent plays this verbatim via session.say() (no translation step); on
+      // Vertex it is wrapped "speak verbatim". So it MUST be in the session
+      // language. The whole-session "never ask what-do-you-want / lead / verify"
+      // contract lives in the GUIDE-MODE block (buildJourneyGuideBlock), which
+      // is injected as a system instruction on BOTH transports (turns 2+).
+      const { buildJourneyGuideOpenerLine } = await import('../../../orb/live/instruction/journey-guide-prompt');
+      const openerLine = buildJourneyGuideOpenerLine(step.key, step.title, inputs.lang);
       const candidate = {
         id: `journey-guide-${step.key}`,
         surface: 'orb_wake',
         kind: 'wake_brief',
         priority: JOURNEY_GUIDE_PRIORITY,
-        userFacingLine: stepDef.execute_prompt,
+        userFacingLine: openerLine,
         // VTID-03264 (Fix-5 hotfix): MUST be a KNOWN_CTA_TYPES value or
         // validateContinuationCandidate rejects the candidate (the provider
         // then errors out and never wins — which is exactly what happened with

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -412,6 +412,7 @@ export async function decideWakeBriefForSession(
         supabase: args.supabase,
         userId: args.userId,
         isReconnect: args.isReconnect,
+        lang: args.lang,
       };
     }
   }

--- a/services/gateway/test/services/assistant-continuation/providers/journey-guide.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/journey-guide.test.ts
@@ -122,9 +122,14 @@ describe('VTID-03257 makeJourneyGuideProvider', () => {
     expect(c.priority).toBe(91);
     expect(c.surface).toBe('orb_wake');
     expect(c.kind).toBe('wake_brief');
-    // The spoken opener IS the step's directive — never "what do you want?".
-    expect(c.userFacingLine).toBe(STEP_DEF.execute_prompt);
-    expect(c.userFacingLine).not.toMatch(/what (do|can) you/i);
+    // VTID-03266 (Fix-6): the spoken opener is a CLEAN, already-localized
+    // directive line (LiveKit session.say plays it verbatim — no instruction
+    // block, no marker, no structured prefix). en default here.
+    expect(c.userFacingLine).toMatch(/Let's set your Life Compass together/);
+    expect(c.userFacingLine).not.toContain('__VTID_03167_STRUCTURED_BLOCK__');
+    expect(c.userFacingLine).not.toContain('<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>');
+    // The opener LEADS — it is not an open-ended "what do you want / how can I help".
+    expect(c.userFacingLine).not.toMatch(/what (do|can) you|how can i help/i);
     expect(c.dedupeKey).toBe('journey_guide:life_compass');
     // GUIDE-MODE content bundled on the candidate for the controller.
     expect(c.journeyGuide).toMatchObject({
@@ -135,6 +140,31 @@ describe('VTID-03257 makeJourneyGuideProvider', () => {
       step_type: 'action',
       navigation_route: '/life-compass',
     });
+  });
+
+  it('VTID-03266: opener line is already in the session language (de → German, en → English)', async () => {
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockGetStepDef.mockReturnValue(STEP_DEF);
+    const p = makeJourneyGuideProvider();
+    // de: spoken line must BE German (LiveKit session.say does not translate).
+    const de = (await p.produce(makeCtx({ lang: 'de' })) as any).candidate.userFacingLine as string;
+    expect(de).toMatch(/Lass uns gemeinsam deinen Lebenskompass setzen/);
+    expect(de).not.toMatch(/Let's set your Life Compass/);
+    expect(de).not.toMatch(/what (do|can) you|wie kann ich (dir )?helfen/i);
+    // en: English line.
+    const en = (await p.produce(makeCtx({ lang: 'en' })) as any).candidate.userFacingLine as string;
+    expect(en).toMatch(/Let's set your Life Compass together/);
+  });
+
+  it('VTID-03266: opener line carries NO instruction/marker text (LiveKit speaks it verbatim)', async () => {
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockGetStepDef.mockReturnValue(STEP_DEF);
+    const p = makeJourneyGuideProvider();
+    const line = (await p.produce(makeCtx({ lang: 'de' })) as any).candidate.userFacingLine as string;
+    // None of these may appear in a string that gets spoken aloud by session.say().
+    for (const forbidden of ['##', 'VERTEX_WAKE_BRIEF', '__VTID_', 'FORBIDDEN', 'OVERRIDE', 'execute_prompt']) {
+      expect(line).not.toContain(forbidden);
+    }
   });
 
   it('priority beats new_day_return (90) and Teacher (85)', async () => {


### PR DESCRIPTION
## VTID-03266 — Fix-6: opener spoken in German, leads the whole session

After Fix-5 made `journey_guide` **win** (log: winner=journey_guide, lang=de every session), two opener-delivery bugs remained:

1. **English despite German.** `userFacingLine` was the step's hardcoded English `execute_prompt`. Vertex wraps it "speak verbatim, do NOT translate"; LiveKit plays it via `session.say()` **literally, no translation** (orb-agent/session.py). So the line must already be in the session language.
2. **Reverts to "what can I do for you".** The Vertex wake-brief block scopes its override to "the first turn only; subsequent turns follow normal flow."

### Fix
- `userFacingLine` is now a **clean, already-localized directive line** (`JOURNEY_OPENER_LINES`, de+en for all 14 steps, in-language fallback). No marker/instruction text → safe for LiveKit `session.say` **and** Vertex verbatim. German session → German speech on both transports.
- `buildJourneyGuideBlock` (GUIDE-MODE, system instruction on **both** transports, governs turns 2+) now enforces "speak ONLY in the user's language even if earlier text is English" and **explicitly overrides** every generic greeting rule "including any that apply for the first turn only or tell you to say How can I help" — for the **whole session**.
- Reverted the structured-block opener (it would have made LiveKit read the instruction block aloud).

### Tests
14 journey-guide cases incl. de→German / en→English + "opener carries no instruction/marker text (LiveKit speaks verbatim)" + ranker validator invariant. livekit-context-parity 27/27. `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)