### PR TITLE
feat(eval): gate canary readiness on ground-truth accuracy (BOOTSTRAP-SHADOW-CORPUS-ACCURACY)

### DIFF
--- a/services/gateway/scripts/eval/canary-readiness-report.ts
+++ b/services/gateway/scripts/eval/canary-readiness-report.ts
@@ -54,6 +54,15 @@ const THRESHOLDS = {
   max_candidate_error_rate: 0.02,
   min_consecutive_clean_days: 5,
   min_dataset_rows: 1000,
+  // BOOTSTRAP-SHADOW-CORPUS-ACCURACY: ground-truth accuracy gate. Agreement
+  // alone can't catch two models confidently agreeing on the WRONG tool — only
+  // accuracy-vs-truth can. These apply once the window carries enough
+  // golden-corpus-grounded comparisons (events with primary_correct /
+  // candidate_correct) to be statistically meaningful.
+  min_labeled_comparisons: 50,
+  min_candidate_accuracy: 0.85,
+  // The candidate may not be materially worse than the primary it would replace.
+  max_accuracy_regression: 0.05,
 } as const;
 
 interface ShadowReport {
@@ -66,6 +75,10 @@ interface ShadowReport {
     agreement_rate: number | null;
     candidate_p95_ms: number;
     candidate_error_rate: number;
+    // Ground-truth accuracy (present once corpus-grounded shadow events land).
+    labeled_comparisons?: number;
+    primary_accuracy?: number | null;
+    candidate_accuracy?: number | null;
   }>;
 }
 
@@ -92,6 +105,54 @@ interface CanaryReadinessReport {
 
 function reason(rule: string, ok: boolean, detail: string): Reason {
   return { rule, ok, detail };
+}
+
+/**
+ * BOOTSTRAP-SHADOW-CORPUS-ACCURACY: ground-truth accuracy gate.
+ *
+ * Pure + exported so it's unit-tested without the network/env the rest of this
+ * script needs. Returns the `candidate_accuracy` Reason for a feature rollup:
+ *   - Not enough labeled (golden-corpus-grounded) comparisons → FAIL with a
+ *     "run the corpus exerciser" nudge (consistent with how every other
+ *     insufficient-evidence rule blocks here).
+ *   - Candidate below the absolute floor → FAIL.
+ *   - Candidate materially worse than the primary it would replace → FAIL.
+ *   - Otherwise → PASS with the numbers.
+ */
+function accuracyReason(
+  rollup: Pick<ShadowReport['features'][number], 'labeled_comparisons' | 'primary_accuracy' | 'candidate_accuracy'> | null,
+  thresholds: Pick<typeof THRESHOLDS, 'min_labeled_comparisons' | 'min_candidate_accuracy' | 'max_accuracy_regression'> = THRESHOLDS,
+): Reason {
+  const labeled = rollup?.labeled_comparisons ?? 0;
+  const candAcc = rollup?.candidate_accuracy ?? null;
+  const primAcc = rollup?.primary_accuracy ?? null;
+
+  if (labeled < thresholds.min_labeled_comparisons || candAcc === null) {
+    return reason(
+      'candidate_accuracy',
+      false,
+      `Only ${labeled} corpus-grounded comparisons (need ${thresholds.min_labeled_comparisons}). Run EXERCISE-STAGING-SHADOW with source=golden-corpus, or wait for labeled organic turns, to score accuracy vs ground truth.`,
+    );
+  }
+  if (candAcc < thresholds.min_candidate_accuracy) {
+    return reason(
+      'candidate_accuracy',
+      false,
+      `Candidate accuracy ${(candAcc * 100).toFixed(1)}% < ${(thresholds.min_candidate_accuracy * 100).toFixed(0)}% floor (over ${labeled} labeled turns).`,
+    );
+  }
+  if (primAcc !== null && candAcc < primAcc - thresholds.max_accuracy_regression) {
+    return reason(
+      'candidate_accuracy',
+      false,
+      `Candidate accuracy ${(candAcc * 100).toFixed(1)}% regresses >${(thresholds.max_accuracy_regression * 100).toFixed(0)}pp below primary ${(primAcc * 100).toFixed(1)}%.`,
+    );
+  }
+  return reason(
+    'candidate_accuracy',
+    true,
+    `Candidate accuracy ${(candAcc * 100).toFixed(1)}%${primAcc !== null ? ` vs primary ${(primAcc * 100).toFixed(1)}%` : ''} over ${labeled} labeled turns (>= ${(thresholds.min_candidate_accuracy * 100).toFixed(0)}% floor).`,
+  );
 }
 
 async function fetchShadowReport(): Promise<ShadowReport> {
@@ -233,6 +294,10 @@ async function generate(): Promise<CanaryReadinessReport> {
     } else {
       reasons.push(reason('candidate_error_rate', true, `Candidate error rate ${(featureRollup.candidate_error_rate * 100).toFixed(2)}% within budget.`));
     }
+
+    // Ground-truth accuracy gate (BOOTSTRAP-SHADOW-CORPUS-ACCURACY): the real
+    // "is the candidate right?" check, beyond mutual agreement.
+    reasons.push(accuracyReason(featureRollup));
   }
 
   // Fine-tune status — must have a successful run
@@ -339,5 +404,5 @@ if (require.main === module) {
   });
 }
 
