### PR TITLE
DEV-COMHU-0513 B2: short audio-safe greeting when context still pending

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -68,6 +68,16 @@ FEATURE_ORB_GREETING_PREBUFFER_ENV=off
 # is restored by setting it very high — not recommended.
 ORB_CONTEXT_READY_GATE_TIMEOUT_MS=4000
 
+# DEV-COMHU-0513 B2 — safe fast greeting. When live AND fast-start defers context
+# AND the greeting is reached before that context resolves (i.e. a low
+# ORB_CONTEXT_READY_GATE_TIMEOUT_MS), emit a short, audio-safe verbatim opener
+# instead of the temporal-misclassified long "first session" intro that makes
+# Gemini Live go text-only (no audio). Full personalization folds in on the next
+# turn. Default off → legacy behavior. Values: off | staging-only | staging+prod.
+# Intended to be paired with a low gate cap (e.g. 1000) to get a ~3-4s greeting
+# that is also reliable.
+FEATURE_ORB_SAFE_FAST_GREETING_ENV=off
+
 # Env vars read ONLY by the standalone latency probe
 # (services/gateway/scripts/orb-latency-probe.mjs) — never by the running
 # service. Documented here so the impact-scan env-binding check is satisfied.

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1490,10 +1490,21 @@ export async function handleLiveSessionStart(
     // Journey blocks — but session/start returns now instead of after the
     // wake-brief + journey round-trips.
     const brainReady = (session as any).contextReadyPromise as Promise<void> | undefined;
-    (session as any).contextReadyPromise = composeContextReady(
+    // DEV-COMHU-0513 B2: mark context as not-yet-resolved while the deferred
+    // wake-brief/journey work runs, so the greeting builder can detect "context
+    // still pending" and (under FEATURE_ORB_SAFE_FAST_GREETING) emit a short,
+    // audio-safe opener instead of a temporal-misclassified long intro that
+    // makes Gemini Live go text-only. Only the fast-start (deferred) path starts
+    // false; legacy/inline sessions never set it, so they read as resolved.
+    (session as any).contextReadyResolved = false;
+    const composedContextReady = composeContextReady(
       brainReady,
       assembleWakeBriefAndJourney,
     );
+    (session as any).contextReadyPromise = composedContextReady;
+    void composedContextReady.finally(() => {
+      (session as any).contextReadyResolved = true;
+    });
     console.log(
       `[ORB-FAST-START] session ${sessionId}: wake-brief + journey deferred onto contextReadyPromise (fast session/start)`,
     );

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1001,6 +1001,12 @@ export interface GeminiLiveSession {
   // first-token latency behind the unlock the legacy path serially waits for.
   prebufferGreetingAudio?: boolean;
   bufferedGreetingChunks?: string[];
+  // DEV-COMHU-0513 B2: false while fast-start's deferred wake-brief/journey work
+  // is still running; flips true when contextReadyPromise settles. Lets the
+  // greeting builder detect "context still pending" and emit a short audio-safe
+  // opener (under FEATURE_ORB_SAFE_FAST_GREETING) instead of a misclassified
+  // long intro. Unset (undefined) for legacy/inline sessions = treated resolved.
+  contextReadyResolved?: boolean;
   // Fallback timer that flushes held greeting audio if the client never acks.
   greetingPrebufferFallbackTimer?: ReturnType<typeof setTimeout>;
   // VTID-01224-FIX: Last session info for context-aware greeting
@@ -7382,6 +7388,48 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
   const _sm: ConversationStateMachine =
     (session as any).conversationSM ?? ((session as any).conversationSM = new ConversationStateMachine());
   if (_sm.state === 'PREWARM') _sm.transition('OPENING', 'session_start');
+
+  // DEV-COMHU-0513 B2 — short, audio-safe opener when the greeting is reached
+  // BEFORE the deferred context resolved (fast-start + a low context-gate cap).
+  // With context unresolved, session.lastSessionInfo is empty, so the temporal
+  // bucket below falls to `first`/default and emits the long "FULL INTRODUCTION"
+  // prompt — the exact shape (per VTID-03102) that makes Gemini Live go
+  // text-only / stall, producing NO audio greeting (observed ~75% no-greeting at
+  // a 1s cap). The diagnostic below fires regardless of the flag so a single
+  // staging run confirms the mechanism; the fix (flag-gated, default off) sends
+  // a guaranteed-short verbatim opener instead, then lets the next turn carry
+  // full personalization once context lands. Anonymous sessions keep their own
+  // intro path untouched.
+  if ((session as any).contextReadyResolved === false && !session.isAnonymous) {
+    const _safeFastLive = isFeatureLive('ORB_SAFE_FAST_GREETING');
+    console.log(
+      `[GREETING-CONTEXT-PENDING] session ${session.sessionId} reached greeting before context resolved (lang=${lang}, safe_fast=${_safeFastLive})`,
+    );
+    emitDiag(session, 'greeting_context_pending', { lang, safe_fast_greeting: _safeFastLive });
+    if (_safeFastLive && ws.readyState === WebSocket.OPEN) {
+      const _menu = pickShortGapGreetings(lang, 6).map((p) => `"${p}"`).join(', ');
+      const _safePrompt =
+        `Open with EXACTLY ONE short phrase, picked from this menu and used VERBATIM ` +
+        `(already in the user's language): ${_menu}. Do NOT say "Hello" or the user's name. ` +
+        `Do NOT introduce yourself. NEVER use two-part sentences. Speak it as audio.`;
+      ws.send(
+        JSON.stringify({
+          client_content: { turns: [{ role: 'user', parts: [{ text: _safePrompt }] }], turn_complete: true },
+        }),
+      );
+      session.greetingSent = true;
+      session.greetingTurnIndex = session.turn_count;
+      _sm.markOpeningDelivered();
+      emitDiag(session, 'greeting_sent', {
+        lang,
+        prompt_len: _safePrompt.length,
+        wake_opener: 'safe_fast_pending_context',
+      });
+      startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
+      console.log(`[GREETING-SAFE-FAST] session ${session.sessionId} sent short audio-safe opener (context still pending)`);
+      return true;
+    }
+  }
 
   const _wb = (session as any).wakeBriefDecision || null;
   const _openDecision = decideOpening({


### PR DESCRIPTION
## DEV-COMHU-0513 B2 — make the greeting reliable on partial context

Follow-up to #2693 (merged: bounded context gate + probe + WS pre-buffer). This lands the **B2** fix the latency work pointed to.

### The problem (proven on staging)
With fast-start ON + a low context-gate cap (`ORB_CONTEXT_READY_GATE_TIMEOUT_MS=1000`), the spoken greeting dropped to **~4.5s** — but was reliable only **~25% (2/8)**. Diagnosis: cutting context off early leaves `session.lastSessionInfo` empty, so the temporal bucket in `sendGreetingPromptToLiveAPI` falls to `first`/default and emits the long **"FULL INTRODUCTION"** prompt. Per this file's own `VTID-03102` history, that long instructional shape makes **Gemini Live go text-only / stall → no audio greeting** — exactly the observed ~75% no-greeting.

So: keeping the context wait = reliable but ~7s; cutting it = fast but broken. The fix has to make the greeting **robust to partial context**.

### The fix (flag-gated, default OFF → zero behavior change)
1. **`live-session-controller.ts`** — set `session.contextReadyResolved = false` while fast-start's deferred wake-brief/journey work runs; flip `true` when `contextReadyPromise` settles. Only the fast-start path starts unresolved; legacy/inline sessions read as resolved.
2. **`sendGreetingPromptToLiveAPI`** — if the greeting is reached with context still pending:
   - **always** log `[GREETING-CONTEXT-PENDING]` + a `greeting_context_pending` diag (so a single staging run *confirms* the mechanism, even with the flag off);
   - under **`FEATURE_ORB_SAFE_FAST_GREETING`**, send a guaranteed-short **verbatim** audio-safe opener (reusing `pickShortGapGreetings`) instead of the misclassified long intro, then let the next turn carry full personalization. Anonymous intro path untouched.

Pairs with a low `ORB_CONTEXT_READY_GATE_TIMEOUT_MS` (≈1000) to target a **~3–4s greeting that is also reliable**.

### Verification plan (honest status)
- ✅ Type-checks clean (tsc 5.9.3).
- ⏳ **Not yet proven on staging** — staging is currently thrashed from many rapid flag redeploys, and the fix isn't deployed there. After merge → staging auto-deploys → set `FEATURE_ORB_SAFE_FAST_GREETING_ENV=staging-only` + `FEATURE_ORB_FAST_START_ENV=staging-only` + `ORB_CONTEXT_READY_GATE_TIMEOUT_MS=1000`, then I re-run the probe (target: reliable ≥7/8 **and** ~3–4s). The always-on diagnostic will confirm the text-only mechanism in the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B85fhJm5pGBLxzqt4Jva8r)_