### PR TITLE
fix(stage-artifacts): package trainer directory output

### DIFF
--- a/.github/workflows/STAGE-ARTIFACTS-GCS.yml
+++ b/.github/workflows/STAGE-ARTIFACTS-GCS.yml
@@ -65,8 +65,10 @@ jobs:
             SRC="${STAGING_BUCKET}/finetune-runs/${TARGET}/"
             DST="${STAGING_BUCKET}/finetune-current/${TARGET}/"
             echo "=== ${TARGET} ==="
-            # List existing runs newest-first; take the first that has a
-            # weights.tar.gz at its root.
+            # List existing runs newest-first. The trainer currently uploads
+            # adapter/tokenizer files as a directory; older staging expected a
+            # prebuilt weights.tar.gz. Support both shapes and publish the
+            # canonical tarball either way.
             LATEST=$(gsutil ls "${SRC}" 2>/dev/null || true)
             LATEST=$(printf "%s\n" "${LATEST}" | sort -r | head -10)
             if [ -z "$LATEST" ]; then
@@ -79,6 +81,19 @@ jobs:
                 echo "selecting ${RUN}weights.tar.gz -> ${DST}weights.tar.gz"
                 gsutil -m cp "${RUN}weights.tar.gz" "${DST}weights.tar.gz"
                 echo "${RUN}" | gsutil -m cp - "${DST}LATEST_RUN.txt"
+                STAGED=1
+                break
+              fi
+              if gsutil -q stat "${RUN}vitana_training_manifest.json" 2>/dev/null; then
+                echo "packaging ${RUN} -> ${DST}weights.tar.gz"
+                WORKDIR="$(mktemp -d)"
+                DOWNLOAD_DIR="${WORKDIR}/artifact"
+                mkdir -p "${DOWNLOAD_DIR}"
+                gsutil -m cp -r "${RUN}*" "${DOWNLOAD_DIR}/"
+                tar -czf "${WORKDIR}/weights.tar.gz" -C "${DOWNLOAD_DIR}" .
+                gsutil -m cp "${WORKDIR}/weights.tar.gz" "${DST}weights.tar.gz"
+                echo "${RUN}" | gsutil -m cp - "${DST}LATEST_RUN.txt"
+                rm -rf "${WORKDIR}"
                 STAGED=1
                 break
               fi


### PR DESCRIPTION
## Summary
- stage directory-shaped trainer output by packaging it into canonical `weights.tar.gz`
- keep support for prebuilt `weights.tar.gz` when present
- use `vitana_training_manifest.json` as the marker that a run directory is complete enough to package

## Root cause
The successful Vertex trainer uploads adapter/tokenizer files directly under the run output URI. `STAGE-ARTIFACTS-GCS` expected `weights.tar.gz` at the run root, so the fixed workflow skipped the successful voice-tool-router run instead of staging it.

## Validation
- confirmed run 26907611514 succeeds but logs `no weights.tar.gz found in latest runs for voice-tool-router; skipping`
- reviewed `trainer-package/finetune/train.py`: it calls `upload_directory(final_dir, args.output_uri)` and never creates `weights.tar.gz`
- runtime validation requires GitHub Actions WIF/GCS after merge
