### PR TITLE
feat(eval): wire consecutive_clean_days from daily snapshots (BOOTSTRAP-SHADOW-REAL-CANDIDATE G5b)

### DIFF
--- a/services/gateway/scripts/eval/canary-readiness-report.ts
+++ b/services/gateway/scripts/eval/canary-readiness-report.ts
@@ -104,6 +104,9 @@ interface CanaryReadinessReport {
     real_traffic_estimate_24h: number;
     finetune_status: string;
     latest_dataset_rows: number | null;
+    snapshot_date: string;
+    clean_today: boolean;
+    consecutive_clean_days: number;
   };
   next_recommended_action: string;
 }
@@ -231,6 +234,110 @@ async function fetchLatestDatasetRows(target: string): Promise<number | null> {
   }
 }
 
+// ───────────────────────── consecutive-clean-days (G5b) ─────────────────────
+// BOOTSTRAP-SHADOW-REAL-CANDIDATE: the gate's "5 consecutive clean days" rule
+// needs cross-day history. Each run persists a per-day snapshot of whether the
+// day was otherwise-ready ("clean"), and reads prior snapshots to count the
+// streak — turning a permanently-false rule into one that can actually be met.
+
+const READINESS_SNAPSHOT_TOPIC = 'canary.readiness.snapshot';
+
+export interface ReadinessSnapshot {
+  date: string; // 'YYYY-MM-DD' (UTC)
+  clean: boolean;
+}
+
+/** Previous calendar day (UTC) for a 'YYYY-MM-DD' string. */
+export function prevUtcDay(day: string): string {
+  const d = new Date(`${day}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Longest run of consecutive clean days ending today. Today's cleanliness is
+ * passed in (computed this run, before the snapshot is persisted); prior days
+ * come from stored snapshots. A missing calendar day breaks the streak — "N
+ * consecutive clean days" requires evidence for each day, so a gap is not clean.
+ */
+export function computeConsecutiveCleanDays(
+  history: ReadinessSnapshot[],
+  todayClean: boolean,
+  today: string,
+): number {
+  if (!todayClean) return 0;
+  // Latest snapshot per date wins (history is newest-first).
+  const byDate = new Map<string, boolean>();
+  for (const h of history) {
+    if (!byDate.has(h.date)) byDate.set(h.date, h.clean);
+  }
+  let streak = 1; // today
+  let cursor = prevUtcDay(today);
+  while (byDate.get(cursor) === true) {
+    streak++;
+    cursor = prevUtcDay(cursor);
+  }
+  return streak;
+}
+
+/** Read prior daily readiness snapshots for a target (last ~14 days). */
+async function fetchReadinessSnapshots(target: string): Promise<ReadinessSnapshot[]> {
+  if (!PROD_SUPABASE_URL || !PROD_SUPABASE_KEY) return [];
+  try {
+    const sinceIso = new Date(Date.now() - 14 * 86_400_000).toISOString();
+    const resp = await fetch(
+      `${PROD_SUPABASE_URL}/rest/v1/oasis_events`
+      + `?topic=eq.${READINESS_SNAPSHOT_TOPIC}`
+      + `&created_at=gte.${encodeURIComponent(sinceIso)}`
+      + `&metadata->>target=eq.${encodeURIComponent(target)}`
+      + '&order=created_at.desc&limit=200&select=created_at,metadata',
+      { headers: { apikey: PROD_SUPABASE_KEY, Authorization: `Bearer ${PROD_SUPABASE_KEY}` } },
+    );
+    if (!resp.ok) return [];
+    const rows = (await resp.json()) as Array<{ created_at: string; metadata: { date?: string; clean?: boolean } | null }>;
+    const out: ReadinessSnapshot[] = [];
+    for (const r of rows) {
+      const date = r.metadata?.date ?? (typeof r.created_at === 'string' ? r.created_at.slice(0, 10) : null);
+      if (date && typeof r.metadata?.clean === 'boolean') out.push({ date, clean: r.metadata.clean });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist today's snapshot so tomorrow's run can read it. Written to the SAME
+ * prod store the read path uses (read/write consistency — the gateway-emit path
+ * would route to a different DB). Best-effort: never fails the report.
+ */
+async function emitReadinessSnapshot(target: string, date: string, clean: boolean, verdict: string): Promise<void> {
+  if (!PROD_SUPABASE_URL || !PROD_SUPABASE_KEY) return;
+  try {
+    await fetch(`${PROD_SUPABASE_URL}/rest/v1/oasis_events`, {
+      method: 'POST',
+      headers: {
+        apikey: PROD_SUPABASE_KEY,
+        Authorization: `Bearer ${PROD_SUPABASE_KEY}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify({
+        vtid: 'VTID-03217',
+        topic: READINESS_SNAPSHOT_TOPIC,
+        service: 'canary-readiness-report',
+        role: 'eval',
+        status: clean ? 'success' : 'info',
+        message: `canary readiness snapshot ${target} ${date}: clean=${clean} verdict=${verdict}`,
+        source: 'scripts/eval/canary-readiness-report',
+        metadata: { target, date, clean, verdict },
+      }),
+    });
+  } catch {
+    /* best-effort telemetry */
+  }
+}
+
 async function generate(): Promise<CanaryReadinessReport> {
   const target = FEATURE_TARGET;
   let shadow: ShadowReport | null = null;
@@ -340,12 +447,18 @@ async function generate(): Promise<CanaryReadinessReport> {
     reasons.push(reason('dataset_rows', true, `${latestRows} rows extracted recently for ${target} (>= ${THRESHOLDS.min_dataset_rows}).`));
   }
 
-  // 5-consecutive-days clean — out of scope for the single-run report;
-  // surfaced as an unmet rule with explicit "needs cron history" note.
+  // 5-consecutive-days clean (G5b): a "clean day" is one where every OTHER
+  // criterion passed. Compute today's cleanliness from the reasons gathered so
+  // far, read prior daily snapshots, and count the streak ending today. main()
+  // persists today's snapshot afterward so tomorrow's run can read it.
+  const snapshotDate = new Date().toISOString().slice(0, 10);
+  const cleanToday = reasons.every((r) => r.ok);
+  const snapshotHistory = await fetchReadinessSnapshots(target);
+  const consecutiveClean = computeConsecutiveCleanDays(snapshotHistory, cleanToday, snapshotDate);
   reasons.push(reason(
     'consecutive_clean_days',
-    false,
-    `Today's report covers a single 24h window; ${THRESHOLDS.min_consecutive_clean_days} consecutive clean days require historical comparison across daily snapshots (not yet wired). Graduation recommender's daily FCM digest is the authoritative source.`,
+    consecutiveClean >= THRESHOLDS.min_consecutive_clean_days,
+    `${consecutiveClean} consecutive clean day(s)${cleanToday ? '' : ' — today not clean, streak reset'}; need ${THRESHOLDS.min_consecutive_clean_days} (read ${snapshotHistory.length} prior daily snapshot(s)).`,
   ));
 
   const allOk = reasons.every((r) => r.ok);
@@ -366,6 +479,9 @@ async function generate(): Promise<CanaryReadinessReport> {
       real_traffic_estimate_24h: realTraffic,
       finetune_status: FINETUNE_STATUS,
       latest_dataset_rows: latestRows,
+      snapshot_date: snapshotDate,
+      clean_today: cleanToday,
+      consecutive_clean_days: consecutiveClean,
     },
     next_recommended_action: nextAction,
   };
