### PR TITLE
feat(orb): guided-topic-narration — tap a Guided Journey topic → Vitana teaches it from the KB (VTID-03290)

### DIFF
--- a/services/gateway/src/orb/live/instruction/guided-topic-narration-prompt.ts
+++ b/services/gateway/src/orb/live/instruction/guided-topic-narration-prompt.ts
@@ -1,0 +1,124 @@
+/**
+ * VTID-03290 — GUIDE MODE (TEACH) system-instruction block for Guided Topic
+ * Narration.
+ *
+ * When a user taps a session/topic in the Guided Journey catalog, this block
+ * turns Vitana into a proactive teacher for THAT topic: she introduces it,
+ * teaches it conversationally FROM the authored KB material (paraphrase — never
+ * a verbatim script read), then guides the user to the topic's practice target.
+ * Bundled onto the guided-topic-narration candidate and injected for the whole
+ * session (turns 2+), the way Teacher Mode / Journey Guide are.
+ */
+
+import type { GuidedTopicNarrationContent } from '../../../services/assistant-continuation/providers/guided-topic-narration';
+
+/**
+ * The SPOKEN opener LINE. CRITICAL transport constraint (same as the journey
+ * guide): on LiveKit the Python agent plays this via `session.say()` LITERALLY —
+ * no LLM translation — and on Vertex it is wrapped "speak verbatim". So it MUST
+ * already be in the session language. It is a short, warm lead-in that NAMES the
+ * topic; the actual teaching lives in the TEACH block below (turns 2+).
+ *
+ * de + en today (the platform's active languages; the user base is German).
+ * Other langs fall back to en — a pre-existing session.say() limitation across
+ * every provider, not specific to this one. The topic title is taken from the
+ * published catalog (German for the German curriculum), so a German session gets
+ * a fully German opener.
+ */
+export function buildGuidedTopicNarrationOpenerLine(
+  topicTitle: string,
+  lang: string,
+  opts?: { firstName?: string | null },
+): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  const name = (opts?.firstName || '').trim();
+  const greet = name ? `Hey ${name}! ` : '';
+  return isDe
+    ? `${greet}Lass uns über „${topicTitle}" sprechen — ich erklär dir, worum es geht und wie es dir hilft.`
+    : `${greet}Let's talk about "${topicTitle}" — I'll walk you through what it is and how it helps you.`;
+}
+
+/**
+ * The GUIDE-MODE TEACH block. Instructs the model to teach the tapped topic FROM
+ * the KB material in its own words (guidance, not verbatim), then guide the user
+ * to the practice target. Governs the whole session and overrides generic
+ * greeting/opening rules — like the Journey Guide block.
+ */
+export function buildGuidedTopicNarrationBlock(
+  content: GuidedTopicNarrationContent,
+  lang: string,
+): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  const exp = content.explanation || {
+    whatItIs: null,
+    userBenefit: null,
+    whenToUse: null,
+    tryThis: null,
+  };
+
+  // The KB material the model teaches FROM (paraphrased). Only include the parts
+  // that are authored, so an empty field never injects a dangling label.
+  const material: string[] = [];
+  if (content.voice_script) material.push(`${isDe ? 'Skript' : 'Script'}: ${content.voice_script}`);
+  if (exp.whatItIs) material.push(`${isDe ? 'Was es ist' : 'What it is'}: ${exp.whatItIs}`);
+  if (exp.userBenefit) material.push(`${isDe ? 'Dein Nutzen' : 'User benefit'}: ${exp.userBenefit}`);
+  if (exp.whenToUse) material.push(`${isDe ? 'Wann es hilft' : 'When to use'}: ${exp.whenToUse}`);
+  if (exp.tryThis) material.push(`${isDe ? 'Probier das' : 'Try this'}: ${exp.tryThis}`);
+  const materialBlock = material.length
+    ? material.map((m) => `- ${m}`).join('\n')
+    : isDe
+      ? '- (Noch kein Skript hinterlegt — erkläre das Thema knapp aus allgemeinem Wissen und führe dann zur Übung.)'
+      : '- (No script authored yet — explain the topic briefly from general knowledge, then lead to the practice.)';
+
+  if (isDe) {
+    return [
+      '',
+      '## GUIDE-MODUS (LEHREN) — du STELLST dieses Thema VOR und LEHRST es',
+      '',
+      'SPRACHE: Sprich AUSSCHLIESSLICH auf Deutsch — auch wenn frühere Anweisungen Englisch enthalten. Dieser GUIDE-MODUS gilt für die GANZE Sitzung und hat Vorrang vor JEDER generischen Begrüßungs- oder Eröffnungsregel.',
+      '',
+      `Die Person hat in „Meine Reise" das Thema „${content.topic_title}" angetippt, um es von dir erklärt zu bekommen. Stell es vor und LEHRE es — proaktiv, in EIGENEN Worten.`,
+      '',
+      'STRENG VERBOTEN — in der GANZEN Sitzung:',
+      '- „Was möchtest du?" / „Wie kann ich dir helfen?" / „Womit fangen wir an?" — du WEISST, worum es geht: dieses Thema.',
+      '- Das Skript Wort für Wort vorlesen. Nutze es als GRUNDLAGE und erkläre es natürlich, im Gespräch.',
+      '',
+      `THEMA: ${content.topic_title}`,
+      'Lehrmaterial (paraphrasieren, NICHT vorlesen):',
+      materialBlock,
+      '',
+      'So führst du:',
+      '- Stell das Thema in 1–2 Sätzen vor, dann erkläre es klar und konkret in eigenen Worten.',
+      '- Halte es im Gespräch: kurze Abschnitte, prüfe das Verständnis, geh auf Rückfragen ein.',
+      content.practice_target
+        ? `- Wenn die Person es verstanden hat, FÜHRE sie zur Übung („${content.practice_target}") — biete an, es direkt gemeinsam zu machen.`
+        : '- Wenn die Person es verstanden hat, schlage einen konkreten nächsten Schritt vor.',
+      '',
+    ].join('\n');
+  }
+
+  return [
+    '',
+    '## GUIDE MODE (TEACH) — you INTRODUCE this topic and TEACH it',
+    '',
+    'LANGUAGE: speak ONLY in the user\'s language — even if earlier instructions contain English. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting/opening rule.',
+    '',
+    `The person tapped the topic "${content.topic_title}" in "My Journey" to have you explain it. Introduce it and TEACH it — proactively, in your OWN words.`,
+    '',
+    'STRICTLY FORBIDDEN — for the WHOLE session:',
+    '- "What do you want?" / "How can I help you?" / "Where should we start?" — you KNOW what this is about: this topic.',
+    '- Reading the script word-for-word. Use it as the BASIS and explain it naturally, conversationally.',
+    '',
+    `TOPIC: ${content.topic_title}`,
+    'Teaching material (paraphrase, do NOT read aloud):',
+    materialBlock,
+    '',
+    'How to lead:',
+    '- Introduce the topic in 1–2 sentences, then explain it clearly and concretely in your own words.',
+    '- Keep it conversational: short chunks, check understanding, answer follow-ups.',
+    content.practice_target
+      ? `- Once they get it, GUIDE them to the practice ("${content.practice_target}") — offer to do it together right now.`
+      : '- Once they get it, propose a concrete next step.',
+    '',
+  ].join('\n');
+}

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -907,6 +907,12 @@ export async function handleLiveSessionStart(
     journey_focus_step: typeof (body as any).journey_focus_step === 'string'
       ? (body as any).journey_focus_step
       : undefined,
+    // VTID-03290: Guided Journey catalog topic tapped. Set when the user opened
+    // the orb by tapping a session/topic; the guided-topic-narration provider
+    // leads turn-1 and teaches that topic from the published KB.
+    guided_topic_id: typeof (body as any).guided_topic_id === 'string'
+      ? (body as any).guided_topic_id
+      : undefined,
   };
 
   // VTID-SESSION-LIMIT: Terminate any existing active sessions for this user.
