### PR TITLE
feat(command-hub): one-click clock revert rolls back BOTH repos (DEV-COMHU-03116)

### DIFF
--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -147,21 +147,56 @@ watch progress.
 2. Find the revision you want to roll back to. Eligible rows show a small
    red "Revert" button — eligibility means `status='success'`, has a
    `cloud_run_revision`, age < 90 days, and not currently active.
-3. Click **Revert**. A confirm overlay opens.
+3. Click **Revert**. A confirm overlay opens — it states that **both repos**
+   will roll back.
 4. Type the 7-char commit short SHA. Click **Revert**.
 
-Server flow (`POST /api/v1/operator/revert`):
+### One-click revert reverts BOTH repos (backend + frontend)
 
-1. Validate `service` ∈ `{gateway, gateway-staging}`.
-2. List revisions on the service, verify target exists + not active + not
-   expired.
-3. Call Cloud Run Admin API `updateService(traffic)` → 100% to target.
-4. Insert `software_versions` row with `deploy_type='rollback'`.
-5. Emit `production.revert.completed` or `staging.revert.completed`.
+The clock revert restores the whole product, not just the API. One click rolls
+back **both** the backend (`gateway`) and the frontend (`community-app`)
+together, so users never see a half-reverted state.
 
-Traffic shifts complete in ~30s — no rebuild. The revert button works on
-both prod and staging Command Hubs (it operates on whichever stack the
-caller is currently viewing, via the `service` body parameter).
+Server flow (`POST /api/v1/operator/revert-both`):
+
+1. Validate the anchor `service` ∈ `{gateway, gateway-staging, community-app,
+   community-app-staging}` and resolve its paired sibling
+   (`gateway`↔`community-app`, `gateway-staging`↔`community-app-staging`).
+2. **Anchor** (the clicked clock row): list revisions, verify target exists +
+   not active + age < 90d, then Cloud Run Admin API `updateService(traffic)` →
+   100% to target.
+3. **Sibling**: resolve the revision the sibling was serving at the anchor
+   revision's deploy time (`target_created_at`), falling back to the sibling's
+   immediately-previous revision; then the same traffic shift.
+4. Insert a `software_versions` row (`deploy_type='rollback'`) and emit
+   `production.revert.completed` / `staging.revert.completed` for **each**
+   service.
+5. Anchor success drives the HTTP status; the sibling result is always reported
+   alongside. Partial failures are surfaced, never hidden.
+
+The legacy single-service endpoint (`POST /api/v1/operator/revert`,
+`service` ∈ `{gateway, gateway-staging}`) is unchanged and still available.
+
+Traffic shifts complete in ~30s — no rebuild. The revert button works on both
+prod and staging Command Hubs (it operates on whichever stack the caller is
+currently viewing, via the anchor `service`).
+
+> **IAM prerequisite for the frontend half.** The gateway service account
+> already holds `roles/run.developer` on `gateway`/`gateway-staging`. For the
+> both-repos revert to shift `community-app`/`community-app-staging` traffic it
+> needs the same role on those services:
+>
+> ```bash
+> gcloud run services add-iam-policy-binding community-app \
+>   --region=us-central1 --project=lovable-vitana-vers1 \
+>   --member="serviceAccount:<gateway-runtime-SA>" --role=roles/run.developer
+> gcloud run services add-iam-policy-binding community-app-staging \
+>   --region=us-central1 --project=lovable-vitana-vers1 \
+>   --member="serviceAccount:<gateway-runtime-SA>" --role=roles/run.developer
+> ```
+>
+> Without it, the backend still reverts and the overlay reports the frontend
+> half as failed with the permission detail (grant the role, then re-click).
 
 ## 5. Migration / publish decoupling
 

--- a/services/gateway/src/frontend/command-hub/command-hub-staging.js
+++ b/services/gateway/src/frontend/command-hub/command-hub-staging.js
@@ -283,12 +283,23 @@
     const cloudRev = version.cloud_run_revision || '(unknown revision)';
     const service = version.service || 'gateway';
     const commit = (version.git_commit || '').slice(0, 7);
