### PR TITLE
feat(vcaop): Shopify own-store catalog sync into /discover

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -37,7 +37,9 @@ PRODUCT_ANALYTICS_ROLLUP_ENABLED=true
 # The admin trigger POST /api/v1/vcaop/shopify/sync works regardless of the worker flag.
 SHOPIFY_SYNC_ENABLED=false
 SHOPIFY_STORE_DOMAIN=
+SHOPIFY_STOREFRONT_PASSWORD=
 SHOPIFY_SOURCE_CURRENCY=BAM
+SHOPIFY_MERCHANT_NAME=Vitanaland (Shopify)
 SHOPIFY_SYNC_INTERVAL_MS=3600000
 
 # VCAOP affiliate postback shared key (Admitad).

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -26,6 +26,20 @@ FRONTEND_DEPLOY_REPO=exafyltd/vitana-v1
 # product_analytics_events (default on; set to "false" to disable)
 PRODUCT_ANALYTICS_ROLLUP_ENABLED=true
 
+# VCAOP Shopify own-store catalog sync.
+# Pulls a Shopify store's public products.json into the /discover catalog
+# (own-store products: full margin; prices converted to EUR at the fixed peg).
+# SHOPIFY_SYNC_ENABLED: set "true" to run the background sync worker on boot.
+# SHOPIFY_STORE_DOMAIN: e.g. 54n0fa-ir.myshopify.com (required when enabled).
+# SHOPIFY_STOREFRONT_PASSWORD: only if the storefront is password-gated (Secret Manager).
+# SHOPIFY_SOURCE_CURRENCY: store currency for price conversion (default BAM).
+# SHOPIFY_SYNC_INTERVAL_MS: worker interval (default 3600000 = 1h, min 60000).
+# The admin trigger POST /api/v1/vcaop/shopify/sync works regardless of the worker flag.
+SHOPIFY_SYNC_ENABLED=false
+SHOPIFY_STORE_DOMAIN=
+SHOPIFY_SOURCE_CURRENCY=BAM
+SHOPIFY_SYNC_INTERVAL_MS=3600000
+
 # VCAOP affiliate postback shared key (Admitad).
 # Verifies inbound affiliate conversion postbacks at
 # GET|POST /api/v1/vcaop/postback/admitad. The handler is FAIL-CLOSED: when this

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -295,6 +295,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const vcaopRouter = require('./routes/vcaop').default;
   // VCAOP: public, key-verified affiliate postback receiver (Admitad) — no user auth
   const vcaopPostbackRouter = require('./routes/vcaop-postback').default;
+  // VCAOP: Shopify own-store catalog sync (admin trigger; background worker in services)
+  const shopifySyncRouter = require('./routes/shopify-sync').default;
   // VTID-01169: Deploy → Ledger Terminalization (terminalize endpoint + repair job)
   const vtidTerminalizeRouter = require('./routes/vtid-terminalize').default;
   // VTID-01157: Supabase JWT Auth Middleware + /api/v1/auth/me endpoint
@@ -658,6 +660,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // VCAOP: public affiliate postback receiver — MUST mount before the authed vcaop
   // router so /api/v1/vcaop/postback/* resolves to the key-verified public handler.
   mountRouterSync(app, '/api/v1/vcaop/postback', vcaopPostbackRouter, { owner: 'vcaop-postback' });
+  // VCAOP: Shopify catalog sync — mount before the vcaop router so the sub-path resolves.
+  mountRouterSync(app, '/api/v1/vcaop/shopify', shopifySyncRouter, { owner: 'vcaop-shopify' });
   // VCAOP: Vitanaland Commerce API — providers/affiliate-programs/shop/wallet/onboarding
   mountRouterSync(app, '/api/v1/vcaop', vcaopRouter, { owner: 'vcaop' });
 
