### PR TITLE
fix(nav): route "Following" to the Events Following tab (COMM.FEED)

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -2312,10 +2312,10 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
   {
     screen_id: 'COMM.FEED', route: '/comm/events-meetups?tab=following', category: 'community',
     access: 'authenticated', anonymous_safe: false,
-    aliases: ['feed', 'community-feed', 'community/feed', '/community/feed'],
+    aliases: ['feed', 'community-feed', 'community/feed', '/community/feed', 'following', 'following-events', 'events-following', 'following-feed'],
     i18n: {
-      en: { title: 'Community Feed', description: 'Your community feed — posts and updates from members and groups you follow.', when_to_visit: 'When the user asks to open the community feed, see community posts, scroll the feed, or check what is new in the community.' },
-      de: { title: 'Community-Feed', description: 'Dein Community-Feed — Posts und Updates von Mitgliedern und Gruppen, denen du folgst.', when_to_visit: 'Wenn der Nutzer den Community-Feed öffnen, Community-Posts sehen, durch den Feed scrollen oder prüfen möchte, was es Neues in der Community gibt.' },
+      en: { title: 'Following Community Feed', description: 'The Following tab of Events & Meetups — your community feed of events, posts, and updates from the members and groups you follow (Following).', when_to_visit: 'When the user asks for the Following tab of Events & Meetups, following, following events, events from people they follow, the people or groups they follow, or to open the community feed and see community posts and updates.' },
+      de: { title: 'Following Community-Feed', description: 'Der „Folge ich"-Tab von Events & Meetups — dein Community-Feed mit Events, Posts und Updates von Mitgliedern und Gruppen, denen du folgst (Following).', when_to_visit: 'Wenn der Nutzer nach dem „Folge ich"-Tab von Events & Meetups, nach Following, nach Events von Personen, denen er folgt, nach den Personen oder Gruppen, denen er folgt, oder nach dem Community-Feed mit Community-Posts und Updates fragt.' },
     },
   },
 

--- a/services/gateway/test/navigation-catalog.test.ts
+++ b/services/gateway/test/navigation-catalog.test.ts
@@ -177,6 +177,12 @@ const ROUTING_CASES: RoutingCase[] = [
   { utterance: 'I want to attend a meetup',                 lang: 'en', expected_screen_id: 'COMM.EVENTS' },
   { utterance: 'wo finde ich die treffen',                  lang: 'de', expected_screen_id: 'COMM.EVENTS' },
   { utterance: 'zeig mir die kommenden veranstaltungen',    lang: 'de', expected_screen_id: 'COMM.EVENTS_UPCOMING' },
+  // Following tab of Events & Meetups (COMM.FEED) — must not fall through to a
+  // generic events tab just because "following" matched no entry before.
+  { utterance: 'following',                                 lang: 'en', expected_screen_id: 'COMM.FEED' },
+  { utterance: 'following events',                          lang: 'en', expected_screen_id: 'COMM.FEED' },
+  { utterance: 'events from people I follow',               lang: 'en', expected_screen_id: 'COMM.FEED' },
+  { utterance: 'community feed',                            lang: 'en', expected_screen_id: 'COMM.FEED' },
 
   // ── COMM.LIVE_ROOMS ──
   { utterance: 'open the live rooms',                       lang: 'en', expected_screen_id: 'COMM.LIVE_ROOMS' },


### PR DESCRIPTION
## Root cause (live trace + real scorer)
"Following" (and "following events") resolved to **`COMM.EVENTS_UPCOMING`** instead of **`COMM.FEED`** (the Following tab of Events & Meetups). The trace showed *"user chose following events" → COMM.EVENTS_UPCOMING*.

Probing `searchCatalog`:
```
[following]        -> (no results)
[following events] -> COMM.EVENTS(30)  COMM.EVENTS_UPCOMING(24)   ✗
```
**Why:** `COMM.FEED` was framed only as "Community Feed" — **no entry contained the token "following"** (entries said "follow"/"folgst", and the scorer doesn't stem). So the "following" query token matched *nothing*, leaving only "events" to score → the generic events tabs won.

## Fix (gateway catalog only — Events page already honors `?tab=following`)
Make `COMM.FEED` carry "following": title **"Following Community Feed"**, aliases `following` / `following-events` / `events-following` / `following-feed`, and "following" in description + `when_to_visit`. The title keeps the contiguous phrase "community feed" so that query still wins.

Verified against the scorer:
```
[following]                 -> COMM.FEED(64) ✓
[following events]          -> COMM.FEED(75) ✓
[following tab]             -> COMM.FEED(54) ✓
[events I am following]     -> COMM.FEED(45) ✓
[open following in events]  -> COMM.FEED(45) ✓
[community feed]            -> COMM.FEED(100) ✓ (preserved)
[upcoming events]           -> COMM.EVENTS_UPCOMING(100) ✓ (unaffected)
[show me hot events]        -> COMM.EVENTS_HOT(57) ✓ (unaffected)
```

## Tests
Added regression cases. `jest` → **246 passed**; `tsc --noEmit` clean.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_