### PR TITLE
DEV-COMHU-0513: orb first-greeting latency — probe, root cause + flag-gated WS greeting pre-buffer

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -60,6 +60,14 @@ ADMITAD_POSTBACK_KEY=
 # staging+prod (see services/gateway/src/services/feature-flags.ts).
 FEATURE_ORB_GREETING_PREBUFFER_ENV=off
 
+# DEV-COMHU-0513 — upper bound (ms) on waiting for session.contextReadyPromise
+# before sending the Gemini setup message / greeting. Safety net so a slow or
+# hung context build (notably when FEATURE_ORB_FAST_START_ENV defers wake-brief/
+# journey work onto that promise) can never strand the greeting; the gate
+# proceeds with partial context after this cap. Default 4000. Unbounded behavior
+# is restored by setting it very high — not recommended.
+ORB_CONTEXT_READY_GATE_TIMEOUT_MS=4000
+
 # Env vars read ONLY by the standalone latency probe
 # (services/gateway/scripts/orb-latency-probe.mjs) — never by the running
 # service. Documented here so the impact-scan env-binding check is satisfied.

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -49,3 +49,26 @@ SHOPIFY_SYNC_INTERVAL_MS=3600000
 # then include it as ?key=<value> in the postback URL pasted into Admitad
 # (Tools -> Postback URL). Bind it as a gateway Cloud Run env / Secret Manager value.
 ADMITAD_POSTBACK_KEY=
+
+# --- DEV-COMHU-0513: ORB first-greeting latency ---
+# Greeting pre-buffer (WebSocket path). When live, the greeting prompt is
+# dispatched to the model as soon as the upstream Live API socket opens (so
+# generation overlaps the client's AudioContext unlock) and the resulting audio
+# is held server-side until the client sends audio_ready (or a 1.5s fallback).
+# Decouples "start generating" from "client ready to play". Default off → legacy
+# behavior (greeting prompt waits for audio_ready). Values: off | staging-only |
+# staging+prod (see services/gateway/src/services/feature-flags.ts).
+FEATURE_ORB_GREETING_PREBUFFER_ENV=off
+
+# Env vars read ONLY by the standalone latency probe
+# (services/gateway/scripts/orb-latency-probe.mjs) — never by the running
+# service. Documented here so the impact-scan env-binding check is satisfied.
+#   GW                  gateway base URL (default staging)
+#   SUPABASE_URL        Supabase project URL (default staging project)
+#   SUPABASE_ANON_KEY   anon key for the password grant (no default)
+#   ORB_EMAIL           test user email (default e2e-test@vitana.dev)
+#   ORB_PASSWORD        test user password (no default; required unless ORB_TOKEN)
+#   ORB_TOKEN           pre-minted JWT (alternative to email/password)
+#   ORB_LANG            greeting language (default de)
+#   TRANSPORT           'sse' (default) or 'ws'
+#   AUDIO_READY_DELAY_MS  WS mode: simulated AudioContext-unlock delay (default 300)