@@ -1571,6 +1575,15 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
         }
       } catch (error) {
         console.warn('⚠️ Admin awareness worker initialization failed (non-fatal):', error);
+      }
+
+      // VCAOP: Shopify own-store catalog sync. Opt-in (SHOPIFY_SYNC_ENABLED=true +
+      // SHOPIFY_STORE_DOMAIN). Pulls products.json on an interval into /discover.
+      try {
+        const { startShopifySyncWorker } = require('./services/shopify-sync');
+        startShopifySyncWorker();
+      } catch (error) {
+        console.warn('⚠️ Shopify sync worker initialization failed (non-fatal):', error);
       }
 
       // Dev Autopilot background executor (cooling→running→ci loop).

--- a/services/gateway/src/routes/shopify-sync.ts
+++ b/services/gateway/src/routes/shopify-sync.ts
@@ -1,0 +1,41 @@
+/**
+ * Admin endpoint to sync the Vitanaland Shopify store catalog into /discover.
+ *   POST /api/v1/vcaop/shopify/sync   (exafy_admin only)
+ *
+ * On-demand twin of the background worker in services/shopify-sync. Pulls the
+ * store's products.json, converts prices to EUR, and upserts them into the
+ * catalog under the own-store merchant.
+ */
+import { Router, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { getSupabase } from '../lib/supabase';
+import { requireAuth } from '../middleware/auth-supabase-jwt';
+import { resolveShopifyConfig, syncShopifyCatalog } from '../services/shopify-sync';
+
+const router = Router();
+router.use(requireAuth as any);
+
+router.post('/sync', async (req: Request, res: Response) => {
+  // impact-allow-no-oasis: this handler DOES record an OASIS event via a direct
+  // oasis_events insert below (the same pattern as emitEvent in vcaop.ts), just
+  // not through the emitOasisEvent helper the scanner greps for.
+  if (!(req as any).identity?.exafy_admin) { res.status(403).json({ ok: false, error: 'forbidden' }); return; }
+  const supabase = getSupabase();
+  if (!supabase) { res.status(503).json({ ok: false, error: 'database unavailable' }); return; }
+  const cfg = resolveShopifyConfig();
+  if (!cfg) { res.status(400).json({ ok: false, error: 'SHOPIFY_STORE_DOMAIN not configured' }); return; }
+  try {
+    const result = await syncShopifyCatalog(supabase, cfg);
+    await supabase.from('oasis_events').insert({
+      id: randomUUID(), service: 'vcaop', source: 'vcaop',
+      type: 'vcaop.shopify.synced', topic: 'vcaop.shopify.synced',
+      status: 'success', message: `shopify sync ${result.upserted}/${result.fetched} products`,
+      metadata: result, created_at: new Date().toISOString(),
+    }).then(() => {}, () => {});
+    res.json({ ok: true, data: result });
+  } catch (e: any) {
+    res.status(502).json({ ok: false, error: String((e && e.message) || e) });
+  }
+});
+
+export default router;

--- a/services/gateway/src/routes/shopify-sync.ts
+++ b/services/gateway/src/routes/shopify-sync.ts
@@ -26,12 +26,14 @@ router.post('/sync', async (req: Request, res: Response) => {
   if (!cfg) { res.status(400).json({ ok: false, error: 'SHOPIFY_STORE_DOMAIN not configured' }); return; }
   try {
     const result = await syncShopifyCatalog(supabase, cfg);
-    await supabase.from('oasis_events').insert({
-      id: randomUUID(), service: 'vcaop', source: 'vcaop',
-      type: 'vcaop.shopify.synced', topic: 'vcaop.shopify.synced',
-      status: 'success', message: `shopify sync ${result.upserted}/${result.fetched} products`,
-      metadata: result, created_at: new Date().toISOString(),
-    }).then(() => {}, () => {});
+    try {
+      await supabase.from('oasis_events').insert({
+        id: randomUUID(), service: 'vcaop', source: 'vcaop',
+        type: 'vcaop.shopify.synced', topic: 'vcaop.shopify.synced',
+        status: 'success', message: `shopify sync ${result.upserted}/${result.fetched} products`,
+        metadata: result, created_at: new Date().toISOString(),
+      });
+    } catch { /* never block the sync response on the audit write */ }
     res.json({ ok: true, data: result });
   } catch (e: any) {
     res.status(502).json({ ok: false, error: String((e && e.message) || e) });

--- a/services/gateway/src/services/shopify-sync.ts
+++ b/services/gateway/src/services/shopify-sync.ts
@@ -1,0 +1,174 @@
+/**
+ * VCAOP Shopify catalog sync (own-store products -> /discover).
+ *
+ * Pulls a Shopify store's public products feed (products.json) and upserts the
+ * products into the consumer catalog (public.products) under a dedicated
+ * own-store merchant, so they surface in /discover. Prices are converted to EUR
+ * (the catalog currency); BAM (the "KM" mark) uses the fixed euro peg.
+ *
+ * Own-store products: full margin; affiliate_url points to the Shopify product
+ * page; rewards are funded by margin (no affiliate commission). Idempotent: each
+ * product gets a deterministic id so re-syncs upsert in place rather than dupe.
+ */
+import { createHash } from 'crypto';
+import { getSupabase } from '../lib/supabase';
+
+export interface ShopifySyncConfig {
+  domain: string;              // e.g. 54n0fa-ir.myshopify.com
+  storefrontPassword?: string; // only needed if the storefront is password-gated
+  sourceCurrency: string;      // store currency (prices in products.json), e.g. BAM
+  merchantId: string;          // catalog merchant uuid for this store
+  merchantName: string;
+}
+
+export interface ShopifySyncResult {
+  ok: boolean;
+  merchantId: string;
+  fetched: number;
+  upserted: number;
+}
+
+// Fixed euro pegs (no FX drift). BAM = Bosnian convertible mark, pegged to EUR.
+const FIXED_PEG_TO_EUR: Record<string, number> = { EUR: 1, BAM: 1.95583 };
+
+export const SHOPIFY_MERCHANT_ID = 'a7e3c1d0-0000-4000-8000-000000000001';
+
+/** Convert a store-currency price to EUR cents at the fixed peg. */
+export function toEurCents(price: number, sourceCurrency: string): number | null {
+  if (!Number.isFinite(price)) return null;
+  const rate = FIXED_PEG_TO_EUR[(sourceCurrency || 'EUR').toUpperCase()] ?? 1;
+  return Math.round((price / rate) * 100);
+}
+
+/** Deterministic uuid (v4-shaped) from a stable key, for idempotent upserts. */
+export function deterministicUuid(key: string): string {
+  const h = createHash('sha256').update(key).digest('hex');
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-4${h.slice(13, 16)}-8${h.slice(17, 20)}-${h.slice(20, 32)}`;
+}
+
+interface ShopifyVariant { price?: string; available?: boolean }
+interface ShopifyImage { src?: string }
+export interface ShopifyProduct {
+  id: number; title: string; handle: string; vendor?: string; product_type?: string;
+  body_html?: string; variants?: ShopifyVariant[]; images?: ShopifyImage[];
+}
+
+/** Map a Shopify products.json product onto a public.products row. */
+export function mapShopifyProduct(p: ShopifyProduct, cfg: ShopifySyncConfig): Record<string, unknown> | null {
+  if (!p || !p.id || !p.title) return null;
+  const v0 = (p.variants || [])[0];
+  const sourceProductId = String(p.id);
+  return {
+    id: deterministicUuid(`shopify:${cfg.domain}:${sourceProductId}`),
+    merchant_id: cfg.merchantId,
+    source_network: 'shopify',
+    source_product_id: sourceProductId,
+    title: p.title,
+    description: (p.body_html || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 2000) || null,
+    brand: p.vendor || cfg.merchantName,
+    category: p.product_type || 'supplements',
+    price_cents: v0 ? toEurCents(Number(v0.price), cfg.sourceCurrency) : null,
+    currency: 'EUR',
+    affiliate_url: `https://${cfg.domain}/products/${p.handle}`,
+    images: (p.images || []).map((i) => i.src).filter((s): s is string => Boolean(s)),
+    availability: v0 && v0.available ? 'in_stock' : 'out_of_stock',
+    ships_to_countries: ['DE', 'AT', 'CH', 'ES', 'BA', 'AE'],
+    ships_to_regions: ['EU', 'MENA', 'GLOBAL'],
+    origin_country: 'DE',
+    origin_region: 'EU',
+    is_active: true,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+async function fetchProductsJson(cfg: ShopifySyncConfig): Promise<ShopifyProduct[]> {
+  const base = `https://${cfg.domain}`;
+  let res = await fetch(`${base}/products.json?limit=250`);
+  // Password-protected storefronts return 401 — do the storefront-password handshake.
+  if (res.status === 401 && cfg.storefrontPassword) {
+    const page = await fetch(`${base}/password`);
+    const html = await page.text();
+    const m = /name="authenticity_token"[^>]*value="([^"]+)"/.exec(html);
+    const cookie = page.headers.get('set-cookie') || '';
+    const body = new URLSearchParams({
+      form_type: 'storefront_password',
+      utf8: '✓',
+      authenticity_token: m ? m[1] : '',
+      password: cfg.storefrontPassword,
+    });
+    const login = await fetch(`${base}/password`, {
+      method: 'POST', redirect: 'manual',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', cookie }, body,
+    });
+    const authCookie = login.headers.get('set-cookie') || cookie;
+    res = await fetch(`${base}/products.json?limit=250`, { headers: { cookie: authCookie } });
+  }
+  if (!res.ok) throw new Error(`products.json HTTP ${res.status}`);
+  const data = (await res.json()) as { products?: ShopifyProduct[] };
+  return data.products || [];
+}
+
+/** Build the sync config from env, or null if no store domain is configured. */
+export function resolveShopifyConfig(): ShopifySyncConfig | null {
+  const domain = process.env.SHOPIFY_STORE_DOMAIN || '';
+  if (!domain) return null;
+  return {
+    domain,
+    storefrontPassword: process.env.SHOPIFY_STOREFRONT_PASSWORD || undefined,
+    sourceCurrency: process.env.SHOPIFY_SOURCE_CURRENCY || 'BAM',
+    merchantId: SHOPIFY_MERCHANT_ID,
+    merchantName: process.env.SHOPIFY_MERCHANT_NAME || 'Vitanaland (Shopify)',
+  };
+}
+
+/** Fetch the Shopify feed and upsert merchant + products into the catalog. */
+export async function syncShopifyCatalog(supabase: any, cfg: ShopifySyncConfig): Promise<ShopifySyncResult> {
+  await supabase.from('merchants').upsert({
+    id: cfg.merchantId, name: cfg.merchantName, source_network: 'shopify',
+    currencies: ['EUR'], is_active: true, updated_at: new Date().toISOString(),
+  }, { onConflict: 'id' });
+
+  const products = await fetchProductsJson(cfg);
+  const rows = products
+    .map((p) => mapShopifyProduct(p, cfg))
+    .filter((r): r is Record<string, unknown> => r !== null);
+
+  let upserted = 0;
+  for (let i = 0; i < rows.length; i += 100) {
+    const chunk = rows.slice(i, i + 100);
+    const { error } = await supabase.from('products').upsert(chunk, { onConflict: 'id' });
+    if (error) throw new Error(error.message);
+    upserted += chunk.length;
+  }
+  return { ok: true, merchantId: cfg.merchantId, fetched: products.length, upserted };
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/** Env-gated background worker: periodically re-syncs the Shopify catalog. */
+export function startShopifySyncWorker(): void {
+  if (process.env.SHOPIFY_SYNC_ENABLED !== 'true') {
+    console.log('⏸️ Shopify sync worker disabled (set SHOPIFY_SYNC_ENABLED=true to enable)');
+    return;
+  }
+  const cfg = resolveShopifyConfig();
+  if (!cfg) {
+    console.warn('⚠️ Shopify sync enabled but SHOPIFY_STORE_DOMAIN not set — skipping');
+    return;
+  }
+  const intervalMs = Math.max(60_000, Number(process.env.SHOPIFY_SYNC_INTERVAL_MS) || 3_600_000);
+  const run = async () => {
+    try {
+      const supabase = getSupabase();
+      if (!supabase) return;
+      const r = await syncShopifyCatalog(supabase, cfg);
+      console.log(`🛍️ Shopify sync: ${r.upserted}/${r.fetched} products from ${cfg.domain}`);
+    } catch (e) {
+      console.warn('⚠️ Shopify sync run failed (non-fatal):', e);
+    }
+  };
+  if (timer) clearInterval(timer);
+  void run(); // initial run on boot
+  timer = setInterval(() => void run(), intervalMs);
+  console.log(`🛍️ Shopify sync worker started (every ${Math.round(intervalMs / 60000)}m) for ${cfg.domain}`);
+}

--- a/services/gateway/test/routes/shopify-sync.test.ts
+++ b/services/gateway/test/routes/shopify-sync.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the Shopify catalog sync mapping + currency conversion
+ * (the logic behind POST /api/v1/vcaop/shopify/sync and the background worker).
+ */
+import {
+  toEurCents,
+  deterministicUuid,
+  mapShopifyProduct,
+  resolveShopifyConfig,
+  type ShopifySyncConfig,
+  type ShopifyProduct,
+} from '../../src/services/shopify-sync';
+
+const cfg: ShopifySyncConfig = {
+  domain: '54n0fa-ir.myshopify.com',
+  sourceCurrency: 'BAM',
+  merchantId: 'a7e3c1d0-0000-4000-8000-000000000001',
+  merchantName: 'Vitanaland (Shopify)',
+};
+
+describe('toEurCents — fixed-peg conversion', () => {
+  test('BAM converts at the 1.95583 euro peg', () => {
+    // 17.90 KM / 1.95583 = 9.1521... -> 915 cents
+    expect(toEurCents(17.9, 'BAM')).toBe(915);
+  });
+  test('EUR passes through unchanged', () => {
+    expect(toEurCents(9.15, 'EUR')).toBe(915);
+  });
+  test('unknown currency is treated 1:1', () => {
+    expect(toEurCents(10, 'XYZ')).toBe(1000);
+  });
+  test('non-numeric price returns null', () => {
+    expect(toEurCents(Number('not-a-price'), 'BAM')).toBeNull();
+  });
+});
+
+describe('deterministicUuid — idempotent ids', () => {
+  test('is stable for the same key and uuid-shaped', () => {
+    const a = deterministicUuid('shopify:store:123');
+    const b = deterministicUuid('shopify:store:123');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-8[0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+  test('differs for different keys', () => {
+    expect(deterministicUuid('a')).not.toBe(deterministicUuid('b'));
+  });
+});
+
+describe('mapShopifyProduct', () => {
+  const product: ShopifyProduct = {
+    id: 15861745090929,
+    title: 'Vitamin D3 4000 IU — Daily Vegan Drops',
+    handle: 'vitamin-d3-4000-iu-daily-vegan-drops',
+    vendor: 'Vitanaland',
+    product_type: 'supplements',
+    body_html: '<p>Daily <b>vegan</b> D3.</p>',
+    variants: [{ price: '17.90', available: true }],
+    images: [{ src: 'https://cdn.example/img.png' }],
+  };
+
+  test('maps core fields + converts price to EUR cents', () => {
+    const row = mapShopifyProduct(product, cfg)!;
+    expect(row.source_network).toBe('shopify');
+    expect(row.source_product_id).toBe('15861745090929');
+    expect(row.price_cents).toBe(915);
+    expect(row.currency).toBe('EUR');
+    expect(row.availability).toBe('in_stock');
+    expect(row.affiliate_url).toBe('https://54n0fa-ir.myshopify.com/products/vitamin-d3-4000-iu-daily-vegan-drops');
+    expect(row.images).toEqual(['https://cdn.example/img.png']);
+    expect(row.description).toBe('Daily vegan D3.'); // html stripped
+    expect(row.merchant_id).toBe(cfg.merchantId);
+  });
+
+  test('out-of-stock when no variant is available', () => {
+    const row = mapShopifyProduct({ ...product, variants: [{ price: '5', available: false }] }, cfg)!;
+    expect(row.availability).toBe('out_of_stock');
+  });
+
+  test('returns null for an invalid product (no id/title)', () => {
+    expect(mapShopifyProduct({ id: 0, title: '', handle: 'x' } as ShopifyProduct, cfg)).toBeNull();
+  });
+});
+
+describe('resolveShopifyConfig', () => {
+  const ORIG = process.env.SHOPIFY_STORE_DOMAIN;
+  afterAll(() => {
+    if (ORIG === undefined) delete process.env.SHOPIFY_STORE_DOMAIN;
+    else process.env.SHOPIFY_STORE_DOMAIN = ORIG;
+  });
+  test('null when no domain configured', () => {
+    delete process.env.SHOPIFY_STORE_DOMAIN;
+    expect(resolveShopifyConfig()).toBeNull();
+  });
+  test('builds config from env', () => {
+    process.env.SHOPIFY_STORE_DOMAIN = 'shop.myshopify.com';
+    const c = resolveShopifyConfig()!;
+    expect(c.domain).toBe('shop.myshopify.com');
+    expect(c.sourceCurrency).toBe('BAM'); // default
+  });
+});


### PR DESCRIPTION
## What

Auto-syncs a **Shopify own-store** catalog into `/discover`, so own-brand products (e.g. Vitana Essentials) flow in automatically instead of being hand-added.

### `services/shopify-sync.ts`
- Fetches the store's public `products.json` (with a **storefront-password handshake** fallback for password-gated/trial stores).
- Maps each product → `public.products`: title, brand (vendor), category, images, availability, `affiliate_url` → the Shopify product page.
- **Currency conversion to EUR** at the fixed peg (BAM `1.95583`; EUR/others pass through) — the catalog is EUR.
- **Deterministic ids** (`sha256(shopify:domain:productId)`) → idempotent re-syncs (upsert in place, no dupes).
- Upserts the **own-store merchant** + products (chunked).
- **Env-gated background worker** (`startShopifySyncWorker`) mirroring the gateway's other scheduled jobs — runs on an interval when `SHOPIFY_SYNC_ENABLED=true`.

### `routes/shopify-sync.ts`
- `POST /api/v1/vcaop/shopify/sync` (exafy_admin) — on-demand run; mounted before the vcaop router.

### Config (`.env.example`)
`SHOPIFY_SYNC_ENABLED`, `SHOPIFY_STORE_DOMAIN`, `SHOPIFY_STOREFRONT_PASSWORD`, `SHOPIFY_SOURCE_CURRENCY`, `SHOPIFY_MERCHANT_NAME`, `SHOPIFY_SYNC_INTERVAL_MS`.

## Model note
Own-store = **full margin** (not affiliate commission); rewards funded by margin. `affiliate_url` points to the Shopify product page.

## Tests / safety
- 11 unit tests: KM→EUR conversion, deterministic ids, product mapping (in/out-of-stock, html-strip, invalid), config resolution.
- `tsc --noEmit` clean; Dev-Autopilot impact scan **0 findings**.
- Worker is opt-in and fail-soft (never fatal); admin endpoint is auth-gated.

https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK)_