### PR TITLE
fix(gateway): allow staging frontend origin (preview.vitanaland.com) in CORS

### DIFF
--- a/services/gateway/src/middleware/cors.ts
+++ b/services/gateway/src/middleware/cors.ts
@@ -15,6 +15,7 @@ const ALLOWED_ORIGINS = [
   "https://id-preview--vitana-v1.lovable.app",               // Lovable preview
   "https://vitanaland.com",                                    // Production custom domain (mobile app)
   "https://www.vitanaland.com",                                // Production custom domain (www)
+  "https://preview.vitanaland.com",                            // Staging frontend (community-app-staging) — staging-first cutover
 ];
 
 // VTID-01226: Dynamic origin patterns for Lovable-hosted frontends


### PR DESCRIPTION
## Problem

On staging, the "My Journey" card shows **"Couldn't load your journey."**

**Root cause:** the staging frontend (`preview.vitanaland.com`) calls the staging gateway (`preview-gateway.vitanaland.com`) cross-origin for `GET /api/v1/my-journey`. The gateway's CORS allowlist (`services/gateway/src/middleware/cors.ts`) was never updated for the staging-first cutover — it includes `vitanaland.com` / `www.vitanaland.com` and the Cloud Run community-app URLs, but **not `https://preview.vitanaland.com`**. So the browser blocks every gateway call from the staging frontend, and the journey fetch fails.

This affects the whole staging frontend (any gateway-backed data), not just the device-preview tool — opening `preview.vitanaland.com/home` directly hits the same wall. Supabase-direct content still renders, which is why only gateway-backed cards failed.

## Fix

Add `https://preview.vitanaland.com` to `ALLOWED_ORIGINS`. One line; only widens the allowlist by one trusted staging origin.

Staging community-app **Cloud Run** URLs (`community-app-staging-*.us-central1.run.app`) are already matched by the existing `community-app[a-z0-9-]*\.us-central1\.run\.app` pattern, so no new pattern is needed — the custom domain was the only gap.

## Deploy impact (staging-first)
Merging auto-deploys to the **staging gateway** (`gateway-staging` / `preview-gateway.vitanaland.com`) — exactly what serves the staging frontend. **Production is untouched** until a PUBLISH. So this fixes staging directly and safely.

## Note (separate)
Staging uses its own Supabase project. Even after this fix, the journey card only populates if the account has a goal/journey in the **staging** DB; otherwise it'll show the normal "set your goal" empty state. That's expected and out of scope here.

## Verification
- ✅ `npm run build` (gateway, `tsc`) — clean

https://claude.ai/code/session_0195utibVv97xGANiJ9Tep2J

---
_Generated by [Claude Code](https://claude.ai/code/session_0195utibVv97xGANiJ9Tep2J)_