### PR TITLE
fix(nav): Events & Meetups tab routing + calendar overlay 404 ("upcoming events")

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -553,12 +553,56 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
       en: {
         title: 'Events & Meetups',
         description: 'Upcoming Maxina community events, in-person meetups, and gatherings.',
-        when_to_visit: 'When the user asks about upcoming events, meetups, things to attend, scheduled gatherings, dance events, wellness workshops, or community activities they can attend in person.',
+        when_to_visit: 'When the user asks about events and meetups in general, the Events & Meetups screen, things to attend, scheduled gatherings, dance events, wellness workshops, or community activities they can attend in person. Lands on the Hot tab by default.',
       },
       de: {
         title: 'Events & Meetups',
         description: 'Kommende Maxina Community Events, persönliche Treffen und Zusammenkünfte.',
-        when_to_visit: 'Wenn der Nutzer nach kommenden Events, Meetups, Veranstaltungen, geplanten Treffen, Tanzveranstaltungen, Wellness-Workshops oder Community-Aktivitäten fragt, an denen teilgenommen werden kann.',
+        when_to_visit: 'Wenn der Nutzer allgemein nach Events und Meetups, dem Events-&-Meetups-Bildschirm, Veranstaltungen, geplanten Treffen, Tanzveranstaltungen, Wellness-Workshops oder Community-Aktivitäten fragt, an denen teilgenommen werden kann. Öffnet standardmäßig den Hot-Tab.',
+      },
+    },
+  },
+  {
+    // VTID-NAV-EVENT-TABS: the Events & Meetups screen has four tabs (Hot,
+    // Upcoming, Today, Following). Hot is the COMM.EVENTS default; Following is
+    // COMM.FEED. These two pin the Upcoming and Today tabs so the Navigator can
+    // land on the exact tab the user names. EventsAndMeetups.tsx reads `?tab=`.
+    screen_id: 'COMM.EVENTS_UPCOMING',
+    route: '/comm/events-meetups?tab=upcoming',
+    category: 'community',
+    access: 'authenticated',
+    anonymous_safe: false,
+    aliases: ['upcoming-events', 'events-upcoming', 'upcoming', 'kommende-veranstaltungen'],
+    i18n: {
+      en: {
+        title: 'Upcoming Events',
+        description: 'Upcoming community events and meetups you can attend.',
+        when_to_visit: 'When the user asks for upcoming events, the upcoming tab, what events are coming up, or future events and meetups in Events & Meetups.',
+      },
+      de: {
+        title: 'Kommende Veranstaltungen',
+        description: 'Kommende Community-Events und Meetups, an denen du teilnehmen kannst.',
+        when_to_visit: 'Wenn der Nutzer nach kommenden Veranstaltungen, anstehenden Events, dem Tab "Kommend" oder zukünftigen Events und Meetups fragt.',
+      },
+    },
+  },
+  {
+    screen_id: 'COMM.EVENTS_TODAY',
+    route: '/comm/events-meetups?tab=today',
+    category: 'community',
+    access: 'authenticated',
+    anonymous_safe: false,
+    aliases: ['today-events', 'events-today', 'todays-events', 'heutige-veranstaltungen'],
+    i18n: {
+      en: {
+        title: "Today's Events",
+        description: 'Community events and meetups happening today.',
+        when_to_visit: "When the user asks what events are happening today, today's events, or the today tab in Events & Meetups.",
+      },
+      de: {
+        title: 'Heutige Veranstaltungen',
+        description: 'Community-Events und Meetups, die heute stattfinden.',
+        when_to_visit: 'Wenn der Nutzer fragt, welche Events heute stattfinden, nach heutigen Veranstaltungen oder dem Tab "Heute".',
       },
     },
   },
