### PR TITLE
feat(nav): make the Events Hot tab voice-addressable (COMM.EVENTS_HOT)

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -653,6 +653,29 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     },
   },
   {
+    // The Hot tab is the Events default, but give it an explicit ?tab=hot entry
+    // so the user can switch TO it by voice when already on another tab (the
+    // bare COMM.EVENTS route has no ?tab and so can't switch tabs in-place).
+    screen_id: 'COMM.EVENTS_HOT',
+    route: '/comm/events-meetups?tab=hot',
+    category: 'community',
+    access: 'authenticated',
+    anonymous_safe: false,
+    aliases: ['hot-events', 'events-hot', 'trending-events', 'featured-events'],
+    i18n: {
+      en: {
+        title: 'Hot Events',
+        description: 'Featured and trending Maxina community events and meetups.',
+        when_to_visit: 'When the user asks for the Hot tab of Events & Meetups, hot events, trending events, featured events, or the highlighted community events.',
+      },
+      de: {
+        title: 'Angesagte Events',
+        description: 'Hervorgehobene und angesagte Maxina-Community-Events und Meetups.',
+        when_to_visit: 'Wenn der Nutzer nach dem Tab „Hot“ von Events & Meetups, angesagten Events, Trend-Events, hervorgehobenen Events oder den Top-Community-Events fragt.',
+      },
+    },
+  },
+  {
     screen_id: 'COMM.LIVE_ROOMS',
     route: '/comm/live-rooms',
     category: 'community',


### PR DESCRIPTION
## What
Adds `COMM.EVENTS_HOT` (`/comm/events-meetups?tab=hot`) so the **Hot** tab of Events & Meetups is voice-addressable like the others.

The Upcoming / Today / Following tabs already had entries (`COMM.EVENTS_UPCOMING`, `COMM.EVENTS_TODAY`, `COMM.FEED`). **Hot** only existed as the parent `COMM.EVENTS` default — and that entry's `route` has no `?tab`, so the Orb couldn't switch *to* Hot when already on another tab. This closes that gap.

## Design note
The page reads `?tab=` in both viewports, so the deep-link lives in `route` (no `is_mobile` dependency). en+de i18n included. Pairs with the frontend PR that makes the page honor external `?tab` changes.

## Tests
`tsc --noEmit` clean; `jest test/navigation-catalog.test.ts` → **237 passed**.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_