### PR TITLE
Guided Journey P1: durable mode + progress state (VTID-03276)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-guided-journey-implementation-handoff.md
+++ b/docs/superpowers/plans/2026-06-08-guided-journey-implementation-handoff.md
@@ -1,0 +1,469 @@
+# Guided Journey Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Guided Journey onboarding mode to Maxina/Vitanaland while preserving the existing Full App design exactly.
+
+**Architecture:** Implement this as an additive UX layer: a durable onboarding/mode state, a Guided Journey catalog inside My Journey, Vitana/ORB-guided explanation and practice flows, and an Admin Knowledge Base Checklist editor. Full App remains the existing app and design surface; Guided Mode routes users through the new learning layer without duplicating account, support, subscription, or sidebar navigation.
+
+**Tech Stack:** Vitana platform backend/data layer, Vitana v1 frontend, existing Vitana v1 design system/components, existing ORB/Vitana assistant bridge, existing Admin/Knowledge Base patterns, existing routing/auth/subscription infrastructure.
+
+---
+
+## Copy-Paste Handoff Prompt
+
+Use this exact instruction block when handing the work to another developer or agent:
+
+```text
+You are implementing the Maxina/Vitanaland Guided Journey onboarding UX.
+
+NON-NEGOTIABLE DESIGN RULE:
+This is not a redesign. Do not change the existing Vitana v1 / Full App design. Do not change existing card sizes, font sizes, colors, spacing, button styling, shadows, radii, header styling, bottom navigation styling, sidebar styling, icons, or page composition in the Full App.
+
+Full App must remain visually identical to the current production/Vitana v1 experience. Guided Journey is an additive UX layer. New Guided Journey components must reuse existing Vitana v1 design tokens, component primitives, typography, colors, spacing, button patterns, card patterns, header patterns, and navigation patterns. Do not copy prototype CSS into production as a new design language.
+
+What we are adding:
+- A user mode: Guided Journey vs Full App.
+- A segmented switch: Guided Journey / Full App.
+- Guided Journey hides sidebar/menu dots. No dots in Guided Mode.
+- Full App keeps the existing full-app three-dot menu/sidebar access.
+- My Journey remains the onboarding home in Guided Mode.
+- The existing My Journey start view stays; add the 90-session / 250-topic catalog below it.
+- Every session/topic click activates Vitana/ORB, Vitana explains, then redirects to the topic explanation or guided practice flow.
+- Topic Explanation has only: short user benefit summary, Replay, Start Practice, Back to Journey.
+- Practice redirects to the real feature screen or controlled guided practice target.
+- Account, subscription, privacy, settings, support, logout, and sidebar navigation are not duplicated in Guided Mode. Users switch to Full App and use the existing Full App account/settings/navigation surfaces.
+- Admin Pages -> Knowledge Base gets a Checklist tab so the 90-session / 250-topic curriculum is editable, validated, published, rolled back, and consumed by My Journey.
+
+What we are not doing:
+- No Full App redesign.
+- No separate Guided Mode account/support overlay.
+- No new sidebar in Guided Mode.
+- No new design system.
+- No marketing/landing page.
+- No calendar-day onboarding logic. Sessions are usage sessions, not real-world days.
+- No lesson completion from listening only. Completion requires a tiny guided-practice action.
+
+Reference docs:
+- docs/superpowers/specs/2026-06-04-my-journey-usage-catalog-design.md
+- docs/superpowers/specs/2026-06-04-maxina-90-day-journey-curriculum-v2.md
+- docs/superpowers/plans/2026-06-08-guided-journey-implementation-handoff.md
+```
+
+## Implementation Boundaries
+
+The current workspace contains the prototype and planning docs, not the real Vitana platform and Vitana v1 repositories. Before writing production code, the implementer must locate both repositories and create a local path map.
+
+Required repository roles:
+
+- **Vitana platform:** durable onboarding/mode state, checklist persistence, Admin Knowledge Base Checklist APIs, publish/rollback/audit, subscription and entitlement checks.
+- **Vitana v1:** My Journey UI integration, Guided Journey catalog rendering, segmented switch, route guards, ORB/Vitana interaction bridge, guided practice UI, Full App navigation behavior.
+
+Required state boundaries:
+
+- `mode`: UX mode, either `guided` or `full`.
+- `journey_progress`: learning/practice progress.
+- `feature_permission`: product access/release rules.
+- `subscription`: commercial entitlement.
+
+Do not combine these into one flag.
+
+## Task 1: Repository And Design Freeze Audit
+
+**Files:**
+- Read: Vitana platform repository root.
+- Read: Vitana v1 repository root.
+- Read: existing Vitana v1 My Journey screen/component files.
+- Read: existing Vitana v1 design system/theme/tokens/components.
+- Create: a path map in the implementation PR description listing the exact production files found for each responsibility below.
+
+- [ ] **Step 1: Locate production files**
+
+Find the real files for:
+
+- My Journey / Autopilot screen.
+- Full App header and three-dot/sidebar navigation.
+- Bottom navigation.
+- ORB/Vitana assistant trigger.
+- Existing buttons, segmented controls/tabs, cards, typography, colors, spacing tokens.
+- Admin Pages / Knowledge Base.
+- User profile/onboarding state.
+- Subscription/entitlement state.
+
+- [ ] **Step 2: Record design-freeze baseline**
+
+Before changes, capture screenshots or visual snapshots of:
+
+- Full App My Journey start view.
+- Full App header with three-dot menu.
+- Full App bottom navigation.
+- Existing account/settings/subscription entry.
+
+Expected result: these screenshots become the visual baseline. Later changes must not alter them.
+
+- [ ] **Step 3: Add a design guardrail note to the implementation PR**
+
+The PR description must include:
+
+```text
+Design guardrail: Full App design is frozen. This PR adds Guided Journey UX and state only. Existing Full App cards, colors, typography, spacing, header, bottom navigation, sidebar/menu, and account/settings surfaces are not redesigned.
+```
+
+## Task 2: Durable Guided/Full Mode State
+
+**Files:**
+- Modify: platform user/profile/onboarding state model.
+- Modify: platform API or data access layer for user onboarding state.
+- Modify: v1 app bootstrap/user context to read mode state.
+- Test: platform state tests and v1 route/bootstrap tests.
+
+- [ ] **Step 1: Add mode state**
+
+Add or extend user onboarding state with:
+
+```ts
+type JourneyMode = "guided" | "full";
+
+type JourneyState = {
+  mode: JourneyMode;
+  currentSession: number;
+  completedTopicIds: string[];
+  completedPracticeCount: number;
+  qualifiedAt: string | null;
+  skippedOnboardingAt: string | null;
+  enteredFullModeAt: string | null;
+  returnedToGuidedAt: string | null;
+};
+```
+
+- [ ] **Step 2: Persist mode changes**
+
+Implement:
+
+```ts
+setJourneyMode(userId: string, mode: "guided" | "full"): Promise<JourneyState>
+```
+
+Rules:
+
+- Switching to `full` sets `enteredFullModeAt` when first entered.
+- Switching to `full` before qualification sets `skippedOnboardingAt` when first skipped.
+- Switching to `guided` sets `returnedToGuidedAt`.
+- Switching modes never deletes progress.
+
+- [ ] **Step 3: Test state separation**
+
+Test:
+
+- Changing `mode` does not alter subscription.
+- Changing `mode` does not alter entitlement/feature permission.
+- Changing `mode` does not clear completed topics.
+- Switching back to `guided` resumes same current session.
+
+## Task 3: Admin Knowledge Base Checklist
+
+**Files:**
+- Modify: platform Admin Pages / Knowledge Base.
+- Create or modify: Checklist data model/table/API.
+- Modify: v1/admin frontend tab if Admin UI is in v1.
+- Test: Admin checklist validation and publish tests.
+
+- [ ] **Step 1: Add Checklist tab**
+
+Add `Admin Pages -> Knowledge Base -> Checklist`.
+
+Checklist fields:
+
+```ts
+type ChecklistTopic = {
+  id: string;
+  session: number;
+  position: number;
+  label: string;
+  shortDescription: string;
+  vitanaVoiceScript: string;
+  topicExplanationSummary: {
+    whatItIs: string;
+    userBenefit: string;
+    whenToUse: string;
+    tryThis: string;
+  };
+  guidedPracticeTarget: string;
+  completionEvent: string;
+  unlockRule: string;
+  sourceRefs: string[];
+  status: "draft" | "published" | "disabled";
+};
+```
+
+- [ ] **Step 2: Add validation**
+
+Publish validation must fail unless:
+
+- 90 sessions exist.
+- 250 topics exist.
+- Sessions 1-20 have 2 topics each.
+- Sessions 21-90 have 3 topics each.
+- Labels are 1-4 words.
+- Every topic has a Vitana voice script.
+- Every topic has a guided practice target.
+- Business/longevity-economy topics are correctly gated.
+
+- [ ] **Step 3: Add publish/rollback**
+
+Admins can:
+
+- Save draft.
+- Preview in My Journey.
+- Publish.
+- Roll back.
+- Export.
+
+My Journey consumes only the published checklist version.
+
+## Task 4: Guided Mode Route Shell
+
+**Files:**
+- Modify: v1 route guard / app shell / My Journey route.
+- Modify: v1 header rendering where My Journey is mounted.
+- Test: Guided/Full route tests and visual checks.
+
+- [ ] **Step 1: Default first-time users to Guided Mode**
+
+After registration/name form, route first-time users to My Journey in Guided Mode.
+
+- [ ] **Step 2: Hide sidebar/menu dots in Guided Mode**
+
+In Guided Mode:
+
+- No top-left dots.
+- No sidebar/mobile drawer entry.
+- No account/support overlay.
+
+In Full App:
+
+- Keep the existing three-dot/sidebar behavior exactly as production currently has it.
+
+- [ ] **Step 3: Route account/settings/support through Full App**
+
+If the user requests account, subscription, privacy, settings, support, logout, or sidebar navigation while in Guided Mode:
+
+1. Switch `mode` to `full`.
+2. Open the existing Full App account/settings/navigation surface.
+3. Do not show a Guided Mode overlay.
+
+## Task 5: My Journey Guided Catalog
+
+**Files:**
+- Modify: existing v1 My Journey screen.
+- Add: Guided Journey catalog component near My Journey route.
+- Reuse: existing v1 cards/buttons/tabs/typography/tokens.
+- Test: catalog render tests and interaction tests.
+
+- [ ] **Step 1: Preserve existing My Journey first viewport**
+
+Do not rebuild the Full App My Journey screen. In Guided Mode, preserve the current start view structure and add onboarding-specific elements without changing production Full App layout.
+
+Guided Mode first viewport:
+
+- MAXINA header and voice button.
+- No menu dots.
+- My Journey title.
+- Existing shortcut row.
+- Existing Journey counter/goal card structure, using approved existing tokens.
+- `Start Journey` before first start.
+- `Start Session N` after started.
+- Segmented `Guided Journey / Full App` switch below the Journey card.
+
+- [ ] **Step 2: Add catalog below first viewport**
+
+Below the Journey card and segmented switch, render:
+
+- Chapter filters.
+- Scrollable 90-session catalog.
+- 250 topic cards from published checklist.
+- Session rows can be clicked.
+- Topic cards can be clicked.
+
+- [ ] **Step 3: Keep text minimal**
+
+Do not add dashboard counters like:
+
+- topic cards complete.
+- usage sessions total.
+- ready to practice.
+- preview locked.
+
+Do not add `Start Practice` on the My Journey start view. Practice starts from Topic Explanation.
+
+## Task 6: Segmented Guided Journey / Full App Switch
+
+**Files:**
+- Modify: v1 My Journey screen or mode switch component.
+- Reuse: existing segmented control/tab/button pattern if available.
+- Test: mode switch interaction tests.
+
+- [ ] **Step 1: Add switch**
+
+Labels:
+
+- `Guided Journey`
+- `Full App`
+
+Guided Mode:
+
+- `Guided Journey` active.
+- `Full App` inactive.
+
+Full App:
+
+- `Full App` active.
+- `Guided Journey` inactive.
+
+- [ ] **Step 2: Persist switch**
+
+Clicking `Full App`:
+
+- Updates `mode` to `full`.
+- Opens Full App My Journey.
+- Does not clear journey progress.
+
+Clicking `Guided Journey`:
+
+- Updates `mode` to `guided`.
+- Opens Guided My Journey.
+- Restores the same current session/progress.
+
+## Task 7: Vitana/ORB Explanation Flow
+
+**Files:**
+- Modify: existing ORB/Vitana assistant bridge.
+- Modify: My Journey catalog interactions.
+- Add: topic explanation route/surface if none exists.
+- Test: ORB command tests and UI flow tests.
+
+- [ ] **Step 1: Start Journey flow**
+
+Click `Start Journey`:
+
+1. Opens ORB/Vitana voice state.
+2. Vitana explains the 90-session journey.
+3. App marks journey started.
+4. Button becomes `Start Session 1`.
+5. Vitana redirects to Session 1 / Topic 1 explanation.
+
+- [ ] **Step 2: Session/topic click flow**
+
+Clicking any session or topic:
+
+1. Activates Vitana/ORB.
+2. Vitana explains the session/topic.
+3. Vitana redirects to Topic Explanation.
+
+Topic Explanation includes:
+
+- Topic title.
+- One short summary section with: what it is, user benefit, when to use, try this.
+- Buttons: `Replay`, `Start Practice`, `Back to Journey`.
+
+Do not show internal admin fields such as source, safety policy, script source, or checklist metadata to the end user.
+
+## Task 8: Guided Practice And Completion
+
+**Files:**
+- Modify: guided practice routing.
+- Modify: existing feature screens only by adding guided entry points where necessary.
+- Test: practice completion tests.
+
+- [ ] **Step 1: Redirect to real feature targets**
+
+`Start Practice` routes to the real feature or controlled guided surface for:
+
+- Life Compass.
+- Vitana Index.
+- Reminder.
+- Calendar.
+- Find a Match.
+- Post Activity.
+- Create Event.
+- Attend/search events.
+- Live Room.
+- Media Hub.
+- Memory.
+- Autopilot.
+- Universal Cart.
+- Business post / business match / client finding.
+
+- [ ] **Step 2: Complete only after tiny action**
+
+Listening is not completion.
+
+Completion requires one small guided-practice event, such as:
+
+- choosing one Life Compass goal.
+- viewing one Vitana Index signal.
+- creating one reminder draft.
+- opening one match explanation.
+- drafting one activity post.
+- previewing one event creation step.
+
+After completion:
+
+- Add topic ID to completed topics.
+- Increment completed practice count.
+- Return to My Journey or continue to next topic based on existing UX pattern.
+
+## Task 9: Full App Visual Regression Gate
+
+**Files:**
+- Add or update visual/e2e tests in the real v1 repository.
+- Include baseline screenshots from Task 1.
+
+- [ ] **Step 1: Verify Full App unchanged**
+
+Compare before/after screenshots for:
+
+- Full App My Journey.
+- Full App header.
+- Full App three-dot menu/sidebar.
+- Full App bottom navigation.
+- Existing account/settings/subscription surfaces.
+
+Acceptance:
+
+- No intentional visual changes in Full App.
+- Any visual diff must be explained as data/content only, not design.
+
+- [ ] **Step 2: Verify Guided Mode additions**
+
+Test:
+
+- Guided Mode has no menu dots.
+- Full App has existing three-dot menu.
+- Guided/Full switch changes mode both ways.
+- Account/settings/support request in Guided Mode switches to Full App.
+- Topic click starts Vitana and opens Topic Explanation.
+- Start Practice completes only after practice event.
+
+## Task 10: Final Acceptance Checklist
+
+The implementation is not complete until all are true:
+
+- [ ] Full App design is unchanged.
+- [ ] Guided Mode is additive and uses existing design patterns.
+- [ ] No Guided Mode account/support overlay exists.
+- [ ] Guided Mode has no dots/sidebar entry.
+- [ ] Full App keeps existing three-dot menu/sidebar.
+- [ ] My Journey remains the onboarding home.
+- [ ] 90-session / 250-topic catalog is admin-editable.
+- [ ] Vitana/ORB explains before redirecting.
+- [ ] Topic Explanation has Replay, Start Practice, Back to Journey.
+- [ ] Completion requires guided practice.
+- [ ] Subscription and entitlement logic are separate from Journey mode.
+- [ ] Visual regression evidence is attached to the PR.
+
+## Source References
+
+- Prototype: `my-journey-screens/prototype/index.html`
+- Design spec: `docs/superpowers/specs/2026-06-04-my-journey-usage-catalog-design.md`
+- Curriculum: `docs/superpowers/specs/2026-06-04-maxina-90-day-journey-curriculum-v2.md`