--- a/services/gateway/scripts/orb-latency-probe.mjs
+++ b/services/gateway/scripts/orb-latency-probe.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * ORB LATENCY PROBE (DEV-COMHU-0513) — headless synthetic orb client that
+ * measures click→first-audio END TO END so we can iterate the first-greeting
+ * latency fix WITHOUT a human pasting browser/gcloud logs.
+ *
+ * It mirrors what the widget does on tap:
+ *   1. mint a JWT for the test user (Supabase password grant)
+ *   2. POST /api/v1/orb/live/session/start           (t = session_started)
+ *   3. GET  /api/v1/orb/live/stream?session_id=...    (SSE; t = stream_open)
+ *   4. POST /api/v1/orb/session/:id/audio-ready       (t = audio_ready_sent)
+ *   5. read the SSE until the FIRST audio chunk        (t = first_audio)
+ * …timestamping each step and printing the breakdown.
+ *
+ * It does NOT model the browser AudioContext unlock (that needs a real
+ * browser / Playwright run) — but it isolates the SERVER + TRANSPORT + greeting
+ * path, which is where we've measured the first-turn tax.
+ *
+ * REQUIRES outbound egress to the gateway + Supabase host (currently blocked by
+ * the env allowlist). Run:
+ *   GW=https://gateway-staging-86804897789.us-central1.run.app \
+ *   SUPABASE_URL=https://inmkhvwdcuyhnxkgfvsb.supabase.co \
+ *   SUPABASE_ANON_KEY=... ORB_EMAIL=e2e-test@vitana.dev ORB_PASSWORD=... \
+ *   node services/gateway/scripts/orb-latency-probe.mjs
+ */
+
+const GW = (process.env.GW || 'https://gateway-staging-86804897789.us-central1.run.app').replace(/\/+$/, '');
+const SUPABASE_URL = (process.env.SUPABASE_URL || 'https://inmkhvwdcuyhnxkgfvsb.supabase.co').replace(/\/+$/, '');
+const ANON_KEY = process.env.SUPABASE_ANON_KEY || '';
+const EMAIL = process.env.ORB_EMAIL || 'e2e-test@vitana.dev';
+const PASSWORD = process.env.ORB_PASSWORD || '';
+const LANG = process.env.ORB_LANG || 'de';
+
+const t0Wall = Date.now();
+const marks = [];
+function mark(name) {
+  const t = Date.now() - t0Wall;
+  marks.push([name, t]);
+  console.log(`  [${String(t).padStart(6)}ms] ${name}`);
+}
+
+async function getToken() {
+  if (process.env.ORB_TOKEN) return process.env.ORB_TOKEN;
+  if (!ANON_KEY || !PASSWORD) throw new Error('Need SUPABASE_ANON_KEY + ORB_PASSWORD (or ORB_TOKEN) to authenticate.');
+  const r = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: ANON_KEY },
+    body: JSON.stringify({ email: EMAIL, password: PASSWORD }),
+  });
+  if (!r.ok) throw new Error(`auth failed: ${r.status} ${await r.text()}`);
+  return (await r.json()).access_token;
+}
+
+async function run() {
+  console.log(`ORB latency probe → ${GW} (lang=${LANG})`);
+  const token = await getToken();
+  mark('auth_ok');
+
+  // 2. session/start
+  const startResp = await fetch(`${GW}/api/v1/orb/live/session/start`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ lang: LANG, voice_style: 'friendly, calm', response_modalities: ['audio', 'text'], current_route: '/' }),
+  });
+  if (!startResp.ok) throw new Error(`session/start failed: ${startResp.status} ${await startResp.text()}`);
+  const startData = await startResp.json();
+  const sessionId = startData.session_id;
+  mark(`session_started (id=${sessionId}, context_status=${startData?.meta?.context_status ?? 'n/a'})`);
+
+  // 3. open SSE stream + 4. audio-ready (fired as soon as the stream opens, in parallel)
+  const ctrl = new AbortController();
+  const streamResp = await fetch(`${GW}/api/v1/orb/live/stream?session_id=${encodeURIComponent(sessionId)}`, {
+    headers: { Authorization: `Bearer ${token}`, Accept: 'text/event-stream' },
+    signal: ctrl.signal,
+  });
+  if (!streamResp.ok || !streamResp.body) throw new Error(`stream failed: ${streamResp.status}`);
+  mark('stream_open');
+
+  fetch(`${GW}/api/v1/orb/session/${encodeURIComponent(sessionId)}/audio-ready`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: '{}',
+  }).then(() => mark('audio_ready_sent')).catch((e) => console.warn('audio-ready failed:', e.message));
+
+  // 5. read SSE until first audio chunk (or 20s timeout)
+  const reader = streamResp.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  let firstAudioSeen = false;
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const { value, done } = await reader.read();
+    if (done) { mark('stream_closed'); break; }
+    buf += dec.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf('\n\n')) !== -1) {
+      const frame = buf.slice(0, idx); buf = buf.slice(idx + 2);
+      const line = frame.split('\n').find((l) => l.startsWith('data:'));
+      if (!line) continue;
+      let msg; try { msg = JSON.parse(line.slice(5).trim()); } catch { continue; }
+      if ((msg.type === 'audio' || msg.data_b64) && !firstAudioSeen) {
+        firstAudioSeen = true;
+        mark(`FIRST_AUDIO (type=${msg.type}, bytes=${(msg.data_b64 || '').length})`);
+        ctrl.abort();
+        break;
+      } else if (msg.type && msg.type !== 'audio') {
+        mark(`sse:${msg.type}`);
+      }
+    }
+    if (firstAudioSeen) break;
+  }
+
+  // breakdown
+  console.log('\n=== BREAKDOWN ===');
+  const get = (n) => (marks.find((m) => m[0].startsWith(n)) || [, null])[1];
+  const sStart = get('session_started'), sOpen = get('stream_open'), sReady = get('audio_ready_sent'), sAudio = get('FIRST_AUDIO');
+  if (sStart != null && sOpen != null) console.log(`  session/start round-trip:     ${sOpen - get('auth_ok')}ms`);
+  if (sReady != null && sOpen != null) console.log(`  stream_open → audio_ready:    ${sReady - sOpen}ms`);
+  if (sAudio != null && sReady != null) console.log(`  audio_ready → FIRST audio:    ${sAudio - sReady}ms  ← model+gen after greeting unblocks`);
+  if (sAudio != null) console.log(`  TOTAL session_started → audio: ${sAudio - sStart}ms`);
+  else console.log('  NO AUDIO within 20s — first-audio path stalled.');
+}
+
+run().catch((e) => { console.error('PROBE FAILED:', e.message); process.exit(1); });

