### PR TITLE
fix(nav): recover invented screen_ids via reason/intent in navigate_to_screen

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -37,6 +37,7 @@ import {
   lookupByRoute,
   suggestSimilar,
   suggestSimilarScored,
+  searchCatalog,
   FUZZY_NAV_MIN_SCORE,
   resolveEffectiveRoles,
   getContent,
@@ -2534,8 +2535,46 @@ export async function tool_navigate_to_screen(
 
   const { emitOasisEvent } = await import('./oasis-event-service');
 
-  // Three-tier resolution: exact → alias → fuzzy.
+  // Three-tier resolution: exact → alias → intent-recovery → fuzzy.
   let entry: NavCatalogEntry | null = lookupScreen(screenIdArg) || lookupByAlias(screenIdArg);
+
+  // VTID-NAV-RECOVER: the model sometimes invents a screen_id that does not
+  // exist (e.g. 'EVENTS.FOLLOWING', 'COMM.EVENTS_MEETUPS'). String-fuzzy then
+  // maps it by surface similarity to the wrong screen — usually the parent
+  // (COMM.EVENTS → Hot) instead of the intended tab. The natural-language
+  // `reason` the model supplies IS reliable intent, so re-derive the target
+  // with the same catalog scorer the free-text `navigate` tool uses, preferring
+  // the reason over the de-slugged (and possibly misleading) screen_id tokens.
+  // Only adopt it on a clear win, otherwise fall through to the fuzzy gate.
+  if (!entry) {
+    const reasonText = typeof args.reason === 'string' ? args.reason.trim() : '';
+    const deslug = screenIdArg.replace(/[._/\-]+/g, ' ').trim();
+    const recoverQuery = reasonText.length >= 4 ? reasonText : deslug;
+    if (recoverQuery) {
+      const recovered = searchCatalog(recoverQuery, lang);
+      const top = recovered[0];
+      const second = recovered[1];
+      if (top && top.score >= 30 && top.score - (second?.score ?? 0) >= 6) {
+        entry = top.entry;
+        emitOasisEvent({
+          vtid: 'VTID-NAV-01',
+          type: 'orb.navigator.blocked',
+          source: 'orb-tools-shared',
+          status: 'info',
+          message: `Recovered invented screen_id '${screenIdArg}' → '${entry.screen_id}' via reason/intent (score ${top.score})`,
+          payload: {
+            session_id: sessionId,
+            attempted_screen_id: screenIdArg,
+            resolved_screen_id: entry.screen_id,
+            recover_score: top.score,
+            recover_query: recoverQuery.slice(0, 120),
+            error_kind: 'intent_recovered',
+          },
+        }).catch(() => {});
+      }
+    }
+  }
+
   if (!entry) {
     // VTID-NAV-CONFIDENCE (VTID-03258): only auto-resolve a fuzzy match when it clears the
     // confidence floor. A weak best-match (title-word-only overlap) is NOT a


### PR DESCRIPTION
## Root cause (live trace)
"Following" and "Upcoming" both opened **Hot**. The trace showed these went through the **`navigate_to_screen`** path (not the free-text `navigate` path that #2642 tuned), where the model **invented** screen_ids:
```
"following" → screen_id 'EVENTS.FOLLOWING'    → fuzzy → COMM.EVENTS (Hot)  ✗
"upcoming"  → screen_id 'COMM.EVENTS_MEETUPS' → fuzzy → COMM.EVENTS (Hot)  ✗
```
`navigate_to_screen` resolves exact → alias → **string-fuzzy**. The invented ids don't match exactly or by alias, and string-fuzzy maps them by surface similarity to the **parent** `COMM.EVENTS` (they share the token "EVENTS"), never the intended tab. Pure screen-id string similarity fundamentally can't reach `COMM.FEED`/`COMM.EVENTS_UPCOMING` from those guesses.

## Fix
Add an **intent-recovery** tier between alias and fuzzy: when the screen_id is unresolvable, re-derive the target with the same `searchCatalog` scorer the free-text `navigate` tool uses, **preferring the model's natural-language `reason`** (which is reliable intent) over the de-slugged screen_id tokens. Adopt only on a clear win (top score ≥ 30 and ≥ 6 above the runner-up); otherwise fall through to the existing fuzzy confidence gate (which asks the user).

Verified against the scorer using the **exact reasons from the trace**:
```
'EVENTS.FOLLOWING'    + "...the 'following' screen..."     → COMM.FEED            ✓
'COMM.EVENTS_MEETUPS' + "...the upcoming events list"      → COMM.EVENTS_UPCOMING ✓
'EVENTS.TODAY'        + "...today's events"                → COMM.EVENTS_TODAY    ✓
'COMM.EVENTS_HOT'     + "...the hot events"                → COMM.EVENTS_HOT      ✓
'ZZZ.NONSENSE'        + "asdf qwer zxcv"                   → falls through (no teleport) ✓
```

This is general — it makes **every** surface robust to the model inventing tab screen_ids, not just Events.

## Tests
`tsc --noEmit` clean; `jest` nav suite **246 passed**, navigate-related suites **21 passed**. Emits an `intent_recovered` telemetry payload (mirrors the existing `fuzzy_resolved` event) for observability.

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_