### PR TITLE
fix(orb): replay starts a clean guided session, not a stuck admin session (VTID-03296 / DEV-COMHU-0512)

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -3155,6 +3155,15 @@
     // provider then leads turn-1 and Vitana TEACHES that topic from the published
     // KB. One-shot: consumed by the upcoming _sessionStart only.
     focusGuidedTopic: function (topicId) {
+      // VTID-03296 (replay fix): tear down ANY existing/in-flight session FIRST so
+      // the new guided session starts from a CLEAN slate. Without this, tapping
+      // Replay right after the teaching auto-close raced the just-closing session
+      // (`if (_s.active) return` in _sessionStart, or a stale start consuming the
+      // one-shot _s.guidedTopic), so the new session went out WITHOUT
+      // guided_topic_id → it fell into the slow non-guided (admin) bootstrap path
+      // and got stuck "Connecting...". _sessionStop is synchronous; _show() below
+      // re-arms everything cleanly.
+      try { _sessionStop(); } catch (e) { /* best-effort */ }
       _s.guidedTopic = (typeof topicId === 'string' && topicId) ? topicId : null;
       // VTID-03294 (#4): a guided-topic open AUTO-CLOSES the overlay once Vitana
       // finishes the teaching turn (reveals the drawer's next-step buttons),


### PR DESCRIPTION
From gateway-staging logs of the user's replay: the replay session showed `guided_topic_narration: skipped — no_topic_tapped` and ran the slow non-guided **role=admin** bootstrap (3.5s, 17k-char context) → stuck "Connecting...", un-closeable.

**Root cause:** tapping Replay right after the teaching auto-close **raced the just-closing session** — `_sessionStart`'s `if (_s.active) return` (or a stale start consuming the one-shot `_s.guidedTopic`) meant the new session went out **without** `guided_topic_id`.

**Fix:** `focusGuidedTopic` now tears down any existing/in-flight session (`_sessionStop`, synchronous) **before** setting the topic + re-showing → the replay reliably starts as a **fast guided** session (skips bootstrap) and carries the topic. A fast guided session also eliminates the long stuck-connecting window.

Widget syntax + continuity tests green. Staging only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)