### PR TITLE
fix(command-hub): Checklist list clipped to 2 rows / no scroll (VTID-03288 / DEV-COMHU-03301)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -6905,12 +6905,23 @@ function renderKbChecklistView() {
     }
 
     // Split: table (screen 05) + editor (screen 06)
+    // VTID-03288 scroll fix: the shared .admin-split-* chain is overflow:hidden
+    // and (lacking min-height:0) lets the 250-row table grow to full height,
+    // which then gets CLIPPED to ~2 rows with no scrollbar. Neutralize the
+    // clipping here and give each pane its own bounded scroll so all 250 topics
+    // are reachable regardless of window height.
+    root.style.overflowY = 'auto';
     var split = kbEl('div', 'admin-split-layout');
     split.style.display = 'flex'; split.style.gap = '1rem'; split.style.alignItems = 'flex-start';
+    split.style.flex = 'none'; split.style.overflow = 'visible'; split.style.minHeight = '0';
     var left = kbEl('div', 'admin-split-left'); left.style.flex = '1'; left.style.minWidth = '0';
-    left.appendChild(renderKbTable());
+    left.style.overflow = 'visible'; left.style.minHeight = '0';
+    var tbl = renderKbTable();
+    tbl.style.flex = 'none'; tbl.style.maxHeight = '72vh'; tbl.style.overflowY = 'auto';
+    left.appendChild(tbl);
     split.appendChild(left);
     var right = kbEl('div', 'admin-split-right'); right.style.flex = '1'; right.style.minWidth = '0';
+    right.style.overflow = 'visible'; right.style.maxHeight = '72vh'; right.style.overflowY = 'auto';
     right.appendChild(renderKbEditor());
     split.appendChild(right);
     root.appendChild(split);

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0504-audio-ready-r3"></script>
-  <script src="/command-hub/app.js?v=20260609-vtid-03288-kb-regen"></script>
+  <script src="/command-hub/app.js?v=20260609-vtid-03288-scrollfix"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
   <!-- Phase 0 staging build (P0.5): PUBLISH→staging-source card + CLOCK revert -->


### PR DESCRIPTION
The Guided Journey Checklist topic list was clipped to ~2 rows with no scrollbar (shared admin-split chain is overflow:hidden + missing min-height:0), so 248 of 250 topics were unreachable. Gives the list + editor panes their own bounded 72vh scroll. 🤖 Generated with [Claude Code](https://claude.com/claude-code)