### PR TITLE
Guided Journey backend: +2 Vitana Index on listen + curriculum localization

### DIFF
--- a/.github/workflows/JOURNEY-TRANSLATIONS-BACKFILL.yml
+++ b/.github/workflows/JOURNEY-TRANSLATIONS-BACKFILL.yml
@@ -1,0 +1,52 @@
+# BOOTSTRAP-GUIDED-JOURNEY-POPUP — backfill Guided Journey curriculum translations.
+#
+# Manual, on-demand: translates the current PUBLISHED curriculum snapshot into
+# en/es/sr via Gemini and upserts into `journey_checklist_translations`. Run it
+# after publishing a new curriculum version (or to add a locale). Idempotent —
+# safe to re-run; upserts on (topic_id, locale).
+#
+# Binds the secrets the standalone script needs (this is also what satisfies the
+# Impact Scan's env-var binding rule for GEMINI / model vars).
+name: Journey Translations Backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      locales:
+        description: 'Comma-separated locales to generate (en,es,sr)'
+        required: true
+        default: 'en,es,sr'
+      curriculum:
+        description: 'Curriculum version'
+        required: false
+        default: 'v2'
+      limit:
+        description: 'Max topics (blank = all)'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Preview without writing / spending tokens'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run translation backfill
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_GEMINI_API_KEY }}
+          GEMINI_TRANSLATE_MODEL: ${{ vars.GEMINI_TRANSLATE_MODEL }}
+        run: |
+          node scripts/journey/generate-checklist-translations.mjs \
+            --locale="${{ inputs.locales }}" \
+            --curriculum="${{ inputs.curriculum }}" \
+            ${{ inputs.limit && format('--limit={0}', inputs.limit) || '' }} \
+            ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -1024,5 +1024,50 @@ training_cycle_days (
 
 ---
 
+### journey_session_index_awards (BOOTSTRAP-GUIDED-JOURNEY-POPUP)
+
+Idempotent ledger of Vitana Index points earned by **listening** to a Guided
+Journey session (+2 per distinct topic). Summed and applied as an additive
+overlay on the user-facing Vitana Index read (`fetchVitanaIndexSnapshot`) — it
+is **never** written into `vitana_index_scores`, so stored daily health history
+stays clean and the bonus is recompute-safe + trivially reversible.
+
+```
+journey_session_index_awards (
+  user_id UUID, topic_id TEXT,
+  points INT DEFAULT 2 CHECK (points >= 0),
+  created_at TIMESTAMPTZ,
+  PRIMARY KEY (user_id, topic_id)
+);
+```
+
+**Auth model:** RLS-on, `service_role` bypass; no permissive policy (gateway only).
+
+---
+
+### journey_checklist_translations (BOOTSTRAP-GUIDED-JOURNEY-POPUP)
+
+Per-locale (`en`/`es`/`sr`) translations of the user-facing Guided Journey topic
+content. The curriculum is authored in German (the source of truth lives in
+`journey_checklist_topics` / the published snapshot); the gateway overlays these
+rows onto the snapshot at read time, falling back to German for any missing
+field. Produced by `scripts/journey/generate-checklist-translations.mjs`.
+
+```
+journey_checklist_translations (
+  topic_id TEXT, locale TEXT CHECK (locale IN ('en','es','sr')),
+  display_label TEXT, short_description TEXT,
+  explanation_what_it_is TEXT, explanation_user_benefit TEXT,
+  explanation_when_to_use TEXT, explanation_try_this TEXT,
+  source_version_id UUID,            -- published version translated from
+  updated_at TIMESTAMPTZ,
+  PRIMARY KEY (topic_id, locale)
+);
+```
+
+**Auth model:** RLS-on, `service_role` bypass; no permissive policy (gateway only).
+
+---
+
 **Remember:** This file is the SINGLE SOURCE OF TRUTH for table names.
 When in doubt, CHECK HERE FIRST!

--- a/scripts/journey/generate-checklist-translations.mjs
+++ b/scripts/journey/generate-checklist-translations.mjs
@@ -41,6 +41,12 @@ const LOCALES = String(args.locale || 'en,es,sr')
 const LIMIT = args.limit ? Number(args.limit) : Infinity;
 const DRY_RUN = Boolean(args['dry-run']);
 const MODEL = process.env.GEMINI_TRANSLATE_MODEL || 'gemini-2.5-flash';
+const FORCE = Boolean(args.force); // re-translate even topics that already exist
+
+// Network resilience: no call may hang the whole run.
+const REST_TIMEOUT_MS = 20_000;
+const GEMINI_TIMEOUT_MS = 45_000;
+const MAX_RETRIES = 2; // per call, with backoff
 
 if (!SUPABASE_URL || !SERVICE_ROLE) {
   console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE');
@@ -67,10 +73,11 @@ const FIELDS = [
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-/** PostgREST helper (service role). */
+/** PostgREST helper (service role). Times out so a stalled call can't hang the run. */
 async function rest(path, init = {}) {
   const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
     ...init,
+    signal: AbortSignal.timeout(REST_TIMEOUT_MS),
     headers: {
       apikey: SERVICE_ROLE,
       Authorization: `Bearer ${SERVICE_ROLE}`,
@@ -121,23 +128,32 @@ async function translateTopic(src, locale) {
   if (DRY_RUN) return payload; // echo source — lets you preview without spending tokens
 
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${GEMINI_API_KEY}`;
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      contents: [{ parts: [{ text: prompt }] }],
-      generationConfig: { temperature: 0.3, responseMimeType: 'application/json' },
-    }),
-  });
-  if (!res.ok) throw new Error(`Gemini ${res.status}: ${await res.text()}`);
-  const data = await res.json();
-  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '{}';
-  try {
-    return JSON.parse(text);
-  } catch {
-    console.warn(`  ! unparseable response for a topic; skipping`);
-    return {};
+  // Retry with backoff; each attempt is time-boxed so a stalled connection
+  // can't hang the run. Returns null after exhausting retries → caller skips
+  // the topic (a later re-run fills it in — the script is resumable).
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        signal: AbortSignal.timeout(GEMINI_TIMEOUT_MS),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0.3, responseMimeType: 'application/json' },
+        }),
+      });
+      if (!res.ok) throw new Error(`Gemini ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      const data = await res.json();
+      const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '{}';
+      return JSON.parse(text);
+    } catch (e) {
+      const last = attempt === MAX_RETRIES;
+      console.warn(`  ! ${locale} topic translate ${last ? 'FAILED (skipping)' : `retry ${attempt + 1}/${MAX_RETRIES}`}: ${e?.message || e}`);
+      if (last) return null;
+      await sleep(1000 * (attempt + 1)); // 1s, 2s backoff
+    }
   }
+  return null;
 }
 
 async function main() {
@@ -148,10 +164,27 @@ async function main() {
   );
 
   for (const locale of LOCALES) {
+    // Resume: skip topics already translated for this locale (unless --force),
+    // so a re-run after an interruption only fills the gaps.
+    let done = new Set();
+    if (!DRY_RUN && !FORCE) {
+      const ids = slice.map((t) => t.topicId);
+      const existing = await rest(
+        `journey_checklist_translations?select=topic_id&locale=eq.${locale}&topic_id=in.(${ids.map((i) => `"${i}"`).join(',')})`,
+      );
+      done = new Set((existing || []).map((r) => r.topic_id));
+      if (done.size) console.log(`  [${locale}] resuming — ${done.size} already done, ${slice.length - done.size} to do`);
+    }
+
     let upserts = 0;
+    let skipped = 0;
+    let failed = 0;
     for (const topic of slice) {
+      if (done.has(topic.topicId)) { skipped++; continue; }
       const src = sourceFields(topic);
       const translated = await translateTopic(src, locale);
+      if (translated === null) { failed++; continue; } // skip; a re-run will retry it
+
       const row = { topic_id: topic.topicId, locale, source_version_id: versionId, updated_at: new Date().toISOString() };
       for (const [col] of FIELDS) row[col] = translated[col] ?? null;
 
@@ -163,10 +196,14 @@ async function main() {
         });
       }
       upserts++;
-      if (upserts % 25 === 0) console.log(`  [${locale}] ${upserts}/${slice.length}`);
+      if (upserts % 25 === 0) console.log(`  [${locale}] ${upserts}/${slice.length - done.size}`);
       await sleep(80); // gentle rate-limit
     }
-    console.log(`✓ [${locale}] ${upserts} topics ${DRY_RUN ? 'previewed' : 'upserted'}`);
+    console.log(
+      `✓ [${locale}] ${upserts} ${DRY_RUN ? 'previewed' : 'upserted'}` +
+        `${skipped ? `, ${skipped} skipped (already done)` : ''}` +
+        `${failed ? `, ${failed} FAILED — re-run to retry` : ''}`,
+    );
   }
   console.log('Done.');
 }

--- a/scripts/journey/generate-checklist-translations.mjs
+++ b/scripts/journey/generate-checklist-translations.mjs
@@ -40,7 +40,7 @@ const LOCALES = String(args.locale || 'en,es,sr')
   .filter((s) => ['en', 'es', 'sr'].includes(s));
 const LIMIT = args.limit ? Number(args.limit) : Infinity;
 const DRY_RUN = Boolean(args['dry-run']);
-const MODEL = process.env.GEMINI_TRANSLATE_MODEL || 'gemini-2.0-flash';
+const MODEL = process.env.GEMINI_TRANSLATE_MODEL || 'gemini-2.5-flash';
 
 if (!SUPABASE_URL || !SERVICE_ROLE) {
   console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE');

--- a/scripts/journey/generate-checklist-translations.mjs
+++ b/scripts/journey/generate-checklist-translations.mjs
@@ -79,7 +79,10 @@ async function rest(path, init = {}) {
     },
   });
   if (!res.ok) throw new Error(`REST ${path} → ${res.status} ${await res.text()}`);
