### PR TITLE
fix(orb): X always closes (instant teardown) + guided lesson in session language (VTID-03295 / DEV-COMHU-0511)

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -2763,12 +2763,12 @@
     try { clearInterval(_s._recoveryWatchdog); } catch (e) { /* noop */ }
     _s._recoveryWatchdog = null;
     // VTID-03295 (X-close fix): STOP AUDIO + CLOSE THE OVERLAY SYNCHRONOUSLY, the
-    // instant X is pressed — BEFORE _sessionStop's async/network teardown. The bug:
-    // _sessionStop() `await`s the /session/stop fetch BEFORE it stops the scheduled
-    // audio sources, so while Vitana was mid-lesson the audio kept playing and the
+    // instant X is pressed — BEFORE the async/network teardown. The bug: the stop
+    // routine awaited the /session/stop fetch BEFORE it stopped the scheduled audio
+    // sources, so while Vitana was mid-lesson the audio kept playing and the
     // teardown stalled on the network → the overlay felt un-closeable. Here we kill
     // playback + mark the session dead first, so X always silences + closes now;
-    // the network cleanup runs fire-and-forget in _sessionStop.
+    // the network cleanup runs fire-and-forget afterwards.
     _s.active = false;
     if (_s.scheduledSources) {
       for (var _i = 0; _i < _s.scheduledSources.length; _i++) {

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1445,15 +1445,19 @@
       try { __es.close(); } catch (e) { /* noop */ }
     }
 
-    // Stop backend session
+    // Stop backend session — VTID-03295: FIRE-AND-FORGET (keepalive), never
+    // `await`. Awaiting the network here stalled teardown behind a slow/hung
+    // request while audio was still playing (the un-closeable-overlay bug). The
+    // overlay + audio are already torn down synchronously in _hide; this is just
+    // best-effort server cleanup.
     if (_s.sessionId) {
       try {
         var headers = { 'Content-Type': 'application/json' };
         if (_cfg.token) headers['Authorization'] = 'Bearer ' + _cfg.token;
-        await fetch(_cfg.gw + '/api/v1/orb/live/session/stop', {
-          method: 'POST', headers: headers,
+        fetch(_cfg.gw + '/api/v1/orb/live/session/stop', {
+          method: 'POST', headers: headers, keepalive: true,
           body: JSON.stringify({ session_id: _s.sessionId })
-        });
+        }).catch(function () { /* ignore */ });
       } catch (e) { /* ignore */ }
     }
 
@@ -2758,18 +2762,34 @@
     _s.guidedAutoClose = false; // VTID-03294 (#4): clear any pending guided auto-close
     try { clearInterval(_s._recoveryWatchdog); } catch (e) { /* noop */ }
     _s._recoveryWatchdog = null;
-    // DEV-COMHU-0503: UI close preserves short-lived continuity (15 min) BEFORE
-    // teardown, so reopening within the window resumes instead of greeting
-    // first-time. _sessionStop still tears down media/SSE exactly as before.
-    _persistContinuity('hide', 15);
-    _sessionStop();
-    _restoreSoundscape();
+    // VTID-03295 (X-close fix): STOP AUDIO + CLOSE THE OVERLAY SYNCHRONOUSLY, the
+    // instant X is pressed — BEFORE _sessionStop's async/network teardown. The bug:
+    // _sessionStop() `await`s the /session/stop fetch BEFORE it stops the scheduled
+    // audio sources, so while Vitana was mid-lesson the audio kept playing and the
+    // teardown stalled on the network → the overlay felt un-closeable. Here we kill
+    // playback + mark the session dead first, so X always silences + closes now;
+    // the network cleanup runs fire-and-forget in _sessionStop.
+    _s.active = false;
+    if (_s.scheduledSources) {
+      for (var _i = 0; _i < _s.scheduledSources.length; _i++) {
+        try { _s.scheduledSources[_i].stop(); } catch (e) { /* ok */ }
+      }
+      _s.scheduledSources = [];
+    }
+    _s.audioQueue = [];
+    _s.audioPlaying = false;
     _s.overlayVisible = false;
     if (_root) {
       _root.classList.remove('vtorb-visible');
       _root.style.display = 'none';
     }
     _updateUI();
+    // DEV-COMHU-0503: UI close preserves short-lived continuity (15 min) BEFORE
+    // teardown, so reopening within the window resumes instead of greeting
+    // first-time. _sessionStop tears down media/SSE + fires /session/stop.
+    _persistContinuity('hide', 15);
+    _sessionStop();
+    _restoreSoundscape();
     if (_cfg.onClose) try { _cfg.onClose(); } catch (e) { /* ignore */ }
   }
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7228,12 +7228,23 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
     // stuck-connecting, no-speech bug). We drop the "ONE short utterance" clamp so
     // the whole lesson is spoken, but keep it a quote so audio stays reliable.
     const isGuidedTeach = !!(session as any).guidedTopicNarrationContent;
