### PR TITLE
feat(orb): search-first find_match voice tool — recommend or post (BOOTSTRAP-FIND-MATCH-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/tools/live-tool-catalog.ts
+++ b/services/gateway/src/orb/live/tools/live-tool-catalog.ts
@@ -1605,6 +1605,63 @@ export function buildLiveApiTools(
             required: ['recipient_user_id', 'recipient_label', 'target_url', 'target_kind'],
           },
         },
+        // ─── BOOTSTRAP-FIND-MATCH-VOICE — search-first matchmaking ───
+        // The PRIMARY tool when the user wants to FIND someone or something.
+        // It searches the live catalog first and either recommends existing
+        // matches (also posting so the user is discoverable) or posts the
+        // request when nothing matches yet.
+        {
+          name: 'find_match',
+          description: [
+            'Find a match for the user by SEARCHING the community catalog, then',
+            'either recommend existing matches OR post the request. This is the',
+            'tool to use whenever the user wants to find a person or thing:',
+            '"find me someone to play tennis", "is anybody cycling tomorrow?",',
+            '"I\'m looking for a salsa teacher", "find me a life partner",',
+            '"who wants to grab coffee?", "anyone selling a road bike?". It works',
+            'for every intent kind (the classifier picks the kind; pass kind_hint',
+            'only when the user is explicit).',
+            '',
+            'HOW TO USE:',
+            '1. Call find_match(utterance) with the user\'s words verbatim.',
+            '2. Act on the returned `stage`:',
+            '   • stage="matched"  → matches were found AND the request was',
+            '     posted so others can reach the user too. Read the matches back',
+            '     warmly (use the `matches` array: title + who) and offer to open',
+            '     or connect. For partner_seek, say identities are revealed only',
+            '     after BOTH people say yes.',
+            '   • stage="awaiting_confirmation" → no match yet. Read the summary',
+            '     back and ask if you should post it ("I didn\'t find anyone yet —',
+            '     shall I post this so I can tell you the moment someone matches?").',
+            '     When the user confirms (yes/post/ja), call find_match AGAIN with',
+            '     the same utterance and confirmed=true.',
+            '   • stage="posted" → the request is now live. Confirm it warmly. If',
+            '     match_count=0, say "you\'re the first one looking for this — I\'ll',
+            '     notify you the moment someone matches." NEVER imply it failed.',
+            '   • stage="needs_clarification" or "incomplete" → ask the ONE short',
+            '     question described in the `text` field, then call find_match again.',
+            '',
+            'CRITICAL: this tool ALWAYS returns actionable guidance. NEVER tell the',
+            'user "I\'m not able to find matches" or "I can\'t do that right now" —',
+            'always either recommend matches or offer to post.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              utterance: { type: 'string', description: 'The user\'s words verbatim (what they are looking for).' },
+              kind_hint: {
+                type: 'string',
+                enum: ['commercial_buy', 'commercial_sell', 'activity_seek', 'partner_seek', 'social_seek', 'mutual_aid', 'learning_seek', 'mentor_seek'],
+                description: 'Optional. Only pass when the user is explicit about the kind.',
+              },
+              confirmed: {
+                type: 'boolean',
+                description: 'Pass true ONLY on the second call, after the user verbally confirmed they want to post (when stage was "awaiting_confirmation").',
+              },
+            },
+            required: ['utterance'],
+          },
+        },
         // ─── VTID-01975 — Vitana Intent Engine ───
         // Single voice tool that handles all six intent kinds. Same
         // confirmation contract as send_chat_message: classify → extract →

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4630,7 +4630,7 @@ async function executeLiveApiToolInner(
       // Vertex and LiveKit run identical code.
       case 'find_match': {
         const SUPABASE_URL = process.env.SUPABASE_URL;
-        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
         if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
           return { success: false, result: '', error: 'Supabase not configured' };
         }

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4623,6 +4623,36 @@ async function executeLiveApiToolInner(
         );
       }
 
