### PR TITLE
fix(orb): guided-topic teaching turn + X-close + auto-close + ES256/JWKS auth (VTID-03292 / DEV-COMHU-0508)

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -130,7 +130,12 @@
     showFab: true,       // Show floating action button (false when parent app has its own trigger)
     onClose: null,       // Callback when overlay closes
     onSessionStart: null, // Callback when voice session starts
-    onSessionEnd: null    // Callback when voice session ends
+    onSessionEnd: null,   // Callback when voice session ends
+    // VTID-03292 (#4): fires when a turn's audio finishes playing, with
+    // { was_greeting } (true for the first turn = the teaching/opener turn).
+    // The host uses this to auto-close the overlay after the guided-topic
+    // teaching turn so the underlying drawer's next-step buttons are usable.
+    onTurnComplete: null
   };
 
   var _s = {
@@ -227,6 +232,12 @@
     // manually-closed EventSource (Android WebView fires it; spec is murky)
     // never spawns a fresh session in the background.
     _userInitiatedStop: false,
+    // VTID-03292 (#3 X-close): hard "the user closed the overlay" flag. Unlike
+    // _userInitiatedStop (which _sessionStart clears on every start, so an
+    // in-flight reconnect wipes it and re-opens), this is cleared ONLY by an
+    // explicit user re-open (_show). Every reconnect/session-start path checks
+    // it and bails, so pressing X always tears down and nothing re-opens.
+    _userRequestedClose: false,
     // VTID-02020: contextual recovery state. _preDisconnectStage captures what
     // the user was doing when the network dropped (idle / listening_user_speaking
     // / thinking / speaking) so the backend's recovery prompt can decide
@@ -1052,6 +1063,13 @@
 
   async function _sessionStart() {
     if (_s.active) return;
+    // VTID-03292 (#3): the user closed the overlay — do NOT (re)start a session.
+    // A reconnect path that races the close lands here and bails, so the orb
+    // stays closed instead of silently re-opening. Cleared only by _show().
+    if (_s._userRequestedClose) {
+      console.log('[VTOrb] _sessionStart: skipped — user requested close');
+      return;
+    }
     console.log('[VTOrb] Starting Gemini Live session...');
 
     // VTID-03098: clear the user-initiated-stop flag at the start of every
@@ -1607,6 +1625,17 @@
               _waitForAudioEnd(); // Still playing — check again in 300ms
               return;
             }
+            // VTID-03292 (#4): audio for this turn has drained. Notify the host
+            // BEFORE the listening transition so a guided-topic flow can close
+            // the overlay (revealing the drawer) instead of dropping to mic.
+            // was_greeting = the first turn (greetingComplete still false here).
+            if (_cfg.onTurnComplete) {
+              try { _cfg.onTurnComplete({ was_greeting: !_s.greetingComplete }); }
+              catch (e) { /* host callback must never break the voice loop */ }
+            }
+            // If the host closed the overlay in the callback (guided auto-close),
+            // stop here — don't beep / arm the mic on a torn-down session.
+            if (!_s.active || _s._userRequestedClose || !_s.overlayVisible) return;
             // VTID-02035b: play the ready beep BEFORE starting mic capture.
             // On iOS / Appilix WebView, getUserMedia switches the audio
             // session to the "voiceChat"/"playAndRecord" category, which
@@ -2579,6 +2608,9 @@
 
   function _show() {
     console.log('[VTOrb] _show() called — gw=' + _cfg.gw + ', _root=' + !!_root);
+    // VTID-03292 (#3): an explicit user re-open clears the hard-close flag so the
+    // session can start again. This is the ONLY place it is cleared.
+    _s._userRequestedClose = false;
     _suppressSoundscape();
     // Refresh token and language on every show — picks up login/logout and language change
     _refreshToken();
@@ -2696,6 +2728,10 @@
   }
 
   function _hide() {
+    // VTID-03292 (#3): mark a hard user-close FIRST so any racing reconnect /
+    // _sessionStart bails (see _sessionStart guard) and the overlay can't
+    // silently re-open. Cleared only on an explicit re-open in _show().
+    _s._userRequestedClose = true;
     // DEV-COMHU-0503: UI close preserves short-lived continuity (15 min) BEFORE
     // teardown, so reopening within the window resumes instead of greeting
     // first-time. _sessionStop still tears down media/SSE exactly as before.

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -3190,3 +3190,5 @@
 
 })(window);
 
+
+// DEV-COMHU-0508: Path Ownership marker (guided-topic ORB fixes — focusGuidedTopic teaching turn, X-close, auto-close).

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1194,6 +1194,16 @@
         _s.journeyFocus = null;
       }
 