--- a/docs/superpowers/specs/2026-06-04-maxina-90-day-journey-curriculum-v2.md
+++ b/docs/superpowers/specs/2026-06-04-maxina-90-day-journey-curriculum-v2.md
@@ -1,0 +1,436 @@
+# Maxina 90-Session Journey Curriculum v2
+
+Date: 2026-06-04
+
+This v2 replaces the first 90-topic concept with a Life Compass-led onboarding curriculum: 90 usage sessions, 250 clickable topic cards, and a progressive story that connects health, trust, community, and optional business creation inside the longevity economy.
+
+"Session" means usage session or lesson number, not calendar day. Users can browse ahead, replay topics, and move faster than one session per calendar day. A session is complete only after a tiny guided-practice action.
+
+## Recommendation
+
+Use exactly 250 clickable topic cards:
+
+- Sessions 1-20: 2 cards per session, 40 cards total. This avoids early overload.
+- Sessions 21-90: 3 cards per session, 210 cards total. This gives enough depth once the user understands the rhythm.
+- Total: 250 cards.
+
+This is the best balance. 200 topics would cover the app, but not the vision. 300 topics would risk feeling like a course catalog. 250 gives enough room for health, trust, community, assistant behavior, privacy, marketplace, sharing, live rooms, business creation, and financial-freedom pathways.
+
+## Narrative Spine
+
+The Journey is not "health first, business later." It is one integrated quality-of-life story:
+
+1. The world is changing quickly because of AI.
+2. It is easier than ever to create, publish, automate, sell, and learn.
+3. It is also harder to know what is true, who to trust, and what path is healthy.
+4. Vitana gives the user a guided plan.
+5. Health is the first asset: more energy, better sleep, stronger mindset, clearer decisions.
+6. Community creates trust: like-minded people, shared experience, accountability, learning.
+7. Trust creates opportunity: profile, posts, events, live rooms, offers, services, referrals.
+8. Opportunity can become income for users who want that.
+9. Income and financial freedom improve quality of life.
+10. Vitanaland is the ecosystem that connects this into the longevity economy.
+
+The business and longevity-economy promise is present from the beginning, but not promoted aggressively. Early copy should say "this can later help you build income if that becomes part of your Life Compass." The full business case opens only after explicit user intent.
+
+## Business Interest Gating
+
+Add a `business_interest_level` signal:
+
+- `none`: Do not promote business. Keep only light references to future opportunity.
+- `curious`: Show optional "where this can lead" cards and simple examples.
+- `active`: Teach offers, live rooms, sharing, invitations, campaigns, wallet, and earnings.
+- `builder`: Use whitepaper-backed facts, market positioning, financial models, and strategy.
+
+Business depth is triggered when the user:
+
+- selects Life Compass goals such as financial freedom, passive income, build a business, or new income
+- taps Longevity Economy or Positioning in the Longevity Economy
+- asks how to earn, build a business, create passive income, or promote an offering
+- opens Business Hub, Sell & Earn, Sharing, Campaigns, or Wallet earning views with clear intent
+
+For users without business intent, the Journey should remain focused on health, energy, trust, community, and quality of life.
+
+## Whitepaper Fact Bank
+
+Use these only for `active` or `builder` users, or when the user explicitly taps a business topic:
+
+- The longevity economy is projected at $27 trillion by 2026, representing more than 20% of global GDP.
+- The global wellness economy reached $6.8 trillion in 2024 and is projected to reach $9.8 trillion by 2029.
+- AI and robotics are expected to reshape 50-55% of jobs in the next two to three years.
+- 170 million new jobs are projected by 2030, alongside 92 million displaced jobs.
+- The gig economy is projected to grow from $582 billion in 2025 to about $2.18 trillion by 2034.
+- The global population aged 60 and older is projected to reach 2.1 billion by 2050.
+- Vitanaland is positioned as the operating system for the longevity economy: health, community, events, services, AI guidance, trust, and business tools in one ecosystem.
+- Vitanaland's model emphasizes direct provider income, preventive wellness, community services, platform operations, and quality and trust systems.
+- Vitanaland projects $205 billion in cumulative economic value creation by 2035 across provider income, healthcare savings, and community multiplier effects.
+
+## Topic Card Rules
+
+Every topic card needs:
+
+- topic id
+- day number
+- display label: 1-4 words maximum
+- optional helper text: one short sentence maximum
+- title
+- short spoken Vitana explanation
+- practice action
+- completion event
+- manual or knowledge source
+- safety level
+- business gate, if any
+
+The visible My Journey catalog must stay simple. The user should see short clickable labels such as "What Is Vitanaland", "Maxina Community", "Vitana Assistant", "Life Compass", "Vitana Index", "Find a Match", or "Create Event". The deeper explanation happens only after the user taps the topic and Vitana starts teaching by voice.
+
+For first-time users, the first 20 topics must answer the basic orientation questions before teaching workflows:
+
+- What is Vitanaland?
+- What is the Maxina community?
+- Who is Vitana?
+- What is My Journey?
+- What is the Life Compass?
+- What is the Vitana Index?
+- What does the ORB do?
+- What does Vitana remember?
+- What can I safely ask Vitana to do?
+- What is the first tiny practice?
+
+Topic states:
+
+- preview
+- ready
+- done
+- mastered
+- skipped
+
+## Knowledge Base Checklist Ownership
+
+The 250-topic checklist must be editable inside Admin Pages, not maintained only in code or Markdown. Add a Knowledge Base tab named `Checklist`.
+
+The `Checklist` tab is the editorial source of truth for the My Journey onboarding catalog. Admin users must be able to create, edit, reorder, disable, translate, preview, and publish checklist topics without developer involvement.
+
+My Journey reads only the published checklist version. Draft edits stay invisible to users until an admin publishes them. Every published version should keep an audit trail so the team can see who changed topic labels, Vitana scripts, practice actions, unlock rules, and manual sources.
+
+The Admin checklist editor must validate the rules in this document:
+
+- exactly 90 usage sessions for the main onboarding journey
+- exactly 250 published topic cards unless a deliberate curriculum version changes this rule
+- 2 cards per session for sessions 1-20
+- 3 cards per session for sessions 21-90
+- display labels limited to 1-4 words
+- each topic connected to a Vitana explanation, practice action, completion event, and knowledge source
+- business-gated topics marked explicitly
+- disabled or draft topics excluded from the user-facing catalog
+
+## Coverage Matrix
+
+The catalog must explicitly cover every Community-role product surface, not only the narrative. This matrix is the guardrail for quality review.
+
+| Product area | Required coverage | Topic IDs |
+|---|---|---|
+| My Journey, Life Compass, and core story | Quality-of-life promise, Life Compass, usage-session model, business curiosity without pressure | T001-T010, T021-T022, T039-T040, T158-T160, T248-T250 |
+| Vitana Assistant, ORB, Autopilot, and voice | Ask, explain, open, act, next best action, voice settings and confirmation behavior | T003-T004, T019-T020, T041-T043, T239-T241 |
+| Health and Vitana Index | Five pillars, Index, sleep, hydration, movement, nutrition, mental wellness, biomarkers, plans, services, education, safety boundaries | T009-T014, T023-T032, T044-T067 |
+| Memory and Diary | Memory overview, what Vitana knows, 13 categories, add memory, diary, timeline, recall, correct or forget, permissions, export | T015-T016, T033-T034, T068-T079 |
+| Calendar, reminders, notifications, and Inbox | Reminders, calendar, agenda, create event, reschedule, Inbox, inspiration, archived, messaging, voice notes | T035-T038, T080-T085, T122-T124, T233-T235 |
+| Profile, public profile, and trust | Profile edit, public preview, visibility, profile preview, QR/share, trust signals | T017-T018, T089-T094, T215-T217 |
+| Find a Match and relationship graph | Match types, why this match, match list search, filters, accept/dismiss/connect, clients, partners, event companions | T095-T100, T191-T193 |
+| Activity intents and open asks | Post activity, seek meetup partners, view matches, respond, share intent, fulfill intent | T101-T106 |
+| Feed, groups, challenges, and community hub | Community overview, highlights, rankings, feed, posts, comments, groups, group detail, group chat, challenges | T086-T115 |
+| Events and meetups | Search events, filter, event drawer, RSVP, ticket safety, calendar, attendee matching, create event, create meetup, invite, edit/cancel | T116-T133, T194-T196 |
+| Live Rooms | Browse, join, listen, speak, chat, create, schedule, go live, record, highlights, summaries | T134-T142, T200-T202 |
+| Media Hub | Shorts, podcasts, music, bookmarks, player overlays, uploads, rights, moderation, content as business asset | T143-T154, T203-T205 |
+| Discover and marketplace | Search products, services, providers, events, product detail, suitability, Universal Cart, orders, checkout safety, refunds | T161-T172 |
+| Wallet and subscriptions | Wallet overview, credits, rewards, subscriptions, billing, transactions, payment methods, Vitana Coin, exchange, earnings, payouts | T173-T178, T236-T238 |
+| Sharing and campaigns | Sharing overview, channels, social share consent, campaign draft, distribution, schedule, analytics, posts history, data consent | T179-T187, T227-T232 |
+| Business Hub and longevity economy | Business path, skill inventory, business post, clients, partners, events, services, live rooms, media, Sell and Earn, reseller links, marketplace autopilot, business safety | T188-T205, T206-T247 |
+| Settings, support, and safety | Privacy, consent, connected apps, billing, support/refunds, safety boundaries, non-diagnostic health, no false claims | T015-T016, T060-T064, T170-T172, T242-T244 |
+
+## 250 Topic Card Catalog
+
+| Session | Story purpose | Clickable topic cards |
+|---:|---|---|
+| 1 | Explain the ecosystem before any workflow. | T001 What Is Vitanaland; T002 Maxina Community |
+| 2 | Introduce the assistant and voice interface. | T003 Vitana Assistant; T004 ORB Voice |
+| 3 | Explain 90 sessions, jumping, and practice qualification. | T005 My Journey; T006 Usage Sessions |
+| 4 | Define the user's personal goal system. | T007 Life Compass; T008 Choose Goal |
+| 5 | Introduce Vitana Index early. | T009 Vitana Index; T010 Improve Index |
+| 6 | Teach the health model simply. | T011 Five Pillars; T012 Weakest Pillar |
+| 7 | Explain the quality-of-life promise. | T013 Quality of Life; T014 Health First |
+| 8 | Establish safety and control. | T015 Privacy Control; T016 Memory Permission |
+| 9 | Explain why profile matters. | T017 Profile Basics; T018 Trust Signal |
+| 10 | Teach first voice commands. | T019 Ask Vitana; T020 Open Screen |
+| 11 | Explain daily onboarding rhythm. | T021 Daily Loop; T022 First Practice |
+| 12 | Start with recovery. | T023 Sleep; T024 Log Sleep |
+| 13 | Give a fast health win. | T025 Hydration; T026 Log Water |
+| 14 | Connect movement to energy. | T027 Movement; T028 Log Movement |
+| 15 | Keep nutrition simple. | T029 Nutrition; T030 Meal Note |
+| 16 | Build mental strength. | T031 Mental Strength; T032 One-Minute Reset |
+| 17 | Make memory practical. | T033 Daily Diary; T034 Voice Diary |
+| 18 | Teach follow-through. | T035 Reminders; T036 Set Reminder |
+| 19 | Turn intention into schedule. | T037 Calendar; T038 Schedule Action |
+| 20 | Let the user choose depth. | T039 Future Paths; T040 Business Curiosity |
+| 21 | Establish the daily operating loop. | T041 Daily Loop; T042 Try Autopilot; T043 Finish or Snooze |
+| 22 | Teach Home as the daily command center. | T044 Home overview; T045 Context tab; T046 AI Feed judgment |
+| 23 | Show how the Index becomes actionable. | T047 Index Drivers; T048 Pillar Subscores; T049 Choose Driver |
+| 24 | Deepen recovery guidance. | T050 Sleep Trend; T051 Sleep Plan; T052 Bedtime Reminder |
+| 25 | Connect daily trackers. | T053 Hydration rhythm; T054 Nutrition pattern; T055 Movement style |
+| 26 | Connect calm to decisions. | T056 Mental wellness pattern; T057 Breathing or meditation log; T058 Stress insight |
+| 27 | Add education without overload. | T059 Health education; T060 Conditions and risks boundaries; T061 Professional or support boundary |
+| 28 | Preview richer health data safely. | T062 Biomarkers Preview; T063 Connected Apps; T064 Connect Later |
+| 29 | Turn health into a plan. | T065 Health Plans; T066 Services Hub; T067 Plan Step |
+| 30 | Teach the full Memory system. | T068 Memory overview; T069 What Vitana knows; T070 Thirteen memory categories |
+| 31 | Teach memory capture and search. | T071 Add Memory; T072 Memory Timeline; T073 Recall Memory |
+| 32 | Teach memory control. | T074 Correct Memory; T075 Memory Permissions; T076 Data Export |
+| 33 | Make diary more than journaling. | T077 Diary streak and rewards; T078 Photo diary; T079 Pillar lift from diary |
+| 34 | Teach calendar operations. | T080 Calendar Agenda; T081 Create Calendar Event; T082 Reschedule Event |
+| 35 | Teach Inbox and communication. | T083 Inbox Overview; T084 Inbox Tabs; T085 Draft Voice Note |
+| 36 | Move from self to community. | T086 Community hub; T087 Today's highlights and rankings; T088 Global and community search |
+| 37 | Teach the Feed. | T089 Feed Tabs; T090 Post Draft; T091 React Safely |
+| 38 | Teach profile trust before contact. | T092 Profile Preview; T093 Public profile visibility; T094 QR and profile sharing |
+| 39 | Teach Find a Match as a core system. | T095 Find a Match; T096 Match Types; T097 Why This Match |
+| 40 | Teach match actions. | T098 Match List; T099 Search Matches; T100 Connect or Dismiss |
+| 41 | Teach activity seeking and open asks. | T101 Post Activity; T102 Seek Meetup; T103 Intent Matches |
+| 42 | Teach the intent loop. | T104 Respond Match; T105 Share Intent; T106 Fulfill Intent |
+| 43 | Teach groups. | T107 Browse Groups; T108 Save Group; T109 Group Draft |
+| 44 | Teach inside a group. | T110 Group Detail; T111 Group Chat; T112 Invite Members |
+| 45 | Teach challenges. | T113 Challenges; T114 Challenge Progress; T115 Share Achievement |
+| 46 | Teach event discovery. | T116 Events Search; T117 Event Filters; T118 Save Event |
+| 47 | Teach event details and participation. | T119 Event Drawer; T120 Free RSVP; T121 Ticket Safety |
+| 48 | Connect events to planning and matching. | T122 Add to Calendar; T123 Event Reminders; T124 Attendee Matching |
+| 49 | Teach event creation explicitly. | T125 Create Event; T126 Event Basics; T127 Event Draft |
+| 50 | Teach meetup creation explicitly. | T128 Create Meetup; T129 Activity, location, and time; T130 Invite members to meetup |
+| 51 | Teach meetup management. | T131 Meetup Drawer; T132 Local Meetup; T133 Meetup Changes |
+| 52 | Teach Live Rooms participation. | T134 Browse Live Rooms; T135 Join Listener; T136 Speak or Chat |
+| 53 | Teach Live Room creation. | T137 Schedule Live Room; T138 Room topic and description; T139 Go Live safety |
+| 54 | Teach Live Room media lifecycle. | T140 Live Room recordings; T141 Highlights and moments; T142 Room summaries |
+| 55 | Teach Media Hub as its own surface. | T143 Media Hub overview; T144 Watch Shorts; T145 Save or bookmark media |
+| 56 | Teach podcasts. | T146 Play Podcasts; T147 Audio Bar; T148 Podcast Routine |
+| 57 | Teach music. | T149 Play Music; T150 Focus Music; T151 Media Overlay |
+| 58 | Teach media upload. | T152 Upload Short; T153 Upload Podcast; T154 Publishing Rights |
+| 59 | Close community foundation. | T155 Community recap; T156 Choose next social action; T157 Community trust becomes opportunity |
+| 60 | Open the optional business doorway. | T158 Path Choice; T159 Economy Positioning; T160 Business Interest |
+| 61 | Teach Discover as search, not sales. | T161 Discover Overview; T162 Search Discover; T163 Why Recommended |
+| 62 | Teach product literacy. | T164 Supplements and products; T165 Product detail and suitability; T166 Save, wishlist, or cart |
+| 63 | Teach provider discovery. | T167 Wellness services; T168 Providers, doctors, and coaches; T169 Provider profile trust |
+| 64 | Teach commerce safety. | T170 Universal Cart; T171 Purchase Rules; T172 Refund Path |
+| 65 | Teach wallet and subscription status. | T173 Wallet overview; T174 Credits, rewards, subscriptions; T175 Current plan and billing |
+| 66 | Teach wallet value layers. | T176 Rewards Program; T177 Payment Methods; T178 Vitana Coin |
+| 67 | Teach sharing as consent-based. | T179 Sharing overview; T180 Channel connector; T181 Social share consent |
+| 68 | Teach campaigns. | T182 Campaign basics; T183 Create campaign draft; T184 Distribution and schedule |
+| 69 | Teach sharing feedback and audit. | T185 Sharing analytics; T186 Posts history; T187 Data consent audit |
+| 70 | Teach Business Hub without forcing it. | T188 My Business overview; T189 Business path check; T190 Skill inventory |
+| 71 | Connect business to matching. | T191 Business Post; T192 Find Clients; T193 Match List |
+| 72 | Teach events as business assets. | T194 Event Asset; T195 Event Plan; T196 Ticket Sales |
+| 73 | Teach services as offers. | T197 Service as offer; T198 Outcome, audience, duration, price; T199 Service draft |
+| 74 | Teach live rooms as trust assets. | T200 Live Trust; T201 Business Live Room; T202 Invite People |
+| 75 | Teach media as business asset. | T203 Media Asset; T204 Content Plan; T205 Campaign Asset |
+| 76 | Use whitepaper facts only after intent. | T206 Fact Bank; T207 $27T Economy; T208 Plain Summary |
+| 77 | Explain AI work shift for builder users. | T209 Future Work; T210 Job Reshaping; T211 AI-Amplified Skill |
+| 78 | Teach market sizing for builders. | T212 Market Size; T213 Wellness Economy; T214 Sector Fit |
+| 79 | Teach demographic demand. | T215 Demographic Demand; T216 Aging Market; T217 Demand Fit |
+| 80 | Teach decentralized work. | T218 Gig Proof; T219 Gig Economy; T220 Flexible Earning |
+| 81 | Build the first offer ladder. | T221 Offer Ladder; T222 Offer Types; T223 First Offer |
+| 82 | Teach Sell and Earn. | T224 Sell and Earn inventory; T225 Reseller link; T226 Commission tracking |
+| 83 | Teach promotion channels. | T227 Promotion Channels; T228 Social Channels; T229 Share Copy |
+| 84 | Teach campaign optimization. | T230 Campaign metrics; T231 Reach, clicks, engagement; T232 Improve one campaign |
+| 85 | Teach client operations. | T233 Client management; T234 Booking, calendar, follow-up; T235 Delivery checklist |
+| 86 | Teach earnings and payouts. | T236 Earnings and payouts; T237 Pending, available, history; T238 Withdrawal readiness |
+| 87 | Teach Marketplace Autopilot. | T239 Marketplace Autopilot; T240 Opportunity suggestions; T241 Review why and permissions |
+| 88 | Teach business safety. | T242 Responsible recommendations; T243 No false claims; T244 Trust and safety checklist |
+| 89 | Convert learning into a sprint. | T245 Seven-day business sprint; T246 Vitana next best action; T247 Choose sprint metric |
+| 90 | Graduate without removing Journey. | T248 Graduation; T249 Full Mode; T250 Next Milestone |
+
+## Implementation Plan
+
+### Phase 1: Content Model
+
+Create `journey_topics` or `journey_lessons` with:
+
+- `topic_id`
+- `curriculum_version`
+- `day_number`
+- `position_in_day`
+- `chapter_id`
+- `title`
+- `short_description`
+- `display_label`
+- `voice_script_id`
+- `manual_path`
+- `practice_action_type`
+- `completion_event`
+- `safety_level`
+- `business_gate`
+- `fallback_topic_id`
+- `unlock_rule`
+- `tenant`
+- `role`
+- `enabled`
+- `status`
+- `published_at`
+- `updated_by_admin_id`
+
+Create or extend Knowledge Base content storage so each checklist topic can point to:
+
+- Vitana voice script
+- transcript or silent-mode summary
+- manual or knowledge source
+- guided-practice definition
+- feature unlock rule
+- admin notes
+- change history
+
+Create `user_journey_progress` with:
+
+- `user_id`
+- `topic_id`
+- `state`
+- `started_at`
+- `completed_at`
+- `mastered_at`
+- `skipped_at`
+- `replay_count`
+- `practice_payload`
+
+Create or extend `user_capability_awareness` for mastery signals outside onboarding.
+
+### Phase 1A: Admin Knowledge Base Checklist
+
+Add `Admin Pages -> Knowledge Base -> Checklist`.
+
+The checklist tab should provide:
+
+- searchable table of all 250 topic cards
+- filters for day, chapter, product area, state, business gate, and enabled/disabled
+- inline editing for label, title, short description, day number, sort position, and topic state
+- detail editor for Vitana script, transcript, practice action, completion event, unlock rule, manual source, and safety level
+- validation before publish
+- draft, preview, publish, and rollback
+- import/export for bulk curriculum work
+- audit log showing admin, timestamp, and changed fields
+
+The My Journey UI must not hardcode the checklist. It should load the published checklist from the Knowledge Base and fall back only to a bundled seed version if the backend is unavailable.
+
+### Phase 2: My Journey UI
+
+My Journey should become the onboarding home:
+
+- one scrollable catalog
+- 90 usage sessions grouped into chapters
+- 2 cards per session for sessions 1-20
+- 3 cards per session for sessions 21-90
+- previewable future sessions
+- topic replay
+- progress state per topic
+- "business path" filter visible only after intent
+- always-accessible account, billing, privacy, support, and emergency/safety paths
+
+Recommended chapter grouping:
+
+- Days 1-20: Trust, Life Compass, and first health wins
+- Days 21-35: Home, health depth, Memory, Calendar, and Inbox
+- Days 36-45: Community hub, Feed, Profile, Find a Match, activity intents, Groups, and Challenges
+- Days 46-59: Events, meetups, Live Rooms, Media Hub, and community recap
+- Days 60-69: Discover, Wallet, Sharing, campaigns, distribution, and consent
+- Days 70-75: Business doorway, matching, events, services, live rooms, and media as assets
+- Days 76-90: Builder mode, whitepaper facts, Sell and Earn, campaigns, clients, payouts, safety, and graduation
+
+### Phase 3: Vitana Voice Behavior
+
+Tapped topic flow:
+
+1. Vitana explains the topic in one short pass.
+2. Vitana offers the tiny guided practice.
+3. The user completes or skips.
+4. Vitana records `teacher_event`.
+5. Vitana records completion only after the practice action.
+6. Vitana suggests one next best action.
+
+Use existing ORB behavior:
+
+- teach-only for "what is this"
+- navigate-only for "open this"
+- teach-then-navigate for "how do I"
+- confirmation for sending messages, purchases, bookings, profile changes, subscription changes, data sharing, and financial actions
+
+### Phase 4: Business Gating
+
+Default users should see only light business mentions.
+
+Business-interested users should unlock:
+
+- Longevity Economy
+- Positioning in the Longevity Economy
+- Business Hub
+- Find Clients or Partners
+- Create Event
+- Create Service
+- Event as Business Asset
+- Sell and Earn
+- Reseller Links
+- Promotions
+- Live Room as Trust Builder
+- Media as Business Asset
+- Social Sharing
+- Wallet Earnings
+- Marketplace Autopilot
+- Whitepaper Facts
+- Builder Strategy
+
+If the user chooses health-only, business cards should remain previewable but not pushed.
+
+### Phase 5: Measurement
+
+Track:
+
+- topic start rate
+- explanation replay rate
+- practice completion rate
+- skip rate
+- drop-off per day
+- business_interest_level changes
+- first community action
+- first memory recall
+- first calendar event or reminder
+- first Inbox triage or voice note draft
+- first profile trust signal
+- first Find a Match action
+- first activity intent or open ask
+- first event search, save, or RSVP
+- first Create Event draft
+- first Create Meetup draft
+- first Media Hub play
+- first media upload draft
+- first sharing consent review
+- first invitation draft
+- first live room plan
+- first offer draft
+- first campaign draft
+- first wallet earning view
+
+Success metrics:
+
+- day 1 completion
+- day 7 retention
+- day 20 Life Compass clarity
+- day 35 personal intelligence adoption: health loop, Memory, Calendar, Inbox
+- day 45 first community connection action
+- day 59 first event, meetup, live room, or media action
+- day 69 Discover, Wallet, Sharing, and consent literacy
+- day 75 business path asset preview for interested users
+- day 90 graduation or Growth Mode continuation
+
+## Product Decision
+
+The final recommendation is:
+
+- Use 250 topic cards.
+- Keep the full app behind My Journey for first-time users.
+- Do not hard-switch onboarding off after 90 lessons.
+- After day 90, convert My Journey into Growth Mode.
+- Mention longevity economy early as a possible path, not as a pitch.
+- Store the 250-topic checklist in Admin Pages under `Knowledge Base -> Checklist`, with My Journey consuming the published version.
+- Use the whitepaper facts only for explicit business interest.
+- Treat financial freedom as a legitimate Life Compass goal.
+- Teach that health creates capacity, community creates trust, trust creates opportunity, and opportunity can create income.

