### PR TITLE
fix(nav): route "Health Supplements" to the Health tracker, not the marketplace

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -805,6 +805,30 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     },
   },
   {
+    // VTID-NAV-HEALTH-SUPP: the personal supplement TRACKER inside the Health
+    // hub (Health → Supplements mode), reached via /health?mode=supplements.
+    // Distinct from DISCOVER.SUPPLEMENTS (the marketplace/shop). "Health
+    // supplements", "my supplements", "my stack" must land HERE, not the shop.
+    screen_id: 'HEALTH.SUPPLEMENTS',
+    route: '/health?mode=supplements',
+    category: 'health',
+    access: 'authenticated',
+    anonymous_safe: false,
+    aliases: ['health-supplements', 'my-supplements', 'supplement-tracker', 'my-stack', 'supplement-stack', 'vitamin-tracker', 'meine-supplements', 'meine-nahrungsergaenzung'],
+    i18n: {
+      en: {
+        title: 'My Supplements',
+        description: 'Track the supplements, vitamins, and minerals you take.',
+        when_to_visit: "When the user wants to view, track, log, or manage THEIR OWN supplements — their supplement stack, the vitamins or minerals THEY take, the 'health supplements' tracker, or add a supplement to their regimen. This is the personal health tracker, NOT shopping the marketplace.",
+      },
+      de: {
+        title: 'Meine Nahrungsergänzung',
+        description: 'Verfolge die Nahrungsergänzungsmittel, Vitamine und Mineralien, die du nimmst.',
+        when_to_visit: 'Wenn der Nutzer SEINE EIGENEN Nahrungsergänzungsmittel ansehen, verfolgen, protokollieren oder verwalten möchte — seinen Supplement-Stack, die Vitamine oder Mineralien, die er nimmt, den "Gesundheits-Supplement"-Tracker, oder ein Supplement zu seiner Routine hinzufügen. Das ist der persönliche Gesundheits-Tracker, NICHT der Marktplatz-Einkauf.',
+      },
+    },
+  },
+  {
     screen_id: 'HEALTH.MY_BIOLOGY',
     route: '/health/my-biology',
     category: 'health',
@@ -909,16 +933,17 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     category: 'discover',
     access: 'authenticated',
     anonymous_safe: false,
+    aliases: ['shop-supplements', 'buy-supplements', 'supplement-shop', 'supplement-store', 'browse-supplements'],
     i18n: {
       en: {
         title: 'Supplements',
         description: 'Curated supplements for longevity and wellness.',
-        when_to_visit: 'When the user asks about supplements, vitamins, minerals, nutraceuticals, or what to take for their health.',
+        when_to_visit: 'When the user wants to browse, show, shop for, or buy supplements, vitamins, minerals, or nutraceuticals in the marketplace — exploring available products, brands, or deals. NOT for tracking the supplements they personally take (that is HEALTH.SUPPLEMENTS).',
       },
       de: {
         title: 'Nahrungsergänzungsmittel',
         description: 'Kuratierte Nahrungsergänzungsmittel für Longevity und Wellness.',
-        when_to_visit: 'Wenn der Nutzer nach Nahrungsergänzungsmitteln, Vitaminen, Mineralien, Nutraceuticals oder dem, was er für seine Gesundheit nehmen sollte, fragt.',
+        when_to_visit: 'Wenn der Nutzer Nahrungsergänzungsmittel, Vitamine, Mineralien oder Nutraceuticals im Marktplatz durchstöbern, ansehen oder kaufen möchte — verfügbare Produkte, Marken oder Angebote erkunden. NICHT zum Verfolgen der Supplements, die er selbst einnimmt (das ist HEALTH.SUPPLEMENTS).',
       },
     },
   },

--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -933,6 +933,11 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     category: 'discover',
     access: 'authenticated',
     anonymous_safe: false,
+    // Canonical destination for a GENERIC "supplements" / "show me supplements"
+    // query — the marketplace wins the tie against HEALTH.SUPPLEMENTS (the
+    // personal tracker), which only wins when the user qualifies it ("health
+    // supplements", "my supplements") via the multi-token coverage bonus.
+    priority: 1,
     aliases: ['shop-supplements', 'buy-supplements', 'supplement-shop', 'supplement-store', 'browse-supplements'],
     i18n: {
       en: {


### PR DESCRIPTION
## Problem

"Take me to the **Health Supplements** screen" navigated to the wrong screen — the **Discover/Marketplace** supplements shop (`/discover/supplements`) instead of the **Health → Supplements** tracker.

OASIS logs confirm it (13:20:27): `orb.navigator.consulted` → "confidence=**high**, primary=**DISCOVER.SUPPLEMENTS**" → dispatched `/discover/supplements`.

**Root cause:**
1. `DISCOVER.SUPPLEMENTS` was the *only* supplements destination in the catalog.
2. Its `when_to_visit` was broad and ended with *"...or what to take **for their health**"* — directly pulling in "health supplements".
3. There was **no** catalog destination for the Health → Supplements tracker (it's a local `mobileTab` in `Health.tsx`, not deep-linkable).

## Change (`navigation-catalog.ts`)

- **Add `HEALTH.SUPPLEMENTS`** → `/health?mode=supplements` (the personal supplement tracker). `when_to_visit` scoped to viewing/tracking/logging **one's own** supplements / "health supplements" / supplement stack. Aliases: `health-supplements`, `my-supplements`, `supplement-tracker`, `my-stack`, …
- **Tighten `DISCOVER.SUPPLEMENTS`** `when_to_visit` to marketplace/shopping intent (browse / show / shop / buy) and add `shop-*` aliases — while keeping generic "show me supplements" on it (existing test at line 218 still holds).

`/health` still resolves to `HEALTH.OVERVIEW` (the new entry's route normalizes to `/health` but `HEALTH.OVERVIEW` is defined first / first-write-wins in `BY_ROUTE`).

## Companion change

Requires **exafyltd/vitana-v1** (same branch): `Health.tsx` reads `?mode=` and opens the matching mode tab.

> Same "already-there" dedup caveat as the Support fix: reliable when navigating to Health from another screen.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_