+      // VTID-03291 / DEV-COMHU-0507: Guided Journey catalog topic tap. When the
+      // host opened the orb via VitanaOrb.focusGuidedTopic(topicId), the topicId
+      // rides along so the guided-topic-narration provider LEADS turn-1 and
+      // Vitana teaches that topic from the published KB. One-shot: consumed for
+      // this session only so the next normal open reverts to default behaviour.
+      if (_s.guidedTopic) {
+        startPayload.guided_topic_id = _s.guidedTopic;
+        _s.guidedTopic = null;
+      }
+
       // VTID-02020: when this _sessionStart is happening as part of a reconnect
       // (NOT a first-time session), send the conversation history + the
       // pre-disconnect stage so the backend can route to the contextual
@@ -3056,6 +3066,16 @@
       _s.journeyFocus = (typeof stepKey === 'string' && stepKey) ? stepKey : null;
       _show();
     },
+
+    // VTID-03291 / DEV-COMHU-0507: open the orb and start a session FOCUSED on a
+    // specific Guided Journey catalog topic. The host (vitana-v1 My Journey)
+    // calls this when the user taps a session/topic; the guided-topic-narration
+    // provider then leads turn-1 and Vitana TEACHES that topic from the published
+    // KB. One-shot: consumed by the upcoming _sessionStart only.
+    focusGuidedTopic: function (topicId) {
+      _s.guidedTopic = (typeof topicId === 'string' && topicId) ? topicId : null;
+      _show();
+    },
     // DEV-COMHU-0503: intentional forget (logout / account switch / start over).
     reset: _reset,
 
@@ -3086,6 +3106,12 @@
       // carries this field) can't clobber a pending focus.
       if (typeof ctx.journey_focus_step === 'string') {
         _s.journeyFocus = ctx.journey_focus_step || null;
+      }
+      // VTID-03291 / DEV-COMHU-0507: pre-arm a one-shot guided-topic focus from
+      // the host. Set only when present so the per-route updateContext stream
+      // (which never carries this field) can't clobber a pending topic focus.
+      if (typeof ctx.guided_topic_id === 'string') {
+        _s.guidedTopic = ctx.guided_topic_id || null;
       }
     },
 

