### PR TITLE
fix(orb): align gateway-staging Supabase to the frontend's project (fixes logged-in voice) (BOOTSTRAP-ORB-STAGING-SUPABASE-ALIGN)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -129,15 +129,20 @@ jobs:
           # staging env vars to be authoritative on this service).
           ENV_VARS_JOINED=$(IFS=, ; echo "${ENV_VARS[*]}")
 
-          # Secrets: staging Supabase trio. JWT/ANON share with prod for Phase 0
-          # — the parent session's experiment exercises the platform from the
-          # same auth boundary; nothing about the JWT secret depends on the
-          # data store. (If isolation tightens later, swap to a staging-specific
-          # JWT secret created in GCP Secret Manager.)
+          # Secrets: Supabase.
+          # BOOTSTRAP-ORB-STAGING-SUPABASE-ALIGN: the staging FRONTEND
+          # (community-app-staging) authenticates users against the PROD Supabase
+          # project (inmkhvwdcuyhnxkgfvsb). Previously the gateway pointed at a
+          # SEPARATE staging Supabase (STAGING_SUPABASE_* → rsdakjqpvcpgomltdmxu),
+          # so logged-in users existed in the frontend's DB but NOT in the
+          # gateway's DB → identity/context resolution failed (journey/state 500,
+          # permitted_roles 404) and authenticated ORB voice hung on "connecting".
+          # Align the gateway to the SAME project the frontend uses by binding the
+          # prod SUPABASE_* secrets. (JWT secret was already shared.)
           SECRETS=(
-            "SUPABASE_URL=STAGING_SUPABASE_URL:latest"
-            "SUPABASE_SERVICE_ROLE=STAGING_SUPABASE_SERVICE_ROLE_KEY:latest"
-            "SUPABASE_ANON_KEY=STAGING_SUPABASE_ANON_KEY:latest"
+            "SUPABASE_URL=SUPABASE_URL:latest"
+            "SUPABASE_SERVICE_ROLE=SUPABASE_SERVICE_ROLE:latest"
+            "SUPABASE_ANON_KEY=SUPABASE_ANON_KEY:latest"
             "SUPABASE_JWT_SECRET=SUPABASE_JWT_SECRET:latest"
             "GOOGLE_GEMINI_API_KEY=GOOGLE_GEMINI_API_KEY:latest"
           )


### PR DESCRIPTION
## Fix logged-in ORB voice on staging: align the gateway's Supabase to the frontend's

**Root cause (from the browser console + gateway health):** the staging frontend authenticates users against the **prod** Supabase project (`inmkhvwdcuyhnxkgfvsb`), but `gateway-staging` was bound to a **separate** staging Supabase (`rsdakjqpvcpgomltdmxu`). So a logged-in user exists in the frontend's DB but **not** in the gateway's DB → the gateway can't resolve the user's identity/context → `journey/state` 500, `permitted_roles` 404, and the authenticated ORB hangs on "Verbinden…". Anonymous works because it needs no identity lookup (pre-login voice is already verified working).

**Fix:** bind `gateway-staging` to the **same** Supabase the frontend logs into by referencing the prod `SUPABASE_*` secrets in `STAGE-DEPLOY.yml` (the JWT secret was already shared). Per the user's decision, staging shares the prod database (the frontend already does).

```
- SUPABASE_URL=STAGING_SUPABASE_URL:latest
- SUPABASE_SERVICE_ROLE=STAGING_SUPABASE_SERVICE_ROLE_KEY:latest
- SUPABASE_ANON_KEY=STAGING_SUPABASE_ANON_KEY:latest
+ SUPABASE_URL=SUPABASE_URL:latest
+ SUPABASE_SERVICE_ROLE=SUPABASE_SERVICE_ROLE:latest
+ SUPABASE_ANON_KEY=SUPABASE_ANON_KEY:latest
```

Merging triggers STAGE-DEPLOY (it watches its own file). After redeploy, `gateway-staging`'s `/admin/health` will report `supabase_host: inmkhvwdcuyhnxkgfvsb`, and I'll verify an **authenticated** `session/start` returns 200 via the probe (using a real prod-Supabase test token), the way I verified the pre-login path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmnFKR4rTuXFXnhVu7epbG)_