### PR TITLE
fix(orb-agent): STT recovery escalates instead of going deaf (BOOTSTRAP-ORB-STT-HARD-RECOVERY)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/oasis.py
+++ b/services/agents/orb-agent/src/orb_agent/oasis.py
@@ -177,8 +177,11 @@ TOPIC_STT_SILENT_STALL = "livekit.stt.silent_stall"
 # decides to attempt an in-place STT swap (build fresh cascade →
 # session.update_agent with a new Agent carrying stt=fresh + preserved
 # llm/tts/instructions/tools/chat_ctx). Outcomes:
-#   - `attempted`: swap scheduled. Includes per-session attempt count.
+#   - `attempted`: swap scheduled. Includes attempt_no, backoff_s, trigger
+#     (silent_stall | stall_watchdog), and an audio_input diagnostic snapshot.
 #   - `succeeded`: a user_input_transcribed event arrived within the
 #     recovery verify window after the swap completed.
-#   - `gave_up`: per-session max swap count reached. We stop trying.
+# BOOTSTRAP-ORB-STT-HARD-RECOVERY: there is no longer a `gave_up` outcome — past the fast-cadence
+# budget recovery continues under exponential backoff rather than stopping,
+# because a permanently deaf agent is strictly worse than one more rebuild.
 TOPIC_STT_RECOVERY = "livekit.stt.recovery"

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -151,7 +151,7 @@ def _get_vad() -> Any:
     return _SHARED_VAD
 
 
-CODE_VERSION = "agent-2026-05-17-vtid-03046-turn-telemetry"
+CODE_VERSION = "agent-2026-06-03-orb-stt-hard-recovery-stt-hard-recovery"
 
 
 # VTID-03014: localized first-greeting templates. session.say() speaks the
@@ -1127,6 +1127,60 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # via soft_reset_count so we can still see how often it fires.
     soft_reset_count = {"n": 0}
 
+    # BOOTSTRAP-ORB-STT-HARD-RECOVERY: shared monotonic marker of the last REAL user transcript.
+    # Updated by every user_input_transcribed hook below. The recovery
+    # watchdogs read it to tell whether a swap/rebuild actually restored
+    # hearing (transcript advanced) vs. thrashed with no effect. Seeded to
+    # "now" so a quiet greeting-only open doesn't look like a stall.
+    last_transcript_at = {"t": time.monotonic()}
+
+    # BOOTSTRAP-ORB-STT-HARD-RECOVERY: escalation from tier-1 (the in-place _stt swap below —
+    # cheap but often a no-op once the running activity has bound the stale
+    # stream; prod 2026-06-02 logged 14 "swapped" soft-resets across 96s of
+    # dead air) to tier-2 (a full agent rebuild via update_agent, the proven
+    # persona-handoff primitive). After this many consecutive soft-resets
+    # land with NO new transcript in between, stop re-swapping a dead slot
+    # and rebuild the agent instead.
+    HARD_RECOVERY_AFTER = 2
+    soft_reset_streak = {"n": 0, "seen_transcript": None}
+
+    # Forward handle to the tier-2 recovery (defined later, alongside the
+    # silent-stall watchdog). Populated once that closure exists so _on_stall
+    # can escalate into it without depending on definition order.
+    _hard_recovery_ref: dict[str, Any] = {"fn": None}
+
+    def _audio_input_diag() -> dict[str, Any]:
+        """Best-effort snapshot of the inbound audio path so a stall event
+        can distinguish 'mic track gone' (audio never arrives) from 'STT deaf
+        while audio flows' (the silent-buffer failure mode). Never raises."""
+        diag: dict[str, Any] = {
+            "remote_participants": 0,
+            "mic_tracks": 0,
+            "subscribed": 0,
+            "muted": 0,
+        }
+        try:
+            room = getattr(ctx, "room", None)
+            rps = getattr(room, "remote_participants", None) or {}
+            parts = rps.values() if hasattr(rps, "values") else rps
+            for p in parts:
+                diag["remote_participants"] += 1
+                pubs = getattr(p, "track_publications", None) or {}
+                pubvals = pubs.values() if hasattr(pubs, "values") else pubs
+                for pub in pubvals:
+                    kind = str(getattr(pub, "kind", "")).lower()
+                    source = str(getattr(pub, "source", "")).lower()
+                    if not (kind.endswith("audio") or source.endswith("microphone")):
+                        continue
+                    diag["mic_tracks"] += 1
+                    if getattr(pub, "subscribed", False):
+                        diag["subscribed"] += 1
+                    if getattr(pub, "muted", False):
+                        diag["muted"] += 1
+        except Exception:  # noqa: BLE001
+            diag["error"] = True
+        return diag
+
     async def _on_stall() -> None:
         stall_count["n"] += 1
         soft_reset_count["n"] += 1