@@ -1074,13 +1118,13 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     i18n: {
       en: {
         title: 'My Calendar',
-        description: 'Your personal calendar — view upcoming events, appointments, scheduled activities, and your schedule. The calendar opens as an overlay.',
-        when_to_visit: 'When the user asks to open their calendar, see their calendar, my calendar, show calendar, check their appointments, view upcoming schedule, check availability, Kalender öffnen, or manage their personal calendar.',
+        description: 'Your personal calendar — your appointments, scheduled activities, and daily schedule. Opens as an overlay.',
+        when_to_visit: 'When the user asks to open their calendar, see their calendar, my calendar, show calendar, check their appointments, view their schedule, check availability, or manage their personal calendar. NOT for community events (that is Events & Meetups).',
       },
       de: {
         title: 'Mein Kalender',
-        description: 'Dein persönlicher Kalender — sieh anstehende Termine, Verabredungen und geplante Aktivitäten. Der Kalender öffnet sich als Overlay.',
-        when_to_visit: 'Wenn der Nutzer seinen Kalender öffnen, Kalender anzeigen, mein Kalender, seinen Zeitplan sehen, Termine prüfen, anstehende Events ansehen, Verfügbarkeit prüfen oder seinen persönlichen Kalender verwalten möchte.',
+        description: 'Dein persönlicher Kalender — deine Termine, Verabredungen und geplante Aktivitäten. Öffnet sich als Overlay.',
+        when_to_visit: 'Wenn der Nutzer seinen Kalender öffnen, Kalender anzeigen, mein Kalender, seinen Zeitplan sehen, Termine prüfen, Verfügbarkeit prüfen oder seinen persönlichen Kalender verwalten möchte. NICHT für Community-Events (das ist Events & Meetups).',
       },
     },
     related_kb_topics: ['calendar', 'schedule', 'appointments', 'events'],

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -2851,6 +2851,7 @@ export async function tool_navigate(
   }
 
   const lang = (id.lang || 'en') as string;
+  const isMobile = (typeof args.is_mobile === 'boolean' ? args.is_mobile : id.is_mobile) ?? false;
   const currentRoute = typeof args.current_route === 'string' && args.current_route.length > 0
     ? args.current_route
     : null;
