### PR TITLE
fix(orb): guided-topic speaks the lesson verbatim (reliable audio) + bulletproof close (VTID-03293 / DEV-COMHU-0509)

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -2732,6 +2732,17 @@
     // _sessionStart bails (see _sessionStart guard) and the overlay can't
     // silently re-open. Cleared only on an explicit re-open in _show().
     _s._userRequestedClose = true;
+    // VTID-03293 (#3 fix-2): kill the reconnect/disconnect machinery so a STALLED
+    // session (e.g. stuck "connecting" with no audio) can ALWAYS be closed. The
+    // recovery watchdog is a setInterval that re-fires _resetAndReconnect; without
+    // stopping it + clearing these flags, the probe could keep the session alive
+    // and the overlay effectively un-closeable. Belt-and-suspenders with the
+    // _userRequestedClose guard above.
+    _s._disconnectActive = false;
+    _s._disconnectStuck = false;
+    _s._isReconnecting = false;
+    try { clearInterval(_s._recoveryWatchdog); } catch (e) { /* noop */ }
+    _s._recoveryWatchdog = null;
     // DEV-COMHU-0503: UI close preserves short-lived continuity (15 min) BEFORE
     // teardown, so reopening within the window resumes instead of greeting
     // first-time. _sessionStop still tears down media/SSE exactly as before.

--- a/services/gateway/src/orb/live/instruction/guided-topic-narration-prompt.ts
+++ b/services/gateway/src/orb/live/instruction/guided-topic-narration-prompt.ts
@@ -39,10 +39,47 @@ export function buildGuidedTopicNarrationOpenerLine(
 }
 
 /**
- * The GUIDE-MODE TEACH block. Instructs the model to teach the tapped topic FROM
- * the KB material in its own words (guidance, not verbatim), then guide the user
- * to the practice target. Governs the whole session and overrides generic
- * greeting/opening rules — like the Journey Guide block.
+ * VTID-03293 — the SPOKEN LESSON: the actual teaching Vitana speaks on turn 1.
+ *
+ * WHY this is the spoken line (not a short opener + "teach more" instruction):
+ * Gemini Live native-audio reliably produces AUDIO only for a SHORT, DIRECT
+ * user turn ("say exactly: <line>"). A long INSTRUCTIONAL trigger ("then teach
+ * across several sentences per the block…") makes it answer text-only or delay
+ * first audio past the AudioContext suspend window → no speech, UI stuck
+ * "connecting" (the VTID-03102 regression we hit on staging). So we put the
+ * teaching INTO the spoken line itself: the authored `voice_script` IS the
+ * lesson (the author wrote it as what Vitana says), and the greeting path speaks
+ * it verbatim — reliable audio + real teaching. Falls back to a short lesson
+ * built from the explanation fields when no script is authored.
+ */
+export function buildGuidedTopicSpokenLesson(
+  content: GuidedTopicNarrationContent,
+  lang: string,
+  opts?: { firstName?: string | null },
+): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  const name = (opts?.firstName || '').trim();
+  const greet = name ? `Hey ${name}! ` : '';
+
+  let body = (content.voice_script || '').trim();
+  if (!body) {
+    const exp = content.explanation || { whatItIs: null, userBenefit: null, whenToUse: null, tryThis: null };
+    const parts: string[] = [];
+    parts.push(isDe ? `Lass uns über „${content.topic_title}" sprechen.` : `Let's talk about "${content.topic_title}".`);
+    if (exp.whatItIs) parts.push(exp.whatItIs);
+    if (exp.userBenefit) parts.push(exp.userBenefit);
+    if (exp.tryThis) parts.push(exp.tryThis);
+    body = parts.join(' ').trim();
+  }
+  return `${greet}${body}`.trim();
+}
+
+/**
+ * The GUIDE-MODE TEACH block. Governs turns 2+ (follow-up Q&A about the topic):
+ * the lesson itself is spoken on turn 1 via the spoken line (see
+ * buildGuidedTopicSpokenLesson); this block tells the model how to handle the
+ * conversation AFTER the lesson. Bundled on the candidate, injected on both
+ * transports — like the Journey Guide block.
  */
 export function buildGuidedTopicNarrationBlock(
   content: GuidedTopicNarrationContent,

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7220,17 +7220,17 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
       ru: `Скажи ровно: "${safe}" — ОДНА короткая фраза. БЕЗ приветствия перед. БЕЗ вопроса после. НЕ перефразируй.`,
       sr: `Реци тачно: "${safe}" — ЈЕДНА кратка реченица. БЕЗ поздрава пре. БЕЗ питања после. НЕ преформулиши.`,
     };