@@ -1143,6 +1149,9 @@ export async function handleLiveSessionStart(
       // VTID-03300: forward the tapped "My Journey" step so journey-guide leads
       // with it. Undefined for normal opens → default next-step behaviour.
       journeyFocusStep: (session as any).journey_focus_step ?? null,
+      // VTID-03290: forward the tapped Guided Journey topic so the
+      // guided-topic-narration provider leads turn-1. Null for normal opens.
+      guidedTopicId: (session as any).guided_topic_id ?? null,
       supabase: supabaseClient,
       // VTID-03085 (Lane 1): pass the compiled spine — unlocks
       // life_compass_alignment, vitana_index_pillar,
@@ -1248,6 +1257,21 @@ export async function handleLiveSessionStart(
         (session as any).journeyGuideContent = bundledJourneyGuide;
         console.log(
           `[VTID-03257] Journey guide leading for ${sessionId}: step=${bundledJourneyGuide.step_key} (${bundledJourneyGuide.step_type}) title="${bundledJourneyGuide.step_title}"`,
+        );
+      }
+
+      // VTID-03290: when guided-topic-narration won (a catalog topic was tapped),
+      // bundle its TEACH content onto the session so the envelope injects the
+      // teach-this-topic-from-the-KB block. Mirrors the journey-guide bundling.
+      const bundledGuidedTopic = (picked as {
+        guidedTopicNarration?:
+          | import('../../../services/assistant-continuation/providers/guided-topic-narration').GuidedTopicNarrationContent
+          | null;
+      }).guidedTopicNarration ?? null;
+      if (bundledGuidedTopic) {
+        (session as any).guidedTopicNarrationContent = bundledGuidedTopic;
+        console.log(
+          `[VTID-03290] Guided topic narration leading for ${sessionId}: topic=${bundledGuidedTopic.topic_id} title="${bundledGuidedTopic.topic_title}" source=${bundledGuidedTopic.source}`,
         );
       }
     }

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1030,6 +1030,10 @@ export interface GeminiLiveSession {
   // journey-guide provider LEADS with that exact step rather than the
   // sequentially-computed current_next_step. One-shot per session.
   journey_focus_step?: string;
+  // VTID-03290: Guided Journey catalog topic the user tapped to open the orb.
+  // When set, the guided-topic-narration provider LEADS turn-1 and Vitana
+  // teaches that topic from the published KB. One-shot per session.
+  guided_topic_id?: string;
   // VTID-NAV: Cached memory pack from the first navigator_consult call this
   // session, with a 30s TTL — subsequent consult calls reuse it instead of
   // re-paying retrieval cost.
@@ -1323,6 +1327,7 @@ export { buildLiveApiTools } from '../orb/live/tools/live-tool-catalog';
 import { buildTeacherModeBlock } from '../orb/teacher/teacher-mode-prompt';
 // VTID-03257 (Fix-1): GUIDE MODE block — Vitana leads the Foundation checklist.
 import { buildJourneyGuideBlock } from '../orb/live/instruction/journey-guide-prompt';
+import { buildGuidedTopicNarrationBlock } from '../orb/live/instruction/guided-topic-narration-prompt';
 // A6.2 (orb-live-refactor): SessionContext + SessionMutator + first
 // lifted navigator handler. orb-live.ts keeps compat shims that build
 // the typed views and forward to handlers under orb/live/tools/handlers/.
@@ -6195,6 +6200,16 @@ async function connectToLiveAPI(
                           + ((session as any).journeyGuideContent
                               ? buildJourneyGuideBlock(
                                   (session as any).journeyGuideContent,
+                                  session.lang,
+                                )
+                              : '')
+                          // VTID-03290: GUIDE MODE (TEACH) — when the user tapped
+                          // a Guided Journey catalog topic, inject the teach-this-
+                          // topic-from-the-KB block so Vitana introduces + teaches
+                          // it (paraphrased) then guides to the practice target.
+                          + ((session as any).guidedTopicNarrationContent
+                              ? buildGuidedTopicNarrationBlock(
+                                  (session as any).guidedTopicNarrationContent,
                                   session.lang,
                                 )
                               : ''),

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -77,6 +77,7 @@ import { buildLiveSystemInstruction } from '../orb/live/instruction/live-system-
 import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../orb/live/instruction/wake-brief-marker';
 // VTID-03257 (Fix-1) — GUIDE-MODE block for LiveKit parity (turns 2+).
 import { buildJourneyGuideBlock } from '../orb/live/instruction/journey-guide-prompt';
+import { buildGuidedTopicNarrationBlock } from '../orb/live/instruction/guided-topic-narration-prompt';
 import {
   optionalAuth,
   requireAuthWithTenant,
@@ -1714,6 +1715,13 @@ router.get(
             (envContext as { timezone?: string } | undefined)?.timezone
               ?? (envContext as { clientContext?: { timezone?: string } } | undefined)?.clientContext?.timezone
               ?? null,
+          // VTID-03290: the Guided Journey catalog topic tapped (LiveKit reads
+          // it from the bootstrap query). When set, guided-topic-narration leads
+          // turn-1 and Vitana teaches that topic from the published KB.
+          guidedTopicId:
+            typeof req.query.guided_topic_id === 'string' && req.query.guided_topic_id
+              ? String(req.query.guided_topic_id)
+              : null,
           recordEmission: true,
         });
         // VTID-03081: bump sessions_today_count. Fire-and-forget; never
@@ -1819,11 +1827,20 @@ first turn only. Subsequent turns follow the normal conversation flow.`;
             | import('../services/assistant-continuation/providers/journey-guide').JourneyGuideContent
             | null;
         }).journeyGuide ?? null;
+        // VTID-03290: LiveKit parity — when the user tapped a Guided Journey
+        // catalog topic, the TEACH block must govern turns 2+ here too (the spoken
+        // opener rides wake_brief_decision.user_facing_line, like the journey guide).
+        const guidedTopicNarration = (picked as {
+          guidedTopicNarration?:
+            | import('../services/assistant-continuation/providers/guided-topic-narration').GuidedTopicNarrationContent
+            | null;
+        }).guidedTopicNarration ?? null;
         const augmentedContext =
           `${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}\n\n` +
           (bootstrapContext ? `${bootstrapContext}\n\n` : '') +
           `${vitanaBehavioralRule}` +
-          (journeyGuide ? buildJourneyGuideBlock(journeyGuide, lang) : '');
+          (journeyGuide ? buildJourneyGuideBlock(journeyGuide, lang) : '') +
+          (guidedTopicNarration ? buildGuidedTopicNarrationBlock(guidedTopicNarration, lang) : '');
         const voiceStyle =
           (voiceConfig as { voice_style?: string } | null)?.voice_style?.trim() ||
           'friendly, calm, empathetic';

--- a/services/gateway/src/services/assistant-continuation/providers/guided-topic-narration.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/guided-topic-narration.ts
@@ -1,0 +1,168 @@
+/**
+ * VTID-03290 — Guided Topic Narration provider.
+ *
+ * THE PRODUCT CONTRACT: when a user taps a session/topic in the Guided Journey
+ * catalog ("My Journey"), Vitana OPENS and TEACHES that topic from the published
+ * knowledge base — she introduces it, explains it in her own words (guidance,
+ * NOT a verbatim script read), then guides the user to the topic's practice
+ * target. This is the voice half of the 90-session / 250-topic curriculum.
+ *
+ * It fires ONLY when a topic was explicitly tapped (`topicId` present), so it
+ * never competes on a normal open. When it does fire it LEADS turn-1 above every
+ * other producer (priority 96 > first_time_welcome 95 > journey_guide 91) — an
+ * explicit tap is a direct request and must win. The KB content is bundled on
+ * the candidate; a GUIDE-MODE (TEACH) block governs the whole session.
+ *
+ * Pickup: getOrbTopicSeed() reads the CURRENT PUBLISHED snapshot (Publish = go
+ * live; unpublished draft edits never reach voice). See VTID-03289.
+ */
+
+import type {
+  AssistantContinuation,
+  ContinuationDecisionContext,
+  ContinuationProvider,
+  ProviderResult,
+} from '../types';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getOrbTopicSeed } from '../../guided-journey/checklist-service';
+import type { ChecklistExplanation } from '../../../types/journey-checklist';
+
+export const GUIDED_TOPIC_NARRATION_PROVIDER_KEY = 'guided_topic_narration';
+export const GUIDED_TOPIC_NARRATION_EXTRA_KEY = 'guided_topic_narration';
+
+// Above first_time_welcome (95) + goal_completion (92) + journey_guide (91): an
+// EXPLICIT topic tap is a direct request to be taught that topic; it leads turn-1
+// over every other producer. Safe to sit this high because the provider only
+// returns a candidate when topicId is present (a real tap) — otherwise it skips.
+const GUIDED_TOPIC_NARRATION_PRIORITY = 96;
+
+/** Bundled TEACH content the controller reads off the winning candidate. */
+export interface GuidedTopicNarrationContent {
+  topic_id: string;
+  topic_title: string;
+  /**
+   * The authored KB voice script. GUIDANCE material — the model teaches FROM it
+   * in its own words and in the user's language; it is NOT read verbatim.
+   */
+  voice_script: string | null;
+  explanation: ChecklistExplanation;
+  /** Where Vitana guides the user after teaching (route or feature key). */
+  practice_target: string | null;
+  /** 'published' | 'draft_fallback' — for telemetry/debugging. */
+  source: string;
+}
+
+interface GuidedTopicNarrationInputs {
+  supabase: SupabaseClient;
+  userId: string;
+  isReconnect?: boolean;
+  lang: string;
+  /** The topicId the user tapped in the Guided Journey catalog. The trigger. */
+  topicId?: string | null;
+  /** Resolved spoken first name for a warm by-name opener. */
+  firstName?: string | null;
+  /** Curriculum line; defaults to v2. */
+  curriculumVersion?: string;
+}
+
+function readInputs(ctx: ContinuationDecisionContext): GuidedTopicNarrationInputs | null {
+  const raw = ctx.extra?.[GUIDED_TOPIC_NARRATION_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  if (!obj.supabase || typeof obj.userId !== 'string' || !obj.userId) return null;
+  return {
+    supabase: obj.supabase as SupabaseClient,
+    userId: obj.userId,
+    isReconnect: obj.isReconnect === true,
+    lang: typeof obj.lang === 'string' && obj.lang ? obj.lang : 'en',
+    topicId: typeof obj.topicId === 'string' && obj.topicId ? obj.topicId : null,
+    firstName: typeof obj.firstName === 'string' && obj.firstName ? obj.firstName : null,
+    curriculumVersion:
+      typeof obj.curriculumVersion === 'string' && obj.curriculumVersion ? obj.curriculumVersion : 'v2',
+  };
+}
+
+export function makeGuidedTopicNarrationProvider(): ContinuationProvider {
+  return {
+    key: GUIDED_TOPIC_NARRATION_PROVIDER_KEY,
+    surfaces: ['orb_wake'],
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return { providerKey: GUIDED_TOPIC_NARRATION_PROVIDER_KEY, status: 'skipped', latencyMs: 0, reason: 'no_guided_topic_inputs' };
+      }
+      // No topic tapped → this provider is irrelevant; cede to the normal ladder.
+      if (!inputs.topicId) {
+        return { providerKey: GUIDED_TOPIC_NARRATION_PROVIDER_KEY, status: 'skipped', latencyMs: 0, reason: 'no_topic_tapped' };
+      }
+      // Transparent reconnect: the previous turn is still alive — don't re-open.
+      if (inputs.isReconnect) {
+        return { providerKey: GUIDED_TOPIC_NARRATION_PROVIDER_KEY, status: 'suppressed', latencyMs: 0, reason: 'forced_skip_reconnect' };
+      }
+
+      let seed: Awaited<ReturnType<typeof getOrbTopicSeed>>;
+      try {
+        seed = await getOrbTopicSeed(inputs.supabase, inputs.topicId, inputs.curriculumVersion);
+      } catch (err) {
+        return {
+          providerKey: GUIDED_TOPIC_NARRATION_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: 0,
+          reason: `guided_topic_seed_failed: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+
+      // Topic not live (not in the published snapshot / disabled). Don't narrate
+      // a topic the catalog isn't serving — cede to the normal ladder.
+      if (!seed) {
+        return { providerKey: GUIDED_TOPIC_NARRATION_PROVIDER_KEY, status: 'suppressed', latencyMs: 0, reason: 'topic_not_live' };
+      }
+
+      const content: GuidedTopicNarrationContent = {
+        topic_id: seed.topicId,
+        topic_title: seed.displayLabel,
+        voice_script: seed.vitanaVoiceScript,
+        explanation: seed.explanation,
+        practice_target: seed.guidedPracticeTarget,
+        source: seed.source,
+      };
+
+      // The SPOKEN opener line. On LiveKit this is played verbatim via
+      // session.say() (no translation step); on Vertex it is wrapped "speak
+      // verbatim". So it MUST already be in the session language. It is a short,
+      // warm lead-in that names the topic — the actual teaching (paraphrase the
+      // KB material, then redirect) lives in the GUIDE-MODE TEACH block, injected
+      // as a system instruction on BOTH transports for turns 2+.
+      const { buildGuidedTopicNarrationOpenerLine } = await import(
+        '../../../orb/live/instruction/guided-topic-narration-prompt'
+      );
+      const openerLine = buildGuidedTopicNarrationOpenerLine(seed.displayLabel, inputs.lang, {
+        firstName: inputs.firstName ?? null,
+      });
+
+      const candidate = {
+        id: `guided-topic-${seed.topicId}`,
+        surface: 'orb_wake',
+        kind: 'wake_brief',
+        priority: GUIDED_TOPIC_NARRATION_PRIORITY,
+        userFacingLine: openerLine,
+        // MUST be a KNOWN_CTA_TYPES value (ask_permission|navigate|offer_demo|
+        // run_tool|explain|noop) or validateContinuationCandidate rejects the
+        // candidate and the provider errors out (the journey-guide 'guide_step'
+        // bug). 'explain' carries no required fields; the teach-then-redirect
+        // behavior comes from userFacingLine + the bundled TEACH block.
+        cta: { type: 'explain', payload: { topic_id: seed.topicId, route: seed.guidedPracticeTarget } },
+        evidence: [
+          { kind: 'source:guided_topic_narration', detail: seed.topicId },
+          { kind: 'guided_topic_source', detail: seed.source },
+        ],
+        dedupeKey: `guided_topic:${seed.topicId}`,
+        privacyMode: 'safe_to_speak',
+        // Bundled — controller / livekit handler read candidate.guidedTopicNarration.
+        guidedTopicNarration: content,
+      } as unknown as AssistantContinuation;
+
+      return { providerKey: GUIDED_TOPIC_NARRATION_PROVIDER_KEY, status: 'returned', latencyMs: 0, candidate };
+    },
+  };
+}

