### PR TITLE
fix(orb): never offer partner matches then retract

### DIFF
--- a/services/gateway/src/orb/live/tools/live-tool-catalog.ts
+++ b/services/gateway/src/orb/live/tools/live-tool-catalog.ts
@@ -1677,14 +1677,31 @@ export function buildLiveApiTools(
         },
         {
           name: 'view_intent_matches',
-          description: 'Pull the top-N matches for one of the user\'s open intents. partner_seek matches show "(redacted)" until both parties express interest.',
+          description: [
+            'Show the user their matches. partner_seek matches show "(redacted)" until both parties express interest.',
+            '',
+            'TWO MODES — pick by what the user said:',
+            '  • Specific post — they named one of their posts ("matches for my salsa request"): pass that intent_id for the top-N matches on that single post.',
+            "  • All matches — they asked broadly (\"show me my partner matches\", \"who matched with me?\", \"any matches?\"): OMIT intent_id. The tool aggregates across all the user's open posts and navigates them to the My Matches screen.",
+            '',
+            "CRITICAL: when the user asks to see their matches without naming a post, just call this with NO intent_id. Do NOT ask which post. Do NOT say you can't show matches — this tool always succeeds and opens the matches screen, even when there are zero matches or no posts yet (it shows a friendly empty state + a CTA to post). Never offer matches and then retract.",
+            '',
+            'Optional intent_kind narrows the aggregate (e.g. partner_seek) when the user was specific about "partner" matches.',
+          ].join('\n'),
           parameters: {
             type: 'object',
             properties: {
-              intent_id: { type: 'string' },
+              intent_id: {
+                type: 'string',
+                description: "Optional. One of the user's open intent_ids to scope matches to a single post. Omit to aggregate across all open posts and open the My Matches screen.",
+              },
+              intent_kind: {
+                type: 'string',
+                enum: ['commercial_buy', 'commercial_sell', 'activity_seek', 'partner_seek', 'social_seek', 'mutual_aid', 'learning_seek', 'mentor_seek'],
+                description: 'Optional filter for the aggregate (no intent_id) mode, e.g. partner_seek for "partner matches".',
+              },
               limit: { type: 'integer' },
             },
-            required: ['intent_id'],
           },
         },
         {

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3173,15 +3173,139 @@ export async function tool_navigate(
 
 const INTENT_MATCH_AUTONAV_GAP = 0.15;
 
+// VTID-PARTNER-MATCHES-UX — aggregate "show me my (partner) matches" path.
+//
+// When the user just asks to see their matches ("show me my partner matches")
+// without naming a specific post, the LLM has no intent_id to pass. The old
+// contract hard-required intent_id, so view_intent_matches returned
+// { ok:false, error:'intent_id is required' } and Vitana — having just offered
+// "I can show you partner matches" — immediately retracted with "I can't show
+// you partner matches right now." Terrible UX.
+//
+// This fans out across the user's open intents (mirrors the frontend
+// getFindPartnerMatches), aggregates the top matches, and hands the user to the
+// Find a Partner matches screen via the same auto_nav directive the
+// single-intent path uses. That screen renders its own graceful empty/error
+// state, so even when there are zero matches (or zero open posts) the offer is
+// fulfilled — we navigate the user there instead of refusing.
+async function viewAllMyMatches(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  limit: number,
+): Promise<OrbToolResult> {
+  const userId = id.user_id;
+  if (!userId) return { ok: false, error: 'authentication required' };
+
+  const route = '/comm/find-partner?view=matches';
+  const directive = {
+    type: 'orb_directive',
+    directive: 'navigate',
+    screen_id: 'COMM.FIND_PARTNER_MATCHES',
+    route,
+    title: 'My Matches',
+    reason: 'view_intent_matches aggregate (no intent_id)',
+    vtid: 'VTID-PARTNER-MATCHES-UX',
+  };
+
+  try {
+    const { createClient } = await import('@supabase/supabase-js');
+    const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Optional kind filter — pass intent_kind only when the user was explicit
+    // ("partner matches" → partner_seek). Otherwise aggregate across every open
+    // intent, exactly like the Find a Partner "My Matches" tab.
+    let q = supabase
+      .from('user_intents')
+      .select('intent_id')
+      .eq('requester_user_id', userId)
+      .in('status', ['open', 'matched', 'engaged'])
+      .order('created_at', { ascending: false })
+      .limit(20);
+    const kindFilter = String(args.intent_kind ?? '').trim();
+    if (kindFilter) q = q.eq('intent_kind', kindFilter);
+    const { data: intents, error } = await q;
+    if (error) return { ok: false, error: error.message };
+
+    // No open posts → no matches are possible yet. Still take the user to the
+    // matches screen (graceful empty state + "post a wish" CTA) rather than
+    // refusing. reason:'no_open_intents' lets the LLM explain warmly.
+    if (!intents || intents.length === 0) {
+      return {
+        ok: true,
+        result: {
+          ok: true,
+          matches: [],
+          decision: 'auto_nav',
+          directive,
+          redirect: { route },
+          reason: 'no_open_intents',
+        },
+        text:
+          "I'm opening your matches now — you don't have any open posts yet, " +
+          'so post a wish and I\'ll let you know the moment someone matches.',
+      };
+    }
+
+    const { surfaceTopMatches } = await import('./intent-matcher');
+    const { redactMatchForReader } = await import('./intent-mutual-reveal');
+    const perIntent = await Promise.all(
+      (intents as Array<{ intent_id: string }>).map(async (it) => {
+        try {
+          const rows = await surfaceTopMatches(it.intent_id, limit);
+          return await Promise.all(rows.map((m) => redactMatchForReader(m, userId)));
+        } catch {
+          return [];
+        }
+      }),
+    );
+    const slim = perIntent
+      .flat()
+      .map((m) => ({
+        match_id: m.match_id,
+        vitana_id_b: m.vitana_id_b,
+        score: m.score,
+        kind_pairing: m.kind_pairing,
+        state: m.state,
+        redacted: m.redacted,
+      }))
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .slice(0, 10);
+
+    return {
+      ok: true,
+      result: {
+        ok: true,
+        matches: slim,
+        decision: 'auto_nav',
+        directive,
+        redirect: { route },
+      },
+      text:
+        slim.length > 0
+          ? `Opening your matches — you have ${slim.length} to look through.`
+          : "I'm opening your matches now. None have come in yet, but your posts are live — I'll flag the moment someone matches.",
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    console.error('[VTID-PARTNER-MATCHES-UX] viewAllMyMatches error:', msg);
+    return { ok: false, error: msg };
+  }
+}
+
 export async function tool_view_intent_matches(
   args: OrbToolArgs,
   id: OrbToolIdentity,
 ): Promise<OrbToolResult> {
-  const intentId = String(args.intent_id ?? '').trim();
-  if (!intentId) return { ok: false, error: 'intent_id is required' };
   if (!id.user_id) return { ok: false, error: 'authentication required' };
-
+  const intentId = String(args.intent_id ?? '').trim();
   const limit = Math.min(Math.max(Number(args.limit) || 3, 1), 10);
+
+  // No specific post named → aggregate across all the user's open intents and
+  // navigate to the My Matches screen. Never hard-fails on a missing intent_id.
+  if (!intentId) return viewAllMyMatches(args, id, limit);
+
   try {
     const { surfaceTopMatches } = await import('./intent-matcher');
     const { redactMatchForReader } = await import('./intent-mutual-reveal');

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -261,7 +261,7 @@
         "user"
       ],
       "status": "live",
-      "description": "View matches on a specific intent.",
+      "description": "View matches on a specific intent, or omit intent_id to aggregate all the user's matches and open the My Matches screen.",
       "wired_in": [
         "livekit",
         "vertex"

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -1269,7 +1269,15 @@ other field — the post is LIVE in the database. You MUST confirm success.
 Do NOT invent failure modes. Do NOT apologize when the server reported success.
 
 ### view_intent_matches
-Pull the top-N matches for one of the user's open intents. partner_seek matches show "(redacted)" until both parties express interest.
+Show the user their matches. partner_seek matches show "(redacted)" until both parties express interest.
+
+TWO MODES — pick by what the user said:
+  • Specific post — they named one of their posts ("matches for my salsa request"): pass that intent_id for the top-N matches on that single post.
+  • All matches — they asked broadly ("show me my partner matches", "who matched with me?", "any matches?"): OMIT intent_id. The tool aggregates across all the user's open posts and navigates them to the My Matches screen.
+
+CRITICAL: when the user asks to see their matches without naming a post, just call this with NO intent_id. Do NOT ask which post. Do NOT say you can't show matches — this tool always succeeds and opens the matches screen, even when there are zero matches or no posts yet (it shows a friendly empty state + a CTA to post). Never offer matches and then retract.
+
+Optional intent_kind narrows the aggregate (e.g. partner_seek) when the user was specific about "partner" matches.
 
 ### list_my_intents
 List the user's open intents. Optional kind filter.
@@ -2496,7 +2504,15 @@ other field — the post is LIVE in the database. You MUST confirm success.
 Do NOT invent failure modes. Do NOT apologize when the server reported success.
 
 ### view_intent_matches
-Pull the top-N matches for one of the user's open intents. partner_seek matches show "(redacted)" until both parties express interest.
+Show the user their matches. partner_seek matches show "(redacted)" until both parties express interest.
+
+TWO MODES — pick by what the user said:
+  • Specific post — they named one of their posts ("matches for my salsa request"): pass that intent_id for the top-N matches on that single post.
+  • All matches — they asked broadly ("show me my partner matches", "who matched with me?", "any matches?"): OMIT intent_id. The tool aggregates across all the user's open posts and navigates them to the My Matches screen.
+
+CRITICAL: when the user asks to see their matches without naming a post, just call this with NO intent_id. Do NOT ask which post. Do NOT say you can't show matches — this tool always succeeds and opens the matches screen, even when there are zero matches or no posts yet (it shows a friendly empty state + a CTA to post). Never offer matches and then retract.
+
+Optional intent_kind narrows the aggregate (e.g. partner_seek) when the user was specific about "partner" matches.
 
 ### list_my_intents
 List the user's open intents. Optional kind filter.

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -1715,20 +1715,40 @@ Do NOT invent failure modes. Do NOT apologize when the server reported success."
         },
       },
       {
-        "description": "Pull the top-N matches for one of the user's open intents. partner_seek matches show "(redacted)" until both parties express interest.",
+        "description": "Show the user their matches. partner_seek matches show "(redacted)" until both parties express interest.
+
+TWO MODES — pick by what the user said:
+  • Specific post — they named one of their posts ("matches for my salsa request"): pass that intent_id for the top-N matches on that single post.
+  • All matches — they asked broadly ("show me my partner matches", "who matched with me?", "any matches?"): OMIT intent_id. The tool aggregates across all the user's open posts and navigates them to the My Matches screen.
+
+CRITICAL: when the user asks to see their matches without naming a post, just call this with NO intent_id. Do NOT ask which post. Do NOT say you can't show matches — this tool always succeeds and opens the matches screen, even when there are zero matches or no posts yet (it shows a friendly empty state + a CTA to post). Never offer matches and then retract.
+
+Optional intent_kind narrows the aggregate (e.g. partner_seek) when the user was specific about "partner" matches.",
         "name": "view_intent_matches",
         "parameters": {
           "properties": {
             "intent_id": {
+              "description": "Optional. One of the user's open intent_ids to scope matches to a single post. Omit to aggregate across all open posts and open the My Matches screen.",
+              "type": "string",
+            },
+            "intent_kind": {
+              "description": "Optional filter for the aggregate (no intent_id) mode, e.g. partner_seek for "partner matches".",
+              "enum": [
+                "commercial_buy",
+                "commercial_sell",
+                "activity_seek",
+                "partner_seek",
+                "social_seek",
+                "mutual_aid",
+                "learning_seek",
+                "mentor_seek",
+              ],
               "type": "string",
             },
             "limit": {
               "type": "integer",
             },
           },
-          "required": [
-            "intent_id",
-          ],
           "type": "object",
         },
       },
@@ -3987,20 +4007,40 @@ Do NOT invent failure modes. Do NOT apologize when the server reported success."
         },
       },
       {
-        "description": "Pull the top-N matches for one of the user's open intents. partner_seek matches show "(redacted)" until both parties express interest.",
+        "description": "Show the user their matches. partner_seek matches show "(redacted)" until both parties express interest.
+
+TWO MODES — pick by what the user said:
+  • Specific post — they named one of their posts ("matches for my salsa request"): pass that intent_id for the top-N matches on that single post.
+  • All matches — they asked broadly ("show me my partner matches", "who matched with me?", "any matches?"): OMIT intent_id. The tool aggregates across all the user's open posts and navigates them to the My Matches screen.
+
+CRITICAL: when the user asks to see their matches without naming a post, just call this with NO intent_id. Do NOT ask which post. Do NOT say you can't show matches — this tool always succeeds and opens the matches screen, even when there are zero matches or no posts yet (it shows a friendly empty state + a CTA to post). Never offer matches and then retract.
+
+Optional intent_kind narrows the aggregate (e.g. partner_seek) when the user was specific about "partner" matches.",
         "name": "view_intent_matches",
         "parameters": {
           "properties": {
             "intent_id": {
+              "description": "Optional. One of the user's open intent_ids to scope matches to a single post. Omit to aggregate across all open posts and open the My Matches screen.",
+              "type": "string",
+            },
+            "intent_kind": {
+              "description": "Optional filter for the aggregate (no intent_id) mode, e.g. partner_seek for "partner matches".",
+              "enum": [
+                "commercial_buy",
+                "commercial_sell",
+                "activity_seek",
+                "partner_seek",
+                "social_seek",
+                "mutual_aid",
+                "learning_seek",
+                "mentor_seek",
+              ],
               "type": "string",
             },
             "limit": {
               "type": "integer",
             },
           },
-          "required": [
-            "intent_id",
-          ],
           "type": "object",
         },
       },


### PR DESCRIPTION
## The bad UX

> **Vitana:** "I can show you partner matches."
> **User:** "Ok, do it."
> **Vitana:** "I can't show you partner matches right now!!!"

Vitana offers matches, the user accepts, and then it immediately retracts the offer. That's the report this fixes.

## Root cause

The ORB `view_intent_matches` tool **hard-required `intent_id`**:

```ts
const intentId = String(args.intent_id ?? '').trim();
if (!intentId) return { ok: false, error: 'intent_id is required' };
```

When the user asks broadly — *"show me my partner matches"*, *"who matched with me?"* — there is no single post in context, so the LLM has no `intent_id` to pass. The tool returned `{ ok:false, error:'intent_id is required' }`, the model treated that as "I can't", and retracted the offer it had just made. (The frontend `getFindPartnerMatches` already aggregates across all of a user's open posts — the voice tool just never got that capability.)

## The fix

Make `intent_id` **optional**. When it's omitted, `view_intent_matches` now:

1. Lists the user's open intents (`open` / `matched` / `engaged`), optional `intent_kind` filter (e.g. `partner_seek` for "partner" matches).
2. Aggregates the top matches across them via `surfaceTopMatches`, with the same `redactMatchForReader` pre-reveal redaction the single-intent path uses.
3. Returns an `auto_nav` directive to the **Find a Partner → My Matches** screen (`COMM.FIND_PARTNER_MATCHES` → `/comm/find-partner?view=matches`) — which already renders its own graceful empty / filtered / error states.

So even with **zero matches** or **zero open posts**, the offer is *fulfilled* (navigate + warm copy: "post a wish and I'll let you know the moment someone matches") instead of refused. The single-intent path is unchanged.

The tool catalog + manifest were updated to document the two modes and explicitly instruct the LLM **not** to ask which post and **not** to retract — mirroring the existing VTID-02861 "never apologize for a non-failure" pattern.

## Files

- `services/gateway/src/services/orb-tools-shared.ts` — `viewAllMyMatches` aggregate helper + optional-`intent_id` branch in `tool_view_intent_matches`.
- `services/gateway/src/orb/live/tools/live-tool-catalog.ts` — `view_intent_matches` description/schema: `intent_id` no longer required, two-mode + no-retract guidance.
- `services/gateway/src/services/tool-manifest.json` — description updated.

## Verification notes

Full `tsc` couldn't run in this environment (`node_modules` not installed; the deprecated `moduleResolution=node10` halts the global TS 6.0 compiler before checking). The change reuses the exact imports, directive shape, and slim-mapping of the existing single-intent path. Recommend confirming a real build in CI / staging before promoting, then a quick voice smoke test: ask Vitana "show me my partner matches" with (a) a user who has matches, (b) a user with open posts but no matches, (c) a user with no posts — all three should open the My Matches screen, none should retract.

https://claude.ai/code/session_015yXqrSTDdctJD9FaLvQ9fE

---
_Generated by [Claude Code](https://claude.ai/code/session_015yXqrSTDdctJD9FaLvQ9fE)_