### PR TITLE
feat(autopilot): implement AP-0309 Host Night Concierge

### DIFF
--- a/services/gateway/src/services/automation-handlers/engagement-events.ts
+++ b/services/gateway/src/services/automation-handlers/engagement-events.ts
@@ -223,6 +223,108 @@ async function runNoShowFollowUp(ctx: AutomationContext) {
   return { usersAffected, actionsTaken: usersAffected };
 }
 
+// ── AP-0309: "Host Night" Concierge ─────────────────────────
+// Daily heartbeat: scan upcoming global community events that are coming up
+// within CONCIERGE_HORIZON_DAYS but are still under-filled, and send the host
+// ONE concierge nudge to promote and fill the room. Events are not linked to
+// groups, so the demand signal is the host's own upcoming event. Grouped per
+// host (their soonest under-filled event wins) with a per-host cooldown so the
+// same host is not nudged on every daily run. In-platform host notification,
+// attributed to Autopilot. The share link points at the public event landing
+// — the page hosts actually share to bring people in.
+const CONCIERGE_HORIZON_DAYS = 30;    // only concierge events coming up within this window
+const CONCIERGE_MIN_LEAD_HOURS = 24;  // skip events too imminent to promote
+const CONCIERGE_COOLDOWN_DAYS = 7;    // max one nudge per host per week
+const CONCIERGE_MIN_VIABLE = 5;       // "filled enough" floor when the event has no cap
+const CONCIERGE_MAX_NUDGES = 50;      // safety cap per run
+
+async function runHostNightConcierge(ctx: AutomationContext) {
+  const { supabase } = ctx;
+  let usersAffected = 0;
+  let actionsTaken = 0;
+
+  const now = Date.now();
+  const leadCutoff = new Date(now + CONCIERGE_MIN_LEAD_HOURS * 3_600_000).toISOString();
+  const horizonCutoff = new Date(now + CONCIERGE_HORIZON_DAYS * 86_400_000).toISOString();
+  const cooldownCutoff = new Date(now - CONCIERGE_COOLDOWN_DAYS * 86_400_000).toISOString();
+
+  // Upcoming events inside the concierge window, soonest first. global_community_events
+  // has no tenant_id — the global community is shared — so we scan across all of them.
+  const { data: events } = await supabase
+    .from('global_community_events')
+    .select('id, title, start_time, participant_count, max_participants, created_by, slug')
+    .gte('start_time', leadCutoff)
+    .lte('start_time', horizonCutoff)
+    .not('created_by', 'is', null)
+    .order('start_time', { ascending: true })
+    .limit(500);
+
+  const handledHosts = new Set<string>();
+  let scanned = 0;
+
+  for (const ev of events || []) {
+    if (actionsTaken >= CONCIERGE_MAX_NUDGES) break;
+    scanned++;
+
+    // One concierge nudge per host per run — the soonest event reaches them first.
+    if (handledHosts.has(ev.created_by)) continue;
+
+    // Under-filled = below half the cap, or below the viable floor when uncapped.
+    const signups = ev.participant_count ?? 0;
+    const cap = ev.max_participants ?? 0;
+    const target = cap > 0 ? Math.ceil(cap / 2) : CONCIERGE_MIN_VIABLE;
+    if (signups >= target) continue;
+
+    // Cooldown: skip (and stop considering this host this run) if they were
+    // already concierged recently for any event.
+    const { data: recentNudge } = await supabase
+      .from('user_notifications')
+      .select('id')
+      .eq('user_id', ev.created_by)
+      .eq('type', 'orb_proactive_message')
+      .contains('data', { automation_id: 'AP-0309' })
+      .gte('created_at', cooldownCutoff)
+      .limit(1);
+    if (recentNudge && recentNudge.length > 0) {
+      handledHosts.add(ev.created_by);
+      continue;
+    }
+
+    const daysUntil = Math.max(0, Math.round((new Date(ev.start_time).getTime() - now) / 86_400_000));
+    const dayWord = daysUntil === 1 ? 'day' : 'days';
+    // The public event landing is the shareable promote page (slug preferred).
+    const shareUrl = ev.slug ? `/e/${ev.slug}` : `/pub/events/${ev.id}`;
+    const title = ev.title || 'your event';
+
+    ctx.notify(ev.created_by, 'orb_proactive_message', {
+      title: `"${title}" is coming up — let's fill the room 🎤`,
+      body: signups > 0
+        ? `${daysUntil} ${dayWord} to go with ${signups} signup${signups === 1 ? '' : 's'}. Share the event link to bring a few more people in.`
+        : `${daysUntil} ${dayWord} to go and no signups yet. Share the event link with your community to get people in the room.`,
+      data: {
+        url: shareUrl,
+        event_id: ev.id,
+        days_until: String(daysUntil),
+        signups: String(signups),
+        via: 'autopilot',
+        automation_id: 'AP-0309',
+      },
+    });
+
+    handledHosts.add(ev.created_by);
+    usersAffected++;
+    actionsTaken++;
+  }
+
+  await ctx.emitEvent('autopilot.host_concierge.scanned', {
+    events_scanned: scanned,
+    nudges_sent: actionsTaken,
+    horizon_days: CONCIERGE_HORIZON_DAYS,
+  });
+
+  return { usersAffected, actionsTaken };
+}
+
 // =============================================================================
 // AP-0500: Engagement Loops
 // =============================================================================
