### PR TITLE
feat(publish): single one-click "Publish to production" — drop canary default (DEV-COMHU-03118)

### DIFF
--- a/services/gateway/src/frontend/command-hub/command-hub-staging.js
+++ b/services/gateway/src/frontend/command-hub/command-hub-staging.js
@@ -486,7 +486,7 @@
     const chipText = ({
       loading:           el('span', {}, spinnerSvg(11, '#cbd5e1'), ' Reading state…'),
       ready:             'Ready to publish',
-      publishing:        el('span', {}, spinnerSvg(11, '#93c5fd'), ' Dispatching canary…'),
+      publishing:        el('span', {}, spinnerSvg(11, '#93c5fd'), ' Publishing…'),
       'canary-active':   '🐤 Canary at 10%',
       promoting:         el('span', {}, spinnerSvg(11, '#93c5fd'), ' Promoting to 100%…'),
       promoted:          '✓ Promoted',
@@ -776,21 +776,22 @@
     if (dispatching) {
       primary.appendChild(spinnerSvg(14, '#93c5fd'));
       primary.appendChild(document.createTextNode(
-        phase === 'full-publishing' ? 'Publishing 100%…' :
+        phase === 'full-publishing' ? 'Publishing…' :
         phase === 'building' ? 'Building…' :
         phase === 'rolling' ? 'Rolling out…' :
-        'Dispatching canary…'
+        'Publishing…'
       ));
     } else if (phase === 'loading') {
       primary.appendChild(spinnerSvg(14, '#cbd5e1'));
       primary.appendChild(document.createTextNode('Loading…'));
     } else {
-      primary.textContent = 'Publish to canary (10%)';
+      primary.textContent = 'Publish to production';
     }
     if (phase === 'ready') {
       primary.addEventListener('click', function (e) {
         e.stopPropagation();
-        dispatchPublish('canary', headers, opts);
+        // Single-click 100% promote (image swap, ~30s). No canary step.
+        dispatchPublish('full', headers, opts);
       });
     }
     card.appendChild(primary);
@@ -816,18 +817,9 @@
     }
 
     if (phase === 'ready') {
-      const skipRow = el('div', { style: 'margin-top:8px;text-align:center;' },
-        el('button', {
-          type: 'button',
-          style: 'background:none;border:none;color:#94a3b8;font-size:11px;cursor:pointer;text-decoration:underline;',
-          onclick: function (e) {
-            e.stopPropagation();
-            if (!window.confirm('Skip canary and publish to 100% immediately?\n\nFor voice, canary is recommended — bad changes reach all users within seconds.')) return;
-            dispatchPublish('full', headers, opts);
-          },
-        }, 'Skip canary — publish 100% now')
-      );
-      card.appendChild(skipRow);
+      card.appendChild(el('div', {
+        style: 'margin-top:8px;text-align:center;color:#94a3b8;font-size:11px;',
+      }, 'One-click promote to 100% · ~30s, no rebuild'));
     }
 
     return card;

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -34,6 +34,6 @@
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
   <!-- Phase 0 staging build (P0.5): PUBLISH→staging-source card + CLOCK revert -->
-  <script src="/command-hub/command-hub-staging.js?v=20260608-fast-publish-spinner-fix"></script>
+  <script src="/command-hub/command-hub-staging.js?v=20260608-one-button-publish"></script>
 </body>
 </html>

--- a/services/gateway/src/routes/operator.ts
+++ b/services/gateway/src/routes/operator.ts
@@ -1386,7 +1386,9 @@ router.post('/publish', requireAdminAuth, async (req: Request, res: Response) =>
     // body.mode='full' opts out of canary for low-risk shipments where the
     // operator wants 100% immediately. Body shape:
     //   { confirm_short_sha?: string, mode?: 'canary'|'full' }
-    const mode: 'canary' | 'full' = (req.body?.mode === 'full') ? 'full' : 'canary';
+    // One-button publish: default to a single 100% promote. Canary is opt-in
+    // only when the caller explicitly asks for mode='canary'.
+    const mode: 'canary' | 'full' = (req.body?.mode === 'canary') ? 'canary' : 'full';
     const isCanary = mode === 'canary';
 
     // Step 7: dispatch the production deploy (EXEC-DEPLOY.yml).


### PR DESCRIPTION
## Why
Canary made PUBLISH a two-step flow (Publish 10% → Promote 100%). Its benefit — limiting blast radius of a bad deploy — doesn't pay off at the current small, supervised traffic; it just adds friction. Per product decision: **one button, no canary.**

## What
- **`command-hub-staging.js`** — the primary button is now **"Publish to production"** and dispatches `mode='full'` directly (single 100% promote = the ~30s image swap). Removed the "Skip canary" link and the "canary (10%)" labels; added a `One-click promote to 100% · ~30s` caption. The canary-active/Promote/Discard UI stays as a safety net **if** a canary is ever already live, but the default flow never creates one. Cache-bust bumped.
- **`/operator/publish`** — default `mode` is now `'full'`; canary is **opt-in** only when a caller explicitly passes `mode='canary'`. `/promote` + `/abort-canary` remain for that path.

## Result
PUBLISH = one click → 100% in ~30s (once the image-promotion change from #2596 is live). No second step, no canary by default.

## Verification
- `npm run build` (gateway) — green.
- `node --check` on `command-hub-staging.js` — green.

https://claude.ai/code/session_01Ad2QucKLZPJTiVkDH8KT9e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ad2QucKLZPJTiVkDH8KT9e)_