### PR TITLE
Fix fast-publish: GIT_COMMIT_SHA stamped twice aborts every gateway promotion

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -317,8 +317,15 @@ jobs:
             # /admin/build-info + cloud-run-admin.describeService can surface a real
             # 7-char SHA (instead of falling back to the *.run.app revision name).
             # Mirrors what STAGE-DEPLOY.yml already does for gateway-staging.
-            EXTRA_ENV_ARGS+=(--update-env-vars=GIT_COMMIT_SHA=${{ steps.deploy_sha.outputs.sha }})
-            EXTRA_ENV_ARGS+=(--update-env-vars=COMMIT_SHA=${{ steps.deploy_sha.outputs.sha }})
+            # Stamp here ONLY in source-build mode. In image-promotion (fast
+            # publish) mode the image block below already stamps
+            # GIT_COMMIT_SHA/COMMIT_SHA from inputs.commit_sha — adding them here
+            # too makes gcloud reject the deploy with "--update-env-vars:
+            # GIT_COMMIT_SHA cannot be specified multiple times".
+            if [ -z "${{ github.event.inputs.image }}" ]; then
+              EXTRA_ENV_ARGS+=(--update-env-vars=GIT_COMMIT_SHA=${{ steps.deploy_sha.outputs.sha }})
+              EXTRA_ENV_ARGS+=(--update-env-vars=COMMIT_SHA=${{ steps.deploy_sha.outputs.sha }})
+            fi
             # VTID-01225: Cognee Extractor URL for entity extraction
             EXTRA_ENV_ARGS+=(--update-env-vars=COGNEE_EXTRACTOR_URL=https://cognee-extractor-86804897789.us-central1.run.app)
             # VTID-01175: Worker verification mode. 'advisory' (default) runs the


### PR DESCRIPTION
## Symptom

The production **PUBLISH** button (Command Hub → staging→prod promotion) hangs at "Publishing 100%…" forever and never goes live. The dispatch succeeds but the EXEC-DEPLOY workflow fails ~90s later.

## Root cause

EXEC-DEPLOY run [`27293153090`](https://github.com/exafyltd/vitana-platform/actions/runs/27293153090) failed at the `gcloud run deploy` step:

```
ERROR: (gcloud.run.deploy) argument --update-env-vars: "GIT_COMMIT_SHA"
cannot be specified multiple times; received: 8c918c0..., 8c918c0...
```

When publishing the **gateway** via the **fast-publish image-promotion path** (`--image`, ~30s, no rebuild), `GIT_COMMIT_SHA`/`COMMIT_SHA` get appended to the deploy args **twice**:

1. the `CLOUD_RUN_SERVICE = gateway` block (from `steps.deploy_sha.outputs.sha`), and
2. the image-promotion block (from `inputs.commit_sha`).

`gcloud run deploy` rejects a repeated `--update-env-vars` key, so **every** image-reuse publish aborts. This path is exercised only by the PUBLISH button's fast publish, so the bug was latent until the first real promotion.

## Fix

Gate the gateway-block SHA stamp to **source-build mode only** (`image` input empty). In image-promotion mode the image block already stamps the promoted commit, so there's exactly one `GIT_COMMIT_SHA` arg. Source-build deploys are unchanged.

## Impact / safety
- Production was never touched — the failed deploy left prod on the prior revision.
- Once merged to `main`, the PUBLISH button (which dispatches EXEC-DEPLOY from `main`) works on the next click.

https://claude.ai/code/session_01PecEbKwcw6wunXj4aSac5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01PecEbKwcw6wunXj4aSac5J)_