### PR TITLE
feat(feedback): distinct human-only Support queue (surface=support)

### DIFF
--- a/services/gateway/src/routes/feedback.ts
+++ b/services/gateway/src/routes/feedback.ts
@@ -70,6 +70,15 @@ const CreateTicketSchema = z.object({
   // Structured fields filled by the specialist intake agent during voice
   // capture. Open shape per kind — see plan for kind-specific schemas.
   structured_fields: z.record(z.unknown()).optional(),
+
+  // Origin surface. Usually left unset and derived from screen_path by the
+  // classifier, but a client may pin it — e.g. the in-app Support → Contact
+  // screen pins 'support' so those tickets form a distinct, human-only queue
+  // that the auto-triage routine skips.
+  surface: z.enum([
+    'community', 'admin', 'command-hub', 'mobile-only',
+    'marketplace', 'infrastructure', 'support',
+  ]).optional(),
 }).refine(
   v => Boolean(v.raw_text) || Boolean(v.raw_transcript) || (v.intake_messages && v.intake_messages.length > 0),
   { message: 'At least one of raw_text, raw_transcript, or intake_messages is required' }
@@ -149,6 +158,9 @@ router.post('/', async (req: Request, res: Response) => {
     screen_path: body.screen_path ?? null,
     app_version: body.app_version ?? null,
     device_meta: body.device_meta ?? null,
+    // Pinned surface (if the client set one) — otherwise the classifier
+    // derives it from screen_path. Support → Contact pins 'support'.
+    ...(body.surface ? { surface: body.surface } : {}),
   };
 
   const { data, error } = await supabase

--- a/supabase/migrations/20260604123000_support_surface_human_only_queue.sql
+++ b/supabase/migrations/20260604123000_support_surface_human_only_queue.sql
@@ -1,0 +1,222 @@
+-- Support → Contact: distinct, human-only feedback queue (surface = 'support')
+--
+-- The member-facing Support → Contact screen now files into the unified
+-- feedback pipeline (feedback_tickets) and pins surface='support'. We want
+-- those tickets to:
+--   1. carry a stable 'support' surface (so the admin dashboard can show a
+--      distinct, clearly-labeled queue), and
+--   2. NEVER be auto-drafted/auto-assigned by the auto_triage routine — a
+--      human always reviews them (human-only queue).
+--
+-- Three changes:
+--   A. CHECK constraint on feedback_tickets.surface (adds 'support' to the
+--      documented enum; NULL still allowed).
+--   B. classify_pending_feedback_tickets(): PRESERVE an explicitly-pinned
+--      surface instead of overwriting it, and recognize the support screen
+--      path as a backup. (Previously it always re-derived surface from
+--      screen_path and would clobber 'support' → 'community'.)
+--   C. auto_triage_pending_feedback_tickets(): skip surface='support' so
+--      Sage/Devon/Mira never auto-draft on support tickets.
+
+-- ===========================================================================
+-- A. CHECK constraint
+-- ===========================================================================
+
+ALTER TABLE public.feedback_tickets
+  DROP CONSTRAINT IF EXISTS feedback_tickets_surface_check;
+
+ALTER TABLE public.feedback_tickets
+  ADD CONSTRAINT feedback_tickets_surface_check
+  CHECK (surface IS NULL OR surface IN (
+    'community', 'admin', 'command-hub', 'mobile-only',
+    'marketplace', 'infrastructure', 'support'
+  ));
+
+-- ===========================================================================
+-- B. classifier — preserve pinned surface, recognize support screen
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION public.classify_pending_feedback_tickets()
+RETURNS TABLE (classified_count INT, dedup_count INT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_classified INT := 0;
+  v_dedup INT := 0;
+  r RECORD;
+  v_pick RECORD;
+  v_kind TEXT;
+  v_priority TEXT;
+  v_surface TEXT;
+  v_dup_id UUID;
+BEGIN
+  FOR r IN
+    SELECT id, user_id, kind, status, raw_transcript, screen_path, structured_fields,
+           classifier_meta, surface
+      FROM public.feedback_tickets
+     WHERE classifier_meta IS NULL
+       AND status IN ('new','triaged')
+     ORDER BY created_at
+     LIMIT 200
+  LOOP
+    -- Re-run keyword router on raw_transcript when present
+    SELECT * INTO v_pick
+      FROM public.pick_specialist_for_text(coalesce(r.raw_transcript, ''));
+
+    -- Kind: respect existing kind from intake (specialist set it on /start);
+    -- only override if it's still the default 'feedback' AND keyword matched.
+    v_kind := r.kind;
+    IF r.kind = 'feedback' AND v_pick.persona_key IS NOT NULL THEN
+      v_kind := CASE v_pick.persona_key
+        WHEN 'devon' THEN 'bug'
+        WHEN 'sage' THEN 'support_question'
+        WHEN 'atlas' THEN 'marketplace_claim'
+        WHEN 'mira' THEN 'account_issue'
+        ELSE 'feedback'
+      END;
+    END IF;
+
+    -- Priority: p1 if user-blocking words present, p2 default.
+    v_priority := CASE
+      WHEN coalesce(r.raw_transcript, '') ~* '(can''t|cannot|locked out|broken|crashed|won''t open|won''t load|stuck|losing money|urgent)' THEN 'p1'
+      WHEN v_kind = 'feature_request' OR v_kind = 'feedback' THEN 'p3'
+      ELSE 'p2'
+    END;
+
+    -- Surface: preserve an explicitly-pinned surface (e.g. 'support' from the
+    -- Support → Contact screen) instead of overwriting it. Otherwise derive
+    -- from screen_path; recognize the support screen as a backup so the queue
+    -- still works even if the surface wasn't pinned at insert.
+    v_surface := COALESCE(r.surface, CASE
+      WHEN r.screen_path LIKE 'support/%' OR r.screen_path LIKE '/support/%' THEN 'support'
+      WHEN r.screen_path LIKE '/admin/%' THEN 'admin'
+      WHEN r.screen_path LIKE '/command-hub/%' THEN 'command-hub'
+      WHEN r.screen_path LIKE '/comm/%' OR r.screen_path LIKE '/community/%' THEN 'community'
+      ELSE 'community'
+    END);
+
+    -- Dedupe: same user, open status, exact normalized raw_transcript match
+    -- within the last 24h. Cheap and catches double-submits.
+    v_dup_id := NULL;
+    IF r.raw_transcript IS NOT NULL THEN
+      SELECT t.id INTO v_dup_id
+        FROM public.feedback_tickets t
+       WHERE t.user_id = r.user_id
+         AND t.id <> r.id
+         AND lower(trim(coalesce(t.raw_transcript, ''))) = lower(trim(r.raw_transcript))
+         AND t.status NOT IN ('rejected','wont_fix','duplicate')
+         AND t.created_at > NOW() - INTERVAL '24 hours'
+       ORDER BY t.created_at ASC
+       LIMIT 1;
+    END IF;
+
+    UPDATE public.feedback_tickets
+       SET kind = v_kind,
+           priority = v_priority,
+           surface = v_surface,
+           status = CASE
+             WHEN v_dup_id IS NOT NULL THEN 'duplicate'
+             WHEN status = 'new' THEN 'triaged'
+             ELSE status
+           END,
+           duplicate_of = v_dup_id,
+           triaged_at = COALESCE(triaged_at, NOW()),
+           classifier_meta = jsonb_build_object(
+             'version', 'v1-keyword',
+             'matched_keyword', v_pick.matched_keyword,
+             'pick_score', v_pick.score,
+             'pick_confidence', v_pick.confidence,
+             'classified_at', NOW()
+           )
+     WHERE id = r.id;
+
+    v_classified := v_classified + 1;
+    IF v_dup_id IS NOT NULL THEN v_dedup := v_dedup + 1; END IF;
+  END LOOP;
+
+  RETURN QUERY SELECT v_classified, v_dedup;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.classify_pending_feedback_tickets() TO service_role;
+
+-- ===========================================================================
+-- C. auto-triage — skip the human-only support queue
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION public.auto_triage_pending_feedback_tickets()
+RETURNS TABLE (
+  auto_drafted_answers INT,
+  auto_drafted_specs INT,
+  auto_drafted_resolutions INT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_answers INT := 0;
+  v_specs INT := 0;
+  v_resolutions INT := 0;
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT id, kind, priority, classifier_meta, raw_transcript, structured_fields
+      FROM public.feedback_tickets
+     WHERE status = 'triaged'
+       AND triaged_at < NOW() - INTERVAL '5 minutes'
+       AND duplicate_of IS NULL
+       AND classifier_meta IS NOT NULL
+       -- Human-only queue: never auto-draft/auto-assign support tickets.
+       AND COALESCE(surface, '') <> 'support'
+     ORDER BY triaged_at
+     LIMIT 100
+  LOOP
+    -- support_question → Sage drafts answer if confidence high enough
+    IF r.kind = 'support_question'
+       AND COALESCE((r.classifier_meta->>'pick_confidence')::REAL, 0) >= 0.5 THEN
+      UPDATE public.feedback_tickets
+         SET status = 'answer_ready',
+             resolver_agent = 'sage',
+             draft_answer_md = '**Sage auto-draft (placeholder)**' || chr(10) || chr(10) ||
+                              '_Generated by auto_triage routine. LLM-backed retrieval lands in resolver-agents follow-up._' || chr(10) || chr(10) ||
+                              'User asked: ' || COALESCE(r.raw_transcript, '(no transcript)')
+       WHERE id = r.id;
+      v_answers := v_answers + 1;
+
+    -- p3 bug → Devon drafts spec (low-priority, low-risk to auto-process)
+    ELSIF r.kind = 'bug' AND r.priority = 'p3' THEN
+      UPDATE public.feedback_tickets
+         SET status = 'spec_ready',
+             resolver_agent = 'devon',
+             spec_md = '# Devon auto-draft spec (placeholder)' || chr(10) ||
+                      '## User report' || chr(10) || COALESCE(r.raw_transcript, '(no transcript)') || chr(10) || chr(10) ||
+                      '## Root cause hypothesis' || chr(10) || 'TBD' || chr(10) || chr(10) ||
+                      '## Risk + rollback' || chr(10) || 'Low (p3 ticket).' || chr(10) || chr(10) ||
+                      '_Generated by auto_triage routine._'
+       WHERE id = r.id;
+      v_specs := v_specs + 1;
+
+    -- account_issue with low-risk keywords → Mira drafts resolution
+    ELSIF r.kind = 'account_issue'
+       AND COALESCE(r.raw_transcript, '') ~* '(password|email|verification|verify)' THEN
+      UPDATE public.feedback_tickets
+         SET status = 'spec_ready',
+             resolver_agent = 'mira',
+             resolution_md = '# Mira auto-draft resolution (placeholder)' || chr(10) ||
+                            '## User report' || chr(10) || COALESCE(r.raw_transcript, '(no transcript)') || chr(10) || chr(10) ||
+                            '## Proposed action' || chr(10) || 'Trigger password reset or resend verification email.' || chr(10) || chr(10) ||
+                            '## Risk' || chr(10) || 'Low — runbook covered.' || chr(10) || chr(10) ||
+                            '_Generated by auto_triage routine. Supervisor approves before action._'
+       WHERE id = r.id;
+      v_resolutions := v_resolutions + 1;
+    END IF;
+  END LOOP;
+
+  RETURN QUERY SELECT v_answers, v_specs, v_resolutions;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.auto_triage_pending_feedback_tickets() TO service_role;


### PR DESCRIPTION
## Why

Companion backend to vitana-v1 #655. The member **Support → Contact** screen now files into the unified feedback pipeline, but per product decision those submissions should form a **distinct, human-only queue** — visible to the team on the admin dashboard, but **never** auto-drafted/auto-assigned by the AI specialists (Sage/Devon/Mira). A human always reviews them.

## What

Introduces a `surface = 'support'` tag and makes the pipeline treat it as human-only.

**`services/gateway/src/routes/feedback.ts`**
- `POST /api/v1/feedback/tickets` now accepts an optional `surface` (enum incl. `'support'`) and writes it on insert. (Frontend pins `'support'`.)

**Migration `20260604123000_support_surface_human_only_queue.sql`**
- **A.** Adds a CHECK constraint on `feedback_tickets.surface` including `'support'` (NULL still allowed; current live values are only NULL + `admin`, so it applies cleanly).
- **B.** `classify_pending_feedback_tickets()` now **preserves** an explicitly-pinned surface via `COALESCE(r.surface, …)` instead of re-deriving and clobbering it (previously it always overwrote surface from `screen_path`, which would have reset `'support'` → `'community'`). Also recognizes the support `screen_path` as a backup.
- **C.** `auto_triage_pending_feedback_tickets()` gains `AND COALESCE(surface,'') <> 'support'` — support tickets are skipped by auto-draft, staying in the human inbox.

## Context discovered

In the live DB, 117/118 `feedback_tickets` have `surface = NULL` (the classifier cron rarely populates it). That's why we **pin** surface at insert in the gateway rather than relying on classifier derivation — explicit tagging is reliable; the classifier change just stops it being overwritten.

## Safety

- Additive + reversible: `CREATE OR REPLACE FUNCTION` (re-deploy old defs to revert), NULL-tolerant CHECK.
- Auto-triage change is strictly *more conservative* (fewer auto-actions).
- `npm run typecheck` (gateway) — 0 errors.

## Rollout (needs coordination — see #655)

1. Apply this migration to the Supabase project (`inmkhvwdcuyhnxkgfvsb`).
2. Deploy the gateway (EXEC-DEPLOY) so `/feedback/tickets` accepts `surface`.
3. Merge/deploy vitana-v1 #655 (pins `surface:'support'` + dashboard queue).
4. Verify: submit from Support → Contact → ticket appears under the **Support** filter on `/admin/feedback/tickets` with the member's name, and is NOT auto-assigned a specialist.

https://claude.ai/code/session_01C1iyWeCVQU5hzGz7rwvSfo

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1iyWeCVQU5hzGz7rwvSfo)_