+    const createdAt = version.createdAt || version.created_at || null;
+    // Backend ↔ frontend pairing — mirrors REVERT_SIBLING on the server.
+    const SIBLING = {
+      'gateway': 'community-app',
+      'community-app': 'gateway',
+      'gateway-staging': 'community-app-staging',
+      'community-app-staging': 'gateway-staging',
+    };
+    const sibling = SIBLING[service] || null;
 
-    modal.appendChild(el('div', { style: 'font-size:16px;font-weight:600;margin-bottom:10px;color:#fca5a5;' }, 'Revert ' + service));
-    modal.appendChild(el('div', { style: 'margin-bottom:6px;' }, 'Target revision: ', el('strong', {}, cloudRev)));
+    modal.appendChild(el('div', { style: 'font-size:16px;font-weight:600;margin-bottom:10px;color:#fca5a5;' }, 'Revert to previous · both repos'));
+    modal.appendChild(el('div', { style: 'margin-bottom:6px;' }, 'Anchor: ', el('strong', {}, service), ' → ', el('strong', {}, cloudRev)));
     modal.appendChild(el('div', { style: 'margin-bottom:6px;' }, 'Commit: ', el('code', { style: 'color:#fde68a;' }, commit || 'unknown')));
     modal.appendChild(el('div', { style: 'margin-bottom:14px;color:#cbd5e1;line-height:1.5;' },
-      'Traffic on ', el('strong', {}, service), ' will move to 100% of this revision within ~30s. No re-deploy; the image already exists.'
+      'This reverts ', el('strong', {}, 'both repositories'), '. Traffic on ', el('strong', {}, service),
+      ' moves to 100% of this revision, and ', el('strong', {}, sibling || 'the paired frontend'),
+      ' is rolled back to the revision it was serving at that time. Both within ~30s — no re-deploy; the images already exist.'
     ));
 
     const input = el('input', {
@@ -324,30 +335,56 @@
       go.style.opacity = ok ? '1' : '0.5';
     });
 