-  return res.status === 204 ? null : res.json();
+  // PostgREST returns an EMPTY body for 204 and for return=minimal upserts —
+  // res.json() would throw "Unexpected end of JSON input". Parse only non-empty.
+  const body = await res.text();
+  return body ? JSON.parse(body) : null;
 }
 
 /** Read the current published snapshot (array of topics). */

--- a/scripts/journey/generate-checklist-translations.mjs
+++ b/scripts/journey/generate-checklist-translations.mjs
@@ -168,12 +168,13 @@ async function main() {
     // so a re-run after an interruption only fills the gaps.
     let done = new Set();
     if (!DRY_RUN && !FORCE) {
-      const ids = slice.map((t) => t.topicId);
+      // Fetch all already-translated ids for this locale (robust — no giant
+      // in.() URL). limit high enough for the full curriculum.
       const existing = await rest(
-        `journey_checklist_translations?select=topic_id&locale=eq.${locale}&topic_id=in.(${ids.map((i) => `"${i}"`).join(',')})`,
+        `journey_checklist_translations?select=topic_id&locale=eq.${locale}&limit=5000`,
       );
       done = new Set((existing || []).map((r) => r.topic_id));
-      if (done.size) console.log(`  [${locale}] resuming — ${done.size} already done, ${slice.length - done.size} to do`);
+      if (done.size) console.log(`  [${locale}] resuming — ${done.size} already done, ${Math.max(0, slice.length - done.size)} to do`);
     }
 
     let upserts = 0;

--- a/scripts/journey/generate-checklist-translations.mjs
+++ b/scripts/journey/generate-checklist-translations.mjs
@@ -30,8 +30,9 @@ const args = Object.fromEntries(
 );
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
-const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY;
-const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+// Accept either GEMINI_API_KEY or the workflow's GOOGLE_GEMINI_API_KEY secret.
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || process.env.GOOGLE_GEMINI_API_KEY;
 const CURRICULUM = String(args.curriculum || 'v2');
 const LOCALES = String(args.locale || 'en,es,sr')
   .split(',')

--- a/scripts/journey/generate-checklist-translations.mjs
+++ b/scripts/journey/generate-checklist-translations.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * BOOTSTRAP-GUIDED-JOURNEY-POPUP — backfill per-locale translations of the
+ * Guided Journey curriculum into `journey_checklist_translations`.
+ *
+ * The curriculum is authored in GERMAN (source of truth). This script reads the
+ * current PUBLISHED snapshot, asks Gemini to translate the six user-facing
+ * fields per topic into the target locale(s), and upserts the result. The
+ * gateway overlays these onto the German snapshot at read time (missing fields
+ * fall back to German), so the Topic Explanation popup renders in the user's
+ * language instead of mixing English labels with German body text.
+ *
+ * Run it wherever the secrets + DB live (CI/Cloud Shell), NOT a dev sandbox:
+ *
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE=... GEMINI_API_KEY=... \
+ *     node scripts/journey/generate-checklist-translations.mjs \
+ *       --locale=en,es,sr [--curriculum=v2] [--limit=N] [--dry-run]
+ *
+ * Idempotent: upserts on (topic_id, locale). Re-running refreshes content and
+ * stamps source_version_id so a future re-publish can detect stale rows.
+ *
+ * Brand voice: informal register (du-form for DE source; tú for ES, ti for SR).
+ */
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const [k, v] = a.replace(/^--/, '').split('=');
+    return [k, v ?? true];
+  }),
+);
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const CURRICULUM = String(args.curriculum || 'v2');
+const LOCALES = String(args.locale || 'en,es,sr')
+  .split(',')
+  .map((s) => s.trim())
+  .filter((s) => ['en', 'es', 'sr'].includes(s));
+const LIMIT = args.limit ? Number(args.limit) : Infinity;
+const DRY_RUN = Boolean(args['dry-run']);
+const MODEL = process.env.GEMINI_TRANSLATE_MODEL || 'gemini-2.0-flash';
+
+if (!SUPABASE_URL || !SERVICE_ROLE) {
+  console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE');
+  process.exit(1);
+}
+if (!GEMINI_API_KEY && !DRY_RUN) {
+  console.error('Missing GEMINI_API_KEY (or pass --dry-run)');
+  process.exit(1);
+}
+if (LOCALES.length === 0) {
+  console.error('No valid --locale given (en,es,sr)');
+  process.exit(1);
+}
+
+const LOCALE_NAME = { en: 'English', es: 'Spanish (Spain, informal "tú")', sr: 'Serbian (informal "ti")' };
+const FIELDS = [
+  ['display_label', 'displayLabel'],
+  ['short_description', 'shortDescription'],
+  ['explanation_what_it_is', 'explanation.whatItIs'],
+  ['explanation_user_benefit', 'explanation.userBenefit'],
+  ['explanation_when_to_use', 'explanation.whenToUse'],
+  ['explanation_try_this', 'explanation.tryThis'],
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** PostgREST helper (service role). */
+async function rest(path, init = {}) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    ...init,
+    headers: {
+      apikey: SERVICE_ROLE,
+      Authorization: `Bearer ${SERVICE_ROLE}`,
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+  if (!res.ok) throw new Error(`REST ${path} → ${res.status} ${await res.text()}`);
+  return res.status === 204 ? null : res.json();
+}
+
+/** Read the current published snapshot (array of topics). */
+async function fetchCurrentSnapshot() {
+  const rows = await rest(
+    `journey_checklist_versions?select=id,snapshot&curriculum_version=eq.${CURRICULUM}&is_current=is.true&limit=1`,
+  );
+  if (!rows || rows.length === 0) throw new Error(`No current published version for curriculum ${CURRICULUM}`);
+  return { versionId: rows[0].id, topics: Array.isArray(rows[0].snapshot) ? rows[0].snapshot : [] };
+}
+
+function sourceFields(topic) {
+  return {
+    display_label: topic.displayLabel ?? null,
+    short_description: topic.shortDescription ?? null,
+    explanation_what_it_is: topic.explanation?.whatItIs ?? null,
+    explanation_user_benefit: topic.explanation?.userBenefit ?? null,
+    explanation_when_to_use: topic.explanation?.whenToUse ?? null,
+    explanation_try_this: topic.explanation?.tryThis ?? null,
+  };
+}
+
+/** Translate one topic's German fields into a locale via Gemini (strict JSON). */
+async function translateTopic(src, locale) {
+  const payload = {};
+  for (const [col] of FIELDS) if (src[col]) payload[col] = src[col];
+  if (Object.keys(payload).length === 0) return {};
+
+  const prompt = [
+    `Translate the following German UI strings for a longevity-community app into ${LOCALE_NAME[locale]}.`,
+    `Use the informal register/second person. Keep it concise and natural — these are short UI labels and explanations.`,
+    `Return ONLY a JSON object with the SAME keys, values translated. Do not add keys or commentary.`,
+    JSON.stringify(payload),
+  ].join('\n');
+
+  if (DRY_RUN) return payload; // echo source — lets you preview without spending tokens
+
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${GEMINI_API_KEY}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.3, responseMimeType: 'application/json' },
+    }),
+  });
+  if (!res.ok) throw new Error(`Gemini ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '{}';
+  try {
+    return JSON.parse(text);
+  } catch {
+    console.warn(`  ! unparseable response for a topic; skipping`);
+    return {};
+  }
+}
+
+async function main() {
+  const { versionId, topics } = await fetchCurrentSnapshot();
+  const slice = topics.slice(0, LIMIT);
+  console.log(
+    `Translating ${slice.length}/${topics.length} topics → [${LOCALES.join(', ')}] from version ${versionId}${DRY_RUN ? ' (dry-run)' : ''}`,
+  );
+
+  for (const locale of LOCALES) {
+    let upserts = 0;
+    for (const topic of slice) {
+      const src = sourceFields(topic);
+      const translated = await translateTopic(src, locale);
+      const row = { topic_id: topic.topicId, locale, source_version_id: versionId, updated_at: new Date().toISOString() };
+      for (const [col] of FIELDS) row[col] = translated[col] ?? null;
+
+      if (!DRY_RUN) {
+        await rest('journey_checklist_translations?on_conflict=topic_id,locale', {
+          method: 'POST',
+          headers: { Prefer: 'resolution=merge-duplicates,return=minimal' },
+          body: JSON.stringify(row),
+        });
+      }
+      upserts++;
+      if (upserts % 25 === 0) console.log(`  [${locale}] ${upserts}/${slice.length}`);
+      await sleep(80); // gentle rate-limit
+    }
+    console.log(`✓ [${locale}] ${upserts} topics ${DRY_RUN ? 'previewed' : 'upserted'}`);
+  }
+  console.log('Done.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/services/gateway/src/routes/guided-journey.ts
+++ b/services/gateway/src/routes/guided-journey.ts
@@ -145,10 +145,15 @@ router.post('/session-listened', requireAuth, async (req: AuthenticatedRequest, 
     // +2 surfaces in the user's Index movement history. Replays award nothing →
     // no event. Best-effort: never block the response on OASIS.
     if (result.awarded) {
-      emitOasisEvent({
+      // Best-effort; emitOasisEvent never throws (internal try/catch returns
+      // { ok:false }), so `void` is safe. actor_id attributes it to the user so
+      // the +2 shows up in their Vitana Index movement history (last_movement).
+      void emitOasisEvent({
         vtid: 'SYSTEM',
         type: 'index.recomputed' as any,
         source: 'guided-journey-api',
+        actor_id: userId,
+        surface: 'api',
         status: 'info',
         message: `Vitana Index +${result.points} for listening to a guided session (${topicId.trim()})`,
         payload: {
@@ -158,7 +163,7 @@ router.post('/session-listened', requireAuth, async (req: AuthenticatedRequest, 
           total_bonus: result.totalBonus,
           reason: 'guided_session_listen',
         },
-      }).catch(() => {});
+      });
     }
     return res.json({
       ok: true,

--- a/services/gateway/src/routes/guided-journey.ts
+++ b/services/gateway/src/routes/guided-journey.ts
@@ -19,6 +19,7 @@ import {
   setJourneyMode,
   completePractice,
 } from '../services/guided-journey/guided-journey-state';
+import { recordSessionListen } from '../services/guided-journey/journey-index-award';
 import type { JourneyMode } from '../types/guided-journey';
 
 const router = Router();
@@ -110,6 +111,44 @@ router.post('/practice-complete', requireAuth, async (req: AuthenticatedRequest,
   } catch (err: any) {
     console.error(`[VTID-03282] practice-complete failed: ${err?.message}`);
     return res.status(500).json({ ok: false, error: 'practice_complete_failed', vtid: 'VTID-03282' });
+  }
+});
+
+// BOOTSTRAP-GUIDED-JOURNEY-POPUP — award +2 Vitana Index points for listening
+// to a session. Fired when the user taps a topic and Vitana narrates it (the
+// Topic Explanation popup then appears). Idempotent per topic: replays never
+// double-award. The bonus surfaces on the user-facing Vitana Index read.
+// POST /api/v1/journey/session-listened  { topicId } → { ok, awarded, points }.
+router.post('/session-listened', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: 'BOOTSTRAP-GUIDED-JOURNEY-POPUP' });
+  }
+  const topicId = req.body?.topicId as unknown;
+  if (typeof topicId !== 'string' || !topicId.trim()) {
+    return res.status(400).json({
+      ok: false,
+      error: 'invalid_topic_id',
+      detail: 'topicId is required',
+      vtid: 'BOOTSTRAP-GUIDED-JOURNEY-POPUP',
+    });
+  }
+  const client = getSupabase();
+  if (!client) {
+    return res.status(500).json({ ok: false, error: 'supabase_not_configured', vtid: 'BOOTSTRAP-GUIDED-JOURNEY-POPUP' });
+  }
+  try {
+    const result = await recordSessionListen(client, userId, topicId.trim());
+    return res.json({
+      ok: true,
+      awarded: result.awarded,
+      points: result.points,
+      total_bonus: result.totalBonus,
+      vtid: 'BOOTSTRAP-GUIDED-JOURNEY-POPUP',
+    });
+  } catch (err: any) {
+    console.error(`[BOOTSTRAP-GUIDED-JOURNEY-POPUP] session-listened failed: ${err?.message}`);
+    return res.status(500).json({ ok: false, error: 'session_listened_failed', vtid: 'BOOTSTRAP-GUIDED-JOURNEY-POPUP' });
   }
 });
 

--- a/services/gateway/src/routes/guided-journey.ts
+++ b/services/gateway/src/routes/guided-journey.ts
@@ -20,6 +20,7 @@ import {
   completePractice,
 } from '../services/guided-journey/guided-journey-state';
 import { recordSessionListen } from '../services/guided-journey/journey-index-award';
+import { emitOasisEvent } from '../services/oasis-event-service';
 import type { JourneyMode } from '../types/guided-journey';
 
 const router = Router();
@@ -139,6 +140,26 @@ router.post('/session-listened', requireAuth, async (req: AuthenticatedRequest, 
   }
   try {
     const result = await recordSessionListen(client, userId, topicId.trim());
+    // Record the index movement only on a real first-time award (the state
+    // transition), mirroring the calendar path's `index.recomputed` event so the
+    // +2 surfaces in the user's Index movement history. Replays award nothing →
+    // no event. Best-effort: never block the response on OASIS.
+    if (result.awarded) {
+      emitOasisEvent({
+        vtid: 'SYSTEM',
+        type: 'index.recomputed' as any,
+        source: 'guided-journey-api',
+        status: 'info',
+        message: `Vitana Index +${result.points} for listening to a guided session (${topicId.trim()})`,
+        payload: {
+          user_id: userId,
+          topic_id: topicId.trim(),
+          delta_total: result.points,
+          total_bonus: result.totalBonus,
+          reason: 'guided_session_listen',
+        },
+      }).catch(() => {});
+    }
     return res.json({
       ok: true,
       awarded: result.awarded,

--- a/services/gateway/src/routes/journey-checklist.ts
+++ b/services/gateway/src/routes/journey-checklist.ts
@@ -11,10 +11,32 @@
 import { Router, Response } from 'express';
 import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 import { getSupabase } from '../lib/supabase';
-import { getPublishedChecklist } from '../services/guided-journey/checklist-service';
+import {
+  getPublishedChecklist,
+  type ChecklistLocale,
+} from '../services/guided-journey/checklist-service';
+import { getUserLocale } from '../i18n/server-locale';
 
 const router = Router();
 const VTID = 'VTID-03277';
+
+const SUPPORTED_LOCALES: readonly ChecklistLocale[] = ['de', 'en', 'es', 'sr'];
+
+/** Resolve the curriculum locale: an explicit `?locale=` (the live UI language,
+ *  authoritative) wins; otherwise fall back to the user's stored profile locale. */
+async function resolveLocale(
+  req: AuthenticatedRequest,
+  client: Parameters<typeof getUserLocale>[0],
+  userId: string,
+): Promise<ChecklistLocale> {
+  const raw = String(req.query.locale ?? '').slice(0, 5).toLowerCase().split('-')[0];
+  if ((SUPPORTED_LOCALES as readonly string[]).includes(raw)) return raw as ChecklistLocale;
+  try {
+    return (await getUserLocale(client, userId)) as ChecklistLocale;
+  } catch {
+    return 'de';
+  }
+}
 
 router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
   if (!req.identity?.user_id) {
@@ -26,11 +48,13 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
   }
   try {
     const curriculumVersion = (req.query.curriculumVersion as string) || 'v2';
-    const result = await getPublishedChecklist(c, curriculumVersion);
+    const locale = await resolveLocale(req, c, req.identity.user_id);
+    const result = await getPublishedChecklist(c, curriculumVersion, locale);
     return res.json({
       ok: true,
       source: result.source,
       versionLabel: result.versionLabel,
+      locale,
       topics: result.topics,
       count: result.topics.length,
       vtid: VTID,

--- a/services/gateway/src/services/guided-journey/checklist-service.ts
+++ b/services/gateway/src/services/guided-journey/checklist-service.ts
@@ -279,6 +279,74 @@ export interface PublishedChecklist {
   topics: PublicChecklistTopic[];
 }
 
+/** Locales the curriculum can be served in. 'de' is the authored source. */
+export type ChecklistLocale = 'de' | 'en' | 'es' | 'sr';
+
+interface ChecklistTranslationRow {
+  topic_id: string;
+  display_label: string | null;
+  short_description: string | null;
+  explanation_what_it_is: string | null;
+  explanation_user_benefit: string | null;
+  explanation_when_to_use: string | null;
+  explanation_try_this: string | null;
+}
+
+/**
+ * Overlay per-locale translations onto the (German) public topics. Each field
+ * falls back to the German source when a translation is absent — so a partially
+ * translated locale still renders, never a blank. Pure/synchronous: the caller
+ * fetches the rows. Exported for unit testing.
+ */
+export function applyTranslations(
+  topics: PublicChecklistTopic[],
+  translations: ChecklistTranslationRow[],
+): PublicChecklistTopic[] {
+  if (translations.length === 0) return topics;
+  const byTopic = new Map<string, ChecklistTranslationRow>();
+  for (const tr of translations) byTopic.set(tr.topic_id, tr);
+  const pick = (translated: string | null | undefined, source: string | null) =>
+    translated != null && translated !== '' ? translated : source;
+  return topics.map((t) => {
+    const tr = byTopic.get(t.topicId);
+    if (!tr) return t;
+    return {
+      ...t,
+      displayLabel: pick(tr.display_label, t.displayLabel) ?? t.displayLabel,
+      shortDescription: pick(tr.short_description, t.shortDescription),
+      explanation: {
+        whatItIs: pick(tr.explanation_what_it_is, t.explanation.whatItIs),
+        userBenefit: pick(tr.explanation_user_benefit, t.explanation.userBenefit),
+        whenToUse: pick(tr.explanation_when_to_use, t.explanation.whenToUse),
+        tryThis: pick(tr.explanation_try_this, t.explanation.tryThis),
+      },
+    };
+  });
+}
+
+/** Fetch the translation rows for a locale + topic set. Best-effort: returns
+ *  [] on any error so the German source is served rather than failing. */
+async function fetchChecklistTranslations(
+  client: SupabaseClient,
+  locale: ChecklistLocale,
+  topicIds: string[],
+): Promise<ChecklistTranslationRow[]> {
+  if (locale === 'de' || topicIds.length === 0) return [];
+  try {
+    const { data, error } = await client
+      .from('journey_checklist_translations')
+      .select(
+        'topic_id, display_label, short_description, explanation_what_it_is, explanation_user_benefit, explanation_when_to_use, explanation_try_this',
+      )
+      .eq('locale', locale)
+      .in('topic_id', topicIds);
+    if (error || !Array.isArray(data)) return [];
+    return data as ChecklistTranslationRow[];
+  } catch {
+    return [];
+  }
+}
+
 /**
  * The user-facing read for My Journey (P5). Returns the current published
  * snapshot; if nothing is published yet (early phases), falls back to the
@@ -288,6 +356,7 @@ export interface PublishedChecklist {
 export async function getPublishedChecklist(
   client: SupabaseClient,
   curriculumVersion = 'v2',
+  locale: ChecklistLocale = 'de',
 ): Promise<PublishedChecklist> {
   const { data: ver, error } = await client
     .from(V)
@@ -297,27 +366,40 @@ export async function getPublishedChecklist(
     .maybeSingle();
   if (error) throw error;
 
+  let result: PublishedChecklist;
   if (ver && Array.isArray((ver as any).snapshot)) {
     // VTID-03289: the stored snapshot now carries the internal vitanaVoiceScript
     // (for the ORB seam). Re-strip to the public shape so it never leaks over
     // this HTTP read. snapshotToPublic tolerates older voice-less snapshots.
     const snap = (ver as any).snapshot as SnapshotChecklistTopic[];
-    return {
+    result = {
       source: 'published',
       versionLabel: (ver as any).version_label ?? null,
       topics: snap.map(snapshotToPublic),
     };
+  } else {
+    // Fallback: live working draft (enabled, not disabled).
+    const working = (await listTopics(client, { curriculumVersion })).filter(
+      (t) => t.enabled && t.status !== 'disabled',
+    );
+    result = {
+      source: 'draft_fallback',
+      versionLabel: null,
+      topics: working.map(toPublicTopic),
+    };
   }
 
-  // Fallback: live working draft (enabled, not disabled).
-  const working = (await listTopics(client, { curriculumVersion })).filter(
-    (t) => t.enabled && t.status !== 'disabled',
-  );
-  return {
-    source: 'draft_fallback',
-    versionLabel: null,
-    topics: working.map(toPublicTopic),
-  };
+  // Overlay per-locale translations onto the German source (no-op for 'de' and
+  // for any field/topic without a translation — those keep the German text).
+  if (locale !== 'de' && result.topics.length > 0) {
+    const translations = await fetchChecklistTranslations(
+      client,
+      locale,
+      result.topics.map((t) => t.topicId),
+    );
+    result = { ...result, topics: applyTranslations(result.topics, translations) };
+  }
+  return result;
 }
 
 /**

--- a/services/gateway/src/services/guided-journey/journey-index-award.ts
+++ b/services/gateway/src/services/guided-journey/journey-index-award.ts
@@ -1,0 +1,84 @@
+/**
+ * Guided Journey — Vitana Index award for listening to a session
+ * (BOOTSTRAP-GUIDED-JOURNEY-POPUP).
+ *
+ * Listening to a Guided Journey session earns the user +2 Vitana Index points.
+ * `recordSessionListen` writes an idempotent ledger row (one per user+topic, so
+ * replays never double-award). `getJourneyEngagementBonus` sums a user's awards;
+ * the user-facing Vitana Index read (`fetchVitanaIndexSnapshot`) adds it on top
+ * of the computed health score so the headline Index reflects the reward —
+ * without polluting the stored daily health history.
+ *
+ * Touches ONLY `journey_session_index_awards`.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const TABLE = 'journey_session_index_awards';
+
+/** Points awarded for listening to one Guided Journey session. */
+export const SESSION_INDEX_POINTS = 2;
+
+/** Hard ceiling on the engagement overlay so it can never dominate the health
+ *  score (250-topic curriculum × 2 = 500; clamp well under the 999 index max). */
+export const MAX_ENGAGEMENT_BONUS = 500;
+
+export interface AwardResult {
+  /** true when THIS call created a new award (first listen of the topic). */
+  awarded: boolean;
+  /** Points carried by this award row. */
+  points: number;
+  /** The user's total engagement bonus after this call (clamped). */
+  totalBonus: number;
+}
+
+/**
+ * Idempotently record that a user listened to a session for `topicId`.
+ * First listen of a topic inserts a +2 row; replays are no-ops for the total.
+ */
+export async function recordSessionListen(
+  client: SupabaseClient,
+  userId: string,
+  topicId: string,
+  points: number = SESSION_INDEX_POINTS,
+): Promise<AwardResult> {
+  // Insert-if-absent. ignoreDuplicates → no row returned when it already
+  // existed, which is exactly how we detect a first-time award.
+  const { data, error } = await client
+    .from(TABLE)
+    .upsert(
+      { user_id: userId, topic_id: topicId, points },
+      { onConflict: 'user_id,topic_id', ignoreDuplicates: true },
+    )
+    .select('topic_id');
+  if (error) throw error;
+
+  const awarded = Array.isArray(data) && data.length > 0;
+  const totalBonus = await getJourneyEngagementBonus(client, userId);
+  return { awarded, points, totalBonus };
+}
+
+/**
+ * Sum a user's Guided Journey engagement bonus (clamped to MAX_ENGAGEMENT_BONUS).
+ * Best-effort: returns 0 on any error so it can never break the Index read.
+ */
+export async function getJourneyEngagementBonus(
+  client: SupabaseClient,
+  userId: string,
+): Promise<number> {
+  if (!userId) return 0;
+  try {
+    const { data, error } = await client
+      .from(TABLE)
+      .select('points')
+      .eq('user_id', userId);
+    if (error || !Array.isArray(data)) return 0;
+    const sum = data.reduce(
+      (acc, r) => acc + (typeof (r as { points?: number }).points === 'number' ? (r as { points: number }).points : 0),
+      0,
+    );
+    return Math.max(0, Math.min(MAX_ENGAGEMENT_BONUS, sum));
+  } catch {
+    return 0;
+  }
+}

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -26,6 +26,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { getCurrentFacts } from './memory-facts-service';
 import { getAwarenessConfig } from './awareness-registry';
+import { getJourneyEngagementBonus } from './guided-journey/journey-index-award';
 
 const TTL_MS = 10 * 60 * 1000;
 const DEFAULT_WINDOW_DAYS = 14;
@@ -473,7 +474,12 @@ async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise
   const latest = rows[rows.length - 1];
   const earliest = rows[0];
   const history_7d = rows.map(r => Number(r.score_total) || 0);
-  const total = Number(latest.score_total) || 0;
+  const baseTotal = Number(latest.score_total) || 0;
+  // Guided Journey engagement overlay: +2 per listened session, applied on top
+  // of the computed health score for the headline Index the user sees/hears.
+  // Best-effort (helper swallows errors → 0) so it never breaks the Index read.
+  const engagementBonus = await getJourneyEngagementBonus(client, userId);
+  const total = Math.min(999, baseTotal + engagementBonus);
   const pillars: Record<PillarKey, number> = {
     nutrition: Number(latest.score_nutrition) || 0,
     hydration: Number(latest.score_hydration) || 0,
@@ -485,7 +491,9 @@ async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise
   pillarEntries.sort((a, b) => a[1] - b[1]);
   const weakest_pillar = { name: pillarEntries[0][0], score: pillarEntries[0][1] };
   const strongest_pillar = { name: pillarEntries[pillarEntries.length - 1][0], score: pillarEntries[pillarEntries.length - 1][1] };
-  const trend_7d = rows.length >= 2 ? total - (Number(earliest.score_total) || 0) : 0;
+  // Trend uses the base (pre-bonus) totals on both ends so the constant
+  // engagement overlay never manufactures a fake 7-day movement.
+  const trend_7d = rows.length >= 2 ? baseTotal - (Number(earliest.score_total) || 0) : 0;
 
   const featureInputs = (latest.feature_inputs as any) || {};
   const balanceFactor = typeof featureInputs.balance_factor === 'number' ? featureInputs.balance_factor : 1.0;

--- a/services/gateway/test/journey-checklist-translations.test.ts
+++ b/services/gateway/test/journey-checklist-translations.test.ts
@@ -1,0 +1,89 @@
+/**
+ * BOOTSTRAP-GUIDED-JOURNEY-POPUP — Guided Journey curriculum translation overlay.
+ * Verifies applyTranslations overlays per-locale fields and falls back to the
+ * German source for any missing field/topic.
+ */
+
+import { applyTranslations } from '../src/services/guided-journey/checklist-service';
+import type { PublicChecklistTopic } from '../src/types/journey-checklist';
+
+function deTopic(id: string): PublicChecklistTopic {
+  return {
+    topicId: id,
+    session: 1,
+    position: 1,
+    chapterId: 'basics',
+    displayLabel: 'Sektor-Fit',
+    shortDescription: 'Kurzbeschreibung',
+    explanation: {
+      whatItIs: 'Was es ist (DE)',
+      userBenefit: 'Dein Nutzen (DE)',
+      whenToUse: 'Wann es hilft (DE)',
+      tryThis: 'Probier das (DE)',
+    },
+    guidedPracticeTarget: null,
+    businessGate: null,
+  };
+}
+
+describe('applyTranslations', () => {
+  it('overlays a fully-translated topic', () => {
+    const out = applyTranslations(
+      [deTopic('T001')],
+      [
+        {
+          topic_id: 'T001',
+          display_label: 'Sector Fit',
+          short_description: 'Short description',
+          explanation_what_it_is: 'What it is (EN)',
+          explanation_user_benefit: 'Your benefit (EN)',
+          explanation_when_to_use: 'When it helps (EN)',
+          explanation_try_this: 'Try this (EN)',
+        },
+      ],
+    );
+    expect(out[0].displayLabel).toBe('Sector Fit');
+    expect(out[0].explanation.whatItIs).toBe('What it is (EN)');
+    expect(out[0].explanation.tryThis).toBe('Try this (EN)');
+  });
+
+  it('falls back to German for missing fields', () => {
+    const out = applyTranslations(
+      [deTopic('T001')],
+      [
+        {
+          topic_id: 'T001',
+          display_label: 'Sector Fit',
+          short_description: null,
+          explanation_what_it_is: 'What it is (EN)',
+          explanation_user_benefit: null, // missing → keep German
+          explanation_when_to_use: '', // empty → keep German
+          explanation_try_this: 'Try this (EN)',
+        },
+      ],
+    );
+    expect(out[0].displayLabel).toBe('Sector Fit');
+    expect(out[0].explanation.whatItIs).toBe('What it is (EN)');
+    expect(out[0].explanation.userBenefit).toBe('Dein Nutzen (DE)');
+    expect(out[0].explanation.whenToUse).toBe('Wann es hilft (DE)');
+  });
+
+  it('leaves untranslated topics untouched and is a no-op with no rows', () => {
+    const topics = [deTopic('T001'), deTopic('T002')];
+    const out = applyTranslations(topics, [
+      {
+        topic_id: 'T001',
+        display_label: 'Sector Fit',
+        short_description: null,
+        explanation_what_it_is: null,
+        explanation_user_benefit: null,
+        explanation_when_to_use: null,
+        explanation_try_this: null,
+      },
+    ]);
+    expect(out[0].displayLabel).toBe('Sector Fit');
+    expect(out[1].displayLabel).toBe('Sektor-Fit'); // untouched
+
+    expect(applyTranslations(topics, [])).toEqual(topics); // no-op
+  });
+});

--- a/services/gateway/test/journey-index-award.test.ts
+++ b/services/gateway/test/journey-index-award.test.ts
@@ -1,0 +1,93 @@
+/**
+ * BOOTSTRAP-GUIDED-JOURNEY-POPUP — Guided Journey "+2 Vitana Index for
+ * listening" award ledger. Verifies:
+ *  - first listen of a topic awards (+2); replays are idempotent no-ops
+ *  - the engagement bonus sums distinct topics and is clamped to the max
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  recordSessionListen,
+  getJourneyEngagementBonus,
+  SESSION_INDEX_POINTS,
+  MAX_ENGAGEMENT_BONUS,
+} from '../src/services/guided-journey/journey-index-award';
+
+/**
+ * Minimal in-memory stand-in for the `journey_session_index_awards` table that
+ * honours the (user_id, topic_id) primary key + ignoreDuplicates upsert.
+ */
+function mockClient(): { client: SupabaseClient; rows: Array<{ user_id: string; topic_id: string; points: number }> } {
+  const rows: Array<{ user_id: string; topic_id: string; points: number }> = [];
+  const client = {
+    from(_table: string) {
+      return {
+        upsert(
+          row: { user_id: string; topic_id: string; points: number },
+          _opts: { onConflict: string; ignoreDuplicates: boolean },
+        ) {
+          const exists = rows.some((r) => r.user_id === row.user_id && r.topic_id === row.topic_id);
+          if (!exists) rows.push({ ...row });
+          return {
+            // ignoreDuplicates: a freshly-inserted row is returned; a duplicate yields [].
+            select(_cols: string) {
+              return Promise.resolve({ data: exists ? [] : [{ topic_id: row.topic_id }], error: null });
+            },
+          };
+        },
+        select(_cols: string) {
+          return {
+            eq(_col: string, userId: string) {
+              return Promise.resolve({
+                data: rows.filter((r) => r.user_id === userId).map((r) => ({ points: r.points })),
+                error: null,
+              });
+            },
+          };
+        },
+      };
+    },
+  } as unknown as SupabaseClient;
+  return { client, rows };
+}
+
+describe('journey-index-award', () => {
+  const USER = 'user-1';
+
+  it('awards +2 on first listen and is idempotent on replay', async () => {
+    const { client } = mockClient();
+
+    const first = await recordSessionListen(client, USER, 'T001');
+    expect(first.awarded).toBe(true);
+    expect(first.points).toBe(SESSION_INDEX_POINTS);
+    expect(first.totalBonus).toBe(2);
+
+    const replay = await recordSessionListen(client, USER, 'T001');
+    expect(replay.awarded).toBe(false);
+    expect(replay.totalBonus).toBe(2); // unchanged — no double award
+  });
+
+  it('sums distinct topics into the engagement bonus', async () => {
+    const { client } = mockClient();
+    await recordSessionListen(client, USER, 'T001');
+    await recordSessionListen(client, USER, 'T002');
+    await recordSessionListen(client, USER, 'T002'); // replay, no-op
+    expect(await getJourneyEngagementBonus(client, USER)).toBe(4);
+  });
+
+  it('clamps the bonus to the maximum', async () => {
+    const { client, rows } = mockClient();
+    // Seed more awards than the clamp allows.
+    const topics = Math.ceil(MAX_ENGAGEMENT_BONUS / SESSION_INDEX_POINTS) + 50;
+    for (let i = 0; i < topics; i++) {
+      rows.push({ user_id: USER, topic_id: `T${i}`, points: SESSION_INDEX_POINTS });
+    }
+    expect(await getJourneyEngagementBonus(client, USER)).toBe(MAX_ENGAGEMENT_BONUS);
+  });
+
+  it('returns 0 bonus for an unknown user', async () => {
+    const { client } = mockClient();
+    expect(await getJourneyEngagementBonus(client, '')).toBe(0);
+    expect(await getJourneyEngagementBonus(client, 'nobody')).toBe(0);
+  });
+});

--- a/supabase/migrations/20260610120000_BOOTSTRAP_journey_session_index_award.sql
+++ b/supabase/migrations/20260610120000_BOOTSTRAP_journey_session_index_award.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- Guided Journey — Vitana Index award for listening to a session
+-- BOOTSTRAP-GUIDED-JOURNEY-POPUP
+-- -----------------------------------------------------------------------------
+-- When a user listens to a Guided Journey session (taps a topic → Vitana
+-- narrates → the Topic Explanation popup appears), they earn +2 Vitana Index
+-- points. This table is the IDEMPOTENT ledger of those awards: the (user_id,
+-- topic_id) primary key guarantees a given session awards at most once, no
+-- matter how many times it's replayed.
+--
+-- The bonus is summed and applied as an ADDITIVE overlay on the user-facing
+-- Vitana Index read (gateway `fetchVitanaIndexSnapshot`) — it is NOT written
+-- into `vitana_index_scores`, so the stored daily health history stays a clean
+-- record of health signals while the headline Index the user sees/hears
+-- reflects their engagement. Recompute-safe by construction (nothing to
+-- overwrite) and trivially reversible (drop this table).
+--
+-- SECURITY: gateway service-role only. RLS enabled with NO permissive policy,
+-- matching the platform's anon-exposure lockdown posture.
+-- =============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.journey_session_index_awards (
+  user_id    uuid NOT NULL,
+  topic_id   text NOT NULL,
+  points     integer NOT NULL DEFAULT 2 CHECK (points >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, topic_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_journey_session_index_awards_user
+  ON public.journey_session_index_awards (user_id);
+
+ALTER TABLE public.journey_session_index_awards ENABLE ROW LEVEL SECURITY;
+-- No permissive policy: only the gateway service-role may read/write.
+
+COMMENT ON TABLE public.journey_session_index_awards IS
+  'BOOTSTRAP-GUIDED-JOURNEY-POPUP — idempotent ledger of Vitana Index points (2 per distinct topic) earned by listening to a Guided Journey session. Summed and applied as an additive overlay on the user-facing Vitana Index read; never written into vitana_index_scores.';
+
+COMMIT;

--- a/supabase/migrations/20260610130000_BOOTSTRAP_journey_checklist_translations.sql
+++ b/supabase/migrations/20260610130000_BOOTSTRAP_journey_checklist_translations.sql
@@ -1,0 +1,47 @@
+-- =============================================================================
+-- Guided Journey — curriculum content translations (per-locale)
+-- BOOTSTRAP-GUIDED-JOURNEY-POPUP
+-- -----------------------------------------------------------------------------
+-- The curriculum (`journey_checklist_topics` + published snapshots) is authored
+-- in GERMAN — the source of truth. The Topic Explanation popup therefore showed
+-- German body text even when the user picked English/Spanish/Serbian (only the
+-- field LABELS were translated client-side). This table holds per-locale
+-- translations of the user-facing topic content; the gateway overlays them onto
+-- the published snapshot at read time, falling back to the German source when a
+-- field/locale is missing.
+--
+-- DE is never stored here (it lives in the snapshot). Rows are produced by
+-- `scripts/journey/generate-checklist-translations.mjs` (LLM batch translate of
+-- the current published snapshot) and refreshed when a new version publishes.
+--
+-- SECURITY: gateway service-role only. RLS enabled with NO permissive policy.
+-- =============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.journey_checklist_translations (
+  topic_id                 text NOT NULL,
+  locale                   text NOT NULL CHECK (locale IN ('en','es','sr')),
+  display_label            text,
+  short_description        text,
+  explanation_what_it_is   text,
+  explanation_user_benefit text,
+  explanation_when_to_use  text,
+  explanation_try_this     text,
+  -- Which published version this translation was generated from, so a re-publish
+  -- can detect stale rows and regenerate. NULL tolerated for bootstrap inserts.
+  source_version_id        uuid,
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (topic_id, locale)
+);
+
+CREATE INDEX IF NOT EXISTS idx_journey_checklist_translations_locale
+  ON public.journey_checklist_translations (locale);
+
+ALTER TABLE public.journey_checklist_translations ENABLE ROW LEVEL SECURITY;
+-- No permissive policy: only the gateway service-role may read/write.
+
+COMMENT ON TABLE public.journey_checklist_translations IS
+  'BOOTSTRAP-GUIDED-JOURNEY-POPUP — per-locale (en/es/sr) translations of user-facing Guided Journey topic content. Overlaid on the published (German) snapshot by the gateway; missing fields fall back to German.';
+
+COMMIT;


### PR DESCRIPTION
## What & why

Backend follow-ups for the **Guided Journey topic popup** (frontend: `vitana-v1` PR #703). The popup now (a) claims "+2 VITANA INDEX for listening to a session" and (b) needs its body content translated. This PR makes both real.

### 1. +2 VITANA INDEX for listening to a session

- **`journey_session_index_awards`** — idempotent ledger (`PK (user_id, topic_id)`), +2 per *distinct* topic.
- **`POST /api/v1/journey/session-listened`** records it; replays never double-award.
- The bonus is summed and applied as an **additive overlay in the single canonical user-facing Index read** (`fetchVitanaIndexSnapshot`) — **not** written into `vitana_index_scores`.

**Why this design (important):** VITANA INDEX is a *daily-computed health score* (5 pillars × balance factor → `score_total`, read in 15+ places, recomputed nightly). A raw bump to the stored row is overwritten by recompute; a pillar contribution gets balance-scaled so it ≠ exactly +2; and a `BEFORE INSERT OR UPDATE` trigger double-counts on the compute RPC's upsert. The overlay-at-canonical-read approach makes the **headline Index the user sees/hears go up by exactly +2 per session**, while:
- stored daily health history stays a clean record of health signals,
- it's recompute-safe (nothing to overwrite) and trivially reversible (drop the table),
- 7-day trend uses pre-bonus totals so the constant overlay never fakes a movement,
- the bonus is clamped (max 500) so engagement can't dominate the health score.

### 2. Curriculum content localization (en/es/sr)

The curriculum is authored in **German** (source of truth); the popup showed German body text under English labels. 

- **`journey_checklist_translations`** — per-locale translations of the user-facing topic fields.
- `getPublishedChecklist(client, version, locale)` overlays translations onto the German snapshot with **field-level fallback to DE**.
- `GET /api/v1/journey-checklist` resolves locale from `?locale=` (the live UI language, authoritative) else the user's profile locale.
- **`scripts/journey/generate-checklist-translations.mjs`** backfills the table from the current published snapshot via Gemini.

## Verification
- Gateway `tsc --noEmit` clean (only 2 pre-existing `express-serve-static-core` errors, unrelated — confirmed present on base).
- **30 journey tests pass**, incl. new suites: award idempotency/sum/clamp/unknown-user, and translation overlay full/partial-fallback/no-op.
- `DATABASE_SCHEMA.md` updated for both tables.

## Remaining step (can't run in sandbox)
The **translation backfill** must be run where the DB + `GEMINI_API_KEY` exist (no LLM/DB access here): `node scripts/journey/generate-checklist-translations.mjs --locale=en,es,sr`. Until then, EN/ES/SR users see German body content (graceful DE fallback) — the mechanism is in place. Migrations + endpoints should be verified on **staging** per the deployment protocol.

Paired frontend: `exafyltd/vitana-v1` PR #703 (fires the award on listen, requests `?locale=`).

https://claude.ai/code/session_01KmfdQ7feAnwrfTBhCwvT5g

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmfdQ7feAnwrfTBhCwvT5g)_