### PR TITLE
feat(journey): ORB topic-seed pickup layer — voice-inclusive snapshot + getOrbTopicSeed (VTID-03289)

### DIFF
--- a/services/gateway/src/services/guided-journey/checklist-publish.ts
+++ b/services/gateway/src/services/guided-journey/checklist-publish.ts
@@ -12,7 +12,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { ChecklistValidationResult, ChecklistVersion } from '../../types/journey-checklist';
-import { listTopics, toPublicTopic } from './checklist-service';
+import { listTopics, toSnapshotTopic } from './checklist-service';
 import { validateChecklist } from './checklist-validator';
 
 const V = 'journey_checklist_versions';
@@ -72,7 +72,9 @@ export async function publishChecklist(
   if (!validation.ok) throw new ChecklistValidationError(validation);
 
   const active = topics.filter((t) => t.enabled && t.status !== 'disabled');
-  const snapshot = active.map(toPublicTopic);
+  // VTID-03289: snapshot the voice-inclusive shape so the ORB seam can narrate
+  // the published topic. The public HTTP read re-strips vitanaVoiceScript.
+  const snapshot = active.map(toSnapshotTopic);
   const versionLabel = `${curriculumVersion}-${now}`;
 
   // Unset previous current for this curriculum line, then insert the new one.

--- a/services/gateway/src/services/guided-journey/checklist-service.ts
+++ b/services/gateway/src/services/guided-journey/checklist-service.ts
@@ -13,6 +13,8 @@ import type {
   ChecklistTopic,
   ChecklistTopicRow,
   PublicChecklistTopic,
+  SnapshotChecklistTopic,
+  OrbTopicSeed,
   ChecklistStatus,
   BusinessGate,
 } from '../../types/journey-checklist';
@@ -67,6 +69,36 @@ export function toPublicTopic(t: ChecklistTopic): PublicChecklistTopic {
     explanation: t.explanation,
     guidedPracticeTarget: t.guidedPracticeTarget,
     businessGate: t.businessGate,
+  };
+}
+
+/**
+ * VTID-03289 — the SERVER-SIDE snapshot shape: the public fields PLUS the
+ * `vitanaVoiceScript` the ORB voice bridge narrates. Stored in
+ * `journey_checklist_versions.snapshot`; stripped back to `PublicChecklistTopic`
+ * before it ever leaves the gateway over the public HTTP read (see
+ * `snapshotToPublic` + `getPublishedChecklist`).
+ */
+export function toSnapshotTopic(t: ChecklistTopic): SnapshotChecklistTopic {
+  return { ...toPublicTopic(t), vitanaVoiceScript: t.vitanaVoiceScript };
+}
+
+/**
+ * VTID-03289 — re-strip a stored snapshot row to the user-facing shape. Picks
+ * ONLY public fields, so even if the snapshot grows new internal fields later
+ * they can never leak through the public HTTP read.
+ */
+export function snapshotToPublic(s: SnapshotChecklistTopic): PublicChecklistTopic {
+  return {
+    topicId: s.topicId,
+    session: s.session,
+    position: s.position,
+    chapterId: s.chapterId,
+    displayLabel: s.displayLabel,
+    shortDescription: s.shortDescription,
+    explanation: s.explanation,
+    guidedPracticeTarget: s.guidedPracticeTarget,
+    businessGate: s.businessGate,
   };
 }
 