@@ -569,6 +671,7 @@ export function registerEngagementEventsHandlers(): void {
   registerHandler('runPostEventFeedback', runPostEventFeedback);
   registerHandler('runTrendingEventsDigest', runTrendingEventsDigest);
   registerHandler('runNoShowFollowUp', runNoShowFollowUp);
+  registerHandler('runHostNightConcierge', runHostNightConcierge);
 
   // Engagement Loops (AP-0500)
   registerHandler('runMorningBriefing', runMorningBriefing);

--- a/services/gateway/src/services/automation-registry.ts
+++ b/services/gateway/src/services/automation-registry.ts
@@ -268,9 +268,10 @@ const EVENTS_LIVE_ROOMS: AutomationDefinition[] = [
   },
   {
     id: 'AP-0309', name: '"Host Night" Concierge', domain: 'events-live-rooms',
-    status: 'PLANNED', priority: 'P0', triggerType: 'heartbeat',
-    triggerConfig: { intervalMinutes: 1440 }, // daily interest-cluster scan
+    status: 'IMPLEMENTED', priority: 'P0', triggerType: 'heartbeat',
+    triggerConfig: { intervalMinutes: 1440 }, // daily upcoming-event concierge scan
     targetRoles: [...MEMBER_ROLES],
+    handler: 'runHostNightConcierge',
     requires: ['AP-0301', 'AP-0302', 'AP-0403', 'AP-0405'],
   },
   {


### PR DESCRIPTION
## AP-0309 "Host Night" Concierge (events-live-rooms, P0, daily heartbeat)

Flips **AP-0309 PLANNED → IMPLEMENTED** and adds the `runHostNightConcierge` handler.

### What it does
A daily heartbeat that scans **upcoming `global_community_events`** within a 30-day horizon that are still **under-filled**, and sends each host **one concierge nudge** to promote and fill the room.

- **Window:** events starting between +24h and +30d (near enough to act, not too imminent).
- **Under-filled:** signups `< ceil(max_participants/2)`, or `< 5` when the event has no cap.
- **Per-host, not per-event:** the host's *soonest* under-filled event reaches them; a **7-day per-host cooldown** (via `user_notifications` `data.automation_id='AP-0309'` containment) stops the daily scan from re-nudging. Safety cap of 50 nudges/run.
- **Share link:** points at the public event landing (`/e/:slug`, falling back to `/pub/events/:id`) — the page hosts actually share. (`/community/events/:id` is **not** a real route.)
- Emits `autopilot.host_concierge.scanned`.

### Grounded in real data (not phantom tables)
Verified against the live DB: `global_community_events` has **133 rows / 40 upcoming** (2 hosts, all under-filled, earliest ~15d out, 5 within 30d) — so this fires on real data. Notably, the `community_meetups` / `matches_daily` tables that **sibling handlers (AP-0301/0302, trending)** query **do not exist** in the schema (real tables are `global_community_events`, `daily_matches`, `live_rooms`) — those siblings silently no-op. Flagged as pre-existing debt; out of scope here.

### Notes
- Follows the existing `engagement-events.ts` handler pattern (matches my AP-0211 cooldown idiom).
- Like its 6 sibling handlers in this file, notification copy is raw English (not the `tt()` i18n catalog) — consistent with current handlers; a catalog pass across all autopilot nudges is a separate follow-up.
- `tsc` build passes.

https://claude.ai/code/session_01AQh8BrYDZJgrbLqb2dGSgU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQh8BrYDZJgrbLqb2dGSgU)_