-export { generate, renderMarkdown };
+export { generate, renderMarkdown, accuracyReason };
 export type { CanaryReadinessReport, Reason };

--- a/services/gateway/test/eval-canary-accuracy.test.ts
+++ b/services/gateway/test/eval-canary-accuracy.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Canary readiness — ground-truth accuracy gate (BOOTSTRAP-SHADOW-CORPUS-ACCURACY).
+ *
+ * The canary-readiness report graduates a candidate model only when the
+ * evidence says it's actually RIGHT, not merely that it AGREES with the
+ * primary. This pins the accuracy rule: insufficient labeled evidence blocks,
+ * a below-floor candidate blocks, a regression vs primary blocks, and a strong
+ * candidate over enough labeled turns passes.
+ */
+process.env.NODE_ENV = 'test';
+
+import { accuracyReason } from '../scripts/eval/canary-readiness-report';
+
+describe('canary readiness — candidate_accuracy gate', () => {
+  test('blocks when there are too few corpus-grounded comparisons', () => {
+    const r = accuracyReason({ labeled_comparisons: 10, primary_accuracy: 1, candidate_accuracy: 0.95 });
+    expect(r.rule).toBe('candidate_accuracy');
+    expect(r.ok).toBe(false);
+    expect(r.detail).toMatch(/corpus-grounded comparisons/);
+  });
+
+  test('blocks when candidate has no labeled accuracy at all (null)', () => {
+    const r = accuracyReason({ labeled_comparisons: 80, primary_accuracy: 0.9, candidate_accuracy: null });
+    expect(r.ok).toBe(false);
+  });
+
+  test('blocks a below-floor candidate', () => {
+    const r = accuracyReason({ labeled_comparisons: 80, primary_accuracy: 0.95, candidate_accuracy: 0.80 });
+    expect(r.ok).toBe(false);
+    expect(r.detail).toMatch(/floor/);
+  });
+
+  test('blocks a candidate that regresses materially below primary', () => {
+    // candidate 0.88 is above the 0.85 floor but >5pp below primary 0.97
+    const r = accuracyReason({ labeled_comparisons: 80, primary_accuracy: 0.97, candidate_accuracy: 0.88 });
+    expect(r.ok).toBe(false);
+    expect(r.detail).toMatch(/regress/);
+  });
+
+  test('passes a strong candidate over enough labeled turns', () => {
+    const r = accuracyReason({ labeled_comparisons: 60, primary_accuracy: 0.90, candidate_accuracy: 0.92 });
+    expect(r.ok).toBe(true);
+    expect(r.detail).toMatch(/92.0%/);
+  });
+
+  test('passes when candidate meets the floor and primary is unknown', () => {
+    const r = accuracyReason({ labeled_comparisons: 60, primary_accuracy: null, candidate_accuracy: 0.86 });
+    expect(r.ok).toBe(true);
+  });
+
+  test('null rollup blocks (no shadow feature data)', () => {
+    expect(accuracyReason(null).ok).toBe(false);
+  });
+
+  test('a candidate exactly at the floor passes', () => {
+    const r = accuracyReason({ labeled_comparisons: 50, primary_accuracy: 0.85, candidate_accuracy: 0.85 });
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

#2566 made the shadow-comparison report **emit** primary/candidate accuracy-vs-truth from the golden corpus. This makes the **canary-readiness gate actually consume it** — the W3 Day-3 workstream.

Mutual agreement can't catch two models confidently agreeing on the **wrong** tool; only accuracy-vs-ground-truth can, and that's the last guard before a candidate model gets real traffic.

## Changes (`scripts/eval/canary-readiness-report.ts`)

- **New thresholds:** `min_labeled_comparisons` (50), `min_candidate_accuracy` (0.85), `max_accuracy_regression` (0.05 — the candidate can't be materially worse than the primary it replaces).
- **New `candidate_accuracy` rule** (pure, exported `accuracyReason()`): blocks on insufficient corpus-grounded evidence, below-floor accuracy, or regression vs primary; passes a strong candidate over enough labeled turns.
- `ShadowReport` interface extended with the `labeled_comparisons` / `primary_accuracy` / `candidate_accuracy` fields the endpoint already returns (from #2566).

## Safety

The rule is **additive and fail-closed**: with no labeled data it blocks (and the verdict was already `NOT_READY` due to the always-on `consecutive_clean_days` rule), so it cannot *loosen* the gate — only tighten it once corpus-grounded shadow events land. The script runs in CI (`CANARY-READINESS-REPORT.yml`), not the gateway runtime.

## Verification

- **8/8** accuracy-gate tests pass (`eval-canary-accuracy.test.ts`); `tsc --noEmit` clean.

Builds on #2566 (merged). Part of finishing Day 3.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_