-    // VTID-03292 (#1): guided-topic narration is a TEACHING turn, not a one-line
-    // opener. The default "ONE short utterance only / do NOT add anything after"
-    // trigger makes the model speak the opener and immediately yield to listening
-    // — which is exactly the "lists instead of teaching" bug. When the session
-    // carries guidedTopicNarrationContent, send a trigger that says: open with
-    // the line, THEN keep teaching in the SAME turn per the GUIDE-MODE (TEACH)
-    // block, do not stop after the opener.
+    // VTID-03293 (#1 fix-2): guided-topic narration speaks the LESSON itself (the
+    // authored voice script, set as `safe` by the provider). Use a DIRECT-QUOTE
+    // trigger ("say this verbatim, in full"), NOT a long instruction. Native
+    // audio reliably produces audio for a direct quote but goes text-only /
+    // stalls on a long instructional prompt (the VTID-03102 regression → the
+    // stuck-connecting, no-speech bug). We drop the "ONE short utterance" clamp so
+    // the whole lesson is spoken, but keep it a quote so audio stays reliable.
     const isGuidedTeach = !!(session as any).guidedTopicNarrationContent;
     const guidedTeachTriggerByLang: Record<string, string> = {
-      en: `Begin by saying: "${safe}" — then, in the SAME turn, immediately TEACH this topic following the "GUIDE MODE (TEACH)" block in your system instruction: explain it in your own words across several sentences. Do NOT stop after the opening line. Do NOT ask "how can I help". When you finish explaining, briefly offer the practice.`,
-      de: `Beginne mit: "${safe}" — und LEHRE dann im SELBEN Redebeitrag sofort dieses Thema gemäß dem Block „GUIDE-MODUS (LEHREN)" in deinem System-Prompt: erkläre es in eigenen Worten über mehrere Sätze. Hör NICHT nach dem ersten Satz auf. Frag NICHT „Wie kann ich helfen". Wenn du fertig erklärt hast, biete kurz die Übung an.`,
+      en: `Say the following VERBATIM and IN FULL — word for word, then stop and listen. Do NOT summarize, shorten, paraphrase, translate, or add a greeting/question: "${safe}"`,
+      de: `Sage Folgendes WÖRTLICH und VOLLSTÄNDIG — Wort für Wort, dann höre auf und höre zu. NICHT zusammenfassen, kürzen, umformulieren, übersetzen oder eine Begrüßung/Frage hinzufügen: "${safe}"`,
     };
     const wakePrompt = isGuidedTeach
       ? (guidedTeachTriggerByLang[lang] || guidedTeachTriggerByLang.en)

--- a/services/gateway/src/services/assistant-continuation/providers/guided-topic-narration.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/guided-topic-narration.ts
@@ -127,16 +127,15 @@ export function makeGuidedTopicNarrationProvider(): ContinuationProvider {
         source: seed.source,
       };
 