@@ -1234,6 +1288,18 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         # STALL_THRESHOLD_MS window, not immediately after this attempt.
         stall.feed()
 
+        # BOOTSTRAP-ORB-STT-HARD-RECOVERY: escalation bookkeeping. Count consecutive soft-resets
+        # with NO new transcript in between; once we cross HARD_RECOVERY_AFTER,
+        # escalate to the tier-2 agent rebuild instead of re-swapping a slot
+        # the running activity has proven it won't read from.
+        cur_tx = last_transcript_at["t"]
+        if cur_tx != soft_reset_streak["seen_transcript"]:
+            soft_reset_streak["n"] = 0
+            soft_reset_streak["seen_transcript"] = cur_tx
+        soft_reset_streak["n"] += 1
+        escalate = soft_reset_streak["n"] >= HARD_RECOVERY_AFTER
+        audio_diag = _audio_input_diag()
+
         try:
             await oasis.emit(
                 topic=TOPIC_STALL_DETECTED,
@@ -1247,10 +1313,21 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                     "soft_reset_count": soft_reset_count["n"],
                     "soft_reset_status": reset_status,
                     "soft_reset_error": reset_error,
+                    "soft_reset_streak": soft_reset_streak["n"],
+                    "escalated_to_hard_recovery": escalate,
+                    "audio_input": audio_diag,
                 },
             )
         except Exception:  # noqa: BLE001
             pass
+
+        # BOOTSTRAP-ORB-STT-HARD-RECOVERY: fire the tier-2 rebuild OUTSIDE the telemetry try so a
+        # failed emit never blocks recovery. _attempt_stt_recovery is itself
+        # re-entrant-safe (in_flight + backoff guards), so this cannot
+        # double-swap with the silent-stall path.
+        if escalate and _hard_recovery_ref["fn"] is not None:
+            soft_reset_streak["n"] = 0
+            asyncio.create_task(_hard_recovery_ref["fn"](trigger="stall_watchdog"))
 
     stall.start(on_stall=_on_stall)
 
@@ -1319,6 +1396,9 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         # above. Capture transcript length defensively — the field name
         # varies across livekit-agents versions.
         turn_state["user_done_at"] = time.monotonic()
