### PR TITLE
fix(orb): login briefing open prompt + yield to goal-completion (safe interim relief)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/login-briefing.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/login-briefing.ts
@@ -33,11 +33,12 @@
  *   E — onboarding qualified/completed       → praise mastery, shift to depth
  *   (F same-day reconnect is handled upstream by greetingPolicy='skip' → suppress.)
  *
- * Priority 93: above journey-guide (91), new-day-return (90), next-action
+ * Priority 92: leads journey-guide (91), new-day-return (90), next-action
  * (90), Teacher (85) and wake-brief (80) — so the unified briefing leads the
- * normal login. Below guided-topic-narration (96, explicit tap),
- * first-time-welcome (95, first-ever session) and goal-completion (92, a
- * passed goal deadline) — those special moments still lead.
+ * normal login. Ties goal-completion-inquiry (92) and YIELDS to it (it is
+ * registered first, so it wins the tie) — a passed goal deadline still leads.
+ * Below first-time-welcome (95, first-ever session) and guided-topic-narration
+ * (96, explicit tap), which also lead.
  */
 
 import { randomUUID } from 'crypto';
@@ -61,8 +62,8 @@ import { fetchLifeCompass, fetchVitanaIndexForProfiler } from '../../user-contex
 export const LOGIN_BRIEFING_PROVIDER_KEY = 'login_briefing';
 export const LOGIN_BRIEFING_EXTRA_KEY = 'loginBriefing' as const;
 
-/** Above journey-guide (91) / new-day-return (90); below goal-completion (92). */
-const DEFAULT_PRIORITY = 93;
+/** Leads journey-guide (91) / new-day-return (90); ties-yields to goal-completion (92). */
+const DEFAULT_PRIORITY = 92;
 
 /** A gap of this many calendar days since the last session triggers State D. */
 const RETURN_GAP_DAYS = 3;
@@ -187,10 +188,15 @@ export function renderBriefingLine(args: RenderArgs, rng: () => number = Math.ra
       : `Next up is Session ${f.nextSessionNumber}: "${f.nextSessionTitle}".`;
   })();
 
+  // Use an OPEN prompt, not a yes/no. A bare "Sollen wir weitermachen?" elicits
+  // a "ja" that the voice pipeline currently has no bound action to execute — so
+  // the assistant appeared to ignore the confirmation and jump elsewhere. An open
+  // question keeps every reply conversational. (The deterministic confirm→execute
+  // flow — "yes" opens the next session — is a separate, properly-wired follow-up.)
   const invite = pickFromPool(
     de
-      ? ['Sollen wir weitermachen?', 'Lust, gleich weiterzumachen?', 'Wollen wir loslegen?']
-      : ['Shall we continue?', 'Want to keep going?', "Shall we get started?"],
+      ? ['Womit möchtest du heute weitermachen?', 'Wo möchtest du heute ansetzen?', 'Was möchtest du als Erstes angehen?']
+      : ['Where would you like to pick up today?', 'Where shall we focus today?', 'What would you like to tackle first?'],
     rng,
   );
 
@@ -224,7 +230,7 @@ export function renderBriefingLine(args: RenderArgs, rng: () => number = Math.ra
       const body = de
         ? `Schön, dass du wieder da bist. Es ist ein paar Tage her — aber deine ${f.sessionsCompleted} ${f.sessionsCompleted === 1 ? 'Session' : 'Sessions'} sind nicht verloren, du knüpfst genau dort wieder an.`
         : `Good to have you back. It has been a few days — but your ${f.sessionsCompleted} ${f.sessionsCompleted === 1 ? 'session' : 'sessions'} are not lost; you pick up right where you left off.`;
-      const invite2 = de ? 'Lass uns den Faden wieder aufnehmen?' : 'Shall we pick the thread back up?';
+      const invite2 = de ? 'Womit möchtest du wieder einsteigen?' : 'Where would you like to jump back in?';
       return [prefix, body, nextClause, invite2].filter(Boolean).join(' ');
     }
 


### PR DESCRIPTION
## What

Two small, safe fixes to the post-login briefing — **interim relief** for the confirm→execute UX bug while the full "yes opens the next session" flow is built properly (it needs the live LiveKit agent, which can't be verified from here).

1. **Open prompt instead of a dead yes/no.** The greeting closed with "Sollen wir weitermachen?" — a yes/no the voice pipeline has no bound action to execute, so when the user said "ja" the assistant appeared to ignore the confirmation and jump to a different suggestion. It now closes with an open question, so every reply is handled conversationally.

2. **Priority 93 → 92.** `login_briefing` beat `goal_completion_inquiry` (92), so a user whose Life Compass goal deadline had passed got the routine briefing instead of the completion check-in (contradicting the provider's own docs). At 92 it ties goal-completion (registered first → wins the tie, so the passed-deadline check-in leads) while still leading journey-guide (91), new-day-return (90), next-action (90), Teacher (85) and wake-brief (80). This also fixes a latent ordering bug that shipped with the original #2677.

## Not in this PR (deliberately)

The deterministic **"yes → opens the next Guided Journey session"** flow. A Codex review correctly found that wiring requires declaring a new tool in **both** voice-model catalogs — including the **Python LiveKit agent** (the live pipeline) — which can't be verified from this sandbox. That's a separate, properly-scoped change with someone able to test the agent. This PR is the safe interim relief.

## Verification

- `npm run typecheck` clean.
- login-briefing + wake-brief-wiring + full assistant-continuation suites green.
- Net diff: **1 file, +15 / −9**, conflict-free on top of current `main`.

https://claude.ai/code/session_0143jXmcPWgRRqc73TE5M35Z