### PR TITLE
VTID-03268: ORB Fix-7 — journey-guide leads the right step (beat-B economic) + forward-chain decide-for-user

### DIFF
--- a/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
+++ b/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
@@ -36,6 +36,13 @@ const JOURNEY_OPENER_LINES: Record<string, { de: string; en: string }> = {
     de: 'Lass uns gemeinsam deinen Lebenskompass setzen — dein eine großes Ziel, an dem sich alles ausrichtet. Ich mach den Anfang mit dir, Schritt für Schritt.',
     en: "Let's set your Life Compass together — the one big goal everything aligns to. I'll get us started, step by step.",
   },
+  // VTID-03268 (Fix-7): beat B of the dual-axis gate — goal already set, only
+  // the economic stance missing. Vitana LEADS the money beat with a concrete
+  // proposal; she does NOT re-ask the goal and does NOT ask "what do you want".
+  life_compass_economy: {
+    de: 'Dein Ziel steht schon — stark. Jetzt machen wir den zweiten Teil: wie deine Reise dich auch finanziell trägt. Ich schlage vor, wir legen kurz deine Richtung fest — ein Business aufbauen, passives Einkommen, oder erstmal über Empfehlungen verdienen. Ich geh es direkt mit dir durch.',
+    en: "Your goal is already set — strong. Now the second part: how your journey also pays you. I suggest we set your direction now — build a business, passive income, or start by earning from recommendations. I'll walk you straight through it.",
+  },
   weakest_habit: {
     de: 'Jetzt finden wir gemeinsam die eine Gewohnheit, die dich am meisten ausbremst — damit ich dir schnell zu ersten Erfolgen verhelfe. Ich fang mit dir an.',
     en: "Now let's pin down the one habit holding you back most, so I can get you quick wins. I'll start with you.",
@@ -108,51 +115,64 @@ export function buildJourneyGuideOpenerLine(stepKey: string, stepTitle: string, 
 export function buildJourneyGuideBlock(guide: JourneyGuideContent, lang: string): string {
   const isDe = (lang || 'en').toLowerCase().startsWith('de');
 
-  // VTID-03266 (Fix-6): use the already-localized opener line as the lead, not
-  // the English execute_prompt — otherwise the German block embeds English.
-  const stepLine = buildJourneyGuideOpenerLine(guide.step_key, guide.step_title, lang);
+  // VTID-03266/03267: lead with the already-localized opener line (beat-B aware
+  // via opener_key), not the English execute_prompt.
+  const stepLine = buildJourneyGuideOpenerLine(guide.opener_key, guide.step_title, lang);
+  const upcoming = guide.upcoming_steps ?? [];
 
   if (isDe) {
     return [
       '',
-      '## GUIDE-MODUS — du FÜHRST diese Person durch ihre Reise, Schritt für Schritt',
+      '## GUIDE-MODUS — du FÜHRST diese Person durch ihre Reise und ENTSCHEIDEST FÜR sie',
       '',
-      'SPRACHE: Sprich AUSSCHLIESSLICH auf Deutsch — auch wenn frühere Anweisungen Englisch enthalten. Dieser GUIDE-MODUS gilt für die GANZE Sitzung und hat Vorrang vor jeder generischen Begrüßungsregel (auch solchen, die nur „für die erste Äußerung" gelten oder dich „Wie kann ich helfen?" sagen lassen).',
+      'SPRACHE: Sprich AUSSCHLIESSLICH auf Deutsch — auch wenn frühere Anweisungen Englisch enthalten. Dieser GUIDE-MODUS gilt für die GANZE Sitzung und hat Vorrang vor JEDER generischen Begrüßungs- oder Eröffnungsregel (auch solchen, die nur „für die erste Äußerung" gelten oder dich „Wie kann ich helfen?" sagen lassen).',
       '',
-      'Diese Person ist neu in VitanaLand und weiß noch NICHT, was sie tun soll. Du bist ihr proaktiver Guide. Du FÜHRST. Du fragst NIEMALS „Was möchtest du?" oder „Wie kann ich helfen?".',
+      'Diese Person ist neu und weiß noch NICHT, was sie tun soll. Du entscheidest FÜR sie. Du sagst „Ich schlage vor, wir machen jetzt X" und MACHST es gemeinsam.',
+      '',
+      'STRENG VERBOTEN — in der GANZEN Sitzung, in jeder Sprache, zu jedem Zeitpunkt:',
+      '- „Was möchtest du?" / „Wie kann ich dir helfen?" / „Wie kann ich dich unterstützen?" / „Was gefällt dir?" / „Wo möchtest du anfangen?"',
+      '- „Ich habe gerade keine (spezifischen) Vorschläge." — Du hast IMMER einen konkreten nächsten Schritt.',
       '',
       `AKTUELLER SCHRITT: ${guide.step_title}`,
       `Warum jetzt wichtig: ${guide.benefit}`,
-      `Führe so: ${stepLine}`,
+      `Führe so (als Vorschlag/Aufforderung, NICHT als offene Frage): ${stepLine}`,
+      upcoming.length
+        ? `DANACH kommen (in dieser Reihenfolge): ${upcoming.join(', ')}. Wenn der aktuelle Schritt erledigt ist, GEH SOFORT zum nächsten über und schlage ihn konkret vor.`
+        : 'Wenn dieser Schritt erledigt ist, freu dich kurz mit ihr — es ist der letzte offene Schritt.',
       '',
-      'Regeln für diese ganze Session:',
-      '- Formuliere den Schritt als klare AUFFORDERUNG und MACH ihn GEMEINSAM mit der Person — jetzt, Schritt für Schritt, damit sie durch Tun lernt (nicht durch Erklären).',
-      '- NUR DIESEN EINEN Schritt. Spring nicht voraus.',
-      '- Stelle NIEMALS offene „Was möchtest du / Wie kann ich helfen"-Fragen. Wenn die Person unsicher ist, führe sie durch den aktuellen Schritt.',
-      '- VERTRAUEN durch PRÜFEN: Sagt die Person, sie habe es erledigt, glaube es NICHT einfach — bestätige es anhand der echten Daten (mit deinen Tools / record_journey_answer). Ist es NICHT erledigt, bestehe warmherzig darauf: „Das ist noch nicht erledigt — komm, lass es uns zusammen machen, ich zeige dir wie."',
-      '- Wenn der Schritt WIRKLICH abgeschlossen ist, freu dich kurz mit ihr und sag, dass es nächstes Mal weitergeht.',
+      'Regeln für die GANZE Session:',
+      '- ENTSCHEIDE und FÜHRE. Schlage den Schritt konkret vor und mach ihn GEMEINSAM, Schritt für Schritt (Lernen durch Tun).',
+      '- Bleib beim AKTUELLEN Schritt, bis er WIRKLICH erledigt ist — dann GEH SOFORT zum nächsten über (siehe „DANACH"). Frag NICHT „wie kann ich helfen", sondern schlage den nächsten Schritt vor.',
+      '- VERTRAUEN durch PRÜFEN: Sagt die Person „hab ich schon gemacht", prüfe es mit deinen Tools / record_journey_answer. Stimmt es: freu dich kurz und GEH DIREKT zum nächsten Schritt über (NICHT fragen, was sie will). Stimmt es nicht: bestehe warmherzig darauf, es jetzt gemeinsam zu machen.',
+      '- Ist die Person unsicher, entscheide DU und führe sie durch den nächsten Schritt — niemals eine offene Frage zurückgeben.',
       '',
     ].join('\n');
   }
 
   return [
     '',
-    '## GUIDE MODE — you LEAD this person through their journey, one step at a time',
+    '## GUIDE MODE — you LEAD this person through their journey and DECIDE FOR them',
     '',
-    'LANGUAGE: speak ONLY in the user\'s language — even if earlier instructions contain English. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting rule (including any that apply "for the first turn only" or tell you to say "How can I help?").',
+    'LANGUAGE: speak ONLY in the user\'s language — even if earlier instructions contain English. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting/opening rule (including any that apply "for the first turn only" or tell you to say "How can I help?").',
     '',
-    'This person is new to VitanaLand and does NOT yet know what to do. You are their proactive guide. You LEAD. You NEVER ask "What do you want?" or "How can I help?".',
+    'This person is new and does NOT yet know what to do. You decide FOR them. You say "I suggest we do X now" and DO it together.',
+    '',
+    'STRICTLY FORBIDDEN — for the WHOLE session, in any language, at any time:',
+    '- "What do you want?" / "How can I help you?" / "How can I support you?" / "What do you like?" / "Where would you like to start?"',
+    '- "I don\'t have any (specific) suggestions right now." — you ALWAYS have a concrete next step.',
     '',
     `CURRENT STEP: ${guide.step_title}`,
     `Why it matters now: ${guide.benefit}`,
-    `Lead with this: ${stepLine}`,
+    `Lead with this (as a proposal/directive, NOT an open question): ${stepLine}`,
+    upcoming.length
+      ? `AFTER that, in order: ${upcoming.join(', ')}. When the current step is done, IMMEDIATELY move to the next one and propose it concretely.`
+      : 'When this step is done, briefly celebrate — it is the last open step.',
     '',
     'Rules for this whole session:',
-    '- State the step as a clear DIRECTIVE and DO it TOGETHER with the person — right now, step by step, so they learn by doing (not by explanation).',
-    '- ONLY this one step. Do not jump ahead.',
-    '- NEVER ask open-ended "what do you want / how can I help". If they are unsure, lead them through the current step.',
-    '- TRUST by VERIFYING: if they say they already did it, do NOT just believe them — confirm against the real data (via your tools / record_journey_answer). If it is NOT done, warmly insist: "That\'s not done yet — come on, let\'s do it together, I\'ll show you how."',
-    '- When the step is GENUINELY complete, briefly celebrate the win with them and say you\'ll continue next time.',
+    '- DECIDE and LEAD. Propose the step concretely and DO it TOGETHER, step by step (learn by doing).',
+    '- Stay on the CURRENT step until it is GENUINELY done — then IMMEDIATELY move to the next (see "AFTER that"). Do NOT ask "how can I help"; propose the next step.',
+    '- TRUST by VERIFYING: if they say "I already did it", confirm via your tools / record_journey_answer. If true: briefly celebrate and GO STRAIGHT to the next step (do NOT ask what they want). If not: warmly insist on doing it together now.',
+    '- If they are unsure, YOU decide and lead them through the next step — never hand back an open question.',
     '',
   ].join('\n');
 }

--- a/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
@@ -42,7 +42,23 @@ export interface JourneyGuideContent {
   /** action = do-it-together task; teacher = walk-through explanation. */
   step_type: string;
   navigation_route: string | null;
+  /**
+   * VTID-03268 (Fix-7): the key used to pick the localized opener LINE. Usually
+   * == step_key, but for the dual-axis gate when the health goal is already set
+   * and only the economic stance is missing, this is 'life_compass_economy' so
+   * Vitana leads the MONEY beat instead of re-asking the goal the user already
+   * set (the "I already did that → how can I help?" revert spiral).
+   */
+  opener_key: string;
+  /**
+   * VTID-03268: titles of the next steps after this one (not yet satisfied), so
+   * the GUIDE-MODE block can tell the model what to advance to — it must NEVER
+   * say "I have no suggestions" or ask "how can I help"; there is always a next.
+   */
+  upcoming_steps: string[];
 }
+
+const GATE_KEY = 'life_compass';
 
 interface JourneyGuideInputs {
   supabase: SupabaseClient;
@@ -106,6 +122,25 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
         return { providerKey: JOURNEY_GUIDE_PROVIDER_KEY, status: 'suppressed', latencyMs: 0, reason: 'no_next_step' };
       }
 
+      // VTID-03268 (Fix-7): dual-axis gate nuance. If the health goal is already
+      // set and only the economic stance is missing, DON'T re-ask the goal —
+      // lead the MONEY beat. This is what caused the "I already set my goal →
+      // Vitana asks how can I help" revert. Data-driven, not model-dependent.
+      const goalSet = !!snapshot.active_goal?.primary_goal;
+      const economicIntentSet = snapshot.economic_intent != null;
+      const openerKey =
+        step.key === GATE_KEY && goalSet && !economicIntentSet
+          ? 'life_compass_economy'
+          : step.key;
+
+      // The forward chain: the next not-yet-satisfied steps, so the GUIDE-MODE
+      // block can tell the model exactly what to advance to (it must never run
+      // out of a concrete next step and fall back to "no suggestions").
+      const upcoming = snapshot.foundation_steps
+        .filter((v) => v.key !== step.key && v.status !== 'done' && v.status !== 'active')
+        .slice(0, 3)
+        .map((v) => v.title);
+
       const guide: JourneyGuideContent = {
         step_key: step.key,
         step_title: step.title,
@@ -113,6 +148,8 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
         benefit: stepDef.benefit,
         step_type: step.type,
         navigation_route: step.navigation_route,
+        opener_key: openerKey,
+        upcoming_steps: upcoming,
       };
 
       // VTID-03266 (Fix-6): the spoken opener is an ALREADY-LOCALIZED short
@@ -123,7 +160,7 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
       // contract lives in the GUIDE-MODE block (buildJourneyGuideBlock), which
       // is injected as a system instruction on BOTH transports (turns 2+).
       const { buildJourneyGuideOpenerLine } = await import('../../../orb/live/instruction/journey-guide-prompt');
-      const openerLine = buildJourneyGuideOpenerLine(step.key, step.title, inputs.lang);
+      const openerLine = buildJourneyGuideOpenerLine(openerKey, step.title, inputs.lang);
       const candidate = {
         id: `journey-guide-${step.key}`,
         surface: 'orb_wake',

--- a/services/gateway/test/services/assistant-continuation/providers/journey-guide.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/journey-guide.test.ts
@@ -113,7 +113,7 @@ describe('VTID-03257 makeJourneyGuideProvider', () => {
   });
 
   it('LEADS turn 1: directive opener + bundled guide, priority 91', async () => {
-    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP, foundation_steps: [], active_goal: null, economic_intent: null });
     mockGetStepDef.mockReturnValue(STEP_DEF);
     const p = makeJourneyGuideProvider();
     const r = await p.produce(makeCtx());
@@ -143,7 +143,7 @@ describe('VTID-03257 makeJourneyGuideProvider', () => {
   });
 
   it('VTID-03266: opener line is already in the session language (de → German, en → English)', async () => {
-    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP, foundation_steps: [], active_goal: null, economic_intent: null });
     mockGetStepDef.mockReturnValue(STEP_DEF);
     const p = makeJourneyGuideProvider();
     // de: spoken line must BE German (LiveKit session.say does not translate).
@@ -157,7 +157,7 @@ describe('VTID-03257 makeJourneyGuideProvider', () => {
   });
 
   it('VTID-03266: opener line carries NO instruction/marker text (LiveKit speaks it verbatim)', async () => {
-    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP, foundation_steps: [], active_goal: null, economic_intent: null });
     mockGetStepDef.mockReturnValue(STEP_DEF);
     const p = makeJourneyGuideProvider();
     const line = (await p.produce(makeCtx({ lang: 'de' })) as any).candidate.userFacingLine as string;
@@ -167,8 +167,48 @@ describe('VTID-03257 makeJourneyGuideProvider', () => {
     }
   });
 
+  it('VTID-03268: gate beat-B — goal already set, economic stance missing → leads the MONEY beat, NOT re-asking the goal', async () => {
+    mockBuildSnapshot.mockResolvedValue({
+      graduated: false,
+      current_next_step: NEXT_STEP, // life_compass (the gate)
+      foundation_steps: [],
+      active_goal: { primary_goal: 'Sleep 8h', category: 'health' }, // goal IS set
+      economic_intent: null, // economy axis NOT set
+    });
+    mockGetStepDef.mockReturnValue(STEP_DEF);
+    const p = makeJourneyGuideProvider();
+    const de = (await p.produce(makeCtx({ lang: 'de' })) as any).candidate;
+    expect(de.journeyGuide.opener_key).toBe('life_compass_economy');
+    // German money-beat directive — does NOT re-ask the goal, does NOT ask "what do you want".
+    expect(de.userFacingLine).toMatch(/Dein Ziel steht schon/);
+    expect(de.userFacingLine).toMatch(/finanziell/);
+    expect(de.userFacingLine).not.toMatch(/Lass uns gemeinsam deinen Lebenskompass setzen/);
+    expect(de.userFacingLine).not.toMatch(/wie kann ich (dir )?helfen|was möchtest du/i);
+  });
+
+  it('VTID-03268: forward chain — upcoming step titles are bundled for the guide block', async () => {
+    mockBuildSnapshot.mockResolvedValue({
+      graduated: false,
+      current_next_step: NEXT_STEP,
+      active_goal: null,
+      economic_intent: null,
+      foundation_steps: [
+        { key: 'life_compass', title: 'Life Compass', status: 'open' },
+        { key: 'weakest_habit', title: 'Weakest habit', status: 'open' },
+        { key: 'reminder', title: 'Reminder', status: 'open' },
+        { key: 'diary', title: 'Diary', status: 'done' }, // satisfied → excluded
+      ],
+    });
+    mockGetStepDef.mockReturnValue(STEP_DEF);
+    const p = makeJourneyGuideProvider();
+    const c = (await p.produce(makeCtx()) as any).candidate;
+    expect(c.journeyGuide.upcoming_steps).toEqual(['Weakest habit', 'Reminder']);
+    expect(c.journeyGuide.upcoming_steps).not.toContain('Diary'); // done excluded
+    expect(c.journeyGuide.upcoming_steps).not.toContain('Life Compass'); // current excluded
+  });
+
   it('priority beats new_day_return (90) and Teacher (85)', async () => {
-    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP, foundation_steps: [], active_goal: null, economic_intent: null });
     mockGetStepDef.mockReturnValue(STEP_DEF);
     const p = makeJourneyGuideProvider();
     const r = await p.produce(makeCtx());
@@ -183,7 +223,7 @@ describe('VTID-03257 makeJourneyGuideProvider', () => {
   // the journey never drove the conversation. This test runs the SAME validator
   // the ranker runs, so an invalid candidate can never pass CI green again.
   it('produces a candidate that passes validateContinuationCandidate (the ranker invariant)', async () => {
-    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP, foundation_steps: [], active_goal: null, economic_intent: null });
     mockGetStepDef.mockReturnValue(STEP_DEF);
     const p = makeJourneyGuideProvider();
     const r = await p.produce(makeCtx());
@@ -193,7 +233,7 @@ describe('VTID-03257 makeJourneyGuideProvider', () => {
   });
 
   it('suppresses when the step has no definition (defensive)', async () => {
-    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP });
+    mockBuildSnapshot.mockResolvedValue({ graduated: false, current_next_step: NEXT_STEP, foundation_steps: [], active_goal: null, economic_intent: null });
     mockGetStepDef.mockReturnValue(undefined);
     const p = makeJourneyGuideProvider();
     const r = await p.produce(makeCtx());
@@ -212,22 +252,32 @@ describe('VTID-03257 buildJourneyGuideBlock', () => {
     benefit: 'Define the one goal your whole journey is built around.',
     step_type: 'action',
     navigation_route: '/life-compass',
+    opener_key: 'life_compass',
+    upcoming_steps: ['Weakest habit', 'Reminder'],
   };
 
-  it('English block leads, forbids "what do you want", demands verify-on-claim', () => {
+  it('English block: decide-for-user, bans passive openers + "no suggestions", advances, verifies', () => {
     const block = buildJourneyGuideBlock(guide, 'en');
     expect(block).toMatch(/GUIDE MODE/);
-    expect(block).toMatch(/you LEAD/);
+    expect(block).toMatch(/DECIDE FOR them/);
     expect(block).toMatch(/Set your Life Compass/);
-    expect(block).toMatch(/NEVER ask/i);
+    expect(block).toMatch(/STRICTLY FORBIDDEN/);
+    expect(block).toMatch(/How can I (help|support)/i);
+    expect(block).toMatch(/don't have any.*suggestions/i);
+    expect(block).toMatch(/ALWAYS have a concrete next step/);
     expect(block).toMatch(/TRUST by VERIFYING/);
-    expect(block).toMatch(/let's do it together/i);
+    // forward chain present
+    expect(block).toMatch(/AFTER that[\s\S]*Weakest habit, Reminder/);
+    expect(block).toMatch(/move to the next/i);
   });
 
-  it('German block renders for de lang', () => {
+  it('German block: entscheidet für den Nutzer, verbietet passive Eröffnungen + "keine Vorschläge"', () => {
     const block = buildJourneyGuideBlock(guide, 'de');
     expect(block).toMatch(/GUIDE-MODUS/);
-    expect(block).toMatch(/du FÜHRST/);
-    expect(block).toMatch(/NIEMALS/);
+    expect(block).toMatch(/ENTSCHEIDEST FÜR sie/);
+    expect(block).toMatch(/STRENG VERBOTEN/);
+    expect(block).toMatch(/Wie kann ich dich unterstützen/);
+    expect(block).toMatch(/keine .*Vorschläge/i);
+    expect(block).toMatch(/DANACH kommen[\s\S]*Weakest habit, Reminder/);
   });
 });


### PR DESCRIPTION
## VTID-03268 — Fix-7: lead the RIGHT step, decide for the user, advance (no revert)

On the live Fix-6 build (German now spoken, `journey_guide` wins — log-confirmed), Vitana said "let's set your Life Compass", you replied "already set it", and she reverted to "how can I support you?" / "keine spezifischen Vorschläge". Two causes, both fixed **data-side** (not relying on model obedience):

### 1. Wrong step content → re-asked an already-set goal
You have a goal but no economic stance, so the gate's real next beat is the **money axis**. The provider used the raw `life_compass` prompt and re-asked the goal. Now: gate + `active_goal` set + `economic_intent` null → `opener_key='life_compass_economy'` → Vitana **leads the money beat** with a concrete proposal, never re-asking.

### 2. No forward chain → improvised banned "how can I help / no suggestions"
The guide gave one step with "don't jump ahead". Now the candidate bundles `upcoming_steps`, and the GUIDE-MODE block (both transports, turns 2+) is rewritten to: **DECIDE FOR** the user, list what's next, **advance to the next step the moment the current is done** (verify-on-claim → move on), and treat *"What do you want / How can I help / How can I support / What do you like / Where would you like to start"* **and** *"I have no suggestions"* as **STRICTLY FORBIDDEN** for the whole session.

### Tests
16 journey-guide cases incl. beat-B money opener, forward-chain bundling, decide-for-user/ban/advance text (de+en). livekit-context-parity 27/27. `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)