### PR TITLE
fix(orb): idempotent /live/session/start — kill voice session churn

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -10,10 +10,16 @@
 # Optional: defaults to 180000 (3 minutes) at the call site when unset.
 AUTOPILOT_REGEN_COOLDOWN_MS=180000
 
-# ORB voice session-start idempotency window (BOOTSTRAP-ORB-SESSION-CHURN).
-# A duplicate POST /api/v1/orb/live/session/start for the same user within this
-# window — while their prior session is still active and has zero turns — returns
-# the existing live session instead of superseding it. Collapses the
-# `superseded_by_new_session` churn that tore down the greeting mid-utterance.
-# Optional: defaults to 120000 (2 minutes) at the call site when unset.
-ORB_SESSION_DEDUP_WINDOW_MS=120000
+# ORB voice session-start idempotency (BOOTSTRAP-ORB-SESSION-CHURN).
+# A duplicate POST /api/v1/orb/live/session/start for the same user returns the
+# existing live session instead of superseding it WHILE that session is active
+# and has taken zero turns (identical greeting state). The decision is
+# state-driven, not clock-driven — this collapses the `superseded_by_new_session`
+# churn that tore the greeting down before it spoke.
+#
+# Kill switch: set to "false" to disable reuse entirely (defense-in-depth).
+ORB_SESSION_REUSE_ENABLED=true
+# Safety backstop only — a zero-turn session older than this is NOT reused (guards
+# against a wedged session). Optional: defaults to the session TTL (1800000 = 30m)
+# at the call site when unset, since a zero-turn session is reusable for its life.
+ORB_SESSION_REUSE_MAX_AGE_MS=1800000

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -9,3 +9,11 @@
 # completes (or a double-tapped force-refresh) from double-generating.
 # Optional: defaults to 180000 (3 minutes) at the call site when unset.
 AUTOPILOT_REGEN_COOLDOWN_MS=180000
+
+# ORB voice session-start idempotency window (BOOTSTRAP-ORB-SESSION-CHURN).
+# A duplicate POST /api/v1/orb/live/session/start for the same user within this
+# window — while their prior session is still active and has zero turns — returns
+# the existing live session instead of superseding it. Collapses the
+# `superseded_by_new_session` churn that tore down the greeting mid-utterance.
+# Optional: defaults to 120000 (2 minutes) at the call site when unset.
+ORB_SESSION_DEDUP_WINDOW_MS=120000

--- a/services/gateway/docs/orb-session-churn-verification.sql
+++ b/services/gateway/docs/orb-session-churn-verification.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- BOOTSTRAP-ORB-SESSION-CHURN — verification queries
+-- ============================================================================
+-- Phase 3 of the ORB voice session-churn fix. Run these against the VITANA
+-- Supabase project (oasis_events) BEFORE and AFTER the gateway + client deploy
+-- to confirm the supersede rate drops and session reuse kicks in.
+--
+-- The event-type lives in `oasis_events.topic`; per-session detail is in
+-- `metadata` (jsonb): reason, turn_count, user_id, session_id, duration_ms.
+--
+-- ----------------------------------------------------------------------------
+-- BASELINE (measured 2026-06-07, pre-fix, ~7 days of dev data):
+--   starts:                722
+--   stops:                 756
+--     expired_ttl:         264   (100.0% zero-turn, ~33 min median life)
+--     user-ended:          263   ( 13.7% zero-turn,    20s median life)
+--     superseded:          229   ( 89.5% zero-turn,    72s median life)  <-- target
+--   superseded-zero-turn:  205   of which 198 had the next start within 5s
+--   sessions never used:   469 / 722  (65%)  [superseded-0 + expired-0]
+--   target after fix: superseded_by_new_session zero-turn -> near 0,
+--                     replaced by `deduplicated=true` reuse events.
+-- ----------------------------------------------------------------------------
+
+-- (1) Stop-reason breakdown — the headline. Watch `superseded_by_new_session`
+--     collapse and its zero-turn share fall.
+select
+  coalesce(metadata->>'reason','(none/user_ended)')                              as reason,
+  count(*)                                                                       as stops,
+  count(*) filter (where (metadata->>'turn_count')::int = 0)                     as zero_turn,
+  round(100.0 * count(*) filter (where (metadata->>'turn_count')::int = 0)
+        / nullif(count(*),0), 1)                                                 as zero_turn_pct,
+  round((percentile_cont(0.5) within group (
+        order by (metadata->>'duration_ms')::numeric) / 1000.0)::numeric, 1)     as median_life_s
+from oasis_events
+where topic = 'vtid.live.session.stop'
+  and created_at > now() - interval '14 days'
+group by 1
+order by stops desc;
+
+-- (2) Reuse adoption — should be ~0 before deploy, then rise to roughly the old
+--     supersede volume. Broken out by the client-declared start_cause.
+select
+  coalesce(metadata->>'start_cause','(unset)')      as start_cause,
+  count(*)                                           as reuse_hits,
+  round(avg((metadata->>'reused_age_ms')::numeric)::numeric, 0) as avg_reused_age_ms
+from oasis_events
+where topic = 'vtid.live.session.start'
+  and (metadata->>'deduplicated') = 'true'
+  and created_at > now() - interval '14 days'
+group by 1
+order by reuse_hits desc;
+
+-- (3) Churn ratio — supersedes per start. Pre-fix ~0.32; target well below 0.05.
+select
+  count(*) filter (where topic = 'vtid.live.session.start'
+                     and coalesce((metadata->>'deduplicated')::bool,false) = false) as real_starts,
+  count(*) filter (where topic = 'vtid.live.session.stop'
+                     and metadata->>'reason' = 'superseded_by_new_session')         as supersedes,
+  round(
+    count(*) filter (where topic = 'vtid.live.session.stop'
+                       and metadata->>'reason' = 'superseded_by_new_session')::numeric
+    / nullif(count(*) filter (where topic = 'vtid.live.session.start'
+                       and coalesce((metadata->>'deduplicated')::bool,false) = false),0),
+    3)                                                                              as supersede_per_start
+from oasis_events
+where topic in ('vtid.live.session.start','vtid.live.session.stop')
+  and created_at > now() - interval '14 days';

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1156,7 +1156,11 @@
         lang: _cfg.lang,
         voice_style: 'friendly, calm, empathetic',
         response_modalities: ['audio', 'text'],
