### PR TITLE
Guided Journey P7 (platform): practice-completion endpoint (VTID-03282)

### DIFF
--- a/services/gateway/src/routes/guided-journey.ts
+++ b/services/gateway/src/routes/guided-journey.ts
@@ -17,6 +17,7 @@ import { getSupabase } from '../lib/supabase';
 import {
   getJourneyState,
   setJourneyMode,
+  completePractice,
 } from '../services/guided-journey/guided-journey-state';
 import type { JourneyMode } from '../types/guided-journey';
 
@@ -83,6 +84,32 @@ router.post('/mode', requireAuth, async (req: AuthenticatedRequest, res: Respons
   } catch (err: any) {
     console.error(`[${VTID}] set journey mode failed: ${err?.message}`);
     return res.status(500).json({ ok: false, error: 'set_mode_failed', vtid: VTID });
+  }
+});
+
+// VTID-03282 (P7) — record a completed guided-practice action for a topic.
+// POST /api/v1/journey/practice-complete  { topicId } → updated JourneyState.
+router.post('/practice-complete', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: 'VTID-03282' });
+  }
+  const topicId = req.body?.topicId as unknown;
+  if (typeof topicId !== 'string' || !topicId.trim()) {
+    return res
+      .status(400)
+      .json({ ok: false, error: 'invalid_topic_id', detail: 'topicId is required', vtid: 'VTID-03282' });
+  }
+  const client = getSupabase();
+  if (!client) {
+    return res.status(500).json({ ok: false, error: 'supabase_not_configured', vtid: 'VTID-03282' });
+  }
+  try {
+    const state = await completePractice(client, userId, topicId);
+    return res.json({ ok: true, state, vtid: 'VTID-03282' });
+  } catch (err: any) {
+    console.error(`[VTID-03282] practice-complete failed: ${err?.message}`);
+    return res.status(500).json({ ok: false, error: 'practice_complete_failed', vtid: 'VTID-03282' });
   }
 });
 

--- a/services/gateway/src/services/guided-journey/guided-journey-state.ts
+++ b/services/gateway/src/services/guided-journey/guided-journey-state.ts
@@ -131,3 +131,55 @@ export async function setJourneyMode(
   if (updated.error) throw updated.error;
   return toJourneyState(updated.data as GuidedJourneyStateRow);
 }
+
+/**
+ * VTID-03282 (P7) — record a completed guided-practice action for a topic.
+ *
+ * Idempotent per topic: the first completion of a topic appends it to
+ * completed_topic_ids and increments completed_practice_count; re-completing the
+ * same topic is a no-op for the counter. When the count first reaches the
+ * qualification threshold, the user is marked 'qualified'. A not_started user
+ * who completes a practice becomes 'in_progress'. Listening alone never calls
+ * this — only a real practice action does.
+ */
+export async function completePractice(
+  client: SupabaseClient,
+  userId: string,
+  topicId: string,
+  now: string = new Date().toISOString(),
+): Promise<JourneyState> {
+  const row = await ensureState(client, userId);
+
+  const completed = new Set(row.completed_topic_ids ?? []);
+  const alreadyDone = completed.has(topicId);
+  completed.add(topicId);
+  const newCount = alreadyDone
+    ? row.completed_practice_count
+    : row.completed_practice_count + 1;
+
+  const patch: Record<string, unknown> = {
+    completed_topic_ids: Array.from(completed),
+    completed_practice_count: newCount,
+    last_opened_topic_id: topicId,
+    updated_at: now,
+  };
+
+  const terminal =
+    row.onboarding_status === 'qualified' || row.onboarding_status === 'completed';
+  if (!terminal && newCount >= row.qualification_threshold) {
+    patch.onboarding_status = 'qualified';
+    if (!row.qualified_at) patch.qualified_at = now;
+  } else if (row.onboarding_status === 'not_started') {
+    patch.onboarding_status = 'in_progress';
+  }
+
+  const updated = await client
+    .from(TABLE)
+    .update(patch)
+    .eq('user_id', userId)
+    .select('*')
+    .single();
+
+  if (updated.error) throw updated.error;
+  return toJourneyState(updated.data as GuidedJourneyStateRow);
+}

--- a/services/gateway/test/guided-journey-state.test.ts
+++ b/services/gateway/test/guided-journey-state.test.ts
@@ -14,6 +14,7 @@ import express from 'express';
 import {
   getJourneyState,
   setJourneyMode,
+  completePractice,
 } from '../src/services/guided-journey/guided-journey-state';
 
 // ---------------------------------------------------------------------------
@@ -179,6 +180,36 @@ describe('guided-journey-state service', () => {
     for (const key of SUBSCRIPTION_OR_PERMISSION_KEYS) {
       expect(state).not.toHaveProperty(key);
     }
+  });
+
+  it('completePractice records a topic + increments count + resumes in_progress', async () => {
+    const sb = makeFakeSupabase();
+    const s = await completePractice(sb, 'user-1', 'T001', FIXED_NOW);
+    expect(s.completedTopicIds).toContain('T001');
+    expect(s.completedPracticeCount).toBe(1);
+    expect(s.onboardingStatus).toBe('in_progress');
+  });
+
+  it('completePractice is idempotent per topic (no double count)', async () => {
+    const sb = makeFakeSupabase();
+    await completePractice(sb, 'user-1', 'T001', FIXED_NOW);
+    const s = await completePractice(sb, 'user-1', 'T001', FIXED_NOW);
+    expect(s.completedTopicIds).toEqual(['T001']);
+    expect(s.completedPracticeCount).toBe(1);
+  });
+
+  it('completePractice flips to qualified when threshold is reached', async () => {
+    const sb = makeFakeSupabase();
+    (sb.__store as Map<string, any>).set('user-q', {
+      ...defaultRow('user-q'),
+      onboarding_status: 'in_progress',
+      completed_practice_count: 59,
+      qualification_threshold: 60,
+    });
+    const s = await completePractice(sb, 'user-q', 'T123', FIXED_NOW);
+    expect(s.completedPracticeCount).toBe(60);
+    expect(s.onboardingStatus).toBe('qualified');
+    expect(s.qualifiedAt).toBe(FIXED_NOW);
   });
 });
 


### PR DESCRIPTION
## Guided Journey — Phase 7 (platform half)

Adds completion recording so **guided practice — not listening — advances the journey**. Backend only.

- **`completePractice(userId, topicId)`** — idempotent per topic: first completion appends to `completed_topic_ids` + increments `completed_practice_count`; flips `onboarding_status → qualified` at the threshold (default 60), else `not_started → in_progress`. Reuses the P1 `user_guided_journey_state` row — **no migration**.
- **`POST /api/v1/journey/practice-complete { topicId }`** (`requireAuth`).
- 3 new tests (record+increment+resume, idempotent per topic, qualify-at-threshold) → **15/15** guided-journey-state tests green; `npm run build` green.

The vitana-v1 half (Guided Practice drawer → Start Practice → real feature + this endpoint) ships separately under the same VTID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)