### PR TITLE
fix(navigator): route "community board" to the full Community Board

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -2199,10 +2199,10 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
   {
     screen_id: 'INTENTS.BOARD', route: '/intents/board', category: 'community',
     access: 'authenticated', anonymous_safe: false, priority: 2,
-    aliases: ['intent-board', 'intent_board', 'community/intent-board', 'intents-board', 'all-intents'],
+    aliases: ['intent-board', 'intent_board', 'community/intent-board', 'intents-board', 'all-intents', 'community-board', 'community_board'],
     i18n: {
-      en: { title: 'Intent Board', description: 'Browse all open community intents and asks across categories.', when_to_visit: 'When the user asks for the intent board, all community posts, what people are asking for, the dance board, or the open community board.' },
-      de: { title: 'Intent-Board', description: 'Durchstöbere alle offenen Community-Anliegen und Anfragen über alle Kategorien hinweg.', when_to_visit: 'Wenn der Nutzer nach dem Intent-Board, allen Community-Posts, was die Leute suchen, dem Tanz-Board oder dem offenen Community-Board fragt.' },
+      en: { title: 'Community Board', description: 'The all-category Community Board — browse every open community intent and ask (learning, mentoring, buying, selling, activity partners, coffee chats, lending) across all categories.', when_to_visit: 'When the user asks to open the community board, the Community Board, all community posts, what people are looking for, what people are asking for, or the open intent board across every category. This is the general all-category board — NOT the dance/fitness partner board.' },
+      de: { title: 'Community-Board', description: 'Das Community-Board über alle Kategorien — durchstöbere jedes offene Community-Anliegen und jede Anfrage (Lernen, Unterrichten, Kaufen, Verkaufen, Aktivitätspartner, Kaffee-Chats, Verleihen) über alle Kategorien hinweg.', when_to_visit: 'Wenn der Nutzer das Community-Board öffnen, das Community-Board, alle Community-Posts, was die Leute suchen oder anbieten oder das offene Intent-Board über alle Kategorien hinweg sehen möchte. Das ist das allgemeine Board über alle Kategorien — NICHT das Tanz-/Fitness-Partner-Board.' },
     },
   },
   {
@@ -2248,8 +2248,8 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     access: 'authenticated', anonymous_safe: false,
     aliases: ['find-partner-board', 'partner-board'],
     i18n: {
-      en: { title: 'Partner Board', description: 'The community board view of dance and fitness partner posts.', when_to_visit: 'When the user asks for the partner board, dance board, the community board for partner posts, or wants to see who is looking.' },
-      de: { title: 'Partner-Board', description: 'Die Community-Board-Ansicht der Tanz- und Fitness-Partner-Posts.', when_to_visit: 'Wenn der Nutzer nach dem Partner-Board, Tanz-Board, dem Community-Board für Partner-Posts fragt oder sehen möchte, wer sucht.' },
+      en: { title: 'Partner Board', description: 'The board view of dance and fitness partner posts — who is looking for a dance or workout partner.', when_to_visit: 'When the user asks specifically for the partner board, the dance partner board, the fitness partner board, or wants to see who is looking for a dance or workout partner. For the general all-category community board, use the Community Board (INTENTS.BOARD) instead.' },
+      de: { title: 'Partner-Board', description: 'Die Board-Ansicht der Tanz- und Fitness-Partner-Posts — wer einen Tanz- oder Trainingspartner sucht.', when_to_visit: 'Wenn der Nutzer ausdrücklich nach dem Partner-Board, dem Tanzpartner-Board, dem Fitnesspartner-Board fragt oder sehen möchte, wer einen Tanz- oder Trainingspartner sucht. Für das allgemeine Community-Board über alle Kategorien ist stattdessen das Community-Board (INTENTS.BOARD) zuständig.' },
     },
   },
   {


### PR DESCRIPTION
## Problem

"Open the community board" was ambiguously matched by the navigator between two catalog entries that both claimed the phrase **"community board"**:

- `INTENTS.BOARD` → `/intents/board` — the all-category Community Board (has content)
- `COMM.FIND_PARTNER_BOARD` → `/comm/find-partner?view=board` — the dance/fitness-only partner board (empty when there are no partner posts)

Depending on catalog ranking, mobile users could land on the **empty partner board** ("Im Board ist gerade Ruhe") instead of the populated Community Board.

## Fix

Make the resolution deterministic (content-only catalog edits, no logic change):

- **`INTENTS.BOARD`** now owns the "community board" phrasing in EN + DE `when_to_visit`, its spoken `title` is aligned to the screen's actual name (`Community Board` / `Community-Board`), and `community-board` / `community_board` aliases were added.
- **`COMM.FIND_PARTNER_BOARD`** is scoped strictly to the dance/fitness **partner** board and explicitly redirects the general all-category board back to `INTENTS.BOARD`.

## Companion change

Frontend shell-wrap so this board renders as a proper mobile screen: `exafyltd/vitana-v1#<companion>`.

## Verification

- `tsc --noEmit` passes (0 errors).
- `jest test/navigation-catalog.test.ts test/nav-redirect-flow.test.ts test/nav-confidence-surface-gate.test.ts` → **268 passed**.
- `jest test/orb/live/characterization` → **229 passed, 9 snapshots** (titles aren't embedded in snapshots; no snapshot updates needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ME4abEDbPr6oFDyXeRqqYD)_