-        vad_silence_ms: 850 // VTID-03019: trimmed 1200→850 to cut ~350ms off end-of-turn latency; constants.ts mirrors
+        vad_silence_ms: 850, // VTID-03019: trimmed 1200→850 to cut ~350ms off end-of-turn latency; constants.ts mirrors
+        // BOOTSTRAP-ORB-SESSION-CHURN: declare WHY this start fired so the gateway
+        // can attribute session reuse vs. supersede per-cause in oasis_events.
+        // Defaults to a user-initiated open; the reconnect block below overrides.
+        start_cause: 'user_open'
       };
       // VTID-03250: send the browser's OWN IANA timezone so the gateway has a
       // reliable local time even when geo-IP rate-limits (HTTP 429). Without
@@ -1194,6 +1198,7 @@
           });
         }
         startPayload.reconnect_stage = _s._preDisconnectStage || 'idle';
+        startPayload.start_cause = 'reconnect';
         if (_s.conversationId) startPayload.conversation_id = _s.conversationId;
         console.log('[VTOrb] _sessionStart: reconnect context — stage=' + startPayload.reconnect_stage
           + ', transcript=' + (startPayload.transcript_history ? startPayload.transcript_history.length : 0) + ' turns'

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -17,7 +17,7 @@
 (function (window) {
   'use strict';
 
-  var _WIDGET_VERSION = '2026-05-08-vtid-02034b-stale-instance-404';
+  var _WIDGET_VERSION = '2026-06-01-devcomhu0503b-persist-continuity-on-disconnect';
   console.log('[VTOrb] Widget version: ' + _WIDGET_VERSION);
 
   // Prevent double-load
@@ -715,6 +715,21 @@
 
     console.warn('[VTOrb] _announceDisconnect: reason=' + reason + ', stage=' + stage);
 
+    // DEV-COMHU-0503 follow-up: persist continuity to the gateway the MOMENT a
+    // disconnect is detected — not only on graceful _hide(). Mobile WebViews
+    // routinely RELOAD the page during an outage (network change, OS
+    // backgrounding/kill, OOM, or a render-crash auto-reload), which wipes the
+    // module-scoped _s — including _transcriptHistory and conversationId. When
+    // that happened the next _sessionStart's continuity GET found nothing had
+    // been persisted for the disconnect, so Vitana greeted "first-time" and the
+    // user lost the entire conversation ("forgets what we talked about"). The
+    // in-memory reconnect path (_resetAndReconnect/_attemptReconnect) already
+    // carries history, but it only survives if the page stays alive. Persisting
+    // here (short 5-min TTL, keepalive so it survives teardown) lets a
+    // reload-during-outage rehydrate conversation_id + the last turns and
+    // resume the same thread instead of starting over.
+    _persistContinuity('connection', 5);
+
     // Gate mic immediately — _sendAudio checks `active` and `voiceState === 'MUTED'`
     // at the VAD processor (line ~1191), so setting MUTED stops outbound audio.
     _s.voiceState = 'MUTED';
@@ -1156,11 +1171,7 @@
         lang: _cfg.lang,
         voice_style: 'friendly, calm, empathetic',
         response_modalities: ['audio', 'text'],
-        vad_silence_ms: 850, // VTID-03019: trimmed 1200→850 to cut ~350ms off end-of-turn latency; constants.ts mirrors
-        // BOOTSTRAP-ORB-SESSION-CHURN: declare WHY this start fired so the gateway
-        // can attribute session reuse vs. supersede per-cause in oasis_events.
-        // Defaults to a user-initiated open; the reconnect block below overrides.
-        start_cause: 'user_open'
+        vad_silence_ms: 850 // VTID-03019: trimmed 1200→850 to cut ~350ms off end-of-turn latency; constants.ts mirrors
       };
       // VTID-03250: send the browser's OWN IANA timezone so the gateway has a
       // reliable local time even when geo-IP rate-limits (HTTP 429). Without
@@ -1198,7 +1209,6 @@
           });
         }
         startPayload.reconnect_stage = _s._preDisconnectStage || 'idle';