--- a/services/gateway/src/services/guided-journey/checklist-publish.ts
+++ b/services/gateway/src/services/guided-journey/checklist-publish.ts
@@ -12,7 +12,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { ChecklistValidationResult, ChecklistVersion } from '../../types/journey-checklist';
-import { listTopics, toPublicTopic } from './checklist-service';
+import { listTopics, toSnapshotTopic } from './checklist-service';
 import { validateChecklist } from './checklist-validator';
 
 const V = 'journey_checklist_versions';
@@ -72,7 +72,9 @@ export async function publishChecklist(
   if (!validation.ok) throw new ChecklistValidationError(validation);
 
   const active = topics.filter((t) => t.enabled && t.status !== 'disabled');
-  const snapshot = active.map(toPublicTopic);
+  // VTID-03289: snapshot the voice-inclusive shape so the ORB seam can narrate
+  // the published topic. The public HTTP read re-strips vitanaVoiceScript.
+  const snapshot = active.map(toSnapshotTopic);
   const versionLabel = `${curriculumVersion}-${now}`;
 
   // Unset previous current for this curriculum line, then insert the new one.

--- a/services/gateway/src/services/guided-journey/checklist-service.ts
+++ b/services/gateway/src/services/guided-journey/checklist-service.ts
@@ -13,6 +13,8 @@ import type {
   ChecklistTopic,
   ChecklistTopicRow,
   PublicChecklistTopic,
+  SnapshotChecklistTopic,
+  OrbTopicSeed,
   ChecklistStatus,
   BusinessGate,
 } from '../../types/journey-checklist';
@@ -67,6 +69,36 @@ export function toPublicTopic(t: ChecklistTopic): PublicChecklistTopic {
     explanation: t.explanation,
     guidedPracticeTarget: t.guidedPracticeTarget,
     businessGate: t.businessGate,
+  };
+}
+
+/**
+ * VTID-03289 — the SERVER-SIDE snapshot shape: the public fields PLUS the
+ * `vitanaVoiceScript` the ORB voice bridge narrates. Stored in
+ * `journey_checklist_versions.snapshot`; stripped back to `PublicChecklistTopic`
+ * before it ever leaves the gateway over the public HTTP read (see
+ * `snapshotToPublic` + `getPublishedChecklist`).
+ */
+export function toSnapshotTopic(t: ChecklistTopic): SnapshotChecklistTopic {
+  return { ...toPublicTopic(t), vitanaVoiceScript: t.vitanaVoiceScript };
+}
+
+/**
+ * VTID-03289 — re-strip a stored snapshot row to the user-facing shape. Picks
+ * ONLY public fields, so even if the snapshot grows new internal fields later
+ * they can never leak through the public HTTP read.
+ */
+export function snapshotToPublic(s: SnapshotChecklistTopic): PublicChecklistTopic {
+  return {
+    topicId: s.topicId,
+    session: s.session,
+    position: s.position,
+    chapterId: s.chapterId,
+    displayLabel: s.displayLabel,
+    shortDescription: s.shortDescription,
+    explanation: s.explanation,
+    guidedPracticeTarget: s.guidedPracticeTarget,
+    businessGate: s.businessGate,
   };
 }
 
