### PR TITLE
Make staging-publish bake time opt-in (default 0 = instant publish)

### DIFF
--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -129,8 +129,10 @@ Server flow (`POST /api/v1/operator/publish`):
 
 1. `requireAdminAuth` — admin JWT + `exafy_admin` role.
 2. Describe `gateway-staging` → resolve active revision + commit SHA.
-3. Refuse if the staging revision is younger than
-   `STAGING_PUBLISH_BAKE_SECONDS` (default 3600s; set to 0 for smoke tests).
+3. Optional bake-time guard (opt-in, default OFF): if
+   `STAGING_PUBLISH_BAKE_SECONDS` is set >0, refuse when the staging revision is
+   younger than that many seconds. Default is `0` → no soak, publish is instant
+   the moment staging is live. Set it to e.g. `3600` to re-impose a 1h soak.
 4. Allocate a VTID via the canonical allocator (EXEC-DEPLOY needs the ledger row).
 5. Call `deployOrchestrator.executeDeploy({ service:'gateway', environment:'production' })`.
 6. Insert `software_versions` row with `source_revision`, `initiator_id`.

--- a/services/gateway/src/routes/operator.ts
+++ b/services/gateway/src/routes/operator.ts
@@ -1258,9 +1258,13 @@ router.get('/revisions', requireAdminAuth, async (req: Request, res: Response) =
   }
 });
 
+// Bake-time guard is OPT-IN. Publish is meant to be instant ("30s, any time"),
+// so the default is 0 (disabled): staging can be promoted to prod the moment it
+// is live. Set STAGING_PUBLISH_BAKE_SECONDS to a positive number of seconds to
+// re-enable a soak period before staging→prod promotion (e.g. for a freeze).
 const STAGING_PUBLISH_BAKE_MS = (() => {
-  const raw = parseInt(process.env.STAGING_PUBLISH_BAKE_SECONDS || '3600', 10);
-  return Number.isFinite(raw) && raw >= 0 ? raw * 1000 : 60 * 60 * 1000;
+  const raw = parseInt(process.env.STAGING_PUBLISH_BAKE_SECONDS || '0', 10);
+  return Number.isFinite(raw) && raw >= 0 ? raw * 1000 : 0;
 })();
 
 /**
@@ -1275,8 +1279,9 @@ const STAGING_PUBLISH_BAKE_MS = (() => {
  *   3. Read the commit SHA from the revision's env (GIT_COMMIT_SHA) and/or
  *      from software_versions by cloud_run_revision. Fail if neither yields a
  *      SHA — without it the audit trail breaks.
- *   4. Bake-time guard: refuse if the staging revision is <STAGING_PUBLISH_BAKE_SECONDS
- *      seconds old (default 3600 = 1h). Set env to 0 to disable for smoke tests.
+ *   4. Bake-time guard (OPT-IN, default OFF): if STAGING_PUBLISH_BAKE_SECONDS is
+ *      set >0, refuse when the staging revision is younger than that many seconds.
+ *      Default is 0 → no soak; publish is instant the moment staging is live.
  *   5. Allocate a VTID via the canonical allocator (EXEC-DEPLOY gate needs it
  *      in vtid_ledger).
  *   6. Call deployOrchestrator.executeDeploy({ service:'gateway',


### PR DESCRIPTION
## Problem

The Command Hub **PUBLISH** button refused to promote staging → production with:

> Staging revision `gateway-staging-00277-rmt` is only 2154s old; needs 3600s. Wait 1446s, or set `STAGING_PUBLISH_BAKE_SECONDS=0` to override.

This is the **bake-time guard** in `POST /api/v1/operator/publish` — it required the staging revision to soak for `STAGING_PUBLISH_BAKE_SECONDS` (default **3600s / 1h**) before it could be published. Not a crash; the gate was working as designed.

## Decision

Per product direction, publish should be **instant at any time** — no soak period. This flips the bake guard from **on-by-default** to **opt-in**:

- Default `STAGING_PUBLISH_BAKE_SECONDS` is now **`0`** → the guard is disabled and staging can be promoted the moment it is live.
- The guard still exists: set the env var to a positive number of seconds (e.g. `3600`) to re-impose a soak window (e.g. during a freeze). The `if (STAGING_PUBLISH_BAKE_MS > 0 && …)` short-circuit already handles 0 cleanly.

## Changes
- `services/gateway/src/routes/operator.ts` — default `3600` → `0` + comment.
- `docs/STAGING.md` — document the opt-in behavior.

## Note on the live prod gateway
The running `gateway` (prod) service still uses the old 1h default until this ships. To unblock the **current** publish without waiting for a deploy, `STAGING_PUBLISH_BAKE_SECONDS=0` is being set on the live prod gateway via the `UPDATE-GATEWAY-ENV` workflow. This PR makes that the durable default so it survives future deploys.

https://claude.ai/code/session_01PecEbKwcw6wunXj4aSac5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01PecEbKwcw6wunXj4aSac5J)_