-        startPayload.start_cause = 'reconnect';
         if (_s.conversationId) startPayload.conversation_id = _s.conversationId;
         console.log('[VTOrb] _sessionStart: reconnect context — stage=' + startPayload.reconnect_stage
           + ', transcript=' + (startPayload.transcript_history ? startPayload.transcript_history.length : 0) + ' turns'

--- a/services/gateway/src/orb/live/config.ts
+++ b/services/gateway/src/orb/live/config.ts
@@ -42,6 +42,33 @@ export const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
 export const CONVERSATION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 
 /**
+ * ORB session-start idempotency (BOOTSTRAP-ORB-SESSION-CHURN).
+ *
+ * Telemetry (oasis_events, dev): 31.7% of `/live/session/start` calls supersede
+ * a still-live session for the SAME user, and 89.5% of those superseded
+ * sessions had ZERO turns — the greeting was torn down before it ever spoke
+ * (the "constant disconnect during the opening" the community reports). The
+ * superseding start lands within ~3.4s on average, so a redundant start (widget
+ * re-show, double-mount, or a supersede→SSE-close→reconnect bounce) should
+ * REUSE the in-flight zero-turn session instead of superseding it.
+ *
+ * The decision is STATE-driven, not clock-driven: a session is reusable while
+ * it is `active` and has taken NO turns — that is the real signal, the same
+ * greeting state a fresh session would be in. The age bound is only a safety
+ * backstop so a wedged session can't be reused forever; it defaults to the
+ * session TTL precisely because a zero-turn session stays in the identical
+ * state for its whole life. Both are env-overridable so ops can tune the
+ * backstop or flip the kill switch without a redeploy (defense-in-depth).
+ */
+export const ORB_SESSION_REUSE_ENABLED =
+  (process.env.ORB_SESSION_REUSE_ENABLED ?? 'true').toLowerCase() !== 'false';
+
+export const ORB_SESSION_REUSE_MAX_AGE_MS = (() => {
+  const raw = Number(process.env.ORB_SESSION_REUSE_MAX_AGE_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : SESSION_TIMEOUT_MS;
+})();
+
+/**
  * Maximum concurrent ORB connections from a single IP. Higher values
  * invite abuse; lower values break shared offices/NAT exits.
  */

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -225,6 +225,50 @@ function getDeps(): LiveSessionControllerDeps {
 }
 
 // =============================================================================
+// VTID-ORB-CHURN: session-start idempotency (kills "superseded_by_new_session")
+// =============================================================================
+// Telemetry showed ~32% of all `/live/session/start` calls were restarts for the
+// SAME user within 2 minutes of the previous start (260/801 over 14d), and 92% of
+// the resulting `superseded_by_new_session` stops had ZERO turns. The client fires
+// a redundant start (token-refresh widget re-init, double-mount, app foreground),
+// each one trips `terminateExistingSessionsForUser()` and tears down the greeting
+// mid-utterance — the user hears "constant disconnects during the opening".
+//
+// This guard makes `/live/session/start` idempotent: if the same user already has
+// an ACTIVE, fully-initialized, ZERO-turn session inside the dedup window, return
+// THAT live session instead of superseding it. Reusing a zero-turn session is safe
+// — it is an abandoned greeting in the exact same state a fresh one would be — and
+// the client opening its SSE against the returned `session_id` is the already-
+// supported reconnect flow. Reconnect starts (transcript history / non-idle stage)
+// are intentional continuity and always bypass this guard.
+const ORB_SESSION_DEDUP_WINDOW_MS = Number(process.env.ORB_SESSION_DEDUP_WINDOW_MS) || 120_000;
+
+/**
+ * Find the most-recent reusable live session for a user: active, owned by the
+ * user, no turns yet, already past first-response (so we never hand back a
+ * half-built session), and younger than the dedup window. Returns null when no
+ * such session exists (the normal "genuine new conversation" path).
+ */
+function findReusableLiveSession(userId: string): GeminiLiveSession | null {
+  const now = Date.now();
+  let best: GeminiLiveSession | null = null;
+  let bestAge = Infinity;
+  for (const session of liveSessions.values()) {
+    if (!session.active) continue;
+    if (!session.identity || session.identity.user_id !== userId) continue;
+    if (session.turn_count !== 0) continue;
+    if (!(session as { startResponseBody?: unknown }).startResponseBody) continue;
+    const age = now - session.createdAt.getTime();
+    if (age > ORB_SESSION_DEDUP_WINDOW_MS) continue;
+    if (age < bestAge) {
+      bestAge = age;
+      best = session;
+    }
+  }
+  return best;
+}
+
+// =============================================================================
 // Lifecycle / cleanup helpers
 // =============================================================================
 
@@ -632,6 +676,37 @@ export async function handleLiveSessionStart(
   // Resolve full identity (JWT verified → real user, or DEV_IDENTITY fallback)
   const orbIdentity = await deps.resolveOrbIdentity(req);
   const bootstrapIdentity: SupabaseIdentity | null = hasJwtIdentity ? orbIdentity : null;
+
+  // VTID-ORB-CHURN: idempotency guard. A duplicate start for a user who already
+  // has a fresh, zero-turn session in flight returns the live session instead of
+  // superseding it — collapsing the session churn that tore down the greeting.
+  // DEV identity is shared across anonymous dev sessions, so it is never deduped
+  // (matches the supersede skip below). Reconnect starts always proceed.
+  const isDevIdentityForDedup = orbIdentity?.user_id === DEV_IDENTITY.USER_ID;
+  if (orbIdentity?.user_id && !isDevIdentityForDedup && !isReconnectStart) {
+    const reusable = findReusableLiveSession(orbIdentity.user_id);
+    if (reusable) {
+      const reusedAgeMs = Date.now() - reusable.createdAt.getTime();
+      console.log(
+        `[VTID-ORB-CHURN] Deduplicated /live/session/start for user=${orbIdentity.user_id.substring(0, 8)}… → reusing live session ${reusable.sessionId} (age=${reusedAgeMs}ms, turns=0); supersede skipped, discarded ${sessionId}`,
+      );
+      deps.emitLiveSessionEvent('vtid.live.session.start', {
+        session_id: reusable.sessionId,
+        user_id: orbIdentity.user_id,
+        tenant_id: orbIdentity.tenant_id || null,
+        transport: 'sse',
+        deduplicated: true,
+        dedup_reason: 'fresh_zero_turn_session_reused',
+        reused_session_id: reusable.sessionId,
+        discarded_session_id: sessionId,
+        reused_age_ms: reusedAgeMs,
+      }).catch(() => {});
+      return res.status(200).json({
+        ...(reusable as unknown as { startResponseBody: Record<string, unknown> }).startResponseBody,
+        deduplicated: true,
+      });
+    }
+  }
 
   // VTID-CONTEXT: Build client context (IP geo, device, time) — for all sessions
   const clientContext = await deps.buildClientContext(req);
@@ -1418,7 +1493,7 @@ export async function handleLiveSessionStart(
   // BOOTSTRAP-VOICE-DEMO: real heartbeat
   recordAgentHeartbeat('orb-live').catch(() => {});
 
-  return res.status(200).json({
+  const startResponseBody = {
     ok: true,
     session_id: sessionId,
     conversation_id: resolvedConversationId,
@@ -1461,7 +1536,14 @@ export async function handleLiveSessionStart(
           }
         : null,
     },
-  });
+  };
+
+  // VTID-ORB-CHURN: stash the exact start response on the session so a duplicate
+  // start within the dedup window can replay it (see findReusableLiveSession).
+  (session as unknown as { startResponseBody: typeof startResponseBody }).startResponseBody =
+    startResponseBody;
+
+  return res.status(200).json(startResponseBody);
 }
 
 /**

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -40,7 +40,13 @@ import type {
   LiveStreamVideoFrame,
 } from '../types';
 import type { ContextPack } from '../../../types/conversation';
-import { SESSION_TIMEOUT_MS, VERTEX_PROJECT_ID } from '../config';
+import {
+  SESSION_TIMEOUT_MS,
+  VERTEX_PROJECT_ID,
+  ORB_SESSION_REUSE_ENABLED,
+  ORB_SESSION_REUSE_MAX_AGE_MS,
+} from '../config';
+import { pickReusableSession } from './session-reuse';
 import { VERTEX_LIVE_MODEL } from '../protocol';
 import {
   // VTID-03124 (Phase D.1): voice thresholds now resolved via PolicyResolver.
@@ -225,47 +231,38 @@ function getDeps(): LiveSessionControllerDeps {
 }
 
 // =============================================================================
-// VTID-ORB-CHURN: session-start idempotency (kills "superseded_by_new_session")
+// BOOTSTRAP-ORB-SESSION-CHURN: session-start idempotency
 // =============================================================================
-// Telemetry showed ~32% of all `/live/session/start` calls were restarts for the
-// SAME user within 2 minutes of the previous start (260/801 over 14d), and 92% of
-// the resulting `superseded_by_new_session` stops had ZERO turns. The client fires
-// a redundant start (token-refresh widget re-init, double-mount, app foreground),
-// each one trips `terminateExistingSessionsForUser()` and tears down the greeting
-// mid-utterance — the user hears "constant disconnects during the opening".
+// Verified against oasis_events (dev): 31.7% of `/live/session/start` calls
+// supersede a still-live session for the SAME user, and 89.5% of those
+// superseded sessions had ZERO turns — torn down before the greeting ever spoke
+// (the "constant disconnect during the opening" the community reports). The
+// superseding start lands ~3.4s later on average — a rapid re-show / double-mount
+// / supersede→SSE-close→reconnect bounce, NOT a slow token-refresh.
 //
-// This guard makes `/live/session/start` idempotent: if the same user already has
-// an ACTIVE, fully-initialized, ZERO-turn session inside the dedup window, return
-// THAT live session instead of superseding it. Reusing a zero-turn session is safe
-// — it is an abandoned greeting in the exact same state a fresh one would be — and
-// the client opening its SSE against the returned `session_id` is the already-
-// supported reconnect flow. Reconnect starts (transcript history / non-idle stage)
-// are intentional continuity and always bypass this guard.
-const ORB_SESSION_DEDUP_WINDOW_MS = Number(process.env.ORB_SESSION_DEDUP_WINDOW_MS) || 120_000;
+// This guard makes `/live/session/start` idempotent: if the same user already
+// has a reusable in-flight session, return THAT live session instead of
+// superseding it. The decision is STATE-driven (active + zero turns) with a
+// configurable age backstop — see ORB_SESSION_REUSE_* in ../config. Reusing a
+// zero-turn session is safe (identical greeting state) and the client opening
+// its SSE against the returned `session_id` is the already-supported reconnect
+// flow. Reconnect starts (transcript history / non-idle stage) carry real
+// continuity and always bypass this guard.
 
 /**
  * Find the most-recent reusable live session for a user: active, owned by the
- * user, no turns yet, already past first-response (so we never hand back a
- * half-built session), and younger than the dedup window. Returns null when no
- * such session exists (the normal "genuine new conversation" path).
+ * user, no turns yet, and already past first-response (so we never hand back a
+ * half-built session). The age backstop (ORB_SESSION_REUSE_MAX_AGE_MS) only
+ * guards against a wedged session; state — not the clock — is the primary gate.
+ * Returns null when no such session exists (the normal new-conversation path).
  */
 function findReusableLiveSession(userId: string): GeminiLiveSession | null {
-  const now = Date.now();
-  let best: GeminiLiveSession | null = null;
-  let bestAge = Infinity;
-  for (const session of liveSessions.values()) {
-    if (!session.active) continue;
-    if (!session.identity || session.identity.user_id !== userId) continue;
-    if (session.turn_count !== 0) continue;
-    if (!(session as { startResponseBody?: unknown }).startResponseBody) continue;
-    const age = now - session.createdAt.getTime();
-    if (age > ORB_SESSION_DEDUP_WINDOW_MS) continue;
-    if (age < bestAge) {
-      bestAge = age;
-      best = session;
-    }
-  }
-  return best;
+  return pickReusableSession(
+    liveSessions.values() as Iterable<GeminiLiveSession & { startResponseBody?: unknown }>,
+    userId,
+    Date.now(),
+    ORB_SESSION_REUSE_MAX_AGE_MS,
+  );
 }
 
 // =============================================================================
@@ -677,18 +674,32 @@ export async function handleLiveSessionStart(
   const orbIdentity = await deps.resolveOrbIdentity(req);
   const bootstrapIdentity: SupabaseIdentity | null = hasJwtIdentity ? orbIdentity : null;
 
-  // VTID-ORB-CHURN: idempotency guard. A duplicate start for a user who already
-  // has a fresh, zero-turn session in flight returns the live session instead of
-  // superseding it — collapsing the session churn that tore down the greeting.
+  // BOOTSTRAP-ORB-SESSION-CHURN: idempotency guard. A duplicate start for a user
+  // who already has an active, zero-turn session in flight returns the live
+  // session instead of superseding it — collapsing the churn that tore down the
+  // greeting before it spoke. Gated by ORB_SESSION_REUSE_ENABLED (kill switch).
   // DEV identity is shared across anonymous dev sessions, so it is never deduped
   // (matches the supersede skip below). Reconnect starts always proceed.
+  //
+  // `start_cause` is a contextual signal the client declares (e.g. 'user_open',
+  // 'reconnect', 'dom_recovery') so the dedup decision is observable per-cause
+  // in oasis_events — it does not change the decision (state does), it explains it.
+  const startCause =
+    typeof (body as { start_cause?: unknown }).start_cause === 'string'
+      ? ((body as { start_cause?: string }).start_cause as string)
+      : null;
   const isDevIdentityForDedup = orbIdentity?.user_id === DEV_IDENTITY.USER_ID;
-  if (orbIdentity?.user_id && !isDevIdentityForDedup && !isReconnectStart) {
+  if (
+    ORB_SESSION_REUSE_ENABLED &&
+    orbIdentity?.user_id &&
+    !isDevIdentityForDedup &&
+    !isReconnectStart
+  ) {
     const reusable = findReusableLiveSession(orbIdentity.user_id);
     if (reusable) {
       const reusedAgeMs = Date.now() - reusable.createdAt.getTime();
       console.log(
-        `[VTID-ORB-CHURN] Deduplicated /live/session/start for user=${orbIdentity.user_id.substring(0, 8)}… → reusing live session ${reusable.sessionId} (age=${reusedAgeMs}ms, turns=0); supersede skipped, discarded ${sessionId}`,
+        `[BOOTSTRAP-ORB-SESSION-CHURN] Reused /live/session/start for user=${orbIdentity.user_id.substring(0, 8)}… cause=${startCause ?? 'unset'} → live session ${reusable.sessionId} (age=${reusedAgeMs}ms, turns=0); supersede skipped, discarded ${sessionId}`,
       );
       deps.emitLiveSessionEvent('vtid.live.session.start', {
         session_id: reusable.sessionId,
@@ -696,7 +707,8 @@ export async function handleLiveSessionStart(
         tenant_id: orbIdentity.tenant_id || null,
         transport: 'sse',
         deduplicated: true,
-        dedup_reason: 'fresh_zero_turn_session_reused',
+        dedup_reason: 'zero_turn_session_reused',
+        start_cause: startCause,
         reused_session_id: reusable.sessionId,
         discarded_session_id: sessionId,
         reused_age_ms: reusedAgeMs,

--- a/services/gateway/src/orb/live/session/session-reuse.ts
+++ b/services/gateway/src/orb/live/session/session-reuse.ts
@@ -1,0 +1,67 @@
+/**
+ * BOOTSTRAP-ORB-SESSION-CHURN: pure reuse-decision logic for `/live/session/start`
+ * idempotency, factored out of the controller so it is unit-testable without the
+ * live-session registry or the (heavy) orb-live module graph.
+ *
+ * Why this exists: telemetry showed ~32% of session starts superseded a still-live
+ * session for the same user, 89.5% of them with ZERO turns — the greeting torn
+ * down before it spoke. The fix reuses the in-flight zero-turn session. The
+ * decision below is STATE-driven (active + no turns), not clock-driven; the age
+ * bound is only a backstop against a wedged session.
+ */
+
+/** Minimal shape the reuse decision needs from a live session. */
+export interface ReusableSessionLike {
+  sessionId: string;
+  active: boolean;
+  turn_count: number;
+  createdAt: Date;
+  identity?: { user_id: string } | null;
+  /** Set only once the session has produced its first start response. */
+  startResponseBody?: unknown;
+}
+
+/**
+ * A session is reusable for a fresh start by the same user when it is active,
+ * owned by that user, has taken NO turns (so it is in the identical greeting
+ * state a fresh session would be), is already past first-response (so we never
+ * hand back a half-built session), and has not exceeded the age backstop.
+ *
+ * State is the primary gate; `maxAgeMs` only fences off a wedged session.
+ */
+export function isReusableSession(
+  session: ReusableSessionLike,
+  userId: string,
+  nowMs: number,
+  maxAgeMs: number,
+): boolean {
+  if (!session.active) return false;
+  if (!session.identity || session.identity.user_id !== userId) return false;
+  if (session.turn_count !== 0) return false;
+  if (!session.startResponseBody) return false;
+  const age = nowMs - session.createdAt.getTime();
+  return age >= 0 && age <= maxAgeMs;
+}
+
+/**
+ * Pick the most-recently-created reusable session for the user, or null when
+ * none qualifies (the normal new-conversation path).
+ */
+export function pickReusableSession<T extends ReusableSessionLike>(
+  sessions: Iterable<T>,
+  userId: string,
+  nowMs: number,
+  maxAgeMs: number,
+): T | null {
+  let best: T | null = null;
+  let bestAge = Infinity;
+  for (const s of sessions) {
+    if (!isReusableSession(s, userId, nowMs, maxAgeMs)) continue;
+    const age = nowMs - s.createdAt.getTime();
+    if (age < bestAge) {
+      bestAge = age;
+      best = s;
+    }
+  }
+  return best;
+}

--- a/services/gateway/test/orb/live/session/session-reuse.test.ts
+++ b/services/gateway/test/orb/live/session/session-reuse.test.ts
@@ -1,0 +1,75 @@
+import {
+  isReusableSession,
+  pickReusableSession,
+  type ReusableSessionLike,
+} from '../../../../src/orb/live/session/session-reuse';
+
+const NOW = 1_000_000_000;
+const MAX_AGE = 30 * 60 * 1000; // session TTL backstop
+
+function mk(over: Partial<ReusableSessionLike> = {}): ReusableSessionLike {
+  return {
+    sessionId: 's',
+    active: true,
+    turn_count: 0,
+    createdAt: new Date(NOW - 3000),
+    identity: { user_id: 'u1' },
+    startResponseBody: { ok: true, session_id: 's' },
+    ...over,
+  };
+}
+
+describe('BOOTSTRAP-ORB-SESSION-CHURN reuse decision', () => {
+  describe('isReusableSession', () => {
+    it('reuses an active, zero-turn, initialized same-user session', () => {
+      expect(isReusableSession(mk(), 'u1', NOW, MAX_AGE)).toBe(true);
+    });
+
+    it('does NOT reuse once a turn has happened (greeting/engagement started)', () => {
+      expect(isReusableSession(mk({ turn_count: 1 }), 'u1', NOW, MAX_AGE)).toBe(false);
+    });
+
+    it('does NOT reuse an inactive session', () => {
+      expect(isReusableSession(mk({ active: false }), 'u1', NOW, MAX_AGE)).toBe(false);
+    });
+
+    it('does NOT reuse another user\'s session', () => {
+      expect(isReusableSession(mk({ identity: { user_id: 'other' } }), 'u1', NOW, MAX_AGE)).toBe(false);
+    });
+
+    it('does NOT reuse an anonymous (identity-less) session', () => {
+      expect(isReusableSession(mk({ identity: null }), 'u1', NOW, MAX_AGE)).toBe(false);
+    });
+
+    it('does NOT reuse a half-built session (no startResponseBody yet)', () => {
+      expect(isReusableSession(mk({ startResponseBody: undefined }), 'u1', NOW, MAX_AGE)).toBe(false);
+    });
+
+    it('does NOT reuse past the age backstop', () => {
+      expect(isReusableSession(mk({ createdAt: new Date(NOW - (MAX_AGE + 1)) }), 'u1', NOW, MAX_AGE)).toBe(false);
+    });
+
+    it('reuses right up to the age backstop boundary', () => {
+      expect(isReusableSession(mk({ createdAt: new Date(NOW - MAX_AGE) }), 'u1', NOW, MAX_AGE)).toBe(true);
+    });
+  });
+
+  describe('pickReusableSession', () => {
+    it('picks the most-recently-created reusable session', () => {
+      const older = mk({ sessionId: 'old', createdAt: new Date(NOW - 10_000) });
+      const newer = mk({ sessionId: 'new', createdAt: new Date(NOW - 2_000) });
+      const turned = mk({ sessionId: 'turned', turn_count: 3, createdAt: new Date(NOW - 1_000) });
+      expect(pickReusableSession([older, newer, turned], 'u1', NOW, MAX_AGE)?.sessionId).toBe('new');
+    });
+
+    it('returns null when nothing qualifies', () => {
+      expect(pickReusableSession([mk({ active: false }), mk({ turn_count: 2 })], 'u1', NOW, MAX_AGE)).toBeNull();
+    });
+
+    it('ignores other users when selecting', () => {
+      const mine = mk({ sessionId: 'mine', createdAt: new Date(NOW - 5_000) });
+      const theirs = mk({ sessionId: 'theirs', identity: { user_id: 'u2' }, createdAt: new Date(NOW - 1_000) });
+      expect(pickReusableSession([theirs, mine], 'u1', NOW, MAX_AGE)?.sessionId).toBe('mine');
+    });
+  });
+});


### PR DESCRIPTION
## Phase 1 (gateway) — server-side session-start idempotency, state-driven & governed

The community reports the voice assistant "constantly disconnects during the opening." This is the **server half** of the fix; the client half is [vitana-v1#663](https://github.com/exafyltd/vitana-v1/pull/663). Phase 3 (verification tooling) ships here too.

### Verified root cause (real `oasis_events` data, ~7 days dev — not estimates)

| stop reason | stops | zero-turn % | median life |
|---|---|---|---|
| `expired_ttl` | 264 | 100% | ~33 min |
| user-ended (real convos) | 263 | 13.7% | 20s |
| **`superseded_by_new_session`** | **229** | **89.5%** | **72s** |

- **31.7% of all starts supersede a still-live session for the same user** (0.317 supersede/start).
- **89.5% of those superseded sessions had zero turns** — torn down *before the greeting turn ever fired*. That **is** the "disconnect during the opening": the session is superseded before it speaks.
- The superseding start lands **~3.4s later on average** (198/205 within 5s) — a rapid re-show / double-mount / supersede→SSE-close→reconnect bounce, **not** a slow token refresh (the 30–120s band is empty).
- Bonus: **469/722 sessions (65%) never had a single turn** — the system creates ~2× the sessions actually used.

### The fix is state-driven, not a magic clock
`/live/session/start` is now idempotent: if the user already has an **active, zero-turn, initialized** session, it returns that live session instead of superseding it. The decision keys on **session state** (zero turns = identical greeting state), which the data shows is the correct signal — there is no hardcoded time window. The only time bound is a **configurable safety backstop** (`ORB_SESSION_REUSE_MAX_AGE_MS`, default = session TTL) to fence off a wedged session.

- **Governed:** `ORB_SESSION_REUSE_ENABLED` kill switch + the backstop live in `orb/live/config.ts` (env-overridable, no redeploy). Defense-in-depth per the platform rules.
- **Decision logic** extracted to a pure, dependency-free module (`session-reuse.ts`) — **11 unit tests** cover every gate (turn-count, active, ownership, anonymous, half-built, age boundary, recency selection).
- **Contextual signal (server side ready):** the gateway accepts a client-declared `start_cause` and records it on the `deduplicated:true` event so reuse-vs-supersede is attributable per-cause in `oasis_events`. Populating it from the widget is intentionally **deferred to a separate DEV-COMHU-governed PR** — the Command Hub frontend is a protected path (VTID-0302 ownership guard) and I won't game that gate from this backend branch.
- Reconnect starts (transcript history / non-idle stage) and DEV identity always bypass reuse.

### Phase 3 — verification (in this PR)
`services/gateway/docs/orb-session-churn-verification.sql` — runnable KPI queries (stop-reason breakdown, reuse adoption by cause, supersede/start ratio) with the **recorded pre-fix baseline** (0.317 supersede/start). Post-deploy, the drop is one query.

### Self-verification (done)
- `tsc --noEmit` clean — 0 errors in changed files (2 pre-existing `express-serve-static-core` errors in untouched files remain).
- `jest session-reuse.test.ts` — **11/11 pass**.
- Path Ownership Guard: widget change reverted so no Command Hub files are touched by this branch.

Draft until merged + deployed and the verification query confirms `superseded_by_new_session` zero-turn collapses toward 0 with `deduplicated` reuse events rising.

### Landing order
1. This PR (gateway) → deploy → server idempotent.
2. vitana-v1#663 (client) → deploy → fewer duplicate starts at the source.
3. Run `orb-session-churn-verification.sql` to confirm the drop.