### PR TITLE
perf(orb): DEV-COMHU-0513 cache vitana-brain ORB context + warm on prewarm — the real ~7s→~2.5s first-audio fix (flag-gated)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -757,14 +757,14 @@ export async function handleLiveSessionStart(
         ? (async () => {
             const brainStart = Date.now();
             try {
-              const { buildBrainSystemInstruction } = await import('../../../services/vitana-brain');
+              const { buildBrainSystemInstructionCached } = await import('../../../services/vitana-brain-cache');
               const bodyRoute = typeof (body as any).current_route === 'string' ? (body as any).current_route : '';
               const brainRole = clientContext.isMobile
                 ? 'community'
                 : bodyRoute.startsWith('/command-hub')
                   ? 'developer'
                   : ((bootstrapIdentity as any).active_role || 'community');
-              const { instruction, contextPack: cp } = await buildBrainSystemInstruction({
+              const { instruction, contextPack: cp } = await buildBrainSystemInstructionCached({
                 user_id: bootstrapIdentity.user_id,
                 tenant_id: bootstrapIdentity.tenant_id || 'default',
                 role: brainRole,

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -11619,6 +11619,22 @@ router.post('/live/session/prewarm', optionalAuth, async (req: AuthenticatedRequ
   }
   void buildBootstrapContextPack(identity, `prewarm-${Date.now()}`)
     .catch((err) => console.warn('[BOOTSTRAP-ORB-LATENCY-PHASE2] prewarm failed (non-fatal):', err?.message || err));
+  // ORB-BRAIN-CACHE (DEV-COMHU-0513): also warm the vitana-brain ORB context —
+  // the path the live session ACTUALLY uses (buildBootstrapContextPack above is
+  // the legacy path). Without this, a prewarmed tap still paid the full ~4.4s
+  // brain build that gates the Gemini setup. Community/orb is the dominant
+  // (and complaining) cohort; other roles warm on their first tap. Flag-gated
+  // (no-op when FEATURE_ORB_BRAIN_CACHE_ENV is off).
+  void import('../services/vitana-brain-cache')
+    .then(({ warmBrainCache }) =>
+      warmBrainCache({
+        user_id: identity.user_id,
+        tenant_id: identity.tenant_id || 'default',
+        role: 'community',
+        channel: 'orb',
+      }),
+    )
+    .catch(() => { /* best-effort warm */ });
   return res.json({ ok: true, prewarm: 'started' });
 });
 

--- a/services/gateway/src/services/vitana-brain-cache.ts
+++ b/services/gateway/src/services/vitana-brain-cache.ts
@@ -1,0 +1,118 @@
+/**
+ * ORB-BRAIN-CACHE (DEV-COMHU-0513) — per-identity cache for the ORB greeting
+ * system instruction.
+ *
+ * WHY: `buildBrainSystemInstruction` (vitana-brain.ts) runs the memory garden
+ * + calendar + OASIS context pack, the Life Compass block, the proactive-guide
+ * block, and the identity guardrail — measured at ~4.4s on the authenticated
+ * community ORB path (`[VITANA-BRAIN] System instruction built in 4395ms`).
+ * That whole build GATES the Gemini setup message — `connectToLiveAPI` awaits
+ * `session.contextReadyPromise` before sending setup (orb-live.ts ~6178) — so
+ * it is the dominant chunk of the ~7s click-to-first-audio.
+ *
+ * The existing prewarm (`POST /live/session/prewarm`) warms
+ * `buildBootstrapContextPack` — the LEGACY path — NOT this brain path, so a
+ * prewarmed tap still paid the full ~4.4s (`Context bootstrap complete … cached=false`).
+ *
+ * This module caches the brain build per (tenant, user, role, channel) with a
+ * short TTL, and exposes `warmBrainCache()` for the prewarm endpoint to call,
+ * so the user's first tap is a cache hit (~tens of ms instead of ~4.4s).
+ *
+ * SAFETY:
+ *  - Flag-gated `FEATURE_ORB_BRAIN_CACHE_ENV`; default OFF → direct passthrough
+ *    to `buildBrainSystemInstruction` (behavior identical to today).
+ *  - Success-only (failures are not cached — the entry is dropped on reject).
+ *  - 5-min TTL (same staleness rationale as the existing bootstrap cache: a
+ *    greeting bootstrap tolerates minute-scale staleness; memory rarely changes
+ *    mid-session).
+ *  - Concurrent-build de-dupe: the in-flight Promise is cached, so prewarm + the
+ *    tap (or repeated prewarms) share ONE build instead of stampeding.
+ *  - Keyed by tenant+user → no cross-tenant / cross-user leakage.
+ */
+import { buildBrainSystemInstruction } from './vitana-brain';
+import { isFeatureLive } from './feature-flags';
+
+type BrainInput = Parameters<typeof buildBrainSystemInstruction>[0];
+type BrainResult = Awaited<ReturnType<typeof buildBrainSystemInstruction>>;
+
+const TTL_MS = 5 * 60 * 1000;
+const MAX_ENTRIES = 500;
+
+interface Entry {
+  promise: Promise<BrainResult>;
+  builtAt: number;
+}
+
+const cache = new Map<string, Entry>();
+
+function keyOf(input: BrainInput): string {
+  // role + channel are baked into the produced instruction, so they MUST be in
+  // the key. tenant + user scope the personalization (no cross-user leakage).
+  return [input.tenant_id, input.user_id, input.role, input.channel].join('|');
+}
+
+function evictIfNeeded(): void {
+  if (cache.size <= MAX_ENTRIES) return;
+  // Map preserves insertion order → drop oldest first until under cap.
+  for (const k of cache.keys()) {
+    cache.delete(k);
+    if (cache.size <= MAX_ENTRIES) break;
+  }
+}
+
+/** Test helpers. */
+export function _resetBrainCacheForTests(): void {
+  cache.clear();
+}
+export function brainCacheSize(): number {
+  return cache.size;
+}
+
+/**
+ * Cached wrapper around `buildBrainSystemInstruction`. When the flag is OFF,
+ * this is a transparent passthrough (no caching). When ON, it serves a fresh
+ * (< TTL) cached build, de-dupes concurrent builds, and never caches failures.
+ */
+export function buildBrainSystemInstructionCached(
+  input: BrainInput,
+  opts: { now?: () => number } = {},
+): Promise<BrainResult> {
+  if (!isFeatureLive('ORB_BRAIN_CACHE')) {
+    return buildBrainSystemInstruction(input);
+  }
+  const now = opts.now ?? Date.now;
+  const key = keyOf(input);
+
+  const hit = cache.get(key);
+  if (hit && now() - hit.builtAt < TTL_MS) {
+    console.log(`[ORB-BRAIN-CACHE] HIT ${key} (age ${now() - hit.builtAt}ms)`);
+    return hit.promise;
+  }
+
+  const builtAt = now();
+  const promise = buildBrainSystemInstruction(input);
+  cache.set(key, { promise, builtAt });
+  evictIfNeeded();
+  console.log(`[ORB-BRAIN-CACHE] MISS ${key} — building`);
+
+  // Never cache a failure: if the build rejects, drop the entry so the next
+  // call rebuilds. Guard on identity so a newer build isn't clobbered.
+  promise.catch(() => {
+    const cur = cache.get(key);
+    if (cur && cur.promise === promise) cache.delete(key);
+  });
+
+  return promise;
+}
+
+/**
+ * Fire-and-forget warm for the prewarm endpoint. Builds (and caches) the brain
+ * instruction for the common authenticated community ORB path so the user's
+ * first tap is a cache hit. No-op when the flag is off; never throws.
+ */
+export function warmBrainCache(input: BrainInput): void {
+  if (!isFeatureLive('ORB_BRAIN_CACHE')) return;
+  void buildBrainSystemInstructionCached(input).catch(() => {
+    /* best-effort warm */
+  });
+}

--- a/services/gateway/test/vitana-brain-cache.test.ts
+++ b/services/gateway/test/vitana-brain-cache.test.ts
@@ -1,0 +1,107 @@
+/**
+ * ORB-BRAIN-CACHE (DEV-COMHU-0513) — unit tests for the per-identity brain
+ * instruction cache. Covers flag-off passthrough, hit/miss, TTL expiry,
+ * concurrent de-dupe, failure non-caching, key isolation, and prewarm warming.
+ * `buildBrainSystemInstruction` is fully mocked so these tests don't load the
+ * heavy real brain stack.
+ */
+
+jest.mock('../src/services/vitana-brain', () => ({
+  buildBrainSystemInstruction: jest.fn(),
+}));
+
+import { buildBrainSystemInstruction } from '../src/services/vitana-brain';
+import {
+  buildBrainSystemInstructionCached,
+  warmBrainCache,
+  _resetBrainCacheForTests,
+  brainCacheSize,
+} from '../src/services/vitana-brain-cache';
+
+const mockBuild = buildBrainSystemInstruction as jest.Mock;
+const FLAG = 'FEATURE_ORB_BRAIN_CACHE_ENV';
+const baseInput = { user_id: 'u1', tenant_id: 't1', role: 'community', channel: 'orb' } as any;
+
+describe('vitana-brain-cache', () => {
+  const prev = process.env[FLAG];
+  beforeEach(() => {
+    _resetBrainCacheForTests();
+    mockBuild.mockReset();
+    mockBuild.mockImplementation(() => Promise.resolve({ instruction: 'INSTR', contextPack: {} }));
+  });
+  afterAll(() => {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+  });
+
+  it('flag OFF → passthrough, no caching (each call rebuilds)', async () => {
+    delete process.env[FLAG];
+    await buildBrainSystemInstructionCached(baseInput);
+    await buildBrainSystemInstructionCached(baseInput);
+    expect(mockBuild).toHaveBeenCalledTimes(2);
+    expect(brainCacheSize()).toBe(0);
+  });
+
+  it('flag ON → MISS then HIT (one build serves two calls)', async () => {
+    process.env[FLAG] = 'staging+prod';
+    const a = await buildBrainSystemInstructionCached(baseInput);
+    const b = await buildBrainSystemInstructionCached(baseInput);
+    expect(mockBuild).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it('flag ON → rebuilds after the 5-min TTL expires', async () => {
+    process.env[FLAG] = 'staging+prod';
+    let t = 1000;
+    const now = () => t;
+    await buildBrainSystemInstructionCached(baseInput, { now });
+    t += 5 * 60 * 1000 + 1; // just past TTL
+    await buildBrainSystemInstructionCached(baseInput, { now });
+    expect(mockBuild).toHaveBeenCalledTimes(2);
+  });
+
+  it('flag ON → concurrent callers share ONE in-flight build (no stampede)', async () => {
+    process.env[FLAG] = 'staging+prod';
+    let resolve!: (v: unknown) => void;
+    mockBuild.mockImplementation(() => new Promise((r) => { resolve = r as (v: unknown) => void; }));
+    const p1 = buildBrainSystemInstructionCached(baseInput);
+    const p2 = buildBrainSystemInstructionCached(baseInput);
+    resolve({ instruction: 'X', contextPack: {} });
+    await Promise.all([p1, p2]);
+    expect(mockBuild).toHaveBeenCalledTimes(1);
+  });
+
+  it('flag ON → failures are NOT cached (next call rebuilds)', async () => {
+    process.env[FLAG] = 'staging+prod';
+    mockBuild.mockImplementationOnce(() => Promise.reject(new Error('boom')));
+    await expect(buildBrainSystemInstructionCached(baseInput)).rejects.toThrow('boom');
+    await new Promise((r) => setTimeout(r, 0)); // let the eviction .catch run
+    mockBuild.mockImplementation(() => Promise.resolve({ instruction: 'OK', contextPack: {} }));
+    const r = await buildBrainSystemInstructionCached(baseInput);
+    expect(r.instruction).toBe('OK');
+    expect(mockBuild).toHaveBeenCalledTimes(2);
+  });
+
+  it('flag ON → different user is a separate cache entry (no cross-user leak)', async () => {
+    process.env[FLAG] = 'staging+prod';
+    await buildBrainSystemInstructionCached(baseInput);
+    await buildBrainSystemInstructionCached({ ...baseInput, user_id: 'u2' });
+    expect(mockBuild).toHaveBeenCalledTimes(2);
+    expect(brainCacheSize()).toBe(2);
+  });
+
+  it('warmBrainCache makes the next real call a HIT', async () => {
+    process.env[FLAG] = 'staging+prod';
+    warmBrainCache(baseInput);
+    await new Promise((r) => setTimeout(r, 0)); // let the warm build settle
+    await buildBrainSystemInstructionCached(baseInput);
+    expect(mockBuild).toHaveBeenCalledTimes(1);
+  });
+
+  it('warmBrainCache is a no-op when the flag is OFF', async () => {
+    delete process.env[FLAG];
+    warmBrainCache(baseInput);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(brainCacheSize()).toBe(0);
+  });
+});


### PR DESCRIPTION
## The real fix for the orb's ~7s first-audio

Staging logs (this user, community/orb) decomposed the delay precisely:

| Segment | Time | Evidence |
|---|---|---|
| **vitana-brain context build** | **~4.4s** | `[VITANA-BRAIN] System instruction built in 4395ms (16475 chars, 25 memory hits, compass=on, guide=on)` |
| Model first-token | ~1.2s | setup sent → first audio chunk |
| Connect/overhead | ~1.4s | — |

`connectToLiveAPI` awaits `session.contextReadyPromise` **before** sending the Gemini setup (orb-live.ts ~6178), so the 4.4s brain build directly gates first audio. **The model is not the bottleneck.**

**Root cause:** the prewarm endpoint warms `buildBootstrapContextPack` (the *legacy* path), but the live session uses `buildBrainSystemInstruction` (vitana-brain) — which was **neither cached nor warmed**. Logs showed `Context bootstrap complete … cached=false` even though the widget prewarmed on load. So every tap paid the full ~4.4s.

## Change (flag-gated `FEATURE_ORB_BRAIN_CACHE_ENV`, default OFF)
- **`services/vitana-brain-cache.ts`** — short-TTL (5 min), 500-cap, success-only, concurrent-build-deduped cache around `buildBrainSystemInstruction`, keyed `tenant|user|role|channel` (no cross-user leak). **Flag off = transparent passthrough**, behavior identical to today.
- **`live-session-controller.ts`** now calls `buildBrainSystemInstructionCached`.
- **`/live/session/prewarm`** now also `warmBrainCache({role:'community',channel:'orb'})` — the path the session actually uses — so a prewarmed community tap is a cache hit.

**Expected (warmed tap):** `[VITANA-BRAIN] built in Xms` drops from ~4400ms → tens of ms; click-to-first-audio **~7s → ~2.5s**. No reconnect, no protocol change, wake-brief opener fully intact.

## Why this and not the earlier phases
Phase 2 made the *UI* connect faster but moved wake-brief/journey into the same gate, so speech didn't improve. Phase 4's cue only masks. This targets the measured 4.4s where the latency actually lives.

## Verification
- `tsc --noEmit`: 0 real errors.
- `test/vitana-brain-cache.test.ts`: 8/8 (flag-off passthrough, hit/miss, TTL expiry, concurrent de-dupe, failure-not-cached, key isolation, prewarm warm).
- End-to-end: staging flag-on → re-pull the `VITANA-BRAIN built in Xms` log on a warmed tap (should be tens of ms) and confirm personalization (memory/wake-brief/role) intact.

## Rollout
`FEATURE_ORB_BRAIN_CACHE_ENV`: off → `staging-only` → `staging+prod`. Rollback = flip off (no redeploy). Merge → staging only.

> No command-hub paths touched (no Path Ownership Guard marker needed); `DEV-COMHU-0513` kept for traceability with the orb-latency workstream.

https://claude.ai/code/session_01Tubx2oUSS1tKcvcfWiQfUx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tubx2oUSS1tKcvcfWiQfUx)_