### PR TITLE
perf(orb): DEV-COMHU-0513 fast-start Phases 1a + 2 + 4 — fast session/start + instant cached wake cue (flag-gated)

### DIFF
--- a/docs/orb-fast-start/ORB_FAST_START_DESIGN.md
+++ b/docs/orb-fast-start/ORB_FAST_START_DESIGN.md
@@ -90,19 +90,34 @@ locked set.
   config) so Phase 2's deferral can be proven to change *timing only*, not
   *content*.
 
-### Phase 2 — Defer wake-brief + journey off the response path (flag-gated)
+### Phase 2 — Defer wake-brief + journey off the response path (flag-gated)  ✅ implemented (flag default off)
 Behind `FEATURE_ORB_FAST_START_ENV` (default `off` → legacy inline behavior):
-- Fold the wake-brief decision (1053-1311) and journey-greeting (1322-1432)
-  into the **existing** `contextReadyPromise` chain instead of awaiting them
-  inline. They still populate the same session fields; they are still awaited at
-  the same `connectToLiveAPI` stream-open gate, so first **personalized** audio
-  is unchanged — but the HTTP response (and thus chime → stream-open) returns
-  fast.
-- `meta.wake_brief` becomes `{ status: 'pending' }` on the fast path (widget
-  must not depend on it synchronously — verify).
-- Quota reservation: keep the hard-block gate, but make the non-blocking
-  reservation path fail-open fast (cache/timeout) so it cannot dominate p95.
-- Gated by parity tests from 1b — content must be byte-identical to legacy.
+- The wake-brief decision + journey-greeting + turn-1 snapshot are wrapped in a
+  closure (`assembleWakeBriefAndJourney`) in `live-session-controller.ts`. The
+  body is **byte-identical** to the prior inline code (diff = pure insertions,
+  zero deletions) — parity by construction.
+- On the fast path the closure is **composed into the existing
+  `session.contextReadyPromise`** via `composeContextReady()`, which the
+  stream-open gate (`orb-live.ts` ~6178) already awaits before building the
+  Gemini setup message. So the first **personalized** turn still carries full
+  wake-brief / Teacher / Journey content; only the HTTP `session/start`
+  response returns earlier.
+- `composeContextReady` uses `Promise.allSettled` → a wake-brief/journey/brain
+  rejection cannot reject the gate (fail-open, same as today's per-block
+  try/catch).
+- `meta.context_status` is `'pending'` on the fast path / `'ready'` on legacy;
+  `meta.wake_brief` is `null` when pending — **widget must not depend on it
+  synchronously** when `context_status==='pending'`.
+- New logic (`shouldDeferWakeWork`, `composeContextReady`) is unit-tested
+  (`test/orb-fast-start.test.ts`, 9 cases incl. default-off, gating, ordering,
+  fail-open). The moved body needs no new test (parity by construction);
+  end-to-end validation is the staging flag-on check via the existing
+  `orb_wake_timelines` stage-breakdown.
+- Anonymous + guided-topic sessions always run inline (they skip or already
+  fast-path this work).
+- **Remaining for a follow-up:** quota reservation still `await`s the hard-block
+  gate (correct for billing); making its non-block path fail-open-fast
+  (cache/timeout) is a separate small change.
 
 ### Phase 3 — Widget prewarm  ⚠️ gated on shared-state/strict-WS
 Only after Phase 6 (or strict WS ownership). Prewarm creates extra unclaimed

--- a/docs/orb-fast-start/ORB_FAST_START_DESIGN.md
+++ b/docs/orb-fast-start/ORB_FAST_START_DESIGN.md
@@ -1,9 +1,19 @@
 # ORB Fast-Start — Grounded Design & Phase Plan
 