--- a/docs/superpowers/specs/2026-06-04-my-journey-usage-catalog-design.md
+++ b/docs/superpowers/specs/2026-06-04-my-journey-usage-catalog-design.md
@@ -1,0 +1,477 @@
+# My Journey Usage Catalog Design
+
+**Date:** 2026-06-04
+
+**Goal:** Reduce first-time Maxina onboarding to one simple home: a scrollable, searchable My Journey catalog where Vitana teaches the application by voice, lesson by lesson, and releases feature access only after a tiny guided practice action.
+
+**Decision:** My Journey becomes the single onboarding home for first-time users. The full app still exists, but first-time users are routed through the catalog until each feature has been explained, practiced, and released.
+
+---
+
+## Non-Negotiable Design Guardrail
+
+This is a UX/routing/state addition, not a redesign.
+
+The existing Vitana v1 / Maxina full app design must remain unchanged. Developers must not change full app card sizes, font sizes, colors, spacing, button styles, navigation styling, header styling, bottom navigation styling, icons, shadows, radii, or page composition. The full app view after switching to `Full App` must render the existing production My Journey/full app surfaces.
+
+Guided Mode may add new onboarding-specific components:
+
+- Guided Journey / Full App segmented switch.
+- 90-session / 250-topic checklist below the current My Journey start view.
+- Vitana voice/ORB teaching overlay and topic explanation flow.
+- Guided-practice surfaces and release gates.
+- Admin Knowledge Base -> Checklist editor.
+
+These new Guided Mode components must reuse existing Vitana v1 design tokens, typography, colors, buttons, card patterns, layout spacing, icons, and component primitives wherever they already exist. Do not introduce a new design language for onboarding. Prototype CSS is only a product/UX reference; developers must map the behavior into the existing design system instead of copying prototype styling into production.
+
+Full App mode is a design freeze. Guided Mode is an additive UX layer.
+
+## Problem
+
+The current onboarding model exposes too much at once:
+
+- A large desktop sidebar and mobile drawer expose many categories immediately.
+- My Journey shows many actions and waves, but the user is still asked to understand the whole app too early.
+- The current post-registration flow explains Vitana, Autopilot, Calendar, and the 90-session journey in a long speech, then redirects users into the app.
+- Voice is the main interface, but most users are not yet trained to use voice confidently.
+
+The result is cognitive overload. Users need a simple cover surface that hides complexity while still allowing exploration.
+
+## Core Model
+
+The journey is session-based, not calendar-based.
+
+`Session 3` means learning session 3, not the third real-world day after registration. A user may complete one session per day or ten sessions in one calendar day, pause for a week, then return to the exact next incomplete session. Progress advances only through session completion.
+
+Each session follows this progression:
+
+1. **Activate ORB:** user starts a session or presses the ORB.
+2. **Explain:** Vitana explains the session or topic by voice.
+3. **Redirect:** Vitana opens the correct screen for the user.
+4. **Practice:** user completes one tiny guided action in a controlled onboarding surface.
+5. **Release:** feature access is unlocked or marked as available for real use.
+6. **Resume:** user returns to My Journey with the session marked complete.
+
+A session is complete only after the guided-practice action is done. Listening alone is not enough.
+
+## Catalog Structure
+
+The catalog should cover 90 sessions, grouped into 6 chapters of 15 sessions:
+
+1. **Basics:** Vitana, voice, account, profile, safety, navigation principles.
+2. **Daily Use:** check-ins, diary, reminders, calendar, routines, simple actions.
+3. **Community:** people, groups, events, live rooms, messaging, sharing boundaries.
+4. **Health:** Vitana Index, goals, reports, biomarker concepts, health consent.
+5. **Intelligence:** memory, patterns, Autopilot, recommendations, personalization.
+6. **Discovery:** marketplace, services, professionals, products, sharing, long-term usage.
+
+The first implementation can ship the catalog framework with a smaller authored session set, but the data model and UI must support the full 90-session curriculum.
+
+The catalog content must belong to the Knowledge Base, not to frontend code alone. Add `Admin Pages -> Knowledge Base -> Checklist` as the editable source of truth for the onboarding checklist. My Journey should consume the published checklist version, while admins can draft, edit, validate, preview, publish, and roll back checklist changes.
+
+## First-Time User Flow
+
+After registration and the name/handle form, the user lands on `/autopilot` / My Journey, not Home or Community.
+
+The first screen must preserve the current My Journey start view. The onboarding catalog should extend this screen, not replace it.
+
+The start view contains:
+
+- app header with MAXINA and voice state; no menu dots in Guided Mode
+- title `My Journey`
+- shortcut row: Search, Calendar, Life Compass
+- the existing large gradient Journey counter/goal card
+- circular session counter inside the card
+- goal card such as `Improve quality of life and extend lifespan`
+- Guided Mode uses the bright Maxina-header blue background on the Journey card as the visual mode signal
+- one clear next button
+- one segmented switch directly below the Journey card with `Guided Journey` and `Full App`
+- the ORB and bottom navigation with `My Journey`, `Inbox`, ORB, `Live`, and `Events`
+
+First-run button states:
+
+- before the user starts: `Start Journey`
+- after Vitana gives the journey introduction: `Start Session 1`
+- after progress begins: `Start Session N`
+
+`Start Journey` is not a reading screen. It opens the ORB overlay and Vitana gives the introductory speech: what the 90 sessions are, how learning works, how Vitana talks, how Vitana redirects, and why the user should press the ORB whenever they need help.
+
+The ORB is not decorative. Pressing the ORB starts Vitana, and Vitana can answer, teach, navigate, or execute after confirmation. Onboarding should train this behavior from the first sessions.
+
+Guided Mode does not expose the sidebar/menu dots. During onboarding, user account, subscription, payments, privacy, settings, support, logout, and sidebar navigation remain reachable by switching to the Full App and opening the existing account/settings or navigation surfaces there. Do not build a separate Guided Mode overlay or duplicate account/support screen.
+
+The start view must not show secondary analytics cards such as `topic cards complete`, `usage-sessions total`, `ready to practice`, or `preview locked`. These make the first viewport feel like a dashboard. Keep them out of the user-facing start view.
+
+The start view must not show `Start Practice`. The user first starts the current session or topic through Vitana; the Topic Explanation screen contains `Replay`, `Start Practice`, and `Back to Journey`.
+
+When the user taps `Start Session 5`, the ORB overlay opens and Vitana starts talking. Vitana explains what Session 5 is, then redirects the user to the correct Session 5 screen. The user should feel from the beginning that answers, learning, navigation, and execution happen through ORB communication.
+
+The first five sessions must anchor the basic mental model:
+
+- Session 1: What is Vitanaland and the Maxina Community?
+- Session 2: Vitana Assistant and ORB voice.
+- Session 3: My Journey, 90 sessions, jumping freely, and practice qualification.
+- Session 4: Life Compass.
+- Session 5: Vitana Index and how to improve it.
+
+The start view must not show a separate text box such as `Ask Vitana what to do today`. During every session explanation, Vitana should teach the habit: "Whenever you have a question, tap the ORB and ask me."
+
+After Vitana redirects to a session, topic explanation, practice screen, or locked preview, the screen should include one small helper cue directly above the bottom ORB: `Need help? Press the ORB and ask Vitana.` The cue should be short, centered, and visually point down toward the ORB. Do not place it under the content buttons as normal scroll content, and do not add it as another large card on the My Journey start view.
+
+The top-right orientation element on redirected learning screens must not show local decorative facts such as `2 topics`, `voice`, or `1 action`. Those facts add no value. Either remove the element or use it for global journey orientation. The chosen pattern is a compact `Session N/90` journey-position badge with the chapter label, so users who jump from Session 5 to Session 77 still know where the selected topic belongs.
+
+Practice completion should generate a separate Journey/Practice progress signal first. Recommended qualification rule: users can browse and preview any of the 90 sessions freely, but first-stage qualification requires 60 completed guided-practice actions. This is enough to reward real use without making the journey feel like school homework. Do not automatically inflate the Vitana Index with lesson completion until the index model explicitly defines how learning progress contributes to health, community, or quality-of-life scoring.
+
+## Guided Mode And Full Mode
+
+Build the journey as two app modes, not as two separate products.
+
+### Guided Mode
+
+Guided Mode is the default state for new users.
+
+- My Journey is the home screen.
+- Vitana explains first, then redirects to Topic Explanation.
+- Topic Explanation contains the short user-facing summary and the three actions: `Replay`, `Start Practice`, `Back to Journey`.
+- Complex product areas can be visible, but unreleased or unpracticed areas route through Vitana explanation gates.
+- Account, subscription, payments, privacy, settings, support, and logout remain available through the existing Full App account/settings area.
+
+### Full Mode
+
+Full Mode is the normal Maxina app experience.
+
+- Full navigation and existing feature surfaces are available.
+- My Journey remains available as an optional learning/progress screen.
+- Vitana remains the voice-first help, navigation, and execution layer.
+- Subscription and permission rules still apply. Full Mode means full interface scope, not free access to paid features.
+
+### Switching Rules
+
+Users can switch both ways.
+
+- Guided Mode shows a two-option segmented switch directly below the Journey card: `Guided Journey` active, `Full App` inactive.
+- Full Mode shows the same segmented switch directly below the Journey card: `Full App` active, `Guided Journey` inactive.
+- Do not render a separate explanatory mode/status card. The switch is only a compact view selector.
+- Switching to Full Mode does not delete topic progress, practice progress, last session, voice history, or qualification state.
+- Returning to Guided Mode resumes the same My Journey progress.
+- If a user skipped early, keep `skipped_onboarding_at` and continue to show My Journey as available, not as a forced gate.
+
+### Qualification
+
+Qualification is separate from skipping.
+
+- `qualified`: user completed the required practice count.
+- `skipped`: user chose Full Mode before qualifying.
+- `guided`: user is still in the guided path.
+- `full`: user is currently using the full interface.
+
+Recommended first-stage qualification remains 60 completed guided-practice actions.
+
+Below the start view, the same scroll continues into:
+
+- current incomplete session
+- chapter tabs or filters
+- scrollable session/topic list
+- visible locked future items that can be explained but not opened for full use
+
+The user can scroll freely to Session 1, Session 12, Session 55, or Session 90. Future sessions are not hidden. Clicking them starts a preview explanation, where Vitana can say that real usage is released later.
+
+After onboarding is finished, the start view stays. The catalog section converts from onboarding mode into Growth Mode, but the user should not feel that the My Journey home was replaced.
+
+## Click Behavior
+
+Clicking a **session**:
+
+- Opens the ORB overlay first.
+- Starts Vitana's overview explanation by voice.
+- Lets Vitana redirect directly to the next unfinished topic's Topic Explanation screen.
+- Avoids a separate Session Detail screen because the My Journey catalog already shows the session topics.
+
+Clicking a **topic**:
+
+- Opens the ORB overlay first.
+- Vitana explains the selected topic by voice.
+- Vitana redirects to the Topic Explanation screen for that topic.
+- The Topic Explanation screen contains the Practice action.
+- The user does not have to find the screen manually.
+
+Clicking a **locked feature topic**:
+
+- Does not navigate to the full feature.
+- Starts a Vitana preview: "This is what the feature does. You will use it after completing Lesson X."
+- Offers "Remind me when released" or "Continue journey."
+
+Clicking a **released feature topic**:
+
+- Allows normal navigation.
+- Still offers "Explain before opening" for users who want guidance.
+
+## Voice Assistant Role
+
+Vitana is the speaking manual for the app.
+
+Vitana must be able to:
+
+- Explain the current session.
+- Explain any topic in the catalog.
+- Explain future locked features without opening them.
+- Start guided practice.
+- Confirm lesson completion.
+- Tell the user what is available now and what is still learning-gated.
+
+Every voice explanation needs a short text transcript or summary on screen for accessibility, noisy environments, and users who prefer reading.
+
+## Guided Practice
+
+Guided practice should be tiny and controlled. It should avoid dropping the user into a full complex screen before they are ready.
+
+Practice means Vitana redirects the user to the real feature screen where the action belongs. Examples: Post Activity, Create Event, Find a Match, Create Reminder, Life Compass, Vitana Index, Universal Cart, Live Room, Media Hub, or Business Hub. Vitana explains what is happening before the redirect and guides one small action after the screen opens.
+
+Examples:
+
+- Voice session: user taps the orb and says one suggested phrase.
+- Diary session: user answers one well-being question, then Vitana saves a sample entry.
+- Community session: user previews a match card, then chooses "save for later" or "not now."
+- Health session: user views a simplified Vitana Index explanation, then identifies one focus area.
+- Calendar session: user confirms one suggested reminder in an onboarding card.
+
+The practice action should be small enough to complete in 30-90 seconds.
+
+## Navigation Gating
+
+Existing navigation should remain structurally intact, but first-time users should be routed back through My Journey when trying to access unreleased areas.
+
+For unreleased features:
+
+- Desktop sidebar/mobile drawer item can remain visible, but route access shows a Vitana explanation/release gate.
+- The gate says what the feature is, when it is released, and which lesson unlocks it.
+- The user can return to My Journey or listen to a preview explanation.
+
+Never gate account and support utilities. User Account, Subscription, Payments, Privacy, Settings, Support, and Logout must remain reachable during onboarding and after onboarding, but they route to the existing Full App account/settings surfaces instead of a Guided Mode overlay.
+
+For released features:
+
+- Navigation works normally.
+- My Journey still remains the user's learning home until the onboarding curriculum is complete.
+
+## State Requirements
+
+The app needs durable per-user onboarding state:
+
+- Current session.
+- Completed session IDs.
+- Completed topic IDs.
+- Practice completion state.
+- Current app mode: `guided` or `full`.
+- Onboarding status: `not_started`, `in_progress`, `qualified`, `skipped`, or `completed`.
+- Qualification count and threshold.
+- `entered_full_mode_at`, `returned_to_guided_at`, and `skipped_onboarding_at` timestamps where applicable.
+- Released feature IDs.
+- Last opened session/topic.
+- Voice explanation seen/heard state.
+- Optional acceleration count: how many sessions completed in the current calendar day.
+
+LocalStorage may be used only as a fast UI hint. Durable state must live in the backend/Supabase because users can change devices or return after a pause.
+
+## Existing App Touchpoints
+
+Likely frontend areas:
+
+- `src/pages/onboarding/OnboardingWelcome.tsx`: redirect first-time users to My Journey after the name form.
+- `src/pages/AutopilotDashboard.tsx`: replace or rework the current dense My Journey layout into the catalog home.
+- `src/config/journeyWaves.ts`: evolve from wave timeline to usage-lesson chapters, or add a new catalog config beside it.
+- `src/components/health/JourneyDayBadge.tsx`: replace the user-facing "Day N of 90" language with "Session N of 90", or rename the component when implementation scope allows.
+- `src/components/health/JourneyWaveMap.tsx`: replace wave strip with chapter/catalog navigation.
+- `src/components/AutopilotPopup.tsx`: keep as task executor; do not overload it as the lesson explainer unless it is explicitly refactored.
+- Voice/ORB bridge: add a callable event or command for "explain lesson/topic" and "start guided practice."
+- Admin Pages Knowledge Base: add a `Checklist` tab for editing the 90-session/250-topic catalog, including labels, Vitana explanations, transcripts, practice actions, unlock rules, knowledge sources, status, publish state, and audit history.
+
+## Repository Integration Notes
+
+This prototype workspace contains the mockup and planning docs only. Before developer execution, verify the exact paths in both repositories:
+
+- Vitana platform repository: own durable onboarding/mode state, route guards, subscription checks, Admin Knowledge Base Checklist, and backend persistence.
+- Vitana v1 repository: map existing My Journey, bottom navigation, ORB bridge, full app navigation, and legacy onboarding entry points to the shared mode model.
+
+Integration must keep these boundaries:
+
+- Mode state is product UX state.
+- Subscription state is commercial entitlement state.
+- Feature permission state is access-control state.
+- Journey progress is learning/practice state.
+
+Do not combine these into one flag. Developers should create or reuse a single user onboarding/mode model and expose it consistently to routing, My Journey, Vitana voice commands, and Admin checklist publishing.
+
+## Changed Screen Set
+
+Build 8 changed screens for the onboarding redesign.
+
+### 01 My Journey Start And Catalog
+
+Purpose: keep the current My Journey start view as the permanent home, then add the 250-topic onboarding catalog below it.
+
+Visible content:
+
+- App header with MAXINA and voice state; no sidebar/menu dots in Guided Mode
+- title `My Journey`
+- current shortcut row: Search, Calendar, Life Compass
+- existing large gradient Journey card
+- circular session counter that stays useful after onboarding
+- goal card, deadline prompt, and motivational line
+- compact learning counter: completed topics out of 250 during onboarding, then Growth Mode milestones after onboarding
+- one clear hero button: `Start Journey` for first-run users, then `Start Session N`
+- segmented Guided Journey / Full App switch
+- chapter filters
+- scrollable list of all 90 sessions
+- each session row shows 2 topic cards for sessions 1-20 and 3 topic cards for sessions 21-90
+- topic cards show short labels, topic IDs, state, and a tap target for Vitana explanation
+- bottom navigation uses `My Journey`, `Inbox`, ORB, `Live`, and `Events`
+
+Scroll behavior:
+
+- top of screen stays close to today's My Journey start view
+- first scroll reveals simple commands, chapter filters, and days 1-10 with orientation topics
+- middle scroll shows health, memory, calendar, community, events, Live Rooms, and Media Hub
+- lower scroll shows Discover, Wallet, Sharing, Business Hub, Sell and Earn, Marketplace Autopilot, safety, and Graduation
+
+### 02 Topic Explanation
+
+Purpose: make every checklist item clickable and teachable by Vitana.
+
+Visible content:
+
+- topic ID and display label
+- global journey-position badge such as `5/90 BASICS`
+- short `What you learn` summary
+- `What it is`: one short sentence explaining the topic
+- `Your benefit`: why the user should care
+- `When to use`: when this topic helps
+- `Try this`: the tiny practice action
+- buttons: `Replay`, `Start Practice`, and `Back to Journey`
+- the three buttons sit in one equal-width row, centered with equal gaps; multi-word labels may wrap to two lines so all buttons keep the same size
+
+Do not show internal metadata such as source, checklist, manual source, voice script, safety level, or business gate in the community-user Topic Explanation screen. Those fields belong in Admin Topic Editor and publish validation.
+
+### 03 Guided Practice
+
+Purpose: complete a topic through a tiny action, not by passive listening.
+
+Visible content:
+
+- one small guided action
+- Vitana coaching prompt
+- safe preview state
+- completion event
+- `Complete`, `Skip for now`, and `Replay explanation`
+
+### 04 Locked Preview Gate
+
+Purpose: allow browsing ahead without dropping the user into complex features too early.
+
+Visible content:
+
+- feature name
+- what the feature does
+- release condition
+- future session
+- `Remind me`, `Preview explanation`, and `Continue Journey`
+
+### 05 Admin Checklist List
+
+Purpose: make the 250-topic checklist editable inside Admin Pages.
+
+Visible content:
+
+- Admin Pages navigation
+- Knowledge Base tabs with `Checklist` selected
+- table of all 250 topic cards
+- search, filters, day/chapter selectors, status filters, business gate filter
+- row actions for edit, disable, preview, and history
+- publish status and current version
+
+### 06 Admin Topic Editor
+
+Purpose: edit one checklist topic without developer involvement.
+
+Visible content:
+
+- topic ID, day number, position, label, title, short description
+- Vitana voice script
+- silent transcript
+- practice action definition
+- completion event
+- unlock rule
+- manual/knowledge source
+- safety level and business gate
+- save draft and preview buttons
+
+### 07 Admin Publish Validation
+
+Purpose: prevent broken onboarding content from reaching users.
+
+Visible content:
+
+- validation summary
+- 90 session check
+- 250 topic-card check
+- 2 cards/session for sessions 1-20
+- 3 cards/session for sessions 21-90
+- 1-4 word label check
+- missing Vitana script check
+- missing practice action check
+- publish, rollback, and export actions
+
+### 08 Full Mode Home
+
+Purpose: show the state after the user qualifies or chooses to use the full app early.
+
+Visible content:
+
+- the original My Journey/full app dashboard design, not a redesigned Full Mode landing page
+- original header with the full-app three-dot menu, shortcut row, Journey counter card, and goal card
+- the full app Journey card keeps the original gradient/background; only Guided Mode turns the card bright blue
+- the segmented switch below the Journey card with `Full App` active
+- original-style feed cards below the Journey card, including people matches, upcoming events, Autopilot, and Vitana Index
+- no new Full Mode feature-grid or separate mode/status card
+
+Behavior:
+
+- opens from tapping `Full App` in the segmented switch
+- opens from the top-left account/menu utility route when a Guided Mode user needs account, subscription, privacy, settings, support, or logout
+- does not reset My Journey progress
+- keeps the ORB available
+- allows the user to return to Guided Mode at any time by tapping `Guided Journey`
+
+## Success Criteria
+
+The redesign succeeds if:
+
+- A first-time user sees one obvious place to begin.
+- The user can understand that "Session" means learning progress, not calendar time.
+- The user can click any lesson or topic and hear Vitana explain it.
+- The user cannot accidentally fall into an unreleased complex screen.
+- A lesson completes only after a tiny guided-practice action.
+- A motivated user can complete multiple sessions in one real day.
+- A returning user resumes exactly where they left off.
+- Existing users are not forced into the first-time catalog gate unless their onboarding state is incomplete.
+- Account, subscription, payments, privacy, settings, support, and logout remain accessible through the existing Full App account/settings area even when onboarding gates product features.
+- Users can choose Full Mode early without destroying onboarding progress.
+- Qualified users can enter Full Mode and later return to My Journey.
+- Full Mode still respects subscription and feature-entitlement rules.
+
+## Open Implementation Questions
+
+These are implementation choices, not unresolved product direction:
+
+- Whether the first seed of checklist content is imported from Markdown, CSV, or backend seed data. The product decision is already made: the editable source of truth is `Admin Pages -> Knowledge Base -> Checklist`.
+- Whether route gating is centralized in `ProtectedRoute`/routing hooks or handled per feature route.
+- Whether Vitana explanations use existing ORB commands immediately or first ship with a text/transcript fallback and voice event hook.
+- Whether the first release contains all 90 lessons or a smaller chapter-one proof while preserving the full 90-lesson data shape.
+
+## Self-Review
+
+- Placeholder scan: no placeholder requirements remain.
+- Scope check: this is one coherent onboarding redesign centered on My Journey.
+- Ambiguity check: lesson progress is explicitly usage-based; completion requires guided practice; future features are explainable but gated.
+- Constraint check: the design preserves existing navigation structure while adding first-time route gates, instead of requiring sidebar restructuring.
+- Content ownership check: the checklist is editable Knowledge Base content in Admin Pages, not a permanently hardcoded frontend list.

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -106,6 +106,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const vitanaIndexRouter = require('./routes/vitana-index').default;
   // VTID-03255: Journey Foundation read path — shared snapshot for voice + Meine Reise + /autopilot.
   const journeyFoundationRouter = require('./routes/journey-foundation').default;