--- a/services/gateway/scripts/orb-latency-probe.mjs
+++ b/services/gateway/scripts/orb-latency-probe.mjs
@@ -82,12 +82,22 @@ async function run() {
     body: '{}',
   }).then(() => mark('audio_ready_sent')).catch((e) => console.warn('audio-ready failed:', e.message));
 
-  // 5. read SSE until first audio chunk (or 20s timeout)
+  // 5. read SSE until the FIRST GREETING audio chunk (or 25s timeout).
+  //
+  // DEV-COMHU-0513 FIX: the gateway sends an "activation chime" (a locally
+  // generated PCM blip, source:'activation_chime') the instant the upstream
+  // Live API socket opens — long before the model has generated a single word.
+  // The old loop stopped at that chime and mislabeled it "FIRST_AUDIO", which
+  // hid the real click→first-greeting latency (the chime tells you nothing
+  // about model/gen time). We now mark the chime separately and KEEP READING
+  // until the first NON-chime audio chunk — the actual spoken greeting — which
+  // is the number the user perceives as "the orb takes forever to talk".
   const reader = streamResp.body.getReader();
   const dec = new TextDecoder();
   let buf = '';
-  let firstAudioSeen = false;
-  const deadline = Date.now() + 20_000;
+  let chimeSeen = false;
+  let greetingSeen = false;
+  const deadline = Date.now() + 25_000;
   while (Date.now() < deadline) {
     const { value, done } = await reader.read();
     if (done) { mark('stream_closed'); break; }
@@ -98,27 +108,36 @@ async function run() {
       const line = frame.split('\n').find((l) => l.startsWith('data:'));
       if (!line) continue;
       let msg; try { msg = JSON.parse(line.slice(5).trim()); } catch { continue; }
-      if ((msg.type === 'audio' || msg.data_b64) && !firstAudioSeen) {
-        firstAudioSeen = true;
-        mark(`FIRST_AUDIO (type=${msg.type}, bytes=${(msg.data_b64 || '').length})`);
+      const isAudio = msg.type === 'audio' || !!msg.data_b64;
+      const isChime = isAudio && msg.source === 'activation_chime';
+      if (isChime && !chimeSeen) {
+        chimeSeen = true;
+        mark(`chime (activation_chime, bytes=${(msg.data_b64 || '').length})`);
+      } else if (isAudio && !isChime && !greetingSeen) {
+        greetingSeen = true;
+        mark(`FIRST_GREETING (type=${msg.type}, bytes=${(msg.data_b64 || '').length})`);
         ctrl.abort();
         break;
-      } else if (msg.type && msg.type !== 'audio') {
+      } else if (msg.type && !isAudio) {
         mark(`sse:${msg.type}`);
       }
     }
-    if (firstAudioSeen) break;
+    if (greetingSeen) break;
   }
 
   // breakdown
   console.log('\n=== BREAKDOWN ===');
   const get = (n) => (marks.find((m) => m[0].startsWith(n)) || [, null])[1];
-  const sStart = get('session_started'), sOpen = get('stream_open'), sReady = get('audio_ready_sent'), sAudio = get('FIRST_AUDIO');
-  if (sStart != null && sOpen != null) console.log(`  session/start round-trip:     ${sOpen - get('auth_ok')}ms`);
+  const sAuth = get('auth_ok');
+  const sStart = get('session_started'), sOpen = get('stream_open'), sReady = get('audio_ready_sent');
+  const sChime = get('chime'), sGreet = get('FIRST_GREETING');
+  if (sStart != null && sOpen != null) console.log(`  session/start round-trip:     ${sOpen - sAuth}ms  ← wake-brief/journey block when fast-start off`);
   if (sReady != null && sOpen != null) console.log(`  stream_open → audio_ready:    ${sReady - sOpen}ms`);
-  if (sAudio != null && sReady != null) console.log(`  audio_ready → FIRST audio:    ${sAudio - sReady}ms  ← model+gen after greeting unblocks`);
-  if (sAudio != null) console.log(`  TOTAL session_started → audio: ${sAudio - sStart}ms`);
-  else console.log('  NO AUDIO within 20s — first-audio path stalled.');
+  if (sChime != null && sOpen != null) console.log(`  stream_open → chime:          ${sChime - sOpen}ms  (instant feedback, not the greeting)`);
+  if (sGreet != null && sChime != null) console.log(`  chime → FIRST greeting:       ${sGreet - sChime}ms  ← model first-token + gen`);
+  if (sGreet != null && sStart != null) console.log(`  session_started → greeting:   ${sGreet - sStart}ms`);
+  if (sGreet != null && sAuth != null) console.log(`  TOTAL (click→first greeting): ${sGreet - sAuth}ms  ← the number that matters`);
+  else console.log('  NO GREETING within 25s — first-greeting path stalled.');
 }
 
 run().catch((e) => { console.error('PROBE FAILED:', e.message); process.exit(1); });

