### PR TITLE
fix(nav): route "supplements in Health" to the Health tab, not the marketplace

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -1232,17 +1232,17 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     category: 'health',
     access: 'authenticated',
     anonymous_safe: false,
-    aliases: ['health-supplements', 'my-supplements', 'supplement-tracker', 'my-stack', 'supplement-stack', 'vitamin-tracker', 'meine-supplements', 'meine-nahrungsergaenzung'],
+    aliases: ['health-supplements', 'supplements-in-health', 'supplements-health', 'my-supplements', 'supplement-tracker', 'my-stack', 'supplement-stack', 'vitamin-tracker', 'meine-supplements', 'meine-nahrungsergaenzung'],
     i18n: {
       en: {
         title: 'My Supplements',
-        description: 'Track the supplements, vitamins, and minerals you take.',
-        when_to_visit: "When the user wants to view, track, log, or manage THEIR OWN supplements — their supplement stack, the vitamins or minerals THEY take, the 'health supplements' tracker, or add a supplement to their regimen. This is the personal health tracker, NOT shopping the marketplace.",
+        description: 'The Supplements tab in Health — track the supplements, vitamins, and minerals you take.',
+        when_to_visit: "When the user asks for the Supplements tab inside the Health screen, 'supplements in Health', 'health supplements', or to open supplements in the Health section — and when they want to view, track, log, or manage THEIR OWN supplements, their supplement stack, or the vitamins and minerals THEY take. This is the Health screen's supplements tracker, NOT shopping the marketplace.",
       },
       de: {
-        title: 'Meine Nahrungsergänzung',
-        description: 'Verfolge die Nahrungsergänzungsmittel, Vitamine und Mineralien, die du nimmst.',
-        when_to_visit: 'Wenn der Nutzer SEINE EIGENEN Nahrungsergänzungsmittel ansehen, verfolgen, protokollieren oder verwalten möchte — seinen Supplement-Stack, die Vitamine oder Mineralien, die er nimmt, den "Gesundheits-Supplement"-Tracker, oder ein Supplement zu seiner Routine hinzufügen. Das ist der persönliche Gesundheits-Tracker, NICHT der Marktplatz-Einkauf.',
+        title: 'Gesundheits-Supplemente',
+        description: 'Der Supplements-Tab im Gesundheitsbereich — verfolge die Nahrungsergänzungsmittel, Vitamine und Mineralien, die du nimmst.',
+        when_to_visit: 'Wenn der Nutzer nach dem Supplements-Tab im Gesundheits-Bildschirm, „Supplements im Gesundheitsbereich", „Gesundheits-Supplements" fragt oder Supplements im Gesundheitsbereich öffnen möchte — und wenn er SEINE EIGENEN Nahrungsergänzungsmittel ansehen, verfolgen, protokollieren oder verwalten möchte, seinen Supplement-Stack oder die Vitamine und Mineralien, die er nimmt. Das ist der Supplements-Tracker des Gesundheits-Bildschirms, NICHT der Marktplatz-Einkauf.',
       },
     },
   },
@@ -1386,12 +1386,12 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
       en: {
         title: 'Supplements',
         description: 'Curated supplements for longevity and wellness.',
-        when_to_visit: 'When the user wants to browse, show, shop for, or buy supplements, vitamins, minerals, or nutraceuticals in the marketplace — exploring available products, brands, or deals. NOT for tracking the supplements they personally take (that is HEALTH.SUPPLEMENTS).',
+        when_to_visit: 'When the user wants to browse, show, shop for, or buy supplements, vitamins, minerals, or nutraceuticals in the marketplace — exploring available products, brands, or deals. NOT for tracking the supplements they personally take (that is the personal tracker tab, not the shop).',
       },
       de: {
         title: 'Nahrungsergänzungsmittel',
         description: 'Kuratierte Nahrungsergänzungsmittel für Longevity und Wellness.',
-        when_to_visit: 'Wenn der Nutzer Nahrungsergänzungsmittel, Vitamine, Mineralien oder Nutraceuticals im Marktplatz durchstöbern, ansehen oder kaufen möchte — verfügbare Produkte, Marken oder Angebote erkunden. NICHT zum Verfolgen der Supplements, die er selbst einnimmt (das ist HEALTH.SUPPLEMENTS).',
+        when_to_visit: 'Wenn der Nutzer Nahrungsergänzungsmittel, Vitamine, Mineralien oder Nutraceuticals im Marktplatz durchstöbern, ansehen oder kaufen möchte — verfügbare Produkte, Marken oder Angebote erkunden. NICHT zum Verfolgen der Supplements, die er selbst einnimmt (das ist der persönliche Tracker-Tab, nicht der Shop).',
       },
     },
   },