@@ -266,10 +298,14 @@ export async function getPublishedChecklist(
   if (error) throw error;
 
   if (ver && Array.isArray((ver as any).snapshot)) {
+    // VTID-03289: the stored snapshot now carries the internal vitanaVoiceScript
+    // (for the ORB seam). Re-strip to the public shape so it never leaks over
+    // this HTTP read. snapshotToPublic tolerates older voice-less snapshots.
+    const snap = (ver as any).snapshot as SnapshotChecklistTopic[];
     return {
       source: 'published',
       versionLabel: (ver as any).version_label ?? null,
-      topics: (ver as any).snapshot as PublicChecklistTopic[],
+      topics: snap.map(snapshotToPublic),
     };
   }
 
@@ -281,5 +317,56 @@ export async function getPublishedChecklist(
     source: 'draft_fallback',
     versionLabel: null,
     topics: working.map(toPublicTopic),
+  };
+}
+
+/**
+ * VTID-03289 — the ORB voice bridge pickup. Given a tapped topicId, return the
+ * narration seed (voice script + explanation + redirect target) for the ORB to
+ * speak. Reads the CURRENT PUBLISHED snapshot first — so "Publish = go live" and
+ * unpublished draft edits never leak into live narration — and only falls back
+ * to the live draft when nothing is published yet (bootstrap), mirroring
+ * `getPublishedChecklist`. Returns null when the topic is not live.
+ */
+export async function getOrbTopicSeed(
+  client: SupabaseClient,
+  topicId: string,
+  curriculumVersion = 'v2',
+): Promise<OrbTopicSeed | null> {
+  const { data: ver, error } = await client
+    .from(V)
+    .select('snapshot')
+    .eq('curriculum_version', curriculumVersion)
+    .eq('is_current', true)
+    .maybeSingle();
+  if (error) throw error;
+
+  // A published version is authoritative: if it exists, the ORB narrates ONLY
+  // what's in it. A topic absent from the snapshot (gated/disabled at publish)
+  // is intentionally not live → no seed, no draft peek.
+  if (ver && Array.isArray((ver as any).snapshot)) {
+    const snap = (ver as any).snapshot as SnapshotChecklistTopic[];
+    const hit = snap.find((t) => t.topicId === topicId);
+    if (!hit) return null;
+    return {
+      topicId: hit.topicId,
+      displayLabel: hit.displayLabel,
+      vitanaVoiceScript: hit.vitanaVoiceScript ?? null,
+      explanation: hit.explanation,
+      guidedPracticeTarget: hit.guidedPracticeTarget ?? null,
+      source: 'published',
+    };
+  }
+
+  // Bootstrap fallback: nothing published yet → read the live draft row.
+  const draft = await getTopic(client, topicId);
+  if (!draft || !draft.enabled || draft.status === 'disabled') return null;
+  return {
+    topicId: draft.topicId,
+    displayLabel: draft.displayLabel,
+    vitanaVoiceScript: draft.vitanaVoiceScript,
+    explanation: draft.explanation,
+    guidedPracticeTarget: draft.guidedPracticeTarget,
+    source: 'draft_fallback',
   };
 }

--- a/services/gateway/src/types/journey-checklist.ts
+++ b/services/gateway/src/types/journey-checklist.ts
@@ -57,6 +57,35 @@ export interface PublicChecklistTopic {
   businessGate: BusinessGate | null;
 }
 