--- a/services/gateway/src/middleware/auth-supabase-jwt.ts
+++ b/services/gateway/src/middleware/auth-supabase-jwt.ts
@@ -92,7 +92,7 @@ export function invalidateVitanaIdCache(userId: string): void {
 /**
  * Auth source: which Supabase project signed the JWT
  */
-export type AuthSource = 'platform' | 'lovable';
+export type AuthSource = 'platform' | 'lovable' | 'jwks';
 
 /**
  * Extended Express Request with identity attached
@@ -140,6 +140,33 @@ function getJwtSecrets(): Array<{ secret: Uint8Array; source: AuthSource }> {
 }
 
 /**
+ * VTID-03292: ES256/asymmetric verification via a remote JWKS.
+ *
+ * Newer Supabase projects sign JWTs with ES256 (asymmetric "JWT signing keys")
+ * instead of the legacy HS256 shared secret. The HS256 path above can't verify
+ * those. When `SUPABASE_AUTH_JWKS_URL` is set (e.g. the staging project's
+ * `/auth/v1/.well-known/jwks.json`), we additionally try ES256 verification
+ * against that JWKS. ADDITIVE + gated: prod leaves the env unset and behaves
+ * exactly as before. `createRemoteJWKSet` caches keys + auto-refreshes on
+ * rotation, so this is a single lazily-created module-level set.
+ */
+let _remoteJwks: ReturnType<typeof jose.createRemoteJWKSet> | null = null;
+let _remoteJwksUrl: string | null = null;
+function getRemoteJwks(): ReturnType<typeof jose.createRemoteJWKSet> | null {
+  const url = process.env.SUPABASE_AUTH_JWKS_URL;
+  if (!url) return null;
+  if (_remoteJwks && _remoteJwksUrl === url) return _remoteJwks;
+  try {
+    _remoteJwks = jose.createRemoteJWKSet(new URL(url));
+    _remoteJwksUrl = url;
+    return _remoteJwks;
+  } catch (e) {
+    console.error(`[VTID-03292] Invalid SUPABASE_AUTH_JWKS_URL: ${(e as Error).message}`);
+    return null;
+  }
+}
+
+/**
  * Extract identity claims from a verified JWT payload.
  */
 function extractIdentity(payload: jose.JWTPayload): SupabaseIdentity {
@@ -167,9 +194,6 @@ export async function verifyAndExtractIdentity(
   token: string
 ): Promise<{ identity: SupabaseIdentity; claims: jose.JWTPayload; auth_source: AuthSource } | null> {
   const secrets = getJwtSecrets();
-  if (secrets.length === 0) {
-    return null;
-  }
 
   for (const { secret, source } of secrets) {
     try {
@@ -184,8 +208,25 @@ export async function verifyAndExtractIdentity(
     }
   }
 
-  // All secrets failed — log the last error type for debugging
-  console.warn('[VTID-ORBC] JWT verification failed against all configured secrets');
+  // VTID-03292: HS256 secrets failed (or none configured) — try ES256 against
+  // the remote JWKS when configured (staging Supabase signs with ES256).
+  const jwks = getRemoteJwks();
+  if (jwks) {
+    try {
+      const { payload } = await jose.jwtVerify(token, jwks, { algorithms: ['ES256'] });
+      const identity = extractIdentity(payload);
+      console.log(`[VTID-03292] JWT verified via JWKS (ES256): user=${identity.user_id}`);
+      return { identity, claims: payload, auth_source: 'jwks' };
+    } catch (_error: any) {
+      // fall through to failure
+    }
+  }
+
+  if (secrets.length === 0 && !jwks) {
+    return null;
+  }
+  // All verification paths failed — log for debugging
+  console.warn('[VTID-ORBC] JWT verification failed against all configured secrets + JWKS');
   return null;
 }
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7153,7 +7153,21 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
       ru: `Скажи ровно: "${safe}" — ОДНА короткая фраза. БЕЗ приветствия перед. БЕЗ вопроса после. НЕ перефразируй.`,
       sr: `Реци тачно: "${safe}" — ЈЕДНА кратка реченица. БЕЗ поздрава пре. БЕЗ питања после. НЕ преформулиши.`,
     };
-    const wakePrompt = wakeTriggerByLang[lang] || wakeTriggerByLang.en;
+    // VTID-03292 (#1): guided-topic narration is a TEACHING turn, not a one-line
+    // opener. The default "ONE short utterance only / do NOT add anything after"
+    // trigger makes the model speak the opener and immediately yield to listening
+    // — which is exactly the "lists instead of teaching" bug. When the session
+    // carries guidedTopicNarrationContent, send a trigger that says: open with
+    // the line, THEN keep teaching in the SAME turn per the GUIDE-MODE (TEACH)
+    // block, do not stop after the opener.
+    const isGuidedTeach = !!(session as any).guidedTopicNarrationContent;
+    const guidedTeachTriggerByLang: Record<string, string> = {
+      en: `Begin by saying: "${safe}" — then, in the SAME turn, immediately TEACH this topic following the "GUIDE MODE (TEACH)" block in your system instruction: explain it in your own words across several sentences. Do NOT stop after the opening line. Do NOT ask "how can I help". When you finish explaining, briefly offer the practice.`,
+      de: `Beginne mit: "${safe}" — und LEHRE dann im SELBEN Redebeitrag sofort dieses Thema gemäß dem Block „GUIDE-MODUS (LEHREN)" in deinem System-Prompt: erkläre es in eigenen Worten über mehrere Sätze. Hör NICHT nach dem ersten Satz auf. Frag NICHT „Wie kann ich helfen". Wenn du fertig erklärt hast, biete kurz die Übung an.`,
+    };
+    const wakePrompt = isGuidedTeach
+      ? (guidedTeachTriggerByLang[lang] || guidedTeachTriggerByLang.en)
+      : (wakeTriggerByLang[lang] || wakeTriggerByLang.en);
     const linePreview = safe.length > 160 ? safe.slice(0, 160) + '...' : safe;
     const promptPreview = wakePrompt.length > 200 ? wakePrompt.slice(0, 200) + '...' : wakePrompt;
     console.log(


### PR DESCRIPTION
Staging fixes for the guided-topic ORB (diagnosed after the prod incident; prod already rolled back).

**#1 Teaching** (`orb-live.ts`): guided-topic sessions previously got the generic *"Say exactly: '<line>' — ONE short utterance only, do NOT add anything after"* greeting trigger → model spoke a fragment then yielded to listening. Now they get a **TEACH trigger**: open with the line, then keep teaching in the SAME turn per the GUIDE-MODE (TEACH) block.

**#3 X-close** (`orb-widget.js`): hard `_userRequestedClose` flag (cleared only by `_show`); `_sessionStart` bails on it so an in-flight reconnect can't re-open the overlay after X.

**#4 Auto-close** (`orb-widget.js`): new `onTurnComplete({was_greeting})` callback so the host closes the overlay after the teaching turn (drawer buttons become usable).

**#5 Staging auth** (`auth-supabase-jwt.ts`): ES256 verification via remote JWKS, tried after HS256, **gated on `SUPABASE_AUTH_JWKS_URL`** (additive, prod unaffected).

**#2 (10s delay): NOT addressed** — the greeting watchdog is 30s, not 8s, so that theory was wrong; it's model first-token latency and needs profiling, not a guess.

Staging only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)