+    // Summarize one service's revert outcome into a single line.
+    function summarize(o) {
+      if (!o) return 'no result';
+      const svc = o.service || '?';
+      if (o.ok || o.status === 'reverted') {
+        return svc + ' → ' + (o.target_revision || '?') + (o.swv_id ? ' (SWV ' + o.swv_id + ')' : '');
+      }
+      if (o.status === 'already_active') return svc + ' already on ' + (o.target_revision || 'target');
+      return svc + ': ' + (o.detail || o.status || 'failed');
+    }
+
     go.addEventListener('click', function () {
       go.disabled = true;
-      go.textContent = 'Reverting…';
+      go.textContent = 'Reverting both…';
       result.style.display = 'block';
       result.style.color = '#9ca3af';
-      result.textContent = 'POST /api/v1/operator/revert — traffic shift in flight.';
+      result.textContent = 'POST /api/v1/operator/revert-both — backend + frontend traffic shifts in flight.';
 
-      fetch('/api/v1/operator/revert', {
+      fetch('/api/v1/operator/revert-both', {
         method: 'POST',
         credentials: 'include',
         headers: Object.assign({ 'Content-Type': 'application/json' }, headers),
-        body: JSON.stringify({ service: service, target_revision: cloudRev, confirm_short_sha: commit }),
+        body: JSON.stringify({
+          service: service,
+          target_revision: cloudRev,
+          target_created_at: createdAt,
+          confirm_short_sha: commit,
+        }),
       })
         .then(function (r) { return r.json().then(function (body) { return { status: r.status, body: body }; }); })
         .then(function (payload) {
-          if (payload.status >= 200 && payload.status < 300 && payload.body && payload.body.ok) {
-            result.style.color = '#86efac';
-            result.textContent = '✓ Revert dispatched. SWV ' + (payload.body.swv_id || '—') + '. Traffic should reach 100% within 30s.';
+          const body = payload.body || {};
+          if (payload.status >= 200 && payload.status < 300 && body.ok) {
+            const beOk = body.backend && (body.backend.ok || body.backend.status === 'reverted');
+            const feOk = body.frontend && (body.frontend.ok || body.frontend.status === 'reverted' || body.frontend.status === 'already_active');
+            result.innerHTML = '';
+            result.appendChild(el('div', { style: 'color:' + (beOk ? '#86efac' : '#fbbf24') + ';' },
+              (beOk ? '✓ ' : '⚠ ') + 'Backend: ' + summarize(body.backend)));
+            result.appendChild(el('div', { style: 'color:' + (feOk ? '#86efac' : '#fbbf24') + ';margin-top:3px;' },
+              (feOk ? '✓ ' : '⚠ ') + 'Frontend: ' + summarize(body.frontend)));
+            if (!body.both_ok) {
+              result.appendChild(el('div', { style: 'margin-top:6px;color:#94a3b8;font-size:11px;line-height:1.5;' },
+                'One half did not revert (the other still did). If the frontend failed with a permission error, grant the gateway service account roles/run.developer on the community-app service.'));
+            }
             go.textContent = 'Done';
-            if (typeof opts.onAfterRevert === 'function') opts.onAfterRevert(payload.body);
-            setTimeout(function () { overlay.remove(); }, 2500);
+            if (typeof opts.onAfterRevert === 'function') opts.onAfterRevert(body);
+            setTimeout(function () { overlay.remove(); }, body.both_ok ? 3000 : 6000);
           } else {
             result.style.color = '#fca5a5';
-            result.textContent = 'Revert refused: ' + ((payload.body && (payload.body.detail || payload.body.error)) || ('HTTP ' + payload.status));
+            result.textContent = 'Revert refused: ' + ((body.detail || body.error) || ('HTTP ' + payload.status));
             go.disabled = false;
             go.textContent = 'Revert';
           }

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -34,6 +34,6 @@
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
   <!-- Phase 0 staging build (P0.5): PUBLISH→staging-source card + CLOCK revert -->
-  <script src="/command-hub/command-hub-staging.js?v=20260521-phase0-staging-build"></script>
+  <script src="/command-hub/command-hub-staging.js?v=20260608-revert-both-repos"></script>
 </body>
 </html>

--- a/services/gateway/src/routes/operator.ts
+++ b/services/gateway/src/routes/operator.ts
@@ -1721,6 +1721,9 @@ async function revertOneService(
  * the sibling result is always reported alongside (skips/failures included).
  */
 router.post('/revert-both', requireAdminAuth, async (req: Request, res: Response) => {
+  // impact-allow-no-oasis: the state-transition events (production/staging.
+  // revert.completed) are emitted inside revertOneService() for each service
+  // this handler reverts, not in the handler body.
   const requestId = randomUUID();
   const { identity } = req as AuthenticatedRequest;
   if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });

--- a/services/gateway/src/routes/operator.ts
+++ b/services/gateway/src/routes/operator.ts
@@ -1554,6 +1554,259 @@ router.post('/publish', requireAdminAuth, async (req: Request, res: Response) =>
  *      cloud_run_revision=<target>, initiator_id=<admin uuid>.
  *   7. Emit production.revert.completed or staging.revert.completed.
  */
+// ====================================================================
+// Shared revert core + both-repos revert (one-click clock revert).
+//
+// The Command Hub clock-revert reverts BOTH the backend (gateway) and the
+// frontend (community-app) together, so a "go back to the previous version"
+// click restores the whole product, not just the API. Both are fast Cloud Run
+// traffic shifts to an existing revision (no rebuild). The gateway service
+// account must hold roles/run.developer on the community-app services for the
+// frontend half; absent that, the frontend result reports shift_failed with the
+// IAM detail and the backend revert still stands (we surface partials, never
+// hide them).
+// ====================================================================
+
+type RevertStatus =
+  | 'reverted'
+  | 'already_active'
+  | 'not_found'
+  | 'too_old'
+  | 'shift_failed'
+  | 'no_target'
+  | 'resolve_failed';
+
+interface RevertOutcome {
+  status: RevertStatus;
+  ok: boolean; // true only for 'reverted'
+  service: string;
+  target_revision?: string;
+  target_commit?: string | null;
+  operation_name?: string;
+  swv_id?: string;
+  detail?: string;
+}
+
+/** Cloud Run service pairing: backend ↔ frontend, per environment. */
+const REVERT_SIBLING: Record<string, string> = {
+  gateway: 'community-app',
+  'community-app': 'gateway',
+  'gateway-staging': 'community-app-staging',
+  'community-app-staging': 'gateway-staging',
+};
+
+function isBackendService(service: string): boolean {
+  return service === 'gateway' || service === 'gateway-staging';
+}
+
+function revertOutcomeToHttp(o: RevertOutcome): number {
+  switch (o.status) {
+    case 'reverted': return 200;
+    case 'not_found': return 404;
+    case 'already_active': return 409;
+    case 'too_old': return 409;
+    case 'shift_failed': return 502;
+    default: return 500;
+  }
+}
+
+/**
+ * Validate a target revision, shift 100% traffic to it, record a `rollback`
+ * software_versions row, and emit the terminal OASIS event. Used by both
+ * POST /revert (single service) and POST /revert-both (gateway + community-app
+ * together). Returns a structured outcome; callers decide HTTP status and
+ * partial-failure handling. Works for any of the four managed Cloud Run
+ * services — environment (production/staging) is derived from the `-staging`
+ * suffix.
+ */
+async function revertOneService(
+  service: string,
+  targetRevisionRaw: string,
+  identity: { user_id: string },
+  requestId: string,
+): Promise<RevertOutcome> {
+  const targetShort = shortRevisionName(targetRevisionRaw);
+  const isStaging = service.endsWith('-staging');
+  const environment = isStaging ? 'staging' : 'production';
+
+  const revisions = await listRevisions(service, 100);
+  const target = revisions.find(r => r.shortName === targetShort);
+  if (!target) {
+    return {
+      status: 'not_found', ok: false, service, target_revision: targetShort,
+      detail: `revision ${targetShort} not found in last 100 revisions of ${service}`,
+    };
+  }
+  if (target.isActive) {
+    return {
+      status: 'already_active', ok: false, service, target_revision: targetShort,
+      target_commit: target.commitSha, detail: `${service} is already serving ${targetShort}`,
+    };
+  }
+  const ageMs = target.createdAt ? Date.now() - Date.parse(target.createdAt) : 0;
+  if (ageMs > REVERT_AGE_LIMIT_MS) {
+    return {
+      status: 'too_old', ok: false, service, target_revision: targetShort,
+      detail: `revision ${targetShort} is ${Math.floor(ageMs / (24 * 60 * 60 * 1000))} days old; >90d. Re-deploy that commit instead.`,
+    };
+  }
+
+  const result = await updateTrafficToRevision(service, targetShort);
+  if (!result.ok) {
+    await emitOasisEvent({
+      vtid: 'BOOTSTRAP-REVERT',
+      type: isStaging ? 'staging.deploy.failed' : 'production.publish.failed',
+      source: 'gateway-operator',
+      status: 'error',
+      message: `revert: ${service} → ${targetShort} traffic-shift failed (${result.error})`,
+      actor_id: identity.user_id,
+      actor_role: 'admin',
+      surface: 'command-hub',
+      payload: { request_id: requestId, service, target_revision: targetShort, error: result.error },
+    });
+    return {
+      status: 'shift_failed', ok: false, service, target_revision: targetShort,
+      target_commit: target.commitSha, detail: result.error,
+    };
+  }
+
+  ACTIVE_REV_CACHE.delete(service); // invalidate cache so next /deployments shows new active
+  const swvId = await getNextSWV();
+  await insertSoftwareVersion({
+    swv_id: swvId,
+    service,
+    git_commit: target.commitSha || '(unknown)',
+    deploy_type: 'rollback',
+    initiator: 'user',
+    status: 'success',
+    environment,
+    cloud_run_revision: targetShort,
+    source_revision: null,
+    initiator_id: identity.user_id,
+  });
+
+  await emitOasisEvent({
+    vtid: 'BOOTSTRAP-REVERT',
+    type: isStaging ? 'staging.revert.completed' : 'production.revert.completed',
+    source: 'gateway-operator',
+    status: 'success',
+    message: `revert: ${service} now serving ${targetShort}`,
+    actor_id: identity.user_id,
+    actor_role: 'admin',
+    surface: 'command-hub',
+    payload: {
+      request_id: requestId,
+      service,
+      target_revision: targetShort,
+      target_commit: target.commitSha,
+      operation_name: result.operationName,
+      swv_id: swvId,
+    },
+  });
+
+  return {
+    status: 'reverted', ok: true, service, target_revision: targetShort,
+    target_commit: target.commitSha, operation_name: result.operationName, swv_id: swvId,
+  };
+}
+
+/**
+ * POST /api/v1/operator/revert-both → /api/v1/operator/revert-both
+ *
+ * One-click "go back to the previous version" across BOTH repos. Reverts the
+ * anchor service (the clicked clock row) to `target_revision`, then reverts its
+ * paired sibling to the revision that sibling was serving at the anchor's deploy
+ * time (`target_created_at`), falling back to the sibling's immediately-previous
+ * revision when no timestamp is supplied. Anchor success drives the HTTP status;
+ * the sibling result is always reported alongside (skips/failures included).
+ */
+router.post('/revert-both', requireAdminAuth, async (req: Request, res: Response) => {
+  const requestId = randomUUID();
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const service = (req.body?.service || '').toString().trim();
+  const targetRevisionRaw = (req.body?.target_revision || '').toString().trim();
+  const anchorCreatedAt = (req.body?.target_created_at || '').toString().trim();
+
+  const sibling = REVERT_SIBLING[service];
+  if (!sibling) {
+    return res.status(400).json({
+      ok: false, error: 'invalid_service',
+      detail: 'service must be gateway, gateway-staging, community-app, or community-app-staging',
+    });
+  }
+  if (!targetRevisionRaw) {
+    return res.status(400).json({ ok: false, error: 'missing_target_revision' });
+  }
+
+  try {
+    // 1. Revert the anchor (the service whose clock row was clicked).
+    const anchor = await revertOneService(service, targetRevisionRaw, identity, requestId);
+
+    // 2. Resolve + revert the sibling. Time-correlate to the anchor deploy when
+    //    we have its timestamp; otherwise step the sibling back one revision.
+    let siblingOutcome: RevertOutcome;
+    try {
+      const sibRevs = await listRevisions(sibling, 100);
+      const sorted = sibRevs.slice().sort((a, b) =>
+        Date.parse(b.createdAt || '0') - Date.parse(a.createdAt || '0'));
+      const active = sorted.find(r => r.isActive) || null;
+      const notActive = (shortName: string) => !active || active.shortName !== shortName;
+
+      let chosen = undefined as (typeof sorted)[number] | undefined;
+      const anchorMs = anchorCreatedAt ? Date.parse(anchorCreatedAt) : NaN;
+      if (!Number.isNaN(anchorMs)) {
+        chosen = sorted.find(r => {
+          const t = Date.parse(r.createdAt || '0');
+          return !Number.isNaN(t) && t <= anchorMs && notActive(r.shortName);
+        });
+      }
+      if (!chosen) {
+        chosen = sorted.find(r => notActive(r.shortName)); // immediately-previous
+      }
+
+      if (!chosen) {
+        siblingOutcome = {
+          status: 'no_target', ok: false, service: sibling,
+          detail: `${sibling} has no earlier revision to revert to.`,
+        };
+      } else if (active && chosen.shortName === active.shortName) {
+        siblingOutcome = {
+          status: 'already_active', ok: false, service: sibling,
+          target_revision: chosen.shortName, target_commit: chosen.commitSha,
+          detail: `${sibling} already serving ${chosen.shortName}`,
+        };
+      } else {
+        siblingOutcome = await revertOneService(sibling, chosen.shortName, identity, requestId);
+      }
+    } catch (sibErr) {
+      siblingOutcome = {
+        status: 'resolve_failed', ok: false, service: sibling,
+        detail: sibErr instanceof Error ? sibErr.message : 'unknown',
+      };
+    }
+
+    // 3. Respond. backend/frontend convenience aliases + raw anchor/sibling.
+    const backend = isBackendService(service) ? anchor : siblingOutcome;
+    const frontend = isBackendService(service) ? siblingOutcome : anchor;
+    const siblingSettled = siblingOutcome.ok || siblingOutcome.status === 'already_active';
+
+    return res.status(anchor.ok ? 200 : revertOutcomeToHttp(anchor)).json({
+      ok: anchor.ok,
+      both_ok: anchor.ok && siblingSettled,
+      backend,
+      frontend,
+      anchor,
+      sibling: siblingOutcome,
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error(`[Operator] /revert-both failed: ${errorMessage}`);
+    return res.status(500).json({ ok: false, error: 'internal_error', detail: errorMessage });
+  }
+});
+
 router.post('/revert', requireAdminAuth, async (req: Request, res: Response) => {
   const requestId = randomUUID();
   const { identity } = req as AuthenticatedRequest;


### PR DESCRIPTION
## What

Makes the Command Hub **clock → version history → Revert** a paired, **both-repos** operation. One click now rolls back **both** the backend (`gateway`) and the frontend (`community-app`) together, so "go back to the previous version" restores the whole product instead of just the API.

Previously the revert was gateway-only (`POST /revert` hard-rejected anything but `gateway`/`gateway-staging`), so a frontend landing-page change had no one-click revert.

## How

**Backend — `services/gateway/src/routes/operator.ts`**
- Extracted a reusable `revertOneService()` core: validate target → Cloud Run traffic-shift → `rollback` `software_versions` row → terminal OASIS event. Generic over all four managed services; environment derived from the `-staging` suffix.
- New `POST /api/v1/operator/revert-both`: reverts the clicked **anchor** service **and its paired sibling** (`gateway`↔`community-app`, `gateway-staging`↔`community-app-staging`). The sibling target is **time-correlated** to the anchor deploy (`target_created_at`), falling back to the sibling's immediately-previous revision. Anchor success drives the HTTP status; the sibling result is always reported alongside — **partial failures are surfaced, never hidden**.
- Legacy single-service `POST /revert` left intact for back-compat.

**Frontend — `command-hub-staging.js`**
- The Revert overlay now states both repos roll back, calls `/revert-both` with the row timestamp, and renders backend + frontend outcomes separately (with an IAM hint if the frontend half is denied).
- Cache-bust bumped in `index.html`.

Both halves are fast Cloud Run **traffic shifts** (~30s, no rebuild).

## ⚠️ IAM prerequisite (frontend half)

The gateway service account already holds `roles/run.developer` on `gateway`/`gateway-staging`. For the both-repos revert to shift `community-app`/`community-app-staging` traffic it needs the **same role on those services** (one-time grant, commands in `docs/STAGING.md §4`). Without it, the backend still reverts and the overlay reports the frontend half as failed with the permission detail.

## Deploy path (staging-first)

This is a gateway change, so per the cutover it auto-deploys to **`gateway-staging`** on merge and reaches prod via the PUBLISH button. The new revert UI is therefore testable on the **staging Command Hub** first.

## Verification done
- `npm run build` (gateway) — green.
- `node --check` on `command-hub-staging.js` — green.
- UI screenshot of the revert overlay still pending (will capture on the staging Command Hub once this lands on `gateway-staging`).

https://claude.ai/code/session_01Ad2QucKLZPJTiVkDH8KT9e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ad2QucKLZPJTiVkDH8KT9e)_