### PR TITLE
fix(nav): make both Orders mode pills voice-addressable

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -1580,11 +1580,35 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
 
   // ── DISCOVER (missing tabs) ─────────────────────────────────────────────
   {
+    // VTID-NAV-ORDERS-TABS: the generic Orders screen (default Active tab).
+    // priority keeps "my orders" here over the Active/History sub-tab entries.
     screen_id: 'DISCOVER.ORDERS', route: '/discover/orders', category: 'discover',
     access: 'authenticated', anonymous_safe: false,
+    priority: 1,
+    aliases: ['orders', 'my-orders'],
     i18n: {
-      en: { title: 'My Orders', description: 'Your order history and active orders.', when_to_visit: 'When the user asks about their orders, order history, order status, deliveries, or what they have bought.' },
-      de: { title: 'Meine Bestellungen', description: 'Deine Bestellhistorie und aktive Bestellungen.', when_to_visit: 'Wenn der Nutzer nach seinen Bestellungen, Bestellhistorie, Bestellstatus, Lieferungen oder dem fragt, was er gekauft hat.' },
+      en: { title: 'My Orders', description: 'Your orders — active and past.', when_to_visit: 'When the user asks about their orders, my orders, order status, deliveries, or what they have bought.' },
+      de: { title: 'Meine Bestellungen', description: 'Deine Bestellungen — aktive und vergangene.', when_to_visit: 'Wenn der Nutzer nach seinen Bestellungen, meinen Bestellungen, Bestellstatus, Lieferungen oder dem fragt, was er gekauft hat.' },
+    },
+  },
+  {
+    // VTID-NAV-ORDERS-TABS: the "Active" mode pill of My Orders.
+    screen_id: 'DISCOVER.ORDERS_ACTIVE', route: '/discover/orders?tab=active', category: 'discover',
+    access: 'authenticated', anonymous_safe: false,
+    aliases: ['active-orders', 'orders-active'],
+    i18n: {
+      en: { title: 'Active Orders', description: 'Your active and in-progress orders.', when_to_visit: 'When the user asks for the Active tab of My Orders, their active orders, current orders, open orders, in-progress orders, or pending deliveries.' },
+      de: { title: 'Aktive Bestellungen', description: 'Deine aktiven und laufenden Bestellungen.', when_to_visit: 'Wenn der Nutzer nach dem Tab "Aktiv" von Meine Bestellungen, seinen aktiven Bestellungen, laufenden Bestellungen, offenen Bestellungen oder ausstehenden Lieferungen fragt.' },
+    },
+  },
+  {
+    // VTID-NAV-ORDERS-TABS: the "History" mode pill of My Orders.
+    screen_id: 'DISCOVER.ORDERS_HISTORY', route: '/discover/orders?tab=history', category: 'discover',
+    access: 'authenticated', anonymous_safe: false,
+    aliases: ['order-history', 'orders-history', 'past-orders'],
+    i18n: {
+      en: { title: 'Order History', description: 'Your past and completed orders.', when_to_visit: 'When the user asks for the History tab of My Orders, their order history, past orders, completed orders, or previously delivered orders.' },
+      de: { title: 'Bestellverlauf', description: 'Deine vergangenen und abgeschlossenen Bestellungen.', when_to_visit: 'Wenn der Nutzer nach dem Tab "Verlauf" von Meine Bestellungen, seinem Bestellverlauf, vergangenen Bestellungen, abgeschlossenen Bestellungen oder bereits gelieferten Bestellungen fragt.' },
     },
   },
   {

--- a/services/gateway/test/navigation-catalog.test.ts
+++ b/services/gateway/test/navigation-catalog.test.ts
@@ -279,6 +279,10 @@ const ROUTING_CASES: RoutingCase[] = [
   // ── DISCOVER expanded ──
   { utterance: 'show me my orders',                          lang: 'en', expected_screen_id: 'DISCOVER.ORDERS' },
   { utterance: 'meine bestellungen',                         lang: 'de', expected_screen_id: 'DISCOVER.ORDERS' },
+  // VTID-NAV-ORDERS-TABS: the 2 Orders mode pills (Active / History).
+  { utterance: 'active orders',                              lang: 'en', expected_screen_id: 'DISCOVER.ORDERS_ACTIVE' },
+  { utterance: 'order history',                              lang: 'en', expected_screen_id: 'DISCOVER.ORDERS_HISTORY' },
+  { utterance: 'bestellverlauf',                             lang: 'de', expected_screen_id: 'DISCOVER.ORDERS_HISTORY' },
   { utterance: 'show me AI picks',                           lang: 'en', expected_screen_id: 'DISCOVER.AI_PICKS' },
   // VTID-NAV-DISCOVER-TABS: the 3 Discover mode pills are voice-addressable.
   { utterance: 'discover categories',                        lang: 'en', expected_screen_id: 'DISCOVER.CATEGORIES' },


### PR DESCRIPTION
## Goal
Make both **Orders** mobile mode pills reachable by Vitana — same pattern as Business Hub / Discover.

## Inventory (`MobileOrdersView.tsx`)
`My Orders` (route `/discover/orders`) has **2 flat mode pills**: **Active** · **History** (`activeMode`, no URL sync). Neither had a catalog destination.

## Changes (`navigation-catalog.ts`)
- Add `DISCOVER.ORDERS_ACTIVE` → `/discover/orders?tab=active` and `DISCOVER.ORDERS_HISTORY` → `/discover/orders?tab=history`.
- Give `DISCOVER.ORDERS` `priority: 1` so the bare "my orders" stays on the generic screen (default Active tab).

Pairs with vitana-v1 PR (MobileOrdersView reads `?tab=`).

## Verification (real `searchCatalog`, 16 cases)
- `active orders` → `ORDERS_ACTIVE` (100), `order history` → `ORDERS_HISTORY` (97), `my orders` → `ORDERS`, `bestellverlauf` → `ORDERS_HISTORY`
- Guards hold: `open my timeline` → `MEMORY.TIMELINE`; Discover (`share and earn`, `categories`, `supplements`) and Business Hub sub-tabs all still pass.

Added as routing-quality tests.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_