### PR TITLE
feat(orb): lead voice session with the tapped My-Journey step (VTID-03300, DEV-COMHU-03300)

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1168,6 +1168,17 @@
       if (_s.currentRoute) startPayload.current_route = _s.currentRoute;
       if (_s.recentRoutes && _s.recentRoutes.length) startPayload.recent_routes = _s.recentRoutes.slice(0, 5);
 
+      // VTID-03300: "My Journey" next-step focus. When the host opens the orb
+      // by tapping a specific Foundation step (VitanaOrb.focusJourneyStep), the
+      // step key rides along so the journey-guide provider LEADS with THAT step
+      // ("Let's improve your Profile…") instead of the sequentially-computed
+      // next step. One-shot: consumed for this session only so the next normal
+      // open reverts to the default next-step behaviour.
+      if (_s.journeyFocus) {
+        startPayload.journey_focus_step = _s.journeyFocus;
+        _s.journeyFocus = null;
+      }
+
       // VTID-02020: when this _sessionStart is happening as part of a reconnect
       // (NOT a first-time session), send the conversation history + the
       // pre-disconnect stage so the backend can route to the contextual
@@ -2936,6 +2947,10 @@
             .filter(function (r) { return typeof r === 'string'; })
             .slice(0, 5);
         }
+        // VTID-03300: optional one-shot journey-step focus (see focusJourneyStep).
+        if (typeof opts.initialContext.journey_focus_step === 'string') {
+          _s.journeyFocus = opts.initialContext.journey_focus_step || null;
+        }
       }
 
       _injectStyles();
@@ -3016,6 +3031,16 @@
 
     show: _show,
     hide: _hide,
+
+    // VTID-03300: open the orb and start a session FOCUSED on a specific
+    // "My Journey" Foundation step. The host calls this when the user taps a
+    // step in the Next-Steps checklist; Vitana then leads with that exact step
+    // ("Let's get your Profile set up…") instead of the default next step.
+    // One-shot: the focus is consumed by the upcoming _sessionStart only.
+    focusJourneyStep: function (stepKey) {
+      _s.journeyFocus = (typeof stepKey === 'string' && stepKey) ? stepKey : null;
+      _show();
+    },
     // DEV-COMHU-0503: intentional forget (logout / account switch / start over).
     reset: _reset,
 
@@ -3040,6 +3065,12 @@
         _s.recentRoutes = ctx.recent_routes
           .filter(function (r) { return typeof r === 'string'; })
           .slice(0, 5);
+      }
+      // VTID-03300: pre-arm a one-shot journey-step focus from the host. Set
+      // only when present, so the per-route updateContext stream (which never
+      // carries this field) can't clobber a pending focus.
+      if (typeof ctx.journey_focus_step === 'string') {
+        _s.journeyFocus = ctx.journey_focus_step || null;
       }
     },
 

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -901,6 +901,12 @@ export async function handleLiveSessionStart(
     is_mobile: typeof (body as any).is_mobile === 'boolean'
       ? (body as any).is_mobile
       : undefined,
+    // VTID-03300: "My Journey" next-step focus. Set when the user opened the
+    // orb by tapping a specific Foundation step; the journey-guide provider
+    // leads with this step instead of the sequentially-computed next step.
+    journey_focus_step: typeof (body as any).journey_focus_step === 'string'
+      ? (body as any).journey_focus_step
+      : undefined,
   };
 
   // VTID-SESSION-LIMIT: Terminate any existing active sessions for this user.
