### PR TITLE
fix(nav): make Wallet Activity & Actions mode pills voice-addressable

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -1026,6 +1026,29 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     },
   },
 
+  // ── WALLET mode pills (VTID-NAV-WALLET-TABS) ────────────────────────────
+  // Activity / Actions tabs of the Wallet, reached via /wallet?tab=<mode>
+  // (query params, NOT new routes). Wallet.tsx reads ?tab=. Balances is the
+  // default (WALLET.OVERVIEW -> /wallet).
+  {
+    screen_id: 'WALLET.ACTIVITY', route: '/wallet?tab=activity', category: 'wallet',
+    access: 'authenticated', anonymous_safe: false,
+    aliases: ['wallet-activity', 'wallet-transactions'],
+    i18n: {
+      en: { title: 'Wallet Activity', description: 'Your wallet activity and transaction history.', when_to_visit: 'When the user asks for the Activity tab of the Wallet, their wallet activity, wallet transactions, transaction history, or recent wallet movements.' },
+      de: { title: 'Wallet-Aktivität', description: 'Deine Wallet-Aktivität und Transaktionshistorie.', when_to_visit: 'Wenn der Nutzer nach dem Tab "Aktivität" im Wallet, seiner Wallet-Aktivität, Wallet-Transaktionen, Transaktionshistorie oder den letzten Wallet-Bewegungen fragt.' },
+    },
+  },
+  {
+    screen_id: 'WALLET.ACTIONS', route: '/wallet?tab=actions', category: 'wallet',
+    access: 'authenticated', anonymous_safe: false,
+    aliases: ['wallet-actions'],
+    i18n: {
+      en: { title: 'Wallet Actions', description: 'Wallet actions — send, request, exchange, buy credits and tokens, add funds, withdraw.', when_to_visit: 'When the user asks for the Actions tab of the Wallet, wallet actions, to send or request a payment, exchange currency, buy credits or tokens, add funds, or withdraw from their wallet.' },
+      de: { title: 'Wallet-Aktionen', description: 'Wallet-Aktionen — senden, anfordern, tauschen, Credits und Tokens kaufen, Geld hinzufügen, abheben.', when_to_visit: 'Wenn der Nutzer nach dem Tab "Aktionen" im Wallet, Wallet-Aktionen, einer Zahlung senden oder anfordern, Währung tauschen, Credits oder Tokens kaufen, Geld hinzufügen oder von seinem Wallet abheben fragt.' },
+    },
+  },
+
   // ── HEALTH ──────────────────────────────────────────────────────────────
   {
     screen_id: 'HEALTH.OVERVIEW',

--- a/services/gateway/test/navigation-catalog.test.ts
+++ b/services/gateway/test/navigation-catalog.test.ts
@@ -229,6 +229,10 @@ const ROUTING_CASES: RoutingCase[] = [
   { utterance: 'show me my referral earnings',              lang: 'en', expected_screen_id: 'WALLET.REWARDS' },
   { utterance: 'meine provisionen anzeigen',                lang: 'de', expected_screen_id: 'WALLET.REWARDS' },
   { utterance: 'meine abonnements verwalten',               lang: 'de', expected_screen_id: 'WALLET.SUBSCRIPTIONS' },
+  // VTID-NAV-WALLET-TABS: the Wallet mode pills (Activity / Actions).
+  { utterance: 'wallet activity',                           lang: 'en', expected_screen_id: 'WALLET.ACTIVITY' },
+  { utterance: 'wallet actions',                            lang: 'en', expected_screen_id: 'WALLET.ACTIONS' },
+  { utterance: 'wallet aktivität',                          lang: 'de', expected_screen_id: 'WALLET.ACTIVITY' },
 
   // ── HEALTH ──
   { utterance: 'how do I track my biology',                 lang: 'en', expected_screen_id: 'HEALTH.MY_BIOLOGY' },


### PR DESCRIPTION
## Goal
Make the Wallet mobile mode pills reachable by Vitana — it currently only ever lands on **Balances**.

## Inventory (`Wallet.tsx`)
3 flat mode pills: **Balances** · **Activity** · **Actions** (`mobileWalletMode`, default "balances", no URL sync). Balances is already covered by `WALLET.OVERVIEW` → `/wallet`; **Activity** and **Actions** had no destination.

## Changes (`navigation-catalog.ts`)
- Add `WALLET.ACTIVITY` → `/wallet?tab=activity` and `WALLET.ACTIONS` → `/wallet?tab=actions`.
- **Query params, not new routes** — respects the platform rule *"Never add new Wallet routes."*

Pairs with vitana-v1 PR (Wallet reads `?tab=`).

## Verification (real `searchCatalog`, 14 cases)
- `wallet activity` → `ACTIVITY` (100), `wallet actions` → `ACTIONS` (100), DE `wallet aktivität`/`aktionen` ✅
- All wallet guards hold: `open my wallet` → `OVERVIEW`, `my balance` → `BALANCE`, `commissions`/`referral earnings` → `REWARDS`, `subscriptions` → `SUBSCRIPTIONS`. Discover/Business/Orders cases still pass.

Added as routing-quality tests.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_