-      // The SPOKEN opener line. On LiveKit this is played verbatim via
-      // session.say() (no translation step); on Vertex it is wrapped "speak
-      // verbatim". So it MUST already be in the session language. It is a short,
-      // warm lead-in that names the topic — the actual teaching (paraphrase the
-      // KB material, then redirect) lives in the GUIDE-MODE TEACH block, injected
-      // as a system instruction on BOTH transports for turns 2+.
-      const { buildGuidedTopicNarrationOpenerLine } = await import(
+      // VTID-03293: the SPOKEN LINE is now the LESSON itself (the authored
+      // voice_script), spoken verbatim via the reliable "say exactly" greeting
+      // path — NOT a short opener + a long "teach more" instruction, which made
+      // native-audio go text-only / stall (the stuck-connecting bug). The lesson
+      // IS the teaching; the bundled GUIDE-MODE block governs follow-up turns.
+      const { buildGuidedTopicSpokenLesson } = await import(
         '../../../orb/live/instruction/guided-topic-narration-prompt'
       );
-      const openerLine = buildGuidedTopicNarrationOpenerLine(seed.displayLabel, inputs.lang, {
+      const spokenLesson = buildGuidedTopicSpokenLesson(content, inputs.lang, {
         firstName: inputs.firstName ?? null,
       });
 
@@ -145,7 +144,7 @@ export function makeGuidedTopicNarrationProvider(): ContinuationProvider {
         surface: 'orb_wake',
         kind: 'wake_brief',
         priority: GUIDED_TOPIC_NARRATION_PRIORITY,
-        userFacingLine: openerLine,
+        userFacingLine: spokenLesson,
         // MUST be a KNOWN_CTA_TYPES value (ask_permission|navigate|offer_demo|
         // run_tool|explain|noop) or validateContinuationCandidate rejects the
         // candidate and the provider errors out (the journey-guide 'guide_step'

--- a/services/gateway/test/services/assistant-continuation/providers/guided-topic-narration.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/guided-topic-narration.test.ts
@@ -106,8 +106,10 @@ describe('guided-topic-narration provider', () => {
     expect(c.cta.type).toBe('explain');
     // the whole candidate passes the framework validator (else it errors + never wins)
     expect(validateContinuationCandidate(c).ok).toBe(true);
-    // spoken opener names the topic + is in session language (de)
-    expect(c.userFacingLine).toContain('Was ist Vitanaland');
+    // VTID-03293: the spoken LINE is now the LESSON itself (the authored voice
+    // script), so native-audio reliably speaks it; not a short opener + a long
+    // "teach more" instruction (which stalled audio).
+    expect(c.userFacingLine).toContain('Vitanaland ist deine');
     // TEACH content bundled for the controller / livekit handler
     expect(c.guidedTopicNarration.topic_id).toBe('T001');
     expect(c.guidedTopicNarration.voice_script).toContain('Vitanaland');


### PR DESCRIPTION
Diagnosed from **gateway-staging logs** of the live session.

**What the logs showed (good):** auth works (`isAnonymous=false`), bootstrap ~2.6s, provider fires (`guided_topic_narration` wins), the teaching trigger is sent, sessions close cleanly (`code=1000`), no watchdog timeout, no errors.

**Root cause of "stuck connecting / no speech":** the #1 teaching trigger was a **long instruction** (~415 chars). Gemini native-audio answers long *instructional* prompts text-only / delays first audio past the AudioContext suspend window (the documented **VTID-03102** regression) → no audio → UI stuck.

**Fix #1 (audio):** the provider now sets `userFacingLine` to the **lesson itself** (the authored `voice_script`; falls back to a short lesson from the explanation fields), sent via a **direct-quote** trigger ("say this VERBATIM and IN FULL, then stop and listen") — the reliable native-audio path. The lesson IS the teaching; the GUIDE-MODE block still handles follow-ups. *Trade-off: Vitana speaks the authored script rather than free-paraphrasing — the reliable way to get teaching audio.*

**Fix #3 (close):** `_hide` now also kills the reconnect machinery (`_recoveryWatchdog` interval + disconnect flags) so a **stalled** connecting session can always be closed with X.

Provider test updated, 7/7 green. Staging only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)