+/**
+ * VTID-03289 — the SERVER-SIDE published snapshot row shape. Identical to the
+ * user-facing `PublicChecklistTopic` PLUS `vitanaVoiceScript`, which the ORB
+ * voice bridge needs to narrate a tapped topic. The voice script is still an
+ * internal field — `routes/journey-checklist.ts` (the public HTTP read) strips
+ * it back out via `getPublishedChecklist`, so it never reaches a generic client.
+ * It is retained only inside `journey_checklist_versions.snapshot` for the ORB
+ * seam to read server-side (see `getOrbTopicSeed`).
+ */
+export interface SnapshotChecklistTopic extends PublicChecklistTopic {
+  vitanaVoiceScript: string | null;
+}
+
+/**
+ * VTID-03289 — what the ORB live bridge picks up when a user taps a Guided
+ * Journey topic/session. Resolved from the current published snapshot (Publish
+ * = go live), falling back to the live draft only when nothing is published yet.
+ */
+export interface OrbTopicSeed {
+  topicId: string;
+  displayLabel: string;
+  /** The verbatim, pre-localized line Vitana speaks for this topic. */
+  vitanaVoiceScript: string | null;
+  explanation: ChecklistExplanation;
+  /** Where Vitana redirects the user after narrating (a route or feature key). */
+  guidedPracticeTarget: string | null;
+  source: 'published' | 'draft_fallback';
+}
+
 export interface ChecklistValidationIssue {
   rule: string;
   detail: string;

--- a/services/gateway/test/journey-checklist.test.ts
+++ b/services/gateway/test/journey-checklist.test.ts
@@ -14,7 +14,7 @@ import {
   rollbackChecklist,
   ChecklistValidationError,
 } from '../src/services/guided-journey/checklist-publish';
-import { getPublishedChecklist } from '../src/services/guided-journey/checklist-service';
+import { getPublishedChecklist, getOrbTopicSeed } from '../src/services/guided-journey/checklist-service';
 import type { ChecklistTopic } from '../src/types/journey-checklist';
 
 // ---------------------------------------------------------------------------
@@ -284,6 +284,68 @@ describe('checklist publish/rollback', () => {
     // public topics carry no internal fields
     expect(after.topics[0]).not.toHaveProperty('vitanaVoiceScript');
     expect(after.topics[0]).not.toHaveProperty('safetyLevel');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VTID-03289 — ORB topic seed (voice-inclusive snapshot + server-side pickup)
+// ---------------------------------------------------------------------------
+describe('ORB topic seed (VTID-03289)', () => {
+  it('publish snapshot retains vitanaVoiceScript (so the ORB can narrate)', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    const stored = sb.__store.journey_checklist_versions[0];
+    expect(stored.snapshot[0]).toHaveProperty('vitanaVoiceScript');
+    expect(stored.snapshot[0].vitanaVoiceScript).toBe('Vitana explains this topic.');
+  });
+
+  it('public read still strips vitanaVoiceScript from the widened snapshot', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    const after = await getPublishedChecklist(sb);
+    expect(after.source).toBe('published');
+    expect(after.topics[0]).not.toHaveProperty('vitanaVoiceScript');
+  });
+
+  it('reads the seed from the PUBLISHED snapshot (Publish = go live)', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    const seed = await getOrbTopicSeed(sb, 'T001');
+    expect(seed).not.toBeNull();
+    expect(seed!.source).toBe('published');
+    expect(seed!.vitanaVoiceScript).toBe('Vitana explains this topic.');
+    expect(seed!.guidedPracticeTarget).toBe('life_compass');
+    expect(seed!.explanation.whatItIs).toBe('x');
+  });
+
+  it('falls back to the live draft when nothing is published yet (bootstrap)', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    const seed = await getOrbTopicSeed(sb, 'T001');
+    expect(seed).not.toBeNull();
+    expect(seed!.source).toBe('draft_fallback');
+    expect(seed!.vitanaVoiceScript).toBe('Vitana explains this topic.');
+  });
+
+  it('returns null for a topic that is not in the published snapshot', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    expect(await getOrbTopicSeed(sb, 'T999')).toBeNull();
+  });
+
+  it('does not peek at the draft once a version is published (authoritative)', async () => {
+    // Publish a set, then add a brand-new draft topic that is NOT in the snapshot.
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    sb.__store.journey_checklist_topics.push({
+      topic_id: 'T777', curriculum_version: 'v2', session: 1, position: 9,
+      chapter_id: 'basics', display_label: 'Unpublished Draft',
+      vitana_voice_script: 'SHOULD NOT BE SPOKEN', enabled: true, status: 'draft',
+      explanation_what_it_is: null, explanation_user_benefit: null,
+      explanation_when_to_use: null, explanation_try_this: null,
+      guided_practice_target: 'life_compass',
+    });
+    // A published version exists → unpublished draft topic must NOT leak to voice.
+    expect(await getOrbTopicSeed(sb, 'T777')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What (Phase 1 of 3)
Wires the Guided Journey **session/topic button** to the **published KB** so Vitana can narrate the tapped topic. This PR is the **server-side pickup layer only** — no ORB pipeline or frontend changes yet.

## The problem this fixes
`publishChecklist()` snapshotted topics via `toPublicTopic`, which **strips `vitanaVoiceScript`**. So the published `journey_checklist_versions.snapshot` had no voice script — the ORB seam would read `null`.

## Changes
- **`publishChecklist`** now snapshots `toSnapshotTopic` (= `PublicChecklistTopic` + `vitanaVoiceScript`) → the published snapshot carries the voice script the ORB narrates.
- **`getPublishedChecklist`** re-strips via `snapshotToPublic` → the **public HTTP read** (`routes/journey-checklist.ts`) still **never leaks** `vitanaVoiceScript` to clients (design rule preserved).
- **`getOrbTopicSeed(client, topicId, v)`** — resolves the narration seed (voice script + explanation + practice target) from the **current published snapshot** (Publish = go live; unpublished draft edits never reach voice), falling back to the live draft only when nothing is published (bootstrap).
- Types: `SnapshotChecklistTopic`, `OrbTopicSeed`.
- **+6 tests** (snapshot retains voice; public read still strips it; published pickup; draft fallback; unknown-topic → null; draft-not-peeked once published). 23/23 green.

## ⚠️ Operational note
The existing published **v2** snapshot predates this and has no voice field. **Re-Publish the curriculum** after this ships to populate it.

## Next phases
2. `guided-topic-narration` continuation provider → decision-contract → renderer (Vertex+LiveKit parity, passes `validateContinuationCandidate`).
3. `focusGuidedTopic` widget method + `activateOrb(topicId)` in vitana-v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)