--- a/services/gateway/scripts/orb-latency-probe.mjs
+++ b/services/gateway/scripts/orb-latency-probe.mjs
@@ -30,6 +30,14 @@ const ANON_KEY = process.env.SUPABASE_ANON_KEY || '';
 const EMAIL = process.env.ORB_EMAIL || 'e2e-test@vitana.dev';
 const PASSWORD = process.env.ORB_PASSWORD || '';
 const LANG = process.env.ORB_LANG || 'de';
+// Transport: 'sse' (default, the legacy probe) or 'ws' (exercises the WebSocket
+// greeting path + the DEV-COMHU-0513 prebuffer gate). In WS mode we wait
+// AUDIO_READY_DELAY_MS after session_started before sending audio_ready, to
+// simulate the client's AudioContext-unlock time. With the prebuffer flag ON,
+// model generation overlaps that delay, so raising the delay should NOT raise
+// the first-greeting time; with it OFF, first-greeting moves out ~linearly.
+const TRANSPORT = (process.env.TRANSPORT || 'sse').toLowerCase();
+const AUDIO_READY_DELAY_MS = Number(process.env.AUDIO_READY_DELAY_MS || 300);
 
 const t0Wall = Date.now();
 const marks = [];
@@ -140,4 +148,72 @@ async function run() {
   else console.log('  NO GREETING within 25s — first-greeting path stalled.');
 }
 
-run().catch((e) => { console.error('PROBE FAILED:', e.message); process.exit(1); });
+// ---------------------------------------------------------------------------
+// WS mode (DEV-COMHU-0513) — exercises the WebSocket greeting path and the
+// flag-gated greeting prebuffer. Node 18+ ships a global WebSocket.
+// ---------------------------------------------------------------------------
+async function runWs() {
+  console.log(`ORB latency probe [WS] → ${GW} (lang=${LANG}, audio_ready_delay=${AUDIO_READY_DELAY_MS}ms)`);
+  const token = await getToken();
+  mark('auth_ok');
+
+  const wsUrl = `${GW.replace(/^http/, 'ws')}/api/v1/orb/live/ws?token=${encodeURIComponent(token)}`;
+  const ws = new WebSocket(wsUrl);
+  let chimeSeen = false;
+  let greetingSeen = false;
+  let audioReadySent = false;
+
+  await new Promise((resolve, reject) => {
+    const deadline = setTimeout(() => { reject(new Error('WS: no greeting within 25s')); }, 25_000);
+    const send = (obj) => ws.send(JSON.stringify(obj));
+
+    ws.addEventListener('open', () => {
+      mark('ws_open');
+      send({ type: 'start', lang: LANG, voice_style: 'friendly, calm', response_modalities: ['audio', 'text'], current_route: '/' });
+    });
+    ws.addEventListener('error', (e) => { clearTimeout(deadline); reject(new Error(`WS error: ${e?.message || e}`)); });
+    ws.addEventListener('close', () => { if (!greetingSeen) { clearTimeout(deadline); reject(new Error('WS closed before greeting')); } });
+
+    ws.addEventListener('message', (ev) => {
+      let msg; try { msg = JSON.parse(typeof ev.data === 'string' ? ev.data : ev.data.toString()); } catch { return; }
+      const isAudio = msg.type === 'audio' || !!msg.data_b64;
+      const isChime = isAudio && msg.source === 'activation_chime';
+      if (msg.type === 'session_started') {
+        mark(`session_started (id=${msg.session_id})`);
+        // Simulate AudioContext unlock latency, then ack readiness.
+        setTimeout(() => {
+          if (audioReadySent) return;
+          audioReadySent = true;
+          mark('audio_ready_sent');
+          send({ type: 'audio_ready' });
+        }, AUDIO_READY_DELAY_MS);
+      } else if (isChime && !chimeSeen) {
+        chimeSeen = true;
+        mark(`chime (activation_chime, bytes=${(msg.data_b64 || '').length})`);
+      } else if (isAudio && !isChime && !greetingSeen) {
+        greetingSeen = true;
+        mark(`FIRST_GREETING (type=${msg.type}, bytes=${(msg.data_b64 || '').length})`);
+        clearTimeout(deadline);
+        try { ws.close(); } catch { /* noop */ }
+        resolve();
+      } else if (msg.type && !isAudio) {
+        mark(`ws:${msg.type}`);
+      }
+    });
+  });
+
+  console.log('\n=== BREAKDOWN [WS] ===');
+  const get = (n) => (marks.find((m) => m[0].startsWith(n)) || [, null])[1];
+  const sAuth = get('auth_ok'), sStart = get('session_started'), sReady = get('audio_ready_sent');
+  const sChime = get('chime'), sGreet = get('FIRST_GREETING');
+  if (sStart != null) console.log(`  start → session_started:      ${sStart - get('ws_open')}ms`);
+  if (sReady != null && sStart != null) console.log(`  session_started → audio_ready: ${sReady - sStart}ms  (simulated AudioContext unlock)`);
+  if (sChime != null && sReady != null) console.log(`  audio_ready → chime:          ${sChime - sReady}ms`);
+  if (sGreet != null && sReady != null) console.log(`  audio_ready → FIRST greeting: ${sGreet - sReady}ms  ← prebuffer ON: ~unchanged as delay grows; OFF: grows with delay`);
+  if (sGreet != null && sStart != null) console.log(`  session_started → greeting:   ${sGreet - sStart}ms  ← prebuffer ON: flat vs delay; OFF: ≈ delay + gen`);
+  if (sGreet != null && sAuth != null) console.log(`  TOTAL (auth→first greeting):  ${sGreet - sAuth}ms`);
+  else console.log('  NO GREETING — WS first-greeting path stalled.');
+}
+
+const main = TRANSPORT === 'ws' ? runWs : run;
+main().catch((e) => { console.error('PROBE FAILED:', e.message); process.exit(1); });

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -46,6 +46,7 @@ import { randomUUID } from 'crypto';
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import { isFeatureLive } from '../services/feature-flags';
 // BOOTSTRAP-PRODUCT-ANALYTICS: server-side product analytics (metadata only)
 import { trackServerEvent, detectTopic } from '../services/product-analytics/track-server';
 // VTID-03250: prefer the browser's own timezone over rate-limit-prone geo-IP