-**Status:** Phase 0/1 (foundation + parity-prep)
+**Status:** Phases 1a + 2 + 4 implemented on branch `claude/relaxed-babbage-4bmpyh` (PR #2682), **flag-gated off**. NOT yet merged → NOT on staging or prod.
 **Date:** 2026-06-15
 **Owner branch:** `claude/relaxed-babbage-4bmpyh`
 **Source brief:** "Orb Fast Start Safe Conversation Design" (2026-06-15)
+
+> **To actually change the orb on staging, ALL of these are required** (merging
+> alone does nothing — both phases default OFF):
+> 1. Merge PR #2682 → `main` → auto-deploys `gateway-staging`.
+> 2. Phase 2: `gcloud run services update gateway-staging --region=us-central1
+>    --project=lovable-vitana-vers1 --update-env-vars FEATURE_ORB_FAST_START_ENV=staging-only`
+> 3. Phase 4: render + commit `wake-cue-*.mp3` (`npx tsx scripts/render-orb-alert-clips.ts`),
+>    then in the staging orb set `localStorage.setItem('vtorb.wakecue','on')`.
+> Only after 1+2 (and 1+3 for the cue) does a tap behave differently.
+
 
 > This document re-bases the original fast-start brief on the **actual state of
 > the codebase as of 2026-06-15**. The brief is sound in spirit, but a code

--- a/docs/orb-fast-start/ORB_FAST_START_DESIGN.md
+++ b/docs/orb-fast-start/ORB_FAST_START_DESIGN.md
@@ -1,0 +1,178 @@
+# ORB Fast-Start — Grounded Design & Phase Plan
+
+**Status:** Phase 0/1 (foundation + parity-prep)
+**Date:** 2026-06-15
+**Owner branch:** `claude/relaxed-babbage-4bmpyh`
+**Source brief:** "Orb Fast Start Safe Conversation Design" (2026-06-15)
+
+> This document re-bases the original fast-start brief on the **actual state of
+> the codebase as of 2026-06-15**. The brief is sound in spirit, but a code
+> audit shows roughly a third of it is already built. Per the platform rule
+> *"never rebuild systems that already exist"*, this design targets only the
+> true remaining gap and explicitly flags where the brief conflicts with
+> existing, locked systems.
+
+---
+
+## 0. Non-negotiable guardrail (unchanged from brief)
+
+This is a **latency** change, not a conversation redesign. The following remain
+authoritative for every real conversation turn and MUST NOT be removed,
+simplified, or bypassed:
+
+Brain/system-instruction assembly · bootstrap context pack · wake-brief
+decisioning · Teacher Mode content · Journey greeting content · memory facts ·
+role & language resolution · tool permissions/availability · transcript
+persistence · safety/confirmation behavior.
+
+The change is only about **when** this work happens relative to the click.
+
+### Conversation invariants (carried verbatim, enforced in code + tests)
+
+1. The wake cue is never persisted as an assistant transcript turn.
+2. The wake cue never writes memory.
+3. The wake cue never advances Journey state.
+4. The wake cue never marks a Teacher lesson started/completed.
+5. The wake cue never consumes or changes wake-brief eligibility.
+6. Full context remains the only source of personalized Brain/memory/role/tool behavior.
+7. If full context is not ready, Vitana may acknowledge presence but must not
+   answer personalized/memory/medical/billing/tool prompts from minimal context.
+8. If context assembly fails, the session fails open into a restricted,
+   non-personalized mode and records telemetry.
+9. The legacy synchronous path stays reachable behind a rollback flag.
+
+---
+
+## 1. What the audit found (this is the important part)
+
+| Brief assumption | Reality in code (2026-06-15) | Consequence |
+|---|---|---|
+| `session/start` blocks on full **brain/bootstrap context** | **Already async.** Heavy Brain/bootstrap is deferred to `contextReadyPromise` (`live-session-controller.ts:710`, comment 707-710) and awaited later in `connectToLiveAPI`'s `ws.on('open')`. | The brief's headline premise is partly stale. Do **not** re-architect context assembly — it is already off the response path. |
+| Wake-timeline telemetry must be built (Phase 0) | **Already built and LOCKED.** `services/gateway/src/services/wake-timeline/` — a 16-event recorder (`timeline-events.ts`), per-stage latency breakdown aggregates, `orb_wake_timelines` table, Command Hub panel (VTID-02917 / VTID-02927). | Phase 0 is essentially done. **Reuse it. Do NOT invent new event names** — the 16 names are explicitly locked by prior user instruction. |
+| Guided-topic skip is "precedent to build" | **Already shipped** (VTID-03294, `live-session-controller.ts:721-743`) — resolves context in a ~0ms microtask to avoid the 7-10s delay. | This is the exact template to generalize. |
+| WebSocket transport is future work | **Already opt-in** in the widget (`orb-widget.js`, `init({transport:'ws'})` / localStorage). SSE is default. | Phase 5 is a rollout/ramp exercise, not a build. |
+| Flags need a new system | **Two exist:** env-var `feature-flags.ts` (`FEATURE_<NAME>_ENV`, runtime, rollback w/o redeploy) and DB-backed `system-controls-service.ts` (audited, 10s cache). | Use these. No new flag framework. |
+| In-memory sessions / scaling | **Real constraint confirmed.** `liveSessions` is an in-memory `Map` (`live-session-registry.ts:58`); gateway pinned `--max-instances=1` (`EXEC-DEPLOY.yml`, `STAGE-DEPLOY.yml`) "until a shared session store lands." | Brief's caution is correct. Prewarm + scaling must not ship before shared state or strict WS ownership. |
+
+### The actual remaining blockers on the `session/start` response
+
+The HTTP response (`live-session-controller.ts:1474`) is returned only **after**
+these still-synchronous awaits (the brain context is already excluded):
+
+1. **Voice-quota reservation** — `await reserveVoiceQuotaAtSessionStart` (line 545). One Supabase round-trip.
+2. **Wake-brief decision** — lines 1053-1311 (awaited inline; already best-effort/try-wrapped).
+3. **Journey-greeting block** — lines 1322-1432 (awaited inline; already best-effort).
+4. **OASIS `emitLiveSessionEvent`** — **`await`ed at line 1455** — pure telemetry on the critical path.
+
+These four — not context assembly — are what the fast-start work must move off
+the response path.
+
+---
+
+## 2. Revised phase plan (only the real gap)
+
+### Phase 0 — Measurement ✅ already in place
+Reuse the existing wake-timeline (16 LOCKED events + stage breakdown). **Action:
+none beyond confirming the client-side `wake_clicked` mark fires** (it is the
+t0 anchor for `time_to_first_audio_ms`). Do **not** add new event names; if a
+new mark is genuinely required it needs explicit user approval to expand the
+locked set.
+
+### Phase 1 — Make telemetry non-blocking + prove parity harness  ← **THIS PR**
+- **1a (shipped here):** Fire-and-forget the awaited `emitLiveSessionEvent`
+  (line 1455). Telemetry must never block the wake path — this matches both the
+  platform telemetry rule and the brief's item 7. The event is still emitted;
+  we just stop blocking the user's response on the DB write. Behavior-preserving
+  for the conversation; removes one round-trip from p50/p95.
+- **1b (next):** Add a parity-test fixture harness that snapshots the resolved
+  session fields (`active_role`, `lang`, `contextInstruction`,
+  `wakeBriefOverrideBlock`, `journeyGreetingBlock`, `teacherModeContent`, tool
+  config) so Phase 2's deferral can be proven to change *timing only*, not
+  *content*.
+
+### Phase 2 — Defer wake-brief + journey off the response path (flag-gated)
+Behind `FEATURE_ORB_FAST_START_ENV` (default `off` → legacy inline behavior):
+- Fold the wake-brief decision (1053-1311) and journey-greeting (1322-1432)
+  into the **existing** `contextReadyPromise` chain instead of awaiting them
+  inline. They still populate the same session fields; they are still awaited at
+  the same `connectToLiveAPI` stream-open gate, so first **personalized** audio
+  is unchanged — but the HTTP response (and thus chime → stream-open) returns
+  fast.
+- `meta.wake_brief` becomes `{ status: 'pending' }` on the fast path (widget
+  must not depend on it synchronously — verify).
+- Quota reservation: keep the hard-block gate, but make the non-blocking
+  reservation path fail-open fast (cache/timeout) so it cannot dominate p95.
+- Gated by parity tests from 1b — content must be byte-identical to legacy.
+
+### Phase 3 — Widget prewarm  ⚠️ gated on shared-state/strict-WS
+Only after Phase 6 (or strict WS ownership). Prewarm creates extra unclaimed
+sessions in the in-memory map — shipping it on `--max-instances=1` worsens the
+scaling cliff. Reuse `system-controls-service` for `orb.prewarm.enabled`.
+
+### Phase 4 — Cached wake phrase
+Short, non-committal, interruptible ("I'm here." / "Ich bin da."). Never written
+to transcript (invariant 1). Bundled or gateway-hosted asset. Flag
+`FEATURE_ORB_CACHED_WAKE_PHRASE_ENV`.
+
+### Phase 5 — WS canary (ramp, not build)
+WS transport already exists; ramp internal → 5% → 25% → 50% → 100% with the
+existing wake-timeline `disconnect`/`reconnect_*` events as the safety signal.
+
+### Phase 6 — Shared session state, then relax `--max-instances=1`
+Redis/Memorystore (or strict WS ownership). Prerequisite for Phase 3 and any
+horizontal scaling.
+
+---
+
+## 3. Flags (using the existing env-var system)
+
+| Flag (env var) | Default | Purpose |
+|---|---|---|
+| `FEATURE_ORB_FAST_START_ENV` | `off` | Defer wake-brief + journey off response path (Phase 2). |
+| `FEATURE_ORB_PREWARM_ENV` | `off` | Widget prewarm (Phase 3 — do not enable pre-shared-state). |
+| `FEATURE_ORB_CACHED_WAKE_PHRASE_ENV` | `off` | Local spoken wake phrase (Phase 4). |
+| `FEATURE_ORB_VOICE_WS_DEFAULT_ENV` | `off` | Make WS the default transport (Phase 5). |
+
+`off` → legacy synchronous path (rollback = flip env var, no redeploy). All
+flags graduate `off` → `staging-only` → `staging+prod`.
+
+---
+
+## 4. Success criteria (carried from brief)
+
+| Metric | Target (p95) |
+|---|---|
+| Click → first audible cue | < 500 ms |
+| Click → first spoken wake phrase | < 1000 ms |
+| Click → personalized audio (warm) | < 2000 ms |
+| `session/start` fast path | < 800 ms |
+| Full context readiness after click | < 2500 ms |
+| Context parity vs legacy | 100% on fixtures |
+| Rollback | one env-var flip |
+
+Measured via the existing `orb_wake_timelines.aggregates.time_to_first_audio_ms`
+and `stage_breakdown`.
+
+---
+
+## 5. Conflicts with the brief (flagged, not silently followed)
+
+1. **New wake-timeline event names** (`prewarm_started`, `audio_ready_sent`,
+   `wake_cue_started`, …) — **conflict** with the LOCKED 16-name set
+   (`timeline-events.ts:12-13`). Resolution: map prewarm/cache marks onto
+   existing names where possible; expanding the locked set needs explicit user
+   approval.
+2. **"session/start blocks on full context"** — outdated; brain context is
+   already async. Phase 2 targets wake-brief/journey/telemetry/quota instead.
+3. **Prewarm before scaling** — brief lists shared-state as an "open question";
+   here it is a **hard prerequisite** for Phase 3 (in-memory map + max-instances=1).
+
+---
+
+## 6. Governance
+
+Per platform rules this requires a VTID with `spec_status=approved` before any
+prod deploy. Post-cutover (we are past Mon 8 Jun 2026), merges to `main`
+auto-deploy **staging only** (`preview-gateway.vitanaland.com`); production is
+the PUBLISH button / escape-hatch. This design and all phase PRs verify on
+staging first.

--- a/docs/orb-fast-start/ORB_FAST_START_DESIGN.md
+++ b/docs/orb-fast-start/ORB_FAST_START_DESIGN.md
@@ -124,10 +124,37 @@ Only after Phase 6 (or strict WS ownership). Prewarm creates extra unclaimed
 sessions in the in-memory map — shipping it on `--max-instances=1` worsens the
 scaling cliff. Reuse `system-controls-service` for `orb.prewarm.enabled`.
 
-### Phase 4 — Cached wake phrase
-Short, non-committal, interruptible ("I'm here." / "Ich bin da."). Never written
-to transcript (invariant 1). Bundled or gateway-hosted asset. Flag
-`FEATURE_ORB_CACHED_WAKE_PHRASE_ENV`.
+### Phase 4 — Cached wake phrase  ✅ implemented (flag default off; needs asset render + staging verify)
+This is the change that actually kills the *perceived* 7-10s dead-air: the orb
+plays Vitana's voice within ~1s of the tap while context + the Live model spin
+up behind it.
+
+- **Reuses the existing alert-clip system** (no new mechanism, no `speechSynthesis`):
+  `render-orb-alert-clips.ts` → committed MP3 in Chirp3-HD (Vitana's voice) →
+  `_preloadAlertClips` → `_playAlert`. Added `wake-cue-en` ("I'm here.") /
+  `wake-cue-de` ("Ich bin da.").
+- Widget plays the cue right after the activation chime, inside the user
+  gesture (`orb-widget.js`), and **stops it the instant the real greeting audio
+  arrives** (`audio_out` first-chunk) and on teardown. Short + non-committal so
+  it never collides with the real wake-brief / Teacher / Journey opener.
+- **Invariants honored:** local UI cue only — not a transcript turn, no memory
+  write, no Journey/Teacher/wake-brief mutation (invariants 1-5). Verbatim
+  reuse of the proven clip path.
+- **Gating:** `_cfg.wakeCue` (default off) via `init({ wakeCue: true })`, or
+  localStorage `vtorb.wakecue='on'` for per-browser staging verification
+  (mirrors the `vtorb.transport` pattern).
+- **Graceful no-op:** if the MP3 isn't rendered/committed yet, the preload 404s
+  and the cue silently does nothing (no error tone) — so shipping the code
+  before the asset is safe.
+
+**Two gates before this reaches the community:**
+1. **Render the assets** — run `npx tsx scripts/render-orb-alert-clips.ts` (default
+   mode hits the deployed gateway TTS, no creds), commit `wake-cue-en.mp3` /
+   `wake-cue-de.mp3`. *(I cannot run this — egress/TTS blocked in my env.)*
+2. **Staging browser verification** — `orb-widget.js` is plain JS (not tsc-checked)
+   and I cannot run a browser here, so this MUST be tapped on staging (flag on)
+   and confirmed: cue plays in Vitana's voice within ~1s, stops cleanly when the
+   real greeting starts, no double-audio, nothing written to transcript.
 
 ### Phase 5 — WS canary (ramp, not build)
 WS transport already exists; ramp internal → 5% → 25% → 50% → 100% with the

--- a/services/gateway/scripts/render-orb-alert-clips.ts
+++ b/services/gateway/scripts/render-orb-alert-clips.ts
@@ -34,6 +34,13 @@ interface Clip {
 }
 
 const CLIPS: Clip[] = [
+  // ORB-FAST-START Phase 4: instant cached wake cue. Played locally the
+  // instant the user taps the orb (Vitana's voice, no model/network) so the
+  // first thing they hear is Vitana — not 7-10s of silence while context +
+  // the Live model spin up. Short + non-committal so it never conflicts with
+  // the real wake-brief / Teacher / Journey opener that follows.
+  { id: 'wake-cue-en',              lang: 'en', text: "I'm here." },
+  { id: 'wake-cue-de',              lang: 'de', text: 'Ich bin da.' },
   // Disconnect alerts
   { id: 'disconnect-mic-en',        lang: 'en', text: "One moment, I can't hear your microphone." },
   { id: 'disconnect-mic-de',        lang: 'de', text: 'Einen Moment, Mikrofon-Problem.' },

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -142,7 +142,16 @@
     // binary-framed JSON both ways, no per-chunk HTTP overhead, no
     // cross-instance 404 class). Opt-in via init({transport:'ws'}) or
     // localStorage 'vtorb.transport'='ws' for staging verification.
-    transport: 'sse'
+    transport: 'sse',
+    // ORB-FAST-START Phase 4: play a cached "I'm here."/"Ich bin da." in
+    // Vitana's voice the instant the orb is tapped, so the user hears Vitana
+    // immediately instead of 7-10s of silence while context + the Live model
+    // spin up. Default OFF. Enable via init({ wakeCue: true }) or, for staging
+    // verification, localStorage 'vtorb.wakecue'='on' (mirrors transport).
+    // It is a LOCAL UI cue only — never sent to the backend transcript, never
+    // writes memory, never advances Journey / Teacher / wake-brief; it stops
+    // the instant Vitana's real greeting audio begins.
+    wakeCue: false
   };
 
   var _s = {
@@ -622,6 +631,10 @@
   // Catalog of MP3 clips rendered by services/gateway/scripts/render-orb-alert-clips.ts.
   // Re-render that script if you change the wording of any label above.
   var _ALERT_CLIPS = [
+    // ORB-FAST-START Phase 4: preloaded alongside the alert clips so the wake
+    // cue plays instantly on tap. Absent MP3 (not yet rendered) → fetch 404 →
+    // clip simply not loaded → _playWakeCue no-ops (graceful, no error tone).
+    'wake-cue-en', 'wake-cue-de',
     'disconnect-mic-en', 'disconnect-mic-de',
     'disconnect-network-en', 'disconnect-network-de',
     'disconnect-connection-en', 'disconnect-connection-de',
@@ -687,6 +700,17 @@
       if (o === 'sse') return false;
     } catch (e) { /* storage blocked — fall through to config */ }
     return _cfg.transport === 'ws';
+  }
+
+  // ORB-FAST-START Phase 4: should the cached wake cue play on tap? localStorage
+  // 'vtorb.wakecue' wins (per-browser staging verification), else init() config.
+  function _useWakeCue() {
+    try {
+      var o = window.localStorage && localStorage.getItem('vtorb.wakecue');
+      if (o === 'on') return true;
+      if (o === 'off') return false;
+    } catch (e) { /* storage blocked — fall through to config */ }
+    return _cfg.wakeCue === true;
   }
 
   // BOOTSTRAP-ORB-LATENCY-PHASE3: tear down the WS transport (idempotent).
@@ -1219,6 +1243,23 @@
     // Play activation chime immediately
     _playChime(_s.playbackCtx);
 
+    // ORB-FAST-START Phase 4: instant cached wake cue. Right after the chime,
+    // inside the user gesture, play Vitana's pre-rendered "I'm here."/"Ich bin
+    // da." so the user hears Vitana within ~1s instead of waiting 7-10s for the
+    // Live model's first token. This is a LOCAL UI cue only — it is NOT a
+    // transcript turn, writes no memory, and does not touch Journey / Teacher /
+    // wake-brief state. It is interruptible: stopped the instant the real
+    // greeting audio arrives (see the audio_out handler). No-ops gracefully if
+    // the clip isn't loaded (flag off, or MP3 not yet rendered/committed).
+    _s._wakeCueSrc = null;
+    if (_useWakeCue()) {
+      try {
+        _s._wakeCueSrc = _playAlert('wake-cue-' + _pickLang());
+      } catch (e) {
+        _s._wakeCueSrc = null;
+      }
+    }
+
     // VTID-02710: keep the ctx warm until the first Gemini audio arrives.
     // The chime ends ~400 ms after this call; without an active source after
     // that, iOS auto-suspends the ctx during the 2-5 s wait for the SSE
@@ -1560,6 +1601,13 @@
     // the session ended before any audio arrived) before closing the ctx.
     _stopCtxKeepAlive();
 
+    // ORB-FAST-START Phase 4: stop the cached wake cue if it's still playing
+    // (user closed before the greeting arrived) so it doesn't tail past close.
+    if (_s._wakeCueSrc) {
+      try { _s._wakeCueSrc.stop(0); } catch (e) { /* already ended */ }
+      _s._wakeCueSrc = null;
+    }
+
     // Stop playback
     if (_s.playbackCtx) { _s.playbackCtx.close().catch(function () {}); _s.playbackCtx = null; }
 
@@ -1710,6 +1758,12 @@
           if (!_s.greetingAudioReceived) {
             _s.greetingAudioReceived = true;
             clearTimeout(_s.stuckGuardTimer);
+            // ORB-FAST-START Phase 4: Vitana's real greeting is taking over —
+            // stop the cached wake cue so the two never overlap.
+            if (_s._wakeCueSrc) {
+              try { _s._wakeCueSrc.stop(0); } catch (e) { /* already ended */ }
+              _s._wakeCueSrc = null;
+            }
             // VTID-02710: real audio is taking over — release the keep-alive
             // pump so it doesn't quietly waste cycles for the rest of the
             // session.

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -56,6 +56,9 @@ import {
   triggerDowngrade,
 } from '../../../services/voice-quota-guard';
 import { recordPaywallEvent } from '../../../services/entitlement-service';
+// ORB-FAST-START Phase 2: defer wake-brief + journey off the session/start
+// response path (flag-gated; default off → legacy inline behavior).
+import { shouldDeferWakeWork, composeContextReady } from './orb-fast-start';
 
 // VTID-03107: per-session voice-meter intervals. Keyed by session_id so cleanup
 // in handleLiveSessionStop can tear down without touching GeminiLiveSession's type.
@@ -1065,6 +1068,24 @@ export async function handleLiveSessionStart(
   // signals into decideGreetingPolicy(). Now we read them from
   // user_assistant_state, pass them through, and record after fire.
   let wakeBriefDecision: Awaited<ReturnType<typeof decideWakeBriefForSession>> | null = null;
+
+  // ORB-FAST-START Phase 2: the wake-brief continuation decision + journey
+  // greeting block + turn-1 snapshot below are wrapped in this closure so they
+  // can run inline (legacy) OR be composed into session.contextReadyPromise
+  // (fast path). The body is byte-identical to the prior inline code — only
+  // WHEN it runs changes. The stream-open gate (orb-live.ts ~6178) already
+  // awaits session.contextReadyPromise before building the Gemini setup
+  // message, so the first personalized turn keeps full wake-brief / Teacher /
+  // Journey behavior either way. `wakeBriefDecision` stays declared in the
+  // outer scope (above) so the response `meta` can still read it on the legacy
+  // path; on the fast path it is null at response time (meta.context_status
+  // reports 'pending') and is populated when this closure runs before the gate.
+  // The closure RETURNS the decision so the legacy branch can assign it — that
+  // lets TS control-flow analysis keep the union type at the meta read; the
+  // fast branch ignores the return value.
+  const assembleWakeBriefAndJourney = async (): Promise<
+    Awaited<ReturnType<typeof decideWakeBriefForSession>> | null
+  > => {
   // VTID-03085 (Lane 1): compile the AssistantDecisionContext on Vertex
   // so the 4 spine-dependent next-action sources can compete here too.
   // Before this fix Vertex passed `decisionContext: null` so:
@@ -1451,6 +1472,37 @@ export async function handleLiveSessionStart(
     timezonePresent: !!session.clientContext?.timezone,
   });
 
+  return wakeBriefDecision;
+  }; // end assembleWakeBriefAndJourney
+
+  // ORB-FAST-START Phase 2: run the wake-brief + journey work inline (legacy)
+  // or defer it onto the stream-open gate's promise (fast). Flag-gated; default
+  // off. Anonymous + guided-topic sessions always run inline (they skip or
+  // already fast-path this work).
+  const fastStartDeferWake = shouldDeferWakeWork({
+    isAnonymousSession,
+    isGuidedTopicSession,
+    hasUserId: !!orbIdentity?.user_id,
+  });
+  if (fastStartDeferWake) {
+    // Compose onto the SAME promise the stream-open gate already awaits, so
+    // first personalized audio still carries the full continuation / Teacher /
+    // Journey blocks — but session/start returns now instead of after the
+    // wake-brief + journey round-trips.
+    const brainReady = (session as any).contextReadyPromise as Promise<void> | undefined;
+    (session as any).contextReadyPromise = composeContextReady(
+      brainReady,
+      assembleWakeBriefAndJourney,
+    );
+    console.log(
+      `[ORB-FAST-START] session ${sessionId}: wake-brief + journey deferred onto contextReadyPromise (fast session/start)`,
+    );
+  } else {
+    // Legacy inline path: assign the return value so TS control-flow analysis
+    // sees wakeBriefDecision populated for the response meta below.
+    wakeBriefDecision = await assembleWakeBriefAndJourney();
+  }
+
   // Emit OASIS event with identity context.
   // ORB-FAST-START Phase 1a: fire-and-forget. session.start IS a real state
   // transition (so we still emit it), but blocking the HTTP response on the
@@ -1510,6 +1562,12 @@ export async function handleLiveSessionStart(
         skipped_reason: contextBootstrapSkippedReason || null,
         deferred: !!contextReadyPromise,
       },
+      // ORB-FAST-START Phase 2: 'pending' when wake-brief + journey were
+      // deferred onto contextReadyPromise (fast path) — they attach before the
+      // first personalized turn. 'ready' on the legacy inline path. The widget
+      // must NOT depend on meta.wake_brief being populated when this is
+      // 'pending'.
+      context_status: fastStartDeferWake ? 'pending' : 'ready',
       wake_brief: wakeBriefDecision
         ? {
             decision_id: wakeBriefDecision.decisionId,

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1451,8 +1451,14 @@ export async function handleLiveSessionStart(
     timezonePresent: !!session.clientContext?.timezone,
   });
 
-  // Emit OASIS event with identity context
-  await deps.emitLiveSessionEvent('vtid.live.session.start', {
+  // Emit OASIS event with identity context.
+  // ORB-FAST-START Phase 1a: fire-and-forget. session.start IS a real state
+  // transition (so we still emit it), but blocking the HTTP response on the
+  // Supabase write put a telemetry round-trip on the wake critical path —
+  // telemetry must never block the wake path. The event still fires; the
+  // user's response no longer waits for it. Errors are swallowed into the
+  // emitter's own logging (it already logs internally).
+  deps.emitLiveSessionEvent('vtid.live.session.start', {
     session_id: sessionId,
     user_id: orbIdentity?.user_id || 'anonymous',
     tenant_id: orbIdentity?.tenant_id || null,
@@ -1464,6 +1470,10 @@ export async function handleLiveSessionStart(
     lang,
     modalities: responseModalities,
     voice: deps.getVoiceForLang(lang),
+  }).catch((err) => {
+    console.warn(
+      `[ORB-FAST-START] emitLiveSessionEvent failed (non-blocking) for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
   });
 
   console.log(`[VTID-ORBC] Live session created: ${sessionId} (user=${orbIdentity?.user_id || 'anonymous'}, tenant=${orbIdentity?.tenant_id || 'none'}, lang=${lang}, contextDeferred=${!!contextReadyPromise})`);

--- a/services/gateway/src/orb/live/session/orb-fast-start.ts
+++ b/services/gateway/src/orb/live/session/orb-fast-start.ts
@@ -1,0 +1,58 @@
+/**
+ * ORB-FAST-START Phase 2 — fast session/start helpers.
+ *
+ * The orb wake critical path historically blocked the `session/start` HTTP
+ * response on the wake-brief continuation decision + journey-greeting block
+ * (the heavy Brain/bootstrap context is already deferred to
+ * `session.contextReadyPromise`). These helpers let the controller defer that
+ * remaining work onto the SAME promise the stream-open gate already awaits
+ * (`orb-live.ts` ~6178), so the response returns immediately while the first
+ * personalized turn still carries full wake-brief / Teacher / Journey content.
+ *
+ * Gated by `FEATURE_ORB_FAST_START_ENV` (default `off` → legacy inline path).
+ * The deferred work itself is byte-identical to the prior inline code — only
+ * WHEN it runs changes. These helpers isolate the only NEW logic (the gating
+ * decision + the promise composition) so it can be unit-tested in isolation.
+ */
+
+import { isFeatureLive } from '../../../services/feature-flags';
+
+/**
+ * Decide whether to defer the wake-brief + journey work off the session/start
+ * response path.
+ *
+ * Only the authenticated, non-guided, non-anonymous path benefits: anonymous
+ * sessions skip wake-brief/journey entirely, and the guided-topic fast path
+ * (VTID-03294) already resolves context in a microtask. Gating those off keeps
+ * their existing (cheap) inline behavior unchanged.
+ */
+export function shouldDeferWakeWork(opts: {
+  isAnonymousSession: boolean;
+  isGuidedTopicSession: boolean;
+  hasUserId: boolean;
+}): boolean {
+  return (
+    isFeatureLive('ORB_FAST_START') &&
+    !opts.isAnonymousSession &&
+    !opts.isGuidedTopicSession &&
+    opts.hasUserId
+  );
+}
+
+/**
+ * Compose the existing brain/bootstrap readiness promise with the deferred
+ * wake-brief + journey work into a single promise the stream-open gate awaits.
+ *
+ * Uses `allSettled` so a rejection in either input cannot reject the composed
+ * gate promise — the gate's own try/catch then proceeds with whatever session
+ * fields were populated (fail-open, identical to today's behavior when a
+ * wake-brief/journey try-block throws).
+ */
+export function composeContextReady(
+  brainReady: Promise<void> | undefined,
+  deferredWork: () => Promise<unknown>,
+): Promise<void> {
+  return (async () => {
+    await Promise.allSettled([brainReady ?? Promise.resolve(), deferredWork()]);
+  })();
+}

--- a/services/gateway/test/orb-fast-start.test.ts
+++ b/services/gateway/test/orb-fast-start.test.ts
@@ -1,0 +1,107 @@
+/**
+ * ORB-FAST-START Phase 2 — unit tests for the gating decision + promise
+ * composition. The deferred wake-brief/journey BODY is byte-identical to the
+ * prior inline code (parity by construction), so these tests cover the only
+ * genuinely new logic: when we defer, and that the composed gate promise
+ * preserves the existing fail-open semantics.
+ */
+
+import { shouldDeferWakeWork, composeContextReady } from '../src/orb/live/session/orb-fast-start';
+
+const FLAG = 'FEATURE_ORB_FAST_START_ENV';
+
+describe('shouldDeferWakeWork', () => {
+  const prev = process.env[FLAG];
+  afterEach(() => {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+  });
+
+  it('defaults OFF — never defers when the flag is unset (legacy path preserved)', () => {
+    delete process.env[FLAG];
+    expect(
+      shouldDeferWakeWork({ isAnonymousSession: false, isGuidedTopicSession: false, hasUserId: true }),
+    ).toBe(false);
+  });
+
+  it('defers for an authenticated, non-guided, non-anonymous session when enabled in prod', () => {
+    process.env[FLAG] = 'staging+prod';
+    expect(
+      shouldDeferWakeWork({ isAnonymousSession: false, isGuidedTopicSession: false, hasUserId: true }),
+    ).toBe(true);
+  });
+
+  it('never defers anonymous sessions (they skip wake-brief/journey anyway)', () => {
+    process.env[FLAG] = 'staging+prod';
+    expect(
+      shouldDeferWakeWork({ isAnonymousSession: true, isGuidedTopicSession: false, hasUserId: false }),
+    ).toBe(false);
+  });
+
+  it('never defers guided-topic sessions (already on the VTID-03294 fast path)', () => {
+    process.env[FLAG] = 'staging+prod';
+    expect(
+      shouldDeferWakeWork({ isAnonymousSession: false, isGuidedTopicSession: true, hasUserId: true }),
+    ).toBe(false);
+  });
+
+  it('never defers when there is no user id', () => {
+    process.env[FLAG] = 'staging+prod';
+    expect(
+      shouldDeferWakeWork({ isAnonymousSession: false, isGuidedTopicSession: false, hasUserId: false }),
+    ).toBe(false);
+  });
+});
+
+describe('composeContextReady', () => {
+  it('resolves only after BOTH the brain promise and the deferred work settle', async () => {
+    const order: string[] = [];
+    let resolveBrain!: () => void;
+    let resolveWork!: () => void;
+    const brain = new Promise<void>((r) => {
+      resolveBrain = () => {
+        order.push('brain');
+        r();
+      };
+    });
+    const work = () =>
+      new Promise<void>((r) => {
+        resolveWork = () => {
+          order.push('work');
+          r();
+        };
+      });
+
+    const gate = composeContextReady(brain, work);
+    let settled = false;
+    void gate.then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveBrain();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(settled).toBe(false); // work still pending
+
+    resolveWork();
+    await gate;
+    expect(settled).toBe(true);
+    expect(order).toEqual(['brain', 'work']);
+  });
+
+  it('is fail-open: a rejection in the deferred work does NOT reject the gate', async () => {
+    const work = () => Promise.reject(new Error('wake-brief blew up'));
+    await expect(composeContextReady(Promise.resolve(), work)).resolves.toBeUndefined();
+  });
+
+  it('is fail-open: a rejection in the brain promise does NOT reject the gate', async () => {
+    const brain = Promise.reject(new Error('brain blew up'));
+    await expect(composeContextReady(brain, () => Promise.resolve())).resolves.toBeUndefined();
+  });
+
+  it('tolerates an undefined brain promise (anonymous/guided never set one)', async () => {
+    await expect(composeContextReady(undefined, () => Promise.resolve())).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
ORB fast-start work, executed phased and behavior-preserving. All flag-gated, **default OFF** — merging is safe, behavior only changes when flags are flipped (staging first).

## Phase 1a — telemetry off the critical path (always on, safe)
`session/start` no longer `await`s the OASIS `emitLiveSessionEvent` — fire-and-forget. Still emits; no longer blocks the response on a Supabase write.

## Phase 2 — defer wake-brief + journey off the response path (`FEATURE_ORB_FAST_START_ENV`)
Wraps the wake-brief decision + journey-greeting in a closure and composes it onto the existing `session.contextReadyPromise` (the stream-open gate already awaits it). `session/start` returns immediately; the first *personalized* turn still carries full wake-brief/Teacher/Journey content. Diff = pure insertions (parity by construction). Fail-open via `Promise.allSettled`. Unit-tested (`test/orb-fast-start.test.ts`, 9/9).

## Phase 4 — instant cached wake cue (`init({wakeCue:true})` / `localStorage vtorb.wakecue=on`)
**This is the change that kills the *perceived* 7-10s dead-air.** Plays Vitana's pre-rendered "I'm here."/"Ich bin da." within ~1s of the tap while context + the Live model spin up.
- Reuses the existing alert-clip system (`render-orb-alert-clips.ts` → committed Chirp3-HD MP3 → `_preloadAlertClips` → `_playAlert`). No new mechanism; no `speechSynthesis` (the widget deliberately rejects it).
- Plays after the activation chime, inside the gesture; **stops the instant the real greeting audio arrives** and on teardown.
- **Invariants:** local UI cue only — not a transcript turn, no memory write, no Journey/Teacher/wake-brief mutation. Graceful no-op if the MP3 isn't rendered yet.

### Why split this way
Phase 2 trims the session-start chain; **Phase 4 is what makes it *feel* instant** (a big chunk of the 7-10s is Gemini first-token latency, which only a local cue can mask).

## Verification done
`tsc --noEmit`: 0 real errors. `node --check orb-widget.js`: OK. Unit tests 9/9.

## Two gates before Phase 4 reaches the community
1. **Render assets:** `npx tsx scripts/render-orb-alert-clips.ts` (default mode → deployed gateway TTS, no creds), commit `wake-cue-en.mp3` / `wake-cue-de.mp3`.
2. **Staging browser verification:** `orb-widget.js` is plain JS (not tsc-checked) and can't be browser-tested in CI here — tap on staging with the flag on and confirm cue plays, stops cleanly, no double-audio, no transcript pollution.

## Rollout
`off` → `staging-only` → `staging+prod` (Phase 2 env flag); `vtorb.wakecue` / `init({wakeCue:true})` for Phase 4. Rollback = flip off. Merge → **staging only**; prod via PUBLISH/escape-hatch.

> Governance: needs a VTID (`spec_status=approved`) before prod. Unrelated to the live nav_catalog/analytics 500s (those are missing migrations from #2647/#2671, not this PR).

https://claude.ai/code/session_01Tubx2oUSS1tKcvcfWiQfUx