### PR TITLE
fix(nav): route "Business Hub Sales" to the Sales tab, not Snapshot

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -730,22 +730,29 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     },
   },
   {
+    // VTID-NAV-BUSINESS-TABS: this is the "Sales" pill of the Business Hub
+    // (mobile) / the "Sell & Earn" tab (desktop), route /business/sell-earn.
+    // The title matches the pill label the user actually sees ("Sales" / DE
+    // "Verkäufe"), and when_to_visit carries the literal "Business Hub Sales"
+    // phrase so "take me to Business Hub Sales" resolves here instead of
+    // BUSINESS.OVERVIEW (whose title is "Business Hub").
     screen_id: 'BUSINESS.SELL_EARN',
     route: '/business/sell-earn',
     category: 'business',
     access: 'authenticated',
     anonymous_safe: false,
     priority: 2,
+    aliases: ['sales', 'business-sales', 'business-hub-sales', 'sell-earn', 'sales-tab', 'verkaeufe', 'verkauf'],
     i18n: {
       en: {
-        title: 'Sell & Earn',
-        description: 'Build a new income stream by selling your services and earning rewards in the Maxina community.',
-        when_to_visit: 'When the user asks how to make money, earn income, build a side income, monetize their skills, monetize coaching, monetize fitness, monetize their expertise, sell services, become a paid creator, set up a new income stream, become a paid coach, or start earning from the Maxina community.',
+        title: 'Sales',
+        description: 'Your Sales area in the Business Hub — sell your services and build a new income stream in the Maxina community.',
+        when_to_visit: 'When the user asks for the Sales tab or the Business Hub Sales section, their sales, or how to make money, earn income, build a side income, monetize their skills, monetize coaching, monetize fitness, monetize their expertise, sell services, become a paid creator, set up a new income stream, become a paid coach, or start earning from the Maxina community.',
       },
       de: {
-        title: 'Verkaufen & Verdienen',
-        description: 'Baue eine neue Einkommensquelle auf, indem du deine Services verkaufst und in der Maxina Community Belohnungen verdienst.',
-        when_to_visit: 'Wenn der Nutzer fragt wie man Geld verdient, Einkommen generiert, ein Nebeneinkommen aufbaut, seine Fähigkeiten monetarisiert, Coaching monetarisiert, Fitness monetarisiert, seine Expertise monetarisiert, Services verkauft, bezahlter Creator wird, eine neue Einkommensquelle aufbaut oder mit der Maxina Community Geld verdienen will.',
+        title: 'Verkäufe',
+        description: 'Dein Verkaufsbereich im Business Hub — verkaufe deine Services und baue eine neue Einkommensquelle in der Maxina Community auf.',
+        when_to_visit: 'Wenn der Nutzer nach dem Tab "Verkäufe", dem Business Hub Verkäufe-Bereich oder seinen Verkäufen fragt, oder wie man Geld verdient, Einkommen generiert, ein Nebeneinkommen aufbaut, seine Fähigkeiten monetarisiert, Coaching monetarisiert, Fitness monetarisiert, seine Expertise monetarisiert, Services verkauft, bezahlter Creator wird, eine neue Einkommensquelle aufbaut oder mit der Maxina Community Geld verdienen will.',
       },
     },
   },

--- a/services/gateway/test/navigation-catalog.test.ts
+++ b/services/gateway/test/navigation-catalog.test.ts
@@ -196,6 +196,13 @@ const ROUTING_CASES: RoutingCase[] = [
   { utterance: 'open my services',                          lang: 'en', expected_screen_id: 'BUSINESS.SERVICES' },
   { utterance: 'show me my clients',                        lang: 'en', expected_screen_id: 'BUSINESS.CLIENTS' },
   { utterance: 'wie laufen meine buchungen',                lang: 'de', expected_screen_id: 'BUSINESS.ANALYTICS' },
+  // VTID-NAV-BUSINESS-TABS: "Business Hub Sales" must reach the Sales tab, not
+  // the Business Hub Snapshot (BUSINESS.OVERVIEW). Plus the plain-parent guard.
+  { utterance: 'take me to business hub sales',             lang: 'en', expected_screen_id: 'BUSINESS.SELL_EARN' },
+  { utterance: 'business hub sales',                        lang: 'en', expected_screen_id: 'BUSINESS.SELL_EARN' },
+  { utterance: 'open my sales',                             lang: 'en', expected_screen_id: 'BUSINESS.SELL_EARN' },
+  { utterance: 'bring mich zum business hub verkäufe',      lang: 'de', expected_screen_id: 'BUSINESS.SELL_EARN' },
+  { utterance: 'open the business hub',                     lang: 'en', expected_screen_id: 'BUSINESS.OVERVIEW' },
 
   // ── WALLET ──
   { utterance: 'open my wallet',                            lang: 'en', expected_screen_id: 'WALLET.OVERVIEW' },


### PR DESCRIPTION
## Symptom

Asking Vitana for **"Business Hub Sales"** opened the Business Hub **Snapshot** (first pill), not the **Sales** pill.

## Root cause

The Navigator scores utterances against each catalog entry's `title` / `when_to_visit` (aliases are **not** scored). For `business hub sales` → tokens `business`, `hub`, `sales`:

- `BUSINESS.OVERVIEW` (title **"Business Hub"**) scored ~39–45 (two title tokens + priority).
- `BUSINESS.SELL_EARN` (title "Sell & Earn") carried **no** `sales`/`business` vocabulary → scored **0**.

So it resolved to Overview → `/business` → Snapshot.

## Fix (`navigation-catalog.ts`)

Align `BUSINESS.SELL_EARN` with the pill the user actually sees:
- Title → **"Sales"** (DE **"Verkäufe"**), matching the mobile pill label.
- Weave the literal **"Business Hub Sales"** phrase + sales/sell wording into `when_to_visit` (keeps all the existing make-money / monetize / earn-income vocabulary).
- Route unchanged (`/business/sell-earn`), which the mobile Business Hub already maps to the Sales pill (vitana-v1 #662).

## Verification (against the real `searchCatalog` scorer)

| Utterance | Result |
|-----------|--------|
| `business hub sales` | **SELL_EARN 96** vs Overview 45 ✅ clean win |
| `take me to business hub sales` | **SELL_EARN 66** vs 45 ✅ |
| `open my sales` | **SELL_EARN** ✅ |
| `business hub` (guard) | **Overview 97** vs SELL_EARN 66 ✅ unchanged |
| `open the business hub` (guard) | **Overview** ✅ |
| all pre-existing business/wallet cases | ✅ still pass |

Added these as routing-quality test cases.

## Deploy note (staging-first)

Post-cutover: merging deploys to **staging** (`preview-gateway.vitanaland.com`); production reached via the **PUBLISH** button. The static catalog is what the Navigator's fast-path uses, so the gateway code deploy is sufficient (no DB reseed required for this high-confidence match).

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_