--- a/services/gateway/test/navigation-catalog.test.ts
+++ b/services/gateway/test/navigation-catalog.test.ts
@@ -241,9 +241,17 @@ const ROUTING_CASES: RoutingCase[] = [
   { utterance: 'meine biomarker zeigen',                    lang: 'de', expected_screen_id: 'HEALTH.MY_BIOLOGY' },
   { utterance: 'open my health plans',                      lang: 'en', expected_screen_id: 'HEALTH.PLANS' },
   { utterance: 'mein ernährungsplan',                       lang: 'de', expected_screen_id: 'HEALTH.PLANS' },
+  // Supplements disambiguation: the Health tab vs the Discover marketplace.
+  // Health-qualified phrasings must land on the Health Supplements tab, not the shop.
+  { utterance: 'open supplements in health',                lang: 'en', expected_screen_id: 'HEALTH.SUPPLEMENTS' },
+  { utterance: 'supplements in health',                     lang: 'en', expected_screen_id: 'HEALTH.SUPPLEMENTS' },
+  { utterance: 'health supplements',                        lang: 'en', expected_screen_id: 'HEALTH.SUPPLEMENTS' },
+  { utterance: 'my supplements',                            lang: 'en', expected_screen_id: 'HEALTH.SUPPLEMENTS' },
 
   // ── DISCOVER ──
+  // Generic / shopping phrasings stay on the marketplace.
   { utterance: 'show me supplements',                       lang: 'en', expected_screen_id: 'DISCOVER.SUPPLEMENTS' },
+  { utterance: 'buy supplements',                           lang: 'en', expected_screen_id: 'DISCOVER.SUPPLEMENTS' },
   { utterance: 'find me a doctor',                          lang: 'en', expected_screen_id: 'DISCOVER.DOCTORS_COACHES' },
   { utterance: 'I want to find a coach',                    lang: 'en', expected_screen_id: 'DISCOVER.DOCTORS_COACHES' },
   { utterance: 'are there any deals',                       lang: 'en', expected_screen_id: 'DISCOVER.DEALS' },


### PR DESCRIPTION
## Root cause (found via the live OASIS trace + the real scorer)
"Open Supplements in Health" was perpetually **ambiguous** and resolved to **`DISCOVER.SUPPLEMENTS`** (the marketplace) instead of **`HEALTH.SUPPLEMENTS`** (the Health screen's Supplements tab). The disambiguation labels were also misleading — the option labeled "Supplements" was the Discover shop, so picking it sent you out of Health.

Probing the actual `searchCatalog` scorer:
```
[supplements in health]      -> DISCOVER.SUPPLEMENTS(45)  HEALTH.SUPPLEMENTS(42)   ✗
[open supplements in health] -> DISCOVER.SUPPLEMENTS(45)  HEALTH.SUPPLEMENTS(42)   ✗
```
**Why:** `DISCOVER.SUPPLEMENTS`'s `when_to_visit` literally contained the string **`HEALTH.SUPPLEMENTS`** — the tokenizer read that as the token "health", so the *marketplace* entry matched "health" and got spuriously boosted on every health-qualified query.

## Fix (gateway catalog only — the Health page already re-syncs `?mode=`)
- Remove the `HEALTH.SUPPLEMENTS` token from `DISCOVER.SUPPLEMENTS`'s `when_to_visit` (en + de) → no more spurious "health" match (DISCOVER drops 45 → 27 on health queries).
- Strengthen `HEALTH.SUPPLEMENTS`'s health-token coverage (description + `when_to_visit` + aliases `supplements-in-health` / `supplements-health`).

Verified against the scorer:
```
[supplements in health]      -> HEALTH.SUPPLEMENTS(75)   ✓
[open supplements in health] -> HEALTH.SUPPLEMENTS(45)   ✓
[health supplements]         -> HEALTH.SUPPLEMENTS(75)   ✓
[my supplements]             -> HEALTH.SUPPLEMENTS(64)   ✓
[show me supplements]        -> DISCOVER.SUPPLEMENTS(27) ✓ (generic → shop, preserved)
[buy supplements]            -> DISCOVER.SUPPLEMENTS(75) ✓
```

## Tests
Added regression cases to `navigation-catalog.test.ts` (both the Health-tab phrasings and the preserved marketplace phrasings). `jest` → **242 passed**; `tsc --noEmit` clean.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_