### PR TITLE
fix(nav): apply mobile_route on the live (DB-backed) navigator path

### DIFF
--- a/services/gateway/src/lib/nav-catalog-db.ts
+++ b/services/gateway/src/lib/nav-catalog-db.ts
@@ -256,6 +256,16 @@ export async function refreshNavCatalogCache(): Promise<void> {
       const perTenantDelta: Map<string, NavCatalogEntryWithRules[]> = new Map();
       const idMap: Map<string, NavCatalogEntryWithRules> = new Map();
 
+      // VTID-NAV-MOBILEROUTE: `mobile_route` is not a nav_catalog column, so a
+      // DB row can't express the mobile deep-link (e.g. Settings pills →
+      // /settings?mode=<section>). Inherit it from the compile-time catalog by
+      // screen_id; without this, DB-present screens always resolve to the
+      // desktop `route` on mobile and land on the wrong (desktop) page.
+      const tsMobileRouteByScreenId = new Map<string, string>();
+      for (const e of NAVIGATION_CATALOG) {
+        if (e.mobile_route) tsMobileRouteByScreenId.set(e.screen_id, e.mobile_route);
+      }
+
       for (const raw of rows as NavCatalogRow[]) {
         const i18n = byCatalogId.get(raw.id) || {};
         if (!i18n.en) {
@@ -278,6 +288,10 @@ export async function refreshNavCatalogCache(): Promise<void> {
           context_rules: (raw.context_rules || {}) as NavContextRules,
           override_triggers: Array.isArray(raw.override_triggers) ? raw.override_triggers as OverrideTrigger[] : [],
         };
+
+        // Inherit the mobile deep-link from the TS catalog (DB has no column).
+        const tsMobileRoute = tsMobileRouteByScreenId.get(raw.screen_id);
+        if (tsMobileRoute) entry.mobile_route = tsMobileRoute;
 
         idMap.set(raw.id, entry);
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2278,6 +2278,10 @@ async function handleNavigate(
       session_id: session.sessionId,
       session_started_iso: session.createdAt.toISOString(),
       turn_number: session.turn_count,
+      // VTID-02789: thread the mobile-viewport flag so tool_navigate applies the
+      // mobile_route override (e.g. Settings pills → /settings?mode=<section>).
+      // Without this the unified navigate path always used the desktop route.
+      is_mobile: session.is_mobile === true,
     },
     sb,
   );


### PR DESCRIPTION
## The real root cause (why the Settings pills never worked at runtime)

The catalog edits were correct, but the **live navigator never used them** for two reasons on the DB-backed path:

### 1. DB-backed entries had no `mobile_route`
The live navigator (`navigator-consult` → `searchCatalogEntries`) reads the **`nav_catalog` DB table**, not the compile-time `navigation-catalog.ts`, once the cache is warm. The DB→entry builder in `nav-catalog-db.ts` constructs entries from DB columns and **`mobile_route` is not a column**, so every screen that exists as a DB row (confirmed: `SETTINGS.PRIVACY`, `SETTINGS.NOTIFICATIONS`, `SETTINGS.OVERVIEW`) always resolved to the **desktop `route`** on mobile. Screens *absent* from the DB (`SETTINGS.PREFERENCES`/`BILLING` + the sub-pills) are gap-filled from TS and *did* carry `mobile_route` — but see #2.

**Fix:** DB-built entries now **inherit `mobile_route` from the TS catalog by `screen_id`** (the same gap-fill source the navigator already trusts).

### 2. The unified `navigate` tool never passed `is_mobile`
The `mobile_route` override only fires when `is_mobile === true`. `navigate_to_screen` threaded it, but the **primary** unified `navigate` dispatch in `orb-live.ts` omitted it, so `tool_navigate` defaulted `isMobile=false` and **never applied the override** — even for entries that had a `mobile_route`.

**Fix:** thread `session.is_mobile` into the `navigate` dispatch.

## Result
On mobile (`is_mobile` is correctly set from `useIsMobile()` in the 390px app), "Settings Privacy / Preferences / Billing" and the sub-pills now deep-link to `/settings?mode=<section>` → `MobileSettings`, instead of the standalone desktop pages.

This is the missing runtime piece behind merged PRs #2623 (parents) and #2624 (sub-pills) — those defined the `mobile_route`s; this makes the live navigator actually apply them.

## Tests
`npx jest test/navigation-catalog.test.ts` → **237 passed**. `tsc --noEmit` clean. (These files aren't covered by the static catalog test, but the change is additive and type-checked; diagnosis was confirmed against the live `nav_catalog` table.)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_