### PR TITLE
fix(orb): keep gateway-staging warm (min-instances=1) — fixes logged-in voice (BOOTSTRAP-ORB-STAGING-WARM)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -101,7 +101,14 @@ jobs:
             --cpu=1
             --timeout=300
             --max-instances=1
-            --min-instances=0
+            # BOOTSTRAP-ORB-STAGING-WARM: keep one warm instance. With
+            # min-instances=0 the gateway cold-starts, and an authenticated
+            # ORB /orb/live/session/start takes ~9.4s cold (vs ~4.4s warm) —
+            # past the widget's 8s AbortSignal.timeout, so the orb aborts and
+            # goes silent on the first open (proven by the e2e harness timing
+            # probe). One warm instance keeps session/start well under 8s,
+            # matching prod behavior.
+            --min-instances=1
           )
 
           # Env vars: VITANA_ENV is the load-bearing switch (P0.3). Anything else


### PR DESCRIPTION
## Fix: logged-in ORB voice on staging — keep one warm instance

**Root cause, proven with hard numbers by the new E2E harness** (drives the real preview, desktop + iPhone-14, from a GitHub runner):

```
[timed-auth-start:cold]  HTTP 200 in 9362ms  ⚠️ >8s  → widget ABORTS (TimeoutError: signal timed out)
[timed-auth-start:warm]  HTTP 200 in 4361ms  under 8s → works (SSE connected, greeting plays)
```

`gateway-staging` runs `min-instances=0`, so it cold-starts. An **authenticated** `/orb/live/session/start` takes **~9.4s cold** (vs ~4.4s warm), but the orb widget hard-aborts that fetch after **8s** (`AbortSignal.timeout`) → `net::ERR_ABORTED` → the orb never starts and sits on "Verbinden…". Pre-login is fast (anonymous skips context) and prod is always warm, which is why only logged-in-on-staging was broken.

**Fix:** `min-instances=0 → 1` so staging always has a warm instance, keeping `session/start` ~4s (well under the 8s limit) — matching prod. One-line change to `STAGE-DEPLOY.yml` (which redeploys on its own change).

### Verification
After redeploy I'll re-run the E2E harness; the `[timed-auth-start:cold]` figure should drop under 8s and both desktop + mobile should pass cleanly without my probes pre-warming the gateway. The harness (`tests/e2e/` + `E2E-PREVIEW-ORB.yml` in vitana-v1) is now the permanent self-test so this is caught automatically going forward.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmnFKR4rTuXFXnhVu7epbG)_