### PR TITLE
feat(orb-agent): LiveKit voice turns feed the dataset via orb.turn.responded (BOOTSTRAP-VOICE-DATASET-EMITTER)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/gateway_client.py
+++ b/services/agents/orb-agent/src/orb_agent/gateway_client.py
@@ -72,6 +72,11 @@ class GatewayClient:
         # gate, and the mobile_route override.
         self.is_mobile: bool = False
         self.is_anonymous: bool = False
+        # BOOTSTRAP-VOICE-DATASET-EMITTER: last tool dispatched this turn, set by
+        # tools._dispatch / _dispatch_with_directive and read+cleared by
+        # session.py's orb.turn.responded emit to carry the tool-routing signal.
+        self.last_tool_name: str | None = None
+        self.last_tool_args: dict[str, Any] | None = None
 
     def _headers(self) -> dict[str, str]:
         h = {"Content-Type": "application/json"}

--- a/services/agents/orb-agent/src/orb_agent/oasis.py
+++ b/services/agents/orb-agent/src/orb_agent/oasis.py
@@ -108,6 +108,12 @@ TOPIC_SESSION_START = "vtid.live.session.start"
 TOPIC_SESSION_STOP = "vtid.live.session.stop"
 TOPIC_STALL_DETECTED = "vtid.live.stall_detected"
 TOPIC_TOOL_EXECUTED = "livekit.tool.executed"
+# BOOTSTRAP-VOICE-DATASET-EMITTER (LiveKit parity): voice-tool-routing dataset
+# source. The agent emits a RAW payload (reply_text + raw transcript + tool
+# signal + user/tenant ids); the gateway's /api/v1/oasis/emit re-runs the same
+# consent/PII gate the Vertex path uses before persisting — no unconsented
+# transcript is ever stored. Extractor reads oasis_events WHERE topic = this.
+TOPIC_TURN_RESPONDED = "orb.turn.responded"
 TOPIC_TOOL_LOOP_GUARD = "livekit.tool_loop_guard_activated"
 TOPIC_CONNECTION_FAILED = "livekit.connection_failed"
 TOPIC_CONFIG_MISSING = "livekit.config_missing"

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -55,6 +55,7 @@ from .oasis import (
     TOPIC_STT_METRICS,
     TOPIC_STT_RECOVERY,
     TOPIC_STT_SILENT_STALL,
+    TOPIC_TURN_RESPONDED,
     OasisEmitter,
 )
 from .providers import build_cascade
@@ -1328,6 +1329,11 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             )
             if isinstance(t, str):
                 text_len = len(t)
+                # BOOTSTRAP-VOICE-DATASET-EMITTER: keep the raw transcript for
+                # the turn so the paired assistant reply can emit
+                # orb.turn.responded with the voice-tool-routing signal
+                # (consent/PII-gated server-side at /api/v1/oasis/emit).
+                turn_state["user_text"] = t
         except Exception:  # noqa: BLE001
             pass
         turn_state["user_text_len"] = text_len
@@ -1456,10 +1462,44 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # appended to chat_ctx — LLM responses, tool calls, etc. If we see
     # `assistant` role items with non-empty text but no audible
     # output, the LLM is producing text but TTS isn't producing audio.
+    # BOOTSTRAP-VOICE-DATASET-EMITTER: emit a RAW orb.turn.responded for the
+    # voice-tool-routing dataset. The gateway (/api/v1/oasis/emit) re-runs the
+    # consent/PII gate before persisting, so transcript/tool fields are dropped
+    # server-side when the tenant hasn't consented — the agent can't read
+    # tenant policy itself, so it sends everything and lets the gateway gate.
+    async def _emit_turn_responded(
+        reply_text: str,
+        user_text: str,
+        tool_name: str | None,
+        tool_args: dict[str, Any] | None,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "orb_session_id": orb_session_id,
+            "conversation_id": orb_session_id,
+            "reply_text": reply_text,
+            "provider": "livekit",
+            "user_id": identity.user_id,
+            "tenant_id": identity.tenant_id,
+        }
+        if user_text:
+            payload["input_text"] = user_text
+            payload["transcript"] = user_text
+        if tool_name:
+            payload["tool_name"] = tool_name
+            tc: dict[str, Any] = {"name": tool_name}
+            if tool_args:
+                tc["arguments"] = tool_args
+            payload["tool_call"] = tc
+        try:
+            await oasis.emit(topic=TOPIC_TURN_RESPONDED, payload=payload)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("orb.turn.responded emit failed: %s", exc)
+
     def _on_conversation_item(ev: Any = None) -> None:
         item = getattr(ev, "item", None) or ev
         role = None
         text_len = 0
