### PR TITLE
fix(journey): correct session-CHECK ordering in onboarding migration (23514)

### DIFF
--- a/supabase/migrations/20260613003000_BOOTSTRAP_first_time_onboarding_sessions.sql
+++ b/supabase/migrations/20260613003000_BOOTSTRAP_first_time_onboarding_sessions.sql
@@ -28,11 +28,10 @@
 
 BEGIN;
 
--- 1. Widen the session bound to fit the four new opening sessions.
+-- 1. Drop the session bound so the two-step renumber can use temporary high
+--    values (a direct ADD of BETWEEN 1 AND 94 here would reject the +1000 shuffle).
 ALTER TABLE journey_checklist_topics
   DROP CONSTRAINT IF EXISTS journey_checklist_topics_session_check;
-ALTER TABLE journey_checklist_topics
-  ADD CONSTRAINT journey_checklist_topics_session_check CHECK (session BETWEEN 1 AND 94);
 
 -- 2 + 3. Renumber the existing draft curriculum and user session pointers.
 DO $mig$
@@ -53,6 +52,10 @@ BEGIN
   END IF;
 END
 $mig$;
+
+-- 1b. Re-add the widened session bound now that all sessions are final (1..94).
+ALTER TABLE journey_checklist_topics
+  ADD CONSTRAINT journey_checklist_topics_session_check CHECK (session BETWEEN 1 AND 94);
 
 -- 4. The four onboarding topics (German source; English voice scripts are LLM
 --    guidance material — the narration provider teaches in the user's locale).


### PR DESCRIPTION
## Problem
`20260613003000_BOOTSTRAP_first_time_onboarding_sessions.sql` re-added the `session` CHECK as `BETWEEN 1 AND 94` **before** its two-step renumber. The first half of that shuffle (`UPDATE … SET session = session + 1000`) produces values like 1007, which the just-tightened constraint rejects:

```
ERROR: 23514: new row for relation "journey_checklist_topics" violates check constraint "journey_checklist_topics_session_check"
CONTEXT: UPDATE journey_checklist_topics SET session = session + 1000 WHERE curriculum_version = 'v2'
```

The SQL was authored but never actually executed, so the bug shipped unnoticed. Any `RUN-STAGING-MIGRATION` / `RUN-MIGRATION` run would have failed.

## Fix
Drop the CHECK before the shift; re-add `BETWEEN 1 AND 94` **after** the renumber DO block, once every session is final (existing v2 → 5–94, new T251–T254 → 1–4). Pure ordering change — no content/data difference.

## Verified
Applied the corrected SQL to the staging Supabase project — result: **94 sessions / 254 topics**, current published snapshot rewritten in place to **254 entries**, T251–T254 at sessions 1–4, T001 shifted to session 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)