### PR TITLE
feat(discover): public guest feed for signed-out marketplace landing

### DIFF
--- a/services/gateway/src/routes/discover-feed.ts
+++ b/services/gateway/src/routes/discover-feed.ts
@@ -17,7 +17,7 @@
 import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { getSupabase } from '../lib/supabase';
-import { getUserHealthContext } from '../services/user-health-context';
+import { getUserHealthContext, type UserHealthContext } from '../services/user-health-context';
 import { applyUserLimitations, type FilterableProduct } from '../services/limitations-filter';
 import { rankFeedProducts, type FeedConfig } from '../services/feed-ranker';
 import * as jose from 'jose';
@@ -42,6 +42,50 @@ function extractUserIdOptimistic(req: Request): string | null {
   }
 }
 
+/**
+ * Public/guest context for the unauthenticated Discover landing experience.
+ *
+ * A signed-out visitor (e.g. someone evaluating the marketplace before
+ * signing up) gets the GLOBAL × onboarding starter selection: no
+ * personalization, no health-limitations filtering (a guest has no
+ * profile, so there is nothing to filter on), no past-purchase exclusion.
+ * Scope is 'international' so candidate fetch applies no origin restriction
+ * and the broadest curated starter set is shown. Carries no PII.
+ */
+function buildGuestHealthContext(): UserHealthContext {
+  return {
+    user_id: 'guest',
+    tenant_id: null,
+    active_conditions: [],
+    active_goals: [],
+    dietary_restrictions: [],
+    allergies: [],
+    contraindications: [],
+    current_medications: [],
+    pregnancy_status: null,
+    age_bracket: null,
+    religious_restrictions: [],
+    ingredient_sensitivities: [],
+    budget_max_per_product_cents: null,
+    budget_monthly_cap_cents: null,
+    budget_preferred_band: null,
+    wearable_summary_7d: null,
+    vitana_index_snapshot: null,
+    upcoming_events: [],
+    past_purchases: [],
+    recent_recommendations_dismissed: [],
+    topic_affinity: {},
+    country_code: null,
+    region_group: 'GLOBAL',
+    scope_preference: 'international',
+    currency: null,
+    lifecycle_stage: 'onboarding',
+    retrieved_at: new Date().toISOString(),
+    sources_queried: [],
+    stale: false,
+  };
+}
+
 router.get('/feed', async (req: Request, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) {
@@ -56,12 +100,12 @@ router.get('/feed', async (req: Request, res: Response) => {
   }
   const { category, limit } = parsed.data;
 
+  // Public landing: a signed-out visitor gets the GLOBAL starter feed instead
+  // of a 401, so the marketplace is viewable (and indexable / reviewable)
+  // without an account. Authenticated requests get the full personalized feed.
   const user_id = extractUserIdOptimistic(req);
-  if (!user_id) {
-    res.status(401).json({ ok: false, error: 'Authentication required for feed' });
-    return;
-  }
-  const ctx = await getUserHealthContext(user_id);
+  const isGuest = !user_id;
+  const ctx = isGuest ? buildGuestHealthContext() : await getUserHealthContext(user_id as string);
 
   const regionGroup = ctx.region_group ?? 'GLOBAL';
   const lifecycleStage = ctx.lifecycle_stage ?? 'onboarding';
@@ -183,6 +227,7 @@ router.get('/feed', async (req: Request, res: Response) => {
       scope: ctx.scope_preference,
       rationale: ranked.rationale,
       config_id: feedConfig?.id ?? null,
+      guest: isGuest,
     },
     hidden_breakdown: {
       ...hidden_breakdown,


### PR DESCRIPTION
## What

Makes the Discover marketplace feed (`GET /api/v1/discover/feed`) viewable **without a login**. Previously the handler returned `401 Authentication required for feed` to any request lacking a Bearer token, so `vitanaland.com/discover` could not be rendered for a signed-out visitor.

A guest now receives the **GLOBAL × onboarding starter selection**:
- no personalization, no `user_health_context` lookup (a guest has no profile)
- no health-limitations filtering (nothing to filter on)
- no past-purchase exclusion
- scope `international` → candidate fetch applies no origin restriction (broadest curated starter set)
- carries **no PII**

The response sets `feed_context.guest = true` so the front-end can render a "sign in to earn rewards" prompt over the public feed. **Authenticated requests are completely unchanged** — they still resolve full `UserHealthContext` and get the personalized, limitations-filtered feed.

## Why

The marketplace needs to be viewable by signed-out visitors — e.g. an affiliate-network reviewer evaluating the property before approving an application, or a prospective member browsing before sign-up. A login wall on `/discover` blocks both.

> Note: this is the **backend half**. The Discover **page UI** lives in the separate front-end app repo; its route guard must also allow unauthenticated render and call this feed without a token. That front-end change is tracked separately.

## Scope / safety

- Single file: `services/gateway/src/routes/discover-feed.ts`
- No new auth surface for mutations; this is a read-only browse feed
- No PII in the guest path (guest context has empty profile fields)
- `tsc --noEmit` clean

https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK)_