### PR TITLE
fix(staging): enable FEATURE_INTENT_ENGINE_A on gateway-staging (VTID-01973)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -136,6 +136,13 @@ jobs:
             # events with the per-phase timeline). staging-only — prod stays
             # off until the experiment window graduates it.
             "FEATURE_LATENCY_TELEMETRY_ENV=staging-only"
+            # VTID-01973: Vitana Intent Engine routes (/api/v1/intents,
+            # /intent-matches, /intent-board, ...) only mount when this flag
+            # is true (see services/gateway/src/index.ts). Prod sets it in
+            # EXEC-DEPLOY.yml; without it here the staging frontend's
+            # Find a Match / My Posts screens fail with
+            # "List intents failed (404)".
+            "FEATURE_INTENT_ENGINE_A=true"
           )
 
           # Comma-joined for --set-env-vars (replaces, not merges — we want the


### PR DESCRIPTION
## Problem

The staging frontend (`preview.vitanaland.com`) shows **"Couldn't load — List intents failed (404)"** on the Find a Match screen (and the same failure hits My Posts / Intent Board / the +New wish composer).

## Root cause

The gateway only mounts the Vitana Intent Engine routers when `FEATURE_INTENT_ENGINE_A === 'true'`:

- `services/gateway/src/index.ts` lines 353–380 conditionally `require()` the routers, and lines 1086–1104 only mount `/api/v1/intents`, `/api/v1/intent-matches`, `/api/v1/intent-board`, `/api/v1/intent-categories`, intent-scan, templates, open-asks, and share routes when the flag is set.

Production gets the flag from `EXEC-DEPLOY.yml` (`--update-env-vars=FEATURE_INTENT_ENGINE_A=true`), but `STAGE-DEPLOY.yml` builds its env with an **authoritative `--set-env-vars` list** that never included it. So `gateway-staging` boots without any intent routes → Express returns its default HTML 404 → the frontend's `listMyIntents()` (`src/lib/intentApi.ts:123`) throws `List intents failed (404)`.

## Fix

Add `FEATURE_INTENT_ENGINE_A=true` to the `ENV_VARS` list in `STAGE-DEPLOY.yml`, with a comment explaining why it must stay there (the `--set-env-vars` list replaces, not merges — same trap previously hit by `GATEWAY_SERVICE_TOKEN` / VTID-03214).

## Rollout

Merging this PR touches `.github/workflows/STAGE-DEPLOY.yml`, which is in the workflow's own `push.paths` trigger — so the merge itself redeploys `gateway-staging` with the flag. No prod impact (prod already has the flag via EXEC-DEPLOY).

## Verify after merge

```bash
curl -s -o /dev/null -w "%{http_code} %{content_type}" \
  https://preview-gateway.vitanaland.com/api/v1/intents
# Expect: 401 application/json (route mounted, auth required)
# Before: 404 text/html (route not mounted)
```

Then reload `preview.vitanaland.com` → Find a Match: the list should load instead of the red error.

https://claude.ai/code/session_01GSuH5NHtdyQrETTiKcVUyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSuH5NHtdyQrETTiKcVUyZ)_