@@ -401,6 +517,13 @@ async function main(): Promise<void> {
     await fs.writeFile(REPORT_MARKDOWN_PATH, renderMarkdown(report), 'utf-8');
     console.error(`[canary-readiness-report] markdown written: ${REPORT_MARKDOWN_PATH}`);
   }
+  // Persist today's snapshot so tomorrow's run can extend the streak (G5b).
+  await emitReadinessSnapshot(
+    report.target,
+    report.evidence.snapshot_date,
+    report.evidence.clean_today,
+    report.verdict,
+  );
 }
 
 if (require.main === module) {
@@ -410,5 +533,5 @@ if (require.main === module) {
   });
 }
 
-export { generate, renderMarkdown, accuracyReason };
+export { generate, renderMarkdown, accuracyReason, computeConsecutiveCleanDays, prevUtcDay };
 export type { CanaryReadinessReport, Reason };

--- a/services/gateway/test/eval-canary-accuracy.test.ts
+++ b/services/gateway/test/eval-canary-accuracy.test.ts
@@ -9,7 +9,11 @@
  */
 process.env.NODE_ENV = 'test';
 
-import { accuracyReason } from '../scripts/eval/canary-readiness-report';
+import {
+  accuracyReason,
+  computeConsecutiveCleanDays,
+  prevUtcDay,
+} from '../scripts/eval/canary-readiness-report';
 
 describe('canary readiness — candidate_accuracy gate', () => {
   test('blocks when there are too few corpus-grounded comparisons', () => {
@@ -55,5 +59,58 @@ describe('canary readiness — candidate_accuracy gate', () => {
   test('a candidate exactly at the floor passes', () => {
     const r = accuracyReason({ real_labeled_comparisons: 50, real_primary_accuracy: 0.85, real_candidate_accuracy: 0.85 });
     expect(r.ok).toBe(true);
+  });
+});
+
+describe('consecutive_clean_days streak (G5b)', () => {
+  test('prevUtcDay steps back one day, across month/year boundaries', () => {
+    expect(prevUtcDay('2026-06-04')).toBe('2026-06-03');
+    expect(prevUtcDay('2026-06-01')).toBe('2026-05-31');
+    expect(prevUtcDay('2026-01-01')).toBe('2025-12-31');
+  });
+
+  test('today not clean → streak 0 regardless of history', () => {
+    const hist = [{ date: '2026-06-03', clean: true }, { date: '2026-06-02', clean: true }];
+    expect(computeConsecutiveCleanDays(hist, false, '2026-06-04')).toBe(0);
+  });
+
+  test('today clean, no history → 1', () => {
+    expect(computeConsecutiveCleanDays([], true, '2026-06-04')).toBe(1);
+  });
+
+  test('today + two prior clean days → 3', () => {
+    const hist = [{ date: '2026-06-03', clean: true }, { date: '2026-06-02', clean: true }];
+    expect(computeConsecutiveCleanDays(hist, true, '2026-06-04')).toBe(3);
+  });
+
+  test('a missing calendar day breaks the streak', () => {
+    // 06-03 missing → only today counts
+    const hist = [{ date: '2026-06-02', clean: true }, { date: '2026-06-01', clean: true }];
+    expect(computeConsecutiveCleanDays(hist, true, '2026-06-04')).toBe(1);
+  });
+
+  test('a not-clean prior day stops the streak', () => {
+    const hist = [{ date: '2026-06-03', clean: true }, { date: '2026-06-02', clean: false }, { date: '2026-06-01', clean: true }];
+    expect(computeConsecutiveCleanDays(hist, true, '2026-06-04')).toBe(2);
+  });
+
+  test('a full 5-day streak meets the threshold', () => {
+    const hist = [
+      { date: '2026-06-03', clean: true },
+      { date: '2026-06-02', clean: true },
+      { date: '2026-06-01', clean: true },
+      { date: '2026-05-31', clean: true },
+    ];
+    expect(computeConsecutiveCleanDays(hist, true, '2026-06-04')).toBe(5);
+  });
+
+  test('newest snapshot per date wins (history is newest-first)', () => {
+    // 06-03 has a later clean=false then an earlier clean=true; newest (false) wins → streak stops at today
+    const hist = [
+      { date: '2026-06-03', clean: false },
+      { date: '2026-06-03', clean: true },
+      { date: '2026-06-02', clean: true },
+    ];
+    expect(computeConsecutiveCleanDays(hist, true, '2026-06-04')).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

**Day-4 G5b** — the last buildable gate piece. The canary-readiness gate's *"5 consecutive clean days"* rule was hardcoded `false` ("needs cron history"), so a `READY_FOR_CANARY` verdict was **permanently unreachable**. This wires the history.

## Changes (`scripts/eval/canary-readiness-report.ts`)

- Each report run **persists a per-day snapshot** (`topic=canary.readiness.snapshot`) recording whether the day was **clean** — i.e. every *other* criterion passed — to the **same prod `oasis_events` store the report reads from** (read/write consistency; the gateway-emit path would route to a different DB).
- **`computeConsecutiveCleanDays()`** (pure, exported): counts the streak of clean days ending today, from today's in-process cleanliness + prior snapshots. A **missing calendar day** or a **not-clean day** breaks the streak; **newest snapshot per date wins**. Passes at `>= min_consecutive_clean_days` (5).
- Snapshot read (last ~14 days) + **best-effort write** (never fails the report). Evidence now carries `snapshot_date` / `clean_today` / `consecutive_clean_days`.

## Why it matters

Combined with the real-candidate seam (G4, #2575) and the real-evidence accuracy gate (G5 safety, #2575), a `READY` verdict is now **reachable** — once real shadow volume + a real candidate + a trained corpus exist, the gate will actually flip instead of being pinned `NOT_READY` by a stub rule.

## Safety

Additive + fail-closed: no snapshots → streak resets to today only (1) → stays `NOT_READY`. The snapshot write is best-effort and can't break the report. CI script, not gateway runtime.

## Verification

- `tsc --noEmit` clean.
- **16/16** canary tests, including **8 streak cases**: day boundaries (month/year), gaps break the streak, a not-clean prior day stops it, a full 5-day streak passes, and newest-per-date wins.

Builds on #2575 (merged). This is the final code piece of Day 4; remaining items are data/traffic-gated.

https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6C7qf2t974CLAktacEmp)_