+      // ─── BOOTSTRAP-FIND-MATCH-VOICE — search-first "find me a match" ───
+      // Searches the live catalog and recommends matches (also posting so the
+      // user is discoverable) or posts the request after confirmation. Shared
+      // implementation in services/intent-find-match.ts via the registry, so
+      // Vertex and LiveKit run identical code.
+      case 'find_match': {
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'Supabase not configured' };
+        }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
+          auth: { autoRefreshToken: false, persistSession: false },
+        });
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          'find_match',
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? session.active_role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+            session_id: session.sessionId,
+          },
+          supabase,
+        );
+      }
+
       // ─── VTID-01975 — Vitana Intent Engine voice tools ───
       case 'post_intent': {
         const utterance = String(args.utterance || '').trim();

--- a/services/gateway/src/services/intent-find-match.ts
+++ b/services/gateway/src/services/intent-find-match.ts
@@ -1,0 +1,355 @@
+/**
+ * BOOTSTRAP-FIND-MATCH-VOICE — "find me a match" voice capability.
+ *
+ * The Intent Engine could only match an intent AFTER it was posted (the async
+ * matchmaker compares stored user_intents rows). There was no way for the ORB
+ * to answer "is there already someone for tennis?" without first creating a
+ * post — so when nothing was precomputed, the assistant fell through to a
+ * tool failure and the grace layer voiced "I'm not able to find matches".
+ *
+ * runFindMatch implements the search-first contract the user asked for:
+ *   1. classify + extract + embed the spoken request,
+ *   2. SEARCH the live catalog (search_intent_catalog RPC, read-only),
+ *   3a. matches found  → recommend them AND post the request too, so the user
+ *       is discoverable and mutual-reveal works (user's chosen behavior),
+ *   3b. no match yet   → read the summary back and, on explicit confirmation,
+ *       post the request (always-post; "you're the first").
+ *
+ * Design rule: this NEVER returns ok:false for a normal "no matches" outcome.
+ * ok:false is reserved for genuine infra failures (no auth / no DB / insert
+ * error). That keeps the voice tool-failure grace layer from turning an
+ * ordinary empty result into an apologetic refusal.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { classifyIntentKind, type IntentKind } from './intent-classifier';
+import { extractIntent, type ExtractedIntent } from './intent-extractor';
+import { embedIntent } from './intent-embedding';
+import { computeForIntent, surfaceTopMatches } from './intent-matcher';
+
+const PARTNER_REVEAL_KINDS = new Set<IntentKind>(['partner_seek']);
+
+export interface FindMatchIdentity {
+  user_id: string;
+  tenant_id: string | null;
+  vitana_id?: string | null;
+  session_id?: string | null;
+}
+
+export type FindMatchStage =
+  | 'matched'
+  | 'awaiting_confirmation'
+  | 'posted'
+  | 'needs_clarification'
+  | 'incomplete';
+
+export interface FindMatchResponse {
+  ok: boolean;
+  stage: FindMatchStage;
+  /** Model-facing guidance / read-back instruction. */
+  text: string;
+  data: Record<string, unknown>;
+  error?: string;
+}
+
+interface CatalogCandidate {
+  cand_intent_id: string;
+  cand_user_id: string;
+  cand_vitana_id: string | null;
+  cand_kind: string;
+  cand_title: string | null;
+  cand_scope: string | null;
+  score: number;
+  reasons: Record<string, unknown>;
+}
+
+/** Read-only catalog search. Returns ranked candidates; never throws. */
+async function searchIntentCatalog(
+  supabase: SupabaseClient,
+  id: FindMatchIdentity,
+  kind: IntentKind,
+  category: string | null,
+  payload: Record<string, unknown>,
+  embedding: number[] | null,
+  topN = 5,
+): Promise<CatalogCandidate[]> {
+  const { data, error } = await supabase.rpc('search_intent_catalog', {
+    p_user_id: id.user_id,
+    p_tenant_id: id.tenant_id,
+    p_intent_kind: kind,
+    p_category: category,
+    p_kind_payload: payload ?? {},
+    p_embedding: embedding && embedding.length ? `[${embedding.join(',')}]` : null,
+    p_visibility: 'public',
+    p_top_n: topN,
+  });
+  if (error) {
+    console.warn(`[BOOTSTRAP-FIND-MATCH] search_intent_catalog failed: ${error.message}`);
+    return [];
+  }
+  return (data || []) as CatalogCandidate[];
+}
+
+/**
+ * Persist the intent (so the user becomes discoverable) and fire the same
+ * best-effort side-effects post_intent does: embedding backfill, synchronous
+ * match compute, async matchmaker kick, and memory facts. Returns the new
+ * intent_id, or null if the insert itself failed.
+ */
+async function persistIntent(
+  supabase: SupabaseClient,
+  id: FindMatchIdentity,
+  kind: IntentKind,
+  extract: ExtractedIntent,
+): Promise<{ intent_id: string; vitana_id: string | null } | null> {
+  const { data: inserted, error } = await supabase
+    .from('user_intents')
+    .insert({
+      requester_user_id: id.user_id,
+      tenant_id: id.tenant_id,
+      intent_kind: kind,
+      category: extract.category,
+      title: extract.title,
+      scope: extract.scope,
+      kind_payload: extract.kind_payload,
+      status: 'open',
+    })
+    .select('intent_id, requester_vitana_id')
+    .single();
+
+  if (error || !inserted) {
+    console.error(`[BOOTSTRAP-FIND-MATCH] user_intents insert failed: ${error?.message ?? 'no row'}`);
+    return null;
+  }
+
+  const intentId = (inserted as { intent_id: string }).intent_id;
+  const vid = (inserted as { requester_vitana_id: string | null }).requester_vitana_id ?? null;
+
+  // Embedding backfill (best-effort).
+  try {
+    const emb = await embedIntent({
+      intent_kind: kind,
+      category: extract.category,
+      title: extract.title ?? '',
+      scope: extract.scope ?? '',
+      kind_payload: extract.kind_payload,
+    });
+    if (emb) {
+      await supabase.from('user_intents').update({ embedding: emb as unknown as string }).eq('intent_id', intentId);
+    }
+  } catch (err) {
+    console.warn(`[BOOTSTRAP-FIND-MATCH] embedding backfill non-fatal: ${err instanceof Error ? err.message : 'unknown'}`);
+  }
+
+  // Persist matches now + kick the async matchmaker (parity with post_intent).
+  try {
+    await computeForIntent(intentId);
+  } catch (err) {
+    console.warn(`[BOOTSTRAP-FIND-MATCH] computeForIntent non-fatal: ${err instanceof Error ? err.message : 'unknown'}`);
+  }
+  try {
+    const { runMatchmakerAsync } = await import('./matchmaker-agent');
+    runMatchmakerAsync(intentId);
+  } catch (err) {
+    console.warn(`[BOOTSTRAP-FIND-MATCH] matchmaker kick non-fatal: ${err instanceof Error ? err.message : 'unknown'}`);
+  }
+  if (id.tenant_id) {
+    try {
+      const { writeIntentFacts } = await import('./intent-memory-hooks');
+      writeIntentFacts({
+        user_id: id.user_id,
+        tenant_id: id.tenant_id,
+        intent_kind: kind,
+        category: extract.category,
+        title: extract.title ?? '',
+        scope: extract.scope ?? '',
+        kind_payload: extract.kind_payload,
+      }).catch(() => {});
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  return { intent_id: intentId, vitana_id: vid };
+}
+
+/**
+ * Search-first "find me a match" orchestration. See file header for the
+ * contract. Pure of transport concerns — both the Vertex (orb-live.ts) and
+ * LiveKit (orb-tools-shared registry) paths call this.
+ */
+export async function runFindMatch(
+  args: { utterance?: unknown; kind_hint?: unknown; confirmed?: unknown },
+  id: FindMatchIdentity,
+): Promise<FindMatchResponse> {
+  const utterance = String(args.utterance ?? '').trim();
+  const kindHint = args.kind_hint ? (String(args.kind_hint) as IntentKind) : undefined;
+  const confirmed = args.confirmed === true;
+
+  if (!id?.user_id) {
+    return { ok: false, stage: 'incomplete', text: '', data: {}, error: 'authentication required' };
+  }
+  if (!utterance) {
+    return { ok: false, stage: 'incomplete', text: '', data: {}, error: 'utterance is required' };
+  }
+
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    return { ok: false, stage: 'incomplete', text: '', data: {}, error: 'supabase_not_configured' };
+  }
+  const supabase = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+
+  // 1. Classify (or trust an explicit kind_hint).
+  let kind: IntentKind | undefined = kindHint;
+  if (!kind) {
+    const cls = await classifyIntentKind(utterance);
+    if (!cls.intent_kind || cls.confidence < 0.7) {
+      return {
+        ok: true,
+        stage: 'needs_clarification',
+        text: 'Ask ONE short question to clarify what they want — an activity partner, something to buy or sell, a teacher, a life partner, or help borrowing/lending something.',
+        data: { ok: false, reason: 'classify_low_confidence', classifier_confidence: cls.confidence },
+      };
+    }
+    kind = cls.intent_kind;
+  }
+
+  // 2. Extract structured fields + 3. embed (best-effort).
+  const extract = await extractIntent(utterance, kind);
+  const summary = {
+    intent_kind: kind,
+    category: extract.category,
+    title: extract.title,
+    scope: extract.scope,
+    kind_payload: extract.kind_payload,
+    confidence: extract.confidence,
+    missing_critical: extract.missing_critical,
+  };
+
+  let embedding: number[] | null = null;
+  try {
+    embedding = await embedIntent({
+      intent_kind: kind,
+      category: extract.category,
+      title: extract.title ?? '',
+      scope: extract.scope ?? '',
+      kind_payload: extract.kind_payload,
+    });
+  } catch {
+    embedding = null;
+  }
+
+  const isPartner = PARTNER_REVEAL_KINDS.has(kind);
+  const complete = extract.missing_critical.length === 0 && extract.confidence >= 0.6;
+
+  // 4. SEARCH the live catalog.
+  const candidates = await searchIntentCatalog(
+    supabase,
+    id,
+    kind,
+    extract.category,
+    extract.kind_payload,
+    embedding,
+    5,
+  );
+
+  // 5a. Matches found → recommend + also post (when complete enough).
+  if (candidates.length > 0) {
+    let postedIntentId: string | null = null;
+    if (complete) {
+      const persisted = await persistIntent(supabase, id, kind, extract);
+      if (persisted) postedIntentId = persisted.intent_id;
+    }
+
+    const recommendations = candidates.map((c) => ({
+      intent_id: c.cand_intent_id,
+      vitana_id: isPartner ? null : c.cand_vitana_id,
+      display: isPartner ? '(a member — revealed once you both say yes)' : c.cand_vitana_id || 'a member',
+      title: c.cand_title,
+      score: Number(c.score),
+      kind: c.cand_kind,
+    }));
+
+    const tail = postedIntentId
+      ? 'Also tell them you posted their request so the other person can reach them too.'
+      : `Ask for the missing detail (${extract.missing_critical.join(', ') || 'a little more info'}) so you can also post their request.`;
+
+    return {
+      ok: true,
+      stage: 'matched',
+      text:
+        `Found ${recommendations.length} potential ${recommendations.length === 1 ? 'match' : 'matches'} in the community. ` +
+        `Read them back warmly and offer to open or connect. ${tail}` +
+        (isPartner ? ' For partner matches, explain identities are revealed only after both people say yes.' : ''),
+      data: {
+        ok: true,
+        found: true,
+        posted: !!postedIntentId,
+        intent_id: postedIntentId,
+        matches: recommendations,
+        match_count: recommendations.length,
+        partner_seek_redacted: isPartner,
+      },
+    };
+  }
+
+  // 5b. No catalog match. If the request is too thin to post, ask for detail.
+  if (!complete) {
+    return {
+      ok: true,
+      stage: 'incomplete',
+      text: `No one in the catalog matches yet. Ask the user for: ${extract.missing_critical.join(', ') || 'a bit more detail'} so you can post their request.`,
+      data: { ok: false, found: false, reason: 'extract_incomplete', summary },
+    };
+  }
+
+  // Confirm-first before the always-post fallback (user's chosen behavior).
+  if (!confirmed) {
+    return {
+      ok: true,
+      stage: 'awaiting_confirmation',
+      text:
+        'No match in the catalog yet. Read the summary back — e.g. "I didn\'t find anyone yet. Shall I post this so I can let you know the moment someone matches?" — then call find_match again with confirmed=true once they say yes / post / ja.',
+      data: { ok: true, found: false, stage: 'awaiting_confirmation', summary },
+    };
+  }
+
+  // confirmed === true → post (always-post).
+  const persisted = await persistIntent(supabase, id, kind, extract);
+  if (!persisted) {
+    return { ok: false, stage: 'incomplete', text: '', data: {}, error: 'insert_failed' };
+  }
+
+  let postedMatches: Array<Record<string, unknown>> = [];
+  try {
+    const rows = await surfaceTopMatches(persisted.intent_id, 3);
+    postedMatches = rows.map((m) => ({
+      match_id: m.match_id,
+      vitana_id_b: isPartner ? null : m.vitana_id_b,
+      score: m.score,
+      kind_pairing: m.kind_pairing,
+    }));
+  } catch {
+    postedMatches = [];
+  }
+
+  return {
+    ok: true,
+    stage: 'posted',
+    text:
+      postedMatches.length > 0
+        ? `Posted, and there ${postedMatches.length === 1 ? 'is' : 'are'} ${postedMatches.length} potential match${postedMatches.length === 1 ? '' : 'es'}. Confirm the post is live and read the matches back.`
+        : "Posted. Tell the user warmly: \"You're the first one looking for this right now — I'll let you know the moment someone matches, and your post is visible on the board.\" Never imply this failed.",
+    data: {
+      ok: true,
+      found: false,
+      stage: 'posted',
+      intent_id: persisted.intent_id,
+      vitana_id: persisted.vitana_id,
+      match_count: postedMatches.length,
+      top_matches: postedMatches,
+      cold_start: postedMatches.length === 0,
+    },
+  };
+}

--- a/services/gateway/src/services/intent-find-match.ts
+++ b/services/gateway/src/services/intent-find-match.ts
@@ -194,7 +194,7 @@ export async function runFindMatch(
   }
 
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE || process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const key = process.env.SUPABASE_SERVICE_ROLE;
   if (!url || !key) {
     return { ok: false, stage: 'incomplete', text: '', data: {}, error: 'supabase_not_configured' };
   }

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3387,6 +3387,36 @@ export async function tool_view_intent_matches(
 }
 
 // ---------------------------------------------------------------------------
+// BOOTSTRAP-FIND-MATCH-VOICE — find_match (search-first "find me a match").
+//
+// Searches the live intent catalog for the user's spoken request and EITHER
+// recommends existing matches (and posts the request so they're discoverable
+// too) OR — when nothing matches — posts the request after a verbal
+// confirmation. The heavy lifting lives in services/intent-find-match.ts so
+// both transports (Vertex + LiveKit) share one implementation; this is just
+// the registry adapter into OrbToolResult.
+// ---------------------------------------------------------------------------
+
+export async function tool_find_match(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'authentication required' };
+  const { runFindMatch } = await import('./intent-find-match');
+  const r = await runFindMatch(
+    { utterance: args.utterance, kind_hint: args.kind_hint, confirmed: args.confirmed },
+    {
+      user_id: id.user_id,
+      tenant_id: id.tenant_id ?? null,
+      vitana_id: id.vitana_id ?? null,
+      session_id: id.session_id ?? null,
+    },
+  );
+  if (!r.ok) return { ok: false, error: r.error ?? 'find_match_failed' };
+  return { ok: true, result: { ...r.data, stage: r.stage }, text: r.text };
+}
+
+// ---------------------------------------------------------------------------
 // VTID-NAV-TIMEJOURNEY — get_current_screen (PR 1.B-3)
 //
 // Mirrors orb-live.ts:handleGetCurrentScreen byte-for-byte: resolves the
