### PR TITLE
fix(orb): baseline greeting register must LEAD, never "how can I help" (VTID-03271)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -345,7 +345,7 @@ function buildTemporalJourneyContextSection(
   lines.push('');
   lines.push('## TONE RULES (CRITICAL)');
   lines.push('- Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.');
-  lines.push('- Baseline register: "how can I help", "what\'s on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.');
+  lines.push('- Baseline register — you LEAD, you NEVER ask the user\'s preference (VTID-03271). A new user cannot tell you what they "would like"; they don\'t know the system yet. So your opener is ALWAYS a lead: "Let me show you where we are.", "Let me show you your next step.", "I\'m listening." NEVER "how can I help", "what\'s on your mind", "how can I support you", "wie kann ich dir helfen", or any "what do you want" question. When a candidate IS provided in the brain context below, lead with that specific next move instead.');
   lines.push('- NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.');
   lines.push('- Even your shortest responses must feel genuinely kind. A single phrase can still be warm.');
   lines.push('');

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -184,7 +184,7 @@ This is real, per-session data. Treat it as ground truth about what the user is 
 
 ## TONE RULES (CRITICAL)
 - Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.
-- Baseline register: "how can I help", "what's on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.
+- Baseline register — you LEAD, you NEVER ask the user's preference (VTID-03271). A new user cannot tell you what they "would like"; they don't know the system yet. So your opener is ALWAYS a lead: "Let me show you where we are.", "Let me show you your next step.", "I'm listening." NEVER "how can I help", "what's on your mind", "how can I support you", "wie kann ich dir helfen", or any "what do you want" question. When a candidate IS provided in the brain context below, lead with that specific next move instead.
 - NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.
 - Even your shortest responses must feel genuinely kind. A single phrase can still be warm.
 
@@ -433,7 +433,7 @@ This is real, per-session data. Treat it as ground truth about what the user is 
 
 ## TONE RULES (CRITICAL)
 - Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.
-- Baseline register: "how can I help", "what's on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.
+- Baseline register — you LEAD, you NEVER ask the user's preference (VTID-03271). A new user cannot tell you what they "would like"; they don't know the system yet. So your opener is ALWAYS a lead: "Let me show you where we are.", "Let me show you your next step.", "I'm listening." NEVER "how can I help", "what's on your mind", "how can I support you", "wie kann ich dir helfen", or any "what do you want" question. When a candidate IS provided in the brain context below, lead with that specific next move instead.
 - NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.
 - Even your shortest responses must feel genuinely kind. A single phrase can still be warm.
 
@@ -1660,7 +1660,7 @@ This is real, per-session data. Treat it as ground truth about what the user is 
 
 ## TONE RULES (CRITICAL)
 - Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.
-- Baseline register: "how can I help", "what's on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.
+- Baseline register — you LEAD, you NEVER ask the user's preference (VTID-03271). A new user cannot tell you what they "would like"; they don't know the system yet. So your opener is ALWAYS a lead: "Let me show you where we are.", "Let me show you your next step.", "I'm listening." NEVER "how can I help", "what's on your mind", "how can I support you", "wie kann ich dir helfen", or any "what do you want" question. When a candidate IS provided in the brain context below, lead with that specific next move instead.
 - NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.
 - Even your shortest responses must feel genuinely kind. A single phrase can still be warm.
 


### PR DESCRIPTION
**Root cause of "Hallo, wie kann ich dir heute helfen"** on turns where `journey_guide` doesn't inject a candidate.

`live-system-instruction.ts` TONE RULES explicitly listed *"how can I help / what's on your mind / how can I support you"* as the acceptable **baseline register** — directly contradicting the PROACTIVE LEADERSHIP block (VTID-03256) and the `ai-personality-service` `forbidden_openings` list (which already bans "How can I help you today?"). When no candidate was provided, Gemini followed the explicit baseline → generic preference greeting.

**Fix:** the baseline register now **leads** — "Let me show you where we are." / "Let me show you your next step." / "I'm listening." — and explicitly bans "how can I help", "wie kann ich dir helfen", and any "what do you want" opener. When a candidate IS provided, lead with that specific next move.

System-instruction characterization snapshots updated (3). `tsc`/CI authoritative.

### Related context (from the same session's wake-decision log, not in this PR)
The reason the baseline was reached at all: `journey_guide` **suppressed with reason `journey_graduated`** for this (long-tenured) user, so the guided journey stepped aside. Whether a returning/existing user should be "graduated" out of the guided journey — and how to let one re-enter it for testing — is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)