@@ -1134,6 +1140,9 @@ export async function handleLiveSessionStart(
       wasFailure: temporal.wasFailure,
       isReconnect: isReconnectStart,
       lang,
+      // VTID-03300: forward the tapped "My Journey" step so journey-guide leads
+      // with it. Undefined for normal opens → default next-step behaviour.
+      journeyFocusStep: (session as any).journey_focus_step ?? null,
       supabase: supabaseClient,
       // VTID-03085 (Lane 1): pass the compiled spine — unlocks
       // life_compass_alignment, vitana_index_pillar,

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1016,6 +1016,11 @@ export interface GeminiLiveSession {
   // hook in the session start payload + every updateContext. Drives the
   // mobile_route override + viewport_only block in handleNavigateToScreen.
   is_mobile?: boolean;
+  // VTID-03300: "My Journey" next-step focus. Set when the user opened the orb
+  // by tapping a specific Foundation step in the Next-Steps checklist, so the
+  // journey-guide provider LEADS with that exact step rather than the
+  // sequentially-computed current_next_step. One-shot per session.
+  journey_focus_step?: string;
   // VTID-NAV: Cached memory pack from the first navigator_consult call this
   // session, with a 30s TTL — subsequent consult calls reuse it instead of
   // re-paying retrieval cost.

--- a/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
@@ -65,6 +65,12 @@ interface JourneyGuideInputs {
   userId: string;
   isReconnect?: boolean;
   lang: string;
+  /**
+   * VTID-03300: the Foundation step key the user tapped in "My Journey" to open
+   * the orb. When set and that step isn't already done, the provider leads with
+   * it instead of the sequentially-computed `current_next_step`.
+   */
+  focusStep?: string | null;
 }
 
 function readInputs(ctx: ContinuationDecisionContext): JourneyGuideInputs | null {
@@ -77,6 +83,7 @@ function readInputs(ctx: ContinuationDecisionContext): JourneyGuideInputs | null
     userId: obj.userId,
     isReconnect: obj.isReconnect === true,
     lang: typeof obj.lang === 'string' && obj.lang ? obj.lang : 'en',
+    focusStep: typeof obj.focusStep === 'string' && obj.focusStep ? obj.focusStep : null,
   };
 }
 
@@ -96,13 +103,33 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
 
       let snapshot: JourneyFoundationSnapshot;
       let stepDef: { execute_prompt: string; benefit: string } | undefined;
+      // VTID-03300: the step to lead with. Defaults to the computed next step,
+      // but a user-tapped focus step overrides it (see below).
+      let leadStep: JourneyFoundationSnapshot['current_next_step'] = null;
+      let isFocusOverride = false;
       try {
         const [{ buildJourneyFoundationSnapshot }, { getStepDef }] = await Promise.all([
           import('../../journey-foundation/journey-foundation-state'),
           import('../../journey-foundation/foundation-steps'),
         ]);
         snapshot = await buildJourneyFoundationSnapshot(inputs.supabase, inputs.userId);
-        const key = snapshot.current_next_step?.key;
+
+        // VTID-03300: when the user tapped a specific step in "My Journey", lead
+        // with THAT step (as long as it isn't already done) instead of the
+        // sequentially-computed next step. Lets the user jump to "Profile" even
+        // if it isn't the strict next gate — Vitana focuses on what they asked.
+        leadStep = snapshot.current_next_step;
+        if (inputs.focusStep) {
+          const focused = snapshot.foundation_steps.find(
+            (v) => v.key === inputs.focusStep && v.status !== 'done',
+          );
+          if (focused) {
+            leadStep = focused;
+            isFocusOverride = true;
+          }
+        }
+
+        const key = leadStep?.key;
         stepDef = key ? getStepDef(key) : undefined;
       } catch (err) {
         return {
@@ -114,10 +141,12 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
       }
 
       // Graduated → the journey is done; hand the floor to the normal ladder.
-      if (snapshot.graduated) {
+      // Exception: an explicit user tap on a still-open step (e.g. an optional
+      // economy-activation step) overrides graduation so Vitana still leads it.
+      if (snapshot.graduated && !isFocusOverride) {
         return { providerKey: JOURNEY_GUIDE_PROVIDER_KEY, status: 'suppressed', latencyMs: 0, reason: 'journey_graduated' };
       }
-      const step = snapshot.current_next_step;
+      const step = leadStep;
       if (!step || !stepDef) {
         return { providerKey: JOURNEY_GUIDE_PROVIDER_KEY, status: 'suppressed', latencyMs: 0, reason: 'no_next_step' };
       }

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -187,6 +187,13 @@ export interface DecideWakeBriefArgs {
   isReconnect: boolean;
   /** Resolved language for the session (post-anonymous browser-lang resolve). */
   lang: string;
+  /**
+   * VTID-03300: the "My Journey" Foundation step the user tapped to open the
+   * orb (from the session-start body's `journey_focus_step`). When set and the
+   * step is not already done, the journey-guide provider leads with this step
+   * instead of the sequentially-computed `current_next_step`.
+   */
+  journeyFocusStep?: string | null;
   /** journeySurface from the ClientContextEnvelope, if any. */
   envelopeJourneySurface?: string;
   /**
@@ -413,6 +420,9 @@ export async function decideWakeBriefForSession(
         userId: args.userId,
         isReconnect: args.isReconnect,
         lang: args.lang,
+        // VTID-03300: when the user tapped a specific Foundation step in "My
+        // Journey", lead with THAT step instead of the computed next step.
+        focusStep: args.journeyFocusStep ?? null,
       };
     }
   }


### PR DESCRIPTION
## What & why

The "My Journey" Next-Steps checklist (mobile + desktop) was a **read-only** list. This makes it actionable: tapping a step opens the ORB and Vitana drives **that exact step** ("Let's get your Profile set up…") instead of talking in generalities. When the step is verified complete, the existing snapshot poll flips its row to a green check — no new completion plumbing needed.

This is the **backend half** (gateway). The frontend half is in `exafyltd/vitana-v1` (same branch).

## Changes (all in `services/gateway`)

- **`orb-widget.js`** — new public `VitanaOrb.focusJourneyStep(stepKey)` that opens the overlay and starts a session pre-armed with the tapped step. Also accepts a one-shot `journey_focus_step` via `init({ initialContext })` / `updateContext()`. The focus is **consumed once** in `_sessionStart`, so the next normal open reverts to default next-step behaviour. Cache-buster bumped on the v1 side.
- **`live-session-controller.ts`** — parse `journey_focus_step` from the session-start body onto the session (same duck-typed channel as `current_route`), and forward it to the wake-brief decision as `journeyFocusStep`.
- **`wake-brief-wiring.ts`** — thread `journeyFocusStep` into the journey-guide provider's inputs as `focusStep`.
- **`journey-guide.ts`** — when a focus step is supplied and **not already done**, LEAD with that step (its localized opener line + `execute_prompt`) instead of the sequentially-computed `current_next_step`. An explicit tap also overrides the `graduated` suppression so a user can still revisit an open optional step. Falls back to the normal next step when no focus is sent.

## Behaviour notes / decisions

- **Any step is tappable**, not just the current one — the user asked to tap "any of these steps". The journey-guide override honours the tapped step regardless of sequential order (still skips already-done steps).
- **Graceful degradation**: if an older cached widget is served, `focusJourneyStep` is absent; the v1 helper falls back to `updateContext + show`, and if even that's stale the orb still opens on the computed next step.

## Verification

- `tsc -p tsconfig.json --noEmit` → **0 errors** (deps installed locally; the standalone `node10` deprecation is a pre-existing tsconfig matter, not from this change).

## ⚠️ Before merge / deploy

- This is a **draft**. `VTID-03300` is used as the feature tag but has **not** been verified/allocated in the OASIS ledger — allocate & approve it before merging, or EXEC-DEPLOY's governance gate will reject the deploy.
- Gateway must be deployed for the new widget + session handling to go live; the v1 cache-buster bump ensures clients refetch the new widget.

https://claude.ai/code/session_01PWvJGbhqKXbG4Uo8HpLa7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWvJGbhqKXbG4Uo8HpLa7s)_