### PR TITLE
fix(my-journey): count goal_day from set_at without requiring a deadline

### DIFF
--- a/services/gateway/src/routes/my-journey.ts
+++ b/services/gateway/src/routes/my-journey.ts
@@ -73,7 +73,14 @@ export function buildGoalBlock(lc: LifeCompassSnapshot, now: Date = new Date()) 
   const goalTotalDays = hasDeadline
     ? Math.max(0, daysBetween(lc.set_at, lc.target_date) ?? 0)
     : null;
-  const goalDay = hasDeadline
+  // Day counter: whole days elapsed since the goal was set. This is NOT gated
+  // on a deadline — the My Journey "Day N" reflects how long the user has been
+  // on the journey, so it must keep counting from set_at even before a target
+  // date is chosen. (Gating it on hasDeadline pinned the mobile North Star to
+  // "Day 1" forever for users who set a goal but no deadline.) Only the
+  // countdown (days_to_deadline) and the progress ring (goal_total_days /
+  // goal_progress_pct) genuinely require a deadline and stay null without one.
+  const goalDay = lc.set_at
     ? Math.max(0, daysBetween(lc.set_at, nowIso) ?? 0)
     : null;
   const goalProgressPct =

--- a/services/gateway/test/routes/my-journey-goal-block.test.ts
+++ b/services/gateway/test/routes/my-journey-goal-block.test.ts
@@ -51,15 +51,24 @@ describe('VTID-03152 my-journey buildGoalBlock', () => {
     expect(block.pillar_focus).toBe('health');
   });
 
-  it('returns null goal-progress fields when no deadline is set', () => {
+  it('counts goal_day from set_at even when no deadline is set, but leaves deadline-only fields null', () => {
+    // Set 30 days before FIXED_NOW, no deadline. The day counter must keep
+    // counting from set_at (so the mobile North Star advances past "Day 1"),
+    // while the countdown / total / progress stay null without a deadline.
     const block = buildGoalBlock(compass({ set_at: '2026-05-02T12:00:00.000Z' }), FIXED_NOW);
     expect(block.has_deadline).toBe(false);
     expect(block.days_to_deadline).toBeNull();
     expect(block.goal_total_days).toBeNull();
-    expect(block.goal_day).toBeNull();
+    expect(block.goal_day).toBe(30);
     expect(block.goal_progress_pct).toBeNull();
     // Goal text/pillar still pass through.
     expect(block.active_goal_text).toBe('Lose 10 kg');
+  });
+
+  it('returns null goal_day only when set_at itself is missing', () => {
+    const block = buildGoalBlock(compass({ set_at: null }), FIXED_NOW);
+    expect(block.has_deadline).toBe(false);
+    expect(block.goal_day).toBeNull();
   });
 
   it('clamps a deadline that is today to 0 days left and 100% progress', () => {


### PR DESCRIPTION
## Problem

On iPhone, the **My Journey ("Meine Reise")** day counter stays stuck on **"TAG 1"** and never advances for affected test users.

## Root cause

The mobile North Star (`DreamNorthStar`) renders the day number as `(goal_day ?? 0) + 1`. The gateway's `buildGoalBlock()` in `services/gateway/src/routes/my-journey.ts` gated **`goal_day` behind `has_deadline`**:

```ts
const goalDay = hasDeadline
  ? Math.max(0, daysBetween(lc.set_at, nowIso) ?? 0)
  : null;
```

A user who has set a goal but **not** a target date (exactly the screenshot's state — note "Füge ein Zieldatum hinzu…" / "Zieldatum hinzufügen") gets `goal_day: null` from the backend. The frontend then computes `(null ?? 0) + 1 = 1` and shows **"TAG 1"** forever, regardless of how many days have actually passed.

The desktop layout (`GoalNorthStar`) hides the ring entirely without a deadline, so this only surfaces on mobile — matching the reported iPhone-only symptom.

## Fix

The day counter reflects *how long the user has been on the journey* and is computable from `set_at` alone. Only the countdown (`days_to_deadline`) and progress ring (`goal_total_days` / `goal_progress_pct`) genuinely require a deadline. So `goal_day` now counts from `set_at` unconditionally, while the deadline-only fields stay `null` without a target date.

This also aligns `my-journey` with `journey-foundation` and `new-day-overview`, which already derive their day-in-journey from `set_at` regardless of deadline.

## Tests

Updated `my-journey-goal-block.test.ts`:
- No-deadline case now asserts `goal_day === 30` (from `set_at`) while `days_to_deadline` / `goal_total_days` / `goal_progress_pct` remain `null`.
- Added a case asserting `goal_day === null` only when `set_at` itself is missing.

All 5 tests in the suite pass.

## Verification note

This is a gateway logic change. Visual confirmation on the deployed mobile screen requires an EXEC-DEPLOY of the gateway service (per the deployment-verification protocol), which is outside this PR. The frontend already handles a non-null `goal_day` without a deadline correctly in both layouts.

https://claude.ai/code/session_013V1KGbsLdjEZdEGB2esVLj

---
_Generated by [Claude Code](https://claude.ai/code/session_013V1KGbsLdjEZdEGB2esVLj)_