### PR TITLE
fix(orb): allow preview.vitanaland.com origin so staging ORB can start sessions (BOOTSTRAP-ORB-STAGING-ORIGIN)

### DIFF
--- a/.github/workflows/ZZ-ORB-STAGING-PROBE.yml
+++ b/.github/workflows/ZZ-ORB-STAGING-PROBE.yml
@@ -3,6 +3,9 @@
 # no side effects. Safe to delete after use. (BOOTSTRAP-ORB-STAGING-PROBE)
 name: ZZ ORB Staging Probe (manual)
 on:
+  push:
+    branches: [claude/sleepy-fermi-migpP]
+    paths: ['.github/workflows/ZZ-ORB-STAGING-PROBE.yml']
   workflow_dispatch: {}
 permissions:
   contents: read

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -383,6 +383,15 @@ const ALLOWED_ORIGINS = [
   // gets 403 "Origin not allowed" on /orb/live/session/* — voice path
   // completely broken for operators using the gateway custom domain.
   'https://gateway.vitanaland.com',
+  // BOOTSTRAP-ORB-STAGING-ORIGIN: staging-first cutover origins. The preview
+  // community-app (preview.vitanaland.com) loads the orb widget from the staging
+  // gateway (preview-gateway.vitanaland.com); without these, /orb/live/session/*
+  // returns 403 "Origin not allowed" and the orb is silent on preview both
+  // pre- and post-login. Confirmed via the ORB staging probe: staging returned
+  // 403 "Origin not allowed" for Origin https://preview.vitanaland.com while
+  // prod returned 200 + a session for its own origin.
+  'https://preview.vitanaland.com',          // Staging community-app (community-app-staging)
+  'https://preview-gateway.vitanaland.com',  // Staging gateway custom domain (command-hub orb)
   'http://localhost:8080',
   'http://localhost:8081',  // VTID-01225: Mobile dev server
   'http://localhost:3000',


### PR DESCRIPTION
## The real, proven root cause: staging ORB rejects the preview origin

I built a probe workflow that hits the gateways from a GitHub runner (open egress) exactly as the pre-login orb does. **Hard evidence:**

```
STAGING  (Origin https://preview.vitanaland.com):
  health: 200 env=staging      widget: 200 (144KB served)
  POST /orb/live/session/start: 403 {"ok":false,"error":"Origin not allowed"}

PROD     (Origin https://vitanaland.com):
  POST /orb/live/session/start: 200 {"ok":true,"session_id":"live-...","meta":{...greeting...}}
```

The ORB `validateOrigin` allowlist (`ALLOWED_ORIGINS` in `routes/orb-live.ts`) — a gate **separate** from CORS — lists prod origins (`vitanaland.com`, `gateway.vitanaland.com`, community-app run.app) but **not** the staging-first cutover origins. So `gateway-staging` returns `403 "Origin not allowed"` for `preview.vitanaland.com` → the orb opens but never starts a session, pre- and post-login. Prod works because it allows its own origin.

### Fix
Add the two staging origins to `ALLOWED_ORIGINS`:
- `https://preview.vitanaland.com` (staging community-app)
- `https://preview-gateway.vitanaland.com` (staging gateway custom domain)

### Verification (I will do it myself, no user testing required)
After this deploys to `gateway-staging`, I'll re-run the probe. The staging `session/start` must flip from **403 "Origin not allowed"** to **200 `{"ok":true,"session_id":...}`** with a greeting — the same proof prod already passes. I'll only report success once the probe shows 200.

(Also includes the temporary probe workflow used to get this evidence; I'll remove it after.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmnFKR4rTuXFXnhVu7epbG)_