@@ -266,10 +298,14 @@ export async function getPublishedChecklist(
   if (error) throw error;
 
   if (ver && Array.isArray((ver as any).snapshot)) {
+    // VTID-03289: the stored snapshot now carries the internal vitanaVoiceScript
+    // (for the ORB seam). Re-strip to the public shape so it never leaks over
+    // this HTTP read. snapshotToPublic tolerates older voice-less snapshots.
+    const snap = (ver as any).snapshot as SnapshotChecklistTopic[];
     return {
       source: 'published',
       versionLabel: (ver as any).version_label ?? null,
-      topics: (ver as any).snapshot as PublicChecklistTopic[],
+      topics: snap.map(snapshotToPublic),
     };
   }
 
@@ -281,5 +317,56 @@ export async function getPublishedChecklist(
     source: 'draft_fallback',
     versionLabel: null,
     topics: working.map(toPublicTopic),
+  };
+}
+
+/**
+ * VTID-03289 — the ORB voice bridge pickup. Given a tapped topicId, return the
+ * narration seed (voice script + explanation + redirect target) for the ORB to
+ * speak. Reads the CURRENT PUBLISHED snapshot first — so "Publish = go live" and
+ * unpublished draft edits never leak into live narration — and only falls back
+ * to the live draft when nothing is published yet (bootstrap), mirroring
+ * `getPublishedChecklist`. Returns null when the topic is not live.
+ */
+export async function getOrbTopicSeed(
+  client: SupabaseClient,
+  topicId: string,
+  curriculumVersion = 'v2',
+): Promise<OrbTopicSeed | null> {
+  const { data: ver, error } = await client
+    .from(V)
+    .select('snapshot')
+    .eq('curriculum_version', curriculumVersion)
+    .eq('is_current', true)
+    .maybeSingle();
+  if (error) throw error;
+
+  // A published version is authoritative: if it exists, the ORB narrates ONLY
+  // what's in it. A topic absent from the snapshot (gated/disabled at publish)
+  // is intentionally not live → no seed, no draft peek.
+  if (ver && Array.isArray((ver as any).snapshot)) {
+    const snap = (ver as any).snapshot as SnapshotChecklistTopic[];
+    const hit = snap.find((t) => t.topicId === topicId);
+    if (!hit) return null;
+    return {
+      topicId: hit.topicId,
+      displayLabel: hit.displayLabel,
+      vitanaVoiceScript: hit.vitanaVoiceScript ?? null,
+      explanation: hit.explanation,
+      guidedPracticeTarget: hit.guidedPracticeTarget ?? null,
+      source: 'published',
+    };
+  }
+
+  // Bootstrap fallback: nothing published yet → read the live draft row.
+  const draft = await getTopic(client, topicId);
+  if (!draft || !draft.enabled || draft.status === 'disabled') return null;
+  return {
+    topicId: draft.topicId,
+    displayLabel: draft.displayLabel,
+    vitanaVoiceScript: draft.vitanaVoiceScript,
+    explanation: draft.explanation,
+    guidedPracticeTarget: draft.guidedPracticeTarget,
+    source: 'draft_fallback',
   };
 }

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -88,6 +88,16 @@ import {
   JOURNEY_GUIDE_EXTRA_KEY,
   JOURNEY_GUIDE_PROVIDER_KEY,
 } from './assistant-continuation/providers/journey-guide';
