### PR TITLE
DEV-COMHU-0513: persist ORB fast-greeting flags on staging (fix env wipe)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -144,6 +144,20 @@ jobs:
             # gateway-staging — every intents/board call 404'd, so Find a
             # Partner / matches could not load on preview.vitanaland.com.
             "FEATURE_INTENT_ENGINE_A=true"
+            # DEV-COMHU-0513 (ORB first-greeting latency): bake the fast-greeting
+            # stack into the staging env so it PERSISTS across every STAGE-DEPLOY
+            # (--set-env-vars REPLACES, so hand-set gcloud flags were wiped on the
+            # next deploy — the cause of "fast-start keeps reverting to off").
+            #   FAST_START      → defer wake-brief/journey off session/start
+            #   SAFE_FAST_GREETING → short audio-safe opener when context is still
+            #                        pending (else the long intro makes Gemini go
+            #                        text-only → no audio greeting)
+            #   GATE cap 300ms  → greeting fires ~immediately after session-ready,
+            #                     targeting a ~3s spoken greeting (vs ~7s legacy)
+            # staging-only; prod stays on the legacy path until this graduates.
+            "FEATURE_ORB_FAST_START_ENV=staging-only"
+            "FEATURE_ORB_SAFE_FAST_GREETING_ENV=staging-only"
+            "ORB_CONTEXT_READY_GATE_TIMEOUT_MS=300"
           )
 
           # Comma-joined for --set-env-vars (replaces, not merges — we want the


### PR DESCRIPTION
## DEV-COMHU-0513 — persist the ORB fast-greeting flags on staging

**Root cause of "nothing sticks":** `STAGE-DEPLOY.yml` deploys with `--set-env-vars`, which **replaces** the entire env. So every staging deploy (any merge to `main`) wiped the `FEATURE_ORB_*` flags set by hand via `gcloud` — which is why `context_status` kept reverting to `ready` (fast-start off) and B2 never actually ran during probes.

**Fix:** bake the stack into the workflow env (same pattern as the existing `FEATURE_LATENCY_TELEMETRY_ENV=staging-only` / `FEATURE_INTENT_ENGINE_A=true` entries), so it survives every deploy:
- `FEATURE_ORB_FAST_START_ENV=staging-only`
- `FEATURE_ORB_SAFE_FAST_GREETING_ENV=staging-only`
- `ORB_CONTEXT_READY_GATE_TIMEOUT_MS=300`

staging-only; production path unchanged.

Once merged, every `gateway-staging` deploy runs the fast-greeting stack with B2's audio-safe opener and a 300ms context cap, targeting a ~3s spoken greeting — and it no longer reverts. Then the probe measures the real number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B85fhJm5pGBLxzqt4Jva8r)_