### PR TITLE
fix(nav): make Settings mode pills voice-addressable

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -1526,19 +1526,22 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     i18n: {
       en: {
         title: 'Settings',
-        description: 'Your account settings and preferences.',
-        when_to_visit: 'When the user asks to open their settings, change preferences, or manage their account.',
+        description: 'Your account settings.',
+        when_to_visit: 'When the user asks to open their settings, the settings screen, or manage their account.',
       },
       de: {
         title: 'Einstellungen',
-        description: 'Deine Kontoeinstellungen und Präferenzen.',
-        when_to_visit: 'Wenn der Nutzer seine Einstellungen öffnen, Präferenzen ändern oder sein Konto verwalten möchte.',
+        description: 'Deine Kontoeinstellungen.',
+        when_to_visit: 'Wenn der Nutzer seine Einstellungen öffnen, den Einstellungsbildschirm öffnen oder sein Konto verwalten möchte.',
       },
     },
   },
   {
     screen_id: 'SETTINGS.PRIVACY',
     route: '/settings/privacy',
+    // VTID-NAV-SETTINGS-TABS: on mobile, land on the Privacy mode pill of the
+    // Settings screen (/settings?mode=privacy). MobileSettings reads ?mode=.
+    mobile_route: '/settings?mode=privacy',
     category: 'settings',
     access: 'authenticated',
     anonymous_safe: false,
@@ -1559,6 +1562,7 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
   {
     screen_id: 'SETTINGS.NOTIFICATIONS',
     route: '/settings/notifications',
+    mobile_route: '/settings?mode=notifications',
     category: 'settings',
     access: 'authenticated',
     anonymous_safe: false,
@@ -1776,7 +1780,7 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
 
   // ── SETTINGS (missing tabs) ─────────────────────────────────────────────
   {
-    screen_id: 'SETTINGS.PREFERENCES', route: '/settings/preferences', category: 'settings',
+    screen_id: 'SETTINGS.PREFERENCES', route: '/settings/preferences', mobile_route: '/settings?mode=preferences', category: 'settings',
     access: 'authenticated', anonymous_safe: false,
     i18n: {
       en: { title: 'Preferences', description: 'Your personal preferences for the app experience.', when_to_visit: 'When the user asks to change their preferences, customize the app, adjust settings, or personalize their experience.' },
@@ -1855,11 +1859,11 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
       de: { title: 'Autopilot-Konnektoren', description: 'Verbinde Autopilot-Agent-Integrationen.', when_to_visit: 'Wenn der Nutzer nach dem Autopilot-Konnektoren-Tab der verbundenen Apps oder dem Verbinden einer Agent- oder Autopilot-App-Integration fragt.' },
     } },
   {
-    screen_id: 'SETTINGS.BILLING', route: '/settings/billing', category: 'settings',
+    screen_id: 'SETTINGS.BILLING', route: '/settings/billing', mobile_route: '/settings?mode=billing', category: 'settings',
     access: 'authenticated', anonymous_safe: false,
     i18n: {
-      en: { title: 'Billing', description: 'Your billing information, payment methods, and invoices.', when_to_visit: 'When the user asks about billing, payment methods, invoices, payment history, credit card, or how to pay.' },
-      de: { title: 'Abrechnung', description: 'Deine Rechnungsinformationen, Zahlungsmethoden und Rechnungen.', when_to_visit: 'Wenn der Nutzer nach Abrechnung, Zahlungsmethoden, Rechnungen, Zahlungshistorie, Kreditkarte oder wie man bezahlt fragt.' },
+      en: { title: 'Billing', description: 'Your billing information, payment methods, and invoices.', when_to_visit: 'When the user asks for the Billing tab of Settings, about billing, payment methods, invoices, payment history, credit card, or how to pay.' },
+      de: { title: 'Abrechnung', description: 'Deine Rechnungsinformationen, Zahlungsmethoden und Rechnungen.', when_to_visit: 'Wenn der Nutzer nach dem Abrechnungs-Tab der Einstellungen, Abrechnung, Zahlungsmethoden, Rechnungen, Zahlungshistorie, Kreditkarte oder wie man bezahlt fragt.' },
     },
   },
   {

--- a/services/gateway/test/navigation-catalog.test.ts
+++ b/services/gateway/test/navigation-catalog.test.ts
@@ -339,6 +339,15 @@ const ROUTING_CASES: RoutingCase[] = [
   { utterance: 'abrechnung öffnen',                          lang: 'de', expected_screen_id: 'SETTINGS.BILLING' },
   { utterance: 'I need help from support',                   lang: 'en', expected_screen_id: 'SETTINGS.SUPPORT' },
   { utterance: 'hilfe und support',                          lang: 'de', expected_screen_id: 'SETTINGS.SUPPORT' },
+  // VTID-NAV-SETTINGS-TABS: the Settings screen's top-level mode pills
+  // (Notifications / Privacy / Preferences / Billing). On mobile these deep-link
+  // via /settings?mode=<section>; MobileSettings reads ?mode= and selects the
+  // matching pill. Keyword-deterministic against the four top pills.
+  { utterance: 'settings notifications',                     lang: 'en', expected_screen_id: 'SETTINGS.NOTIFICATIONS' },
+  { utterance: 'settings privacy',                           lang: 'en', expected_screen_id: 'SETTINGS.PRIVACY' },
+  { utterance: 'settings preferences',                       lang: 'en', expected_screen_id: 'SETTINGS.PREFERENCES' },
+  { utterance: 'settings billing',                           lang: 'en', expected_screen_id: 'SETTINGS.BILLING' },
+  { utterance: 'einstellungen abrechnung',                   lang: 'de', expected_screen_id: 'SETTINGS.BILLING' },
 
   // ── HEALTH expanded ──
   { utterance: 'show me the health pillars',                 lang: 'en', expected_screen_id: 'HEALTH.PILLARS' },


### PR DESCRIPTION
## What

Make the **Settings** screen's four top-level mode pills voice-addressable via the Vitana ORB navigator, continuing the per-screen mode-pill navigation work (Business Hub, Discover, Orders, Wallet, Daily Diary, Connectors).

| Pill | Screen ID | Deep-link |
|------|-----------|-----------|
| Notifications | `SETTINGS.NOTIFICATIONS` | `/settings?mode=notifications` |
| Privacy | `SETTINGS.PRIVACY` | `/settings?mode=privacy` |
| Preferences | `SETTINGS.PREFERENCES` | `/settings?mode=preferences` |
| Billing | `SETTINGS.BILLING` | `/settings?mode=billing` |

## How

- Added `mobile_route: '/settings?mode=<section>'` to the four existing top-level Settings catalog entries. On mobile the navigator uses `mobile_route`; `MobileSettings` already reads `?mode=` and selects the matching pill (and strips the param), so **this is a gateway-only change — no frontend PR needed.**
- Disambiguation tuning so the four pills don't collide with the Settings landing screen:
  - Trimmed `SETTINGS.OVERVIEW` so it no longer grabs "settings preferences".
  - Anchored `SETTINGS.BILLING`'s `when_to_visit` to the Settings tab.

## Tests

Added five routing-quality cases to `test/navigation-catalog.test.ts`:
- `settings notifications` → `SETTINGS.NOTIFICATIONS`
- `settings privacy` → `SETTINGS.PRIVACY`
- `settings preferences` → `SETTINGS.PREFERENCES`
- `settings billing` → `SETTINGS.BILLING`
- `einstellungen abrechnung` (de) → `SETTINGS.BILLING`

`npx jest test/navigation-catalog.test.ts` → **225 passed**. `tsc --noEmit` clean.

## Scope

Deep sub-tabs (privacy.data, billing.invoices, …) were intentionally **not** added — they produced unresolvable ties against the parent pills. Scope is the four top-level pills, matching the screen's primary mode pills.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_