### PR TITLE
feat(orb): rotate the conversation opener across sessions (VTID-03301)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/decide-continuation.ts
+++ b/services/gateway/src/services/assistant-continuation/decide-continuation.ts
@@ -69,6 +69,38 @@ export interface DecideContinuationOptions {
   now?: () => Date;
   /** Injected for testability. Defaults to `randomUUID`. */
   newId?: () => string;
+  /**
+   * VTID-03301 — opener dedupe keys this user was recently served, MOST-RECENT
+   * FIRST. The ranker demotes any candidate whose `dedupeKey` is in this list so
+   * the same opener does not win session after session (the "complete your
+   * profile every time" defect). It is a soft penalty, not exclusion: a single
+   * genuinely-high-priority item (e.g. a due reminder) can still win if nothing
+   * fresher is comparable.
+   */
+  recentlyServedDedupeKeys?: ReadonlyArray<string>;
+  /** Penalty applied to a recently-served candidate's effective priority. */
+  recencyPenalty?: number;
+}
+
+/** Default soft penalty — large enough to flip ties between same-tier providers. */
+export const DEFAULT_RECENCY_PENALTY = 30;
+
+/**
+ * VTID-03301 — effective priority after the rotation penalty. The exact opener
+ * served LAST time is demoted hardest (×1.5) so it almost never repeats
+ * back-to-back; anything else in the recent window gets the base penalty.
+ * Returns the unchanged priority when the key is fresh.
+ */
+export function effectivePriority(
+  basePriority: number,
+  dedupeKey: string,
+  recentlyServed: ReadonlyArray<string>,
+  penalty: number,
+): number {
+  if (recentlyServed.length === 0) return basePriority;
+  if (recentlyServed[0] === dedupeKey) return basePriority - penalty * 1.5;
+  if (recentlyServed.includes(dedupeKey)) return basePriority - penalty;
+  return basePriority;
 }
 
 /**
@@ -98,16 +130,24 @@ export async function decideContinuation(
     results.push(await invokeProviderSafely(provider, fullContext, now));
   }
 
-  // Rank: only `returned` candidates are eligible. Stable sort by
-  // descending priority. Ties keep registration order (which providers.
-  // forSurface returns in deterministic Map-iteration order).
+  // Rank: only `returned` candidates are eligible. Stable sort by descending
+  // EFFECTIVE priority (base priority minus the VTID-03301 rotation penalty for
+  // recently-served openers), then registration order on ties. The penalty is
+  // what stops the same provider+step ("journey_guide:life_compass") winning
+  // every session and lets reminders / continuity / a different step rotate in.
+  const recentlyServed = opts.recentlyServedDedupeKeys ?? [];
+  const penalty = opts.recencyPenalty ?? DEFAULT_RECENCY_PENALTY;
   const candidates = results
     .filter((r): r is ProviderResult & { candidate: AssistantContinuation } =>
       r.status === 'returned' && r.candidate !== undefined,
     )
-    .map((r, idx) => ({ result: r, idx }))
+    .map((r, idx) => ({
+      result: r,
+      idx,
+      eff: effectivePriority(r.candidate.priority, r.candidate.dedupeKey, recentlyServed, penalty),
+    }))
     .sort((a, b) => {
-      const dp = b.result.candidate.priority - a.result.candidate.priority;
+      const dp = b.eff - a.eff;
       return dp !== 0 ? dp : a.idx - b.idx;
     });
 

--- a/services/gateway/src/services/orb/orb-session-state.ts
+++ b/services/gateway/src/services/orb/orb-session-state.ts
@@ -16,7 +16,14 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-export type OrbSessionStateKey = 'continuity' | 'audio_ready_ack' | 'pending_cta';
+export type OrbSessionStateKey =
+  | 'continuity'
+  | 'audio_ready_ack'
+  | 'pending_cta'
+  // VTID-03301 — rolling list of recently-served opener dedupe keys
+  // (most-recent first), used to rotate the wake-brief opener across sessions
+  // so users don't hear the same "complete your profile" line every time.
+  | 'recent_openers';
 
 export interface OrbSessionStateRecord<T = unknown> {
   value: T;

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -115,6 +115,13 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 // caller (live-session-controller / orb-livekit) so we can keep this
 // module pure on the read side.
 import { recordWakeBriefEmitted } from './wake-cadence-signals';
+// VTID-03301 — cross-session opener rotation.
+import { readOrbSessionState } from './orb/orb-session-state';
+
+/** How many recent openers to remember per user (the rotation window). */
+const RECENT_OPENERS_WINDOW = 6;
+/** TTL for the rotation memory (48h) — long enough to vary day-to-day. */
+const RECENT_OPENERS_TTL_MIN = 48 * 60;
 
 // ---------------------------------------------------------------------------
 // One-time provider registration. The default registry started empty in
