### PR TITLE
feat(eval): config-driven real candidate model + provenance-gated accuracy (BOOTSTRAP-SHADOW-REAL-CANDIDATE)

### DIFF
--- a/services/gateway/scripts/eval/canary-readiness-report.ts
+++ b/services/gateway/scripts/eval/canary-readiness-report.ts
@@ -79,6 +79,11 @@ interface ShadowReport {
     labeled_comparisons?: number;
     primary_accuracy?: number | null;
     candidate_accuracy?: number | null;
+    // Real-model-only accuracy (excludes simulated_models=true). The gate keys
+    // off these so a candidate never graduates on simulated evidence.
+    real_labeled_comparisons?: number;
+    real_primary_accuracy?: number | null;
+    real_candidate_accuracy?: number | null;
   }>;
 }
 
@@ -120,18 +125,19 @@ function reason(rule: string, ok: boolean, detail: string): Reason {
  *   - Otherwise → PASS with the numbers.
  */
 function accuracyReason(
-  rollup: Pick<ShadowReport['features'][number], 'labeled_comparisons' | 'primary_accuracy' | 'candidate_accuracy'> | null,
+  rollup: Pick<ShadowReport['features'][number], 'real_labeled_comparisons' | 'real_primary_accuracy' | 'real_candidate_accuracy'> | null,
   thresholds: Pick<typeof THRESHOLDS, 'min_labeled_comparisons' | 'min_candidate_accuracy' | 'max_accuracy_regression'> = THRESHOLDS,
 ): Reason {
-  const labeled = rollup?.labeled_comparisons ?? 0;
-  const candAcc = rollup?.candidate_accuracy ?? null;
-  const primAcc = rollup?.primary_accuracy ?? null;
+  // Real-model evidence ONLY — simulated comparisons never graduate a candidate.
+  const labeled = rollup?.real_labeled_comparisons ?? 0;
+  const candAcc = rollup?.real_candidate_accuracy ?? null;
+  const primAcc = rollup?.real_primary_accuracy ?? null;
 
   if (labeled < thresholds.min_labeled_comparisons || candAcc === null) {
     return reason(
       'candidate_accuracy',
       false,
-      `Only ${labeled} corpus-grounded comparisons (need ${thresholds.min_labeled_comparisons}). Run EXERCISE-STAGING-SHADOW with source=golden-corpus, or wait for labeled organic turns, to score accuracy vs ground truth.`,
+      `Only ${labeled} REAL (non-simulated) corpus-grounded comparisons (need ${thresholds.min_labeled_comparisons}). Deploy the fine-tuned candidate to a Vertex endpoint (set CANDIDATE_ENDPOINT__voice_tool_router) and run EXERCISE-STAGING-SHADOW with source=golden-corpus — simulated comparisons do not count toward readiness.`,
     );
   }
   if (candAcc < thresholds.min_candidate_accuracy) {

--- a/services/gateway/src/routes/admin-staging.ts
+++ b/services/gateway/src/routes/admin-staging.ts
@@ -28,6 +28,7 @@ import { isStaging } from '../env';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import { runWithShadowAwaitable } from '../services/llm-router-shadow';
 import { accuracyRollup } from '../services/shadow-accuracy';
+import { candidateEndpointFor, vertexPredictToolName } from '../services/candidate-model-provider';
 
 const router = Router();
 
@@ -205,6 +206,11 @@ interface ShadowFeatureRollup {
   labeled_comparisons: number;
   primary_accuracy: number | null;
   candidate_accuracy: number | null;
+  // Real-model-only accuracy (excludes simulated_models=true) — what the
+  // canary-readiness gate graduates on (BOOTSTRAP-SHADOW-REAL-CANDIDATE).
+  real_labeled_comparisons: number;
+  real_primary_accuracy: number | null;
+  real_candidate_accuracy: number | null;
 }
 
 function percentile(sorted: number[], p: number): number {
@@ -251,7 +257,7 @@ function rollupFeature(feature: string, rows: ShadowEventRow[]): ShadowFeatureRo
   const ratedTotal = agreed + mismatched;
   // Ground-truth accuracy over labeled (golden-corpus) comparisons in this
   // feature bucket. Pure helper, shared with the shadow primitive's scorer.
-  const acc = accuracyRollup(rows.map((r) => (r.metadata ?? {}) as { primary_correct?: unknown; candidate_correct?: unknown }));
+  const acc = accuracyRollup(rows.map((r) => (r.metadata ?? {}) as { primary_correct?: unknown; candidate_correct?: unknown; simulated_models?: unknown }));
   return {
     feature,
     total_comparisons: total,
@@ -268,6 +274,9 @@ function rollupFeature(feature: string, rows: ShadowEventRow[]): ShadowFeatureRo
     labeled_comparisons: acc.labeled_comparisons,
     primary_accuracy: acc.primary_accuracy,
     candidate_accuracy: acc.candidate_accuracy,
+    real_labeled_comparisons: acc.real_labeled_comparisons,
+    real_primary_accuracy: acc.real_primary_accuracy,
+    real_candidate_accuracy: acc.real_candidate_accuracy,
   };
 }
 
@@ -473,6 +482,23 @@ router.post(
       // deterministically *different* (wrong) tool when simulating a miss.
       const toolPool = Array.from(new Set(turns.map((t) => t.expected_tool)));
 
+      // G4 (BOOTSTRAP-SHADOW-REAL-CANDIDATE): resolve the candidate source once.
+      // When CANDIDATE_ENDPOINT__voice_tool_router is set, the candidate is the
+      // REAL fine-tuned model on Vertex (simulated_models=false); otherwise we
+      // fall back to the deterministic simulation below, tagged honestly so the
+      // accuracy gate never graduates on simulated evidence. The fallback is
+      // logged (not silent).
+      const candidateEndpoint = candidateEndpointFor(feature);
+      const candidateSimulated = candidateEndpoint === null;
+      const candidateSource: 'vertex_endpoint' | 'simulation' =
+        candidateEndpoint ? 'vertex_endpoint' : 'simulation';
+      if (candidateSimulated) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[admin-staging corpus exerciser] feature='${feature}' candidate=SIMULATION — CANDIDATE_ENDPOINT__${feature.replace(/[^a-z0-9]+/gi, '_').toLowerCase()} unset`,
+        );
+      }
+
       const started = Date.now();
       let emitted = 0;
       let primaryCorrect = 0;
@@ -498,6 +524,12 @@ router.post(
         const primaryDelay = 80 + hashIdx(`${seed}:p-delay`, i, 100);
         const candidateDelay = 60 + hashIdx(`${seed}:c-delay`, i, 160);
 
+        // Capture the candidate's ACTUAL decision so the response summary is
+        // honest for both the real-endpoint and simulation paths (the
+        // per-turn eval.shadow.compared events remain the authoritative source
+        // the report endpoint aggregates).
+        let candTool: string | null = null;
+        let candErrored = false;
         const { shadowDone } = await runWithShadowAwaitable({
           feature,
           input: { text: t.user_input, exerciser_source: exerciserSource } as Record<string, unknown>,
@@ -506,15 +538,25 @@ router.post(
             return { tool_name: primaryTool };
           },
           candidate: async () => {
+            if (candidateEndpoint) {
+              const out = await vertexPredictToolName(candidateEndpoint, t.user_input);
+              candTool = out.tool_name;
+              return out;
+            }
             await new Promise((r) => setTimeout(r, candidateDelay));
-            if (candidateWillError) throw new Error('synthetic candidate error (corpus exerciser)');
+            if (candidateWillError) {
+              candErrored = true;
+              throw new Error('synthetic candidate error (corpus exerciser)');
+            }
+            candTool = candidateTool;
             return { tool_name: candidateTool };
           },
           extractKey: (out) => (out as { tool_name?: string }).tool_name ?? null,
           groundTruthKey: expected,
           labels: {
             corpus_grounded: true,
-            simulated_models: true,
+            simulated_models: candidateSimulated,
+            candidate_source: candidateSource,
             exerciser_source: exerciserSource,
             fixture_id: t.fixture_id,
             corpus_turn: t.turn,
@@ -525,8 +567,8 @@ router.post(
 
         emitted++;
         if (primaryTool === expected) primaryCorrect++;
-        if (!candidateWillError && candidateTool === expected) candidateCorrect++;
-        if (candidateWillError) candidateErrors++;
+        if (!candErrored && candTool === expected) candidateCorrect++;
+        if (candErrored) candidateErrors++;
         if (sample.length < 5) {
           sample.push({
             fixture_id: t.fixture_id,
@@ -534,9 +576,9 @@ router.post(
             input: t.user_input,
             expected,
             primary: primaryTool,
-            candidate: candidateWillError ? '(error)' : candidateTool,
+            candidate: candErrored ? '(error)' : (candTool ?? '(null)'),
             primary_ok: primaryTool === expected,
-            candidate_ok: !candidateWillError && candidateTool === expected,
+            candidate_ok: !candErrored && candTool === expected,
           });
         }
       }
@@ -552,7 +594,8 @@ router.post(
           env: 'staging',
           exerciser_source: exerciserSource,
           corpus_grounded: true,
-          simulated_models: true,
+          simulated_models: candidateSimulated,
+          candidate_source: candidateSource,
           is_exerciser_rollup: true,
           seed,
           feature,

--- a/services/gateway/src/services/candidate-model-provider.ts
+++ b/services/gateway/src/services/candidate-model-provider.ts
@@ -1,0 +1,155 @@
+/**
+ * Candidate-model provider — BOOTSTRAP-SHADOW-REAL-CANDIDATE (Day-4 G4).
+ *
+ * The shadow harness (`llm-router-shadow.ts`) takes a caller-supplied
+ * `candidate: () => Promise<TOutput>` closure. Until now every call site
+ * hardcoded a deterministic SIMULATION of the fine-tuned model (tagged
+ * `simulated_models: true`) because the real candidate isn't reachable from the
+ * gateway request path. This module turns that hardcoded simulation into a
+ * config-driven seam:
+ *
+ *   - When a Vertex endpoint is configured for the feature
+ *     (`CANDIDATE_ENDPOINT__<feature>`), the candidate is the REAL fine-tuned
+ *     model served there → provenance `vertex_endpoint`, `simulated_models:false`.
+ *   - Otherwise it falls back to an explicit, caller-supplied simulation →
+ *     provenance `simulation`, `simulated_models:true`. The fallback is LOGGED,
+ *     never silent (CLAUDE.md: "Never allow silent model fallback").
+ *
+ * The `simulated_models` flag is the load-bearing part: the canary-readiness
+ * accuracy gate must refuse to graduate a candidate on simulated evidence, so
+ * every emitted comparison has to carry honest provenance. Wiring the real
+ * model later is now a deploy + one env var — "only the candidate closure
+ * changes", exactly as the shadow harness was designed for.
+ */
+
+/** The comparable output of a tool-routing turn (matches the shadow extractKey). */
+export interface ToolChoice {
+  tool_name: string | null;
+}
+
+export interface CandidateProvenance {
+  /** Where the candidate decision came from. */
+  candidate_source: 'vertex_endpoint' | 'simulation';
+  /** True when the candidate is NOT a real model — gate must not graduate on these. */
+  simulated_models: boolean;
+  /** The resolved endpoint, when real. */
+  endpoint?: string;
+}
+
+export interface CandidateRunner {
+  run: (input: { text: string }) => Promise<ToolChoice>;
+  provenance: CandidateProvenance;
+}
+
+/** Env var that names the Vertex endpoint for a feature's candidate model. */
+export function candidateEnvKey(feature: string): string {
+  return `CANDIDATE_ENDPOINT__${feature.replace(/[^a-z0-9]+/gi, '_').toLowerCase()}`;
+}
+
+/** Resolve the configured candidate endpoint for a feature, or null. */
+export function candidateEndpointFor(
+  feature: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const v = env[candidateEnvKey(feature)];
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : null;
+}
+
+/**
+ * Default predictor: POST the turn text to a Vertex-served fine-tune and read
+ * back the chosen tool. The serving contract is intentionally tolerant — it
+ * accepts the common Vertex `{ predictions: [...] }` envelope and reads
+ * `tool_name` (or `tool_call.name`) off the first prediction, falling back to a
+ * bare `{ tool_name }` body. Auth: an optional bearer from
+ * `CANDIDATE_ENDPOINT_TOKEN` (on Cloud Run the real wiring swaps this for ADC;
+ * the transport stays the same). Injectable `fetchImpl` keeps it unit-testable.
+ */
+export async function vertexPredictToolName(
+  endpoint: string,
+  text: string,
+  opts: { fetchImpl?: typeof fetch; token?: string; timeoutMs?: number } = {},
+): Promise<ToolChoice> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const token = opts.token ?? process.env.CANDIDATE_ENDPOINT_TOKEN;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 8000);
+  try {
+    const resp = await doFetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ instances: [{ text }] }),
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`candidate endpoint HTTP ${resp.status}`);
+    }
+    const body = (await resp.json()) as unknown;
+    return { tool_name: extractToolName(body) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Tolerant tool-name extraction from a prediction body. */
+export function extractToolName(body: unknown): string | null {
+  if (!body || typeof body !== 'object') return null;
+  const b = body as Record<string, unknown>;
+  const first = Array.isArray(b.predictions) ? b.predictions[0] : b;
+  if (!first || typeof first !== 'object') return null;
+  const p = first as Record<string, unknown>;
+  if (typeof p.tool_name === 'string' && p.tool_name.length > 0) return p.tool_name;
+  const tc = p.tool_call;
+  if (tc && typeof tc === 'object' && typeof (tc as Record<string, unknown>).name === 'string') {
+    return (tc as { name: string }).name;
+  }
+  return null;
+}
+
+export interface ResolveOpts {
+  env?: NodeJS.ProcessEnv;
+  /** Injectable predictor (tests / custom transport). Defaults to vertexPredictToolName. */
+  predict?: (endpoint: string, text: string) => Promise<ToolChoice>;
+  /** Explicit simulation fallback when no real endpoint is configured. */
+  simulation?: (input: { text: string }) => Promise<ToolChoice>;
+  /** Called when falling back to simulation — for non-silent logging. */
+  onFallback?: (feature: string, reason: string) => void;
+}
+
+function defaultOnFallback(feature: string, reason: string): void {
+  // eslint-disable-next-line no-console
+  console.warn(`[candidate-model-provider] feature='${feature}' candidate=SIMULATION — ${reason}`);
+}
+
+/**
+ * Resolve the candidate runner for a feature. Real model when an endpoint is
+ * configured; otherwise the supplied simulation with honest provenance and a
+ * logged (never silent) fallback. Throws when neither is available rather than
+ * fabricating a candidate.
+ */
+export function resolveCandidateRunner(feature: string, opts: ResolveOpts = {}): CandidateRunner {
+  const env = opts.env ?? process.env;
+  const endpoint = candidateEndpointFor(feature, env);
+
+  if (endpoint) {
+    const predict = opts.predict ?? ((ep: string, text: string) => vertexPredictToolName(ep, text));
+    return {
+      run: (input) => predict(endpoint, input.text),
+      provenance: { candidate_source: 'vertex_endpoint', simulated_models: false, endpoint },
+    };
+  }
+
+  const reason = `no candidate endpoint configured (${candidateEnvKey(feature)} unset)`;
+  (opts.onFallback ?? defaultOnFallback)(feature, reason);
+  if (!opts.simulation) {
+    throw new Error(
+      `candidate-model-provider: ${reason} and no simulation fallback supplied for '${feature}'`,
+    );
+  }
+  return {
+    run: opts.simulation,
+    provenance: { candidate_source: 'simulation', simulated_models: true },
+  };
+}

--- a/services/gateway/src/services/shadow-accuracy.ts
+++ b/services/gateway/src/services/shadow-accuracy.ts
@@ -55,33 +55,61 @@ export interface AccuracyRollup {
   primary_accuracy: number | null;
   /** Share of labeled comparisons (with a non-null candidate_correct) where the candidate matched. null when none. */
   candidate_accuracy: number | null;
+  // ── Real-model-only view (BOOTSTRAP-SHADOW-REAL-CANDIDATE, Day-4 G5) ──
+  // Identical to the above but EXCLUDING rows tagged `simulated_models: true`.
+  // The canary gate keys off these so a candidate can never graduate on
+  // simulated evidence — simulated comparisons still count toward display
+  // accuracy but NOT toward readiness.
+  /** Labeled comparisons from a REAL candidate model (simulated_models !== true). */
+  real_labeled_comparisons: number;
+  /** Primary accuracy over real-candidate labeled comparisons. null when none. */
+  real_primary_accuracy: number | null;
+  /** Candidate accuracy over real-candidate labeled comparisons. null when none. */
+  real_candidate_accuracy: number | null;
 }
 
-/** Minimal row shape — just the two correctness flags from event metadata. */
+/** Minimal row shape — the correctness flags + provenance from event metadata. */
 export interface ScoredRow {
   primary_correct?: unknown;
   candidate_correct?: unknown;
+  /** When strictly true, the candidate was a simulation — excluded from real_* counts. */
+  simulated_models?: unknown;
 }
 
 /**
  * Roll a set of scored events into a feature-level accuracy. Rows without a
  * boolean `primary_correct` are ignored (unlabeled shadow traffic), so this is
- * safe to run over a mixed stream of labeled + unlabeled comparisons.
+ * safe to run over a mixed stream of labeled + unlabeled comparisons. Rows
+ * tagged `simulated_models: true` count toward the display accuracy but are
+ * excluded from the `real_*` fields the readiness gate consumes.
  */
 export function accuracyRollup(rows: ScoredRow[]): AccuracyRollup {
   let labeled = 0;
   let primaryHits = 0;
   let candidateLabeled = 0;
   let candidateHits = 0;
+  let realLabeled = 0;
+  let realPrimaryHits = 0;
+  let realCandidateLabeled = 0;
+  let realCandidateHits = 0;
 
   for (const r of rows) {
+    const real = r.simulated_models !== true;
     if (typeof r.primary_correct === 'boolean') {
       labeled++;
       if (r.primary_correct) primaryHits++;
+      if (real) {
+        realLabeled++;
+        if (r.primary_correct) realPrimaryHits++;
+      }
     }
     if (typeof r.candidate_correct === 'boolean') {
       candidateLabeled++;
       if (r.candidate_correct) candidateHits++;
+      if (real) {
+        realCandidateLabeled++;
+        if (r.candidate_correct) realCandidateHits++;
+      }
     }
   }
 
@@ -89,5 +117,8 @@ export function accuracyRollup(rows: ScoredRow[]): AccuracyRollup {
     labeled_comparisons: labeled,
     primary_accuracy: labeled > 0 ? primaryHits / labeled : null,
     candidate_accuracy: candidateLabeled > 0 ? candidateHits / candidateLabeled : null,
+    real_labeled_comparisons: realLabeled,
+    real_primary_accuracy: realLabeled > 0 ? realPrimaryHits / realLabeled : null,
+    real_candidate_accuracy: realCandidateLabeled > 0 ? realCandidateHits / realCandidateLabeled : null,
   };
 }

--- a/services/gateway/test/candidate-model-provider.test.ts
+++ b/services/gateway/test/candidate-model-provider.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Candidate-model provider (BOOTSTRAP-SHADOW-REAL-CANDIDATE, Day-4 G4).
+ *
+ * The shadow candidate must be the REAL fine-tuned model when an endpoint is
+ * configured, and an HONESTLY-TAGGED simulation otherwise — never a silent
+ * fallback, and never simulated evidence masquerading as real. These pin that.
+ */
+process.env.NODE_ENV = 'test';
+
+import {
+  candidateEnvKey,
+  candidateEndpointFor,
+  extractToolName,
+  vertexPredictToolName,
+  resolveCandidateRunner,
+  type ToolChoice,
+} from '../src/services/candidate-model-provider';
+
+describe('candidate endpoint resolution', () => {
+  test('env key is feature-namespaced and normalized', () => {
+    expect(candidateEnvKey('voice-tool-router')).toBe('CANDIDATE_ENDPOINT__voice_tool_router');
+    expect(candidateEnvKey('intent-kind')).toBe('CANDIDATE_ENDPOINT__intent_kind');
+  });
+
+  test('returns the endpoint when set, null when unset/blank', () => {
+    expect(candidateEndpointFor('voice-tool-router', { CANDIDATE_ENDPOINT__voice_tool_router: 'https://ep' })).toBe('https://ep');
+    expect(candidateEndpointFor('voice-tool-router', {})).toBeNull();
+    expect(candidateEndpointFor('voice-tool-router', { CANDIDATE_ENDPOINT__voice_tool_router: '   ' })).toBeNull();
+  });
+});
+
+describe('extractToolName — tolerant parsing', () => {
+  test('reads tool_name off a Vertex predictions envelope', () => {
+    expect(extractToolName({ predictions: [{ tool_name: 'get_weather' }] })).toBe('get_weather');
+  });
+  test('reads tool_call.name fallback', () => {
+    expect(extractToolName({ predictions: [{ tool_call: { name: 'send_message' } }] })).toBe('send_message');
+  });
+  test('reads a bare prediction body', () => {
+    expect(extractToolName({ tool_name: 'open_app' })).toBe('open_app');
+  });
+  test('returns null on junk / empty', () => {
+    expect(extractToolName({ predictions: [{}] })).toBeNull();
+    expect(extractToolName(null)).toBeNull();
+    expect(extractToolName('nope')).toBeNull();
+  });
+});
+
+describe('vertexPredictToolName', () => {
+  test('posts text and extracts the predicted tool', async () => {
+    let captured: { url: string; body: unknown } | null = null;
+    const fakeFetch = (async (url: string, init: { body: string }) => {
+      captured = { url, body: JSON.parse(init.body) };
+      return { ok: true, json: async () => ({ predictions: [{ tool_name: 'get_today_plan' }] }) };
+    }) as unknown as typeof fetch;
+    const out = await vertexPredictToolName('https://ep/predict', 'what is on today', { fetchImpl: fakeFetch });
+    expect(out.tool_name).toBe('get_today_plan');
+    expect(captured!.url).toBe('https://ep/predict');
+    expect(captured!.body).toEqual({ instances: [{ text: 'what is on today' }] });
+  });
+
+  test('throws on non-ok HTTP so the shadow harness records a candidate error', async () => {
+    const fakeFetch = (async () => ({ ok: false, status: 503, json: async () => ({}) })) as unknown as typeof fetch;
+    await expect(vertexPredictToolName('https://ep', 'hi', { fetchImpl: fakeFetch })).rejects.toThrow(/HTTP 503/);
+  });
+});
+
+describe('resolveCandidateRunner', () => {
+  test('endpoint set → real runner, simulated_models=false, calls predict', async () => {
+    const calls: string[] = [];
+    const predict = async (ep: string, text: string): Promise<ToolChoice> => {
+      calls.push(`${ep}::${text}`);
+      return { tool_name: 'real_tool' };
+    };
+    const runner = resolveCandidateRunner('voice-tool-router', {
+      env: { CANDIDATE_ENDPOINT__voice_tool_router: 'https://real' },
+      predict,
+    });
+    expect(runner.provenance).toEqual({ candidate_source: 'vertex_endpoint', simulated_models: false, endpoint: 'https://real' });
+    const out = await runner.run({ text: 'hello' });
+    expect(out.tool_name).toBe('real_tool');
+    expect(calls).toEqual(['https://real::hello']);
+  });
+
+  test('no endpoint + simulation → simulation provenance + logged (non-silent) fallback', async () => {
+    const fellBack: string[] = [];
+    const runner = resolveCandidateRunner('voice-tool-router', {
+      env: {},
+      simulation: async () => ({ tool_name: 'sim_tool' }),
+      onFallback: (f, reason) => fellBack.push(`${f}:${reason}`),
+    });
+    expect(runner.provenance.simulated_models).toBe(true);
+    expect(runner.provenance.candidate_source).toBe('simulation');
+    expect(fellBack).toHaveLength(1);
+    expect(fellBack[0]).toMatch(/CANDIDATE_ENDPOINT__voice_tool_router unset/);
+    expect((await runner.run({ text: 'x' })).tool_name).toBe('sim_tool');
+  });
+
+  test('no endpoint + no simulation → throws rather than fabricating a candidate', () => {
+    expect(() => resolveCandidateRunner('voice-tool-router', { env: {}, onFallback: () => {} })).toThrow(/no simulation fallback/);
+  });
+});

--- a/services/gateway/test/eval-canary-accuracy.test.ts
+++ b/services/gateway/test/eval-canary-accuracy.test.ts
@@ -13,38 +13,38 @@ import { accuracyReason } from '../scripts/eval/canary-readiness-report';
 
 describe('canary readiness — candidate_accuracy gate', () => {
   test('blocks when there are too few corpus-grounded comparisons', () => {
-    const r = accuracyReason({ labeled_comparisons: 10, primary_accuracy: 1, candidate_accuracy: 0.95 });
+    const r = accuracyReason({ real_labeled_comparisons: 10, real_primary_accuracy: 1, real_candidate_accuracy: 0.95 });
     expect(r.rule).toBe('candidate_accuracy');
     expect(r.ok).toBe(false);
     expect(r.detail).toMatch(/corpus-grounded comparisons/);
   });
 
   test('blocks when candidate has no labeled accuracy at all (null)', () => {
-    const r = accuracyReason({ labeled_comparisons: 80, primary_accuracy: 0.9, candidate_accuracy: null });
+    const r = accuracyReason({ real_labeled_comparisons: 80, real_primary_accuracy: 0.9, real_candidate_accuracy: null });
     expect(r.ok).toBe(false);
   });
 
   test('blocks a below-floor candidate', () => {
-    const r = accuracyReason({ labeled_comparisons: 80, primary_accuracy: 0.95, candidate_accuracy: 0.80 });
+    const r = accuracyReason({ real_labeled_comparisons: 80, real_primary_accuracy: 0.95, real_candidate_accuracy: 0.80 });
     expect(r.ok).toBe(false);
     expect(r.detail).toMatch(/floor/);
   });
 
   test('blocks a candidate that regresses materially below primary', () => {
     // candidate 0.88 is above the 0.85 floor but >5pp below primary 0.97
-    const r = accuracyReason({ labeled_comparisons: 80, primary_accuracy: 0.97, candidate_accuracy: 0.88 });
+    const r = accuracyReason({ real_labeled_comparisons: 80, real_primary_accuracy: 0.97, real_candidate_accuracy: 0.88 });
     expect(r.ok).toBe(false);
     expect(r.detail).toMatch(/regress/);
   });
 
   test('passes a strong candidate over enough labeled turns', () => {
-    const r = accuracyReason({ labeled_comparisons: 60, primary_accuracy: 0.90, candidate_accuracy: 0.92 });
+    const r = accuracyReason({ real_labeled_comparisons: 60, real_primary_accuracy: 0.90, real_candidate_accuracy: 0.92 });
     expect(r.ok).toBe(true);
     expect(r.detail).toMatch(/92.0%/);
   });
 
   test('passes when candidate meets the floor and primary is unknown', () => {
-    const r = accuracyReason({ labeled_comparisons: 60, primary_accuracy: null, candidate_accuracy: 0.86 });
+    const r = accuracyReason({ real_labeled_comparisons: 60, real_primary_accuracy: null, real_candidate_accuracy: 0.86 });
     expect(r.ok).toBe(true);
   });
 
@@ -53,7 +53,7 @@ describe('canary readiness — candidate_accuracy gate', () => {
   });
 
   test('a candidate exactly at the floor passes', () => {
-    const r = accuracyReason({ labeled_comparisons: 50, primary_accuracy: 0.85, candidate_accuracy: 0.85 });
+    const r = accuracyReason({ real_labeled_comparisons: 50, real_primary_accuracy: 0.85, real_candidate_accuracy: 0.85 });
     expect(r.ok).toBe(true);
   });
 });

--- a/services/gateway/test/eval-shadow-corpus.test.ts
+++ b/services/gateway/test/eval-shadow-corpus.test.ts
@@ -74,7 +74,28 @@ describe('accuracyRollup', () => {
 
   test('no labeled rows → null accuracy, zero labeled', () => {
     const acc = accuracyRollup([{ agreement: false }, {}]);
-    expect(acc).toEqual({ labeled_comparisons: 0, primary_accuracy: null, candidate_accuracy: null });
+    expect(acc).toEqual({
+      labeled_comparisons: 0, primary_accuracy: null, candidate_accuracy: null,
+      real_labeled_comparisons: 0, real_primary_accuracy: null, real_candidate_accuracy: null,
+    });
+  });
+
+  test('simulated rows count toward display accuracy but NOT real_* (gate safety)', () => {
+    const acc = accuracyRollup([
+      // two simulated labeled comparisons (both candidate-correct)
+      { primary_correct: true, candidate_correct: true, simulated_models: true },
+      { primary_correct: true, candidate_correct: true, simulated_models: true },
+      // one REAL labeled comparison (candidate wrong)
+      { primary_correct: true, candidate_correct: false, simulated_models: false },
+    ]);
+    // Display view sees all three.
+    expect(acc.labeled_comparisons).toBe(3);
+    expect(acc.candidate_accuracy).toBeCloseTo(2 / 3);
+    // Real view sees only the one non-simulated row — so the gate can't be
+    // fooled by simulated candidate accuracy.
+    expect(acc.real_labeled_comparisons).toBe(1);
+    expect(acc.real_primary_accuracy).toBe(1);
+    expect(acc.real_candidate_accuracy).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

**Day-4 G4 + the safety half of G5.** The shadow harness was built so that *"only the candidate closure changes"* when a real fine-tuned model is wired in — but every call site still hardcoded a deterministic **simulation** tagged `simulated_models: true`. This PR turns the candidate into a **config-driven seam** and makes the canary gate **refuse to graduate on simulated evidence**.

## G4 — real candidate seam

- **`candidate-model-provider.ts`** (new): `resolveCandidateRunner(feature)` returns the **real** fine-tuned model on a Vertex endpoint when `CANDIDATE_ENDPOINT__<feature>` is set (`provenance: vertex_endpoint`, `simulated_models: false`), else an **explicit, logged (never silent)** simulation fallback. `vertexPredictToolName()` is a tolerant, injectable-fetch predict client. Throws rather than fabricating a candidate when neither is available.
- **`admin-staging` corpus exerciser**: the candidate closure now calls the real endpoint when configured; otherwise the existing simulation, tagged honestly (`simulated_models` + `candidate_source`) from provenance. The per-turn candidate decision is captured so the response summary is honest on both paths.

## G5 (safety) — provenance-gated accuracy

- **`shadow-accuracy.accuracyRollup`** now also computes `real_labeled_comparisons` / `real_primary_accuracy` / `real_candidate_accuracy`, **excluding `simulated_models: true` rows**. Simulated comparisons still count toward *display* accuracy but never toward *readiness*.
- The **shadow-comparison-report** feature rollup surfaces the `real_*` fields.
- The **canary-readiness gate** (`accuracyReason`) keys off `real_*` — a candidate can no longer graduate on simulated evidence; the blocker message tells the operator to deploy the candidate endpoint.

## Why it's safe to merge

**Env-gated and additive.** With `CANDIDATE_ENDPOINT__*` unset, behavior is byte-identical to today (simulation), so there's no runtime regression. Wiring the real model later is a deploy + one env var. The accuracy fields are additive; the gate only gets *stricter* (real evidence required).

## Verification

- `tsc --noEmit` clean.
- **44/44** tests across `candidate-model-provider`, `eval-canary-accuracy`, `eval-shadow-corpus`, and the shadow suites — including a new test pinning that **simulated rows are excluded from `real_*`** (the gate can't be fooled by simulated candidate accuracy).

## Follow-up (tracked, not in scope)

The remaining G5 pieces to make a `READY_FOR_CANARY` verdict actually *reachable*: wiring `consecutive_clean_days` history (daily-snapshot store) and accumulating real-traffic shadow volume (≥200). Both are conservative-by-omission today (gate stays `NOT_READY`).

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_