### PR TITLE
fix(self-healing): classify Cloud Run deploy concurrency races as environmental

### DIFF
--- a/services/gateway/src/services/dev-autopilot-self-heal-log.ts
+++ b/services/gateway/src/services/dev-autopilot-self-heal-log.ts
@@ -369,5 +369,13 @@ export function isEnvironmentalBlocker(errorMessage: string | undefined | null):
   // backs up the gateway times out per-task at 720s before the worker even
   // gets to run the LLM. That's a capacity problem, not a code defect; the
   // triage agent can't fix it.
-  return /ENOSPC|out of memory|OOMKilled|ECONNREFUSED|ETIMEDOUT.*supabase|GITHUB_TOKEN.*not set|GITHUB_SAFE_MERGE_TOKEN.*not set|container recycled mid-execution|worker-queue wait time|worker queue.*timeout/i.test(errorMessage);
+  //
+  // 2026-06-07: also short-circuit on Cloud Run deploy concurrency races.
+  // When multiple EXEC-DEPLOY runs target the same service in overlapping
+  // windows, `gcloud run deploy` aborts with an optimistic-concurrency
+  // conflict ("ABORTED: Conflict for resource 'gateway': version 'X' was
+  // specified but current version is 'Y'"). The same commit deploys fine on
+  // retry — it's a deploy-time race, not a code defect, so the triage agent
+  // must not spend a retry trying to "fix" it.
+  return /ENOSPC|out of memory|OOMKilled|ECONNREFUSED|ETIMEDOUT.*supabase|GITHUB_TOKEN.*not set|GITHUB_SAFE_MERGE_TOKEN.*not set|container recycled mid-execution|worker-queue wait time|worker queue.*timeout|ABORTED: Conflict for resource|was specified but current version is|gcloud\.run\.deploy.*ABORTED/i.test(errorMessage);
 }

--- a/services/gateway/test/dev-autopilot-failure-actionability.test.ts
+++ b/services/gateway/test/dev-autopilot-failure-actionability.test.ts
@@ -51,6 +51,22 @@ describe('classifyAutopilotFailure', () => {
     expect(result.non_actionable_reason).toBe('policy_block');
   });
 
+  it('classifies a Cloud Run deploy concurrency race as environmental (real EXEC-DEPLOY failure 2026-06-07)', () => {
+    // Verbatim gcloud error from a failed gateway EXEC-DEPLOY run where three
+    // deploys overlapped; the same commit deployed fine on retry. A code retry
+    // can't fix a deploy-time optimistic-concurrency conflict.
+    const result = classifyAutopilotFailure({
+      failure_class: 'deploy',
+      diagnosis: {
+        summary:
+          "ERROR: (gcloud.run.deploy) ABORTED: Conflict for resource 'gateway': version '1780664786361038' was specified but current version is '1780664788904494'.",
+      },
+    });
+    expect(result.failure_class).toBe('environmental_blocker');
+    expect(result.actionable).toBe(false);
+    expect(result.non_actionable_reason).toBe('environmental');
+  });
+
   it('leaves a genuinely auto-fixable code failure actionable and unchanged', () => {
     const result = classifyAutopilotFailure({
       failure_class: 'dev_autopilot_pr_open_failed',


### PR DESCRIPTION
## Real error → run through the self-healing system → fix

You asked me to pick up a task that reports an error and run it through the self-healing build. Here's the end-to-end:

### 1. Picked a real reported error
Failed gateway **EXEC-DEPLOY** run [`27016551246`](https://github.com/exafyltd/vitana-platform/actions/runs/27016551246) (2026-06-05). Step 7 "Deploy to Cloud Run (Source Deploy)" failed with:

```
ERROR: (gcloud.run.deploy) ABORTED: Conflict for resource 'gateway':
version '1780664786361038' was specified but current version is '1780664788904494'.
```

### 2. Diagnosed (root cause)
Three EXEC-DEPLOY runs deployed the **same** gateway service in overlapping windows (13:05:12, 13:05:52, 13:06:49). The pre-deploy `gcloud run services update` read one revision version and `gcloud run deploy` then hit an **optimistic-concurrency conflict**. The *same commit* (`4dc66c6`) deployed successfully on the adjacent runs → transient infra race, **not a code defect**.

### 3. Ran it through the self-healing classifier — and found a gap
Fed the error through Step 2's `classifyAutopilotFailure` / `isEnvironmentalBlocker`. **It did not match** — so the loop would have treated this infra race as *actionable*, spawned a triage agent, and burned a code-fix retry on something no code change can fix. That's exactly the queue pollution + wasted-retry pattern Steps 2 & 4 exist to prevent.

### 4. Fixed it (the self-healing way)
Extended `isEnvironmentalBlocker()` with the deploy-race signatures (`ABORTED: Conflict for resource`, `was specified but current version is`, `gcloud.run.deploy …ABORTED`). Now `classifyAutopilotFailure()` normalises these to `failure_class='environmental_blocker'` (`actionable=false`), so:
- the reconciler short-circuits retries (Step 2/3),
- per-stage calibration returns the `∞` bar for environmental (Step 4) → never retries,
- the metrics endpoint counts it under `non_actionable_reasons.environmental` (Step 5).

### Verification
- Regression test added with the **verbatim** gcloud error → asserts `environmental_blocker` / `actionable:false`.
- `npm run build` ✅ (0 TS errors)
- Full self-healing + dev-autopilot suite ✅ **257/257**

### Note
The original deploy already self-resolved (the adjacent runs deployed the same commit; the gateway is live), so no rollback was needed — this PR hardens the *classifier* so future deploy races are correctly escalated instead of triggering phantom code-fix retries.

https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ay2U6FkPAtGrMpREZnS9KB)_