### PR TITLE
ci: staging-first cutover + one-button publish (drift fix + frontend promote)

### DIFF
--- a/.github/workflows/AUTO-DEPLOY.yml
+++ b/.github/workflows/AUTO-DEPLOY.yml
@@ -1,19 +1,33 @@
-name: Auto Deploy (Canonical → EXEC-DEPLOY)
+name: Auto Deploy (Manual prod dispatch — staging-first cutover)
 
-# VTID-01082-FIX: Fixed VTID extraction from truncated merge commit messages
-# GitHub truncates commit messages in merge commits, causing VTID extraction to fail.
-# This workflow now:
-# 1. Checks out the repo to get full commit message via git
-# 2. Searches the full commit body (not just subject line)
-# 3. Falls back to branch name extraction if commit message fails
+# ============================================================================
+# STAGING-FIRST CUTOVER (2026-06-04): AUTO-TO-PROD IS DISABLED.
+# ----------------------------------------------------------------------------
+# This workflow used to trigger on every push to `main` and dispatch
+# EXEC-DEPLOY.yml straight to PRODUCTION (gateway + worker-runner). That
+# auto-to-prod path has been CUT.
+#
+#   • Auto deploy on push to `main`  →  STAGING only, via STAGE-DEPLOY.yml.
+#   • Production is reached ONLY via:
+#       1. the one PUBLISH button in the Command Hub, or
+#       2. the documented manual escape hatch:
+#          scripts/deploy/publish-to-prod.sh  (the explicit exception).
+#
+# The dispatch logic below is retained for compatibility and is now
+# `workflow_dispatch`-only. Triggering it is a deliberate, governed prod
+# deploy — never an automatic consequence of a push. Prefer the escape-hatch
+# script, which records a `--reason` and labels the action as the exception.
+# ============================================================================
+#
+# VTID-01082-FIX: Robust VTID extraction from truncated merge commit messages
+# (retained for manual dispatch traceability).
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - "services/gateway/**"
-      - "services/worker-runner/**"
-      - ".github/workflows/**"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why are you deploying to PROD manually (the documented exception)?'
+        required: true
 
 permissions:
   contents: read
@@ -27,6 +41,15 @@ jobs:
   dispatch_exec_deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Announce manual prod deploy (the documented exception)
+        run: |
+          echo "==========================================================================="
+          echo "⚠️  MANUAL PRODUCTION DEPLOY — staging-first exception path"
+          echo "Reason: ${{ github.event.inputs.reason }}"
+          echo "Actor:  ${{ github.actor }}"
+          echo "This is NOT an automatic deploy. Auto pushes go to STAGING (STAGE-DEPLOY.yml)."
+          echo "==========================================================================="
+
       # VTID-01082-FIX: Checkout repo to get full commit message
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/AUTO-DEPLOY.yml
+++ b/.github/workflows/AUTO-DEPLOY.yml
@@ -1,28 +1,33 @@
-name: Auto Deploy (Manual prod dispatch — staging-first cutover)
+name: Auto Deploy (Canonical → EXEC-DEPLOY)
 
 # ============================================================================
-# STAGING-FIRST CUTOVER (2026-06-04): AUTO-TO-PROD IS DISABLED.
+# STAGING-FIRST CUTOVER (effective Mon 8 Jun 2026, 10:00 Europe/Berlin).
 # ----------------------------------------------------------------------------
-# This workflow used to trigger on every push to `main` and dispatch
-# EXEC-DEPLOY.yml straight to PRODUCTION (gateway + worker-runner). That
-# auto-to-prod path has been CUT.
+# BEFORE the cutover instant: a push to `main` dispatches EXEC-DEPLOY.yml to
+# PRODUCTION (gateway + worker-runner), exactly as before — deploy-to-live
+# keeps working on every path until the deadline.
 #
-#   • Auto deploy on push to `main`  →  STAGING only, via STAGE-DEPLOY.yml.
-#   • Production is reached ONLY via:
-#       1. the one PUBLISH button in the Command Hub, or
-#       2. the documented manual escape hatch:
-#          scripts/deploy/publish-to-prod.sh  (the explicit exception).
+# AT/AFTER the cutover instant: the automatic (push) path is FROZEN. Code that
+# lands on `main` deploys to STAGING only (gateway via STAGE-DEPLOY.yml).
+# Production is then reached only via:
+#   1. the single PUBLISH button in the Command Hub, or
+#   2. a deliberate manual run — either this workflow's `workflow_dispatch`
+#      (with a recorded reason) or scripts/deploy/publish-to-prod.sh.
 #
-# The dispatch logic below is retained for compatibility and is now
-# `workflow_dispatch`-only. Triggering it is a deliberate, governed prod
-# deploy — never an automatic consequence of a push. Prefer the escape-hatch
-# script, which records a `--reason` and labels the action as the exception.
+# Manual `workflow_dispatch` is NEVER frozen — it is the documented exception.
+# The switch is purely time-based (see the `cutover_gate` job); no redeploy is
+# needed to flip it.
 # ============================================================================
 #
-# VTID-01082-FIX: Robust VTID extraction from truncated merge commit messages
-# (retained for manual dispatch traceability).
+# VTID-01082-FIX: Robust VTID extraction from truncated merge commit messages.
 
 on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "services/gateway/**"
+      - "services/worker-runner/**"
+      - ".github/workflows/**"
   workflow_dispatch:
     inputs:
       reason:
@@ -38,19 +43,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # --------------------------------------------------------------------------
+  # Staging-first cutover gate. Freezes the AUTOMATIC (push) deploy-to-prod path
+  # at/after Mon 8 Jun 2026, 10:00 Europe/Berlin. Manual dispatch is exempt.
+  # --------------------------------------------------------------------------
+  cutover_gate:
+    runs-on: ubuntu-latest
+    outputs:
+      frozen: ${{ steps.gate.outputs.frozen }}
+    steps:
+      - name: Evaluate staging-first cutover
+        id: gate
+        shell: bash
+        run: |
+          CUTOVER_EPOCH="$(date -d 'TZ="Europe/Berlin" 2026-06-08 10:00:00' +%s)"
+          NOW_EPOCH="$(date -u +%s)"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch (reason: ${{ github.event.inputs.reason }}) → not frozen (deliberate prod exception)."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          elif [ "$NOW_EPOCH" -ge "$CUTOVER_EPOCH" ]; then
+            echo "::warning::Staging-first cutover ACTIVE (since $(date -u -d @${CUTOVER_EPOCH})) — auto deploy to LIVE is frozen. Promote via the Command Hub PUBLISH button or a manual dispatch."
+            echo "frozen=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pre-cutover — auto deploy to live proceeds normally (cutover at $(date -u -d @${CUTOVER_EPOCH}) UTC)."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          fi
+
   dispatch_exec_deploy:
