### PR TITLE
fix(autopilot): wire AP-0212 Welcome Squad to real community tables + add global-group join endpoint

### DIFF
--- a/services/gateway/src/routes/community.ts
+++ b/services/gateway/src/routes/community.ts
@@ -361,6 +361,118 @@ router.post('/groups/:id/join', async (req: Request, res: Response) => {
 });
 
 /**
+ * POST /global-groups/:id/join -> POST /api/v1/community/global-groups/:id/join
+ *
+ * Join a *global community group* — the real, populated schema
+ * (global_community_groups / global_community_group_members), as opposed to
+ * the never-deployed VTID-01084 community_groups schema used by
+ * /groups/:id/join.
+ *
+ * Writes the membership row under the user's RLS context (the
+ * "Users can join groups" policy permits self-insert), then dispatches the
+ * `community.member.joined` automation event WITH `user_id` so AP-0212
+ * (Welcome Squad) and AP-0203 can fire. member_count and chat participants
+ * are maintained automatically by DB triggers on insert.
+ */
+router.post('/global-groups/:id/join', async (req: Request, res: Response) => {
+  const groupId = req.params.id;
+  console.log(`[${VTID}] POST /community/global-groups/${groupId}/join`);
+
+  const token = getBearerToken(req);
+  if (!token) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const uuidValidation = z.string().uuid('Invalid group ID').safeParse(groupId);
+  if (!uuidValidation.success) {
+    return res.status(400).json({ ok: false, error: 'Invalid group ID format' });
+  }
+
+  // Resolve the authenticated user id from the JWT (matches existing pattern).
+  let userId = '';
+  try {
+    userId = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).sub;
+  } catch {
+    /* fall through to the unauth check below */
+  }
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_ANON_KEY) {
+    return res.status(503).json({ ok: false, error: 'Gateway misconfigured' });
+  }
+
+  try {
+    const supabase = createUserSupabaseClient(token);
+
+    // Confirm the group exists (and is visible under RLS) before joining.
+    const { data: group, error: groupErr } = await supabase
+      .from('global_community_groups')
+      .select('id, name')
+      .eq('id', groupId)
+      .maybeSingle();
+    if (groupErr) {
+      return res.status(502).json({ ok: false, error: groupErr.message });
+    }
+    if (!group) {
+      return res.status(404).json({ ok: false, error: 'GROUP_NOT_FOUND' });
+    }
+
+    // Idempotent membership: only insert if not already a member.
+    const { data: existing } = await supabase
+      .from('global_community_group_members')
+      .select('id')
+      .eq('group_id', groupId)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    let alreadyMember = !!existing;
+
+    if (!existing) {
+      const { error: insErr } = await supabase
+        .from('global_community_group_members')
+        .insert({ group_id: groupId, user_id: userId, role: 'member' });
+      if (insErr) {
+        // Unique-violation => raced with a concurrent join; treat as success.
+        if (insErr.code === '23505') {
+          alreadyMember = true;
+        } else {
+          console.error(`[${VTID}] global group join insert error:`, insErr.message);
+          return res.status(502).json({ ok: false, error: insErr.message });
+        }
+      }
+    }
+
+    // Emit an OASIS event for observability.
+    await emitCommunityEvent(
+      'community.membership.joined',
+      'success',
+      `User joined global group: ${groupId}`,
+      { group_id: groupId, user_id: userId, already_member: alreadyMember }
+    );
+
+    // Dispatch the automation event WITH user_id (only on a genuinely new
+    // join) so AP-0212 (Welcome Squad) / AP-0203 can fire.
+    if (!alreadyMember) {
+      const tenantId = process.env.DEFAULT_TENANT_ID;
+      if (tenantId) {
+        dispatchEvent(tenantId, 'community.member.joined', {
+          group_id: groupId,
+          user_id: userId,
+        }).catch(err => console.warn(`[${VTID}] dispatch community.member.joined failed:`, err.message));
+      }
+    }
+
+    console.log(`[${VTID}] User ${userId.slice(0, 8)}… joined global group ${groupId} (new=${!alreadyMember})`);
+    return res.status(200).json({ ok: true, data: { group_id: groupId, already_member: alreadyMember } });
+  } catch (err: any) {
+    console.error(`[${VTID}] global group join error:`, err.message);
+    return res.status(502).json({ ok: false, error: err.message });
+  }
+});
+
+/**
  * POST /meetups -> POST /api/v1/community/meetups
  *
  * Create a new meetup.

--- a/services/gateway/src/services/automation-handlers/community-groups.ts
+++ b/services/gateway/src/services/automation-handlers/community-groups.ts
@@ -89,6 +89,148 @@ async function runNewMemberWelcome(ctx: AutomationContext) {
   return { usersAffected: 2, actionsTaken: 2 };
 }
 
+// ── AP-0212: "Welcome Squad" New-Member Activation ──────────
+// Multi-step orchestration fired on community.member.joined:
+//   1. Introduce the newcomer to up to 3 existing group members ("the squad")
+//   2. Suggest related groups (topic overlap) + an upcoming meetup
+//   3. Send the newcomer a warm welcome with the intros + suggestions
+//   4. Notify the group host their Welcome Squad went out (auto-fire,
+//      in-platform members only, attributed "via Autopilot")
+//   5. Seed Autopilot recommendation cards so the newcomer's Autopilot
+//      page is populated with one-tap "approve" actions
+// Guardrails: intros capped at SQUAD_SIZE; all sends are in-platform
+// member notifications (no external channels); messages are attributed.
+const SQUAD_SIZE = 3;
+
+async function runWelcomeSquad(ctx: AutomationContext) {
+  const payload = ctx.run.metadata as any;
+  const { user_id, group_id } = payload || {};
+  if (!user_id || !group_id) return { usersAffected: 0, actionsTaken: 0 };
+
+  const { supabase, tenantId } = ctx;
+  let usersAffected = 0;
+  let actionsTaken = 0;
+
+  const { data: group } = await supabase
+    .from('community_groups')
+    .select('name, description, created_by, topic_keys')
+    .eq('id', group_id)
+    .maybeSingle();
+  if (!group) return { usersAffected: 0, actionsTaken: 0 };
+
+  const { data: newMember } = await supabase
+    .from('app_users')
+    .select('display_name')
+    .eq('id', user_id)
+    .maybeSingle();
+  const newMemberName = newMember?.display_name || 'A new member';
+
+  // Step 1 — pick the squad: up to 3 existing members of this group
+  // (excluding the newcomer and the host, who is notified separately).
+  const { data: members } = await supabase
+    .from('community_memberships')
+    .select('user_id')
+    .eq('group_id', group_id)
+    .neq('user_id', user_id)
+    .limit(50);
+
+  const squad: string[] = [];
+  for (const m of members || []) {
+    if (m.user_id === group.created_by) continue;
+    squad.push(m.user_id);
+    if (squad.length >= SQUAD_SIZE) break;
+  }
+
+  // Step 2 — suggest related groups (topic overlap) + an upcoming meetup.
+  let suggestedGroups: Array<{ id: string; name: string }> = [];
+  if (Array.isArray(group.topic_keys) && group.topic_keys.length > 0) {
+    const { data: related } = await supabase
+      .from('community_groups')
+      .select('id, name')
+      .eq('tenant_id', tenantId)
+      .neq('id', group_id)
+      .overlaps('topic_keys', group.topic_keys)
+      .limit(2);
+    suggestedGroups = related || [];
+  }
+
+  const { data: upcomingMeetup } = await supabase
+    .from('community_meetups')
+    .select('id, title')
+    .eq('tenant_id', tenantId)
+    .eq('group_id', group_id)
+    .gte('starts_at', new Date().toISOString())
+    .order('starts_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  // Step 3 — warm welcome to the newcomer with the squad + suggestions.
+  const squadLine = squad.length
+    ? `Meet ${squad.length} member${squad.length > 1 ? 's' : ''} to connect with`
+    : 'Say hi to the group';
+  const extras: string[] = [];
+  if (suggestedGroups.length) {
+    extras.push(`${suggestedGroups.length} related group${suggestedGroups.length > 1 ? 's' : ''} you'll like`);
+  }
+  if (upcomingMeetup) extras.push(`"${upcomingMeetup.title}" coming up`);
+
+  ctx.notify(user_id, 'orb_proactive_message', {
+    title: `Welcome to ${group.name}! Your squad is ready 👋`,
+    body: [squadLine, ...extras].join(' · '),
+    data: {
+      url: `/community/groups/${group_id}`,
+      group_id,
+      squad_user_ids: squad.join(','),
+      suggested_group_ids: suggestedGroups.map((g) => g.id).join(','),
+      meetup_id: upcomingMeetup?.id || '',
+      via: 'autopilot',
+      automation_id: 'AP-0212',
+    },
+  });
+  usersAffected++;
+  actionsTaken++;
+
+  // Step 4 — notify the host their Welcome Squad went out (auto-fire,
+  // in-platform member, attributed).
+  if (group.created_by && group.created_by !== user_id) {
+    ctx.notify(group.created_by, 'someone_joined_your_group', {
+      title: `Welcome Squad sent for ${newMemberName} 🎉`,
+      body: `Autopilot introduced them to ${squad.length} member${squad.length === 1 ? '' : 's'} in ${group.name} and shared what to do next.`,
+      data: {
+        url: `/community/groups/${group_id}`,
+        group_id,
+        new_member_id: user_id,
+        via: 'autopilot',
+        automation_id: 'AP-0212',
+      },
+    });
+    usersAffected++;
+    actionsTaken++;
+  }
+
+  // Step 5 — seed Autopilot recommendation cards for the newcomer so the
+  // Autopilot page has one-tap "approve" actions waiting.
+  try {
+    const { generatePersonalRecommendations } = await import('../recommendation-engine');
+    await generatePersonalRecommendations(user_id, tenantId, {
+      trigger_type: 'auto_replenish',
+    });
+    actionsTaken++;
+  } catch (err: any) {
+    ctx.log(`AP-0212: recommendation seeding skipped (${err?.message || err})`);
+  }
+
+  await ctx.emitEvent('autopilot.welcome_squad.sent', {
+    user_id,
+    group_id,
+    squad_size: squad.length,
+    suggested_groups: suggestedGroups.length,
+    has_meetup: !!upcomingMeetup,
+  });
+
+  return { usersAffected, actionsTaken };
+}
+
 // ── AP-0207: Meetup RSVP Encouragement ──────────────────────
 async function runMeetupRsvpEncouragement(ctx: AutomationContext) {
   const { supabase, tenantId } = ctx;
@@ -217,6 +359,7 @@ async function runCommunityCreatorDigest(ctx: AutomationContext) {
 export function registerCommunityGroupsHandlers(): void {
   registerHandler('runGroupInviteFollowUp', runGroupInviteFollowUp);
   registerHandler('runNewMemberWelcome', runNewMemberWelcome);
+  registerHandler('runWelcomeSquad', runWelcomeSquad);
   registerHandler('runMeetupRsvpEncouragement', runMeetupRsvpEncouragement);
   registerHandler('runPostMeetupConnect', runPostMeetupConnect);
   registerHandler('runCommunityCreatorDigest', runCommunityCreatorDigest);

--- a/services/gateway/src/services/automation-handlers/community-groups.ts
+++ b/services/gateway/src/services/automation-handlers/community-groups.ts
@@ -92,7 +92,7 @@ async function runNewMemberWelcome(ctx: AutomationContext) {
 // ── AP-0212: "Welcome Squad" New-Member Activation ──────────
 // Multi-step orchestration fired on community.member.joined:
 //   1. Introduce the newcomer to up to 3 existing group members ("the squad")
-//   2. Suggest related groups (topic overlap) + an upcoming meetup
+//   2. Suggest related public groups in the same category
 //   3. Send the newcomer a warm welcome with the intros + suggestions
 //   4. Notify the group host their Welcome Squad went out (auto-fire,
 //      in-platform members only, attributed "via Autopilot")
@@ -111,9 +111,12 @@ async function runWelcomeSquad(ctx: AutomationContext) {
   let usersAffected = 0;
   let actionsTaken = 0;
 
+  // Real schema: global_community_groups / global_community_group_members
+  // (the VTID-01084 community_groups/_memberships tables were never deployed
+  // to production; the live, populated tables are the global_* ones).
   const { data: group } = await supabase
-    .from('community_groups')
-    .select('name, description, created_by, topic_keys')
+    .from('global_community_groups')
+    .select('name, description, created_by, category')
     .eq('id', group_id)
     .maybeSingle();
   if (!group) return { usersAffected: 0, actionsTaken: 0 };
@@ -127,11 +130,13 @@ async function runWelcomeSquad(ctx: AutomationContext) {
 
   // Step 1 — pick the squad: up to 3 existing members of this group
   // (excluding the newcomer and the host, who is notified separately).
+  // Oldest members first so the newcomer meets established regulars.
   const { data: members } = await supabase
-    .from('community_memberships')
+    .from('global_community_group_members')
     .select('user_id')
     .eq('group_id', group_id)
     .neq('user_id', user_id)
+    .order('joined_at', { ascending: true })
     .limit(50);
 
   const squad: string[] = [];
@@ -141,28 +146,18 @@ async function runWelcomeSquad(ctx: AutomationContext) {
     if (squad.length >= SQUAD_SIZE) break;
   }
 
-  // Step 2 — suggest related groups (topic overlap) + an upcoming meetup.
+  // Step 2 — suggest related public groups in the same category.
   let suggestedGroups: Array<{ id: string; name: string }> = [];
-  if (Array.isArray(group.topic_keys) && group.topic_keys.length > 0) {
+  if (group.category) {
     const { data: related } = await supabase
-      .from('community_groups')
+      .from('global_community_groups')
       .select('id, name')
-      .eq('tenant_id', tenantId)
+      .eq('category', group.category)
+      .eq('is_public', true)
       .neq('id', group_id)
-      .overlaps('topic_keys', group.topic_keys)
       .limit(2);
     suggestedGroups = related || [];
   }
-
-  const { data: upcomingMeetup } = await supabase
-    .from('community_meetups')
-    .select('id, title')
-    .eq('tenant_id', tenantId)
-    .eq('group_id', group_id)
-    .gte('starts_at', new Date().toISOString())
-    .order('starts_at', { ascending: true })
-    .limit(1)
-    .maybeSingle();
 
   // Step 3 — warm welcome to the newcomer with the squad + suggestions.
   const squadLine = squad.length
@@ -172,7 +167,6 @@ async function runWelcomeSquad(ctx: AutomationContext) {
   if (suggestedGroups.length) {
     extras.push(`${suggestedGroups.length} related group${suggestedGroups.length > 1 ? 's' : ''} you'll like`);
   }
-  if (upcomingMeetup) extras.push(`"${upcomingMeetup.title}" coming up`);
 
   ctx.notify(user_id, 'orb_proactive_message', {
     title: `Welcome to ${group.name}! Your squad is ready 👋`,
@@ -182,7 +176,6 @@ async function runWelcomeSquad(ctx: AutomationContext) {
       group_id,
       squad_user_ids: squad.join(','),
       suggested_group_ids: suggestedGroups.map((g) => g.id).join(','),
-      meetup_id: upcomingMeetup?.id || '',
       via: 'autopilot',
       automation_id: 'AP-0212',
     },
@@ -225,7 +218,6 @@ async function runWelcomeSquad(ctx: AutomationContext) {
     group_id,
     squad_size: squad.length,
     suggested_groups: suggestedGroups.length,
-    has_meetup: !!upcomingMeetup,
   });
 
   return { usersAffected, actionsTaken };

--- a/services/gateway/src/services/automation-registry.ts
+++ b/services/gateway/src/services/automation-registry.ts
@@ -199,9 +199,10 @@ const COMMUNITY_GROUPS: AutomationDefinition[] = [
   },
   {
     id: 'AP-0212', name: '"Welcome Squad" New-Member Activation', domain: 'community-groups',
-    status: 'PLANNED', priority: 'P1', triggerType: 'event',
+    status: 'IMPLEMENTED', priority: 'P1', triggerType: 'event',
     triggerConfig: { eventTopic: 'community.member.joined' },
     targetRoles: [...MEMBER_ROLES],
+    handler: 'runWelcomeSquad',
     requires: ['AP-0203', 'AP-0103'],
   },
 ];


### PR DESCRIPTION
## Problem

While continuing the AP-02xx community-groups automations, I verified the **live** database directly and found that the entire `community-groups` handler family (AP-0202/03/07/08/10 **and** the AP-0212 Welcome Squad already merged in #2543) queries tables that **do not exist in production**:

- ❌ `community_groups`, `community_memberships`, `community_meetups` — never deployed (the VTID-01084 schema)
- ✅ The live, populated tables are **`global_community_groups`** (`created_by`, `member_count`, `category`, `status`, `is_public`) and **`global_community_group_members`** (`role`, `joined_at`)

As shipped, `runWelcomeSquad` hits the phantom tables, gets nothing back, and silently no-ops. On top of that, the **only** emitter of the `community.member.joined` trigger (`routes/community.ts` → RPC `community_join_group`) is itself on the phantom schema (503s) and emits **no `user_id`**, while real joins happen frontend-direct to `global_community_group_members`, bypassing the gateway entirely — so the trigger never fires in prod.

Per discussion, this PR does the **full real wiring for AP-0212** (sibling handlers AP-0202/03/07/08/10 are intentionally left for a separate domain-wide remediation).

## Changes

**1. `runWelcomeSquad` (AP-0212) → real tables**
- Reads `global_community_groups` (`name, description, created_by, category`) and `global_community_group_members` (oldest-first `joined_at` for the squad).
- Suggests related **public** groups by `category` (replaces the non-existent `topic_keys` overlap).
- Drops the meetup suggestion — there is no real per-group meetup table (`events` is the OASIS event log).

**2. New `POST /api/v1/community/global-groups/:id/join`**
- Resolves `user_id` from the JWT, writes the membership row under the user's RLS context (the `"Users can join groups"` policy permits self-insert), **idempotently** (existence check + `23505` race guard).
- Dispatches `community.member.joined` **with `user_id`** on a genuinely new join, so AP-0212 (and AP-0203) can actually fire.
- `member_count` and group-chat participants are maintained automatically by existing DB triggers (`trg_sync_group_member_count`, `trg_sync_group_chat_participant`) — no manual count update.

## Verification
- `tsc --noEmit` passes clean.
- Live-schema facts confirmed via Supabase: real tables/columns, the membership unique + RLS policies, the count/chat triggers, and that `global_community_group_members` is the populated table (`global_group_members` is empty).

## Follow-ups (not in this PR)
- **Frontend (`vitana-v1`)**: point the group-join action at this endpoint so real joins emit the trigger.
- **i18n**: notification strings here remain hardcoded English, matching the existing sibling handlers — the gateway catalog (`tt()`) should be applied across this notification surface.
- **Domain remediation**: AP-0202/03/07/08/10 and `/groups/:id/join` still target the phantom schema.

https://claude.ai/code/session_01AQh8BrYDZJgrbLqb2dGSgU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQh8BrYDZJgrbLqb2dGSgU)_