### PR TITLE
feat(orb): Greeting v2 Phases 1–3 — My Longevity Journey-centric login briefing

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/login-briefing.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/login-briefing.ts
@@ -1,0 +1,466 @@
+/**
+ * Greeting v2 — Login Briefing continuation provider.
+ *
+ * The single, always-on, "My Longevity Journey"-centric greeting the user
+ * hears after login. Replaces the fragmented behaviour where a returning
+ * user got a generic Feature-Discovery pitch ("Lass mich dir eine Entdeckung
+ * zeigen") instead of a warm, motivational status check-in on their journey.
+ *
+ * Design (approved with the product owner):
+ *   - Source of truth for "sessions completed / next session" is the
+ *     90-session GUIDED JOURNEY curriculum (user_guided_journey_state +
+ *     the published journey_checklist), NOT the waves/Foundation models.
+ *   - The compliment is EARNED-ONLY: every praise line is tied to a real
+ *     number (sessions completed, Vitana Index delta). When there is no
+ *     measurable progress yet, the greeting ORIENTS and INVITES — it never
+ *     flatters with empty encouragement.
+ *   - Time-of-day + name awareness is GUARANTEED here (slot 1). It reuses
+ *     the proven timezone-aware salutation logic from new-day-return so the
+ *     greeting always opens with "Guten Morgen/Tag/Abend, {name}" regardless
+ *     of which journey state fires. (Previously this only existed in
+ *     new-day-return, which fires once per calendar day, so it "disappeared"
+ *     whenever the Teacher won the ranker.)
+ *   - "Speak fast, enrich after": the salutation is always producible from
+ *     timezone alone; the journey reads run in parallel and degrade
+ *     gracefully (a slow/failed checklist read just drops the next-session
+ *     title, never the greeting).
+ *
+ * State machine (one warm paragraph, slots filled per state):
+ *   A — no journey progress + no goal      → orient + invite, NO compliment
+ *   B — 1+ sessions, steady                 → "{n} sessions done" + earned praise + next session
+ *   C — 1+ sessions, Index up               → adds the real Index delta as the compliment
+ *   D — returning after a multi-day gap      → welcoming, "your {n} sessions aren't lost", next session
+ *   E — onboarding qualified/completed       → praise mastery, shift to depth
+ *   (F same-day reconnect is handled upstream by greetingPolicy='skip' → suppress.)
+ *
+ * Priority 93: above journey-guide (91), new-day-return (90), next-action
+ * (90), Teacher (85) and wake-brief (80) — so the unified briefing leads the
+ * normal login. Below guided-topic-narration (96, explicit tap),
+ * first-time-welcome (95, first-ever session) and goal-completion (92, a
+ * passed goal deadline) — those special moments still lead.
+ */
+
+import { randomUUID } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  ContinuationDecisionContext,
+  ContinuationProvider,
+  ProviderResult,
+  AssistantContinuation,
+} from '../types';
+import {
+  localHourInTimezone,
+  pickSalutationKind,
+  todayInTimezone,
+  type SalutationKind,
+} from './new-day-return';
+import { getJourneyState } from '../../guided-journey/guided-journey-state';
+import { getPublishedChecklist } from '../../guided-journey/checklist-service';
+import { fetchLifeCompass, fetchVitanaIndexForProfiler } from '../../user-context-profiler';
+
+export const LOGIN_BRIEFING_PROVIDER_KEY = 'login_briefing';
+export const LOGIN_BRIEFING_EXTRA_KEY = 'loginBriefing' as const;
+
+/** Above journey-guide (91) / new-day-return (90); below goal-completion (92). */
+const DEFAULT_PRIORITY = 93;
+
+/** A gap of this many calendar days since the last session triggers State D. */
+const RETURN_GAP_DAYS = 3;
+/** An Index 7-day delta of at least this magnitude is "material" enough to praise. */
+const MATERIAL_INDEX_DELTA = 5;
+
+export interface LoginBriefingInputs {
+  supabase: SupabaseClient;
+  userId: string;
+  tenantId: string;
+  lang: string;
+  firstName: string | null;
+  /** IANA timezone from clientContext.timezone. Drives the salutation. */
+  timezone: string | null;
+  /** From the greeting-policy decision. `skip` → suppress (silent reconnect). */
+  greetingPolicy: string;
+}
+
+export interface LoginBriefingProviderOptions {
+  newId?: () => string;
+  now?: () => number;
+  priority?: number;
+  rng?: () => number;
+}
+
+// ---------------------------------------------------------------------------
+// State model
+// ---------------------------------------------------------------------------
+
+export type BriefingState = 'orient' | 'building' | 'momentum' | 'returning' | 'graduated';
+
+export interface BriefingFacts {
+  /** Sessions the user has finished (the ones before the current pointer). */
+  sessionsCompleted: number;
+  /** The session the user is on / about to do. */
+  nextSessionNumber: number;
+  /** Title of the next session, when the published checklist resolved it. */
+  nextSessionTitle: string | null;
+  /** Onboarding lifecycle from the guided-journey state. */
+  graduated: boolean;
+  /** True when the user has set a Life Compass primary goal. */
+  hasGoal: boolean;
+  /** Material positive Vitana Index 7-day delta, else null. */
+  indexDeltaUp: number | null;
+  /** Days since the last session (in user TZ), when known. */
+  daysSinceLastSession: number | null;
+}
+
+/** Pick the state purely from the gathered facts. Exported for tests. */
+export function pickBriefingState(f: BriefingFacts): BriefingState {
+  if (f.graduated) return 'graduated';
+  if (f.sessionsCompleted <= 0) return 'orient';
+  if (f.daysSinceLastSession !== null && f.daysSinceLastSession >= RETURN_GAP_DAYS) {
+    return 'returning';
+  }
+  if (f.indexDeltaUp !== null) return 'momentum';
+  return 'building';
+}
+
+// ---------------------------------------------------------------------------
+// Copy — DE is the source of truth (du-form). EN mirrors it. Each state has a
+// small pool so the opening does not repeat word-for-word every login.
+// ---------------------------------------------------------------------------
+
+function salutationPrefix(lang: string, s: SalutationKind, firstName: string | null): string {
+  const word =
+    lang === 'de'
+      ? s === 'morning'
+        ? 'Guten Morgen'
+        : s === 'afternoon'
+          ? 'Guten Tag'
+          : 'Guten Abend'
+      : s === 'morning'
+        ? 'Good morning'
+        : s === 'afternoon'
+          ? 'Good afternoon'
+          : 'Good evening';
+  return firstName ? `${word}, ${firstName}.` : `${word}.`;
+}
+
+function pickFromPool(pool: string[], rng: () => number): string {
+  if (pool.length === 0) return '';
+  const idx = Math.min(pool.length - 1, Math.max(0, Math.floor(rng() * pool.length)));
+  return pool[idx];
+}
+
+/** The "what's missing" nudge — at most one, framed as an upgrade, never nagging. */
+function buildNudge(lang: string, f: BriefingFacts): string {
+  // Only nudge users who are actually on the journey; State A already invites.
+  if (f.sessionsCompleted <= 0) return '';
+  if (!f.hasGoal) {
+    return lang === 'de'
+      ? 'Wenn du magst, richten wir noch dein persönliches Ziel ein — dann schneide ich deine Journey genau darauf zu.'
+      : 'If you like, we can set your personal goal too — then I can tailor your journey precisely to it.';
+  }
+  return '';
+}
+
+interface RenderArgs {
+  lang: string;
+  salutation: SalutationKind;
+  firstName: string | null;
+  facts: BriefingFacts;
+}
+
+/** Compose the spoken briefing line for the picked state. Pure. Exported for tests. */
+export function renderBriefingLine(args: RenderArgs, rng: () => number = Math.random): string {
+  const de = args.lang === 'de';
+  const prefix = salutationPrefix(args.lang, args.salutation, args.firstName);
+  const f = args.facts;
+  const state = pickBriefingState(f);
+
+  // The next-session clause is only spoken when the title resolved.
+  const nextClause = (() => {
+    if (!f.nextSessionTitle) {
+      return de
+        ? 'Deine nächste Session wartet schon auf dich.'
+        : 'Your next session is ready for you.';
+    }
+    return de
+      ? `Als Nächstes käme Session ${f.nextSessionNumber}: „${f.nextSessionTitle}".`
+      : `Next up is Session ${f.nextSessionNumber}: "${f.nextSessionTitle}".`;
+  })();
+
+  const invite = pickFromPool(
+    de
+      ? ['Sollen wir weitermachen?', 'Lust, gleich weiterzumachen?', 'Wollen wir loslegen?']
+      : ['Shall we continue?', 'Want to keep going?', "Shall we get started?"],
+    rng,
+  );
+
+  switch (state) {
+    case 'orient': {
+      // No measurable progress → orient + invite. No compliment (earned-only).
+      const body = de
+        ? 'Deine Longevity-Journey wartet noch auf ihren ersten Schritt. Lass uns kurz dein Ziel setzen — das gibt allem eine Richtung.'
+        : 'Your longevity journey is still waiting for its first step. Let us set your goal — it gives everything direction.';
+      return [prefix, body, invite].filter(Boolean).join(' ');
+    }
+
+    case 'building': {
+      const praise = de
+        ? `Stark — du hast schon ${f.sessionsCompleted} ${f.sessionsCompleted === 1 ? 'Session' : 'Sessions'} geschafft.`
+        : `Strong work — you have already completed ${f.sessionsCompleted} ${f.sessionsCompleted === 1 ? 'session' : 'sessions'}.`;
+      const nudge = buildNudge(args.lang, f);
+      return [prefix, praise, nextClause, nudge, invite].filter(Boolean).join(' ');
+    }
+
+    case 'momentum': {
+      const delta = f.indexDeltaUp ?? 0;
+      const praise = de
+        ? `Schön, dich zu hören. Du bist bei Session ${f.nextSessionNumber} — und dein Vitana Index ist diese Woche um ${delta} Punkte gestiegen. Das ist echte Konstanz.`
+        : `Good to hear you. You are on Session ${f.nextSessionNumber} — and your Vitana Index is up ${delta} points this week. That is real consistency.`;
+      const nudge = buildNudge(args.lang, f);
+      return [prefix, praise, nextClause, nudge, invite].filter(Boolean).join(' ');
+    }
+
+    case 'returning': {
+      const body = de
+        ? `Schön, dass du wieder da bist. Es ist ein paar Tage her — aber deine ${f.sessionsCompleted} ${f.sessionsCompleted === 1 ? 'Session' : 'Sessions'} sind nicht verloren, du knüpfst genau dort wieder an.`
+        : `Good to have you back. It has been a few days — but your ${f.sessionsCompleted} ${f.sessionsCompleted === 1 ? 'session' : 'sessions'} are not lost; you pick up right where you left off.`;
+      const invite2 = de ? 'Lass uns den Faden wieder aufnehmen?' : 'Shall we pick the thread back up?';
+      return [prefix, body, nextClause, invite2].filter(Boolean).join(' ');
+    }
+
+    case 'graduated': {
+      const body =
+        f.sessionsCompleted > 0
+          ? de
+            ? `Du hast deine Onboarding-Journey komplett gemeistert — ${f.sessionsCompleted} Sessions, alle dein. Jetzt geht es um Tiefe.`
+            : `You have fully mastered your onboarding journey — ${f.sessionsCompleted} sessions, all yours. Now it is about depth.`
+          : de
+            ? 'Du hast deine Onboarding-Journey gemeistert. Jetzt geht es um Tiefe.'
+            : 'You have mastered your onboarding journey. Now it is about depth.';
+      const invite2 = de
+        ? 'Wo möchtest du heute ansetzen?'
+        : 'Where would you like to focus today?';
+      return [prefix, body, invite2].filter(Boolean).join(' ');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Input reading + DB gathering
+// ---------------------------------------------------------------------------
+
+function readInputs(ctx: ContinuationDecisionContext): LoginBriefingInputs | null {
+  const extra = ctx.extra;
+  if (!extra || typeof extra !== 'object') return null;
+  const raw = (extra as Record<string, unknown>)[LOGIN_BRIEFING_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.userId !== 'string' || o.userId.length === 0) return null;
+  if (typeof o.tenantId !== 'string' || o.tenantId.length === 0) return null;
+  if (!o.supabase) return null;
+  return {
+    supabase: o.supabase as SupabaseClient,
+    userId: o.userId,
+    tenantId: o.tenantId,
+    lang: typeof o.lang === 'string' && o.lang.length > 0 ? o.lang : 'en',
+    firstName: typeof o.firstName === 'string' && o.firstName.length > 0 ? o.firstName : null,
+    timezone: typeof o.timezone === 'string' && o.timezone.length > 0 ? o.timezone : null,
+    greetingPolicy: typeof o.greetingPolicy === 'string' ? o.greetingPolicy : 'fresh_intro',
+  };
+}
+
+interface UserJourneyRow {
+  last_session_date: string | null; // YYYY-MM-DD in user TZ
+  is_first_session: boolean;
+}
+
+/** Whole-day difference between two YYYY-MM-DD strings, or null when unknown. */
+function dayDiff(todayIso: string, lastIso: string | null): number | null {
+  if (!lastIso) return null;
+  const a = Date.parse(`${todayIso}T00:00:00Z`);
+  const b = Date.parse(`${lastIso}T00:00:00Z`);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+  return Math.max(0, Math.round((a - b) / 86_400_000));
+}
+
+/** Narrow the session lang to a checklist locale the service understands. */
+function checklistLocale(lang: string): 'de' | 'en' {
+  return lang === 'de' ? 'de' : 'en';
+}
+
+/**
+ * Resolve the title of the session the user is about to do (the lowest-position
+ * topic whose `session` equals `nextSessionNumber`). Best-effort: returns null
+ * on any failure so the briefing degrades to "your next session is ready".
+ */
+async function resolveNextSessionTitle(
+  supabase: SupabaseClient,
+  lang: string,
+  nextSessionNumber: number,
+): Promise<string | null> {
+  try {
+    const checklist = await getPublishedChecklist(supabase, 'v2', checklistLocale(lang));
+    const inSession = checklist.topics
+      .filter((t) => t.session === nextSessionNumber)
+      .sort((a, b) => a.position - b.position);
+    const title = inSession[0]?.displayLabel;
+    return typeof title === 'string' && title.trim().length > 0 ? title.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function makeLoginBriefingProvider(
+  opts: LoginBriefingProviderOptions = {},
+): ContinuationProvider {
+  const newId = opts.newId ?? randomUUID;
+  const now = opts.now ?? (() => Date.now());
+  const priority = opts.priority ?? DEFAULT_PRIORITY;
+  const rng = opts.rng ?? Math.random;
+
+  return {
+    key: LOGIN_BRIEFING_PROVIDER_KEY,
+    surfaces: ['orb_wake'],
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const t0 = now();
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return {
+          providerKey: LOGIN_BRIEFING_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'no_login_briefing_inputs',
+        };
+      }
+
+      // Silent reconnect / greeted-too-recently: stay quiet and let the
+      // upstream skip policy hold. (State F — same-day quick reconnect.)
+      if (inputs.greetingPolicy === 'skip') {
+        return {
+          providerKey: LOGIN_BRIEFING_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'greeting_policy_skip',
+        };
+      }
+
+      // Gather journey facts in parallel; each source degrades to a safe
+      // default so a single slow/failed read never blocks the greeting.
+      const nowDate = new Date(now());
+      const [journeyState, userJourney, lifeCompass, indexSnap] = await Promise.all([
+        getJourneyState(inputs.supabase, inputs.userId).catch(() => null),
+        fetchUserJourneyRow(inputs.supabase, inputs.userId).catch(() => null),
+        fetchLifeCompass(inputs.supabase, inputs.userId).catch(() => null),
+        fetchVitanaIndexForProfiler(inputs.supabase, inputs.userId).catch(() => null),
+      ]);
+
+      // Brand-new users belong to first-time-welcome (priority 95) — yield so
+      // we never double-brief someone on their very first session.
+      if (userJourney?.is_first_session === true) {
+        return {
+          providerKey: LOGIN_BRIEFING_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'is_first_session_true',
+        };
+      }
+
+      const currentSession =
+        journeyState && Number.isFinite(journeyState.currentSession)
+          ? Math.max(1, journeyState.currentSession)
+          : 1;
+      const sessionsCompleted = Math.max(0, currentSession - 1);
+      const graduated =
+        journeyState?.onboardingStatus === 'qualified' ||
+        journeyState?.onboardingStatus === 'completed';
+
+      const nextSessionTitle = await resolveNextSessionTitle(
+        inputs.supabase,
+        inputs.lang,
+        currentSession,
+      );
+
+      const trend = readIndexTrend(indexSnap);
+      const indexDeltaUp = trend !== null && trend >= MATERIAL_INDEX_DELTA ? trend : null;
+
+      const todayIso = todayInTimezone(nowDate, inputs.timezone);
+      const daysSinceLastSession = dayDiff(todayIso, userJourney?.last_session_date ?? null);
+
+      const facts: BriefingFacts = {
+        sessionsCompleted,
+        nextSessionNumber: currentSession,
+        nextSessionTitle,
+        graduated,
+        hasGoal: !!(lifeCompass && (lifeCompass as { primary_goal?: unknown }).primary_goal),
+        indexDeltaUp,
+        daysSinceLastSession,
+      };
+
+      const localHour = localHourInTimezone(nowDate, inputs.timezone);
+      const salutation = pickSalutationKind(localHour);
+      const line = renderBriefingLine(
+        { lang: inputs.lang, salutation, firstName: inputs.firstName, facts },
+        rng,
+      );
+      if (!line) {
+        return {
+          providerKey: LOGIN_BRIEFING_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'renderer_produced_empty_line',
+        };
+      }
+
+      const state = pickBriefingState(facts);
+      const candidate: AssistantContinuation = {
+        id: `login-briefing-${newId()}`,
+        surface: 'orb_wake',
+        kind: 'wake_brief',
+        priority,
+        userFacingLine: line,
+        cta: { type: 'explain' },
+        evidence: [
+          { kind: 'login_briefing_state', detail: state },
+          { kind: 'sessions_completed', detail: String(sessionsCompleted) },
+          { kind: 'next_session', detail: nextSessionTitle ? `${currentSession}:${nextSessionTitle}` : String(currentSession) },
+        ],
+        // One briefing per (user × calendar day × state) so the rotation
+        // window does not replay the exact same opener back-to-back.
+        dedupeKey: `login-briefing:${todayIso}:${state}`,
+        privacyMode: 'safe_to_speak',
+      };
+
+      return {
+        providerKey: LOGIN_BRIEFING_PROVIDER_KEY,
+        status: 'returned',
+        latencyMs: Math.max(0, now() - t0),
+        candidate,
+      };
+    },
+  };
+}
+
+/** Read the small user_journey row used for first-session + gap detection. */
+async function fetchUserJourneyRow(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<UserJourneyRow | null> {
+  const { data, error } = await supabase
+    .from('user_journey')
+    .select('last_session_date, is_first_session')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data ?? null) as UserJourneyRow | null;
+}
+
+/** Pull the 7-day Index trend from the profiler snapshot, defensively. */
+function readIndexTrend(snap: unknown): number | null {
+  if (!snap || typeof snap !== 'object') return null;
+  const t = (snap as { trend_7d?: unknown }).trend_7d;
+  return typeof t === 'number' && Number.isFinite(t) ? t : null;
+}

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -98,6 +98,17 @@ import {
   GUIDED_TOPIC_NARRATION_EXTRA_KEY,
   GUIDED_TOPIC_NARRATION_PROVIDER_KEY,
 } from './assistant-continuation/providers/guided-topic-narration';
+// Greeting v2: login-briefing — the unified, "My Longevity Journey"-centric
+// greeting for a normal login. Priority 93 so it LEADS over journey-guide (91),
+// new-day-return (90), Teacher (85) and wake-brief (80); it yields to the
+// explicit-tap (96), first-ever-session (95) and passed-goal-deadline (92)
+// providers. Suppresses on greetingPolicy='skip' and on the user's first-ever
+// session, so it never blocks those specialized paths.
+import {
+  makeLoginBriefingProvider,
+  LOGIN_BRIEFING_EXTRA_KEY,
+  LOGIN_BRIEFING_PROVIDER_KEY,
+} from './assistant-continuation/providers/login-briefing';
 // VTID-03061 (B0d-real Xf.1): auto-emit OASIS next_action.suggested/
 // .suppressed events when a wake-brief decision lands. Fire-and-forget;
 // never blocks the voice path.
@@ -184,6 +195,13 @@ export function ensureWakeBriefProviderRegistered(): void {
   // never blocks journey-guide / new-day-return / Teacher on a normal open.
   if (!defaultProviderRegistry.get(GUIDED_TOPIC_NARRATION_PROVIDER_KEY)) {
     defaultProviderRegistry.register(makeGuidedTopicNarrationProvider());
+  }
+  // Greeting v2: login-briefing at priority 93 — the unified journey briefing
+  // that leads a normal login. Suppresses cleanly (greeting_policy_skip /
+  // is_first_session_true) so it never blocks the silent-reconnect or
+  // first-time-welcome paths.
+  if (!defaultProviderRegistry.get(LOGIN_BRIEFING_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeLoginBriefingProvider());
   }
   _registered = true;
 }
@@ -466,6 +484,19 @@ export async function decideWakeBriefForSession(
         lang: args.lang,
         topicId: args.guidedTopicId ?? null,
         firstName: args.firstName ?? null,
+      };
+      // Greeting v2: login-briefing inputs. The provider reads the 90-session
+      // guided-journey state + next-session title + Life Compass + Vitana Index
+      // and composes the journey-centric briefing. greetingPolicy lets it stay
+      // silent on a reconnect-class skip; timezone drives the salutation.
+      extra[LOGIN_BRIEFING_EXTRA_KEY] = {
+        supabase: args.supabase,
+        userId: args.userId,
+        tenantId: args.tenantId,
+        lang: args.lang,
+        firstName: args.firstName ?? null,
+        timezone: args.timezone ?? null,
+        greetingPolicy,
       };
     }
   }

--- a/services/gateway/test/services/assistant-continuation/providers/login-briefing.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/login-briefing.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Greeting v2 — login-briefing provider tests.
+ *
+ * Locks the contract:
+ *   - pickBriefingState maps facts → the right state (graduated > returning >
+ *     momentum > building > orient).
+ *   - renderBriefingLine always opens with a time-aware, named salutation.
+ *   - Compliments are EARNED-ONLY: orient state carries no praise; building/
+ *     momentum cite a real number; momentum cites the Index delta.
+ *   - The next-session clause names the session number + title when known.
+ *   - The provider suppresses cleanly on greetingPolicy='skip' and skips when
+ *     no inputs are wired — so it never blocks the silent-reconnect path.
+ */
+
+import {
+  makeLoginBriefingProvider,
+  LOGIN_BRIEFING_PROVIDER_KEY,
+  pickBriefingState,
+  renderBriefingLine,
+  type BriefingFacts,
+} from '../../../../src/services/assistant-continuation/providers/login-briefing';
+
+const BASE_FACTS: BriefingFacts = {
+  sessionsCompleted: 3,
+  nextSessionNumber: 4,
+  nextSessionTitle: 'Schlaf-Routine',
+  graduated: false,
+  hasGoal: true,
+  indexDeltaUp: null,
+  daysSinceLastSession: 0,
+};
+
+describe('pickBriefingState', () => {
+  it('graduated beats everything', () => {
+    expect(pickBriefingState({ ...BASE_FACTS, graduated: true, indexDeltaUp: 12, daysSinceLastSession: 9 }))
+      .toBe('graduated');
+  });
+
+  it('no progress + not graduated → orient', () => {
+    expect(pickBriefingState({ ...BASE_FACTS, sessionsCompleted: 0 })).toBe('orient');
+  });
+
+  it('multi-day gap → returning', () => {
+    expect(pickBriefingState({ ...BASE_FACTS, daysSinceLastSession: 4 })).toBe('returning');
+  });
+
+  it('positive Index delta (recent) → momentum', () => {
+    expect(pickBriefingState({ ...BASE_FACTS, indexDeltaUp: 8, daysSinceLastSession: 1 })).toBe('momentum');
+  });
+
+  it('steady progress, no delta → building', () => {
+    expect(pickBriefingState({ ...BASE_FACTS, indexDeltaUp: null, daysSinceLastSession: 1 })).toBe('building');
+  });
+});
+
+describe('renderBriefingLine (DE)', () => {
+  const det = () => 0; // deterministic pool pick
+
+  it('always opens with a time-aware, named salutation', () => {
+    const morning = renderBriefingLine({ lang: 'de', salutation: 'morning', firstName: 'Maria', facts: BASE_FACTS }, det);
+    expect(morning.startsWith('Guten Morgen, Maria.')).toBe(true);
+    const afternoon = renderBriefingLine({ lang: 'de', salutation: 'afternoon', firstName: 'Maria', facts: BASE_FACTS }, det);
+    expect(afternoon.startsWith('Guten Tag, Maria.')).toBe(true);
+    const evening = renderBriefingLine({ lang: 'de', salutation: 'evening', firstName: 'Maria', facts: BASE_FACTS }, det);
+    expect(evening.startsWith('Guten Abend, Maria.')).toBe(true);
+  });
+
+  it('orient state carries NO earned-number praise', () => {
+    const line = renderBriefingLine(
+      { lang: 'de', salutation: 'afternoon', firstName: 'Maria', facts: { ...BASE_FACTS, sessionsCompleted: 0, hasGoal: false } },
+      det,
+    );
+    expect(line).toContain('ersten Schritt');
+    expect(line).not.toMatch(/\d+ Sessions/);
+  });
+
+  it('building state cites the real session count and the next session', () => {
+    const line = renderBriefingLine(
+      { lang: 'de', salutation: 'morning', firstName: 'Maria', facts: { ...BASE_FACTS, sessionsCompleted: 3, indexDeltaUp: null } },
+      det,
+    );
+    expect(line).toContain('3 Sessions');
+    expect(line).toContain('Session 4: „Schlaf-Routine"');
+  });
+
+  it('momentum state cites the Vitana Index delta as the compliment', () => {
+    const line = renderBriefingLine(
+      { lang: 'de', salutation: 'morning', firstName: 'Maria', facts: { ...BASE_FACTS, indexDeltaUp: 12 } },
+      det,
+    );
+    expect(line).toContain('12 Punkte');
+  });
+
+  it('missing next-session title degrades gracefully', () => {
+    const line = renderBriefingLine(
+      { lang: 'de', salutation: 'morning', firstName: 'Maria', facts: { ...BASE_FACTS, nextSessionTitle: null } },
+      det,
+    );
+    expect(line).toContain('nächste Session');
+    expect(line).not.toContain('null');
+  });
+
+  it('nudges to set a goal only when one is missing', () => {
+    const withGap = renderBriefingLine(
+      { lang: 'de', salutation: 'morning', firstName: 'Maria', facts: { ...BASE_FACTS, hasGoal: false } },
+      det,
+    );
+    expect(withGap).toContain('persönliches Ziel');
+    const withGoal = renderBriefingLine(
+      { lang: 'de', salutation: 'morning', firstName: 'Maria', facts: { ...BASE_FACTS, hasGoal: true } },
+      det,
+    );
+    expect(withGoal).not.toContain('persönliches Ziel');
+  });
+});
+
+describe('makeLoginBriefingProvider — guardrails', () => {
+  it('skips when no inputs are wired', async () => {
+    const provider = makeLoginBriefingProvider();
+    const res = await provider.produce({ surface: 'orb_wake', extra: {} } as any);
+    expect(res.providerKey).toBe(LOGIN_BRIEFING_PROVIDER_KEY);
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('no_login_briefing_inputs');
+  });
+
+  it('suppresses on greetingPolicy=skip (silent reconnect)', async () => {
+    const provider = makeLoginBriefingProvider();
+    const res = await provider.produce({
+      surface: 'orb_wake',
+      extra: {
+        loginBriefing: {
+          supabase: {} as any,
+          userId: 'u1',
+          tenantId: 't1',
+          lang: 'de',
+          firstName: 'Maria',
+          timezone: 'Europe/Berlin',
+          greetingPolicy: 'skip',
+        },
+      },
+    } as any);
+    expect(res.status).toBe('suppressed');
+    expect(res.reason).toBe('greeting_policy_skip');
+  });
+});


### PR DESCRIPTION
## What

Adds a new `login_briefing` continuation provider — the single, always-on greeting a returning user hears after login. It replaces the fragmented behaviour where the **Feature-Discovery Teacher** ("Lass mich dir eine Entdeckung zeigen" → "Lass mich dir den Activity Plan zeigen") won the ranker and pitched a feature instead of briefing the user on their journey.

Backend half of the Greeting v2 rebuild. (Phase 0 — removing the frontend 5s auto-greeting / second voice — is in vitana-v1 #723.)

## Behaviour (one warm paragraph, state-driven)

- **Slot 1 (always): time-aware + named salutation** — "Guten Morgen / Guten Tag / Guten Abend, Maria", reusing `new-day-return`'s timezone-aware hour logic. This salutation no longer depends on which provider wins the ranker (previously it only lived in `new-day-return`, which fires once per calendar day, so it "disappeared" whenever the Teacher won).
- **90-session Guided Journey is the source of truth** for "you've completed N sessions, your next is Session X: «title»" (`user_guided_journey_state` + the published `journey_checklist`).
- **Earned-only compliments** — praise is tied to a real number (sessions completed, Vitana Index 7-day delta). The `orient` state (no progress yet) **invites** instead of flattering.
- **One "what's missing" nudge** (set your goal), framed as an upgrade, never nagging.
- **States:** `orient` / `building` / `momentum` / `returning` (after a multi-day gap) / `graduated`. Same-day reconnects stay silent via `greetingPolicy='skip'`.

## Priority / ranker placement

`login_briefing` registers at **priority 93**:
- **Leads** journey-guide (91), new-day-return (90), next-action (90), Teacher (85), wake-brief (80) on a normal login.
- **Yields** to guided-topic-narration (96, explicit topic tap), first-time-welcome (95, first-ever session), goal-completion (92, passed goal deadline).
- **Suppresses** cleanly on silent reconnect (`greeting_policy_skip`) and on the user's first-ever session (`is_first_session_true`), and degrades gracefully when journey reads are slow/empty (the salutation is always producible from timezone alone — honoring "speak fast, enrich after").

## ⚠️ One product call worth confirming

At priority 93, the unified briefing **outranks `next-action` (90)** — so a due calendar reminder ("you have a 3pm meeting") no longer leads the *login* greeting; the journey briefing does. If you'd rather a genuinely-due reminder still lead on login, I can either (a) drop `login_briefing` below next-action, or (b) fold a due-reminder line into the briefing. Flagging because it's a one-line knob.

## Files

- `services/gateway/src/services/assistant-continuation/providers/login-briefing.ts` (new provider)
- `services/gateway/test/services/assistant-continuation/providers/login-briefing.test.ts` (13 new tests)
- `services/gateway/src/services/wake-brief-wiring.ts` (register + identity-gated inputs)

## Verification

- `npm run typecheck` → clean.
- New suite: **13/13** pass.
- Regression: full assistant-continuation + characterization suites — **786 tests, 9 snapshots, all green**. No existing wiring test passes a `supabase` client, so the new provider stays inert in those and the ranker behaviour is unchanged where untested.
- Not yet verified live in the ORB (needs a staging deploy + a logged-in voice session).

## Follow-up

Phase 4: deploy to staging and verify the spoken greeting end-to-end (wake-click → first word, correct state + salutation) per the deployment-verification protocol.

https://claude.ai/code/session_0143jXmcPWgRRqc73TE5M35Z

---
_Generated by [Claude Code](https://claude.ai/code/session_0143jXmcPWgRRqc73TE5M35Z)_