### PR TITLE
fix(journey): My-Journey done-step tap opens Vitana in enrich mode, greeting by name (VTID-03300)

### DIFF
--- a/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
+++ b/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
@@ -101,24 +101,100 @@ const JOURNEY_OPENER_LINES: Record<string, { de: string; en: string }> = {
  * The clean, already-localized spoken opener line for a step. Falls back to a
  * generic lead-in (still a directive, still in-language) for any step key not
  * in the map, so a new step never silently produces an English/empty opener.
+ *
+ * VTID-03300 (follow-up):
+ * - `opts.firstName` greets by name ("Hey Dragan! …"). Omitted/blank → no name.
+ * - `opts.done` switches to an "enrich / build on it" opener: the user tapped a
+ *   step they've ALREADY completed, so leading with "let's set it up" would feel
+ *   broken. Generic over any step via its title.
  */
-export function buildJourneyGuideOpenerLine(stepKey: string, stepTitle: string, lang: string): string {
+export function buildJourneyGuideOpenerLine(
+  stepKey: string,
+  stepTitle: string,
+  lang: string,
+  opts?: { firstName?: string | null; done?: boolean },
+): string {
   const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  const name = (opts?.firstName || '').trim();
+  // Warm, du-form name greeting. Kept as its own clause so the localized step
+  // lines below keep their leading capital and read naturally.
+  const greet = name ? `Hey ${name}! ` : '';
+
+  // Enrich framing — already-completed step the user explicitly tapped.
+  if (opts?.done) {
+    return isDe
+      ? `${greet}„${stepTitle}" hast du schon erledigt — stark. Lass uns das gemeinsam noch besser machen.`
+      : `${greet}You've already done "${stepTitle}" — nice work. Let's build on it together and make it even stronger.`;
+  }
+
   const entry = JOURNEY_OPENER_LINES[stepKey];
-  if (entry) return isDe ? entry.de : entry.en;
+  if (entry) return `${greet}${isDe ? entry.de : entry.en}`;
   // Generic directive fallback — still leads, still in-language, names the step.
   return isDe
-    ? `Lass uns gemeinsam an deinem nächsten Schritt arbeiten: ${stepTitle}. Ich mach den Anfang mit dir.`
-    : `Let's work on your next step together: ${stepTitle}. I'll get us started.`;
+    ? `${greet}Lass uns gemeinsam an deinem nächsten Schritt arbeiten: ${stepTitle}. Ich mach den Anfang mit dir.`
+    : `${greet}Let's work on your next step together: ${stepTitle}. I'll get us started.`;
 }
 
 export function buildJourneyGuideBlock(guide: JourneyGuideContent, lang: string): string {
   const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  const done = guide.focus_done === true;
 
   // VTID-03266/03267: lead with the already-localized opener line (beat-B aware
-  // via opener_key), not the English execute_prompt.
-  const stepLine = buildJourneyGuideOpenerLine(guide.opener_key, guide.step_title, lang);
+  // via opener_key), not the English execute_prompt. VTID-03300: when the user
+  // tapped an already-done step, the opener uses "enrich" framing.
+  const stepLine = buildJourneyGuideOpenerLine(guide.opener_key, guide.step_title, lang, { done });
   const upcoming = guide.upcoming_steps ?? [];
+
+  // VTID-03300 (follow-up): ENRICH MODE — the user tapped a step they've already
+  // completed. Vitana must NOT restart it or treat them as a new user; she
+  // acknowledges it's done and helps them strengthen/extend it, then offers the
+  // next open step. Still never "how can I help".
+  if (done) {
+    if (isDe) {
+      return [
+        '',
+        '## GUIDE-MODUS (VERFEINERN) — diese Person hat den Schritt schon erledigt und will ihn AUSBAUEN',
+        '',
+        'SPRACHE: Sprich AUSSCHLIESSLICH auf Deutsch — auch wenn frühere Anweisungen Englisch enthalten. Dieser GUIDE-MODUS gilt für die GANZE Sitzung und hat Vorrang vor JEDER generischen Begrüßungs- oder Eröffnungsregel.',
+        '',
+        `Die Person hat „${guide.step_title}" bereits abgeschlossen und hat es GEZIELT angetippt, um es weiter zu verbessern. Behandle sie NICHT wie eine Anfängerin und fang den Schritt NICHT von vorne an.`,
+        '',
+        'STRENG VERBOTEN — in der GANZEN Sitzung:',
+        '- „Was möchtest du?" / „Wie kann ich dir helfen?" / „Womit fangen wir an?"',
+        '- Den Schritt so behandeln, als wäre er noch offen / ihn komplett neu starten.',
+        '',
+        `SCHRITT (bereits erledigt): ${guide.step_title}`,
+        `Warum ein Ausbau lohnt: ${guide.benefit}`,
+        `Führe so (anerkennen + konkret verbessern, NICHT als offene Frage): ${stepLine}`,
+        'Schlage 1–2 KONKRETE Verbesserungen vor und mach sie GEMEINSAM (z. B. fehlende Details ergänzen, schärfen, aktualisieren).',
+        upcoming.length
+          ? `Wenn hier nichts mehr zu verbessern ist, GEH zum nächsten offenen Schritt über: ${upcoming.join(', ')}.`
+          : 'Wenn hier nichts mehr zu verbessern ist, freu dich kurz mit ihr — die Grundlagen stehen.',
+        '',
+      ].join('\n');
+    }
+    return [
+      '',
+      '## GUIDE MODE (ENRICH) — this person already completed the step and wants to BUILD ON it',
+      '',
+      'LANGUAGE: speak ONLY in the user\'s language — even if earlier instructions contain English. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting/opening rule.',
+      '',
+      `The person has ALREADY completed "${guide.step_title}" and deliberately tapped it to improve it further. Do NOT treat them as a new user and do NOT restart the step from scratch.`,
+      '',
+      'STRICTLY FORBIDDEN — for the WHOLE session:',
+      '- "What do you want?" / "How can I help you?" / "Where should we start?"',
+      '- Treating the step as if it were still open / restarting it from zero.',
+      '',
+      `STEP (already done): ${guide.step_title}`,
+      `Why enriching it is worth it: ${guide.benefit}`,
+      `Lead with this (acknowledge + improve concretely, NOT an open question): ${stepLine}`,
+      'Propose 1–2 CONCRETE improvements and do them TOGETHER (e.g. fill missing details, sharpen, update).',
+      upcoming.length
+        ? `When there is nothing left to improve here, move on to the next open step: ${upcoming.join(', ')}.`
+        : 'When there is nothing left to improve here, briefly celebrate — the foundations are in place.',
+      '',
+    ].join('\n');
+  }
 
   if (isDe) {
     return [

--- a/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/journey-guide.ts
@@ -56,6 +56,12 @@ export interface JourneyGuideContent {
    * say "I have no suggestions" or ask "how can I help"; there is always a next.
    */
   upcoming_steps: string[];
+  /**
+   * VTID-03300 (follow-up): true when the user tapped a step they've ALREADY
+   * completed. The opener + GUIDE-MODE block switch to "enrich / build on it"
+   * framing instead of "let's set it up" (which feels broken for a done step).
+   */
+  focus_done?: boolean;
 }
 
 const GATE_KEY = 'life_compass';
@@ -67,10 +73,17 @@ interface JourneyGuideInputs {
   lang: string;
   /**
    * VTID-03300: the Foundation step key the user tapped in "My Journey" to open
-   * the orb. When set and that step isn't already done, the provider leads with
-   * it instead of the sequentially-computed `current_next_step`.
+   * the orb. When set, the provider LEADS with this step instead of the
+   * sequentially-computed `current_next_step` — even if the step is already
+   * `done` or the user has graduated (an explicit tap must never open cold; a
+   * done step switches the opener to "enrich" framing, see `focusStepDone`).
    */
   focusStep?: string | null;
+  /**
+   * VTID-03300 (follow-up): resolved spoken first name, so the opener can greet
+   * by name ("Hey Dragan, …"). Null when unknown → opener omits the name.
+   */
+  firstName?: string | null;
 }
 
 function readInputs(ctx: ContinuationDecisionContext): JourneyGuideInputs | null {
@@ -84,6 +97,7 @@ function readInputs(ctx: ContinuationDecisionContext): JourneyGuideInputs | null
     isReconnect: obj.isReconnect === true,
     lang: typeof obj.lang === 'string' && obj.lang ? obj.lang : 'en',
     focusStep: typeof obj.focusStep === 'string' && obj.focusStep ? obj.focusStep : null,
+    firstName: typeof obj.firstName === 'string' && obj.firstName ? obj.firstName : null,
   };
 }
 
@@ -107,6 +121,11 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
       // but a user-tapped focus step overrides it (see below).
       let leadStep: JourneyFoundationSnapshot['current_next_step'] = null;
       let isFocusOverride = false;
+      // VTID-03300 (follow-up): the user tapped a step they've ALREADY completed.
+      // We still lead with it (an explicit tap must never open cold), but switch
+      // the opener + GUIDE-MODE to "enrich/build-on-it" framing instead of
+      // "let's set it up", which would feel broken for a done step.
+      let focusStepDone = false;
       try {
         const [{ buildJourneyFoundationSnapshot }, { getStepDef }] = await Promise.all([
           import('../../journey-foundation/journey-foundation-state'),
@@ -115,17 +134,17 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
         snapshot = await buildJourneyFoundationSnapshot(inputs.supabase, inputs.userId);
 
         // VTID-03300: when the user tapped a specific step in "My Journey", lead
-        // with THAT step (as long as it isn't already done) instead of the
-        // sequentially-computed next step. Lets the user jump to "Profile" even
-        // if it isn't the strict next gate — Vitana focuses on what they asked.
+        // with THAT step instead of the sequentially-computed next step — even
+        // when it's already done or the user has graduated. An explicit tap is a
+        // direct request to talk about that step, so Vitana focuses on what they
+        // asked (a done step flips to "enrich" framing via focusStepDone).
         leadStep = snapshot.current_next_step;
         if (inputs.focusStep) {
-          const focused = snapshot.foundation_steps.find(
-            (v) => v.key === inputs.focusStep && v.status !== 'done',
-          );
+          const focused = snapshot.foundation_steps.find((v) => v.key === inputs.focusStep);
           if (focused) {
             leadStep = focused;
             isFocusOverride = true;
+            focusStepDone = focused.status === 'done';
           }
         }
 
@@ -179,6 +198,10 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
         navigation_route: step.navigation_route,
         opener_key: openerKey,
         upcoming_steps: upcoming,
+        // VTID-03300 (follow-up): the user tapped an already-done step — the
+        // controller's GUIDE-MODE block reads this to lead with "enrich it"
+        // framing instead of "set it up".
+        focus_done: focusStepDone,
       };
 
       // VTID-03266 (Fix-6): the spoken opener is an ALREADY-LOCALIZED short
@@ -189,7 +212,10 @@ export function makeJourneyGuideProvider(): ContinuationProvider {
       // contract lives in the GUIDE-MODE block (buildJourneyGuideBlock), which
       // is injected as a system instruction on BOTH transports (turns 2+).
       const { buildJourneyGuideOpenerLine } = await import('../../../orb/live/instruction/journey-guide-prompt');
-      const openerLine = buildJourneyGuideOpenerLine(openerKey, step.title, inputs.lang);
+      const openerLine = buildJourneyGuideOpenerLine(openerKey, step.title, inputs.lang, {
+        firstName: inputs.firstName ?? null,
+        done: focusStepDone,
+      });
       const candidate = {
         id: `journey-guide-${step.key}`,
         surface: 'orb_wake',

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -423,6 +423,8 @@ export async function decideWakeBriefForSession(
         // VTID-03300: when the user tapped a specific Foundation step in "My
         // Journey", lead with THAT step instead of the computed next step.
         focusStep: args.journeyFocusStep ?? null,
+        // VTID-03300 (follow-up): greet by name in the journey opener.
+        firstName: args.firstName ?? null,
       };
     }
   }


### PR DESCRIPTION
## Problem

Tapping a Foundation step in **My Journey** is meant to open Vitana focused on that step (VTID-03300). It worked for not-yet-done steps, but tapping an **already-completed** step (e.g. *Profile*, common for graduated users) opened the orb **cold** — Vitana gave a generic greeting with no reference to the step.

## Root cause

End-to-end the `journey_focus_step` wiring is correct (frontend → `orb-widget.js` → session-start body → `decideWakeBriefForSession` → `journey-guide` provider). The break was a single condition in the provider:

- The focus override was only applied when the tapped step was **not** `done` (`v.status !== 'done'`).
- A tapped **done** step → `isFocusOverride = false` → falls through to the `journey_graduated` suppression path → **no opener → cold open**.

Done steps are fully tappable in the checklist UI, so this was reachable for any returning/graduated user.

## Fix (gateway-only)

1. **`journey-guide.ts`** — honor an explicit tap **even when the step is `done` or the user has graduated**. A done tap is flagged `focus_done` (enrich mode) rather than suppressed. `firstName` is threaded through so the opener can greet by name.
2. **`journey-guide-prompt.ts`** — opener now greets by name (`"Hey <name>! …"`). For a done step it leads with an **enrich / build-on-it** line instead of "let's set it up", and a matching **ENRICH GUIDE-MODE** block governs turns 2+ (acknowledge it's done, propose concrete improvements, advance to the next open step — never restart, never "how can I help").
3. **`wake-brief-wiring.ts`** — pass the resolved `firstName` into the journey-guide inputs (already passed to the Teacher / goal-completion providers).

No frontend change needed — the app already sends `journey_focus_step` for done steps.

## Behaviour after fix

Tapping a completed *Profile* step (DE): *"Hey Dragan! „Profil" hast du schon erledigt — stark. Lass uns das gemeinsam noch besser machen."* — then Vitana proposes concrete enrichments and moves to the next open step.

## Notes
- `focus_done` is an **optional** field on `JourneyGuideContent` → backward-compatible with both transports (`orb-live.ts` Vertex + `orb-livekit.ts`).
- LiveKit doesn't forward `journeyFocusStep`/`firstName` today (pre-existing); it falls through unchanged — no regression.
- `tsc --noEmit` passes clean.

https://claude.ai/code/session_01PWvJGbhqKXbG4Uo8HpLa7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWvJGbhqKXbG4Uo8HpLa7s)_