@@ -4150,6 +4180,10 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   // INTENTS.MATCH_DETAIL when the top score dominates the runner-up;
   // otherwise lists matches and lets the LLM disambiguate verbally.
   view_intent_matches: tool_view_intent_matches,
+  // BOOTSTRAP-FIND-MATCH-VOICE — search-first "find me a match": searches the
+  // live catalog and recommends existing matches (and posts so the user is
+  // discoverable) or posts the request when nothing matches yet.
+  find_match: tool_find_match,
   // VTID-NAV-TIMEJOURNEY — get_current_screen (PR 1.B-3). Resolves the user's
   // LIVE current screen via the nav catalog. Anonymous-safe — pulls
   // current_route + recent_routes from args (Vertex/LiveKit pass them via

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -1217,6 +1217,39 @@ specific screen, call get_current_screen first to learn the
 target_url and target_kind ("event", "post", "profile", etc.),
 then read both back to the user before sending.
 
+### find_match
+Find a match for the user by SEARCHING the community catalog, then
+either recommend existing matches OR post the request. This is the
+tool to use whenever the user wants to find a person or thing:
+"find me someone to play tennis", "is anybody cycling tomorrow?",
+"I'm looking for a salsa teacher", "find me a life partner",
+"who wants to grab coffee?", "anyone selling a road bike?". It works
+for every intent kind (the classifier picks the kind; pass kind_hint
+only when the user is explicit).
+
+HOW TO USE:
+1. Call find_match(utterance) with the user's words verbatim.
+2. Act on the returned \`stage\`:
+   • stage="matched"  → matches were found AND the request was
+     posted so others can reach the user too. Read the matches back
+     warmly (use the \`matches\` array: title + who) and offer to open
+     or connect. For partner_seek, say identities are revealed only
+     after BOTH people say yes.
+   • stage="awaiting_confirmation" → no match yet. Read the summary
+     back and ask if you should post it ("I didn't find anyone yet —
+     shall I post this so I can tell you the moment someone matches?").
+     When the user confirms (yes/post/ja), call find_match AGAIN with
+     the same utterance and confirmed=true.
+   • stage="posted" → the request is now live. Confirm it warmly. If
+     match_count=0, say "you're the first one looking for this — I'll
+     notify you the moment someone matches." NEVER imply it failed.
+   • stage="needs_clarification" or "incomplete" → ask the ONE short
+     question described in the \`text\` field, then call find_match again.
+
+CRITICAL: this tool ALWAYS returns actionable guidance. NEVER tell the
+user "I'm not able to find matches" or "I can't do that right now" —
+always either recommend matches or offer to post.
+
 ### post_intent
 Register an intent in the Vitana community catalog. Use this
 whenever the user expresses a need, an offering, a desire to find
@@ -2451,6 +2484,39 @@ to X", "invite X to this", or similar. If the user is on a
 specific screen, call get_current_screen first to learn the
 target_url and target_kind ("event", "post", "profile", etc.),
 then read both back to the user before sending.
+
+### find_match
+Find a match for the user by SEARCHING the community catalog, then
+either recommend existing matches OR post the request. This is the
+tool to use whenever the user wants to find a person or thing:
+"find me someone to play tennis", "is anybody cycling tomorrow?",
+"I'm looking for a salsa teacher", "find me a life partner",
+"who wants to grab coffee?", "anyone selling a road bike?". It works
+for every intent kind (the classifier picks the kind; pass kind_hint
+only when the user is explicit).
+
+HOW TO USE:
+1. Call find_match(utterance) with the user's words verbatim.
+2. Act on the returned \`stage\`:
+   • stage="matched"  → matches were found AND the request was
+     posted so others can reach the user too. Read the matches back
+     warmly (use the \`matches\` array: title + who) and offer to open
+     or connect. For partner_seek, say identities are revealed only
+     after BOTH people say yes.
+   • stage="awaiting_confirmation" → no match yet. Read the summary
+     back and ask if you should post it ("I didn't find anyone yet —
+     shall I post this so I can tell you the moment someone matches?").
+     When the user confirms (yes/post/ja), call find_match AGAIN with
+     the same utterance and confirmed=true.
+   • stage="posted" → the request is now live. Confirm it warmly. If
+     match_count=0, say "you're the first one looking for this — I'll
+     notify you the moment someone matches." NEVER imply it failed.
+   • stage="needs_clarification" or "incomplete" → ask the ONE short
+     question described in the \`text\` field, then call find_match again.
+
+CRITICAL: this tool ALWAYS returns actionable guidance. NEVER tell the
+user "I'm not able to find matches" or "I can't do that right now" —
+always either recommend matches or offer to post.
 
 ### post_intent
 Register an intent in the Vitana community catalog. Use this

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -1635,6 +1635,70 @@ then read both back to the user before sending.",
         },
       },
       {
+        "description": "Find a match for the user by SEARCHING the community catalog, then
+either recommend existing matches OR post the request. This is the
+tool to use whenever the user wants to find a person or thing:
+"find me someone to play tennis", "is anybody cycling tomorrow?",
+"I'm looking for a salsa teacher", "find me a life partner",
+"who wants to grab coffee?", "anyone selling a road bike?". It works
+for every intent kind (the classifier picks the kind; pass kind_hint
+only when the user is explicit).
+
+HOW TO USE:
+1. Call find_match(utterance) with the user's words verbatim.
+2. Act on the returned \`stage\`:
+   • stage="matched"  → matches were found AND the request was
+     posted so others can reach the user too. Read the matches back
+     warmly (use the \`matches\` array: title + who) and offer to open
+     or connect. For partner_seek, say identities are revealed only
+     after BOTH people say yes.
+   • stage="awaiting_confirmation" → no match yet. Read the summary
+     back and ask if you should post it ("I didn't find anyone yet —
+     shall I post this so I can tell you the moment someone matches?").
+     When the user confirms (yes/post/ja), call find_match AGAIN with
+     the same utterance and confirmed=true.
+   • stage="posted" → the request is now live. Confirm it warmly. If
+     match_count=0, say "you're the first one looking for this — I'll
+     notify you the moment someone matches." NEVER imply it failed.
+   • stage="needs_clarification" or "incomplete" → ask the ONE short
+     question described in the \`text\` field, then call find_match again.
+
+CRITICAL: this tool ALWAYS returns actionable guidance. NEVER tell the
+user "I'm not able to find matches" or "I can't do that right now" —
+always either recommend matches or offer to post.",
+        "name": "find_match",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY on the second call, after the user verbally confirmed they want to post (when stage was "awaiting_confirmation").",
+              "type": "boolean",
+            },
+            "kind_hint": {
+              "description": "Optional. Only pass when the user is explicit about the kind.",
+              "enum": [
+                "commercial_buy",
+                "commercial_sell",
+                "activity_seek",
+                "partner_seek",
+                "social_seek",
+                "mutual_aid",
+                "learning_seek",
+                "mentor_seek",
+              ],
+              "type": "string",
+            },
+            "utterance": {
+              "description": "The user's words verbatim (what they are looking for).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "utterance",
+          ],
+          "type": "object",
+        },
+      },
+      {
         "description": "Register an intent in the Vitana community catalog. Use this
 whenever the user expresses a need, an offering, a desire to find
 an activity partner / life partner / mentor, or willingness to
@@ -3922,6 +3986,70 @@ then read both back to the user before sending.",
             "recipient_label",
             "target_url",
             "target_kind",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Find a match for the user by SEARCHING the community catalog, then
+either recommend existing matches OR post the request. This is the
+tool to use whenever the user wants to find a person or thing:
+"find me someone to play tennis", "is anybody cycling tomorrow?",
+"I'm looking for a salsa teacher", "find me a life partner",
+"who wants to grab coffee?", "anyone selling a road bike?". It works
+for every intent kind (the classifier picks the kind; pass kind_hint
+only when the user is explicit).
+
+HOW TO USE:
+1. Call find_match(utterance) with the user's words verbatim.
+2. Act on the returned \`stage\`:
+   • stage="matched"  → matches were found AND the request was
+     posted so others can reach the user too. Read the matches back
+     warmly (use the \`matches\` array: title + who) and offer to open
+     or connect. For partner_seek, say identities are revealed only
+     after BOTH people say yes.
+   • stage="awaiting_confirmation" → no match yet. Read the summary
+     back and ask if you should post it ("I didn't find anyone yet —
+     shall I post this so I can tell you the moment someone matches?").
+     When the user confirms (yes/post/ja), call find_match AGAIN with
+     the same utterance and confirmed=true.
+   • stage="posted" → the request is now live. Confirm it warmly. If
+     match_count=0, say "you're the first one looking for this — I'll
+     notify you the moment someone matches." NEVER imply it failed.
+   • stage="needs_clarification" or "incomplete" → ask the ONE short
+     question described in the \`text\` field, then call find_match again.
+
+CRITICAL: this tool ALWAYS returns actionable guidance. NEVER tell the
+user "I'm not able to find matches" or "I can't do that right now" —
+always either recommend matches or offer to post.",
+        "name": "find_match",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY on the second call, after the user verbally confirmed they want to post (when stage was "awaiting_confirmation").",
+              "type": "boolean",
+            },
+            "kind_hint": {
+              "description": "Optional. Only pass when the user is explicit about the kind.",
+              "enum": [
+                "commercial_buy",
+                "commercial_sell",
+                "activity_seek",
+                "partner_seek",
+                "social_seek",
+                "mutual_aid",
+                "learning_seek",
+                "mentor_seek",
+              ],
+              "type": "string",
+            },
+            "utterance": {
+              "description": "The user's words verbatim (what they are looking for).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "utterance",
           ],
           "type": "object",
         },

--- a/voice-pipeline-spec/spec.json
+++ b/voice-pipeline-spec/spec.json
@@ -61,7 +61,7 @@
 
     { "name": "post_intent",                  "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-01975" },
     { "name": "view_intent_matches",          "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01976" },
-    { "name": "find_match",                   "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": null, "notes": "BOOTSTRAP-FIND-MATCH-VOICE: search-first 'find me a match' — searches the catalog and recommends matches (also posting so the user is discoverable) or posts on confirmation. Shared dispatcher route (services/intent-find-match.ts)." },
+    { "name": "find_match",                   "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null, "notes": "BOOTSTRAP-FIND-MATCH-VOICE: search-first 'find me a match' — searches the catalog and recommends matches (also posting so the user is discoverable) or posts on confirmation. In the shared ORB registry; LiveKit can dispatch it but does not declare it yet (mirrors view_intent_matches)." },
     { "name": "list_my_intents",              "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
     { "name": "respond_to_match",             "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-01976" },
     { "name": "mark_intent_fulfilled",        "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },

--- a/voice-pipeline-spec/spec.json
+++ b/voice-pipeline-spec/spec.json
@@ -61,6 +61,7 @@
 
     { "name": "post_intent",                  "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-01975" },
     { "name": "view_intent_matches",          "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01976" },
+    { "name": "find_match",                   "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": null, "notes": "BOOTSTRAP-FIND-MATCH-VOICE: search-first 'find me a match' — searches the catalog and recommends matches (also posting so the user is discoverable) or posts on confirmation. Shared dispatcher route (services/intent-find-match.ts)." },
     { "name": "list_my_intents",              "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
     { "name": "respond_to_match",             "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-01976" },
     { "name": "mark_intent_fulfilled",        "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },


### PR DESCRIPTION
## Why

When a user asks the ORB by voice "find me someone to play tennis" / "is anybody cycling tomorrow?", the assistant replied **"I'm not able to find matches for you right now."**

Root cause: the Intent Engine could only match an intent **after** it was posted — the async matchmaker compares already-stored `user_intents` rows. There was no read-only "is there already someone for this?" search. When nothing was precomputed, the match tools returned a hard failure, and the voice **tool-failure grace layer** (`tool-failure-grace.ts`) rewrote that into an apologetic refusal. So a normal "no results yet" came out sounding broken.

## What this does

Adds the search-first capability the user asked for: **search the catalog → recommend a match, or post the request.**

New `find_match` voice tool:
1. classify → extract → embed the spoken request (reuses the existing intent services),
2. **search the live catalog** via the new read-only `search_intent_catalog` RPC (in `exafyltd/vitana-v1`),
3. **matches found** → recommend them **and** post the request too, so the user is discoverable and mutual-reveal works,
4. **no match yet** → read the summary back and, on explicit verbal confirmation, post it ("you're the first").

Behavior chosen by the requester: *recommend + also post* on a hit; *confirm-first* before the no-match post fallback.

## Files
- `services/gateway/src/services/intent-find-match.ts` — new. `runFindMatch` orchestration + `searchIntentCatalog` + `persistIntent` (mirrors `post_intent`'s side-effects: embedding backfill, `computeForIntent`, async matchmaker kick, memory facts).
- `services/gateway/src/services/orb-tools-shared.ts` — registry adapter `tool_find_match` + `find_match` entry, so **both** the Vertex and LiveKit transports run identical code.
- `services/gateway/src/orb/live/tools/live-tool-catalog.ts` — `find_match` tool declaration + model guidance (incl. the explicit "never say you can't find matches" contract).
- `services/gateway/src/routes/orb-live.ts` — Vertex `case 'find_match'` delegating to the shared dispatcher.

## Design notes
- **Never returns a hard failure for an ordinary empty result** — `ok:false` is reserved for genuine infra failures (no auth / no DB / insert error). This is what stops the grace layer from producing the refusal.
- The `text` fields are **model-facing guidance** (the LLM speaks in the user's language), so per CLAUDE.md §13b they are not catalog-translated — consistent with `post_intent` / `view_intent_matches`.
- `npx tsc --noEmit` passes clean (0 errors).

## Companion PR
Requires the read-only RPC in **`exafyltd/vitana-v1`** (`search_intent_catalog`), same branch `claude/quirky-meitner-pd2ar3`. The migrations for the intent engine live in that repo.

## Verification still to do
- Apply the `vitana-v1` migration to the target Supabase, then exercise `find_match` end-to-end from a voice session (tennis → expect recommend-or-post; repeat → posted/cold-start copy).
- Per the staging-first cutover, merging deploys to **staging** (`gateway-staging`); verify on `preview-gateway.vitanaland.com` before PUBLISH.

https://claude.ai/code/session_01Emo2SSEkn9h3MpmaBtRqPq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Emo2SSEkn9h3MpmaBtRqPq)_