@@ -463,9 +470,23 @@ export async function decideWakeBriefForSession(
     }
   }
 
+  // VTID-03301 — load the openers this user was recently served so the ranker
+  // can rotate. Most-recent first. Best-effort: a read failure just means no
+  // penalty (old behaviour). Authenticated users only (anonymous have no state).
+  let recentlyServedDedupeKeys: string[] = [];
+  if (args.supabase && args.userId) {
+    try {
+      const rec = await readOrbSessionState<string[]>(args.supabase, args.userId, 'recent_openers');
+      if (rec && Array.isArray(rec.value)) {
+        recentlyServedDedupeKeys = rec.value.filter((k) => typeof k === 'string').slice(0, RECENT_OPENERS_WINDOW);
+      }
+    } catch { /* best-effort — no penalty on read failure */ }
+  }
+
   const t0 = now();
   const decision = await decideContinuation({
     surface: 'orb_wake',
+    recentlyServedDedupeKeys,
     context: {
       sessionId: args.sessionId,
       userId: args.userId ?? undefined,
@@ -510,6 +531,20 @@ export async function decideWakeBriefForSession(
     tenantId: args.tenantId,
     surface: 'orb_wake',
   });
+
+  // VTID-03301 — persist the opener we just served so the NEXT session rotates
+  // away from it. Most-recent first, capped to the window. Only on a real
+  // emission (recordEmission) with an authenticated user + a selected opener.
+  if (args.recordEmission && args.supabase && args.userId && decision.selectedContinuation?.dedupeKey) {
+    const servedKey = decision.selectedContinuation.dedupeKey;
+    const nextList = [servedKey, ...recentlyServedDedupeKeys.filter((k) => k !== servedKey)]
+      .slice(0, RECENT_OPENERS_WINDOW);
+    void import('./orb/orb-session-state')
+      .then(({ writeOrbSessionState }) =>
+        writeOrbSessionState(args.supabase!, args.userId!, 'recent_openers', nextList, RECENT_OPENERS_TTL_MIN),
+      )
+      .catch(() => { /* best-effort — rotation degrades gracefully */ });
+  }
 
   // VTID-03081 (B1 wiring): record greeting style + timestamp so the
   // next session can dampen. Fire-and-forget — write failure is

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -473,15 +473,27 @@ export async function decideWakeBriefForSession(
   // VTID-03301 — load the openers this user was recently served so the ranker
   // can rotate. Most-recent first. Best-effort: a read failure just means no
   // penalty (old behaviour). Authenticated users only (anonymous have no state).
-  let recentlyServedDedupeKeys: string[] = [];
+  //
+  // Codex review fix: rotation applies ONLY to PASSIVE/ambient opens. When the
+  // user EXPLICITLY tapped a Guided Journey topic (`guidedTopicId`) or a
+  // Foundation focus step (`journeyFocusStep`), that is a direct user action
+  // that MUST lead turn 1 — demoting it would open the wrong conversation than
+  // the one the user just asked for. So we skip rotation entirely on explicit
+  // opens and honor the tapped candidate at its true priority.
+  const isExplicitSelection = !!(args.guidedTopicId || args.journeyFocusStep);
+  let storedRecentOpeners: string[] = [];
   if (args.supabase && args.userId) {
     try {
       const rec = await readOrbSessionState<string[]>(args.supabase, args.userId, 'recent_openers');
       if (rec && Array.isArray(rec.value)) {
-        recentlyServedDedupeKeys = rec.value.filter((k) => typeof k === 'string').slice(0, RECENT_OPENERS_WINDOW);
+        storedRecentOpeners = rec.value.filter((k) => typeof k === 'string').slice(0, RECENT_OPENERS_WINDOW);
       }
     } catch { /* best-effort — no penalty on read failure */ }
   }
+  // Withhold the rotation penalty from the ranker on explicit opens (the tapped
+  // candidate must lead), but keep `storedRecentOpeners` so the write below
+  // still merges onto the real history instead of wiping it.
+  const recentlyServedDedupeKeys: string[] = isExplicitSelection ? [] : storedRecentOpeners;
 
   const t0 = now();
   const decision = await decideContinuation({
@@ -537,7 +549,7 @@ export async function decideWakeBriefForSession(
   // emission (recordEmission) with an authenticated user + a selected opener.
   if (args.recordEmission && args.supabase && args.userId && decision.selectedContinuation?.dedupeKey) {
     const servedKey = decision.selectedContinuation.dedupeKey;
-    const nextList = [servedKey, ...recentlyServedDedupeKeys.filter((k) => k !== servedKey)]
+    const nextList = [servedKey, ...storedRecentOpeners.filter((k) => k !== servedKey)]
       .slice(0, RECENT_OPENERS_WINDOW);
     void import('./orb/orb-session-state')
       .then(({ writeOrbSessionState }) =>

--- a/services/gateway/test/services/assistant-continuation/decide-continuation.test.ts
+++ b/services/gateway/test/services/assistant-continuation/decide-continuation.test.ts
@@ -878,3 +878,67 @@ describe('B0d.1 decideContinuation — rollUpSuppressionReason helper', () => {
     ).toBe('no_provider_returned_a_candidate');
   });
 });
+
+// ---------------------------------------------------------------------------
+// VTID-03301 — cross-session opener rotation penalty
+// ---------------------------------------------------------------------------
+import {
+  effectivePriority,
+  DEFAULT_RECENCY_PENALTY,
+} from '../../../src/services/assistant-continuation/decide-continuation';
+
+describe('VTID-03301 rotation penalty', () => {
+  it('effectivePriority: fresh key unchanged; last-served demoted hardest; in-window demoted', () => {
+    const recent = ['journey_guide:life_compass', 'reminder_due:abc'];
+    // fresh
+    expect(effectivePriority(91, 'calendar_upcoming:x', recent, 30)).toBe(91);
+    // most-recent (index 0) → base - 30*1.5
+    expect(effectivePriority(91, 'journey_guide:life_compass', recent, 30)).toBe(91 - 45);
+    // in window but not most-recent → base - 30
+    expect(effectivePriority(90, 'reminder_due:abc', recent, 30)).toBe(90 - 30);
+    // empty recent → no penalty
+    expect(effectivePriority(91, 'anything', [], 30)).toBe(91);
+  });
+
+  it('without recency, the highest base priority wins (baseline behaviour preserved)', async () => {
+    const registry = createProviderRegistry();
+    registry.register(returningProvider('journey', wakeBriefCandidate({ id: 'j', priority: 91, line: 'complete your profile', dedupeKey: 'journey_guide:life_compass' })));
+    registry.register(returningProvider('reminder', wakeBriefCandidate({ id: 'r', priority: 90, line: 'your reminder is due', dedupeKey: 'reminder_due:abc' })));
+    const d = await decideContinuation({
+      surface: 'orb_wake',
+      context: { sessionId: 's', userId: 'u' },
+      registry, now: frozenNow(), newId: newIdFactory(),
+    });
+    expect(d.selectedContinuation?.dedupeKey).toBe('journey_guide:life_compass');
+  });
+
+  it('when the top opener was just served, a DIFFERENT relevant opener wins instead', async () => {
+    const registry = createProviderRegistry();
+    registry.register(returningProvider('journey', wakeBriefCandidate({ id: 'j', priority: 91, line: 'complete your profile', dedupeKey: 'journey_guide:life_compass' })));
+    registry.register(returningProvider('reminder', wakeBriefCandidate({ id: 'r', priority: 90, line: 'your reminder is due', dedupeKey: 'reminder_due:abc' })));
+    const d = await decideContinuation({
+      surface: 'orb_wake',
+      context: { sessionId: 's', userId: 'u' },
+      registry, now: frozenNow(), newId: newIdFactory(),
+      recentlyServedDedupeKeys: ['journey_guide:life_compass'],
+    });
+    // journey 91 - 45 = 46 < reminder 90 → reminder rotates in
+    expect(d.selectedContinuation?.dedupeKey).toBe('reminder_due:abc');
+  });
+
+  it('rotation is a soft penalty: a lone recently-served opener still wins if nothing else qualifies', async () => {
+    const registry = createProviderRegistry();
+    registry.register(returningProvider('journey', wakeBriefCandidate({ id: 'j', priority: 91, line: 'complete your profile', dedupeKey: 'journey_guide:life_compass' })));
+    const d = await decideContinuation({
+      surface: 'orb_wake',
+      context: { sessionId: 's', userId: 'u' },
+      registry, now: frozenNow(), newId: newIdFactory(),
+      recentlyServedDedupeKeys: ['journey_guide:life_compass'],
+    });
+    expect(d.selectedContinuation?.dedupeKey).toBe('journey_guide:life_compass');
+  });
+
+  it('DEFAULT_RECENCY_PENALTY is exported and positive', () => {
+    expect(DEFAULT_RECENCY_PENALTY).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Rotate the conversation opener across sessions (VTID-03301)

**This targets the real complaint: every conversation opens with the same "complete your profile" line.**

### Root cause — from production telemetry, not theory
The wake-brief ranker (`decideContinuation`) sorted purely by descending priority with **zero recency**. So `journey_guide:life_compass` (priority 91) won **200 times across 18 production community users in 7 days** — the same opener every session — while `reminder_due`, continuity, calendar, and other journey steps almost never won (each ≤2 times). That is the robot-repeat users feel.

### Fix
- **`decide-continuation.ts`** — a cross-session **rotation penalty**: a candidate whose `dedupeKey` was recently served is demoted (the exact last opener hardest, ×1.5; others in the window by the base penalty). It's a **soft** penalty — a lone genuinely-high-priority item (e.g. a due reminder) still wins if nothing fresher is comparable. Pure + unit-tested.
- **`wake-brief-wiring.ts`** — reads the user's `recent_openers` before ranking and **persists** the served opener after (`orb_session_state`, key `recent_openers`, window 6, 48h TTL). This is the persistence that was missing — so the next conversation can't pick what the last one did.
- **`orb-session-state.ts`** — new `recent_openers` state key.

Net effect: first conversation today → journey step; next → a reminder / continuity / a *different* step. **People feel the difference when starting a new conversation.**

### Verification
- **46** ranker tests (5 new: penalty math + "different opener wins after repeat" + soft-penalty fallback) and **560** continuation/wake tests green; `tsc --noEmit` clean.
- Diagnosed against real production `next_action.suggested` dedupe-key telemetry (the 200× `journey_guide:life_compass`).

### Deployment reality (so this actually reaches the community)
Merging deploys to **staging only**. The community users are on **production** — this must be **PUBLISHed** to prod (Command Hub PUBLISH button, or `scripts/deploy/publish-to-prod.sh`) to reach them. I'll verify on staging after merge; promoting to prod is the step that puts it in front of the 100 users.

https://claude.ai/code/session_01EmnFKR4rTuXFXnhVu7epbG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmnFKR4rTuXFXnhVu7epbG)_