+  // VTID-03276: Guided Journey durable mode/progress state (guided|full UX shell).
+  const guidedJourneyRouter = require('./routes/guided-journey').default;
   // VTID-03152 Slice B + J: unified my-journey payload + landing-route resolver.
   const myJourneyRouter = require('./routes/my-journey').default;
   const goalPlannerRouter = require('./routes/goal-planner').default;
@@ -743,6 +745,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // VTID-03255: Journey Foundation — shared goal-gated, dual-axis journey snapshot.
   mountRouterSync(app, '/api/v1/journey-foundation', journeyFoundationRouter, { owner: 'journey-foundation' });
+
+  // VTID-03276: Guided Journey durable mode/progress state (additive onboarding UX layer).
+  mountRouterSync(app, '/api/v1/journey', guidedJourneyRouter, { owner: 'guided-journey' });
 
   // VTID-03152: journey-foundation endpoints.
   mountRouterSync(app, '/api/v1/my-journey', myJourneyRouter, { owner: 'my-journey' });

--- a/services/gateway/src/routes/guided-journey.ts
+++ b/services/gateway/src/routes/guided-journey.ts
@@ -1,0 +1,89 @@
+/**
+ * VTID-03276 — Guided Journey HTTP surface (P1).
+ *
+ *   GET  /api/v1/journey/state   → full durable JourneyState (creates row lazily)
+ *   GET  /api/v1/journey/mode    → { mode } only
+ *   POST /api/v1/journey/mode    → { mode: 'guided' | 'full' } applies the
+ *                                  lossless switch rules, returns the new state
+ *
+ * Mode is PRODUCT/UX state. These routes never read or write subscription or
+ * feature-permission state. Per-topic progress + practice-completion writes land
+ * with the catalog (P5/P7).
+ */
+
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+import {
+  getJourneyState,
+  setJourneyMode,
+} from '../services/guided-journey/guided-journey-state';
+import type { JourneyMode } from '../types/guided-journey';
+
+const router = Router();
+
+const VTID = 'VTID-03276';
+
+const VALID_MODES: readonly JourneyMode[] = ['guided', 'full'];
+
+router.get('/state', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: VTID });
+  }
+  const client = getSupabase();
+  if (!client) {
+    return res.status(500).json({ ok: false, error: 'supabase_not_configured', vtid: VTID });
+  }
+  try {
+    const state = await getJourneyState(client, userId);
+    return res.json({ ok: true, state, vtid: VTID });
+  } catch (err: any) {
+    console.error(`[${VTID}] get journey state failed: ${err?.message}`);
+    return res.status(500).json({ ok: false, error: 'state_failed', vtid: VTID });
+  }
+});
+
+router.get('/mode', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: VTID });
+  }
+  const client = getSupabase();
+  if (!client) {
+    return res.status(500).json({ ok: false, error: 'supabase_not_configured', vtid: VTID });
+  }
+  try {
+    const state = await getJourneyState(client, userId);
+    return res.json({ ok: true, mode: state.mode, vtid: VTID });
+  } catch (err: any) {
+    console.error(`[${VTID}] get journey mode failed: ${err?.message}`);
+    return res.status(500).json({ ok: false, error: 'mode_failed', vtid: VTID });
+  }
+});
+
+router.post('/mode', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: VTID });
+  }
+  const mode = req.body?.mode as unknown;
+  if (typeof mode !== 'string' || !VALID_MODES.includes(mode as JourneyMode)) {
+    return res
+      .status(400)
+      .json({ ok: false, error: 'invalid_mode', detail: "mode must be 'guided' or 'full'", vtid: VTID });
+  }
+  const client = getSupabase();
+  if (!client) {
+    return res.status(500).json({ ok: false, error: 'supabase_not_configured', vtid: VTID });
+  }
+  try {
+    const state = await setJourneyMode(client, userId, mode as JourneyMode);
+    return res.json({ ok: true, state, vtid: VTID });
+  } catch (err: any) {
+    console.error(`[${VTID}] set journey mode failed: ${err?.message}`);
+    return res.status(500).json({ ok: false, error: 'set_mode_failed', vtid: VTID });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/guided-journey/guided-journey-state.ts
+++ b/services/gateway/src/services/guided-journey/guided-journey-state.ts
@@ -1,0 +1,133 @@
+/**
+ * VTID-03276 — Guided Journey durable state service (P1).
+ *
+ * Reads/writes `user_guided_journey_state` (guided|full mode + onboarding
+ * lifecycle + practice qualification). The HTTP surface (routes/guided-journey.ts)
+ * is a thin delegator over these functions; tests exercise these directly with a
+ * mocked Supabase client.
+ *
+ * INVARIANTS (enforced here, documented in the migration):
+ *  - Switching mode NEVER mutates progress (current_session, completed_topic_ids,
+ *    completed_practice_count, qualification) — only mode + audit timestamps move.
+ *  - This service touches ONLY journey UX state. It never reads or writes
+ *    subscription or feature-permission state.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  JourneyMode,
+  JourneyState,
+  GuidedJourneyStateRow,
+} from '../../types/guided-journey';
+
+const TABLE = 'user_guided_journey_state';
+
+/** Map a raw DB row to the camel-cased client view. */
+export function toJourneyState(row: GuidedJourneyStateRow): JourneyState {
+  return {
+    mode: row.mode,
+    onboardingStatus: row.onboarding_status,
+    currentSession: row.current_session,
+    completedTopicIds: row.completed_topic_ids ?? [],
+    completedPracticeCount: row.completed_practice_count,
+    qualificationThreshold: row.qualification_threshold,
+    qualifiedAt: row.qualified_at,
+    skippedOnboardingAt: row.skipped_onboarding_at,
+    enteredFullModeAt: row.entered_full_mode_at,
+    returnedToGuidedAt: row.returned_to_guided_at,
+    lastOpenedTopicId: row.last_opened_topic_id,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Fetch the user's journey-state row, lazily creating a default one if absent.
+ * Default mode is 'guided' (the first-time onboarding shell); the routing layer
+ * (P4) decides whether an *established* user is shown guided or full — this just
+ * guarantees a row exists to read/update.
+ */
+export async function ensureState(
+  client: SupabaseClient,
+  userId: string,
+): Promise<GuidedJourneyStateRow> {
+  const existing = await client
+    .from(TABLE)
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (existing.error) throw existing.error;
+  if (existing.data) return existing.data as GuidedJourneyStateRow;
+
+  // No row yet — insert defaults. Use upsert with ignoreDuplicates so a
+  // concurrent create doesn't error; then re-read the authoritative row.
+  const inserted = await client
+    .from(TABLE)
+    .upsert({ user_id: userId }, { onConflict: 'user_id', ignoreDuplicates: true })
+    .select('*')
+    .maybeSingle();
+
+  if (inserted.error) throw inserted.error;
+  if (inserted.data) return inserted.data as GuidedJourneyStateRow;
+
+  // Lost the insert race (ignoreDuplicates returned no row) — read the winner.
+  const reread = await client
+    .from(TABLE)
+    .select('*')
+    .eq('user_id', userId)
+    .single();
+  if (reread.error) throw reread.error;
+  return reread.data as GuidedJourneyStateRow;
+}
+
+/** Full durable journey state for a user (creates the row on first read). */
+export async function getJourneyState(
+  client: SupabaseClient,
+  userId: string,
+): Promise<JourneyState> {
+  return toJourneyState(await ensureState(client, userId));
+}
+
+/**
+ * Switch the user between 'guided' and 'full', applying the spec's lossless
+ * switch rules:
+ *   → full:  stamp entered_full_mode_at once; if switching before qualifying,
+ *            stamp skipped_onboarding_at once and mark status 'skipped'.
+ *   → guided: stamp returned_to_guided_at; if previously 'skipped', resume as
+ *            'in_progress'. Progress fields are never touched.
+ */
+export async function setJourneyMode(
+  client: SupabaseClient,
+  userId: string,
+  mode: JourneyMode,
+  now: string = new Date().toISOString(),
+): Promise<JourneyState> {
+  const row = await ensureState(client, userId);
+
+  const patch: Record<string, unknown> = { mode, updated_at: now };
+
+  if (mode === 'full') {
+    if (!row.entered_full_mode_at) patch.entered_full_mode_at = now;
+    const qualified =
+      row.onboarding_status === 'qualified' || row.onboarding_status === 'completed';
+    if (!qualified && !row.skipped_onboarding_at) {
+      patch.skipped_onboarding_at = now;
+      patch.onboarding_status = 'skipped';
+    }
+  } else {
+    patch.returned_to_guided_at = now;
+    if (row.onboarding_status === 'skipped') {
+      patch.onboarding_status = 'in_progress';
+    }
+  }
+
+  const updated = await client
+    .from(TABLE)
+    .update(patch)
+    .eq('user_id', userId)
+    .select('*')
+    .single();
+
+  if (updated.error) throw updated.error;
+  return toJourneyState(updated.data as GuidedJourneyStateRow);
+}

--- a/services/gateway/src/types/guided-journey.ts
+++ b/services/gateway/src/types/guided-journey.ts
@@ -1,0 +1,53 @@
+/**
+ * VTID-03276 — Guided Journey shared types (P1).
+ *
+ * The durable per-user UX state for the additive Guided Journey onboarding layer.
+ * This is PRODUCT/UX state only — it is intentionally decoupled from subscription
+ * (commercial entitlement) and feature_permission (access control). Never fold
+ * those concerns into this shape.
+ */
+
+export type JourneyMode = 'guided' | 'full';
+
+export type JourneyOnboardingStatus =
+  | 'not_started'
+  | 'in_progress'
+  | 'qualified'
+  | 'skipped'
+  | 'completed';
+
+/** Camel-cased view of a `user_guided_journey_state` row, as served to clients. */
+export interface JourneyState {
+  mode: JourneyMode;
+  onboardingStatus: JourneyOnboardingStatus;
+  /** Usage session the user is on (NOT a calendar day). Always >= 1. */
+  currentSession: number;
+  completedTopicIds: string[];
+  completedPracticeCount: number;
+  qualificationThreshold: number;
+  qualifiedAt: string | null;
+  skippedOnboardingAt: string | null;
+  enteredFullModeAt: string | null;
+  returnedToGuidedAt: string | null;
+  lastOpenedTopicId: string | null;
+  updatedAt: string;
+}
+
+/** The raw DB row shape (snake_case) for `user_guided_journey_state`. */
+export interface GuidedJourneyStateRow {
+  user_id: string;
+  mode: JourneyMode;
+  onboarding_status: JourneyOnboardingStatus;
+  current_session: number;
+  completed_topic_ids: string[] | null;
+  completed_practice_count: number;
+  qualification_threshold: number;
+  qualified_at: string | null;
+  skipped_onboarding_at: string | null;
+  entered_full_mode_at: string | null;
+  returned_to_guided_at: string | null;
+  last_opened_topic_id: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/services/gateway/test/guided-journey-state.test.ts
+++ b/services/gateway/test/guided-journey-state.test.ts
@@ -1,0 +1,262 @@
+/**
+ * VTID-03276 — Guided Journey durable mode/progress state (P1) tests.
+ *
+ * Covers:
+ *  - lossless guided⇄full switching + audit-timestamp rules (handoff Task 2.2)
+ *  - state separation: mode changes never touch progress, and the served shape
+ *    carries no subscription/entitlement fields (handoff Task 2.3)
+ *  - HTTP boundaries: 401 unauth, 400 invalid mode, 200 happy paths
+ */
+
+import request from 'supertest';
+import express from 'express';
+
+import {
+  getJourneyState,
+  setJourneyMode,
+} from '../src/services/guided-journey/guided-journey-state';
+
+// ---------------------------------------------------------------------------
+// In-memory fake Supabase client supporting exactly the chains the service uses:
+//   .select('*').eq('user_id', id).maybeSingle()/.single()
+//   .upsert({user_id}, {onConflict, ignoreDuplicates}).select('*').maybeSingle()
+//   .update(patch).eq('user_id', id).select('*').single()
+// ---------------------------------------------------------------------------
+const FIXED_NOW = '2026-06-08T00:00:00.000Z';
+
+function defaultRow(userId: string) {
+  return {
+    user_id: userId,
+    mode: 'guided',
+    onboarding_status: 'not_started',
+    current_session: 1,
+    completed_topic_ids: [] as string[],
+    completed_practice_count: 0,
+    qualification_threshold: 60,
+    qualified_at: null,
+    skipped_onboarding_at: null,
+    entered_full_mode_at: null,
+    returned_to_guided_at: null,
+    last_opened_topic_id: null,
+    metadata: {},
+    created_at: FIXED_NOW,
+    updated_at: FIXED_NOW,
+  };
+}
+
+function makeFakeSupabase() {
+  const store = new Map<string, any>();
+  const client: any = {
+    __store: store,
+    from(_table: string) {
+      let op: 'select' | 'upsert' | 'update' = 'select';
+      let filterId: string | null = null;
+      let payload: any = null;
+      let upsertOpts: any = null;
+
+      const resolve = (requireRow: boolean) => {
+        if (op === 'upsert') {
+          const id = payload.user_id;
+          if (!store.has(id)) {
+            store.set(id, { ...defaultRow(id), ...payload });
+            return Promise.resolve({ data: store.get(id), error: null });
+          }
+          if (upsertOpts?.ignoreDuplicates) {
+            return Promise.resolve({ data: null, error: null });
+          }
+          store.set(id, { ...store.get(id), ...payload });
+          return Promise.resolve({ data: store.get(id), error: null });
+        }
+        if (op === 'update') {
+          const row = filterId != null ? store.get(filterId) : null;
+          if (!row) {
+            return Promise.resolve({ data: null, error: requireRow ? { message: 'no row' } : null });
+          }
+          store.set(filterId as string, { ...row, ...payload });
+          return Promise.resolve({ data: store.get(filterId as string), error: null });
+        }
+        const row = filterId != null ? store.get(filterId) ?? null : null;
+        if (!row && requireRow) return Promise.resolve({ data: null, error: { message: 'no rows' } });
+        return Promise.resolve({ data: row, error: null });
+      };
+
+      const builder: any = {
+        select() { return builder; },
+        eq(col: string, val: string) { if (col === 'user_id') filterId = val; return builder; },
+        upsert(p: any, opts: any) { op = 'upsert'; payload = p; upsertOpts = opts; return builder; },
+        update(p: any) { op = 'update'; payload = p; return builder; },
+        maybeSingle() { return resolve(false); },
+        single() { return resolve(true); },
+      };
+      return builder;
+    },
+  };
+  return client;
+}
+
+const SUBSCRIPTION_OR_PERMISSION_KEYS = [
+  'subscription', 'subscriptionStatus', 'subscription_status',
+  'entitlement', 'entitlements', 'featurePermission', 'feature_permission',
+  'plan', 'tier', 'billing',
+];
+
+describe('guided-journey-state service', () => {
+  it('lazily creates a default guided row on first read', async () => {
+    const sb = makeFakeSupabase();
+    const state = await getJourneyState(sb, 'user-1');
+    expect(state.mode).toBe('guided');
+    expect(state.onboardingStatus).toBe('not_started');
+    expect(state.currentSession).toBe(1);
+    expect(state.completedTopicIds).toEqual([]);
+    expect(state.qualificationThreshold).toBe(60);
+  });
+
+  it('switching to full before qualifying stamps entered_full_mode_at + skip', async () => {
+    const sb = makeFakeSupabase();
+    const state = await setJourneyMode(sb, 'user-1', 'full', FIXED_NOW);
+    expect(state.mode).toBe('full');
+    expect(state.enteredFullModeAt).toBe(FIXED_NOW);
+    expect(state.skippedOnboardingAt).toBe(FIXED_NOW);
+    expect(state.onboardingStatus).toBe('skipped');
+  });
+
+  it('does not re-stamp entered_full_mode_at / skip on a second full switch', async () => {
+    const sb = makeFakeSupabase();
+    await setJourneyMode(sb, 'user-1', 'full', '2026-06-08T01:00:00.000Z');
+    await setJourneyMode(sb, 'user-1', 'guided', '2026-06-08T02:00:00.000Z');
+    const again = await setJourneyMode(sb, 'user-1', 'full', '2026-06-08T03:00:00.000Z');
+    expect(again.enteredFullModeAt).toBe('2026-06-08T01:00:00.000Z'); // first entry preserved
+    expect(again.skippedOnboardingAt).toBe('2026-06-08T01:00:00.000Z'); // first skip preserved
+  });
+
+  it('returning to guided after a skip resumes as in_progress and stamps return', async () => {
+    const sb = makeFakeSupabase();
+    await setJourneyMode(sb, 'user-1', 'full', '2026-06-08T01:00:00.000Z');
+    const back = await setJourneyMode(sb, 'user-1', 'guided', '2026-06-08T02:00:00.000Z');
+    expect(back.mode).toBe('guided');
+    expect(back.onboardingStatus).toBe('in_progress');
+    expect(back.returnedToGuidedAt).toBe('2026-06-08T02:00:00.000Z');
+  });
+
+  it('switching to full when already qualified does NOT mark skipped', async () => {
+    const sb = makeFakeSupabase();
+    // Seed a qualified user directly in the store.
+    (sb.__store as Map<string, any>).set('user-q', {
+      ...defaultRow('user-q'),
+      onboarding_status: 'qualified',
+      completed_practice_count: 60,
+      qualified_at: '2026-06-07T00:00:00.000Z',
+    });
+    const state = await setJourneyMode(sb, 'user-q', 'full', FIXED_NOW);
+    expect(state.onboardingStatus).toBe('qualified');
+    expect(state.skippedOnboardingAt).toBeNull();
+    expect(state.enteredFullModeAt).toBe(FIXED_NOW);
+  });
+
+  it('switching mode never mutates progress (current_session, topics, practice count)', async () => {
+    const sb = makeFakeSupabase();
+    (sb.__store as Map<string, any>).set('user-p', {
+      ...defaultRow('user-p'),
+      onboarding_status: 'in_progress',
+      current_session: 7,
+      completed_topic_ids: ['T001', 'T002', 'T003'],
+      completed_practice_count: 12,
+    });
+    const toFull = await setJourneyMode(sb, 'user-p', 'full', FIXED_NOW);
+    expect(toFull.currentSession).toBe(7);
+    expect(toFull.completedTopicIds).toEqual(['T001', 'T002', 'T003']);
+    expect(toFull.completedPracticeCount).toBe(12);
+
+    const backToGuided = await setJourneyMode(sb, 'user-p', 'guided', FIXED_NOW);
+    expect(backToGuided.currentSession).toBe(7); // resumes same session
+    expect(backToGuided.completedTopicIds).toEqual(['T001', 'T002', 'T003']);
+    expect(backToGuided.completedPracticeCount).toBe(12);
+  });
+
+  it('served state carries NO subscription/entitlement/permission fields', async () => {
+    const sb = makeFakeSupabase();
+    const state = await getJourneyState(sb, 'user-1');
+    for (const key of SUBSCRIPTION_OR_PERMISSION_KEYS) {
+      expect(state).not.toHaveProperty(key);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP surface
+// ---------------------------------------------------------------------------
+let mockSupabase: any;
+
+jest.mock('../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    const authHeader = req.headers.authorization;
+    if (authHeader === 'Bearer valid-user') {
+      req.identity = { user_id: 'http-user-1', email: 'u@example.com', exafy_admin: false };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'unauthenticated' });
+  },
+}));
+
+jest.mock('../src/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const guidedJourneyRouter = require('../src/routes/guided-journey').default;
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/journey', guidedJourneyRouter);
+  return app;
+}
+
+describe('Guided Journey HTTP routes', () => {
+  beforeEach(() => {
+    mockSupabase = makeFakeSupabase();
+  });
+
+  it('GET /state → 401 without a token', async () => {
+    const res = await request(makeApp()).get('/api/v1/journey/state');
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /state → 200 with default guided state', async () => {
+    const res = await request(makeApp())
+      .get('/api/v1/journey/state')
+      .set('Authorization', 'Bearer valid-user');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.state.mode).toBe('guided');
+    expect(res.body.vtid).toBe('VTID-03276');
+  });
+
+  it('GET /mode → 200 returns just the mode', async () => {
+    const res = await request(makeApp())
+      .get('/api/v1/journey/mode')
+      .set('Authorization', 'Bearer valid-user');
+    expect(res.status).toBe(200);
+    expect(res.body.mode).toBe('guided');
+  });
+
+  it('POST /mode → 400 on invalid mode', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/journey/mode')
+      .set('Authorization', 'Bearer valid-user')
+      .send({ mode: 'turbo' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_mode');
+  });
+
+  it('POST /mode → 200 switches to full', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/journey/mode')
+      .set('Authorization', 'Bearer valid-user')
+      .send({ mode: 'full' });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.state.mode).toBe('full');
+    expect(res.body.state.enteredFullModeAt).not.toBeNull();
+  });
+});

--- a/supabase/migrations/20260608160000_VTID_03276_guided_journey_mode_state.sql
+++ b/supabase/migrations/20260608160000_VTID_03276_guided_journey_mode_state.sql
@@ -1,0 +1,79 @@
+-- =============================================================================
+-- VTID-03276 — Guided Journey: durable Guided/Full mode + onboarding state (P1)
+-- -----------------------------------------------------------------------------
+-- The Guided Journey is an ADDITIVE onboarding UX layer over the existing Full
+-- App. This table holds the durable, per-user UX state that drives it:
+--   * mode                — 'guided' | 'full' (which UX shell the user sees)
+--   * onboarding lifecycle — not_started → in_progress → qualified/skipped/completed
+--   * practice progress    — current usage session + completed topics/practice count
+--   * qualification        — threshold + the moment the user qualified
+--   * audit timestamps     — first full-mode entry, return-to-guided, skip
+--
+-- BOUNDARY CONTRACT (from the design spec — do NOT violate):
+--   This is PRODUCT/UX state ONLY. It must never hold or be conflated with:
+--     - subscription        (commercial entitlement)  → its own billing system
+--     - feature_permission  (access control / release) → its own system
+--   Journey mode is never derived from, and never derives, those two. Switching
+--   mode NEVER deletes progress (completed topics, current session, qualification
+--   all survive a guided⇄full round-trip).
+--
+-- DIAGNOSE-BEFORE-EDIT: production already has user_journey (ORB/voice journey
+-- state: waves, milestones, greeting cadence) and user_journey_foundation
+-- (VTID-03255 thin foundation-steps holder). Neither models guided/full UX mode,
+-- so this is a NEW dedicated table rather than an overload of either — keeping
+-- the four state boundaries (mode / progress / subscription / permission) clean.
+-- =============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS user_guided_journey_state (
+  user_id                  uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  -- Which UX shell the user is in. New users start guided; existing/qualified
+  -- users live in full. Switching is reversible and lossless.
+  mode                     text NOT NULL DEFAULT 'guided'
+    CHECK (mode IN ('guided','full')),
+  -- Onboarding lifecycle. 'skipped' = chose Full App before qualifying;
+  -- 'qualified' = hit the practice threshold; 'completed' = finished curriculum.
+  onboarding_status        text NOT NULL DEFAULT 'not_started'
+    CHECK (onboarding_status IN ('not_started','in_progress','qualified','skipped','completed')),
+  -- Usage session the user is currently on (NOT a calendar day). Always >= 1.
+  current_session          integer NOT NULL DEFAULT 1
+    CHECK (current_session >= 1),
+  -- Topic IDs whose guided-practice action is done. Denormalized convenience for
+  -- the catalog; per-topic granular progress lands with the checklist (P2/P5).
+  completed_topic_ids      text[] NOT NULL DEFAULT '{}',
+  -- Count of completed guided-practice actions (drives qualification).
+  completed_practice_count integer NOT NULL DEFAULT 0
+    CHECK (completed_practice_count >= 0),
+  -- First-stage qualification target (spec default: 60 practice actions).
+  qualification_threshold  integer NOT NULL DEFAULT 60
+    CHECK (qualification_threshold >= 1),
+  -- Set when completed_practice_count first reaches the threshold.
+  qualified_at             timestamptz,
+  -- Set the first time the user chooses Full App before qualifying.
+  skipped_onboarding_at    timestamptz,
+  -- Set the first time the user enters Full App mode.
+  entered_full_mode_at     timestamptz,
+  -- Set whenever the user switches back to Guided.
+  returned_to_guided_at    timestamptz,
+  -- Resume hint: last topic the user opened.
+  last_opened_topic_id     text,
+  metadata                 jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE user_guided_journey_state ENABLE ROW LEVEL SECURITY;
+
+-- Per-user self read/write. The gateway uses the service-role key (bypasses RLS);
+-- this policy guards any direct anon/auth client access to a user's own row only.
+DROP POLICY IF EXISTS "user_guided_journey_state_self_rw" ON user_guided_journey_state;
+CREATE POLICY "user_guided_journey_state_self_rw"
+  ON user_guided_journey_state FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE user_guided_journey_state IS
+  'VTID-03276 — Guided Journey durable per-user UX state: guided|full mode + onboarding lifecycle + practice qualification. PRODUCT/UX state ONLY; never holds subscription (commercial entitlement) or feature_permission (access control), and mode is never derived from either. Switching mode never deletes progress.';
+
+COMMIT;


### PR DESCRIPTION
## Guided Journey — Phase 1 (backend state)

First phase of the **additive** Guided Journey onboarding layer. Adds the durable per-user **guided | full** UX mode + onboarding/qualification state and the read/switch HTTP surface that later phases (catalog UI, ORB explanation, practice) consume.

**Design guardrail:** Full App / Vitana v1 design is frozen. This PR is backend-only state + API; it adds no UI and changes no existing surface.

### What's in it
- **Migration** `user_guided_journey_state` (RLS self-rw). A **new dedicated table** — does *not* overload `user_journey` (ORB/voice state) or `user_journey_foundation` (VTID-03255 thin steps). Keeps the four boundaries clean: **mode / progress / subscription / feature_permission** are never conflated. Diagnose-before-edit: live schema introspected first (known `user_journey` drift respected).
- **Service** `services/guided-journey/guided-journey-state.ts` — `getJourneyState` / `setJourneyMode` with lossless switch rules (stamp entered_full_mode_at once; skip before qualifying; resume on return). **Progress is never mutated on a mode switch.**
- **Routes** (requireAuth): `GET /api/v1/journey/state`, `GET /api/v1/journey/mode`, `POST /api/v1/journey/mode`.
- **Docs**: the three Guided Journey source specs brought into `docs/superpowers/`.

### Verification
- `npm run build` (full tsc + copy steps) passes
- Jest: **12/12 passing** — switch rules, state separation (served shape carries no subscription/entitlement fields), HTTP 401/400/200.

### Boundary contract
This table is PRODUCT/UX state only. It never holds or derives subscription (commercial entitlement) or feature_permission (access control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)