### PR TITLE
fix(orb): voice assistant can't find registered users by name; share-link send fails

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -1640,7 +1640,10 @@ export async function tool_resolve_recipient(
     p_actor: id.user_id,
     p_token: spoken,
     p_limit: limit,
-    p_global: false,
+    // Cross-tenant: the resolver ranks the actor's own tenant first (+0.15
+    // same-tenant boost) but still surfaces a registered member who sits in
+    // the sibling tenant, so voice can reach anyone with a Vitana account.
+    p_global: true,
   });
   if (error) {
     return { ok: false, error: error.message };
@@ -1713,6 +1716,164 @@ async function emitChatSendFailure(
   }
 }
 
+interface ValidatedRecipient {
+  recipientUserId: string;
+  recipientVitanaId: string | null;
+  recipientDisplayName: string | null;
+  tenantId: string;
+}
+
+/**
+ * Shared recipient resolution + validation for every voice "send to a person"
+ * tool (message, share-link, …). This is the hardening tool_send_chat_message
+ * gained under VTID-02966, lifted into one place so tool_share_link — which
+ * previously had none of it and silently failed the chat_messages insert when
+ * Gemini passed a spoken label instead of a UUID, or when the voice session
+ * carried a null tenant — gets identical safety:
+ *   1. Re-resolve a spoken label to a UUID when Gemini drops the id across a
+ *      turn boundary (cross-tenant resolve; same-tenant ranked first).
+ *   2. Reject missing / non-UUID / self recipients.
+ *   3. Backfill tenant from app_users (chat_messages.tenant_id is NOT NULL).
+ *   4. Confirm the receiver still exists in app_users.
+ *   5. Confirm the spoken label still matches the resolved person.
+ * The optional onFailure callback lets callers keep their OASIS telemetry.
+ */
+async function resolveAndValidateRecipient(
+  rawRecipientId: string,
+  recipientLabel: string,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+  onFailure?: (reason: string, extra?: Record<string, unknown>) => Promise<void>,
+): Promise<{ ok: true; data: ValidatedRecipient } | { ok: false; error: string }> {
+  const fail = async (reason: string, extra?: Record<string, unknown>) => {
+    if (onFailure) await onFailure(reason, extra);
+  };
+  let recipientUserId = String(rawRecipientId ?? '').trim();
+  const label = String(recipientLabel ?? '').trim();
+
+  // 1. Re-resolve label -> UUID when Gemini handed us a name (or nothing).
+  if (!UUID_REGEX.test(recipientUserId) && label) {
+    try {
+      const { data, error } = await sb.rpc('resolve_recipient_candidates', {
+        p_actor: id.user_id,
+        p_token: label,
+        p_limit: 3,
+        p_global: true,
+      });
+      if (error) {
+        await fail('label_recovery_rpc_error', { rpc_error: error.message, label });
+        return { ok: false, error: `I had a problem looking up ${label}. Want me to try once more?` };
+      }
+      const candidates = (data || []) as Array<{ user_id: string; score: number }>;
+      const top = candidates[0];
+      const topScore = top ? Number(top.score) : 0;
+      const secondScore = candidates[1] ? Number(candidates[1].score) : 0;
+      const recoverable = Boolean(top) && topScore >= 0.9 && secondScore / Math.max(topScore, 0.0001) < 0.85;
+      if (!recoverable) {
+        await fail(candidates.length === 0 ? 'label_recovery_no_match' : 'label_recovery_ambiguous', {
+          label,
+          candidate_count: candidates.length,
+          top_score: topScore,
+        });
+        return {
+          ok: false,
+          error:
+            candidates.length === 0
+              ? `I couldn't find ${label} in the community right now.`
+              : `I'm not sure which ${label} you meant — can you say their Vitana ID?`,
+        };
+      }
+      recipientUserId = top.user_id;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'label resolve failed';
+      await fail('label_recovery_exception', { error: msg, label });
+      return { ok: false, error: `I had a problem looking up ${label}. Want me to try once more?` };
+    }
+  }
+
+  // 2. Basic shape checks.
+  if (!recipientUserId) {
+    await fail('missing_recipient');
+    return { ok: false, error: 'Who would you like me to send this to?' };
+  }
+  if (!UUID_REGEX.test(recipientUserId)) {
+    await fail('recipient_not_uuid', { recipient_value: recipientUserId });
+    return { ok: false, error: `I lost track of who you meant — can you say their name again?` };
+  }
+  if (recipientUserId === id.user_id) {
+    await fail('self_message');
+    return { ok: false, error: 'cannot message yourself' };
+  }
+
+  // 3. Tenant backfill — chat_messages.tenant_id is NOT NULL.
+  let tenantId = id.tenant_id;
+  if (!tenantId) {
+    const { data: appUser } = await sb
+      .from('app_users')
+      .select('tenant_id')
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    tenantId = (appUser as { tenant_id?: string } | null)?.tenant_id ?? null;
+    if (!tenantId) {
+      await fail('missing_tenant');
+      return {
+        ok: false,
+        error: `I can't send right now — I'm missing some account context. Try once more in a moment.`,
+      };
+    }
+  }
+
+  // 4. Receiver must still exist.
+  const { data: receiverRow, error: receiverErr } = await sb
+    .from('app_users')
+    .select('user_id, display_name, vitana_id')
+    .eq('user_id', recipientUserId)
+    .maybeSingle();
+  if (receiverErr) {
+    await fail('receiver_lookup_error', { recipient_user_id: recipientUserId, db_error: receiverErr.message });
+    return { ok: false, error: `I had a problem checking who you meant. Want me to try once more?` };
+  }
+  if (!receiverRow) {
+    await fail('receiver_not_found', { recipient_user_id: recipientUserId, recipient_label: label || null });
+    return {
+      ok: false,
+      error: label
+        ? `I couldn't find ${label} — they may have left the community.`
+        : `I couldn't find that person — they may have left the community.`,
+    };
+  }
+  const recipientVitanaId = (receiverRow as { vitana_id?: string | null }).vitana_id ?? null;
+  const recipientDisplayName = (receiverRow as { display_name?: string | null }).display_name ?? null;
+
+  // 5. Label/identity consistency: a spoken label must share a 3+ char token
+  // with the resolved person's display name or vitana_id.
+  if (label) {
+    const lbl = label.toLowerCase();
+    const dn = (recipientDisplayName ?? '').toLowerCase();
+    const vid = (recipientVitanaId ?? '').toLowerCase();
+    const tokens = lbl.split(/\s+/).filter((t) => t.length >= 3);
+    const anyMatch =
+      tokens.length === 0 ||
+      tokens.some((t) => dn.includes(t) || vid.includes(t)) ||
+      dn === lbl ||
+      vid === lbl;
+    if (!anyMatch) {
+      await fail('label_id_mismatch', {
+        recipient_user_id: recipientUserId,
+        recipient_label: label,
+        resolved_display_name: recipientDisplayName,
+        resolved_vitana_id: recipientVitanaId,
+      });
+      return { ok: false, error: `I'm not sure I got the right person — can you say their name again?` };
+    }
+  }
+
+  return {
+    ok: true,
+    data: { recipientUserId, recipientVitanaId, recipientDisplayName, tenantId },
+  };
+}
+
 export async function tool_send_chat_message(
   args: OrbToolArgs,
   id: OrbToolIdentity,
@@ -1750,7 +1911,7 @@ export async function tool_send_chat_message(
         p_actor: id.user_id,
         p_token: recipientLabel,
         p_limit: 3,
-        p_global: false,
+        p_global: true,
       });
       if (error) {
         await emitChatSendFailure('label_recovery_rpc_error', id, args, {
@@ -2225,23 +2386,43 @@ export async function tool_share_link(
   // self-share guard, voice-send quota check, and metadata shape.
   // Accepts the legacy LiveKit args (url, with_recipient) AND Vertex args
   // (target_url, recipient_user_id, recipient_label, target_kind).
-  const recipientUserId = String(args.recipient_user_id ?? args.with_recipient ?? '').trim();
+  //
+  // FIX (people-search bootstrap): previously this tool required
+  // recipient_user_id to already be a UUID, never re-resolved a spoken label,
+  // and inserted id.tenant_id raw. So when Gemini handed it the verbal name
+  // (common across the confirm turn) or the voice session carried a null
+  // tenant, the chat_messages insert was rejected and the user heard "I could
+  // not send the post" AFTER the resolver had confidently found the person.
+  // It now runs the same resolveAndValidateRecipient() path as
+  // tool_send_chat_message: label->UUID recovery, tenant backfill, receiver
+  // existence + label-consistency checks.
+  const rawRecipient = String(args.recipient_user_id ?? args.with_recipient ?? '').trim();
   const recipientLabel = String(args.recipient_label ?? '').trim();
   const targetUrl = String(args.target_url ?? args.url ?? '').trim();
   const targetKind = String(args.target_kind ?? 'page').trim();
 
-  if (!recipientUserId || !targetUrl) {
-    return { ok: false, error: 'recipient_user_id and target_url are required' };
+  if (!targetUrl) {
+    return { ok: false, error: 'target_url is required' };
   }
-  if (recipientUserId === id.user_id) {
-    return { ok: false, error: 'cannot share with yourself' };
+  if (!rawRecipient && !recipientLabel) {
+    return { ok: false, error: 'recipient_user_id or recipient_label is required' };
   }
+
+  const resolved = await resolveAndValidateRecipient(
+    rawRecipient,
+    recipientLabel,
+    id,
+    sb,
+    (reason, extra) => emitChatSendFailure(reason, id, args, extra),
+  );
+  if (!resolved.ok) {
+    return { ok: false, error: resolved.error };
+  }
+  const { recipientUserId, recipientVitanaId, recipientDisplayName, tenantId } = resolved.data;
 
   try {
     const { checkVoiceSendQuota } = await import('./voice-message-guard');
     const { resolveVitanaId } = await import('../middleware/auth-supabase-jwt');
-
-    const recipientVitanaId = await resolveVitanaId(recipientUserId);
 
     const quota = await checkVoiceSendQuota({
       // session_id is Vertex-specific; pass user_id so the quota guard can
@@ -2268,7 +2449,7 @@ export async function tool_share_link(
     const previewBody = `🔗 ${targetUrl}`;
 
     const { error: insErr } = await sb.from('chat_messages').insert({
-      tenant_id: id.tenant_id,
+      tenant_id: tenantId,
       sender_id: id.user_id,
       receiver_id: recipientUserId,
       content: previewBody,
@@ -2281,14 +2462,19 @@ export async function tool_share_link(
         kind: 'shared_link',
         target_url: targetUrl,
         target_kind: targetKind,
-        recipient_label: recipientLabel || recipientVitanaId,
+        recipient_label: recipientLabel || recipientDisplayName || recipientVitanaId,
       },
     });
     if (insErr) {
-      return { ok: false, error: insErr.message };
+      await emitChatSendFailure('share_link_insert_error', id, args, {
+        db_error: insErr.message,
+        recipient_user_id: recipientUserId,
+      });
+      return { ok: false, error: `I couldn't send the link just now — want me to try once more?` };
     }
 
-    const recipDisplay = recipientLabel || recipientVitanaId || recipientUserId;
+    const recipDisplay =
+      recipientLabel || recipientDisplayName || recipientVitanaId || recipientUserId;
     return {
       ok: true,
       result: {
@@ -2300,7 +2486,8 @@ export async function tool_share_link(
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : 'share_link error';
-    return { ok: false, error: msg };
+    await emitChatSendFailure('share_link_exception', id, args, { error: msg });
+    return { ok: false, error: `I hit a snag sharing that — want me to try once more?` };
   }
 }
 

--- a/supabase/migrations/20260618000000_BOOTSTRAP_canonical_people_search.sql
+++ b/supabase/migrations/20260618000000_BOOTSTRAP_canonical_people_search.sql
@@ -1,0 +1,225 @@
+-- BOOTSTRAP: Canonical people search for the voice resolver.
+--
+-- Symptom (reported via ORB voice):
+--   "Send a text message to Maria Maxina" -> "I can't find that user", even
+--   though Mariia Maksina IS a registered, community-visible account in the
+--   speaker's own tenant.
+--
+-- Root cause (data-verified against prod):
+--   resolve_recipient_candidates() built its candidate pool from
+--   public.profiles and then HARD-FILTERED to rows that have an `active`
+--   row in public.memberships for the actor's tenant. But the canonical
+--   messaging tenant lives on public.app_users.tenant_id, and ~20% of
+--   registered users (17/98 app_users at time of writing, including BOTH
+--   "Mariia Maksina" accounts) have NO membership row at all. Those users
+--   were silently dropped from the candidate set BEFORE any name matching
+--   ran — so they were unreachable no matter how their name was spelled.
+--   The resolver instead surfaced unrelated chat-peers ("Marion", "Marc")
+--   via the relaxed trigram lane, making it look like a fuzzy-match problem
+--   when it was really an eligibility problem.
+--
+--   Secondary issues fixed here:
+--     * Name search only looked at profiles.display_name. Names also live in
+--       app_users.display_name, global_community_profiles.display_name,
+--       profiles.full_name and first/last. We now coalesce across all of
+--       them and score the BEST form.
+--     * No exact lanes for vitana_id-as-spoken, @handle, or email.
+--     * The 0.4 trigram floor dropped foreign-name ASR slips for anyone the
+--       actor had not already chatted with. Relaxed to 0.2 for everyone,
+--       with same-tenant + chat-peer + phonetic boosts used for RANKING
+--       (not eligibility) so exact/strong matches still win.
+--     * When the actor's tenant could not be resolved the function used to
+--       RETURN empty (zero candidates). It now degrades to a global search
+--       instead of returning nothing.
+--
+-- Tenant model: p_global=false keeps results scoped to the actor's tenant
+-- (now resolved from auth meta -> app_users.tenant_id -> memberships, in that
+-- order). p_global=true searches every tenant but ranks the actor's own
+-- tenant first via a +0.15 same-tenant boost. The voice tools call with
+-- p_global=true so a speaker can reach a registered member who happens to sit
+-- in the sibling tenant, while local members still rank above them.
+
+-- Trigram indexes on the real name columns (cheap now, future-proofs growth).
+CREATE INDEX IF NOT EXISTS idx_app_users_display_name_trgm
+  ON public.app_users USING gin (lower(coalesce(display_name, '')) gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_profiles_display_name_trgm
+  ON public.profiles USING gin (lower(coalesce(display_name, '')) gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_profiles_full_name_trgm
+  ON public.profiles USING gin (lower(coalesce(full_name, '')) gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_gcp_display_name_trgm
+  ON public.global_community_profiles USING gin (lower(coalesce(display_name, '')) gin_trgm_ops);
+
+CREATE OR REPLACE FUNCTION public.resolve_recipient_candidates(
+  p_actor  uuid,
+  p_token  text,
+  p_limit  int  DEFAULT 5,
+  p_global boolean DEFAULT false
+) RETURNS TABLE (
+  user_id      uuid,
+  vitana_id    text,
+  display_name text,
+  avatar_url   text,
+  score        numeric,
+  reason       text
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_token        text;
+  v_actor_tenant uuid;
+BEGIN
+  -- 1. Normalize the spoken token: strip leading '@', lowercase, unaccent.
+  v_token := lower(public.unaccent(coalesce(p_token, '')));
+  v_token := trim(ltrim(v_token, '@'));
+  IF v_token = '' THEN
+    RETURN;
+  END IF;
+
+  -- 2. Resolve the actor's tenant. Canonical messaging tenant is
+  --    app_users.tenant_id; auth metadata is the fast path; memberships is a
+  --    last resort. We do NOT return early when this is null any more — an
+  --    unknown tenant degrades to a global search rather than zero results.
+  SELECT (au.raw_app_meta_data ->> 'active_tenant_id')::uuid
+    INTO v_actor_tenant
+    FROM auth.users au
+   WHERE au.id = p_actor;
+
+  IF v_actor_tenant IS NULL THEN
+    SELECT a.tenant_id INTO v_actor_tenant
+      FROM public.app_users a
+     WHERE a.user_id = p_actor;
+  END IF;
+
+  IF v_actor_tenant IS NULL THEN
+    SELECT m.tenant_id INTO v_actor_tenant
+      FROM public.memberships m
+     WHERE m.user_id = p_actor
+       AND m.status = 'active'
+     ORDER BY m.created_at ASC
+     LIMIT 1;
+  END IF;
+
+  RETURN QUERY
+  WITH chat_peers AS (
+    -- Recent two-way chat partners, used for a RANKING boost only.
+    SELECT DISTINCT peer
+      FROM (
+        (SELECT cm.sender_id   AS peer FROM public.chat_messages cm
+          WHERE cm.receiver_id = p_actor
+          ORDER BY cm.created_at DESC LIMIT 200)
+        UNION ALL
+        (SELECT cm.receiver_id AS peer FROM public.chat_messages cm
+          WHERE cm.sender_id   = p_actor
+          ORDER BY cm.created_at DESC LIMIT 200)
+      ) recent
+     WHERE peer IS NOT NULL
+  ),
+  cand AS (
+    -- Candidate pool = every active app_users row (the canonical account +
+    -- tenant table). NO membership gate. Names coalesced across all stores.
+    SELECT
+      au.user_id,
+      au.vitana_id,
+      au.tenant_id,
+      g.avatar_url,
+      coalesce(
+        nullif(trim(au.display_name), ''),
+        nullif(trim(p.display_name), ''),
+        nullif(trim(g.display_name), ''),
+        nullif(trim(p.full_name), ''),
+        nullif(trim(concat_ws(' ', p.first_name, p.last_name)), '')
+      ) AS name,
+      lower(coalesce(p.handle, '')) AS handle,
+      lower(coalesce(au.email, '')) AS email,
+      EXISTS (SELECT 1 FROM chat_peers cp WHERE cp.peer = au.user_id) AS is_chat_peer
+    FROM public.app_users au
+    LEFT JOIN public.profiles p ON p.user_id = au.user_id
+    LEFT JOIN public.global_community_profiles g ON g.user_id = au.user_id
+    WHERE au.user_id <> p_actor
+      AND coalesce(au.status, 'active') = 'active'
+  ),
+  scored AS (
+    SELECT
+      c.user_id,
+      c.vitana_id,
+      c.name AS display_name,
+      c.avatar_url,
+      c.is_chat_peer,
+      c.tenant_id,
+      similarity(lower(public.unaccent(coalesce(c.name, ''))), v_token) AS name_sim,
+      CASE
+        WHEN lower(coalesce(c.vitana_id, '')) = v_token THEN 1.00::numeric
+        WHEN c.handle <> '' AND c.handle = v_token THEN 0.97::numeric
+        WHEN c.email <> '' AND c.email = v_token THEN 0.95::numeric
+        WHEN EXISTS (
+          SELECT 1 FROM public.handle_aliases ha
+           WHERE ha.user_id = c.user_id AND ha.old_handle = v_token
+        ) THEN 0.92::numeric
+        WHEN similarity(lower(public.unaccent(coalesce(c.name, ''))), v_token) > 0.4
+          THEN (0.55 + similarity(lower(public.unaccent(coalesce(c.name, ''))), v_token) * 0.30)::numeric
+        WHEN similarity(lower(public.unaccent(coalesce(c.name, ''))), v_token) > 0.2
+          THEN (0.42 + similarity(lower(public.unaccent(coalesce(c.name, ''))), v_token) * 0.30)::numeric
+        ELSE 0.00::numeric
+      END AS base_score,
+      CASE
+        WHEN lower(coalesce(c.vitana_id, '')) = v_token THEN 'vitana_id_exact'
+        WHEN c.handle <> '' AND c.handle = v_token THEN 'handle_exact'
+        WHEN c.email <> '' AND c.email = v_token THEN 'email_exact'
+        WHEN EXISTS (
+          SELECT 1 FROM public.handle_aliases ha
+           WHERE ha.user_id = c.user_id AND ha.old_handle = v_token
+        ) THEN 'legacy_handle'
+        WHEN similarity(lower(public.unaccent(coalesce(c.name, ''))), v_token) > 0.4
+          THEN 'fuzzy_name'
+        WHEN similarity(lower(public.unaccent(coalesce(c.name, ''))), v_token) > 0.2
+          THEN 'fuzzy_name_relaxed'
+        ELSE 'none'
+      END AS base_reason
+    FROM cand c
+  ),
+  ranked AS (
+    SELECT
+      s.user_id,
+      s.vitana_id,
+      s.display_name,
+      s.avatar_url,
+      (
+        s.base_score
+        + CASE
+            WHEN s.base_reason IN ('fuzzy_name', 'fuzzy_name_relaxed', 'none')
+             AND s.display_name IS NOT NULL
+             AND length(v_token) >= 3
+             AND metaphone(lower(public.unaccent(split_part(s.display_name, ' ', 1))), 6)
+               = metaphone(v_token, 6)
+            THEN 0.10 ELSE 0
+          END
+        + CASE WHEN s.is_chat_peer THEN 0.10 ELSE 0 END
+        + CASE
+            WHEN v_actor_tenant IS NOT NULL AND s.tenant_id = v_actor_tenant
+            THEN 0.15 ELSE 0
+          END
+      ) AS score,
+      s.base_reason AS reason
+    FROM scored s
+    WHERE s.base_score > 0
+      -- Eligibility: when not global, scope to the actor's tenant IF it is
+      -- known. If tenant is unknown, fall through to a global search so we
+      -- never silently return nothing.
+      AND (
+        p_global = true
+        OR v_actor_tenant IS NULL
+        OR s.tenant_id = v_actor_tenant
+      )
+  )
+  SELECT r.user_id, r.vitana_id, r.display_name, r.avatar_url, r.score, r.reason
+  FROM ranked r
+  ORDER BY r.score DESC, r.display_name ASC
+  LIMIT GREATEST(coalesce(p_limit, 5), 1);
+END;
+$$;
+
+COMMENT ON FUNCTION public.resolve_recipient_candidates(uuid, text, int, boolean) IS
+  'Canonical voice/people resolver. Candidate pool = active app_users (no membership gate); tenant from app_users.tenant_id. Matches on exact vitana_id/@handle/email + legacy alias + fuzzy name (>=0.2) coalesced across app_users/profiles/global_community_profiles. p_global=false scopes to actor tenant when known (else global); p_global=true searches all tenants with a +0.15 same-tenant ranking boost.';


### PR DESCRIPTION
## Problem

In ORB voice:
1. **"Send a text message to Maria Maxina"** → *can't find the user*, even though she's a registered, community-visible account.
2. **"Share a post with Maria Maxina"** → resolver found her, user confirmed, then *"I could not send the post."*

## Root causes (verified against prod data)

**1. The resolver excluded ~20% of registered users before name matching even ran.**
`resolve_recipient_candidates()` built its candidate pool from `profiles` and hard-filtered to rows with an **active `public.memberships` row in the actor's tenant**. But the canonical messaging tenant lives on `app_users.tenant_id`, and ~20% of registered users (17/98 `app_users`, including **both** "Mariia Maksina" accounts — the real person behind the ASR's "Maria Maxina") have **no membership row at all**. They were dropped from the candidate set *before* any name comparison, so they were unreachable no matter how the name was spelled. The resolver surfaced unrelated chat-peers (`Marion`, `Marc`) via the relaxed trigram lane instead — making this look like a fuzzy-match problem when it was an *eligibility* problem.

Secondary: name search only looked at `profiles.display_name` (names also live in `app_users.display_name`, `global_community_profiles.display_name`, `profiles.full_name`, first/last); no exact lanes for spoken vitana_id / `@handle` / email; the 0.4 trigram floor dropped foreign-name ASR slips for non-chat-peers; and an unknown actor tenant caused an empty `RETURN` (zero candidates).

**2. `tool_share_link` never got the hardening `tool_send_chat_message` gained under VTID-02966.** It required `recipient_user_id` to already be a UUID, never re-resolved a spoken label, and inserted `id.tenant_id` raw. So when Gemini handed it the verbal name (common across the confirm turn) or the voice session carried a null tenant, the `chat_messages` insert was rejected → *"I could not send the post"* **after** a confident resolve.

## Changes

- **Migration** `20260618000000_BOOTSTRAP_canonical_people_search.sql`: rewrite `resolve_recipient_candidates()` to
  - source candidates from **active `app_users`** (no membership gate), tenant via `app_users.tenant_id` (auth-meta → app_users → memberships);
  - match on exact `vitana_id` / `@handle` / `email` + legacy alias + fuzzy name (≥0.2) **coalesced** across `app_users` / `profiles` / `global_community_profiles`;
  - use same-tenant (+0.15), chat-peer, and phonetic boosts for **ranking** (not eligibility);
  - support **cross-tenant** search (`p_global=true`) with the actor's tenant ranked first;
  - degrade to a global search instead of returning empty when tenant is unknown;
  - add trigram indexes on the name columns.
- **Gateway** (`orb-tools-shared.ts`): extract `resolveAndValidateRecipient()` (label→UUID recovery, tenant backfill, receiver-existence + label-consistency checks) and use it in `tool_share_link` so **share reaches parity with send**. Voice resolver calls now pass `p_global=true` for cross-tenant reach.

## Verification

Read-only against prod data, as the test user resolving **"Maria Maxina"**:
- **Before:** returns `Marion Hanekamp`, `Marion Pierfitte`, `Marc Oliver` (chat-peers) — never Mariia.
- **After:** returns **`Mariia Maksina` (mariia6) ranked top at 0.92**, plus the duplicate `mariia11`.

## Notes / follow-ups
- The cross-tenant behavior was explicitly requested. Same-tenant members always rank first.
- Surfaced **data-quality issues** worth a separate cleanup: duplicate accounts (two `Mariia Maksina`, two `Mette`, two `Jovana`, two `Biljana`…) cause "which one did you mean?" loops, and ~20% of `app_users` lack a `memberships` row.
- `tool_send_chat_message` keeps its proven inline validation; it can later delegate to the shared helper too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9MgTXkYNPoqFt37RTjMnN)_