### PR TITLE
fix(nav): return resolved mobile route from tool_navigate (session-state parity)

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3009,6 +3009,11 @@ export async function tool_navigate(
           session_id: id.session_id || null,
           screen_id: entry.screen_id,
           route: resolvedRoute,
+          // VTID-NAV-MOBILEROUTE: surface the viewport flag + whether a mobile
+          // deep-link existed, so we can tell mobile_route misses apart from a
+          // false is_mobile when a redirect lands on the wrong (desktop) page.
+          is_mobile: isMobile,
+          had_mobile_route: !!entry.mobile_route,
           drain_wait_ms: 0,
         },
       }).catch(() => {});
@@ -3025,6 +3030,8 @@ export async function tool_navigate(
           route: resolvedRoute,
           reason: question,
           is_anonymous: isAnonymous,
+          is_mobile: isMobile,
+          had_mobile_route: !!entry.mobile_route,
         },
       }).catch(() => {});
 

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3047,7 +3047,13 @@ export async function tool_navigate(
           decision: 'confident',
           confidence: consultResult.confidence,
           screen_id: entry.screen_id,
-          route: entry.route,
+          // Return the RESOLVED route (honors mobile_route + overlay marker),
+          // matching the directive sent to the client and navigate_to_screen's
+          // contract. The caller stores result.route into session.current_route /
+          // pendingNavigation / navigator memory, so returning the raw desktop
+          // entry.route here would desync session state from where the client
+          // actually navigated (e.g. /settings/privacy vs /settings?mode=privacy).
+          route: resolvedRoute,
           title: content.title,
           reason: question,
           directive,


### PR DESCRIPTION
## What
Follow-up to #2625, addressing a P2 from Codex review.

`tool_navigate` builds the client navigation **directive** from the *resolved* route (honoring `mobile_route`), but returned `result.route` as the raw **desktop** `entry.route`. The `orb-live` handler stores `result.route` into `session.current_route`, `pendingNavigation`, and navigator-action memory.

Before #2625 `isMobile` was always `false`, so resolved == desktop and they never diverged. Now that the unified `navigate` path threads `is_mobile`, on mobile the client navigates to `/settings?mode=privacy` while the session records `/settings/privacy` — desyncing follow-up routing / current-screen / "already there" logic.

## Fix
Return `route: resolvedRoute` from `tool_navigate`, matching the dispatched directive **and** the existing `navigate_to_screen` contract (which already returns `resolvedRoute`, per the comment at `orb-tools-shared.ts:2823-2824`: *"updates current_route from result.route"*). `screen_id` is returned alongside, so screen identity is unchanged.

## Tests
`tsc --noEmit` clean; `jest test/navigation-catalog.test.ts` → **237 passed**.

Credit: flagged by `chatgpt-codex-connector` on #2625.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_