+    needs: cutover_gate
+    if: needs.cutover_gate.outputs.frozen != 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Announce manual prod deploy (the documented exception)
-        run: |
-          echo "==========================================================================="
-          echo "⚠️  MANUAL PRODUCTION DEPLOY — staging-first exception path"
-          echo "Reason: ${{ github.event.inputs.reason }}"
-          echo "Actor:  ${{ github.actor }}"
-          echo "This is NOT an automatic deploy. Auto pushes go to STAGING (STAGE-DEPLOY.yml)."
-          echo "==========================================================================="
-
-      # VTID-01082-FIX: Checkout repo to get full commit message
+      # VTID-01082-FIX: Checkout repo to get full commit message via git
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -195,3 +219,18 @@ jobs:
               });
               core.info(`✅ Dispatched EXEC-DEPLOY.yml for VTID=${vtid} service=worker-runner`);
             }
+
+  # Emitted only when the cutover has frozen the automatic path, so the run
+  # surfaces a clear "went to staging, not prod" signal instead of a silent skip.
+  cutover_notice:
+    needs: cutover_gate
+    if: needs.cutover_gate.outputs.frozen == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain the freeze
+        run: |
+          echo "🛑 Staging-first cutover is ACTIVE — this push did NOT deploy to production."
+          echo "    Gateway changes auto-deploy to STAGING via STAGE-DEPLOY.yml (gateway-staging)."
+          echo "    worker-runner has no staging twin — it is freeze-only on the auto path."
+          echo "    To ship to LIVE: use the Command Hub PUBLISH button, or run"
+          echo "    scripts/deploy/publish-to-prod.sh (the documented manual exception)."

--- a/.github/workflows/DEPLOY-AUTOPILOT-JOB.yml
+++ b/.github/workflows/DEPLOY-AUTOPILOT-JOB.yml
@@ -50,7 +50,36 @@ on:
         default: '2'
 
 jobs:
+  # Staging-first cutover gate. Freezes the AUTOMATIC (push) build+deploy of the
+  # live autopilot Cloud Run Job at/after Mon 8 Jun 2026, 10:00 Europe/Berlin.
+  # No staging twin for the job, so the push path is freeze-only post-cutover;
+  # deploy via manual workflow_dispatch (the documented exception). Manual
+  # dispatch is never frozen.
+  cutover_gate:
+    runs-on: ubuntu-latest
+    outputs:
+      frozen: ${{ steps.gate.outputs.frozen }}
+    steps:
+      - name: Evaluate staging-first cutover
+        id: gate
+        shell: bash
+        run: |
+          CUTOVER_EPOCH="$(date -d 'TZ="Europe/Berlin" 2026-06-08 10:00:00' +%s)"
+          NOW_EPOCH="$(date -u +%s)"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch → not frozen (deliberate prod exception)."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          elif [ "$NOW_EPOCH" -ge "$CUTOVER_EPOCH" ]; then
+            echo "::warning::Staging-first cutover ACTIVE — auto deploy of the autopilot job to LIVE is frozen. Use a manual workflow_dispatch to ship."
+            echo "frozen=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pre-cutover — auto deploy proceeds (cutover at $(date -u -d @${CUTOVER_EPOCH}) UTC)."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          fi
+
   deploy:
+    needs: cutover_gate
+    if: needs.cutover_gate.outputs.frozen != 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/DEPLOY-ORB-AGENT.yml
+++ b/.github/workflows/DEPLOY-ORB-AGENT.yml
@@ -42,7 +42,36 @@ env:
   IMAGE_REPO: us-central1-docker.pkg.dev/lovable-vitana-vers1/vitana-services/orb-agent
 
 jobs:
+  # Staging-first cutover gate. Freezes the AUTOMATIC (push) deploy of the live
+  # vitana-orb-agent service at/after Mon 8 Jun 2026, 10:00 Europe/Berlin.
+  # orb-agent has no staging twin, so post-cutover the push path is freeze-only;
+  # deploy via manual workflow_dispatch (the documented exception). Manual
+  # dispatch is never frozen.
+  cutover_gate:
+    runs-on: ubuntu-latest
+    outputs:
+      frozen: ${{ steps.gate.outputs.frozen }}
+    steps:
+      - name: Evaluate staging-first cutover
+        id: gate
+        shell: bash
+        run: |
+          CUTOVER_EPOCH="$(date -d 'TZ="Europe/Berlin" 2026-06-08 10:00:00' +%s)"
+          NOW_EPOCH="$(date -u +%s)"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch → not frozen (deliberate prod exception)."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          elif [ "$NOW_EPOCH" -ge "$CUTOVER_EPOCH" ]; then
+            echo "::warning::Staging-first cutover ACTIVE — auto deploy of vitana-orb-agent to LIVE is frozen. Use a manual workflow_dispatch to ship."
+            echo "frozen=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pre-cutover — auto deploy proceeds (cutover at $(date -u -d @${CUTOVER_EPOCH}) UTC)."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-deploy:
+    needs: cutover_gate
+    if: needs.cutover_gate.outputs.frozen != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -47,6 +47,10 @@ on:
         description: 'If true, deploy with --no-traffic so the new revision is created but not serving. The operator promotes it via /operator/promote after verifying staging metrics. Defaults to false (existing 100%-on-deploy behavior).'
         required: false
         default: 'false'
+      commit_sha:
+        description: 'Exact commit SHA to build/deploy (the tested staging commit). When empty, falls back to main HEAD (legacy behavior). Threaded by the PUBLISH flow so prod ships the EXACT bits verified on staging — no "tested X, shipped Y" drift.'
+        required: false
+        default: ''
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -54,7 +58,19 @@ jobs:
       id-token: write
       contents: read
     steps:
+      # Check out the exact commit the publish flow tested on staging when
+      # commit_sha is provided; otherwise main HEAD (legacy). workflow_dispatch
+      # must run against a branch (main), so the SHA is selected here, not at
+      # dispatch time.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_sha != '' && github.event.inputs.commit_sha || github.sha }}
+      # Resolve the ACTUAL deployed commit (the checked-out HEAD) so every
+      # downstream SHA bake records what really shipped, not the dispatch ref.
+      - name: Resolve deploy SHA
+        id: deploy_sha
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
@@ -297,8 +313,8 @@ jobs:
             # /admin/build-info + cloud-run-admin.describeService can surface a real
             # 7-char SHA (instead of falling back to the *.run.app revision name).
             # Mirrors what STAGE-DEPLOY.yml already does for gateway-staging.
