### PR TITLE
fix(staging): mount intent engine on gateway-staging (FEATURE_INTENT_ENGINE_A)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -136,6 +136,14 @@ jobs:
             # events with the per-phase timeline). staging-only — prod stays
             # off until the experiment window graduates it.
             "FEATURE_LATENCY_TELEMETRY_ENV=staging-only"
+            # VTID-01973 / VTID-01975 / VTID-01976: enable the Vitana Intent
+            # Engine routes (/intents, /intent-matches, /intent-board,
+            # /intent-categories, /intent-scan, …). Prod sets this in
+            # EXEC-DEPLOY.yml; staging omitted it, and because --set-env-vars
+            # REPLACES (not merges) the env, the routes never mounted on
+            # gateway-staging — every intents/board call 404'd, so Find a
+            # Partner / matches could not load on preview.vitanaland.com.
+            "FEATURE_INTENT_ENGINE_A=true"
           )
 
           # Comma-joined for --set-env-vars (replaces, not merges — we want the


### PR DESCRIPTION
## Symptom

On `preview.vitanaland.com`, **Find a Partner / "show me my matches" loads nothing**. Browser console shows 404s from the staging gateway:

- `GET /api/v1/intents?status=open` → **404**
- `GET /api/v1/intent-board?...surface=find_a_partner&limit=50` → **404**

This is why partner matches still appeared broken on staging even after PR #2661 (the voice-tool fix) merged — the failure is one layer lower, at the HTTP API.

## Root cause

The entire Vitana Intent Engine is gated behind a boot flag:

```ts
// services/gateway/src/index.ts:355
const intentEngineEnabled = process.env.FEATURE_INTENT_ENGINE_A === 'true';
const intentsRouter      = intentEngineEnabled ? require('./routes/intents').default : null;
const intentBoardRouter  = intentEngineEnabled ? require('./routes/intent-board').default : null;
// …intent-matches, intent-categories, intent-scan, intent-open-asks, intents-share, …
```

- **Production** sets it: `EXEC-DEPLOY.yml:409` → `--update-env-vars=FEATURE_INTENT_ENGINE_A=true`.
- **Staging** did **not**. `STAGE-DEPLOY.yml`'s `ENV_VARS` array omitted it, and the staging deploy uses `gcloud run deploy --set-env-vars=…`, which **replaces** (not merges) the service env. So `gateway-staging` booted with the flag unset → none of the intent routers mounted → every `/api/v1/intents*` and `/api/v1/intent-board*` call returned a 404 → matches/board/posts could not load anywhere on the staging frontend.

The workflow comment even states the rule this missed: *"Anything else the staging gateway needs MUST be additive."*

## Fix

Add `FEATURE_INTENT_ENGINE_A=true` to the staging `ENV_VARS` list so staging matches production and the intent engine actually runs on `gateway-staging`. One line; staging-only; no application code changed.

## After merge

Merging auto-deploys `gateway-staging` (`STAGE-DEPLOY.yml`). Once it's green, the intent routes will mount on staging and the 404s clear. Then the PR #2661 voice fix can finally be exercised end-to-end on `preview.vitanaland.com`:
- `/api/v1/intents?status=open` and the board endpoint should return **200 JSON** (not 404).
- Find a Partner → My Matches loads; "show me my partner matches" in ORB opens the screen instead of retracting.

**Note for prod:** production already has this flag, so nothing changes there — this only brings staging in line.

https://claude.ai/code/session_015yXqrSTDdctJD9FaLvQ9fE

---
_Generated by [Claude Code](https://claude.ai/code/session_015yXqrSTDdctJD9FaLvQ9fE)_