### PR TITLE
feat(gateway): bulk mark-as-read endpoint for Inbox (POST /api/v1/chat/read-all)

### DIFF
--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -313,6 +313,28 @@ router.post('/read', requireAuth, requireTenant, async (req: Request, res: Respo
   return res.json({ ok: true });
 });
 
+// ── POST /read-all — Mark ALL of the caller's unread DMs as read ──
+
+router.post('/read-all', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+  const { error, count } = await supabase
+    .from('chat_messages')
+    .update({ read_at: new Date().toISOString() }, { count: 'exact' })
+    .eq('tenant_id', identity.tenant_id)
+    .eq('receiver_id', identity.user_id)
+    .is('read_at', null);
+
+  if (error) {
+    console.error('[Chat] Mark all read error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({ ok: true, updated: count ?? 0 });
+});
+
 // ── GET /unread-count — Total unread messages ────────────────
 
 router.get('/unread-count', requireAuth, requireTenant, async (req: Request, res: Response) => {

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -319,6 +319,9 @@ router.post('/read-all', requireAuth, requireTenant, async (req: Request, res: R
   const { identity } = req as AuthenticatedRequest;
   if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
 
+  // impact-allow-no-oasis: marking chat messages as read is a routine user
+  // read-receipt, not a governed state transition — consistent with the sibling
+  // POST /read handler, which likewise emits no OASIS event.
   const supabase = getSupabase();
   const { error, count } = await supabase
     .from('chat_messages')


### PR DESCRIPTION
## What

Adds `POST /api/v1/chat/read-all` to the gateway chat routes — marks **every** unread direct message for the caller as read in a single UPDATE and returns the count. Backs the new Inbox "Mark all as read" overflow action in `exafyltd/vitana-v1` (branch `claude/read-all-placement-k1zzfi`).

## How

Mirrors the existing `POST /read` handler (`services/gateway/src/routes/chat.ts`), but without a `peer_id` filter:

```ts
.from('chat_messages')
.update({ read_at: new Date().toISOString() }, { count: 'exact' })
.eq('tenant_id', identity.tenant_id)
.eq('receiver_id', identity.user_id)
.is('read_at', null)
```

Returns `{ ok: true, updated: <count> }`. Group threads use a `last_read_at` watermark (not `read_at`), so the group half is handled client-side in one bulk update, consistent with the existing per-thread `markAsRead` split.

## Governance / deploy

`BOOTSTRAP-INBOX-READ-ALL`. Staging-first: merging to `main` auto-deploys `gateway-staging` — verify on `preview-gateway.vitanaland.com`, then PUBLISH to prod. A VTID should be allocated/confirmed before the prod promotion.

## Verification (post-deploy)

```bash
curl -s -o /dev/null -w "%{http_code} %{content_type}" \
  -X POST "https://<gateway-staging-url>/api/v1/chat/read-all" \
  -H "Content-Type: application/json" -d '{}'
# Expect: 401 application/json (route exists, auth required) — NOT 404 text/html
```
Then authenticated: seed unread DMs → call `/read-all` → `GET /api/v1/chat/unread-count` returns 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y159a9SW7KU9QmAe2Sq49f)_