### PR TITLE
fix(eval): unbreak canary-readiness report — duplicate export crashing the daily cron

### DIFF
--- a/services/gateway/scripts/eval/canary-readiness-report.ts
+++ b/services/gateway/scripts/eval/canary-readiness-report.ts
@@ -533,5 +533,9 @@ if (require.main === module) {
   });
 }
 
-export { generate, renderMarkdown, accuracyReason, computeConsecutiveCleanDays, prevUtcDay };
+// NOTE: computeConsecutiveCleanDays and prevUtcDay are already exported inline
+// at their declarations above. Re-exporting them here is a duplicate export
+// that breaks the esbuild transform — the cause of CANARY-READINESS-REPORT
+// failing daily since #2582 merged. Only re-export names declared without `export`.
+export { generate, renderMarkdown, accuracyReason };
 export type { CanaryReadinessReport, Reason };


### PR DESCRIPTION
## The stuck process

The `CANARY-READINESS-REPORT` cron — the gate that decides whether a candidate voice-tool-router model is ready for real traffic — has **failed on every run since Jun 5** (Jun 5/6/7/8), producing **no verdict for 4 days**. This is the "stuck since days" process from session `01YL6C7qf2t974CLAktacEmp` (the shadow-eval / canary-readiness workstream). All of that session's code merged fine; what it left behind was a continuously-running pipeline that silently went red the day after the session went idle.

## Root cause

`services/gateway/scripts/eval/canary-readiness-report.ts` re-exported `computeConsecutiveCleanDays` and `prevUtcDay` in a trailing `export { ... }` even though both are **already exported inline** at their declarations (lines 251 / 263). esbuild rejects duplicate exports, so `npx tsx scripts/eval/canary-readiness-report.ts` crashed before doing anything:

```
canary-readiness-report.ts:536: ERROR: Multiple exports with the same name "computeConsecutiveCleanDays"
canary-readiness-report.ts:536: ERROR: Multiple exports with the same name "prevUtcDay"
```

Introduced when **#2582** ("wire consecutive_clean_days from daily snapshots") merged on Jun 4 17:18. The Jun 4 readiness run fired *before* that merge (passed); every run since hit the duplicate export and died. The sibling `CRON-SHADOW-COMPARISON-REPORT` was untouched and kept succeeding — which is why only the gate went red.

## Fix

Drop the two already-inline-exported names from the trailing re-export, keeping `generate` / `renderMarkdown` / `accuracyReason` (which are declared without `export` and genuinely need it).

## Verification

- `esbuild --bundle` of the script now succeeds (exit 0); before the fix it failed with both errors above. This is the exact transform layer `npx tsx` uses in the workflow.
- One-line behavioral change; no logic touched.

## How the process continues after this lands

Once merged to `main`, the next scheduled `CANARY-READINESS-REPORT` run (and the on-demand `workflow_dispatch`) will transform and emit a verdict again, resuming the daily canary-readiness gate. Worth a manual dispatch right after merge to confirm green and recover the lost verdict.

https://claude.ai/code/session_01UWYpLpdCgMX7DuoSvY39e1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWYpLpdCgMX7DuoSvY39e1)_