+        reply_text_val = ""
         try:
             role = getattr(item, "role", None) or (
                 item.get("role") if isinstance(item, dict) else None
@@ -1472,6 +1512,7 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                 or ""
             )
             text_len = len(text) if isinstance(text, str) else 0
+            reply_text_val = text if isinstance(text, str) else ""
         except Exception:
             pass
         asyncio.create_task(
@@ -1487,6 +1528,27 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                 },
             )
         )
+        # BOOTSTRAP-VOICE-DATASET-EMITTER: on a substantive assistant reply that
+        # answers a real user turn, emit orb.turn.responded. Only fire when a
+        # pending user transcript exists — this skips the greeting (no preceding
+        # user turn). Clear the per-turn signal on read so a tool-loop's extra
+        # assistant items don't double-emit the same turn.
+        try:
+            if str(role) == "assistant" and reply_text_val.strip():
+                pending_user = turn_state.get("user_text")
+                if pending_user:
+                    tool_name = getattr(gw, "last_tool_name", None)
+                    tool_args = getattr(gw, "last_tool_args", None)
+                    turn_state["user_text"] = None
+                    gw.last_tool_name = None
+                    gw.last_tool_args = None
+                    asyncio.create_task(
+                        _emit_turn_responded(
+                            reply_text_val, pending_user, tool_name, tool_args,
+                        )
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("orb.turn.responded hook failed: %s", exc)
 
     try:
         session.on("conversation_item_added")(_on_conversation_item)  # type: ignore[misc]

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -115,7 +115,13 @@ async def _dispatch(ctx: RunContext, name: str, args: dict[str, Any] | None = No
     business logic. Tools whose endpoint already exists as a standalone route
     keep calling it directly (calendar, reminders, intents, vitana-index).
     """
-    return await _gw(ctx).post("/api/v1/orb/tool", {"name": name, "args": args or {}})
+    gw = _gw(ctx)
+    # BOOTSTRAP-VOICE-DATASET-EMITTER: record the dispatched tool for the turn so
+    # session.py's orb.turn.responded emit can carry the voice-tool-routing
+    # signal. Read + cleared per turn in the conversation_item hook.
+    gw.last_tool_name = name
+    gw.last_tool_args = args or None
+    return await gw.post("/api/v1/orb/tool", {"name": name, "args": args or {}})
 
 
 async def _dispatch_with_directive(
@@ -138,6 +144,10 @@ async def _dispatch_with_directive(
     from .directives import extract_directive, publish_orb_directive  # local import
 
     gw = _gw(ctx)
+    # BOOTSTRAP-VOICE-DATASET-EMITTER: record the dispatched tool for the turn
+    # (same as _dispatch) so the turn.responded emit carries the routing signal.
+    gw.last_tool_name = name
+    gw.last_tool_args = args or None
     body = await gw.post("/api/v1/orb/tool", {"name": name, "args": args or {}})
     directive = extract_directive(body)
     if directive is not None:

--- a/services/agents/orb-agent/tests/test_turn_responded_emitter.py
+++ b/services/agents/orb-agent/tests/test_turn_responded_emitter.py
@@ -1,0 +1,89 @@
+"""BOOTSTRAP-VOICE-DATASET-EMITTER (LiveKit parity) — orb.turn.responded emit.
+
+The LiveKit agent previously contributed ZERO rows to the voice-tool-routing
+dataset because it never emitted `orb.turn.responded` (only the Vertex path
+did). These structural tests pin the wiring that closes that gap. The emit
+itself runs inside agent_entrypoint, which can't be exercised without a full
+LiveKit runtime, so we pin the contract on the source + topic constant:
+
+  1. The topic constant exists with the exact string the extractor queries.
+  2. The agent emits a RAW payload carrying the fields the gateway gate +
+     extractor need (reply_text, transcript/input_text, user/tenant ids,
+     tool_name, tool_call) — the gateway re-runs the consent/PII gate.
+  3. The emit is gated on a pending user transcript, which skips the greeting
+     (no preceding user turn), and clears per-turn signal so a tool-loop's
+     extra assistant items don't double-emit.
+  4. The dispatched tool is recorded per turn in tools.py so the routing
+     signal is available at emit time.
+"""
+from __future__ import annotations
+
+import pathlib
+
+
+def _src(name: str) -> str:
+    return (
+        pathlib.Path(__file__).resolve().parent.parent / "src" / "orb_agent" / name
+    ).read_text(encoding="utf-8")
+
+
+def test_topic_exists_with_exact_string() -> None:
+    """The extractor reads oasis_events WHERE topic = 'orb.turn.responded'.
+    Pin the literal so a rename can't silently zero the dataset again."""
+    from src.orb_agent.oasis import TOPIC_TURN_RESPONDED
+
+    assert TOPIC_TURN_RESPONDED == "orb.turn.responded"
+
+
+def test_emitter_sends_raw_dataset_fields() -> None:
+    """The agent can't read tenant policy, so it emits a RAW payload and lets
+    the gateway gate it. The payload MUST carry every field the gateway's
+    buildOrbTurnRespondedPayload + the extractor depend on."""
+    src = _src("session.py")
+    start = src.find("async def _emit_turn_responded")
+    assert start != -1, "regression: _emit_turn_responded helper missing"
+    block = src[start : start + 1600]
+    for required in (
+        '"orb_session_id"',
+        '"reply_text"',
+        '"user_id"',
+        '"tenant_id"',
+        '"input_text"',
+        '"transcript"',
+        '"tool_name"',
+        '"tool_call"',
+        '"provider": "livekit"',
+        "TOPIC_TURN_RESPONDED",
+    ):
+        assert required in block, (
+            f"regression: orb.turn.responded payload missing {required}"
+        )
+
+
+def test_emit_gated_on_user_turn_and_clears_signal() -> None:
+    """Fire only on an assistant reply that answers a real user turn (skips the
+    greeting), and clear the per-turn signal on read so tool-loop assistant
+    items don't double-emit the same turn."""
+    src = _src("session.py")
+    hook = src.find("def _on_conversation_item")
+    assert hook != -1
+    block = src[hook : hook + 2500]
+    assert 'str(role) == "assistant"' in block, "must gate on assistant role"
+    assert 'turn_state.get("user_text")' in block, (
+        "must require a pending user transcript (skips greeting)"
+    )
+    assert 'turn_state["user_text"] = None' in block, (
+        "must clear user_text on read to prevent double-emit"
+    )
+    assert "gw.last_tool_name = None" in block, "must clear the tool signal on read"
+    assert "_emit_turn_responded(" in block, "hook must call the emitter"
+
+
+def test_dispatch_records_tool_signal() -> None:
+    """tools._dispatch / _dispatch_with_directive must record the dispatched
+    tool on the GatewayClient so session.py can read it at emit time."""
+    src = _src("tools.py")
+    assert src.count("gw.last_tool_name = name") >= 2, (
+        "both _dispatch and _dispatch_with_directive must record the tool"
+    )
+    assert "gw.last_tool_args = args or None" in src

--- a/services/gateway/src/routes/oasis-emit.ts
+++ b/services/gateway/src/routes/oasis-emit.ts
@@ -34,6 +34,8 @@ import {
   AuthenticatedRequest,
 } from '../middleware/auth-supabase-jwt';
 import type { CicdEventType } from '../types/cicd';
+import { dataExportConsentTag } from '../services/data-export-consent';
+import { buildOrbTurnRespondedPayload } from './orb-turn-event-payload';
 
 const router = Router();
 
@@ -55,7 +57,17 @@ const MAX_BODY_BYTES = 16 * 1024;
 // RUN-STAGING-MIGRATION.yml workflow can emit success/failure telemetry from
 // GitHub Actions via this proxy (the runner has the GATEWAY_SERVICE_TOKEN but
 // no Supabase write surface, same shape as the orb-agent path).
-const ALLOWED_PREFIXES = ['orb.livekit.', 'livekit.', 'vtid.live.', 'staging.migration.'] as const;
+// BOOTSTRAP-VOICE-DATASET-EMITTER (LiveKit parity): `orb.turn.responded` added
+// so LiveKit voice turns contribute to the voice-tool-routing dataset, same as
+// the Vertex path. This topic is consent/PII-gated server-side below (the agent
+// can't read tenant policy) — no raw transcript is persisted without consent.
+const ALLOWED_PREFIXES = [
+  'orb.livekit.',
+  'livekit.',
+  'vtid.live.',
+  'staging.migration.',
+  'orb.turn.responded',
+] as const;
 
 function isAllowedTopic(topic: unknown): topic is string {
   if (typeof topic !== 'string') return false;
@@ -187,13 +199,55 @@ router.post(
     const actor = (req as Request & { __emit_actor?: string }).__emit_actor ?? 'service:unknown';
     const emitVtid = body.vtid && body.vtid.length > 0 ? body.vtid : VTID;
 
+    // BOOTSTRAP-VOICE-DATASET-EMITTER (LiveKit parity): the orb-agent emits a
+    // RAW orb.turn.responded payload (full reply_text + raw transcript + tool
+    // signal + user/tenant ids) because it cannot read tenant export policy.
+    // Re-run the SAME consent/PII gate the Vertex path uses
+    // (buildOrbTurnRespondedPayload + dataExportConsentTag) so the persisted
+    // row is byte-identical in shape and NO unconsented transcript is ever
+    // stored. Single source of truth — no agent-side consent cache to drift.
+    let effectivePayload: Record<string, unknown> = body.payload ?? {};
+    if (body.topic === 'orb.turn.responded') {
+      const p = effectivePayload;
+      const consentTag = await dataExportConsentTag({
+        userId: typeof p.user_id === 'string' ? p.user_id : null,
+        tenantId: typeof p.tenant_id === 'string' ? p.tenant_id : null,
+      });
+      const rawToolCall =
+        p.tool_call && typeof p.tool_call === 'object'
+          ? (p.tool_call as { name?: string; arguments?: Record<string, unknown> })
+          : null;
+      const orbSessionId = typeof p.orb_session_id === 'string' ? p.orb_session_id : '';
+      effectivePayload = buildOrbTurnRespondedPayload({
+        orbSessionId,
+        conversationId:
+          typeof p.conversation_id === 'string' && p.conversation_id.length > 0
+            ? p.conversation_id
+            : orbSessionId,
+        replyText: typeof p.reply_text === 'string' ? p.reply_text : '',
+        provider: typeof p.provider === 'string' ? p.provider : 'livekit',
+        consentTag,
+        toolSignal: {
+          toolName: typeof p.tool_name === 'string' ? p.tool_name : null,
+          inputText:
+            typeof p.input_text === 'string'
+              ? p.input_text
+              : typeof p.transcript === 'string'
+                ? p.transcript
+                : null,
+          toolCall: rawToolCall,
+        },
+        guardrailExcluded: p.guardrail_excluded === true,
+      });
+    }
+
     const result = await emitOasisEvent({
       vtid: emitVtid,
       type: body.topic as CicdEventType,
       source: 'orb-agent',
       status: 'info',
       message: `[${body.topic}] emitted via /api/v1/oasis/emit`,
-      payload: body.payload ?? {},
+      payload: effectivePayload,
       actor_role: actor.startsWith('admin:') ? 'admin' : 'agent',
       surface: 'api',
     });

--- a/services/gateway/test/oasis-emit-turn-responded.test.ts
+++ b/services/gateway/test/oasis-emit-turn-responded.test.ts
@@ -1,0 +1,126 @@
+/**
+ * BOOTSTRAP-VOICE-DATASET-EMITTER (LiveKit parity) — /api/v1/oasis/emit ingest gate.
+ *
+ * The LiveKit orb-agent cannot read tenant export policy, so it POSTs a RAW
+ * `orb.turn.responded` payload (full reply_text + raw transcript + tool signal
+ * + user/tenant ids). This proves the emit route:
+ *   1. ACCEPTS the `orb.turn.responded` topic (previously refused by the prefix
+ *      allowlist — it doesn't match `orb.livekit.`).
+ *   2. Re-runs the consent/PII gate server-side via buildOrbTurnRespondedPayload:
+ *      the persisted payload carries transcript + tool signal ONLY when consent
+ *      holds, and is stripped to the non-PII envelope otherwise.
+ *
+ * Mirrors the Vertex path's gating exactly (same builder), so a consented
+ * LiveKit turn contributes a real extractor row and a non-consented one cannot.
+ */
+process.env.NODE_ENV = 'test';
+process.env.GATEWAY_SERVICE_TOKEN = 'test-service-token';
+
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn(async () => ({ ok: true, event_id: 'evt-1' })),
+}));
+jest.mock('../src/services/data-export-consent', () => ({
+  dataExportConsentTag: jest.fn(),
+}));
+
+import { emitOasisEvent } from '../src/services/oasis-event-service';
+import { dataExportConsentTag } from '../src/services/data-export-consent';
+import oasisEmitRouter from '../src/routes/oasis-emit';
+
+const emitOasisEventMock = emitOasisEvent as unknown as jest.Mock;
+const consentTagMock = dataExportConsentTag as unknown as jest.Mock;
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', oasisEmitRouter);
+  return app;
+}
+
+const AUTH = { Authorization: 'Bearer test-service-token' };
+const RAW = {
+  orb_session_id: 'orb-1',
+  conversation_id: 'conv-1',
+  reply_text: 'Opened your calendar.',
+  provider: 'livekit',
+  user_id: 'u-1',
+  tenant_id: 't-1',
+  tool_name: 'create_calendar_event',
+  input_text: 'book a dentist tomorrow',
+  tool_call: { name: 'create_calendar_event', arguments: { when: 'tomorrow' } },
+};
+
+beforeEach(() => {
+  emitOasisEventMock.mockClear();
+  consentTagMock.mockReset();
+});
+
+describe('POST /api/v1/oasis/emit — orb.turn.responded ingest gate', () => {
+  test('accepts the topic and persists the PII signal when consented', async () => {
+    consentTagMock.mockResolvedValue({ data_export_ok: true });
+    const res = await request(makeApp())
+      .post('/api/v1/oasis/emit')
+      .set(AUTH)
+      .send({ topic: 'orb.turn.responded', payload: RAW });
+
+    expect(res.status).toBe(200);
+    expect(emitOasisEventMock).toHaveBeenCalledTimes(1);
+    const arg = emitOasisEventMock.mock.calls[0][0] as { type: string; payload: Record<string, unknown> };
+    expect(arg.type).toBe('orb.turn.responded');
+    expect(arg.payload.transcript).toBe('book a dentist tomorrow');
+    expect(arg.payload.input_text).toBe('book a dentist tomorrow');
+    expect(arg.payload.tool_name).toBe('create_calendar_event');
+    expect(arg.payload.tool_dispatched).toBe(true);
+    expect(arg.payload.tool_call).toEqual({
+      name: 'create_calendar_event',
+      arguments: { when: 'tomorrow' },
+    });
+    expect(arg.payload.data_export_ok).toBe(true);
+    // non-PII envelope always present
+    expect(arg.payload.reply_preview).toBe('Opened your calendar.');
+  });
+
+  test('strips transcript + tool signal when NOT consented (envelope only)', async () => {
+    consentTagMock.mockResolvedValue({});
+    const res = await request(makeApp())
+      .post('/api/v1/oasis/emit')
+      .set(AUTH)
+      .send({ topic: 'orb.turn.responded', payload: RAW });
+
+    expect(res.status).toBe(200);
+    const arg = emitOasisEventMock.mock.calls[0][0] as { payload: Record<string, unknown> };
+    expect(arg.payload.transcript).toBeUndefined();
+    expect(arg.payload.input_text).toBeUndefined();
+    expect(arg.payload.tool_name).toBeUndefined();
+    expect(arg.payload.tool_call).toBeUndefined();
+    expect(arg.payload.data_export_ok).toBeUndefined();
+    // non-PII envelope preserved
+    expect(arg.payload.reply_preview).toBe('Opened your calendar.');
+    expect(arg.payload.provider).toBe('livekit');
+  });
+
+  test('does not run the consent gate for unrelated topics', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/oasis/emit')
+      .set(AUTH)
+      .send({ topic: 'livekit.stt.recovery', payload: { outcome: 'attempted' } });
+
+    expect(res.status).toBe(200);
+    expect(consentTagMock).not.toHaveBeenCalled();
+    const arg = emitOasisEventMock.mock.calls[0][0] as { payload: Record<string, unknown> };
+    expect(arg.payload.outcome).toBe('attempted');
+  });
+
+  test('still refuses a non-allowlisted topic', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/oasis/emit')
+      .set(AUTH)
+      .send({ topic: 'evil.forged.topic', payload: {} });
+
+    expect(res.status).toBe(400);
+    expect(emitOasisEventMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

The Phase-1 **voice-tool-routing dataset** extractor reads `oasis_events WHERE topic='orb.turn.responded'`. Only the **Vertex** path emitted that event — the **LiveKit agent emitted zero** — so every LiveKit voice turn contributed **no training rows**. This is the highest-upside data-unblock for the 35-Day training program: it roughly doubles dataset coverage by turning on the second voice provider.

This closes the gap with the **same field shape and PII gate** as the Vertex path.

## Design decision (deviates from the patch-spec — flagged for review)

The patch-spec (`docs/patches/orb-agent/BOOTSTRAP-VOICE-DATASET-EMITTER.md`) suggested an **agent-side** consent client + 5-min cache. The agent can't read `tenant_settings` directly (no Supabase surface), and the event already transits the gateway's `/api/v1/oasis/emit` endpoint. So instead:

- The agent emits a **raw** payload (full `reply_text` + raw transcript + tool signal + `user_id`/`tenant_id`).
- The gateway re-runs the **same** gate the Vertex path uses — `dataExportConsentTag` + `buildOrbTurnRespondedPayload` — before persisting.

**Why this is better here:** single source of truth for consent (no agent↔gateway cache drift), the persisted row is **byte-identical** to the Vertex path (same builder), and **no unconsented transcript is ever stored**. The agent→gateway hop is the same trusted channel every tool call already uses for transcripts. I'm flagging it because it's a deliberate departure from the written spec.

Also corrected a spec assumption: it said to hook where `livekit.tool.executed` is emitted — **that topic is declared but never emitted**. The real per-turn capture point is `_dispatch()` in `tools.py`.

## Changes

- **`gateway/routes/oasis-emit.ts`** — allow `orb.turn.responded`; for that topic, resolve consent and rebuild the payload via the canonical builder (transcript/tool fields only under consent; non-PII envelope otherwise).
- **`agent/oasis.py`** — `TOPIC_TURN_RESPONDED` constant.
- **`agent/tools.py`** + **`gateway_client.py`** — record the dispatched tool per turn on the `GatewayClient`.
- **`agent/session.py`** — capture the raw user transcript per turn; emit `orb.turn.responded` from the `conversation_item` hook on a substantive assistant reply that answers a real user turn (skips the greeting; clears per-turn signal so tool-loop items don't double-emit).

## Tests

- **Gateway** (`oasis-emit-turn-responded.test.ts`): topic accepted; PII persisted **under consent**; stripped to envelope **without consent**; unrelated topics bypass the gate; forged topics still `400`. **4/4 pass.** Adjacent payload/consent suites **25/25** still green.
- **Agent** (`test_turn_responded_emitter.py`): structural contract for the topic literal, the raw-field payload, the greeting-skip gate + double-emit guard, and the tool-capture wiring. **4/4 pass.**

## Expected behaviour after merge

The dataset stays empty on staging until **consent is flipped** (`tenant_settings.feature_flags.data_export_ok`) **and** organic voice traffic accumulates — same precondition the Vertex path has. Verify with:
```bash
DATASET_DRY_RUN=1 npx tsx services/gateway/scripts/datasets/voice-tool-routing.ts
```

## Relationship to the other open PR

Independent of #2556 (STT hard-recovery) — different files/regions, separate `main`-based branch, can merge in either order. The two reinforce each other: #2556 stops 96-second-deaf sessions from writing garbage rows into the dataset this PR fills.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_