@@ -991,6 +992,17 @@ export interface GeminiLiveSession {
   // VTID-AUDIO-READY: Whether greeting is deferred until client sends audio_ready.
   // Used by WebSocket (mobile) path to avoid greeting truncation from race condition.
   greetingDeferred: boolean;
+  // DEV-COMHU-0513 (greeting pre-buffer, FEATURE_ORB_GREETING_PREBUFFER_ENV):
+  // When true, the upstream greeting prompt has already been dispatched (so model
+  // generation runs DURING the client's AudioContext unlock instead of after it),
+  // and the resulting greeting audio is held server-side in bufferedGreetingChunks
+  // until the client signals audio_ready (or a fallback timer fires). This
+  // decouples "start generating" from "client ready to play", hiding the model's
+  // first-token latency behind the unlock the legacy path serially waits for.
+  prebufferGreetingAudio?: boolean;
+  bufferedGreetingChunks?: string[];
+  // Fallback timer that flushes held greeting audio if the client never acks.
+  greetingPrebufferFallbackTimer?: ReturnType<typeof setTimeout>;
   // VTID-01224-FIX: Last session info for context-aware greeting
   lastSessionInfo?: { time: string; wasFailure: boolean } | null;
   // VTID-WATCHDOG: Response watchdog timer — fires when model doesn't respond in time
@@ -1580,6 +1592,66 @@ function generateChimePcm(): string {
 
 // Pre-generate at module load
 generateChimePcm();
+
+// DEV-COMHU-0513 — greeting pre-buffer fallback. If the client never sends
+// audio_ready (e.g. an old widget build, or a stalled AudioContext), flush the
+// held greeting audio anyway so the user is never left in silence. Chosen >
+// typical model first-token time so a healthy session always flushes on the
+// real audio_ready, not the timer.
+const GREETING_PREBUFFER_FALLBACK_MS = 1500;
+
+/**
+ * DEV-COMHU-0513 — flush any greeting audio held back by the pre-buffer gate.
+ *
+ * Sends the activation chime first (instant feedback, same as the legacy paths),
+ * then replays the buffered greeting chunks in order, then disables the hold so
+ * subsequent chunks forward live. Idempotent: a no-op once the hold is cleared,
+ * so the audio_ready ack and the fallback timer can both call it safely.
+ */
+function flushPrebufferedGreeting(
+  session: GeminiLiveSession,
+  clientWs: WebSocket,
+  reason: 'audio_ready' | 'fallback',
+): void {
+  if (!session.prebufferGreetingAudio) return; // already flushed (or never armed)
+  session.prebufferGreetingAudio = false;
+  if (session.greetingPrebufferFallbackTimer) {
+    clearTimeout(session.greetingPrebufferFallbackTimer);
+    session.greetingPrebufferFallbackTimer = undefined;
+  }
+  const chunks = session.bufferedGreetingChunks || [];
+  session.bufferedGreetingChunks = [];
+  if (clientWs.readyState !== WebSocket.OPEN) return;
+  try {
+    // Instant feedback chime, mirroring the legacy deferred/audio_ready paths.
+    sendWsMessage(clientWs, {
+      type: 'audio',
+      data_b64: generateChimePcm(),
+      mime: 'audio/pcm;rate=24000',
+      chunk_number: session.audioOutChunks++,
+      source: 'activation_chime',
+    });
+  } catch (err) {
+    console.warn('[GREETING-PREBUFFER] Failed to send chime on flush:', err);
+  }
+  for (const data_b64 of chunks) {
+    if (clientWs.readyState !== WebSocket.OPEN) break;
+    try {
+      sendWsMessage(clientWs, {
+        type: 'audio',
+        data_b64,
+        mime: 'audio/pcm;rate=24000',
+        chunk_number: session.audioOutChunks,
+      });
+    } catch (err) {
+      console.error('[GREETING-PREBUFFER] Failed to flush buffered chunk:', err);
+      break;
+    }
+  }
+  console.log(
+    `[GREETING-PREBUFFER] Flushed ${chunks.length} held greeting chunk(s) on ${reason} for session ${session.sessionId}`,
+  );
+}
 
 // BOOTSTRAP-ORB-MOVE: Phase 2 (move-only) — constants + greeting phrase pool
 // that previously lived here are now imported from the orb/ tree at the top
@@ -12985,6 +13057,14 @@ async function handleWsClientMessage(clientSession: WsClientSession, message: Ws
         // ORB-CONVERSATION-LATENCY: greeting dispatched upstream — remaining
         // gap to audio_out_first_chunk is the model's first-token time.
         liveSession.establishLatency?.mark('greeting_sent', { deferred: true });
+      } else if (liveSession.prebufferGreetingAudio) {
+        // DEV-COMHU-0513 — greeting pre-buffer: generation already started at
+        // connect; the client is now ready, so release the held greeting audio
+        // (chime first, then buffered chunks). This is the common case — the ack
+        // typically arrives before the model has produced its first chunk, so the
+        // buffer is usually empty and greeting audio then forwards live.
+        console.log(`[GREETING-PREBUFFER] Client audio_ready received — flushing held greeting for session ${liveSession.sessionId}`);
+        flushPrebufferedGreeting(liveSession, clientWs, 'audio_ready');
       } else {
         console.log(`[VTID-AUDIO-READY] audio_ready received but greeting already sent or not deferred: session=${liveSession.sessionId}`);
       }
@@ -13324,6 +13404,17 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
           void liveSession.establishLatency.finalize('success');
           liveSession.establishLatency = null;
         }
+        // DEV-COMHU-0513 — greeting pre-buffer: when the greeting was dispatched
+        // early (before the client's audio_ready), hold its audio server-side
+        // instead of forwarding, so the first words can't arrive before the
+        // client's player is unlocked. flushPrebufferedGreeting() replays these
+        // in order on audio_ready (or the fallback timer). Only greeting-era
+        // audio is held; once flushed, prebufferGreetingAudio is false and all
+        // later turns forward live with zero overhead.
+        if (liveSession.prebufferGreetingAudio) {
+          (liveSession.bufferedGreetingChunks ||= []).push(audioB64);
+          return;
+        }
         if (clientWs.readyState === WebSocket.OPEN) {
           try {
             // Send raw PCM - client uses Web Audio API scheduling for seamless playback
@@ -13474,7 +13565,26 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
     // client audio player is initialized). Fallback: send after 1s if no audio_ready
     // (BOOTSTRAP-ORB-LATENCY-PHASE1: 2s→1s — the ack normally arrives in <300ms;
     // a 2s fallback only stretched session start for clients that never ack).
-    if (liveSession.greetingDeferred) {
+    if (liveSession.greetingDeferred && isFeatureLive('ORB_GREETING_PREBUFFER')) {
+      // DEV-COMHU-0513 — greeting pre-buffer (flag-gated). Instead of waiting for
+      // audio_ready before we even ASK the model for the greeting (which serially
+      // stacks model generation AFTER the client's AudioContext unlock), dispatch
+      // the greeting prompt NOW so generation overlaps the unlock, and hold the
+      // resulting audio until audio_ready (or the fallback timer) so first words
+      // still can't arrive before the client's player is ready.
+      console.log(`[GREETING-PREBUFFER] Dispatching greeting early + holding audio until audio_ready: session=${sessionId}`);
+      liveSession.prebufferGreetingAudio = true;
+      liveSession.bufferedGreetingChunks = [];
+      liveSession.greetingDeferred = false;
+      sendGreetingPromptToLiveAPI(upstreamWs, liveSession);
+      liveSession.establishLatency?.mark('greeting_sent', { prebuffer: true });
+      liveSession.greetingPrebufferFallbackTimer = setTimeout(() => {
+        if (liveSession.active && liveSession.prebufferGreetingAudio) {
+          console.log(`[GREETING-PREBUFFER] Fallback flush after ${GREETING_PREBUFFER_FALLBACK_MS}ms (no audio_ready): session=${sessionId}`);
+          flushPrebufferedGreeting(liveSession, clientWs, 'fallback');
+        }
+      }, GREETING_PREBUFFER_FALLBACK_MS);
+    } else if (liveSession.greetingDeferred) {
       console.log(`[VTID-AUDIO-READY] Greeting deferred — waiting for client audio_ready: session=${sessionId}`);
       setTimeout(() => {
         if (!liveSession.greetingSent && liveSession.active && liveSession.upstreamWs) {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1600,6 +1600,19 @@ generateChimePcm();
 // real audio_ready, not the timer.
 const GREETING_PREBUFFER_FALLBACK_MS = 1500;
 
+// DEV-COMHU-0513 — upper bound on how long the upstream-setup path will wait on
+// session.contextReadyPromise before building the Gemini setup message (and thus
+// before the greeting can be generated). The legacy inline path ran the
+// wake-brief/journey work INSIDE session/start (request-timeout-bounded); when
+// FEATURE_ORB_FAST_START_ENV composes that work onto contextReadyPromise, the
+// gate's previously-unbounded `await` could be blocked indefinitely by a slow or
+// hung context call — stranding the greeting entirely (observed ~60% no-greeting
+// on staging). Capping the wait makes the gate fail-open: proceed with whatever
+// context is populated rather than never greeting. With fast-start OFF the
+// promise resolves well under this cap, so behavior is unchanged. Env-tunable
+// for staging without a redeploy.
+const CONTEXT_READY_GATE_TIMEOUT_MS = Number(process.env.ORB_CONTEXT_READY_GATE_TIMEOUT_MS || 4000);
+
 /**
  * DEV-COMHU-0513 — flush any greeting audio held back by the pre-buffer gate.
  *
@@ -6250,17 +6263,39 @@ async function connectToLiveAPI(
       const ctxPromise = (session as any).contextReadyPromise as Promise<void> | undefined;
       if (ctxPromise) {
         const awaitStart = Date.now();
+        // DEV-COMHU-0513: bound this await. Previously an unbounded `await
+        // ctxPromise` — fine when the promise resolved fast (legacy inline path),
+        // but under fast-start the heavy wake-brief/journey work is composed onto
+        // it, so a slow/hung context call blocked the Gemini setup forever and the
+        // greeting never fired. Race against a timeout so we always proceed (with
+        // whatever context is populated) instead of stranding the user.
+        let ctxTimedOut = false;
         try {
-          await ctxPromise;
+          await Promise.race([
+            ctxPromise.catch(() => {
+              // Promise's own .catch already logged; treat as resolved so the
+              // race settles and we proceed with partial context.
+            }),
+            new Promise<void>((resolve) =>
+              setTimeout(() => {
+                ctxTimedOut = true;
+                resolve();
+              }, CONTEXT_READY_GATE_TIMEOUT_MS),
+            ),
+          ]);
         } catch (e) {
-          // Promise's own .catch already logged; proceed with whatever session fields are populated.
+          // Defensive: proceed with whatever session fields are populated.
         }
         const ctxAwaitMs = Date.now() - awaitStart;
         // ORB-CONVERSATION-LATENCY: residual context-build time that did NOT
         // overlap the handshake. This is the number a context-slim (D.2) would
         // move; if it's already ~0, the win is in the model's first-token time.
-        session.establishLatency?.mark('context_awaited', { awaited_ms: ctxAwaitMs });
-        console.log(`[BOOTSTRAP-ORB-CRITICAL-PATH] Awaited contextReadyPromise for ${ctxAwaitMs}ms before Gemini setup for session ${session.sessionId}`);
+        session.establishLatency?.mark('context_awaited', { awaited_ms: ctxAwaitMs, timed_out: ctxTimedOut });
+        console.log(
+          `[BOOTSTRAP-ORB-CRITICAL-PATH] Awaited contextReadyPromise for ${ctxAwaitMs}ms` +
+            (ctxTimedOut ? ` (TIMED OUT at ${CONTEXT_READY_GATE_TIMEOUT_MS}ms — proceeding with partial context)` : '') +
+            ` before Gemini setup for session ${session.sessionId}`,
+        );
       }
 
       // Send setup message with model and configuration

--- a/voice-pipeline-spec/spec.json
+++ b/voice-pipeline-spec/spec.json
@@ -144,6 +144,7 @@
     { "name": "max_tool_response_chars",    "value": 4000,     "description": "Default cap; some sites use 2000/3000", "implementations": ["vertex"] },
     { "name": "max_history_chars",          "value": 4000,     "description": "System-instruction last-turns budget", "implementations": ["vertex"] },
     { "name": "extraction_throttle_ms",     "value": 60000,    "description": "Cognee fact-extraction debounce", "implementations": ["vertex"] },
+    { "name": "greeting_prebuffer_fallback_ms","value": 1500,   "description": "DEV-COMHU-0513 — GREETING_PREBUFFER_FALLBACK_MS in orb-live.ts. When FEATURE_ORB_GREETING_PREBUFFER_ENV is live, the WS greeting prompt is dispatched on connect and its audio held until the client's audio_ready; if that ack never arrives, the held greeting is flushed after this timeout so the user is never left in silence.", "implementations": ["vertex"] },
     { "name": "bootstrap_rebuild_min_age_ms","value": 60000,   "description": "Re-bootstrap floor on reconnect", "implementations": ["vertex"] },
     { "name": "token_refresh_skew_ms",      "value": 300000,   "description": "5 min — refresh the cached ADC access token this far ahead of expiry so getAccessToken() never blocks the live-connect path", "implementations": ["vertex"] },
     { "name": "token_default_ttl_ms",       "value": 3300000,  "description": "55 min — fallback ADC token TTL when the auth client doesn't expose expiry_date", "implementations": ["vertex"] },


### PR DESCRIPTION
## DEV-COMHU-0513 — ORB first-greeting latency

Probe upgrade, root-cause diagnosis from **live staging measurement**, and the code fix that makes the existing fast-start path safe to enable.

### 1. Probe upgrades (`scripts/orb-latency-probe.mjs`)
- **Measures the real greeting, not the chime.** It used to stop at the first audio chunk — the locally-generated activation chime — emitted before the model speaks. Now it marks the chime separately and reads on to the first spoken-greeting audio.
- **New `TRANSPORT=ws` mode** drives the WebSocket greeting path and waits `AUDIO_READY_DELAY_MS` after `session_started` before acking (simulates AudioContext unlock).

### 2. Root cause
`session/start` (~5.5s warm) is ~83% of the click→greeting tax. The already-merged fast-start work (PR #2682) defers that wake-brief/journey block off `session/start` but was dormant (`FEATURE_ORB_FAST_START_ENV` unset).

### 3. Live staging test of `FAST_START` — it was **not** safe to just flip on
Enabling `FEATURE_ORB_FAST_START_ENV=staging-only` on `gateway-staging`:
- `session/start` dropped ~5.5s → ~1.5s ✅, **but**
- the spoken greeting arrived in only **~3 of 8 warm runs (~38%)** — the rest stalled or the session ended with no greeting, and end-to-end time did **not** improve (~6.3–7.4s when it arrived).

**Why:** the upstream-setup path gated the Gemini setup message on an **unbounded** `await session.contextReadyPromise` (`orb-live.ts`). Legacy ran that work inside `session/start` (request-timeout-bounded); fast-start composes it onto `contextReadyPromise`, so a slow/hung context call blocked setup forever → the greeting never fired. (Flags have since been rolled back; reliable ~7.5s greeting confirmed restored, 3/3.)

### 4. Fixes in this PR
1. **Bounded the context gate** (`ORB_CONTEXT_READY_GATE_TIMEOUT_MS`, default 4000ms): race the `await` against a timeout so the gate is fail-open — proceed with whatever context is populated instead of stranding the greeting. With fast-start OFF the promise resolves well under the cap → **current behavior unchanged**; this only removes the indefinite hang the flag exposed. This is the prerequisite that makes fast-start safe to enable.
2. **Flag-gated WS greeting pre-buffer** (`FEATURE_ORB_GREETING_PREBUFFER_ENV`, default off): dispatch the greeting prompt on connect so model gen overlaps the AudioContext unlock; hold the audio until `audio_ready` (or a 1.5s fallback). Idempotent flush; later turns forward live.

### Verification
- ✅ Gateway type-checks clean (tsc 5.9.3); all 13 CI checks green.
- ✅ Rollback to flags-off verified on staging: greeting reliable again (3/3, ~7.5s).
- ⏳ **Post-merge plan:** staging auto-deploys the bounded gate → re-enable `FEATURE_ORB_FAST_START_ENV=staging-only` → re-probe to confirm fast-start is now reliable *and* faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)