### PR TITLE
fix(orb): guided fast first-audio (skip bootstrap) + auto-close after teaching (VTID-03294 / DEV-COMHU-0510)

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -238,6 +238,9 @@
     // explicit user re-open (_show). Every reconnect/session-start path checks
     // it and bails, so pressing X always tears down and nothing re-opens.
     _userRequestedClose: false,
+    // VTID-03294 (#4): when true, the overlay auto-closes after the first
+    // (teaching) turn finishes — set by focusGuidedTopic, one-shot.
+    guidedAutoClose: false,
     // VTID-02020: contextual recovery state. _preDisconnectStage captures what
     // the user was doing when the network dropped (idle / listening_user_speaking
     // / thinking / speaking) so the backend's recovery prompt can decide
@@ -1633,6 +1636,17 @@
               try { _cfg.onTurnComplete({ was_greeting: !_s.greetingComplete }); }
               catch (e) { /* host callback must never break the voice loop */ }
             }
+            // VTID-03294 (#4): GUIDED auto-close. The teaching turn (turn 1,
+            // greetingComplete still false) has finished playing — close the
+            // overlay so the underlying Topic drawer's next-step buttons are
+            // usable, instead of dropping to listening. Widget-side so it does
+            // not depend on the host wiring. One-shot (cleared here).
+            if (_s.guidedAutoClose && !_s.greetingComplete) {
+              _s.guidedAutoClose = false;
+              console.log('[VTOrb] guided teaching turn complete — auto-closing overlay (reveal drawer)');
+              _hide();
+              return;
+            }
             // If the host closed the overlay in the callback (guided auto-close),
             // stop here — don't beep / arm the mic on a torn-down session.
             if (!_s.active || _s._userRequestedClose || !_s.overlayVisible) return;
@@ -2741,6 +2755,7 @@
     _s._disconnectActive = false;
     _s._disconnectStuck = false;
     _s._isReconnecting = false;
+    _s.guidedAutoClose = false; // VTID-03294 (#4): clear any pending guided auto-close
     try { clearInterval(_s._recoveryWatchdog); } catch (e) { /* noop */ }
     _s._recoveryWatchdog = null;
     // DEV-COMHU-0503: UI close preserves short-lived continuity (15 min) BEFORE
@@ -3121,6 +3136,11 @@
     // KB. One-shot: consumed by the upcoming _sessionStart only.
     focusGuidedTopic: function (topicId) {
       _s.guidedTopic = (typeof topicId === 'string' && topicId) ? topicId : null;
+      // VTID-03294 (#4): a guided-topic open AUTO-CLOSES the overlay once Vitana
+      // finishes the teaching turn (reveals the drawer's next-step buttons),
+      // instead of dropping to listening. Set AFTER _s.guidedTopic; _show() does
+      // not touch it. Consumed/reset on the first turn-complete or on _hide.
+      _s.guidedAutoClose = true;
       _show();
     },
     // DEV-COMHU-0503: intentional forget (logout / account switch / start over).

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -709,9 +709,38 @@ export async function handleLiveSessionStart(
   // awaited by connectToLiveAPI's ws.on('open') handler.
   let contextReadyPromise: Promise<void> | undefined;
 
+  // VTID-03294: a Guided-Journey topic tap needs ZERO context — Vitana just
+  // picks up the KB lesson and speaks it. Detect it here so we can skip the
+  // heavy Brain/memory/history/admin bootstrap (the 7-10s first-audio delay).
+  const isGuidedTopicSession =
+    typeof (body as any).guided_topic_id === 'string' && !!(body as any).guided_topic_id;
+
   if (isAnonymousSession) {
     contextBootstrapSkippedReason = 'anonymous_session';
     console.log(`[VTID-ANON] Anonymous session ${sessionId} — skipping memory, tools, lastSessionInfo. Context: city=${clientContext.city || 'unknown'}`);
+  } else if (isGuidedTopicSession && bootstrapIdentity) {
+    // VTID-03294: GUIDED FAST PATH. The lesson (spoken verbatim) + the GUIDE-MODE
+    // (TEACH) block carry everything; the model only needs a short persona. We
+    // skip the Brain context, memory, last-session, role lookup, admin briefing
+    // and Autopilot offer entirely so first audio is ~real-time instead of
+    // 7-10s. contextReadyPromise resolves in a microtask, so the setup-message
+    // await in connectToLiveAPI is ~0ms.
+    contextBootstrapSkippedReason = 'guided_topic_minimal';
+    sseActiveRole = 'community';
+    const isDe = (lang || 'en').toLowerCase().startsWith('de');
+    const minimalGuidedContext = isDe
+      ? 'Du bist Vitana — die warme, ruhige Stimme der Vitanaland-Langlebigkeits-Community. Du stellst gerade ein Thema aus der geführten Reise vor und erklärst es. Halte dich an die dir vorgegebene Lektion.'
+      : 'You are Vitana — the warm, calm voice of the Vitanaland longevity community. You are introducing and teaching one Guided Journey topic. Stay on the lesson you are given.';
+    contextReadyPromise = Promise.resolve().then(() => {
+      session.active_role = 'community';
+      session.lastSessionInfo = null;
+      session.contextInstruction = minimalGuidedContext;
+      session.contextPack = undefined;
+      session.contextBootstrapLatencyMs = 0;
+      session.contextBootstrapSkippedReason = 'guided_topic_minimal';
+      session.contextBootstrapBuiltAt = Date.now();
+    });
+    console.log(`[VTID-03294] Guided-topic session ${sessionId}: minimal context (skipped heavy bootstrap) for fast first audio`);
   } else if (bootstrapIdentity) {
     const usingDevFallback = bootstrapIdentity.user_id === DEV_IDENTITY.USER_ID;
     console.log(`[VTID-01224] Building bootstrap context for SSE session ${sessionId} user=${bootstrapIdentity.user_id.substring(0, 8)}...${usingDevFallback ? ' (DEV_IDENTITY fallback)' : ''}`);


### PR DESCRIPTION
Two remaining guided-ORB issues from the staging test.

**#2 — 7-10s start → ~real-time.** A guided-topic tap needs ZERO context. The session-start was running the full Brain+memory+history+admin+autopilot bootstrap (~19089-char system instruction; the setup message *awaits* it). Added a **guided fast path** in `live-session-controller`: when `guided_topic_id` is set, skip the heavy bootstrap, use a short Vitana persona, and resolve `contextReadyPromise` in a microtask (await ~0ms). The lesson (spoken verbatim) + GUIDE-MODE block carry everything.

**#4 — auto-close after teaching.** The overlay now closes after the teaching turn (revealing the Topic drawer's next-step buttons) instead of dropping to listening. Done **widget-side** (`focusGuidedTopic` arms `_s.guidedAutoClose`; `turn_complete` closes on the first turn) so it doesn't depend on host wiring. One-shot.

Build clean, 23 tests green (provider + wake-brief-wiring). Staging only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)