-            EXTRA_ENV_ARGS+=(--update-env-vars=GIT_COMMIT_SHA=${{ github.sha }})
-            EXTRA_ENV_ARGS+=(--update-env-vars=COMMIT_SHA=${{ github.sha }})
+            EXTRA_ENV_ARGS+=(--update-env-vars=GIT_COMMIT_SHA=${{ steps.deploy_sha.outputs.sha }})
+            EXTRA_ENV_ARGS+=(--update-env-vars=COMMIT_SHA=${{ steps.deploy_sha.outputs.sha }})
             # VTID-01225: Cognee Extractor URL for entity extraction
             EXTRA_ENV_ARGS+=(--update-env-vars=COGNEE_EXTRACTOR_URL=https://cognee-extractor-86804897789.us-central1.run.app)
             # VTID-01175: Worker verification mode. 'advisory' (default) runs the
@@ -722,7 +738,7 @@ jobs:
         run: |
           # Record deployment version in OASIS via Gateway API
           SERVICE_NAME="${{ steps.deploy.outputs.cloud_run_service }}"
-          GIT_COMMIT="${{ github.sha }}"
+          GIT_COMMIT="${{ steps.deploy_sha.outputs.sha }}"
 
           # BOOTSTRAP-PHASE0-UX: include the Cloud Run revision name so the
           # CLOCK dropdown can match this row to the currently-serving

--- a/.github/workflows/VTID-02409-BOOTSTRAP.yml
+++ b/.github/workflows/VTID-02409-BOOTSTRAP.yml
@@ -12,7 +12,34 @@ permissions:
   actions: write
 
 jobs:
+  # Staging-first cutover gate. Freezes the AUTOMATIC (push) prod-gateway
+  # dispatch at/after Mon 8 Jun 2026, 10:00 Europe/Berlin. Manual dispatch is
+  # the documented exception and is never frozen.
+  cutover_gate:
+    runs-on: ubuntu-latest
+    outputs:
+      frozen: ${{ steps.gate.outputs.frozen }}
+    steps:
+      - name: Evaluate staging-first cutover
+        id: gate
+        shell: bash
+        run: |
+          CUTOVER_EPOCH="$(date -d 'TZ="Europe/Berlin" 2026-06-08 10:00:00' +%s)"
+          NOW_EPOCH="$(date -u +%s)"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch → not frozen (deliberate prod exception)."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          elif [ "$NOW_EPOCH" -ge "$CUTOVER_EPOCH" ]; then
+            echo "::warning::Staging-first cutover ACTIVE — auto prod dispatch frozen."
+            echo "frozen=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pre-cutover — proceeds (cutover at $(date -u -d @${CUTOVER_EPOCH}) UTC)."
+            echo "frozen=false" >> "$GITHUB_OUTPUT"
+          fi
+
   bootstrap:
+    needs: cutover_gate
+    if: needs.cutover_gate.outputs.frozen != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,16 +232,21 @@ await page.reload();
 
 ### CI/CD Pipeline — STAGING-FIRST (CRITICAL - Updated 2026-06-04)
 
-> **Cutover rule:** Auto deploys go to **STAGING ONLY**. Production is reached
-> **only** via (a) the single PUBLISH button in the Command Hub, or (b) the
-> documented manual escape hatch `scripts/deploy/publish-to-prod.sh`. There is
-> **no** auto-to-prod path anymore — `AUTO-DEPLOY.yml` is `workflow_dispatch`-only.
+> **Cutover rule (time-gated):** the switch flips at **Mon 8 Jun 2026, 10:00
+> Europe/Berlin** (08:00 UTC). **Before** that instant, every deploy path
+> reaches production on push as it always did. **At/after** it, every automatic
+> (push) deploy path is FROZEN from prod and auto deploys land on **staging
+> only**. Production is then reached **only** via (a) the single PUBLISH button
+> in the Command Hub, or (b) a deliberate manual run — `workflow_dispatch` of
+> the relevant deploy workflow, or `scripts/deploy/publish-to-prod.sh`. The gate
+> lives in each deploy workflow's `cutover_gate` job; manual dispatch is never
+> frozen. No redeploy is needed to flip it — it is purely time-based.
 
-21. **IF** you push/merge to `main` → **THEN it deploys to STAGING via `STAGE-DEPLOY.yml` (`gateway-staging`). It does NOT touch production. Verify on `preview-gateway.vitanaland.com`, not prod.**
-22. **IF** you need code on PRODUCTION → **THEN do NOT push and expect prod to update. Either click PUBLISH in the Command Hub (promotes the tested staging build) or run `scripts/deploy/publish-to-prod.sh --service <svc> --vtid <id> --reason "<why>"` (the explicit exception).**
-23. **IF** you are tempted to manually dispatch `EXEC-DEPLOY.yml` to prod "to be safe" → **THEN STOP. That is the old auto-to-prod habit. Auto = staging. Prod = PUBLISH button or escape-hatch script only, with a recorded reason.**
-24. **IF** `worker-runner` needs a prod update → **THEN use the escape-hatch script. `worker-runner` has no staging twin yet, so it is freeze-only on the auto path until one exists.**
-25. **IF** making frontend CSS/JS changes (Command Hub) → **THEN bump the `?v=` cache-busting parameter in index.html. The change auto-deploys to STAGING; it reaches prod only when PUBLISH is clicked.**
+21. **IF** you push/merge to `main` **on/after the cutover** → **THEN it deploys to STAGING (gateway via `STAGE-DEPLOY.yml` → `gateway-staging`). It does NOT touch production. Verify on `preview-gateway.vitanaland.com`, not prod.**
+22. **IF** you need code on PRODUCTION (post-cutover) → **THEN do NOT push and expect prod to update. Either click PUBLISH in the Command Hub (promotes the tested staging build) or run `scripts/deploy/publish-to-prod.sh --service <svc> --vtid <id> --reason "<why>"` (the explicit exception).**
+23. **IF** you are tempted to manually dispatch `EXEC-DEPLOY.yml` to prod "to be safe" post-cutover → **THEN STOP. That is the old auto-to-prod habit. Auto = staging. Prod = PUBLISH button or escape-hatch/manual dispatch only, with a recorded reason.**
+24. **IF** `worker-runner` / `vitana-orb-agent` / the autopilot job needs a prod update post-cutover → **THEN use the escape-hatch script or the workflow's manual `workflow_dispatch`. These have no staging twin yet, so they are freeze-only on the auto path until one exists.**
+25. **IF** making frontend CSS/JS changes (Command Hub) → **THEN bump the `?v=` cache-busting parameter in index.html. Post-cutover the change auto-deploys to STAGING; it reaches prod only when PUBLISH is clicked.**
 
 ### Memory
 
@@ -867,12 +872,14 @@ write_fact(
 
 Deployments have repeatedly failed because Cloud Shell had stale code, or the wrong branch was deployed. This protocol prevents that.
 
-> **Staging-first note (2026-06-04):** by default you are verifying **STAGING**
+> **Staging-first note (effective Mon 8 Jun 2026, 10:00 Europe/Berlin):** from
+> the cutover instant you are by default verifying **STAGING**
 > (`gateway-staging` / `preview-gateway.vitanaland.com`), because pushes to
 > `main` auto-deploy staging only. The same curl/revision checks below apply —
 > just point them at the staging URL and expect `env=staging`. You verify
 > **production** only after a PUBLISH-button promotion or an escape-hatch
-> (`scripts/deploy/publish-to-prod.sh`) deploy — never as a side effect of a push.
+> (`scripts/deploy/publish-to-prod.sh`) / manual-dispatch deploy — never as a
+> side effect of a push. (Before the cutover, pushes still reach prod.)
 
 ### Pre-Deploy Verification (BEFORE `gcloud builds submit`)
 
@@ -939,6 +946,10 @@ the old "merge to main → manually dispatch EXEC-DEPLOY to prod" flow is GONE.*
 
 ### The model: push freely → staging; one button → prod
 
+The cutover is **time-gated** — it flips at **Mon 8 Jun 2026, 10:00
+Europe/Berlin**. Before then, push still reaches prod; the table below
+describes behavior **at/after** the cutover.
+
 | Action | Where it lands | How |
 |--------|----------------|-----|
 | Push / merge to `main` (gateway) | **STAGING** (`gateway-staging`) | `STAGE-DEPLOY.yml`, automatic |
@@ -947,9 +958,13 @@ the old "merge to main → manually dispatch EXEC-DEPLOY to prod" flow is GONE.*
 
 - **`STAGE-DEPLOY.yml`** auto-deploys staging on every push to `main` under
   `services/gateway/**`. Smoke-gates on `/api/v1/admin/health` → `env=staging`.
-- **`AUTO-DEPLOY.yml`** no longer fires on push — it is `workflow_dispatch`-only
-  and requires a `reason`. It is **not** the normal path; it is a low-level
-  manual lever. Prefer the escape-hatch script, which records the reason.
+  Unaffected by the cutover — staging deploys always run.
+- **`AUTO-DEPLOY.yml`** (and `DEPLOY-ORB-AGENT.yml`, `DEPLOY-AUTOPILOT-JOB.yml`,
+  `VTID-02409-BOOTSTRAP.yml`) each carry a `cutover_gate` job. On a push
+  **at/after** the cutover instant the prod path is frozen (auto = staging);
+  **before** it, prod deploys as before. Their manual `workflow_dispatch`
+  (which requires a `reason` on AUTO-DEPLOY) is **never** frozen — it is the
+  deliberate prod lever. Prefer the escape-hatch script, which records the reason.
 - **`EXEC-DEPLOY.yml`** is still the canonical governed prod deploy, driven by
   the PUBLISH button and the escape-hatch script (both `workflow_dispatch`).
 
@@ -1003,7 +1018,7 @@ Use these PATs with the GitHub REST API (`api.github.com`) for all PR and deploy
 
 | Date | Change | VTID |
 |------|--------|------|
-| 2026-06-04 | Staging-first cutover (backend / workstream A): cut auto-to-prod (`AUTO-DEPLOY.yml` → `workflow_dispatch`-only), added manual escape hatch `scripts/deploy/publish-to-prod.sh`, rewrote §15/§16 + IF-THEN CI/CD rules. Auto = staging; prod = PUBLISH button or escape hatch. | BOOTSTRAP-STAGING-FIRST-CUTOVER |
+| 2026-06-04 | Staging-first cutover (time-gated, effective Mon 8 Jun 2026 10:00 Europe/Berlin): added a `cutover_gate` job to every auto-to-prod workflow (`AUTO-DEPLOY`, `DEPLOY-ORB-AGENT`, `DEPLOY-AUTOPILOT-JOB`, `VTID-02409-BOOTSTRAP`) that freezes the push path post-cutover while leaving manual dispatch open; added manual escape hatch `scripts/deploy/publish-to-prod.sh`; rewrote §15/§16 + IF-THEN CI/CD rules. Before cutover all paths still reach prod; after, auto = staging, prod = PUBLISH button / manual exception. Frontend (`vitana-v1`) gated in parallel. | BOOTSTRAP-STAGING-FIRST-CUTOVER |
 | 2026-04-14 | Replaced broad visual verification with targeted protocol: screenshot what you changed, interact with it, verify it works | VTID-01917 |
 | 2026-03-19 | Added CI/CD deployment pipeline critical lessons (Auto Deploy ≠ actual deploy) | BOOTSTRAP-OPERATOR-NAV-FIX |
 | 2026-02-13 | Added Deployment Verification Protocol section + rules | VTID-01228 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,13 +230,18 @@ await page.evaluate(s => {
 await page.reload();
 ```
 
-### CI/CD Pipeline (CRITICAL - Added 2026-03-19)
+### CI/CD Pipeline — STAGING-FIRST (CRITICAL - Updated 2026-06-04)
 
-21. **IF** Auto Deploy shows "success" → **THEN check EXEC-DEPLOY runs to confirm actual deployment was dispatched. Auto Deploy success does NOT mean code was deployed.**
-22. **IF** commit message has no VTID → **THEN Auto Deploy will NOT dispatch EXEC-DEPLOY. Manually trigger EXEC-DEPLOY with BOOTSTRAP prefix.**
-23. **IF** merging a PR to main → **THEN ALWAYS verify EXEC-DEPLOY is running after merge. Do NOT assume Auto Deploy handled it.**
-24. **IF** EXEC-DEPLOY was not dispatched → **THEN manually dispatch it via GitHub API with `BOOTSTRAP-<description>` as the VTID.**
-25. **IF** making frontend CSS/JS changes → **THEN bump the `?v=` cache-busting parameter in index.html AND verify EXEC-DEPLOY completes.**
+> **Cutover rule:** Auto deploys go to **STAGING ONLY**. Production is reached
+> **only** via (a) the single PUBLISH button in the Command Hub, or (b) the
+> documented manual escape hatch `scripts/deploy/publish-to-prod.sh`. There is
+> **no** auto-to-prod path anymore — `AUTO-DEPLOY.yml` is `workflow_dispatch`-only.
+
+21. **IF** you push/merge to `main` → **THEN it deploys to STAGING via `STAGE-DEPLOY.yml` (`gateway-staging`). It does NOT touch production. Verify on `preview-gateway.vitanaland.com`, not prod.**
+22. **IF** you need code on PRODUCTION → **THEN do NOT push and expect prod to update. Either click PUBLISH in the Command Hub (promotes the tested staging build) or run `scripts/deploy/publish-to-prod.sh --service <svc> --vtid <id> --reason "<why>"` (the explicit exception).**
+23. **IF** you are tempted to manually dispatch `EXEC-DEPLOY.yml` to prod "to be safe" → **THEN STOP. That is the old auto-to-prod habit. Auto = staging. Prod = PUBLISH button or escape-hatch script only, with a recorded reason.**
+24. **IF** `worker-runner` needs a prod update → **THEN use the escape-hatch script. `worker-runner` has no staging twin yet, so it is freeze-only on the auto path until one exists.**
+25. **IF** making frontend CSS/JS changes (Command Hub) → **THEN bump the `?v=` cache-busting parameter in index.html. The change auto-deploys to STAGING; it reaches prod only when PUBLISH is clicked.**
 
 ### Memory
 
@@ -862,6 +867,13 @@ write_fact(
 
 Deployments have repeatedly failed because Cloud Shell had stale code, or the wrong branch was deployed. This protocol prevents that.
 
+> **Staging-first note (2026-06-04):** by default you are verifying **STAGING**
+> (`gateway-staging` / `preview-gateway.vitanaland.com`), because pushes to
+> `main` auto-deploy staging only. The same curl/revision checks below apply —
+> just point them at the staging URL and expect `env=staging`. You verify
+> **production** only after a PUBLISH-button promotion or an escape-hatch
+> (`scripts/deploy/publish-to-prod.sh`) deploy — never as a side effect of a push.
+
 ### Pre-Deploy Verification (BEFORE `gcloud builds submit`)
 
 1. **Verify source code has the expected changes:**
@@ -920,56 +932,55 @@ If post-deploy verification fails:
 
 ---
 
-## 16. CI/CD DEPLOYMENT PIPELINE — CRITICAL LESSONS (2026-03-19)
+## 16. CI/CD DEPLOYMENT PIPELINE — STAGING-FIRST (Updated 2026-06-04)
 
-**This section exists because of repeated deployment failures. READ CAREFULLY.**
+**This section was rewritten for the staging-first cutover. READ CAREFULLY —
+the old "merge to main → manually dispatch EXEC-DEPLOY to prod" flow is GONE.**
 
-### AUTO-DEPLOY Does NOT Mean Code Is Deployed
+### The model: push freely → staging; one button → prod
 
-The `AUTO-DEPLOY.yml` workflow triggers on pushes to `main` under `services/gateway/**`, but it **ONLY dispatches `EXEC-DEPLOY.yml` if a VTID is found in the commit message**. If no VTID is found, the workflow exits with `success` status but **NO actual Cloud Run deployment happens**.
+| Action | Where it lands | How |
+|--------|----------------|-----|
+| Push / merge to `main` (gateway) | **STAGING** (`gateway-staging`) | `STAGE-DEPLOY.yml`, automatic |
+| Promote to **production** | `gateway` (+ frontend) | **PUBLISH button** in Command Hub |
+| Exceptional manual prod deploy | single service | `scripts/deploy/publish-to-prod.sh` |
 
-**This is deceptive**: The GitHub Actions UI shows Auto Deploy as "success" even when nothing was deployed.
+- **`STAGE-DEPLOY.yml`** auto-deploys staging on every push to `main` under
+  `services/gateway/**`. Smoke-gates on `/api/v1/admin/health` → `env=staging`.
+- **`AUTO-DEPLOY.yml`** no longer fires on push — it is `workflow_dispatch`-only
+  and requires a `reason`. It is **not** the normal path; it is a low-level
+  manual lever. Prefer the escape-hatch script, which records the reason.
+- **`EXEC-DEPLOY.yml`** is still the canonical governed prod deploy, driven by
+  the PUBLISH button and the escape-hatch script (both `workflow_dispatch`).
 
-### End-to-End Deployment Checklist (MANDATORY)
+### End-to-End Deployment Checklist (STAGING-FIRST)
 
-When fixing bugs and deploying changes, you MUST complete ALL steps:
+When changing code:
 
-1. **Code fix** — Make the change on the feature branch
-2. **Commit** — Include a VTID in the commit message (e.g., `fix: description (VTID-XXXXX)`)
-   - If no VTID exists, use `BOOTSTRAP-<description>` prefix
-3. **Push** — Push to the `claude/` branch
-4. **Create PR** — Via GitHub API using the Vitana Platform PAT
-5. **Merge PR** — Via GitHub API (squash merge)
-6. **Verify EXEC-DEPLOY was dispatched** — Check if Auto Deploy actually dispatched EXEC-DEPLOY:
+1. **Code fix** — on the feature/`claude/` branch.
+2. **Commit** — include a VTID (`(VTID-XXXXX)`) or `BOOTSTRAP-<description>`.
+3. **Push** — to the `claude/` branch; open a PR.
+4. **Merge to `main`** — this auto-deploys to **STAGING only**.
+5. **Verify on staging** — `preview-gateway.vitanaland.com` (gateway) /
+   `preview.vitanaland.com` (frontend). Confirm `env=staging`. Do **NOT**
+   expect or look for a prod deploy here.
+6. **Ship to production** — when staging is verified, click **PUBLISH** in the
+   Command Hub (promotes the exact tested staging build). For the rare
+   out-of-band case, run:
    ```
-   GET /repos/exafyltd/vitana-platform/actions/workflows/EXEC-DEPLOY.yml/runs?per_page=3
+   scripts/deploy/publish-to-prod.sh --service gateway --vtid VTID-XXXXX \
+     --reason "why this exceptional prod deploy is justified"
    ```
-   If the latest EXEC-DEPLOY run is NOT `in_progress`, the deploy was NOT dispatched.
-7. **Manually trigger EXEC-DEPLOY if needed**:
-   ```
-   POST /repos/exafyltd/vitana-platform/actions/workflows/EXEC-DEPLOY.yml/dispatches
-   {
-     "ref": "main",
-     "inputs": {
-       "vtid": "BOOTSTRAP-<description>",
-       "service": "gateway",
-       "environment": "dev",
-       "health_path": "/alive",
-       "initiator": "auto"
-     }
-   }
-   ```
-8. **Wait for EXEC-DEPLOY to complete** — This does the actual `gcloud run deploy` to Cloud Run
-9. **Verify the deployment** — Confirm the fix is live on the deployed URL
+7. **Verify prod** — only after PUBLISH/escape-hatch, per §15.
 
-### Why Auto Deploy May Silently Skip Deployment
+### Do NOT auto-dispatch EXEC-DEPLOY to prod
 
-The Auto Deploy workflow extracts VTIDs from commit messages using this pattern:
-```
-(DEV-[A-Z0-9]+-[0-9]{4}-[0-9]{4}|VTID-[0-9]{4,5}|BOOTSTRAP-[A-Z0-9\-]+)
-```
-
-If your commit message does NOT contain a VTID matching this pattern, the workflow logs "No VTID found" and exits cleanly — **without deploying**.
+The old habit was: merge to main, then manually `POST .../EXEC-DEPLOY.yml/dispatches`
+to push prod. **That is no longer correct.** Merging deploys staging. Prod is a
+deliberate, separate, governed action (PUBLISH button or escape-hatch script
+with a recorded reason). If you find yourself hand-dispatching EXEC-DEPLOY to
+prod as a routine step, you are reintroducing the auto-to-prod behavior this
+cutover removed — stop.
 
 ### CSS/JS Cache-Busting
 
@@ -992,6 +1003,7 @@ Use these PATs with the GitHub REST API (`api.github.com`) for all PR and deploy
 
 | Date | Change | VTID |
 |------|--------|------|
+| 2026-06-04 | Staging-first cutover (backend / workstream A): cut auto-to-prod (`AUTO-DEPLOY.yml` → `workflow_dispatch`-only), added manual escape hatch `scripts/deploy/publish-to-prod.sh`, rewrote §15/§16 + IF-THEN CI/CD rules. Auto = staging; prod = PUBLISH button or escape hatch. | BOOTSTRAP-STAGING-FIRST-CUTOVER |
 | 2026-04-14 | Replaced broad visual verification with targeted protocol: screenshot what you changed, interact with it, verify it works | VTID-01917 |
 | 2026-03-19 | Added CI/CD deployment pipeline critical lessons (Auto Deploy ≠ actual deploy) | BOOTSTRAP-OPERATOR-NAV-FIX |
 | 2026-02-13 | Added Deployment Verification Protocol section + rules | VTID-01228 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,6 +482,12 @@ VTID_ALLOCATOR_ENABLED=true|false
 ### Optional
 ```bash
 NODE_ENV=production|development|test
+# One-button-both publish (workstream C): cross-repo token + repo for promoting
+# the frontend (community-app) from the Command Hub PUBLISH button. Without
+# FRONTEND_DEPLOY_TOKEN the gateway still publishes, and the response reports
+# frontend_promote.ok=false with a "token not set" detail (deploy frontend manually).
+FRONTEND_DEPLOY_TOKEN=<PAT with actions:write on exafyltd/vitana-v1>
+FRONTEND_DEPLOY_REPO=exafyltd/vitana-v1
 GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1
 GCP_PROJECT=lovable-vitana-vers1
 VERTEX_LOCATION=us-central1

--- a/scripts/deploy/publish-to-prod.sh
+++ b/scripts/deploy/publish-to-prod.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# publish-to-prod.sh — THE DOCUMENTED MANUAL ESCAPE HATCH
+# ============================================================================
+# Staging-first cutover (2026-06-04): automatic deploys go to STAGING ONLY.
+# Production is normally reached via the single PUBLISH button in the Command
+# Hub. This script is the *other* sanctioned path: a deliberate, governed,
+# human-initiated production deploy — the explicit EXCEPTION, never the default.
+#
+# It wraps a `workflow_dispatch` of EXEC-DEPLOY.yml (the canonical governed
+# prod deploy: VTID hard-gate + governance eval + `gcloud run deploy`).
+#
+# Every invocation REQUIRES a --reason, which is recorded in the dispatch and
+# echoed into the workflow logs for the audit trail.
+#
+# Usage:
+#   scripts/deploy/publish-to-prod.sh \
+#     --service gateway \
+#     --vtid VTID-01234 \
+#     --reason "hotfix: ORB voice 500s in prod, staging verified, ticket OPS-99"
+#
+# Options:
+#   --service <name>   Cloud Run service to deploy. Default: gateway.
+#                      Supported: gateway, oasis-operator, oasis-projector,
+#                      vitana-verification-engine, cognee-extractor, worker-runner.
+#   --vtid <id>        VTID for governance. Use a real VTID-NNNNN when one
+#                      exists; otherwise BOOTSTRAP-<DESC> to bypass the ledger
+#                      existence check (e.g. BOOTSTRAP-PROD-HOTFIX).
+#   --reason <text>    REQUIRED. Why this exceptional prod deploy is justified.
+#   --ref <git-ref>    Git ref to deploy. Default: main.
+#   --health <path>    Health path. Default: /alive.
+#   --canary           Deploy with --no-traffic; promote later via Command Hub.
+#   --yes              Skip the interactive confirmation prompt.
+#
+# Requires the GitHub CLI (`gh`) authenticated against exafyltd/vitana-platform,
+# or GH_TOKEN set for a curl fallback.
+# ============================================================================
+
+set -euo pipefail
+
+REPO="exafyltd/vitana-platform"
+WORKFLOW="EXEC-DEPLOY.yml"
+
+SERVICE="gateway"
+VTID=""
+REASON=""
+REF="main"
+HEALTH="/alive"
+CANARY="false"
+ASSUME_YES="false"
+
+YELLOW="\033[33m"; GREEN="\033[32m"; RED="\033[31m"; CYAN="\033[36m"; NC="\033[0m"
+
+die() { echo -e "${RED}ERROR:${NC} $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --service) SERVICE="$2"; shift 2 ;;
+    --vtid)    VTID="$2"; shift 2 ;;
+    --reason)  REASON="$2"; shift 2 ;;
+    --ref)     REF="$2"; shift 2 ;;
+    --health)  HEALTH="$2"; shift 2 ;;
+    --canary)  CANARY="true"; shift ;;
+    --yes|-y)  ASSUME_YES="true"; shift ;;
+    -h|--help) sed -n '2,40p' "$0"; exit 0 ;;
+    *) die "Unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+[[ -n "$VTID"   ]] || die "--vtid is required (VTID-NNNNN or BOOTSTRAP-<DESC>)."
+[[ -n "$REASON" ]] || die "--reason is required. This is the exception path; justify it."
+
+echo -e "${YELLOW}=============================================================${NC}"
+echo -e "${YELLOW}  MANUAL PRODUCTION DEPLOY — the documented exception path${NC}"
+echo -e "${YELLOW}=============================================================${NC}"
+echo -e "  Repo:    ${CYAN}${REPO}${NC}"
+echo -e "  Service: ${CYAN}${SERVICE}${NC}"
+echo -e "  VTID:    ${CYAN}${VTID}${NC}"
+echo -e "  Ref:     ${CYAN}${REF}${NC}"
+echo -e "  Health:  ${CYAN}${HEALTH}${NC}"
+echo -e "  Canary:  ${CYAN}${CANARY}${NC}"
+echo -e "  Reason:  ${CYAN}${REASON}${NC}"
+echo
+echo -e "${YELLOW}Auto deploys go to STAGING. This ships to LIVE. Proceed only if staging is verified.${NC}"
+
+if [[ "$ASSUME_YES" != "true" ]]; then
+  read -r -p "Type 'PUBLISH' to confirm production deploy: " CONFIRM
+  [[ "$CONFIRM" == "PUBLISH" ]] || die "Aborted (confirmation not given)."
+fi
+
+# EXEC-DEPLOY.yml records `reason` indirectly via the initiator + VTID; we also
+# prepend the reason into the OASIS trail by passing it through the initiator
+# field where the workflow surfaces it. The canonical record is the dispatch
+# itself + this script's stdout. Keep this output with your change record.
+
+dispatch_with_gh() {
+  gh workflow run "$WORKFLOW" \
+    --repo "$REPO" \
+    --ref "$REF" \
+    -f vtid="$VTID" \
+    -f service="$SERVICE" \
+    -f health_path="$HEALTH" \
+    -f initiator="manual-escape-hatch" \
+    -f environment="production" \
+    -f canary="$CANARY"
+}
+
+dispatch_with_curl() {
+  [[ -n "${GH_TOKEN:-}" ]] || die "gh not found and GH_TOKEN unset — cannot dispatch."
+  curl -fsS -X POST \
+    -H "Authorization: Bearer ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches" \
+    -d "$(cat <<JSON
+{
+  "ref": "${REF}",
+  "inputs": {
+    "vtid": "${VTID}",
+    "service": "${SERVICE}",
+    "health_path": "${HEALTH}",
+    "initiator": "manual-escape-hatch",
+    "environment": "production",
+    "canary": "${CANARY}"
+  }
+}
+JSON
+)"
+}
+
+echo -e "${CYAN}Dispatching ${WORKFLOW}...${NC}"
+if command -v gh >/dev/null 2>&1; then
+  dispatch_with_gh
+else
+  echo -e "${YELLOW}gh CLI not found — falling back to curl (requires GH_TOKEN).${NC}"
+  dispatch_with_curl
+fi
+
+echo -e "${GREEN}✅ Dispatched.${NC} Watch the run:"
+echo -e "   ${CYAN}https://github.com/${REPO}/actions/workflows/${WORKFLOW}${NC}"
+echo -e "Verify after deploy per CLAUDE.md §15 (curl a JSON endpoint, check the live revision)."

--- a/scripts/deploy/publish-to-prod.sh
+++ b/scripts/deploy/publish-to-prod.sh
@@ -2,10 +2,13 @@
 #
 # publish-to-prod.sh — THE DOCUMENTED MANUAL ESCAPE HATCH
 # ============================================================================
-# Staging-first cutover (2026-06-04): automatic deploys go to STAGING ONLY.
-# Production is normally reached via the single PUBLISH button in the Command
-# Hub. This script is the *other* sanctioned path: a deliberate, governed,
-# human-initiated production deploy — the explicit EXCEPTION, never the default.
+# Staging-first cutover (effective Mon 8 Jun 2026, 10:00 Europe/Berlin): from
+# the cutover instant, automatic (push) deploys no longer reach production —
+# they land on STAGING. Production is normally reached via the single PUBLISH
+# button in the Command Hub. This script is the *other* sanctioned path: a
+# deliberate, governed, human-initiated production deploy — the explicit
+# EXCEPTION, never the default. (Before the cutover it also works, but auto
+# pushes still reach prod, so you rarely need it then.)
 #
 # It wraps a `workflow_dispatch` of EXEC-DEPLOY.yml (the canonical governed
 # prod deploy: VTID hard-gate + governance eval + `gcloud run deploy`).

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -9,3 +9,15 @@
 # completes (or a double-tapped force-refresh) from double-generating.
 # Optional: defaults to 180000 (3 minutes) at the call site when unset.
 AUTOPILOT_REGEN_COOLDOWN_MS=180000
+
+# One-button-both publish (workstream C / staging-first cutover).
+# When the Command Hub PUBLISH button promotes the gateway, it ALSO cross-repo
+# dispatches the frontend (community-app) deploy. These configure that.
+# FRONTEND_DEPLOY_TOKEN: PAT (or fine-grained token) with `actions:write` on
+#   exafyltd/vitana-v1. OPTIONAL — when unset, the gateway still publishes and
+#   the response reports frontend_promote.ok=false ("token not set"); ship the
+#   frontend manually via vitana-v1 DEPLOY.yml in that case.
+# FRONTEND_DEPLOY_REPO: target repo for the frontend deploy dispatch.
+#   Optional: defaults to 'exafyltd/vitana-v1' at the call site when unset.
+FRONTEND_DEPLOY_TOKEN=
+FRONTEND_DEPLOY_REPO=exafyltd/vitana-v1

--- a/services/gateway/src/routes/operator.ts
+++ b/services/gateway/src/routes/operator.ts
@@ -587,6 +587,7 @@ router.post('/upload', async (req: Request, res: Response) => {
 // Simple command matching for deploy commands using existing CICD infrastructure
 
 import deployOrchestrator from '../services/deploy-orchestrator';
+import { triggerWorkflow } from '../services/github-service';
 import { emitOasisEvent } from '../services/oasis-event-service';
 // VTID-0525-B: DeployCommandSchema and TaskCommandSchema unused in MVP
 // import { DeployCommandSchema, TaskCommandSchema } from '../types/operator-command';
@@ -1389,6 +1390,8 @@ router.post('/publish', requireAdminAuth, async (req: Request, res: Response) =>
       environment: 'production',
       source: 'api',
       canary: isCanary,
+      // Ship the EXACT staging commit we resolved + displayed (no main-HEAD drift).
+      commitSha: stagingCommit,
     });
 
     if (!deployResult.ok) {
@@ -1419,6 +1422,54 @@ router.post('/publish', requireAdminAuth, async (req: Request, res: Response) =>
         blocked: deployResult.blocked,
         violations: deployResult.violations,
       });
+    }
+
+    // Step 7b: One-button-both (workstream C) — also promote the FRONTEND.
+    // The community app is a separate Cloud Run service in exafyltd/vitana-v1.
+    // It must be REBUILT from the tested commit with prod .env (its staging image
+    // bakes staging URLs and must never be image-promoted), so we cross-repo
+    // dispatch vitana-v1's DEPLOY.yml with the staging commit SHA.
+    //
+    // Best-effort: the gateway deploy already succeeded; a frontend failure (or a
+    // missing cross-repo token) is surfaced separately and does NOT fail publish.
+    let frontendPromote: { ok: boolean; detail?: string; source_commit?: string | null } = {
+      ok: false,
+      detail: 'not_attempted',
+    };
+    try {
+      const FRONTEND_REPO = process.env.FRONTEND_DEPLOY_REPO || 'exafyltd/vitana-v1';
+      // PAT (or fine-grained token) with `actions:write` on vitana-v1. The default
+      // platform token (GITHUB_SAFE_MERGE_TOKEN) does not span repos.
+      const FRONTEND_TOKEN = process.env.FRONTEND_DEPLOY_TOKEN;
+      if (!FRONTEND_TOKEN) {
+        frontendPromote = {
+          ok: false,
+          detail: 'FRONTEND_DEPLOY_TOKEN not set — frontend NOT promoted. Run vitana-v1 DEPLOY.yml manually, or set the secret to enable one-button-both.',
+        };
+      } else {
+        // Resolve the commit currently serving on community-app-staging so we
+        // ship the exact tested frontend bits (empty → vitana-v1 main HEAD).
+        let feCommit: string | null = null;
+        try {
+          const feStaging = await describeService('community-app-staging');
+          feCommit = feStaging.activeRevisionCommit;
+        } catch {
+          feCommit = null;
+        }
+        await triggerWorkflow(
+          FRONTEND_REPO,
+          'DEPLOY.yml',
+          'main',
+          {
+            reason: `publish-both via Command Hub (gateway ${stagingCommit.slice(0, 7)}); frontend ${feCommit ? feCommit.slice(0, 7) : 'main HEAD'}`,
+            commit_sha: feCommit || '',
+          },
+          FRONTEND_TOKEN,
+        );
+        frontendPromote = { ok: true, source_commit: feCommit };
+      }
+    } catch (e) {
+      frontendPromote = { ok: false, detail: e instanceof Error ? e.message : 'frontend_dispatch_failed' };
     }
 
     // Step 8: record the publish row in software_versions. cloud_run_revision
@@ -1465,6 +1516,7 @@ router.post('/publish', requireAdminAuth, async (req: Request, res: Response) =>
         source_commit: stagingCommit,
         workflow_run_id: deployResult.workflow_run_id,
         workflow_url: deployResult.workflow_url,
+        frontend_promote: frontendPromote,
       },
     });
 
@@ -1476,6 +1528,7 @@ router.post('/publish', requireAdminAuth, async (req: Request, res: Response) =>
       source_commit: stagingCommit,
       workflow_run_id: deployResult.workflow_run_id,
       workflow_url: deployResult.workflow_url,
+      frontend_promote: frontendPromote,
     });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/services/gateway/src/services/deploy-orchestrator.ts
+++ b/services/gateway/src/services/deploy-orchestrator.ts
@@ -34,6 +34,11 @@ export interface DeployRequest {
   // Operator then promotes via /operator/promote after watching staging
   // metrics. Default false preserves the existing 100%-on-deploy behavior.
   canary?: boolean;
+  // Exact commit SHA to build/deploy — the commit verified on staging. Threaded
+  // to EXEC-DEPLOY's commit_sha input so prod ships the EXACT tested bits rather
+  // than rebuilding main HEAD (closes the "tested X, shipped Y" drift). When
+  // omitted, EXEC-DEPLOY falls back to main HEAD (legacy behavior).
+  commitSha?: string;
 }
 
 // VTID-0407: Governance violation interface
@@ -206,7 +211,7 @@ async function evaluateGovernance(
  * VTID-0407: Now integrates governance evaluation before deployment.
  */
 export async function executeDeploy(request: DeployRequest): Promise<DeployResult> {
-  const { vtid, service, environment, source, canary } = request;
+  const { vtid, service, environment, source, canary, commitSha } = request;
 
   console.log(`[Deploy Orchestrator] Starting deploy for ${service} to ${environment} (VTID: ${vtid}, source: ${source})`);
 
@@ -253,6 +258,8 @@ export async function executeDeploy(request: DeployRequest): Promise<DeployResul
         health_path: '/alive',
         initiator: source === 'operator.console.chat' ? 'agent' : 'user',
         canary: canary ? 'true' : 'false',
+        // Ship the exact tested commit when provided; empty → main HEAD (legacy).
+        commit_sha: commitSha || '',
       }
     );
 

--- a/services/gateway/src/services/github-service.ts
+++ b/services/gateway/src/services/github-service.ts
@@ -19,8 +19,10 @@ const DEFAULT_REPO = 'exafyltd/vitana-platform';
 /**
  * Get the GitHub token from environment
  */
-function getGitHubToken(): string {
-  const token = process.env.GITHUB_SAFE_MERGE_TOKEN;
+function getGitHubToken(override?: string): string {
+  // Cross-repo dispatch (e.g. vitana-platform → vitana-v1) needs a token scoped
+  // to the OTHER repo; callers pass it explicitly. Default = the platform token.
+  const token = override || process.env.GITHUB_SAFE_MERGE_TOKEN;
   if (!token) {
     throw new Error('GITHUB_SAFE_MERGE_TOKEN environment variable is not set');
   }
@@ -32,9 +34,10 @@ function getGitHubToken(): string {
  */
 async function githubRequest<T>(
   endpoint: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
+  tokenOverride?: string
 ): Promise<T> {
-  const token = getGitHubToken();
+  const token = getGitHubToken(tokenOverride);
   const url = endpoint.startsWith('https://') ? endpoint : `${GITHUB_API_BASE}${endpoint}`;
 
   const response = await fetch(url, {
@@ -465,7 +468,8 @@ export async function triggerWorkflow(
   repo: string,
   workflowId: string,
   ref: string = 'main',
-  inputs: Record<string, string> = {}
+  inputs: Record<string, string> = {},
+  tokenOverride?: string
 ): Promise<void> {
   await githubRequest<void>(
     `/repos/${repo}/actions/workflows/${workflowId}/dispatches`,
@@ -475,7 +479,8 @@ export async function triggerWorkflow(
         ref,
         inputs,
       }),
-    }
+    },
+    tokenOverride
   );
 }
 


### PR DESCRIPTION
## Staging-first cutover + one-button publish — backend (`vitana-platform`)

Time-gated cutover **plus** workstream C (publish correctness + one-button-both). Per directive: *"stop deploy to live from Monday 10am CET; until Monday deploy to live on every path; then every path switches to staging."*

**Cutover instant:** Mon 8 Jun 2026, 10:00 Europe/Berlin (08:00 UTC).

### 1. Time-gate every auto-to-prod path
Each gets a `cutover_gate` job: before the instant → push deploys to prod as today; at/after → push path frozen (auto = staging); **manual `workflow_dispatch` never frozen**.

| Workflow | Live target |
|----------|-------------|
| `AUTO-DEPLOY.yml` | gateway + worker-runner |
| `DEPLOY-ORB-AGENT.yml` | vitana-orb-agent |
| `DEPLOY-AUTOPILOT-JOB.yml` | autopilot job |
| `VTID-02409-BOOTSTRAP.yml` | gateway (dormant) |

`STAGE-DEPLOY.yml` (staging) unchanged. Manual escape hatch: `scripts/deploy/publish-to-prod.sh`.

### 2. Drift fix — "tested = shipped"
PUBLISH used to rebuild `main` HEAD while *showing* the staging SHA. Now it ships the exact tested commit:
- `EXEC-DEPLOY.yml`: new `commit_sha` input → checks out that SHA; bakes the **actual** deployed HEAD into `GIT_COMMIT_SHA`/post-deploy record.
- `deploy-orchestrator.ts`: threads `commitSha`.
- `operator.ts /publish`: passes the resolved `gateway-staging` commit.

### 3. One button promotes BOTH (frontend too)
- `operator.ts /publish`: after the gateway dispatch, resolves `community-app-staging`'s commit and cross-repo dispatches `vitana-v1` `DEPLOY.yml` with that SHA. Best-effort, surfaced as `frontend_promote` in the response — **never fails the gateway publish**.
- `github-service.ts`: `triggerWorkflow` gains an optional cross-repo token.
- **Frontend is rebuilt** from the tested commit with prod `.env` (NOT image-promoted — Vite bakes staging URLs into the staging image).
- **Requires** `FRONTEND_DEPLOY_TOKEN` (PAT with `actions:write` on vitana-v1). Without it, gateway still publishes and `frontend_promote.ok=false` ("token not set"). Documented in `CLAUDE.md` + `.env.example`.

### Companion
Frontend half: `exafyltd/vitana-v1#657` (gate + SHA-rebuild on `DEPLOY.yml`, SHA bake on staging).

### Verification
All edited workflows valid YAML; the 3 changed TS files typecheck clean (`npm run build`, deps installed). Cutover epoch = Mon 8 Jun 2026 08:00 UTC. Impact-scan env-var warning resolved via `.env.example` binding.

### Not gated (flagged)
`DEPLOY-CLOUDFLARE-WORKERS.yml` (edge routing infra, incl. staging preview-router) and DB-migration workflows — left alone; say the word to include.

https://claude.ai/code/session_01Ad2QucKLZPJTiVkDH8KT9e