### PR TITLE
Daily-pace: add user_id + force debug params for on-call test pushes

### DIFF
--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -429,11 +429,28 @@ router.post('/daily-pace-notifications', async (req: Request, res: Response) => 
   const tenantId = getTenantId(req);
   if (!tenantId) return res.status(400).json({ ok: false, error: 'tenant_id required' });
 
+  // Debug params for on-call / manual testing:
+  //   user_id — process ONLY this user (skip the tenant fan-out)
+  //   force   — also bypass the wrong_hour gate so you can fire a test
+  //             push at any time of day. Both also accepted as query string.
+  const debugUserId =
+    (req.body?.user_id as string | undefined) ||
+    (req.query?.user_id as string | undefined) ||
+    undefined;
+  const force =
+    req.body?.force === true ||
+    req.body?.force === 'true' ||
+    req.query?.force === 'true' ||
+    req.query?.force === '1';
+
   const supa = await getServiceClient();
   if (!supa) return res.status(503).json({ ok: false, error: 'Supabase not configured' });
 
   const nowUtc = new Date();
-  const users = await getActiveUsers(supa, tenantId);
+  const allUsers = await getActiveUsers(supa, tenantId);
+  const users = debugUserId
+    ? allUsers.filter((u) => u.user_id === debugUserId)
+    : allUsers;
 
   // Pre-fetch locales for the whole tenant in one query (same pattern as
   // the other fan-out routes — avoids N round-trips for catalog lookups).
@@ -453,7 +470,9 @@ router.post('/daily-pace-notifications', async (req: Request, res: Response) => 
 
   for (const { user_id } of users) {
     try {
-      const decision = await computePaceDecision(supa, user_id, tenantId, nowUtc);
+      const decision = await computePaceDecision(supa, user_id, tenantId, nowUtc, {
+        skipHourCheck: force,
+      });
 
       if (!decision.shouldNotify) {
         if (decision.skipReason) skipped[decision.skipReason]++;

--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -447,10 +447,15 @@ router.post('/daily-pace-notifications', async (req: Request, res: Response) => 
   if (!supa) return res.status(503).json({ ok: false, error: 'Supabase not configured' });
 
   const nowUtc = new Date();
-  const allUsers = await getActiveUsers(supa, tenantId);
+  // When user_id is supplied, target that user directly instead of
+  // fetching the tenant fan-out and filtering in memory — Supabase REST
+  // pages at ~1k rows so a valid user on a later page would otherwise be
+  // silently dropped (codex review). computePaceDecision already
+  // tenant-scopes every read it does, so bogus UUIDs surface as the
+  // expected skip reasons (no_goal etc.) in the response.
   const users = debugUserId
-    ? allUsers.filter((u) => u.user_id === debugUserId)
-    : allUsers;
+    ? [{ user_id: debugUserId }]
+    : await getActiveUsers(supa, tenantId);
 
   // Pre-fetch locales for the whole tenant in one query (same pattern as
   // the other fan-out routes — avoids N round-trips for catalog lookups).

--- a/services/gateway/src/services/daily-pace-service.ts
+++ b/services/gateway/src/services/daily-pace-service.ts
@@ -247,6 +247,7 @@ export async function computePaceDecision(
   userId: string,
   tenantId: string,
   nowUtc: Date,
+  opts?: { skipHourCheck?: boolean },
 ): Promise<PaceDecision> {
   // 1. Resolve tz. Invalid strings fall through to Europe/Berlin via
   //    getUserTimezone's isValidTimezone guard, so this never throws.
@@ -264,7 +265,10 @@ export async function computePaceDecision(
     return { shouldNotify: false, skipReason: 'invalid_tz', timezone: tz };
   }
 
-  if (localHour !== 19) {
+  // The wrong_hour gate is bypassable only via the explicit debug param
+  // on the route (?force=true) so on-call can fire a test push for a
+  // single user without waiting for their local 19:00 tick.
+  if (!opts?.skipHourCheck && localHour !== 19) {
     return {
       shouldNotify: false,
       skipReason: 'wrong_hour',


### PR DESCRIPTION
## Summary

Adds two optional debug inputs to `POST /api/v1/scheduled-notifications/daily-pace-notifications` so on-call can fire a test push to a single user any time of day, without waiting for their local 19:00 tick.

- **`user_id`** — when set, the route processes ONLY that user from the tenant (skips the rest of the fan-out).
- **`force`** — when `true`, `computePaceDecision` bypasses the `wrong_hour` gate. The other guards (`no_goal`, `insufficient_actions`, `muted`, `already_sent`, `invalid_tz`) still apply, so the response still tells you why a user can't receive one if there's a real reason.

Both accepted via JSON body or query string. The Cloud Scheduler's existing body shape (just `tenant_id`) keeps working unchanged.

## Use case

```bash
curl -sS -X POST \
  "https://gateway-q74ibpv6ia-uc.a.run.app/api/v1/scheduled-notifications/daily-pace-notifications" \
  -H "Content-Type: application/json" \
  -d '{"tenant_id":"<tid>","user_id":"<uid>","force":true}'
```

→ runs the pace decision for that one user, ignores the hour check, sends a real push if all other guards pass.

## Test plan
- [ ] Without `user_id`/`force`: existing behaviour — all-tenant fan-out with hour gate enforced.
- [ ] With `user_id` only: only that user evaluated; hour gate still enforced.
- [ ] With `force: true` only: all users evaluated, hour gate bypassed (could spam — intended for `user_id` pair).
- [ ] With both: the one user gets a push regardless of local time, if other guards pass.

https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU)_