+        # BOOTSTRAP-ORB-STT-HARD-RECOVERY: a real transcript landed — advance the shared marker so
+        # the recovery watchdogs know hearing is (still) working.
+        last_transcript_at["t"] = turn_state["user_done_at"]
         text_len = 0
         try:
             t = (
@@ -1854,7 +1934,9 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         logger.debug("could not hook user_state_changed for silent-stall: %s", exc)
 
     def _on_transcript_for_stall(_ev: Any = None) -> None:
-        stall_state["last_transcript_at"] = time.monotonic()
+        _now = time.monotonic()
+        stall_state["last_transcript_at"] = _now
+        last_transcript_at["t"] = _now  # BOOTSTRAP-ORB-STT-HARD-RECOVERY: shared recovery marker
         stall_state["user_speaking_since"] = None        # turn closed cleanly
         stall_state["expecting_transcript_since"] = None  # VTID-03080: transcript arrived after speech_end
 
@@ -1883,9 +1965,11 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     #      as VTID-03046 persona handoff). Bounded by 5s wait on the
     #      activity-transition task.
     #
-    # Bounded to STT_RECOVERY_MAX_ATTEMPTS per session. After exhausting
-    # attempts the watchdog stays telemetry-only — likely a deeper
-    # LiveKit transport problem, not STT. Kill switch:
+    # BOOTSTRAP-ORB-STT-HARD-RECOVERY: the first STT_RECOVERY_MAX_ATTEMPTS rebuilds fire at the
+    # watchdog's normal cadence; beyond that recovery CONTINUES under
+    # exponential backoff (capped at STT_RECOVERY_BACKOFF_CEILING_S) rather
+    # than giving up — the old hard cap caused permanent deafness once a
+    # recoverable stall needed >5 swaps. Kill switch:
     # ORB_STT_RECOVERY_ENABLED=false reverts to detection-only behavior.
     # ------------------------------------------------------------------
     # VTID-03079: bumped from 3 → 5. The previous cap was burned by
@@ -1895,7 +1979,17 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # legitimately need 4-5 recoveries. Each attempt is bounded to ~3s
     # by the activity-swap wait, so 5 attempts cost at most ~15s of
     # total session disruption — still well under any user's patience.
+    # BOOTSTRAP-ORB-STT-HARD-RECOVERY: fast-cadence attempt budget. The first
+    # STT_RECOVERY_MAX_ATTEMPTS recoveries fire at the watchdog's normal
+    # ~8s cadence. Beyond that we DO NOT give up — the old behavior went
+    # permanently deaf after 5 (prod 2026-06-02: 96s of dead air while the
+    # tier-1 swap thrashed). Instead we keep rebuilding under exponential
+    # backoff capped at STT_RECOVERY_BACKOFF_CEILING_S, so a chronic upstream
+    # problem costs at most ~1 rebuild/min (no STT/Deepgram connection churn —
+    # honoring the original VTID-03079 cost guard) while a recoverable stall
+    # still eventually restores hearing instead of dying silently.
     STT_RECOVERY_MAX_ATTEMPTS = 5
+    STT_RECOVERY_BACKOFF_CEILING_S = 60.0
 
     def _stt_recovery_enabled() -> bool:
         return os.environ.get("ORB_STT_RECOVERY_ENABLED", "true").lower() not in (
@@ -1906,41 +2000,55 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         "attempts": 0,
         "last_attempt_at": 0.0,
         "in_flight": False,
+        "backoff_until": 0.0,
+        "seen_transcript": None,
     }
 
-    async def _attempt_stt_recovery() -> None:
-        """Build a fresh STT cascade and swap it onto the current Agent.
-        Bounded; runs at most STT_RECOVERY_MAX_ATTEMPTS per session and
-        guards against re-entry while a previous swap is still completing."""
+    async def _attempt_stt_recovery(trigger: str = "silent_stall") -> None:
+        """Build a fresh STT cascade and swap it onto the current Agent via
+        update_agent (the proven persona-handoff primitive). Never gives up
+        permanently (BOOTSTRAP-ORB-STT-HARD-RECOVERY): past the fast-cadence budget it continues
+        under exponential backoff. Re-entrant-safe via the in_flight guard,
+        so the broad stall watchdog and the silent-stall watchdog can both
+        call it without double-swapping."""
         if not _stt_recovery_enabled():
             return
         if recovery_state["in_flight"]:
             return
-        attempts = int(recovery_state["attempts"])
-        if attempts >= STT_RECOVERY_MAX_ATTEMPTS:
-            # Emit gave_up exactly once when we hit the cap.
-            if attempts == STT_RECOVERY_MAX_ATTEMPTS:
-                recovery_state["attempts"] = attempts + 1  # idempotent
-                asyncio.create_task(
-                    oasis.emit(
-                        topic=TOPIC_STT_RECOVERY,
-                        payload={
-                            "user_id": identity.user_id,
-                            "orb_session_id": orb_session_id,
-                            "outcome": "gave_up",
-                            "attempts": attempts,
-                            "max_attempts": STT_RECOVERY_MAX_ATTEMPTS,
-                        },
-                    )
-                )
-            return
+        now = time.monotonic()
+        if now < float(recovery_state["backoff_until"]):
+            return  # still cooling down after a prior rebuild
+
+        # If a real transcript arrived since our last attempt, hearing was
+        # restored — reset the budget so a LATER stall starts fresh at the
+        # fast cadence rather than inheriting a deep backoff.
+        cur_tx = last_transcript_at["t"]
+        if (
+            recovery_state["seen_transcript"] is not None
+            and cur_tx != recovery_state["seen_transcript"]
+        ):
+            recovery_state["attempts"] = 0
+        recovery_state["seen_transcript"] = cur_tx
 
         recovery_state["in_flight"] = True
-        recovery_state["attempts"] = attempts + 1
-        recovery_state["last_attempt_at"] = time.monotonic()
-        attempt_no = recovery_state["attempts"]
+        recovery_state["attempts"] = int(recovery_state["attempts"]) + 1
+        recovery_state["last_attempt_at"] = now
+        attempt_no = int(recovery_state["attempts"])
 
-        # Telemetry: announce the attempt.
+        # Past the fast budget, schedule the NEXT attempt under exponential
+        # backoff (capped). Within the budget, no extra delay — rely on the
+        # watchdog's own SILENT_STALL_REPEAT_S cadence.
+        if attempt_no > STT_RECOVERY_MAX_ATTEMPTS:
+            backoff_s = min(
+                SILENT_STALL_REPEAT_S * (2 ** (attempt_no - STT_RECOVERY_MAX_ATTEMPTS)),
+                STT_RECOVERY_BACKOFF_CEILING_S,
+            )
+        else:
+            backoff_s = 0.0
+        recovery_state["backoff_until"] = now + backoff_s
+
+        # Telemetry: announce the attempt, with audio-path diagnostics so the
+        # next bad session is unambiguous (mic-track-loss vs STT-deaf).
         asyncio.create_task(
             oasis.emit(
                 topic=TOPIC_STT_RECOVERY,
@@ -1949,7 +2057,10 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                     "orb_session_id": orb_session_id,
                     "outcome": "attempted",
                     "attempt_no": attempt_no,
-                    "max_attempts": STT_RECOVERY_MAX_ATTEMPTS,
+                    "fast_budget": STT_RECOVERY_MAX_ATTEMPTS,
+                    "backoff_s": round(backoff_s, 1),
+                    "trigger": trigger,
+                    "audio_input": _audio_input_diag(),
                 },
             )
         )