@@ -2976,13 +2977,25 @@ export async function tool_navigate(
     const entry = lookupScreen(consultResult.primary.screen_id);
     if (entry) {
       const content = getContent(entry, lang);
+      // VTID-NAV-OVERLAY: resolve the route the SAME way navigate_to_screen
+      // does — honor mobile_route, and for overlay entries append the
+      // `?open=<query_marker>` marker the frontend intercepts. Without this the
+      // auto-redirect path dispatched the raw `entry.route` (e.g. `/calendar`),
+      // which is not a real page → 404. Overlays must open as a drawer instead.
+      const baseRoute = (isMobile && entry.mobile_route) ? entry.mobile_route : entry.route;
+      let resolvedRoute = baseRoute;
+      if (entry.entry_kind === 'overlay' && entry.overlay) {
+        const sep = resolvedRoute.includes('?') ? '&' : '?';
+        resolvedRoute = `${resolvedRoute}${sep}open=${entry.overlay.query_marker}`;
+      }
       const directive = {
         type: 'orb_directive',
         directive: 'navigate',
         screen_id: entry.screen_id,
-        route: entry.route,
+        route: resolvedRoute,
         title: content.title,
         reason: question,
+        entry_kind: entry.entry_kind || 'route',
         vtid: 'VTID-NAV-01',
       };
 
@@ -2995,7 +3008,7 @@ export async function tool_navigate(
         payload: {
           session_id: id.session_id || null,
           screen_id: entry.screen_id,
-          route: entry.route,
+          route: resolvedRoute,
           drain_wait_ms: 0,
         },
       }).catch(() => {});
@@ -3005,11 +3018,11 @@ export async function tool_navigate(
         type: 'orb.navigator.requested',
         source: 'orb-tools-shared',
         status: 'info',
-        message: `navigate auto-redirect to ${entry.screen_id} (${entry.route})`,
+        message: `navigate auto-redirect to ${entry.screen_id} (${resolvedRoute})`,
         payload: {
           session_id: id.session_id || null,
           screen_id: entry.screen_id,
-          route: entry.route,
+          route: resolvedRoute,
           reason: question,
           is_anonymous: isAnonymous,
         },

--- a/services/gateway/test/navigation-catalog.test.ts
+++ b/services/gateway/test/navigation-catalog.test.ts
@@ -173,10 +173,10 @@ const ROUTING_CASES: RoutingCase[] = [
   // ── COMM.EVENTS (P0) ──
   { utterance: 'take me to the events page',                lang: 'en', expected_screen_id: 'COMM.EVENTS' },
   { utterance: 'where can I find the meetups',              lang: 'en', expected_screen_id: 'COMM.EVENTS' },
-  { utterance: 'show me upcoming events',                   lang: 'en', expected_screen_id: 'COMM.EVENTS' },
+  { utterance: 'show me upcoming events',                   lang: 'en', expected_screen_id: 'COMM.EVENTS_UPCOMING' },
   { utterance: 'I want to attend a meetup',                 lang: 'en', expected_screen_id: 'COMM.EVENTS' },
   { utterance: 'wo finde ich die treffen',                  lang: 'de', expected_screen_id: 'COMM.EVENTS' },
-  { utterance: 'zeig mir die kommenden veranstaltungen',    lang: 'de', expected_screen_id: 'COMM.EVENTS' },
+  { utterance: 'zeig mir die kommenden veranstaltungen',    lang: 'de', expected_screen_id: 'COMM.EVENTS_UPCOMING' },
 
   // ── COMM.LIVE_ROOMS ──
   { utterance: 'open the live rooms',                       lang: 'en', expected_screen_id: 'COMM.LIVE_ROOMS' },


### PR DESCRIPTION
## Problem

"Take me to the **Events & Meetups** screen, **Upcoming Events**" → **404**.

OASIS logs: the navigator's auto-redirect path dispatched `CALENDAR.OVERVIEW → /calendar`. Two defects combined:

1. **"Upcoming events" matched the calendar.** `CALENDAR.OVERVIEW` had `priority: 3` and wording *"view upcoming events / schedule"* / *"anstehende Events ansehen"*, so the **semantic** ranker (warmed in prod) put "upcoming events" on the calendar. (CI passed because its keyword-only scorer picked `COMM.EVENTS`.)
2. **The calendar dead-routed.** `CALENDAR.OVERVIEW` is an **overlay** (opens via `?open=calendar`), but the auto-redirect path (`tool_navigate`) dispatched the raw `entry.route` (`/calendar`) — a non-existent page → 404. (The other path, `navigate_to_screen`, already handled overlays; this one didn't.)

## Change

**`orb-tools-shared.ts` (`tool_navigate`)** — resolve the directive route like `navigate_to_screen` does: honor `mobile_route` and append `?open=<query_marker>` for `entry_kind: 'overlay'`. So the calendar (and any overlay) opens as a drawer instead of dead-routing.

**`navigation-catalog.ts`**
- Add `COMM.EVENTS_UPCOMING` → `/comm/events-meetups?tab=upcoming` and `COMM.EVENTS_TODAY` → `/comm/events-meetups?tab=today`. (Hot = `COMM.EVENTS` default; Following = existing `COMM.FEED`.) The Events screen already reads `?tab=`.
- Remove "upcoming events / schedule" wording from `CALENDAR.OVERVIEW` so it stops capturing "upcoming events"; de-emphasize "upcoming" in `COMM.EVENTS` (now the Hot default).

**Tests** — updated two utterances (`"show me upcoming events"`, DE equivalent) from `COMM.EVENTS` → `COMM.EVENTS_UPCOMING`, reflecting the new tab-specific intent.

Net effect: "Events & Meetups" → Hot; "upcoming events" → Upcoming tab; "today's events" → Today tab; "following" → Following; and "open my calendar" opens the calendar drawer instead of 404'ing. Frontend needs no change.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_