### PR TITLE
perf(goal-plan): never block plan display on the translate-on-view LLM call (VTID-03152)

### DIFF
--- a/services/gateway/src/routes/goal-planner.ts
+++ b/services/gateway/src/routes/goal-planner.ts
@@ -19,7 +19,7 @@ import {
   clarifyGoalIfNeeded,
   type ClarificationAnswer,
 } from '../services/journey/goal-planner-service';
-import { localizeGoalPlan } from '../services/journey/goal-plan-i18n';
+import { localizeGoalPlan, VIEW_TRANSLATE_DEADLINE_MS } from '../services/journey/goal-plan-i18n';
 import { getUserLocale } from '../i18n/server-locale';
 
 const router = Router();
@@ -75,7 +75,7 @@ router.post('/generate', requireAuth, async (req: AuthenticatedRequest, res: Res
       // The plan was just authored in the user's locale; localize only if the
       // active toggle differs (e.g. an EN user generated a DE-sourced plan).
       const locale = await resolveLocale(client, userId, req.query.locale ?? req.body?.locale);
-      plan = await localizeGoalPlan(client, plan, plan.source_lang, locale);
+      plan = await localizeGoalPlan(client, plan, plan.source_lang, locale, { deadlineMs: VIEW_TRANSLATE_DEADLINE_MS });
     }
     return res.status(200).json({ ok: true, vtid: VTID, plan_id: result.plan_id, step_count: result.step_count, plan });
   } catch (err: any) {
@@ -95,8 +95,11 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
     if (plan) {
       // Render in the app's active language (toggle), translating + caching on
       // first view of a non-source locale so subsequent toggles are instant.
+      // Cap how long the view waits on the LLM: the plan must display fast, so a
+      // slow first-view translation finishes in the background and seeds the
+      // cache for the next view instead of hanging the spinner.
       const locale = await resolveLocale(client, userId, req.query.locale);
-      plan = await localizeGoalPlan(client, plan, plan.source_lang, locale);
+      plan = await localizeGoalPlan(client, plan, plan.source_lang, locale, { deadlineMs: VIEW_TRANSLATE_DEADLINE_MS });
     }
     return res.status(200).json({ ok: true, vtid: VTID, plan });
   } catch (err: any) {

--- a/services/gateway/src/services/journey/goal-plan-i18n.ts
+++ b/services/gateway/src/services/journey/goal-plan-i18n.ts
@@ -41,6 +41,31 @@ interface TranslatableStep {
   description: string | null;
 }
 
+// How long a *view* (GET) is allowed to wait on the translate-on-view LLM call
+// before it returns the best-available text and finishes translating in the
+// background. The plan rows are already in the DB and must render instantly; the
+// localized wording is a progressive enhancement that fills the cache for the
+// next view. Capping this keeps the My Journey plan drawer from spinning on a
+// slow LLM round-trip (the iPhone "takes forever to display" symptom).
+export const VIEW_TRANSLATE_DEADLINE_MS = 3500;
+
+// Sentinel for the deadline race (distinct from any translate result/null).
+const TRANSLATE_TIMEOUT = Symbol('goal-plan-i18n-translate-timeout');
+
+// Result of filling the per-locale cache for the misses of one plan: the
+// localized summary (undefined when it wasn't missing) and a map of step_id →
+// localized text. Shared by the in-flight dedupe below.
+interface TranslateFill {
+  plan_summary?: string | null;
+  steps: Map<string, { title: string; description: string | null }>;
+}
+
+// Coalesce concurrent identical fills (plan_id:locale). A spinning client that
+// retries the GET, or React double-mounting the drawer, would otherwise fan out
+// into several redundant LLM calls for the same plan+locale; the first call's
+// promise is shared so they all resolve from one translation.
+const inflightFills = new Map<string, Promise<TranslateFill | null>>();
+
 /** All steps across the three kinds, flattened, preserving their ids. */
 function flattenSteps(plan: GoalPlanView): GoalPlanStep[] {
   return [...plan.milestones, ...plan.checkpoints, ...plan.habits];
@@ -162,6 +187,7 @@ export async function localizeGoalPlan(
   plan: GoalPlanView,
   sourceLang: string | null,
   targetLocaleRaw: string,
+  opts?: { deadlineMs?: number },
 ): Promise<GoalPlanView> {
   void sourceLang;
   const target = normalizeLocale(targetLocaleRaw);
@@ -187,46 +213,79 @@ export async function localizeGoalPlan(
     console.warn(`${LOG} cache read failed (continuing): ${e?.message}`);
   }
 
-  // 2. Determine what's missing and translate it in one shot.
+  // 2. Determine what's missing and translate it. The translation (one LLM call)
+  //    is the slow part; the plan rows are already in hand. So we DON'T let it
+  //    block the response past `opts.deadlineMs` when a deadline is given: we
+  //    return the best-available text now and let the translation finish in the
+  //    background, seeding the cache so the next view is an instant cache hit.
   const missingSteps = steps.filter((s) => !cachedSteps.has(s.id));
   const summaryMissing = cachedSummary === undefined && plan.plan_summary != null;
   if (missingSteps.length > 0 || summaryMissing) {
-    const translated = await translateBatch(
-      language,
-      REGISTER_HINT[target] ?? '',
-      summaryMissing ? plan.plan_summary : null,
-      missingSteps.map((s) => ({ id: s.id, title: s.title, description: s.description })),
-    );
-    if (translated) {
-      // Persist new translations to the cache (best-effort; never blocks the response).
-      try {
-        if (summaryMissing) {
-          cachedSummary = translated.plan_summary ?? plan.plan_summary;
-          await client
-            .from('goal_plan_i18n')
-            .upsert({ plan_id: plan.id, locale: target, plan_summary: cachedSummary }, { onConflict: 'plan_id,locale' });
-        }
-        const rows = missingSteps.map((s) => {
-          const tr = translated.steps[s.id];
-          const title = tr?.title ?? s.title;
-          const description = tr ? tr.description : s.description;
-          cachedSteps.set(s.id, { title, description });
-          return { step_id: s.id, locale: target, title, description };
-        });
-        if (rows.length > 0) {
-          await client.from('goal_plan_step_i18n').upsert(rows, { onConflict: 'step_id,locale' });
-        }
-      } catch (e: any) {
-        console.warn(`${LOG} cache write failed (non-fatal): ${e?.message}`);
-        // Still apply in-memory translations below even if caching failed.
-        if (summaryMissing && cachedSummary === undefined) cachedSummary = translated.plan_summary ?? plan.plan_summary;
+    const fillKey = `${plan.id}:${target}`;
+    let fill = inflightFills.get(fillKey);
+    if (!fill) {
+      fill = (async (): Promise<TranslateFill | null> => {
+        const translated = await translateBatch(
+          language,
+          REGISTER_HINT[target] ?? '',
+          summaryMissing ? plan.plan_summary : null,
+          missingSteps.map((s) => ({ id: s.id, title: s.title, description: s.description })),
+        );
+        if (!translated) return null;
+        const out: TranslateFill = { steps: new Map() };
+        if (summaryMissing) out.plan_summary = translated.plan_summary ?? plan.plan_summary;
         for (const s of missingSteps) {
-          if (!cachedSteps.has(s.id)) {
-            const tr = translated.steps[s.id];
-            cachedSteps.set(s.id, { title: tr?.title ?? s.title, description: tr ? tr.description : s.description });
-          }
+          const tr = translated.steps[s.id];
+          out.steps.set(s.id, { title: tr?.title ?? s.title, description: tr ? tr.description : s.description });
         }
+        // Persist to the cache (best-effort; a write failure still returns the
+        // in-memory translation so this view is localized, it just re-translates
+        // next time).
+        try {
+          if (out.plan_summary !== undefined) {
+            await client
+              .from('goal_plan_i18n')
+              .upsert({ plan_id: plan.id, locale: target, plan_summary: out.plan_summary }, { onConflict: 'plan_id,locale' });
+          }
+          const rows = [...out.steps].map(([step_id, v]) => ({ step_id, locale: target, title: v.title, description: v.description }));
+          if (rows.length > 0) {
+            await client.from('goal_plan_step_i18n').upsert(rows, { onConflict: 'step_id,locale' });
+          }
+        } catch (e: any) {
+          console.warn(`${LOG} cache write failed (non-fatal): ${e?.message}`);
+        }
+        return out;
+      })();
+      inflightFills.set(fillKey, fill);
+      // Drop the in-flight entry once settled, regardless of outcome.
+      void fill.catch(() => null).finally(() => {
+        if (inflightFills.get(fillKey) === fill) inflightFills.delete(fillKey);
+      });
+    }
+
+    const applyFill = (f: TranslateFill | null) => {
+      if (!f) return;
+      if (f.plan_summary !== undefined) cachedSummary = f.plan_summary;
+      for (const [id, v] of f.steps) cachedSteps.set(id, v);
+    };
+
+    const deadlineMs = opts?.deadlineMs;
+    if (deadlineMs && deadlineMs > 0) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<typeof TRANSLATE_TIMEOUT>((resolve) => {
+        timer = setTimeout(() => resolve(TRANSLATE_TIMEOUT), deadlineMs);
+      });
+      const winner = await Promise.race([fill.catch(() => null), timeout]);
+      if (timer) clearTimeout(timer);
+      if (winner === TRANSLATE_TIMEOUT) {
+        // Spinner would hang on a slow LLM round-trip — return source text now,
+        // let the shared fill finish caching for the next view.
+        console.log(`${LOG} translate exceeded ${deadlineMs}ms — serving source, caching in background (plan=${plan.id} locale=${target})`);
+      } else {
+        applyFill(winner);
       }
+    } else {
+      applyFill(await fill.catch(() => null));
     }
   }
 


### PR DESCRIPTION
## Problem

On iPhone, opening an **already-generated** plan in the My Journey "Your plan" drawer showed an endless loading spinner (see report screenshot).

## Root cause

`GET /api/v1/goal-plan` localizes the plan through `localizeGoalPlan`, which makes a **synchronous, blocking LLM translation call** (`translateBatch` — worker model, up to 12k tokens) on *any* per-locale i18n cache miss. The plan rows are already in the DB and could render instantly, but the HTTP response — and therefore the spinner — waits on the LLM.

A cache miss happens for:
- **Every plan generated before the i18n cache shipped (VTID-03152b)** — no seeded cache, so even a same-language view triggers a normalize-translation.
- **Any cross-language toggle** the first time.

On a phone, that slow round-trip is the "takes forever to display" symptom.

## Fix

Make plan **display** non-blocking on translation:

- **GET passes a 3.5s deadline.** If the translate-on-view call finishes within it → localized text is served (fast paths stay correct). If not → the best-available text (cached where present, source text otherwise) renders **immediately**, and the translation finishes in the **background**, seeding `goal_plan_i18n` / `goal_plan_step_i18n` so the next view is an instant cache hit.
- **Concurrent identical fills are coalesced** (`plan_id:locale`) so a retrying spinner or a double-mounted drawer can't fan out into several redundant LLM calls.

The common path (same-language, seeded cache) is unchanged — still a cache hit with **no** LLM call. Plan steps, dates, and progress are never touched; only the displayed wording is localized.

For legacy same-language plans (the reported case), the source text shown on a deadline timeout is *already* in the correct language, so there is no visible downside — just a fast first view plus a background cache seed.

## Testing

- `npm run build` — clean (TypeScript compiles).
- `jest test/services/journey/goal-planner-service.test.ts` — 3/3 pass.

## Notes

Frontend (separate Lovable app) needs no changes; the next natural load/toggle picks up the cached translation.

https://claude.ai/code/session_013kqyDvAkSkRWSMoaef4rNz

---
_Generated by [Claude Code](https://claude.ai/code/session_013kqyDvAkSkRWSMoaef4rNz)_