### PR TITLE
DEV-COMHU-2644: Fix KB checklist filter layout + scroll jump on topic select

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -5260,11 +5260,22 @@ function renderApp() {
         var moduleScroller = document.querySelector('.module-content-wrapper');
         var preservedModuleScrollTop = moduleScroller ? moduleScroller.scrollTop : 0;
         var preservedWindowY = window.scrollY || 0;
+        // Views with their own scroll containers (e.g. the KB checklist's topic
+        // table) tag them with data-preserve-scroll="<unique-key>" to survive
+        // the full-DOM rebuild — same rationale as the module-wrapper restore.
+        var preservedScrollers = {};
+        document.querySelectorAll('[data-preserve-scroll]').forEach(function (el) {
+            if (el.scrollTop > 0) preservedScrollers[el.getAttribute('data-preserve-scroll')] = el.scrollTop;
+        });
         _renderAppCore();
         var newModule = document.querySelector('.module-content-wrapper');
         if (newModule && preservedModuleScrollTop > 0) {
             newModule.scrollTop = preservedModuleScrollTop;
         }
+        Object.keys(preservedScrollers).forEach(function (key) {
+            var el = document.querySelector('[data-preserve-scroll="' + key + '"]');
+            if (el) el.scrollTop = preservedScrollers[key];
+        });
         if (preservedWindowY > 0) window.scrollTo(0, preservedWindowY);
     });
 }
@@ -6450,6 +6461,10 @@ function kbSelectTopic(id) {
     s.selectedId = id;
     var t = s.topics.find(function (x) { return x.topicId === id; });
     s.editor = t ? JSON.parse(JSON.stringify(t)) : null;
+    // New topic = new editor content: start its pane at the top (zeroing it now
+    // means renderApp's scroll preservation won't carry the old position over).
+    var ed = document.querySelector('[data-preserve-scroll="kb-checklist-editor"]');
+    if (ed) ed.scrollTop = 0;
     renderApp();
 }
 