-    const guidedTeachTriggerByLang: Record<string, string> = {
-      en: `Say the following VERBATIM and IN FULL — word for word, then stop and listen. Do NOT summarize, shorten, paraphrase, translate, or add a greeting/question: "${safe}"`,
-      de: `Sage Folgendes WÖRTLICH und VOLLSTÄNDIG — Wort für Wort, dann höre auf und höre zu. NICHT zusammenfassen, kürzen, umformulieren, übersetzen oder eine Begrüßung/Frage hinzufügen: "${safe}"`,
+    // VTID-03295: the KB content is German (v1). For a GERMAN session, speak it
+    // verbatim (proven-reliable audio). For ANY OTHER language, instruct the model
+    // to TRANSLATE the lesson into the session language and speak only that — a
+    // bounded transformation that keeps audio reliable (unlike a long "teach"
+    // instruction, which goes text-only). A per-language KB later removes the
+    // translation step. Fixes "English user gets a German lesson".
+    const _guidedIsDe = (lang || 'en').toLowerCase().startsWith('de');
+    const _GUIDED_LANG_NAMES: Record<string, string> = {
+      en: 'English', de: 'German', es: 'Spanish', fr: 'French',
+      sr: 'Serbian', ar: 'Arabic', zh: 'Chinese', ru: 'Russian', it: 'Italian', pt: 'Portuguese',
     };
+    const _guidedLangName = _GUIDED_LANG_NAMES[(lang || 'en').slice(0, 2).toLowerCase()] || 'English';
+    const guidedTeachTrigger = _guidedIsDe
+      ? `Sage Folgendes WÖRTLICH und VOLLSTÄNDIG — Wort für Wort, dann höre auf und höre zu. NICHT zusammenfassen, kürzen, umformulieren oder eine Begrüßung/Frage hinzufügen: "${safe}"`
+      : `Say the following lesson to the user in fluent ${_guidedLangName}. The text may be in another language — translate it faithfully and completely into ${_guidedLangName} and speak ONLY that translation, then stop and listen. Do NOT summarize, shorten, add a greeting, or ask a question: "${safe}"`;
     const wakePrompt = isGuidedTeach
-      ? (guidedTeachTriggerByLang[lang] || guidedTeachTriggerByLang.en)
+      ? guidedTeachTrigger
       : (wakeTriggerByLang[lang] || wakeTriggerByLang.en);
     const linePreview = safe.length > 160 ? safe.slice(0, 160) + '...' : safe;
     const promptPreview = wakePrompt.length > 200 ? wakePrompt.slice(0, 200) + '...' : wakePrompt;


### PR DESCRIPTION
Two issues from the latest staging test.

**X won't close during the lesson.** `_sessionStop` **awaited** the `/session/stop` network call *before* stopping the scheduled audio sources — so tapping X mid-lesson left Vitana talking and stalled teardown on the network → overlay felt un-closeable. Now `_hide` stops audio + closes the overlay **synchronously** (kills scheduled sources, `active=false`, `display=none`) the instant X is pressed; `/session/stop` is **fire-and-forget** (keepalive), never awaited. Matches the documented teardown order.

**English user hears a German lesson.** The KB content is German (v1). The guided trigger is now **language-aware**: German session → speak verbatim (proven reliable audio); any other language → **translate** the lesson into the session language and speak only that (bounded transform, keeps audio reliable). A per-language KB later removes the translation step.

Build clean, 7/7 provider tests green. Staging only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)