@@ -2016,6 +2127,11 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             logger.exception("VTID-03078: STT recovery attempt %d failed: %s", attempt_no, exc)
         finally:
             recovery_state["in_flight"] = False
+
+    # BOOTSTRAP-ORB-STT-HARD-RECOVERY: expose the tier-2 recovery to the broad stall watchdog
+    # (_on_stall, defined earlier) so it can escalate after consecutive
+    # ineffective soft-resets.
+    _hard_recovery_ref["fn"] = _attempt_stt_recovery
 
     def _check_for_stall(now: float) -> tuple[str, dict[str, Any]] | None:
         """Return (detection_reason, telemetry_extras) if a stall should
@@ -2097,11 +2213,11 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                     + " ".join(f"{k}={v}" for k, v in extras.items() if k != "detector")
                 )
                 await _publish_client_alert(reason="stt_silent_stall", detail=client_detail)
-                # VTID-03078: fire the actual recovery — fresh STT cascade
-                # swapped onto the current Agent via session.update_agent.
-                # Bounded (max 3 attempts per session); kill-switchable via
-                # ORB_STT_RECOVERY_ENABLED=false.
-                asyncio.create_task(_attempt_stt_recovery())
+                # VTID-03078 / BOOTSTRAP-ORB-STT-HARD-RECOVERY: fire the actual recovery — fresh STT
+                # cascade swapped onto the current Agent via update_agent.
+                # Fast cadence then exponential backoff (never permanently
+                # gives up); kill-switchable via ORB_STT_RECOVERY_ENABLED=false.
+                asyncio.create_task(_attempt_stt_recovery(trigger="silent_stall"))
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # noqa: BLE001

--- a/services/agents/orb-agent/tests/test_stt_recovery.py
+++ b/services/agents/orb-agent/tests/test_stt_recovery.py
@@ -58,16 +58,81 @@ def test_recovery_kill_switch_off_variants(monkeypatch) -> None:  # type: ignore
         assert val in ("false", "0", "no", "off"), v
 
 
-def test_max_attempts_constant_pinned_at_five() -> None:
-    """VTID-03079 bumped 3 → 5 once the tighter predicate started
-    rejecting false positives. 5 attempts cost at most ~15s of swap
-    activity (each bounded by the 5s activity-swap wait); a longer
-    session may legitimately need 4-5 recoveries. Anything higher risks
-    churning Google STT / Deepgram connections on a chronic problem;
-    anything lower means we give up before the user does."""
+def test_fast_budget_constant_pinned_at_five() -> None:
+    """BOOTSTRAP-ORB-STT-HARD-RECOVERY: STT_RECOVERY_MAX_ATTEMPTS is now the FAST-cadence budget,
+    not a hard give-up. The first 5 rebuilds fire at the watchdog cadence;
+    beyond that recovery continues under backoff. The constant stays 5 so the
+    fast phase matches the prior tuning (VTID-03079)."""
     src = _session_src()
     assert "STT_RECOVERY_MAX_ATTEMPTS = 5" in src, (
-        "VTID-03079 regression: STT_RECOVERY_MAX_ATTEMPTS must be 5"
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: STT_RECOVERY_MAX_ATTEMPTS (fast budget) must be 5"
+    )
+
+
+def test_recovery_never_permanently_gives_up() -> None:
+    """BOOTSTRAP-ORB-STT-HARD-RECOVERY: the hard cap caused 96s of dead air in prod (2026-06-02)
+    once a recoverable stall needed >5 swaps. Recovery must no longer emit a
+    `gave_up` outcome or otherwise stop trying — past the fast budget it
+    continues under exponential backoff capped at a ceiling constant."""
+    src = _session_src()
+    assert '"gave_up"' not in src, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: recovery must not permanently give up "
+        "(no `gave_up` outcome)"
+    )
+    assert "STT_RECOVERY_BACKOFF_CEILING_S" in src, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: backoff ceiling constant missing — recovery "
+        "would either give up or churn unbounded"
+    )
+    # The backoff must be bounded (cost guard preserved): a ceiling, applied
+    # via min(...), so chronic upstream failure costs ~1 rebuild/min not a
+    # tight loop.
+    recovery_start = src.find("async def _attempt_stt_recovery")
+    recovery_block = src[recovery_start : recovery_start + 4000]
+    assert "backoff_until" in recovery_block, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: no backoff gating in _attempt_stt_recovery"
+    )
+    assert "STT_RECOVERY_BACKOFF_CEILING_S" in recovery_block, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: backoff ceiling not applied in recovery"
+    )
+
+
+def test_broad_stall_watchdog_escalates_to_hard_recovery() -> None:
+    """BOOTSTRAP-ORB-STT-HARD-RECOVERY: the broad StallWatchdog (_on_stall) previously only did the
+    in-place _stt swap — the no-op that thrashed 14× in prod. It must now
+    escalate into the proven update_agent rebuild after consecutive
+    ineffective soft-resets."""
+    src = _session_src()
+    assert "HARD_RECOVERY_AFTER" in src, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: escalation threshold constant missing"
+    )
+    stall_start = src.find("async def _on_stall")
+    # Slice to the watchdog registration that immediately follows _on_stall
+    # so the window covers the whole closure regardless of its length.
+    stall_end = src.find("stall.start(on_stall=_on_stall)", stall_start)
+    stall_block = src[stall_start:stall_end]
+    assert "_hard_recovery_ref" in stall_block, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: _on_stall does not escalate to tier-2 recovery"
+    )
+    assert 'trigger="stall_watchdog"' in stall_block, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: escalation must tag its trigger for telemetry"
+    )
+    # And the forward handle must actually be populated to the recovery fn.
+    assert "_hard_recovery_ref[\"fn\"] = _attempt_stt_recovery" in src, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: tier-2 recovery never wired to the forward ref"
+    )
+
+
+def test_stall_events_carry_audio_input_diagnostics() -> None:
+    """BOOTSTRAP-ORB-STT-HARD-RECOVERY: every recovery/stall event must carry an audio-path
+    snapshot so the next bad session distinguishes 'mic track gone' from
+    'STT deaf while audio flows' — the ambiguity that cost us weeks."""
+    src = _session_src()
+    assert "def _audio_input_diag" in src, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: audio-input diagnostic helper missing"
+    )
+    assert src.count("_audio_input_diag()") >= 2, (
+        "BOOTSTRAP-ORB-STT-HARD-RECOVERY regression: audio diagnostics must be attached to BOTH "
+        "the stall event and the recovery event"
     )
 
 
@@ -103,7 +168,9 @@ def test_recovery_preserves_chat_ctx_tools_instructions() -> None:
     # Find the Agent(...) construction inside _attempt_stt_recovery.
     recovery_start = src.find("async def _attempt_stt_recovery")
     assert recovery_start != -1
-    recovery_block = src[recovery_start : recovery_start + 4000]
+    # Window widened (BOOTSTRAP-ORB-STT-HARD-RECOVERY added backoff gating + telemetry ahead of the
+    # Agent() construction, pushing it down ~1.5k chars).
+    recovery_block = src[recovery_start : recovery_start + 6000]
 
     # Each of these MUST appear inside the recovery's Agent() call.
     for required in ("instructions=", "tools=", "chat_ctx=", "stt=", "llm=", "tts="):


### PR DESCRIPTION
## Summary

Users report the ORB voice agent "disconnects" 4–7×/min in the first minute. **It is not a transport drop.** Production OASIS telemetry from a single session (2026‑06‑02, user `0adc6ff6…`) shows the real failure:

- `vtid.live.stall_detected` → `soft_reset_status="swapped"`, `stall_count` climbing **9 → 14**
- `livekit.stt.recovery` → `outcome="gave_up"`, `attempts=5/5`
- `livekit.stt.silent_stall` → `since_last_transcript_s=96` — **96 seconds of dead air**

The STT engine went silently deaf, the watchdogs thrashed, then permanently gave up. The user experiences that as repeated disconnects.

## Root cause

Two recovery paths, neither of which fully recovered:

1. **Broad `StallWatchdog` (`_on_stall`)** did an in‑place `session._stt = new_stt` attribute swap. The verify check passes (the attribute *is* the new object), but the already‑running `AgentSession` activity keeps feeding the **old/dead** stream, so the new STT never receives audio. The swap is a **no‑op** — it thrashed 14×.
2. **Silent‑stall path (`_attempt_stt_recovery`)** uses the **proven** primitive — build a fresh `Agent(stt=…)` + `session.update_agent(...)`, the same path as persona handoff — but was **hard‑capped at 5 attempts**, then emitted `gave_up` and went permanently deaf.

## Fix

- **Never give up permanently.** Past the fast‑cadence budget (still 5), recovery continues under **exponential backoff capped at 60s** (`STT_RECOVERY_BACKOFF_CEILING_S`). A chronic upstream problem costs ~1 rebuild/min — **honoring the original VTID‑03079 cost guard** (no STT/Deepgram connection churn) — while a *recoverable* stall eventually restores hearing instead of dying silently.
- **Escalate the broad watchdog.** After `HARD_RECOVERY_AFTER` (2) consecutive soft‑resets with **no new transcript in between**, `_on_stall` routes into the proven `update_agent` rebuild instead of re‑swapping a dead slot. Re‑entrant‑safe via the `in_flight` + backoff guards, so the two paths cannot double‑swap.
- **Shared transcript marker** so recovery can tell a real restore from a thrash, and resets the budget when hearing returns.
- **Audio‑input diagnostics** (`_audio_input_diag`) attached to every stall + recovery event — mic track subscribed/muted counts — so the next bad session unambiguously separates *mic‑track‑loss* from *STT‑deaf‑while‑audio‑flows*.

## On the cap I changed

`STT_RECOVERY_MAX_ATTEMPTS = 5` was a **deliberate, tested** guard (its test rationale: *"anything higher risks churning Google STT / Deepgram connections"*). I did **not** remove the cost protection — I changed its *meaning* from "give up after 5" (which caused the deafness) to "fast cadence for 5, then backoff." The cost guard's intent is preserved by the 60s ceiling; the deafness bug is removed. The test is rewritten to pin the new contract.

## Tests

- Rewrote the cap test → backoff contract; added coverage for **never‑gives‑up**, **broad‑watchdog escalation**, and **audio diagnostics**.
- **34/34** STT + stall‑domain tests pass. The unrelated full‑suite failures pre‑exist on the clean `main` tree (missing native deps in this CI env) — verified by stashing.

## ⚠️ Draft — one live check before merge

The recovery primitive (`update_agent` rebuild) is already deployed and proven. What is **new** is the escalation + backoff interplay. This can't be fully exercised without a live LiveKit runtime, so it warrants **one real-session check** (force a silent stall, confirm `livekit.stt.recovery` keeps firing past attempt 5 under backoff and that a transcript resumes) before merge.

Kill switch unchanged: `ORB_STT_RECOVERY_ENABLED=false` reverts to detection‑only.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_