### PR TITLE
fix(stage-artifacts): upload latest run marker without parallel cp

### DIFF
--- a/.github/workflows/STAGE-ARTIFACTS-GCS.yml
+++ b/.github/workflows/STAGE-ARTIFACTS-GCS.yml
@@ -80,7 +80,7 @@ jobs:
               if gsutil -q stat "${RUN}weights.tar.gz" 2>/dev/null; then
                 echo "selecting ${RUN}weights.tar.gz -> ${DST}weights.tar.gz"
                 gsutil -m cp "${RUN}weights.tar.gz" "${DST}weights.tar.gz"
-                echo "${RUN}" | gsutil -m cp - "${DST}LATEST_RUN.txt"
+                echo "${RUN}" | gsutil cp - "${DST}LATEST_RUN.txt"
                 STAGED=1
                 break
               fi
@@ -92,7 +92,7 @@ jobs:
                 gsutil -m cp -r "${RUN}*" "${DOWNLOAD_DIR}/"
                 tar -czf "${WORKDIR}/weights.tar.gz" -C "${DOWNLOAD_DIR}" .
                 gsutil -m cp "${WORKDIR}/weights.tar.gz" "${DST}weights.tar.gz"
-                echo "${RUN}" | gsutil -m cp - "${DST}LATEST_RUN.txt"
+                echo "${RUN}" | gsutil cp - "${DST}LATEST_RUN.txt"
                 rm -rf "${WORKDIR}"
                 STAGED=1
                 break


### PR DESCRIPTION
## Summary
- use plain `gsutil cp -` for `LATEST_RUN.txt` stream uploads
- keeps parallel `gsutil -m cp` for normal file/object copies

## Root cause
Run 26907951208 successfully packaged and uploaded `finetune-current/voice-tool-router/weights.tar.gz`, then failed because `gsutil -m cp -` does not support stdin stream uploads.

## Validation
- confirmed failure text in STAGE-ARTIFACTS-GCS run 26907951208
- this is a one-line command-mode fix in both marker-write paths