+// VTID-03290: guided-topic-narration — when a user taps a session/topic in the
+// Guided Journey catalog, Vitana opens and TEACHES that topic from the published
+// KB. Priority 96 (above first_time_welcome 95) so an explicit tap leads turn-1.
+// Fires ONLY when a topicId was tapped; otherwise skips, so it never blocks the
+// normal ladder.
+import {
+  makeGuidedTopicNarrationProvider,
+  GUIDED_TOPIC_NARRATION_EXTRA_KEY,
+  GUIDED_TOPIC_NARRATION_PROVIDER_KEY,
+} from './assistant-continuation/providers/guided-topic-narration';
 // VTID-03061 (B0d-real Xf.1): auto-emit OASIS next_action.suggested/
 // .suppressed events when a wake-brief decision lands. Fire-and-forget;
 // never blocks the voice path.
@@ -162,6 +172,12 @@ export function ensureWakeBriefProviderRegistered(): void {
   if (!defaultProviderRegistry.get(JOURNEY_GUIDE_PROVIDER_KEY)) {
     defaultProviderRegistry.register(makeJourneyGuideProvider());
   }
+  // VTID-03290: guided-topic-narration at priority 96 — leads turn-1 when a
+  // catalog topic was tapped. Skips cleanly when no topic was tapped, so it
+  // never blocks journey-guide / new-day-return / Teacher on a normal open.
+  if (!defaultProviderRegistry.get(GUIDED_TOPIC_NARRATION_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeGuidedTopicNarrationProvider());
+  }
   _registered = true;
 }
 
