### PR TITLE
Publish modal: scope success/failure to current attempt — stale reused-VTID event caused false failure (VTID-0541)

### DIFF
--- a/services/gateway/src/frontend/command-hub/command-hub-staging.js
+++ b/services/gateway/src/frontend/command-hub/command-hub-staging.js
@@ -909,16 +909,36 @@
             if (typeof opts.onAfterPublish === 'function') opts.onAfterPublish(sf);
             return;
           }
-          // 2) Commit is NOT live yet — only now treat a terminal deploy FAILURE
-          //    for this publish VTID as fatal, so we surface a real failed deploy
-          //    instead of spinning "Publishing 100%…" forever.
+          // 2) Commit is NOT live yet. Inspect THIS attempt's OASIS events —
+          //    but publish VTIDs get REUSED, so a stale deploy.<svc>.failed (or
+          //    .success) from a previous life of this VTID must be ignored.
+          //    Only events at/after this publish started count.
           if (!sf.vtid) { setTimeout(tick, 6000); return; }
+          var freshFloor = (sf.startedAt || startMs) - 3 * 60 * 1000; // clock-skew buffer
           fetch('/api/v1/oasis/events?vtid=' + encodeURIComponent(sf.vtid) + '&limit=20', { credentials: 'include', headers })
             .then(function (r) { return r.ok ? r.json() : null; })
             .then(function (body) {
-              const evs = (body && body.data) || [];
-              const failed = evs.some(function (e) {
-                const t = (e.topic || e.type || '');
+              var evs = ((body && body.data) || []).filter(function (e) {
+                var ts = e.created_at ? Date.parse(e.created_at) : 0;
+                return ts >= freshFloor;
+              });
+              // A fresh governed SUCCESS event for this attempt also confirms the
+              // promotion is live — build-info can briefly lag traffic shifting,
+              // but deploy.<svc>.success / vtid.lifecycle.completed will not.
+              var succeeded = evs.some(function (e) {
+                var t = (e.topic || e.type || '');
+                return /deploy\.[a-z0-9_-]+\.success$/.test(t) ||
+                       (t === 'vtid.lifecycle.completed' && e.status === 'success');
+              });
+              if (succeeded) {
+                sf.phase = 'full-verified';
+                if (typeof renderApp === 'function') renderApp();
+                if (typeof opts.onAfterPublish === 'function') opts.onAfterPublish(sf);
+                return;
+              }
+              // Only a FRESH deploy/publish .failed (this attempt) is fatal.
+              var failed = evs.some(function (e) {
+                var t = (e.topic || e.type || '');
                 return /\.failed$/.test(t) && /deploy|publish/.test(t);
               });
               if (failed) {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -34,6 +34,6 @@
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
   <!-- Phase 0 staging build (P0.5): PUBLISH→staging-source card + CLOCK revert -->
-  <script src="/command-hub/command-hub-staging.js?v=20260610-publish-verify-live-first"></script>
+  <script src="/command-hub/command-hub-staging.js?v=20260612-publish-fresh-events-only"></script>
 </body>
 </html>


### PR DESCRIPTION
## Symptom

PUBLISH showed **"Deploy failed — production was NOT updated"** even though the deploy actually **succeeded** and production was updated to the promoted commit (`505e4b4`).

## Root cause

Two things combined:
1. The publish was allocated a **reused VTID** (`VTID-03301`). That VTID carried a `deploy.gateway.failed` event from **June 2** (a previous life of the same VTID number).
2. The publish poller (`pollUntilFullVerified`) queried *all* OASIS events for the VTID and matched **any** `deploy/publish .failed` topic — with no time scoping. So it found the 10-day-old stale failure and declared the current publish failed, while today's run emitted `deploy.gateway.success` + `vtid.lifecycle.completed (success)` and prod went live.

Verified via OASIS: both of today's publishes (`VTID-03300`, `VTID-03301`) reached `deploy.gateway.success` / lifecycle `success`; the only `.failed` events on those VTIDs are dated 2026-06-02/03.

## Fix (frontend, `command-hub-staging.js`)

- **Time-scope** event inspection to events at/after `sf.startedAt` (3-min clock-skew buffer). Stale events from a prior life of a reused VTID are ignored.
- Accept a **fresh** `deploy.<svc>.success` / `vtid.lifecycle.completed(success)` as positive confirmation (in addition to the `/admin/build-info` commit match), since build-info can briefly lag Cloud Run traffic shifting.
- A fresh `.failed` for *this* attempt is still surfaced as a real error.

`node -c` syntax-checked. Cache-bust param bumped.

## Note on the underlying reuse
The deeper cause is the publish allocator handing out a VTID that already had terminal events. This frontend fix makes the UI robust regardless. Hardening the allocator to never reuse a terminalized VTID is a separate backend change — happy to follow up if you want it.

(VTID-0541 — publish modal semantics)

https://claude.ai/code/session_01PecEbKwcw6wunXj4aSac5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01PecEbKwcw6wunXj4aSac5J)_