### PR TITLE
fix(nav): make Daily Diary mode pills voice-addressable

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -1363,8 +1363,8 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
       },
       de: {
         title: 'Fehlerberichte',
-        description: 'Melde einen Fehler oder eine UX-Verbesserung aus deinem Tagebuch.',
-        when_to_visit: 'Wenn der Nutzer nach dem Tab "Fehlerberichte" im Tagebuch fragt, einen Fehler melden, ein App-Problem festhalten oder eine UX-Verbesserung aus dem Tagebuch vorschlagen möchte.',
+        description: 'Melde einen Fehler oder eine UX-Verbesserung aus deinem Tagesbuch.',
+        when_to_visit: 'Wenn der Nutzer nach dem Tab "Fehlerberichte" im Tagesbuch fragt, einen Fehler melden, ein App-Problem festhalten oder eine UX-Verbesserung aus dem Tagesbuch vorschlagen möchte.',
       },
     },
   },

--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -1328,21 +1328,43 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     // layout. On mobile the real diary surface is MobileDailyDiary at /daily-diary,
     // so redirect there — otherwise "open my daily diary" strands mobile users on
     // the read-only activity-timeline hub.
-    mobile_route: '/daily-diary',
+    mobile_route: '/daily-diary?tab=health',
     category: 'memory',
     access: 'authenticated',
     anonymous_safe: false,
-    aliases: ['diary', 'daily-diary', '/diary', '/daily-diary', 'tagebuch'],
+    aliases: ['diary', 'daily-diary', '/diary', '/daily-diary', 'tagebuch', 'health-diary'],
     i18n: {
       en: {
         title: 'Daily Diary',
         description: 'Your daily diary entries — log thoughts, moods, and reflections.',
-        when_to_visit: 'When the user asks to write a diary entry, log how they feel, journal their day, or open their daily diary.',
+        when_to_visit: 'When the user asks to write a diary entry, the Health Diary tab, log how they feel, journal their day, track symptoms, or open their daily diary.',
       },
       de: {
         title: 'Tagesbuch',
         description: 'Deine täglichen Tagebucheinträge — halte Gedanken, Stimmungen und Reflexionen fest.',
-        when_to_visit: 'Wenn der Nutzer einen Tagebucheintrag schreiben, festhalten wie er sich fühlt, seinen Tag journaling oder sein Tagebuch öffnen möchte.',
+        when_to_visit: 'Wenn der Nutzer einen Tagebucheintrag schreiben, das Gesundheitstagebuch öffnen, festhalten wie er sich fühlt, seinen Tag journaling oder sein Tagebuch öffnen möchte.',
+      },
+    },
+  },
+  {
+    // VTID-NAV-DIARY-TABS: the "Bug Reports" mode pill of the Daily Diary
+    // (mobile), reached via /daily-diary?tab=bugs. NOT the Support screen.
+    screen_id: 'MEMORY.DIARY_BUGS',
+    route: '/daily-diary?tab=bugs',
+    category: 'memory',
+    access: 'authenticated',
+    anonymous_safe: false,
+    aliases: ['bug-reports', 'diary-bug-reports', 'report-a-bug'],
+    i18n: {
+      en: {
+        title: 'Bug Reports',
+        description: 'Report a bug or a UX improvement from your Daily Diary.',
+        when_to_visit: 'When the user asks for the Bug Reports tab of the Daily Diary, to report a bug, log an app issue, or suggest a UX improvement from the diary.',
+      },
+      de: {
+        title: 'Fehlerberichte',
+        description: 'Melde einen Fehler oder eine UX-Verbesserung aus deinem Tagebuch.',
+        when_to_visit: 'Wenn der Nutzer nach dem Tab "Fehlerberichte" im Tagebuch fragt, einen Fehler melden, ein App-Problem festhalten oder eine UX-Verbesserung aus dem Tagebuch vorschlagen möchte.',
       },
     },
   },

--- a/services/gateway/test/navigation-catalog.test.ts
+++ b/services/gateway/test/navigation-catalog.test.ts
@@ -314,6 +314,10 @@ const ROUTING_CASES: RoutingCase[] = [
   { utterance: 'search my memories',                         lang: 'en', expected_screen_id: 'MEMORY.RECALL' },
   { utterance: 'erinnerungen durchsuchen',                   lang: 'de', expected_screen_id: 'MEMORY.RECALL' },
   { utterance: 'memory permissions',                         lang: 'en', expected_screen_id: 'MEMORY.PERMISSIONS' },
+  // VTID-NAV-DIARY-TABS: the Daily Diary mode pills (Health Diary / Bug Reports).
+  { utterance: 'health diary',                               lang: 'en', expected_screen_id: 'MEMORY.DIARY' },
+  { utterance: 'daily diary bug reports',                    lang: 'en', expected_screen_id: 'MEMORY.DIARY_BUGS' },
+  { utterance: 'fehlerberichte',                             lang: 'de', expected_screen_id: 'MEMORY.DIARY_BUGS' },
 
   // ── SETTINGS expanded ──
   { utterance: 'customize my app preferences',               lang: 'en', expected_screen_id: 'SETTINGS.PREFERENCES' },


### PR DESCRIPTION
## Goal
Make the Daily Diary mobile mode pills reachable by Vitana.

## Inventory (`MobileDailyDiary.tsx`, `/daily-diary`)
2 flat mode pills: **Health Diary** (`health`, default) · **Bug Reports** (`bugs`). `activeTab` local, no URL sync — so only Health Diary was reachable.

## Changes (`navigation-catalog.ts`)
- Reinforce existing `MEMORY.DIARY` for "Health Diary" + point its `mobile_route` at `/daily-diary?tab=health`.
- Add `MEMORY.DIARY_BUGS` → `/daily-diary?tab=bugs` (scoped to the diary, **not** the Support screen).

Pairs with vitana-v1 PR (MobileDailyDiary reads `?tab=`).

## Verification (real `searchCatalog`, 12 cases)
- `health diary` → `MEMORY.DIARY`, `daily diary bug reports`/`bug reports`/`report a bug` → `MEMORY.DIARY_BUGS`, DE `fehlerberichte` → `DIARY_BUGS`
- Guard: `I need help from support` → `SETTINGS.SUPPORT` (unchanged). Wallet/Orders cases still pass.

Added as routing-quality tests.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_