@@ -194,6 +210,13 @@ export interface DecideWakeBriefArgs {
    * instead of the sequentially-computed `current_next_step`.
    */
   journeyFocusStep?: string | null;
+  /**
+   * VTID-03290: the Guided Journey catalog topic the user tapped to open the orb
+   * (from the session-start body's `guided_topic_id`). When set, the
+   * guided-topic-narration provider LEADS turn-1 — Vitana teaches that topic from
+   * the published KB. Undefined for normal opens.
+   */
+  guidedTopicId?: string | null;
   /** journeySurface from the ClientContextEnvelope, if any. */
   envelopeJourneySurface?: string;
   /**
@@ -424,6 +447,17 @@ export async function decideWakeBriefForSession(
         // Journey", lead with THAT step instead of the computed next step.
         focusStep: args.journeyFocusStep ?? null,
         // VTID-03300 (follow-up): greet by name in the journey opener.
+        firstName: args.firstName ?? null,
+      };
+      // VTID-03290: guided-topic-narration inputs. The provider skips unless a
+      // catalog topic was tapped (guidedTopicId set), so passing the extra always
+      // is safe — when active it LEADS turn-1 (priority 96) and teaches the topic.
+      extra[GUIDED_TOPIC_NARRATION_EXTRA_KEY] = {
+        supabase: args.supabase,
+        userId: args.userId,
+        isReconnect: args.isReconnect,
+        lang: args.lang,
+        topicId: args.guidedTopicId ?? null,
         firstName: args.firstName ?? null,
       };
     }

--- a/services/gateway/src/types/journey-checklist.ts
+++ b/services/gateway/src/types/journey-checklist.ts
@@ -57,6 +57,35 @@ export interface PublicChecklistTopic {
   businessGate: BusinessGate | null;
 }
 
+/**
+ * VTID-03289 — the SERVER-SIDE published snapshot row shape. Identical to the
+ * user-facing `PublicChecklistTopic` PLUS `vitanaVoiceScript`, which the ORB
+ * voice bridge needs to narrate a tapped topic. The voice script is still an
+ * internal field — `routes/journey-checklist.ts` (the public HTTP read) strips
+ * it back out via `getPublishedChecklist`, so it never reaches a generic client.
+ * It is retained only inside `journey_checklist_versions.snapshot` for the ORB
+ * seam to read server-side (see `getOrbTopicSeed`).
+ */
+export interface SnapshotChecklistTopic extends PublicChecklistTopic {
+  vitanaVoiceScript: string | null;
+}
+
+/**
+ * VTID-03289 — what the ORB live bridge picks up when a user taps a Guided
+ * Journey topic/session. Resolved from the current published snapshot (Publish
+ * = go live), falling back to the live draft only when nothing is published yet.
+ */
+export interface OrbTopicSeed {
+  topicId: string;
+  displayLabel: string;
+  /** The verbatim, pre-localized line Vitana speaks for this topic. */
+  vitanaVoiceScript: string | null;
+  explanation: ChecklistExplanation;
+  /** Where Vitana redirects the user after narrating (a route or feature key). */
+  guidedPracticeTarget: string | null;
+  source: 'published' | 'draft_fallback';
+}
+
 export interface ChecklistValidationIssue {
   rule: string;
   detail: string;

--- a/services/gateway/test/journey-checklist.test.ts
+++ b/services/gateway/test/journey-checklist.test.ts
@@ -14,7 +14,7 @@ import {
   rollbackChecklist,
   ChecklistValidationError,
 } from '../src/services/guided-journey/checklist-publish';
-import { getPublishedChecklist } from '../src/services/guided-journey/checklist-service';
+import { getPublishedChecklist, getOrbTopicSeed } from '../src/services/guided-journey/checklist-service';
 import type { ChecklistTopic } from '../src/types/journey-checklist';
 
 // ---------------------------------------------------------------------------
@@ -284,6 +284,68 @@ describe('checklist publish/rollback', () => {
     // public topics carry no internal fields
     expect(after.topics[0]).not.toHaveProperty('vitanaVoiceScript');
     expect(after.topics[0]).not.toHaveProperty('safetyLevel');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VTID-03289 — ORB topic seed (voice-inclusive snapshot + server-side pickup)
+// ---------------------------------------------------------------------------
+describe('ORB topic seed (VTID-03289)', () => {
+  it('publish snapshot retains vitanaVoiceScript (so the ORB can narrate)', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    const stored = sb.__store.journey_checklist_versions[0];
+    expect(stored.snapshot[0]).toHaveProperty('vitanaVoiceScript');
+    expect(stored.snapshot[0].vitanaVoiceScript).toBe('Vitana explains this topic.');
+  });
+
+  it('public read still strips vitanaVoiceScript from the widened snapshot', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    const after = await getPublishedChecklist(sb);
+    expect(after.source).toBe('published');
+    expect(after.topics[0]).not.toHaveProperty('vitanaVoiceScript');
+  });
+
+  it('reads the seed from the PUBLISHED snapshot (Publish = go live)', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    const seed = await getOrbTopicSeed(sb, 'T001');
+    expect(seed).not.toBeNull();
+    expect(seed!.source).toBe('published');
+    expect(seed!.vitanaVoiceScript).toBe('Vitana explains this topic.');
+    expect(seed!.guidedPracticeTarget).toBe('life_compass');
+    expect(seed!.explanation.whatItIs).toBe('x');
+  });
+
+  it('falls back to the live draft when nothing is published yet (bootstrap)', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    const seed = await getOrbTopicSeed(sb, 'T001');
+    expect(seed).not.toBeNull();
+    expect(seed!.source).toBe('draft_fallback');
+    expect(seed!.vitanaVoiceScript).toBe('Vitana explains this topic.');
+  });
+
+  it('returns null for a topic that is not in the published snapshot', async () => {
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    expect(await getOrbTopicSeed(sb, 'T999')).toBeNull();
+  });
+
+  it('does not peek at the draft once a version is published (authoritative)', async () => {
+    // Publish a set, then add a brand-new draft topic that is NOT in the snapshot.
+    const sb = makeFakeSupabase(fullValidSet());
+    await publishChecklist(sb, 'admin-1', { now: '2026-06-08T10:00:00Z' });
+    sb.__store.journey_checklist_topics.push({
+      topic_id: 'T777', curriculum_version: 'v2', session: 1, position: 9,
+      chapter_id: 'basics', display_label: 'Unpublished Draft',
+      vitana_voice_script: 'SHOULD NOT BE SPOKEN', enabled: true, status: 'draft',
+      explanation_what_it_is: null, explanation_user_benefit: null,
+      explanation_when_to_use: null, explanation_try_this: null,
+      guided_practice_target: 'life_compass',
+    });
+    // A published version exists → unpublished draft topic must NOT leak to voice.
+    expect(await getOrbTopicSeed(sb, 'T777')).toBeNull();
   });
 });
 

