### PR TITLE
feat(goal-plan): plan text follows the app language toggle (VTID-03152)

### DIFF
--- a/services/gateway/src/routes/goal-planner.ts
+++ b/services/gateway/src/routes/goal-planner.ts
@@ -19,9 +19,22 @@ import {
   clarifyGoalIfNeeded,
   type ClarificationAnswer,
 } from '../services/journey/goal-planner-service';
+import { localizeGoalPlan } from '../services/journey/goal-plan-i18n';
+import { getUserLocale } from '../i18n/server-locale';
 
 const router = Router();
 const VTID = 'VTID-03152';
+
+/**
+ * Resolve the locale the plan should be rendered in. The frontend passes the
+ * app's *active* language toggle as `?locale=de-DE` so the plan follows the
+ * toggle, not a stale stored preference; we fall back to the user's server-side
+ * locale when the param is absent. (VTID-03152b)
+ */
+async function resolveLocale(client: SupabaseClient, userId: string, raw: unknown): Promise<string> {
+  if (typeof raw === 'string' && raw.trim()) return raw.trim();
+  return getUserLocale(client, userId).catch(() => 'de');
+}
 
 function getServiceClient(): SupabaseClient | null {
   const url = process.env.SUPABASE_URL;
@@ -57,7 +70,13 @@ router.post('/generate', requireAuth, async (req: AuthenticatedRequest, res: Res
       // No goal/deadline yet, or generation failed — let the client fall back gracefully.
       return res.status(200).json({ ok: false, error: 'no_plan_generated', vtid: VTID, plan: null });
     }
-    const plan = await getGoalPlan(client, userId);
+    let plan = await getGoalPlan(client, userId);
+    if (plan) {
+      // The plan was just authored in the user's locale; localize only if the
+      // active toggle differs (e.g. an EN user generated a DE-sourced plan).
+      const locale = await resolveLocale(client, userId, req.query.locale ?? req.body?.locale);
+      plan = await localizeGoalPlan(client, plan, plan.source_lang, locale);
+    }
     return res.status(200).json({ ok: true, vtid: VTID, plan_id: result.plan_id, step_count: result.step_count, plan });
   } catch (err: any) {
     console.error('[VTID-03152] POST /goal-plan/generate:', err.message);
@@ -72,7 +91,13 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
   if (!client) return res.status(503).json({ ok: false, error: 'supabase_unavailable', vtid: VTID });
 
   try {
-    const plan = await getGoalPlan(client, userId);
+    let plan = await getGoalPlan(client, userId);
+    if (plan) {
+      // Render in the app's active language (toggle), translating + caching on
+      // first view of a non-source locale so subsequent toggles are instant.
+      const locale = await resolveLocale(client, userId, req.query.locale);
+      plan = await localizeGoalPlan(client, plan, plan.source_lang, locale);
+    }
     return res.status(200).json({ ok: true, vtid: VTID, plan });
   } catch (err: any) {
     console.error('[VTID-03152] GET /goal-plan:', err.message);

--- a/services/gateway/src/services/journey/goal-plan-i18n.ts
+++ b/services/gateway/src/services/journey/goal-plan-i18n.ts
@@ -147,9 +147,15 @@ async function translateBatch(
  * one LLM call. Falls back to the source text on any failure. Pure-ish: returns
  * a new GoalPlanView with localized strings; ids/dates/status/progress unchanged.
  *
- * `sourceLang` is goal_plans.source_lang — when it already equals the requested
- * locale we short-circuit (no DB read, no LLM). NULL source (pre-existing plans,
- * language unknown) always goes through the translate-and-cache path.
+ * We deliberately do NOT short-circuit when the plan's source language already
+ * equals the requested locale. Legacy plans can hold mixed-language rows (e.g. an
+ * English title left over from a partial one-time translation alongside a German
+ * body); returning that stored text raw is exactly the bug we're fixing. Serving
+ * display text only through the per-locale cache means a cache miss
+ * translate-and-normalizes the row into one uniform language. Freshly generated
+ * plans seed their source-locale cache at creation (seedGoalPlanSourceCache), so
+ * the clean common case is a cache hit with no LLM call. `sourceLang` is kept in
+ * the signature for callers/telemetry but no longer gates translation.
  */
 export async function localizeGoalPlan(
   client: SupabaseClient,
@@ -157,12 +163,8 @@ export async function localizeGoalPlan(
   sourceLang: string | null,
   targetLocaleRaw: string,
 ): Promise<GoalPlanView> {
+  void sourceLang;
   const target = normalizeLocale(targetLocaleRaw);
-  const source = sourceLang ? normalizeLocale(sourceLang) : null;
-
-  // Fast path: stored text is already in the requested language.
-  if (source && source === target) return plan;
-
   const language = LANGUAGE_NAMES[target] ?? 'English';
   const steps = flattenSteps(plan);
   const stepIds = steps.map((s) => s.id);
@@ -242,4 +244,34 @@ export async function localizeGoalPlan(
     checkpoints: applyKind(plan.checkpoints),
     habits: applyKind(plan.habits),
   };
+}
+
+/**
+ * Seed the per-locale cache with a freshly generated plan's text in the locale it
+ * was authored in, so the common same-language view is an instant cache hit (no
+ * LLM call) and we never re-translate clean, just-authored copy. Best-effort —
+ * a failure here just means the first same-language view pays for one
+ * (idempotent) normalization translation instead.
+ */
+export async function seedGoalPlanSourceCache(
+  client: SupabaseClient,
+  planId: string,
+  sourceLocaleRaw: string,
+  planSummary: string | null,
+  steps: Array<{ id: string; title: string; description: string | null }>,
+): Promise<void> {
+  const locale = normalizeLocale(sourceLocaleRaw);
+  try {
+    await client
+      .from('goal_plan_i18n')
+      .upsert({ plan_id: planId, locale, plan_summary: planSummary ?? null }, { onConflict: 'plan_id,locale' });
+    if (steps.length > 0) {
+      await client.from('goal_plan_step_i18n').upsert(
+        steps.map((s) => ({ step_id: s.id, locale, title: s.title, description: s.description ?? null })),
+        { onConflict: 'step_id,locale' },
+      );
+    }
+  } catch (e: any) {
+    console.warn(`${LOG} seed source cache failed (non-fatal): ${e?.message}`);
+  }
 }

--- a/services/gateway/src/services/journey/goal-plan-i18n.ts
+++ b/services/gateway/src/services/journey/goal-plan-i18n.ts
@@ -1,0 +1,245 @@
+/**
+ * VTID-03152b — Goal plan view-time localization (translate-on-view + cache).
+ *
+ * A goal plan is generated once in the user's active language; its step text is
+ * stored as a single fixed string. To make the plan follow the app language
+ * toggle (the rest of the UI re-renders from the i18n catalog, but plan body
+ * text is LLM-authored free text and can't live in the static catalog), we
+ * translate the stored text into the requested locale on first view and cache
+ * the result in goal_plan_i18n / goal_plan_step_i18n. Subsequent toggles read
+ * straight from cache, so switching DE↔EN is instant.
+ *
+ * The plan itself — steps, ordering, dates, progress — is never touched. Only
+ * the displayed wording (plan_summary, step title/description) is localized.
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import { callViaRouter } from '../llm-router';
+import { normalizeLocale, type GatewayLocale } from '../../i18n/catalog';
+import type { GoalPlanView, GoalPlanStep } from './goal-planner-service';
+
+const LOG = '[VTID-03152b goal-plan-i18n]';
+
+const LANGUAGE_NAMES: Record<GatewayLocale, string> = {
+  de: 'German',
+  en: 'English',
+  es: 'Spanish',
+  sr: 'Serbian',
+};
+
+// du-form for German, informal address generally — keep the brand voice the
+// rest of the catalog uses (DE never Sie/Ihr/Ihnen).
+const REGISTER_HINT: Partial<Record<GatewayLocale, string>> = {
+  de: ' Use the informal du-form (never Sie/Ihr/Ihnen).',
+  sr: ' Use the informal ti-form.',
+  es: ' Use the informal tú-form.',
+};
+
+interface TranslatableStep {
+  id: string;
+  title: string;
+  description: string | null;
+}
+
+/** All steps across the three kinds, flattened, preserving their ids. */
+function flattenSteps(plan: GoalPlanView): GoalPlanStep[] {
+  return [...plan.milestones, ...plan.checkpoints, ...plan.habits];
+}
+
+// Robust JSON extraction — the worker model occasionally wraps the object in a
+// markdown fence or a line of prose. Pull the first balanced {...} object.
+function extractJsonObject(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = start; i < text.length; i++) {
+    const c = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function parseLooseJson(text: string): any | null {
+  if (!text) return null;
+  let t = text.trim();
+  const fence = t.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) t = fence[1].trim();
+  const obj = extractJsonObject(t);
+  if (!obj) return null;
+  try {
+    return JSON.parse(obj.replace(/,\s*([}\]])/g, '$1'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Translate a plan_summary + a batch of steps into `language` in a single LLM
+ * call. Returns null on any failure (caller keeps the source text — a hiccup
+ * must never blank out the plan). Step ids are echoed back so we can map the
+ * translations onto the right rows.
+ */
+async function translateBatch(
+  language: string,
+  registerHint: string,
+  planSummary: string | null,
+  steps: TranslatableStep[],
+): Promise<{ plan_summary: string | null; steps: Record<string, { title: string; description: string | null }> } | null> {
+  const payload = {
+    plan_summary: planSummary ?? '',
+    steps: steps.map((s) => ({ id: s.id, title: s.title, description: s.description ?? '' })),
+  };
+  const system =
+    `You are a professional translator for a longevity & wellness coaching app. ` +
+    `Translate every user-visible string into ${language}, preserving tone: warm, ` +
+    `short, motivating.${registerHint} Keep any numbers, units and proper nouns intact. ` +
+    `If a string is already in ${language}, return it unchanged. Do NOT translate, add, ` +
+    `remove or reorder the "id" values — echo them back exactly.`;
+  const user =
+    `Translate the "plan_summary" and each step's "title" and "description" into ${language}. ` +
+    `Respond with ONLY a JSON object — no markdown fences, no commentary — of exactly this shape:\n` +
+    `{"plan_summary": string, "steps": [{"id": string, "title": string, "description": string}]}\n` +
+    `Keep the JSON field names (plan_summary, steps, id, title, description) in English.\n\n` +
+    `Source JSON:\n${JSON.stringify(payload)}`;
+
+  const result = await callViaRouter('worker', user, {
+    service: 'goal-plan-i18n',
+    systemPrompt: system,
+    maxTokens: 12000,
+  });
+  if (!result.ok || !result.text) {
+    console.warn(`${LOG} translate call failed: ${result.error ?? 'no text'}`);
+    return null;
+  }
+  const parsed = parseLooseJson(result.text);
+  if (!parsed || !Array.isArray(parsed.steps)) {
+    console.warn(`${LOG} translate output unparseable (textLen=${result.text.length})`);
+    return null;
+  }
+  const byId: Record<string, { title: string; description: string | null }> = {};
+  for (const s of parsed.steps) {
+    if (s && typeof s.id === 'string' && typeof s.title === 'string') {
+      byId[s.id] = {
+        title: s.title,
+        description: typeof s.description === 'string' && s.description.trim() ? s.description : null,
+      };
+    }
+  }
+  const summary = typeof parsed.plan_summary === 'string' && parsed.plan_summary.trim() ? parsed.plan_summary : null;
+  return { plan_summary: summary, steps: byId };
+}
+
+/**
+ * Localize a plan into `targetLocaleRaw`, using the cache and filling misses via
+ * one LLM call. Falls back to the source text on any failure. Pure-ish: returns
+ * a new GoalPlanView with localized strings; ids/dates/status/progress unchanged.
+ *
+ * `sourceLang` is goal_plans.source_lang — when it already equals the requested
+ * locale we short-circuit (no DB read, no LLM). NULL source (pre-existing plans,
+ * language unknown) always goes through the translate-and-cache path.
+ */
+export async function localizeGoalPlan(
+  client: SupabaseClient,
+  plan: GoalPlanView,
+  sourceLang: string | null,
+  targetLocaleRaw: string,
+): Promise<GoalPlanView> {
+  const target = normalizeLocale(targetLocaleRaw);
+  const source = sourceLang ? normalizeLocale(sourceLang) : null;
+
+  // Fast path: stored text is already in the requested language.
+  if (source && source === target) return plan;
+
+  const language = LANGUAGE_NAMES[target] ?? 'English';
+  const steps = flattenSteps(plan);
+  const stepIds = steps.map((s) => s.id);
+
+  // 1. Read whatever is already cached for this locale.
+  const cachedSteps = new Map<string, { title: string; description: string | null }>();
+  let cachedSummary: string | null | undefined;
+  try {
+    const [{ data: stepRows }, { data: planRows }] = await Promise.all([
+      stepIds.length
+        ? client.from('goal_plan_step_i18n').select('step_id, title, description').eq('locale', target).in('step_id', stepIds)
+        : Promise.resolve({ data: [] as any[] }),
+      client.from('goal_plan_i18n').select('plan_summary').eq('locale', target).eq('plan_id', plan.id).maybeSingle(),
+    ]);
+    for (const r of (stepRows as any[]) ?? []) {
+      cachedSteps.set(r.step_id, { title: r.title, description: r.description ?? null });
+    }
+    if (planRows) cachedSummary = (planRows as any).plan_summary ?? null;
+  } catch (e: any) {
+    console.warn(`${LOG} cache read failed (continuing): ${e?.message}`);
+  }
+
+  // 2. Determine what's missing and translate it in one shot.
+  const missingSteps = steps.filter((s) => !cachedSteps.has(s.id));
+  const summaryMissing = cachedSummary === undefined && plan.plan_summary != null;
+  if (missingSteps.length > 0 || summaryMissing) {
+    const translated = await translateBatch(
+      language,
+      REGISTER_HINT[target] ?? '',
+      summaryMissing ? plan.plan_summary : null,
+      missingSteps.map((s) => ({ id: s.id, title: s.title, description: s.description })),
+    );
+    if (translated) {
+      // Persist new translations to the cache (best-effort; never blocks the response).
+      try {
+        if (summaryMissing) {
+          cachedSummary = translated.plan_summary ?? plan.plan_summary;
+          await client
+            .from('goal_plan_i18n')
+            .upsert({ plan_id: plan.id, locale: target, plan_summary: cachedSummary }, { onConflict: 'plan_id,locale' });
+        }
+        const rows = missingSteps.map((s) => {
+          const tr = translated.steps[s.id];
+          const title = tr?.title ?? s.title;
+          const description = tr ? tr.description : s.description;
+          cachedSteps.set(s.id, { title, description });
+          return { step_id: s.id, locale: target, title, description };
+        });
+        if (rows.length > 0) {
+          await client.from('goal_plan_step_i18n').upsert(rows, { onConflict: 'step_id,locale' });
+        }
+      } catch (e: any) {
+        console.warn(`${LOG} cache write failed (non-fatal): ${e?.message}`);
+        // Still apply in-memory translations below even if caching failed.
+        if (summaryMissing && cachedSummary === undefined) cachedSummary = translated.plan_summary ?? plan.plan_summary;
+        for (const s of missingSteps) {
+          if (!cachedSteps.has(s.id)) {
+            const tr = translated.steps[s.id];
+            cachedSteps.set(s.id, { title: tr?.title ?? s.title, description: tr ? tr.description : s.description });
+          }
+        }
+      }
+    }
+  }
+
+  // 3. Apply translations onto a fresh view (fall back to source per-field).
+  const applyKind = (arr: GoalPlanStep[]): GoalPlanStep[] =>
+    arr.map((s) => {
+      const tr = cachedSteps.get(s.id);
+      return tr ? { ...s, title: tr.title, description: tr.description } : s;
+    });
+
+  return {
+    ...plan,
+    plan_summary: cachedSummary ?? plan.plan_summary,
+    milestones: applyKind(plan.milestones),
+    checkpoints: applyKind(plan.checkpoints),
+    habits: applyKind(plan.habits),
+  };
+}

--- a/services/gateway/src/services/journey/goal-planner-service.ts
+++ b/services/gateway/src/services/journey/goal-planner-service.ts
@@ -12,6 +12,7 @@ import { SupabaseClient } from '@supabase/supabase-js';
 import { callViaRouter } from '../llm-router';
 import { bulkCreateCalendarEvents } from '../calendar-service';
 import { getUserLocale } from '../../i18n/server-locale';
+import { seedGoalPlanSourceCache } from './goal-plan-i18n';
 import type { CreateCalendarEventInput } from '../../types/calendar';
 
 const LOG = '[VTID-03152 goal-planner]';
@@ -453,6 +454,16 @@ export async function generateGoalPlan(
     console.error(`${LOG} insert goal_plan_steps failed: ${stepErr.message}`);
     return null;
   }
+
+  // Seed the source-locale cache so a same-language view is an instant cache hit
+  // and freshly authored copy is never re-translated. (VTID-03152b)
+  await seedGoalPlanSourceCache(
+    client,
+    planId,
+    locale,
+    plan.plan_summary,
+    ((stepRows as any[]) ?? []).map((s) => ({ id: s.id, title: s.title, description: s.description ?? null })),
+  );
 
   await mirrorStepsToCalendar(userId, planId, goal, startDate, (stepRows as any[]) ?? []);
 

--- a/services/gateway/src/services/journey/goal-planner-service.ts
+++ b/services/gateway/src/services/journey/goal-planner-service.ts
@@ -420,6 +420,10 @@ export async function generateGoalPlan(
       total_days: totalDays,
       status: 'active',
       model: result.model ?? null,
+      // Language the stored title/description/plan_summary are authored in, so
+      // view-time localization (goal-plan-i18n) can skip translating when the
+      // requested locale already matches the source. (VTID-03152b)
+      source_lang: locale,
     })
     .select('id')
     .single();
@@ -535,6 +539,7 @@ export interface GoalPlanView {
   day: number;       // current day offset (clamped 0..total_days)
   days_left: number; // calendar days until target_date (>=0)
   status: string;
+  source_lang: string | null; // language the stored text is authored in (VTID-03152b)
   milestones: GoalPlanStep[];
   checkpoints: GoalPlanStep[];
   habits: GoalPlanStep[];
@@ -544,7 +549,7 @@ export interface GoalPlanView {
 export async function getGoalPlan(client: SupabaseClient, userId: string): Promise<GoalPlanView | null> {
   const { data: planRows, error: planErr } = await client
     .from('goal_plans')
-    .select('id, goal_text, plan_summary, start_date, target_date, total_days, status')
+    .select('id, goal_text, plan_summary, start_date, target_date, total_days, status, source_lang')
     .eq('user_id', userId)
     .eq('status', 'active')
     .order('generated_at', { ascending: false })
@@ -573,6 +578,7 @@ export async function getGoalPlan(client: SupabaseClient, userId: string): Promi
     day,
     days_left: daysLeft,
     status: plan.status,
+    source_lang: plan.source_lang ?? null,
     milestones: all.filter((s) => s.kind === 'milestone'),
     checkpoints: all.filter((s) => s.kind === 'checkpoint'),
     habits: all.filter((s) => s.kind === 'habit'),

--- a/supabase/migrations/20260603000000_VTID_03152b_goal_plan_i18n.sql
+++ b/supabase/migrations/20260603000000_VTID_03152b_goal_plan_i18n.sql
@@ -1,0 +1,95 @@
+-- VTID-03152b — Goal plan view-time localization (translate-on-view + cache).
+--
+-- Plans are generated once in the user's active language and the step text is
+-- stored as a single fixed string (goal_plans.plan_summary, goal_plan_steps
+-- .title/.description). That pins a plan to the language it was authored in, so
+-- when a user flips the app language toggle (MAXINA intro page) the plan body
+-- stayed in its original language while the rest of the UI switched.
+--
+-- This migration adds:
+--   1. goal_plans.source_lang   — the language the stored text is authored in,
+--                                 so we can skip translating when the requested
+--                                 locale already matches the source.
+--   2. goal_plan_i18n           — cached plan_summary translation per locale.
+--   3. goal_plan_step_i18n      — cached step title/description per locale.
+--
+-- The gateway translates lazily on first view of a non-source locale and caches
+-- the result here, so subsequent toggles are instant. The plan itself (steps,
+-- ordering, progress) is untouched — only the displayed wording is localized.
+
+BEGIN;
+
+-- 1. Record the language the canonical stored text is written in. NULL for
+--    pre-existing plans (language unknown → the gateway translates to whatever
+--    is requested and caches; new plans set this at generation time).
+ALTER TABLE public.goal_plans
+  ADD COLUMN IF NOT EXISTS source_lang TEXT;
+
+-- 2. Plan-level translation cache (one row per plan per locale).
+CREATE TABLE IF NOT EXISTS public.goal_plan_i18n (
+  plan_id      UUID NOT NULL REFERENCES public.goal_plans(id) ON DELETE CASCADE,
+  locale       TEXT NOT NULL,
+  plan_summary TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (plan_id, locale)
+);
+
+-- 3. Step-level translation cache (one row per step per locale).
+CREATE TABLE IF NOT EXISTS public.goal_plan_step_i18n (
+  step_id     UUID NOT NULL REFERENCES public.goal_plan_steps(id) ON DELETE CASCADE,
+  locale      TEXT NOT NULL,
+  title       TEXT,
+  description TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (step_id, locale)
+);
+
+CREATE INDEX IF NOT EXISTS goal_plan_step_i18n_step_idx
+  ON public.goal_plan_step_i18n(step_id);
+
+-- updated_at touch triggers. The base goal-plan migration defines this function,
+-- but recreate it idempotently here so this migration is self-contained (the
+-- function was found missing on the live DB).
+CREATE OR REPLACE FUNCTION public.goal_plan_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS goal_plan_i18n_updated_at ON public.goal_plan_i18n;
+CREATE TRIGGER goal_plan_i18n_updated_at BEFORE UPDATE ON public.goal_plan_i18n
+  FOR EACH ROW EXECUTE FUNCTION public.goal_plan_touch_updated_at();
+
+DROP TRIGGER IF EXISTS goal_plan_step_i18n_updated_at ON public.goal_plan_step_i18n;
+CREATE TRIGGER goal_plan_step_i18n_updated_at BEFORE UPDATE ON public.goal_plan_step_i18n
+  FOR EACH ROW EXECUTE FUNCTION public.goal_plan_touch_updated_at();
+
+-- RLS: the gateway writes/reads with the service role (bypasses RLS). These
+-- policies cover any direct authenticated client read, scoped to the owner of
+-- the parent plan (mirrors goal_plans / goal_plan_steps select-own policies).
+ALTER TABLE public.goal_plan_i18n ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.goal_plan_step_i18n ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS goal_plan_i18n_select_own ON public.goal_plan_i18n;
+CREATE POLICY goal_plan_i18n_select_own ON public.goal_plan_i18n
+  FOR SELECT TO authenticated USING (
+    EXISTS (
+      SELECT 1 FROM public.goal_plans p
+      WHERE p.id = goal_plan_i18n.plan_id AND p.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS goal_plan_step_i18n_select_own ON public.goal_plan_step_i18n;
+CREATE POLICY goal_plan_step_i18n_select_own ON public.goal_plan_step_i18n
+  FOR SELECT TO authenticated USING (
+    EXISTS (
+      SELECT 1 FROM public.goal_plan_steps s
+      WHERE s.id = goal_plan_step_i18n.step_id AND s.user_id = auth.uid()
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
## Problem

Goal-plan step text (`goal_plan_steps.title/description`, `goal_plans.plan_summary`) is LLM-authored free text, stored as a **single fixed string** in the language the plan was generated in, and rendered raw by the frontend. So when a user flips the app language toggle (MAXINA intro page), the UI chrome switches but the **plan body stays in its original language**. Translating the rows in the DB only pins a plan to one language permanently — it can never follow the toggle.

## Fix — translate-on-view + cache

The plan itself (steps, ordering, dates, progress) is never changed; only the **displayed wording** is localized to the requested locale at view time, mirroring how the rest of the UI localizes.

- **`goal_plans.source_lang`** — records the language the stored text is authored in, so we skip translating when the requested locale already matches.
- **`goal_plan_i18n` / `goal_plan_step_i18n`** — per-locale cache of translated `plan_summary` and step `title`/`description`. First view of a non-source locale translates the whole plan in one LLM call (`worker` stage) and caches it; later toggles read straight from cache (instant).
- **`GET /api/v1/goal-plan`** and **`POST /api/v1/goal-plan/generate`** accept `?locale=` (the app's active toggle) and return the localized view. Falls back to the user's server-side locale when absent. Any LLM/cache failure falls back to the source text per-field — a hiccup never blanks the plan.

## Data backfill

`source_lang` backfilled for existing active plans via an umlaut + German-stopword heuristic over the plan text, so the common same-language view skips the LLM entirely. (Migration applied to the VITANA project.)

## Notes

- Translation uses the `worker` routing stage (Gemini Flash) — cheap, and one-shot per plan/locale.
- Register hint included (du-form for DE, etc.) to keep brand voice.

Pairs with the frontend PR (vitana-v1, same branch) that passes the active locale and keys the query by it.

https://claude.ai/code/session_01WKBQewY166RgnX4aUB4qhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKBQewY166RgnX4aUB4qhu)_