@@ -6837,36 +6852,40 @@ function renderKbChecklistView() {
 
     if (s.view === 'versions') { root.appendChild(renderKbVersions()); return root; }
 
-    // Filters
+    // Filters — single compact row. .form-control is width:100% globally, so
+    // each control must override it (flex sizing) or they stack one per line.
     var filters = kbEl('div', 'admin-toolbar');
-    filters.style.display = 'flex'; filters.style.gap = '0.5rem'; filters.style.flexWrap = 'wrap'; filters.style.padding = '0.25rem 0';
+    filters.style.display = 'flex'; filters.style.gap = '0.5rem'; filters.style.flexWrap = 'wrap';
+    filters.style.alignItems = 'center'; filters.style.padding = '0.25rem 0';
+    function inRow(el, flex) { el.style.width = 'auto'; el.style.minWidth = '0'; el.style.flex = flex; return el; }
     var search = document.createElement('input');
     search.type = 'text'; search.className = 'form-control'; search.placeholder = 'Search label…'; search.value = s.filters.search;
     search.oninput = function (ev) { s.filters.search = ev.target.value; };
     search.onkeydown = function (ev) { if (ev.key === 'Enter') fetchKbChecklist(); };
-    filters.appendChild(search);
+    filters.appendChild(inRow(search, '2 1 10rem'));
     // VTID-03288: Session # filter — also the target for per-session AI regeneration.
     var sessionInput = document.createElement('input');
     sessionInput.type = 'number'; sessionInput.min = '1'; sessionInput.max = '90';
-    sessionInput.className = 'form-control'; sessionInput.placeholder = 'Session #'; sessionInput.style.width = '7rem';
+    sessionInput.className = 'form-control'; sessionInput.placeholder = 'Session #';
     sessionInput.value = s.filters.session;
     sessionInput.onchange = function (ev) { s.filters.session = ev.target.value; fetchKbChecklist(); };
-    filters.appendChild(sessionInput);
+    filters.appendChild(inRow(sessionInput, '0 1 7rem'));
     function sel(options, current, onchange) {
         var el = document.createElement('select'); el.className = 'form-control';
         options.forEach(function (o) { var op = document.createElement('option'); op.value = o.v; op.textContent = o.t; if (o.v === current) op.selected = true; el.appendChild(op); });
         el.onchange = onchange; return el;
     }
-    filters.appendChild(sel(
+    filters.appendChild(inRow(sel(
         [{ v: '', t: 'All chapters' }, { v: 'basics', t: 'basics' }, { v: 'daily_use', t: 'daily_use' }, { v: 'community', t: 'community' }, { v: 'health', t: 'health' }, { v: 'intelligence', t: 'intelligence' }, { v: 'discovery', t: 'discovery' }],
-        s.filters.chapter, function (ev) { s.filters.chapter = ev.target.value; fetchKbChecklist(); }));
-    filters.appendChild(sel(
+        s.filters.chapter, function (ev) { s.filters.chapter = ev.target.value; fetchKbChecklist(); }), '1 1 8rem'));
+    filters.appendChild(inRow(sel(
         [{ v: '', t: 'All status' }, { v: 'draft', t: 'draft' }, { v: 'published', t: 'published' }, { v: 'disabled', t: 'disabled' }],
-        s.filters.status, function (ev) { s.filters.status = ev.target.value; fetchKbChecklist(); }));
-    filters.appendChild(sel(
+        s.filters.status, function (ev) { s.filters.status = ev.target.value; fetchKbChecklist(); }), '1 1 8rem'));
+    filters.appendChild(inRow(sel(
         [{ v: '', t: 'All gates' }, { v: 'curious', t: 'curious' }, { v: 'active', t: 'active' }, { v: 'builder', t: 'builder' }],
-        s.filters.businessGate, function (ev) { s.filters.businessGate = ev.target.value; fetchKbChecklist(); }));
+        s.filters.businessGate, function (ev) { s.filters.businessGate = ev.target.value; fetchKbChecklist(); }), '1 1 8rem'));
     var applyBtn = kbEl('button', 'btn btn-sm btn-secondary', 'Apply');
+    applyBtn.style.flex = 'none';
     applyBtn.onclick = fetchKbChecklist;
     filters.appendChild(applyBtn);
     root.appendChild(filters);
@@ -6911,6 +6930,10 @@ function renderKbChecklistView() {
     // clipping here and give each pane its own bounded scroll so all 250 topics
     // are reachable regardless of window height.
     root.style.overflowY = 'auto';
+    // Selecting a topic re-renders the whole app; these containers carry
+    // data-preserve-scroll so renderApp() restores their position instead of
+    // snapping the list/editor back to the top.
+    root.setAttribute('data-preserve-scroll', 'kb-checklist-root');
     var split = kbEl('div', 'admin-split-layout');
     split.style.display = 'flex'; split.style.gap = '1rem'; split.style.alignItems = 'flex-start';
     split.style.flex = 'none'; split.style.overflow = 'visible'; split.style.minHeight = '0';
@@ -6918,10 +6941,12 @@ function renderKbChecklistView() {
     left.style.overflow = 'visible'; left.style.minHeight = '0';
     var tbl = renderKbTable();
     tbl.style.flex = 'none'; tbl.style.maxHeight = '72vh'; tbl.style.overflowY = 'auto';
+    tbl.setAttribute('data-preserve-scroll', 'kb-checklist-table');
     left.appendChild(tbl);
     split.appendChild(left);
     var right = kbEl('div', 'admin-split-right'); right.style.flex = '1'; right.style.minWidth = '0';
     right.style.overflow = 'visible'; right.style.maxHeight = '72vh'; right.style.overflowY = 'auto';
+    right.setAttribute('data-preserve-scroll', 'kb-checklist-editor');
     right.appendChild(renderKbEditor());
     split.appendChild(right);
     root.appendChild(split);

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0504-audio-ready-r3"></script>
-  <script src="/command-hub/app.js?v=20260609-vtid-03288-scrollfix"></script>
+  <script src="/command-hub/app.js?v=20260610-kb-filters-scroll"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
   <!-- Phase 0 staging build (P0.5): PUBLISH→staging-source card + CLOCK revert -->


### PR DESCRIPTION
## Problem

Two UX defects on the Command Hub **Knowledge Base — Guided Journey Checklist** page (`/command-hub/knowledge-base/checklist/`):

1. **Filters stacked vertically** — search, Session #, chapter, status, and gate filters each took a full row, pushing the actual topic table below the fold. Root cause: the global `.form-control { width: 100% }` rule forces every control onto its own flex line despite the row being `display:flex`.
2. **Page jumps to top on topic selection** — clicking a row calls `kbSelectTopic()` → `renderApp()`, which rebuilds the entire DOM. The checklist view's own scroll containers (screen root, topic table, editor pane) were rebuilt at `scrollTop=0`. The existing scroll preservation in `renderApp()` only covered `.module-content-wrapper` and the window.

## Fix

- **One-row filters**: each filter control now overrides the global width with flex sizing (`width:auto; flex: 1 1 …`), so all five filters + Apply share a single row and wrap gracefully on narrow screens.
- **Generic scroll preservation**: `renderApp()` now captures/restores `scrollTop` for any element tagged `data-preserve-scroll="<key>"`, alongside the existing module-wrapper/window restore. The checklist root, topic table, and editor pane are tagged.
- **Editor reset on topic switch**: selecting a *different* topic intentionally zeroes the editor pane scroll (new content starts at top) while the topic list keeps its position.
- Bumped the `?v=` cache-busting parameter on `app.js` in `index.html`.

## Verification

Playwright's browser CDN is blocked by this environment's network policy, so verification was done DOM-level with jsdom (loading the real `app.js`, rendering `renderKbChecklistView()` with stubbed state, and exercising `kbSelectTopic()` through the real `renderApp()` rAF path). All 11 checks pass:

- 5 filter controls in a flex/wrap row, each with `width:auto` + flex sizing
- root / table / editor tagged with `data-preserve-scroll`
- table `scrollTop=437` survives topic selection and re-render (twice)
- editor pane resets to top on topic switch and shows the newly selected topic

Post-merge this auto-deploys to **staging** (`STAGE-DEPLOY.yml`); verify on `preview-gateway.vitanaland.com`, then promote via the PUBLISH button.

https://claude.ai/code/session_01N7DWvFjaJkwsBrbxDZyhc3

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7DWvFjaJkwsBrbxDZyhc3)_