--- a/services/gateway/test/services/assistant-continuation/providers/guided-topic-narration.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/guided-topic-narration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * VTID-03290 — guided-topic-narration provider tests.
+ *
+ * Locks the product contract: when a user taps a Guided Journey catalog topic,
+ * the provider LEADS turn-1 (priority 96 > first_time_welcome 95) — the spoken
+ * opener names the topic, the TEACH content is bundled, the cta is a valid
+ * KNOWN_CTA_TYPES value. Skips when no topic was tapped, suppresses on reconnect
+ * and when the topic isn't live, errors-not-throws when the seed read fails.
+ */
+
+import {
+  makeGuidedTopicNarrationProvider,
+  GUIDED_TOPIC_NARRATION_PROVIDER_KEY,
+  GUIDED_TOPIC_NARRATION_EXTRA_KEY,
+} from '../../../../src/services/assistant-continuation/providers/guided-topic-narration';
+import { validateContinuationCandidate } from '../../../../src/services/assistant-continuation/types';
+
+// The provider statically imports getOrbTopicSeed — mock the service module.
+const mockGetOrbTopicSeed = jest.fn();
+jest.mock('../../../../src/services/guided-journey/checklist-service', () => ({
+  getOrbTopicSeed: (...args: any[]) => mockGetOrbTopicSeed(...args),
+}));
+
+const FAKE_SB = { from: () => ({}) } as any;
+
+function makeCtx(extraOverride: any = {}) {
+  return {
+    surface: 'orb_wake',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    extra: {
+      [GUIDED_TOPIC_NARRATION_EXTRA_KEY]: {
+        supabase: FAKE_SB,
+        userId: 'u1',
+        isReconnect: false,
+        lang: 'de',
+        topicId: 'T001',
+        ...extraOverride,
+      },
+    },
+  } as any;
+}
+
+const SEED = {
+  topicId: 'T001',
+  displayLabel: 'Was ist Vitanaland',
+  vitanaVoiceScript: 'Vitanaland ist deine Langlebigkeits-Community …',
+  explanation: { whatItIs: 'Eine Community', userBenefit: 'Du lernst', whenToUse: 'Täglich', tryThis: 'Schau rein' },
+  guidedPracticeTarget: 'community',
+  source: 'published' as const,
+};
+
+beforeEach(() => {
+  mockGetOrbTopicSeed.mockReset();
+});
+
+describe('guided-topic-narration provider', () => {
+  it('skips when no inputs are present', async () => {
+    const p = makeGuidedTopicNarrationProvider();
+    const r = await p.produce({ surface: 'orb_wake', extra: {} } as any);
+    expect(r.status).toBe('skipped');
+    expect(r.providerKey).toBe(GUIDED_TOPIC_NARRATION_PROVIDER_KEY);
+  });
+
+  it('skips when no topic was tapped (normal open)', async () => {
+    const p = makeGuidedTopicNarrationProvider();
+    const r = await p.produce(makeCtx({ topicId: null }));
+    expect(r.status).toBe('skipped');
+    expect(r.reason).toBe('no_topic_tapped');
+    expect(mockGetOrbTopicSeed).not.toHaveBeenCalled();
+  });
+
+  it('suppresses on transparent reconnect', async () => {
+    const p = makeGuidedTopicNarrationProvider();
+    const r = await p.produce(makeCtx({ isReconnect: true }));
+    expect(r.status).toBe('suppressed');
+    expect(r.reason).toBe('forced_skip_reconnect');
+  });
+
+  it('suppresses when the topic is not live (no seed)', async () => {
+    mockGetOrbTopicSeed.mockResolvedValue(null);
+    const p = makeGuidedTopicNarrationProvider();
+    const r = await p.produce(makeCtx());
+    expect(r.status).toBe('suppressed');
+    expect(r.reason).toBe('topic_not_live');
+  });
+
+  it('errors (not throws) when the seed read fails', async () => {
+    mockGetOrbTopicSeed.mockRejectedValue(new Error('db down'));
+    const p = makeGuidedTopicNarrationProvider();
+    const r = await p.produce(makeCtx());
+    expect(r.status).toBe('errored');
+    expect(r.reason).toContain('guided_topic_seed_failed');
+  });
+
+  it('LEADS turn-1 with a valid, bundled candidate when a topic was tapped', async () => {
+    mockGetOrbTopicSeed.mockResolvedValue(SEED);
+    const p = makeGuidedTopicNarrationProvider();
+    const r = await p.produce(makeCtx());
+    expect(r.status).toBe('returned');
+    const c = r.candidate as any;
+    // priority beats first_time_welcome (95)
+    expect(c.priority).toBe(96);
+    // cta MUST be a KNOWN_CTA_TYPES value (the journey-guide 'guide_step' bug)
+    expect(c.cta.type).toBe('explain');
+    // the whole candidate passes the framework validator (else it errors + never wins)
+    expect(validateContinuationCandidate(c).ok).toBe(true);
+    // spoken opener names the topic + is in session language (de)
+    expect(c.userFacingLine).toContain('Was ist Vitanaland');
+    // TEACH content bundled for the controller / livekit handler
+    expect(c.guidedTopicNarration.topic_id).toBe('T001');
+    expect(c.guidedTopicNarration.voice_script).toContain('Vitanaland');
+    expect(c.guidedTopicNarration.practice_target).toBe('community');
+    expect(mockGetOrbTopicSeed).toHaveBeenCalledWith(FAKE_SB, 'T001', 'v2');
+  });
+
+  it('greets by name when firstName is provided', async () => {
+    mockGetOrbTopicSeed.mockResolvedValue(SEED);
+    const p = makeGuidedTopicNarrationProvider();
+    const r = await p.produce(makeCtx({ firstName: 'Dragan' }));
+    expect((r.candidate as any).userFacingLine).toContain('Dragan');
+  });
+});


