### PR TITLE
fix(chat): let Vitana send DMs from text chat

### DIFF
--- a/services/gateway/src/services/conversation-client.ts
+++ b/services/gateway/src/services/conversation-client.ts
@@ -25,7 +25,7 @@ import {
 import { ContextLens, createContextLens } from '../types/context-lens';
 import { computeRetrievalRouterDecision, logRetrievalRouterDecision } from './retrieval-router';
 import { buildContextPack, formatContextPackForLLM, BuildContextPackInput, extractLanguageFromContextPack, buildLanguageDirective } from './context-pack-builder';
-import { processWithGemini } from './gemini-operator';
+import { processWithGemini, setThreadIdentity } from './gemini-operator';
 import { getGeminiToolDefinitions, logToolExecution } from './tool-registry';
 import { classifyCategory } from '../routes/memory';
 import { getPersonalityConfigSync } from './ai-personality-service';
@@ -327,6 +327,18 @@ export async function processConversationTurn(
     // Step 5: Get tool definitions
     const toolDefs = getGeminiToolDefinitions(input.role);
 
+    // VTID-CHAT-SEND: Register the user's identity for this thread BEFORE the
+    // LLM runs, so identity-bound tools the executor dispatches (send_chat_message,
+    // resolve_recipient, get_user_matches, recall_conversation_at_time) can act
+    // on the user's behalf. The text-DM brain previously never set this, so
+    // those tools silently failed with "User context not available" — which is
+    // why asking Vitana to message someone fell back to an events search.
+    setThreadIdentity(thread.thread_id, {
+      tenant_id: input.tenant_id,
+      user_id: input.user_id,
+      role: input.role,
+    });
+
     // Step 6: Call LLM
     const llmStartTime = Date.now();
     let reply = '';
@@ -535,6 +547,13 @@ User's role: ${role}
 Instructions:
 ${ucConfig.common_instructions || '- Use the memory context to personalize responses\n- Use knowledge context for Vitana-specific questions\n- Be helpful and accurate'}
 - ${channel === 'orb' ? (ucConfig.instructions_orb || 'Keep responses brief and natural for voice') : (ucConfig.instructions_operator || 'You can use markdown formatting and be more detailed')}
+
+Sending messages to other members:
+- You CAN send a direct chat message to another community member on the user's behalf using the send_chat_message tool. When the user asks to message someone ("send Maria a message saying ...", "schick Mariia eine Nachricht: ..."), do this:
+  1. Confirm the recipient and the exact message text with the user first ("Soll ich die Nachricht an <name> senden?").
+  2. When the user confirms (e.g. "yes, send it" / "ja, versende es"), call send_chat_message with recipient_label set to the name the user used (full name preferred) and body set to the exact message text.
+  3. If the name is ambiguous, call resolve_recipient first to disambiguate, then confirm with the user.
+- NEVER claim a message was sent unless send_chat_message returned ok. If it returns an error, tell the user honestly and offer to try again — do NOT silently switch to a different action like searching for events.
 
 Sharing Links:
 - Event search results include a "Link:" field with a URL like https://vitanaland.com/e/{slug}. When the user asks about an event or asks for a link, you MUST copy this exact URL into your response on its own line. NEVER say "the link is on its way" or "I'll send the link" — paste the actual URL.

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -25,6 +25,7 @@
 
 import fetch from 'node-fetch';
 import { randomUUID } from 'crypto';
+import { createClient } from '@supabase/supabase-js';
 import { VertexAI, GenerateContentResult, Content, Part, FunctionDeclaration, Tool } from '@google-cloud/vertexai';
 import {
   createOperatorTask,
@@ -464,6 +465,56 @@ Returns checklist items with pass/fail status based on OASIS evidence.`,
           }
         },
         required: []
+      }
+    },
+    // VTID-CHAT-SEND: Direct-message tools so Vitana can send a chat message to
+    // another community member on the user's behalf (text-chat parity with the
+    // ORB voice surface). Backed by the same shared handlers used by voice.
+    {
+      name: 'resolve_recipient',
+      description: `Resolve the person the user wants to message to one or more candidate community members. Call this when the user names someone to message but you are not sure exactly who they mean (e.g. ambiguous first name). Returns scored candidates; if exactly one high-confidence match is returned you can proceed, otherwise ask the user to clarify. You usually do NOT need this when the user gave a full, unambiguous name — in that case call send_chat_message directly with recipient_label set to that name.`,
+      parameters: {
+        type: 'object',
+        properties: {
+          spoken_name: {
+            type: 'string',
+            description: 'The name of the person to message, exactly as the user said it (e.g. "Maria", "Mariia Maksina", or a Vitana ID).'
+          },
+          limit: {
+            type: 'integer',
+            description: 'Maximum number of candidates to return. Defaults to 5.'
+          }
+        },
+        required: ['spoken_name']
+      }
+    },
+    {
+      name: 'send_chat_message',
+      description: `Send a direct chat message to another community member on the user's behalf. Use this when the user asks to send/write a message to a person (e.g. "send Maria a message saying ...", "schick Mariia eine Nachricht: ...").
+
+FLOW:
+1. Read back the recipient and the exact message text and ask the user to confirm ("Soll ich die Nachricht senden?").
+2. ONLY after the user confirms (e.g. "yes, send it" / "ja, versende es") call this tool.
+3. Pass recipient_label as the name the user used (full name preferred) and body as the EXACT message text the user dictated.
+
+NEVER claim a message was sent unless this tool returned ok. If it returns an error, tell the user honestly and offer to try again — do NOT silently switch to a different action.`,
+      parameters: {
+        type: 'object',
+        properties: {
+          recipient_user_id: {
+            type: 'string',
+            description: 'The recipient\'s user UUID, if you already have it from a previous resolve_recipient call. Optional — if you only have the name, leave this out and set recipient_label.'
+          },
+          recipient_label: {
+            type: 'string',
+            description: 'The recipient\'s name exactly as the user referred to them (full name preferred, e.g. "Mariia Maksina"). Used to look up and verify the recipient.'
+          },
+          body: {
+            type: 'string',
+            description: 'The message text to send, exactly as the user dictated it.'
+          }
+        },
+        required: ['body']
       }
     },
     // ===== VTID-DEV-ASSIST: Developer Assistant Tools =====
@@ -2641,6 +2692,60 @@ export async function executeTool(
             error: 'User context not available for matchmaking tool',
           };
         }
+        break;
+      }
+
+      // VTID-CHAT-SEND: Direct-message tools (text-chat parity with ORB voice).
+      // Both delegate to the shared, battle-tested handlers in
+      // orb-tools-shared.ts so text and voice send messages identically
+      // (recipient resolution, receiver verification, rate-limit, push notify).
+      case 'resolve_recipient': {
+        const sendIdentity = threadIdentityMap.get(threadId);
+        if (!sendIdentity?.user_id) {
+          result = { ok: false, error: 'User context not available for messaging' };
+          break;
+        }
+        const { tool_resolve_recipient } = await import('./orb-tools-shared');
+        const sb = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE!);
+        const r = await tool_resolve_recipient(
+          args as Record<string, unknown>,
+          {
+            user_id: sendIdentity.user_id,
+            tenant_id: sendIdentity.tenant_id ?? null,
+            role: sendIdentity.role ?? 'community',
+            vitana_id: sendIdentity.vitana_id ?? null,
+          },
+          sb,
+        );
+        result = r.ok
+          ? { ok: true, data: { ...((r as { result?: Record<string, unknown> }).result ?? {}), message: (r as { text?: string }).text } }
+          : { ok: false, error: (r as { error: string }).error };
+        break;
+      }
+
+      case 'send_chat_message': {
+        const sendIdentity = threadIdentityMap.get(threadId);
+        if (!sendIdentity?.user_id) {
+          result = { ok: false, error: 'User context not available for messaging' };
+          break;
+        }
+        const { tool_send_chat_message } = await import('./orb-tools-shared');
+        const sb = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE!);
+        const r = await tool_send_chat_message(
+          args as Record<string, unknown>,
+          {
+            user_id: sendIdentity.user_id,
+            tenant_id: sendIdentity.tenant_id ?? null,
+            role: sendIdentity.role ?? 'community',
+            vitana_id: sendIdentity.vitana_id ?? null,
+            // Use the thread id as the rate-limit session key for text chat.
+            session_id: threadId,
+          },
+          sb,
+        );
+        result = r.ok
+          ? { ok: true, data: { ...((r as { result?: Record<string, unknown> }).result ?? {}), message: (r as { text?: string }).text } }
+          : { ok: false, error: (r as { error: string }).error };
         break;
       }
 


### PR DESCRIPTION
## Problem

Asking Vitana to send a message in the **text DM** ("send Mariia a message: …") failed and fell back to an events search ("Das konnte ich gerade nicht abschließen. Möchtest du stattdessen eine Suche nach Events starten?").

[reported behaviour](symptom)

## Root cause

The live text brain runs through `processBrainTurn` → `processConversationTurn` → `processWithGemini` (gemini-operator) — confirmed live: `system_controls.vitana_brain_enabled = true`.

That tool set (`GEMINI_TOOL_DEFINITIONS` in `gemini-operator.ts`) had **no `send_chat_message` / `resolve_recipient` tool**, and the text path **never called `setThreadIdentity`** (unlike the operator console and ORB voice). So:

1. The model had no tool to actually send a DM, so it fell through to the only people/events-ish tool available (`search_events`) → "Suche nach Events".
2. Even identity-bound tools (`get_user_matches`, `recall_conversation_at_time`) silently failed with "User context not available" on this path.

The full send implementation already exists and works on the **voice** surface (`orb-tools-shared.ts: tool_send_chat_message` / `tool_resolve_recipient`, writing to the canonical `chat_messages` table). The text brain just wasn't wired to it.

> Note: the `chat_messages` table columns are all present in the live DB (`sender_vitana_id`, `receiver_vitana_id`, `metadata`, …) — the insert was never the failure. The failure was purely the missing tool + missing identity on the text path.

## Fix (text-chat parity with ORB voice)

- **`gemini-operator.ts`** — add `resolve_recipient` + `send_chat_message` tool definitions and `executeTool` cases that delegate to the shared, proven handlers in `orb-tools-shared.ts` (recipient resolution via `resolve_recipient_candidates`, receiver verification, rate-limit, push-notify, canonical `chat_messages` insert).
- **`conversation-client.ts`** — call `setThreadIdentity()` before the LLM runs so the send/resolve (and matches/recall) tools can act on the user's behalf, plus a messaging instruction block: confirm-then-send, never claim sent unless the tool returned `ok`, never silently switch to an events search.

## Verification

- Gateway `tsc --noEmit` clean.
- Runtime: both tools register and `executeTool` dispatches to the new cases (no-identity guard returns the expected error, not "Unknown tool").
- `resolve_recipient_candidates(actor, 'Mariia Maksina')` → top match **score 1.00** (second 0.65), so the handler's label-recovery auto-resolves with just `recipient_label`.
- The exact canonical `chat_messages` insert the handler performs succeeds against the **live** schema + RLS — validated inside a rolled-back transaction, so **no message was delivered** to the real member.

## Deploy

Gateway change → ensure `EXEC-DEPLOY` runs after merge (commit carries a `BOOTSTRAP-` tag so AUTO-DEPLOY will dispatch).

https://claude.ai/code/session_017Cee8pjTazHT78jVkTuxPQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017Cee8pjTazHT78jVkTuxPQ)_