### PR DESCRIPTION
## What (Phase 2 of 3)
Makes a tapped session/topic in the Guided Journey catalog **actually teach**: a new continuation provider opens Vitana and has her **introduce + teach that topic from the published KB** (guidance, not verbatim), then guide the user to the topic's practice target. Mirrors the shipped VTID-03300 `journey_focus_step` pattern.

## Changes
- **`guided-topic-narration.ts`** provider — fires ONLY when `guided_topic_id` is set (an explicit tap); reads `getOrbTopicSeed` (VTID-03289 published snapshot); **priority 96** so the tap LEADS turn-1 (> first_time_welcome 95 > journey_guide 91). `cta:'explain'` — a `KNOWN_CTA_TYPES` value (avoids the journey-guide `guide_step` validator-reject bug). Skips on no-tap, suppresses on reconnect / topic-not-live, **errors-not-throws** on seed failure.
- **`guided-topic-narration-prompt.ts`** — short localized **spoken opener** naming the topic + a **GUIDE-MODE (TEACH) block** that teaches FROM the KB material in the model's own words, then redirects. de/en.
- **`wake-brief-wiring`** — register provider + `guidedTopicId` arg + `extra`.
- **`live-session-controller`** (Vertex) — parse `guided_topic_id` from the start body, forward `guidedTopicId`, bundle `guidedTopicNarration` → session.
- **`routes/orb-live`** (Vertex) + **`routes/orb-livekit`** (LiveKit) — inject the TEACH block on **both transports** (parity); LiveKit reads `guided_topic_id` from the `/orb/context-bootstrap` query.

## Tests
+7 provider tests (skip / suppress / error-not-throw / **leads turn-1** / **validateContinuationCandidate passes** / named opener). All green. No regression: wake-brief-wiring (16), journey-guide + checklist (39). Build clean.

## Design (confirmed with product owner)
Narration is **guidance, not verbatim** — the KB voice script seeds the system instruction; Vitana paraphrases. Reads **published-only** (Publish = go live).

## Next
Phase 3 (vitana-v1): `focusGuidedTopic(topicId)` widget method + `activateOrb(topicId)` from the catalog click — lights this up end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)