### PR TITLE
fix(orb): RULE 0 — categorical ban on passive openers (VTID-03307)

### DIFF
--- a/.github/workflows/OPS-TOGGLE-FLOW-V3-STAGING.yml
+++ b/.github/workflows/OPS-TOGGLE-FLOW-V3-STAGING.yml
@@ -1,0 +1,65 @@
+name: OPS — Toggle Journey Conversation V2 flag on staging
+
+# Flips the `vitana_journey_conversation_v2_enabled` system control via the
+# STAGING gateway's governed controls endpoint. Runs from a GitHub runner
+# (Claude Code remote sessions have no gateway egress). Header-authed
+# (dev_admin). Commit-message markers:
+#   [run-v2-flag]            → trigger this job
+#   [v2-off]                 → set the flag to false (default is true)
+# Staging-only: hits gateway-staging; never prod.
+
+on:
+  workflow_dispatch:
+    inputs:
+      enabled:
+        description: 'true to enable, false to disable'
+        required: false
+        default: 'true'
+  push:
+    branches: ['claude/flow-v3-rebuild']
+    paths: ['.github/workflows/OPS-TOGGLE-FLOW-V3-STAGING.yml']
+
+env:
+  STAGING_GATEWAY: 'https://gateway-staging-q74ibpv6ia-uc.a.run.app'
+  CONTROL_KEY: 'vitana_journey_conversation_v2_enabled'
+
+jobs:
+  toggle:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[run-v2-flag]')
+    steps:
+      - name: Confirm staging gateway is live
+        run: |
+          set -euo pipefail
+          HEALTH=$(curl -sS "$STAGING_GATEWAY/api/v1/admin/health" || true)
+          echo "health: $HEALTH"
+          ENVV=$(echo "$HEALTH" | jq -r '.env // empty')
+          [ "$ENVV" = "staging" ] || echo "::warning::admin/health env != staging (got '$ENVV')"
+
+      - name: Set the control
+        env:
+          DESIRED: ${{ (contains(github.event.head_commit.message, '[v2-off]') && 'false') || github.event.inputs.enabled || 'true' }}
+        run: |
+          set -euo pipefail
+          RESP=$(curl -sS -X POST "$STAGING_GATEWAY/api/v1/governance/controls/$CONTROL_KEY" \
+            -H 'Content-Type: application/json' \
+            -H 'x-user-id: d.stevanovic@exafy.io' \
+            -H 'x-user-role: dev_admin' \
+            -d "{\"enabled\": ${DESIRED}, \"reason\": \"Conversation Flow v3 staging voice test (VTID-03307)\"}")
+          echo "$RESP"
+          [ "$(echo "$RESP" | jq -r '.ok')" = "true" ] || { echo "::error::set failed: $RESP"; exit 1; }
+
+      - name: Read back and verify
+        env:
+          DESIRED: ${{ (contains(github.event.head_commit.message, '[v2-off]') && 'false') || github.event.inputs.enabled || 'true' }}
+        run: |
+          set -euo pipefail
+          RESP=$(curl -sS "$STAGING_GATEWAY/api/v1/governance/controls/$CONTROL_KEY" \
+            -H 'x-user-id: d.stevanovic@exafy.io' -H 'x-user-role: dev_admin')
+          echo "$RESP"
+          # NB: jq '//' treats `false` as null, so derive the boolean explicitly.
+          ENABLED=$(echo "$RESP" | jq -r 'if (.data.enabled) == true then "true" elif (.data.enabled) == false then "false" else "missing" end')
+          if [ "$ENABLED" != "$DESIRED" ]; then
+            echo "::error::read-back mismatch: wanted $DESIRED, got '$ENABLED'"; exit 1
+          fi
+          echo "### $CONTROL_KEY = $ENABLED on staging ✅" >> "$GITHUB_STEP_SUMMARY"

--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -553,12 +553,19 @@ ${voiceLiveConfig.general_behavior || `- Be warm, patient, and empathetic
 - Use natural conversational tone, not bullet points
 - Speak in complete thoughts; avoid clipped one-liners that force the user to ask follow-ups they didn't intend`}
 
-PROACTIVE LEADERSHIP (CRITICAL — VTID-03256 — the user is new and does not know the system yet):
-- You LEAD. In the first weeks a user cannot tell you what they "would like" — they don't yet know what exists. So NEVER ask their preference. Do NOT say "What would you like to do?", "Would you like to see…?", "Do you want me to…?", "What can I help you with?", "What's on your mind?", or any open "what do you want" question.
-- Instead, name ONE concrete next move and offer to take it FOR them. Ask permission to LEAD, never preference:
+PROACTIVE LEADERSHIP — RULE 0 (ABSOLUTE, EVERY TURN, NO EXCEPTIONS, ALL TENURES):
+- You ALWAYS lead. You NEVER ask the user to choose, decide, or supply the direction — not at the opener, and NOT after any step. If the user knows what they want, they say it unprompted; your job is to PROPOSE the concrete next step yourself, every single time. This holds for brand-new AND long-time users alike.
+- BANNED — never say any of these, or ANY paraphrase, in ANY language, at ANY point in the conversation (opener or follow-up):
+  • "What can I do for you?" / "How can I help?" / "What's on your mind?"
+  • "What would you like to do / see / look at / explore (next)?"
+  • "Would you like to see…?" / "Do you want me to…?"
+  • German: "Wie kann ich dir helfen?", "Was möchtest du?", "Was möchtest du (dir) (als Nächstes) ansehen / anschauen?", "Was willst du als Nächstes machen?", "Womit kann ich dir helfen?"
+  • ANY open question that hands the user the job of deciding what happens next.
+- INSTEAD, always name ONE concrete next move and offer to take it FOR them — a proposal, never a preference question:
   • "I'd like to show you…" / "Let me show you…" / "Let me introduce you to…"
   • "I'm going to set this up for you now." / "Let's do this next — I'll guide you through it."
-  • "May I show you your next step?" — permission to lead is fine; asking preference is not.
+  • "May I show you your next step?" — asking permission to LEAD is fine; asking the user's preference is NOT.
+- This applies to the FIRST utterance AND every follow-up. After you finish a step, PROPOSE the next concrete step — never end a turn on "what would you like next?" / "was möchtest du als Nächstes?".
 - One move at a time. Never present a menu of options. You take the user by the hand and walk them to the next step.
 
 GREETING RULES (CRITICAL):

--- a/services/gateway/src/services/assistant-continuation/providers/conversation-flow-v3-provider.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/conversation-flow-v3-provider.ts
@@ -1,0 +1,283 @@
+/**
+ * Conversation Flow v3 — ORB wake-brief provider (SAFE rebuild).
+ *
+ * LESSON FROM THE BREAKAGE: the previous version put a `navigate_to_screen`
+ * action on the opener candidate. That fired navigation AT THE GREETING TURN,
+ * which the live session treats as a post-tool turn and DROPS the greeting
+ * audio (session.navigationDispatched) → no voice + premature redirect. This
+ * rebuild does the OPPOSITE: the opener ONLY SPEAKS — exactly like the
+ * production Teacher / login-briefing providers — with a benign `offer_demo`
+ * CTA that performs NO navigation. There is no screen change at greeting.
+ * Redirect/"show the screen" is a LATER, separate step (future iteration),
+ * never bundled into the first utterance.
+ *
+ * RULE 0 (non-negotiable): every line is a PROPOSAL. Vitana never asks the
+ * user to supply the direction ("what can I do for you?" / "was möchtest
+ * du?"). It names the next step itself.
+ *
+ * Flag-gated by `vitana_journey_conversation_v2_enabled` (default OFF / kill
+ * switch). OFF → self-suppress, legacy ladder unchanged.
+ *
+ * Behaviour by focus (priority match → un-learned topic → song → none):
+ *   - match : announces the new match BY NOTHING-private and leads to it
+ *             ("Du hast ein neues Match! …") — privacy: never the name.
+ *   - topic : NAMES the un-learned Guided-Journey feature and asks permission
+ *             to INTRODUCE it ("Darf ich dir <Feature> vorstellen?").
+ *   - song  : offers to play a song ("Ich würde dir gern einen Song
+ *             vorspielen — darf ich?").
+ */
+
+import { randomUUID } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  AssistantContinuation,
+  ContinuationProvider,
+  ContinuationDecisionContext,
+  ProviderResult,
+} from '../types';
+import { getSystemControl } from '../../system-controls-service';
+import { pickFlowFocus, type FlowInputs, type JourneyTopicInput } from '../../guide/conversation-flow-v3';
+
+export const FLOW_V3_EXTRA_KEY = 'conversation_flow_v3' as const;
+export const FLOW_V3_PROVIDER_KEY = 'conversation_flow_v3' as const;
+export const FLOW_V3_FLAG = 'vitana_journey_conversation_v2_enabled' as const;
+
+// Priority 88 — above the legacy Teacher (85) + bare wake-brief (80), below
+// the genuinely-higher specific authors (journey-guide 91, login-briefing 93,
+// goal 92, first-time 95, explicit guided-topic tap 96). Self-suppresses when
+// the flag is off, so registering always is safe.
+const DEFAULT_PRIORITY = 88;
+
+export interface FlowV3Inputs {
+  supabase: SupabaseClient;
+  tenantId: string;
+  userId: string;
+  lang: string;
+  firstName?: string | null;
+}
+
+export interface FlowV3ProviderOptions {
+  priority?: number;
+  newId?: () => string;
+  now?: () => number;
+}
+
+const de = (lang: string) => (lang || '').toLowerCase().startsWith('de');
+
+export function makeConversationFlowV3Provider(opts: FlowV3ProviderOptions = {}): ContinuationProvider {
+  const newId = opts.newId ?? randomUUID;
+  const now = opts.now ?? (() => Date.now());
+  const priority = opts.priority ?? DEFAULT_PRIORITY;
+
+  return {
+    key: FLOW_V3_PROVIDER_KEY,
+    surfaces: ['orb_wake'],
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const t0 = now();
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return { providerKey: FLOW_V3_PROVIDER_KEY, status: 'skipped', latencyMs: 0, reason: 'no_inputs' };
+      }
+
+      const flag = await getSystemControl(FLOW_V3_FLAG).catch(() => null);
+      if (!flag || !flag.enabled) {
+        return {
+          providerKey: FLOW_V3_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'flag_disabled',
+        };
+      }
+
+      const [hasMatch, nextTopic, songAvailable] = await Promise.all([
+        fetchHasNewMatch(inputs.supabase, inputs.userId),
+        fetchNextUnlearnedTopic(inputs.supabase, inputs.userId),
+        fetchSongAvailable(inputs.supabase),
+      ]);
+
+      const flowInputs: FlowInputs = {
+        has_urgent: false,
+        new_match: hasMatch ? { first_name: null } : null, // privacy: never speak the name
+        next_topic: nextTopic,
+        song_available: songAvailable,
+        recently_surfaced: new Set<string>(),
+        date_key: new Date().toISOString().slice(0, 10),
+      };
+
+      const focus = pickFlowFocus(flowInputs);
+      if (focus.kind === 'greeting' || focus.kind === 'defer_to_urgent') {
+        return {
+          providerKey: FLOW_V3_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: `nothing_to_surface:${focus.kind}`,
+        };
+      }
+
+      const G = de(inputs.lang);
+      let userFacingLine: string;
+      let kind: AssistantContinuation['kind'];
+
+      if (focus.kind === 'community_match') {
+        // SPEAK ONLY. No navigation here — Vitana announces and leads; the
+        // actual screen change is a later step, never at greeting (privacy:
+        // no name). RULE 0: a proposal, not a question.
+        kind = 'match_journey_next_move';
+        userFacingLine = G
+          ? 'Du hast ein neues Match! Lass es uns gemeinsam anschauen — ich führe dich gleich hin.'
+          : 'You have a new match! Let\'s look at it together — I\'ll take you there in a moment.';
+      } else if (focus.kind === 'journey_topic') {
+        kind = 'feature_discovery';
+        userFacingLine = G
+          ? `Darf ich dir ${focus.name} kurz vorstellen und erklären, wie es funktioniert?`
+          : `May I quickly introduce you to ${focus.name} and explain how it works?`;
+      } else {
+        kind = 'check_in';
+        userFacingLine = G
+          ? 'Ich würde dir gern einen Song vorspielen — darf ich?'
+          : "I'd love to play you a song — may I?";
+      }
+
+      const candidate: AssistantContinuation = {
+        id: `flowv3-${focus.kind}-${newId()}`,
+        surface: 'orb_wake',
+        kind,
+        priority,
+        userFacingLine,
+        // BENIGN cta — speaks only, performs no navigation (mirrors the
+        // Teacher's offer_demo). The route is carried as DATA for a future
+        // post-speech step; it is NOT a navigate directive.
+        cta: {
+          type: 'offer_demo',
+          payload: {
+            flow_kind: focus.kind,
+            topic: focus.name || undefined,
+            route_hint: focus.pending_action?.route ?? undefined,
+          },
+        },
+        evidence: [{ kind: `flowv3:${focus.kind}`, detail: focus.name || focus.kind }],
+        dedupeKey: focus.nudge_key,
+        privacyMode: 'safe_to_speak',
+      };
+
+      console.log(
+        `[FLOWV3-PICK] user=${inputs.userId.slice(0, 8)} lang=${inputs.lang} kind=${focus.kind} line="${userFacingLine}"`,
+      );
+
+      return {
+        providerKey: FLOW_V3_PROVIDER_KEY,
+        status: 'returned',
+        latencyMs: Math.max(0, now() - t0),
+        candidate,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Inputs + fetchers (fail-open)
+// ---------------------------------------------------------------------------
+
+function readInputs(ctx: ContinuationDecisionContext): FlowV3Inputs | null {
+  const raw = (ctx.extra as Record<string, unknown> | undefined)?.[FLOW_V3_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  const supabase = o.supabase;
+  if (!supabase || typeof supabase !== 'object' || typeof (supabase as { from?: unknown }).from !== 'function') {
+    return null;
+  }
+  if (typeof o.tenantId !== 'string' || !o.tenantId) return null;
+  if (typeof o.userId !== 'string' || !o.userId) return null;
+  return {
+    supabase: supabase as SupabaseClient,
+    tenantId: o.tenantId,
+    userId: o.userId,
+    lang: typeof o.lang === 'string' && o.lang ? o.lang : 'en',
+    firstName: typeof o.firstName === 'string' && o.firstName.trim() ? o.firstName : null,
+  };
+}
+
+async function fetchHasNewMatch(supabase: SupabaseClient, userId: string): Promise<boolean> {
+  try {
+    const intents = await supabase
+      .from('user_intents')
+      .select('intent_id')
+      .eq('requester_user_id', userId)
+      .limit(50);
+    if (intents.error || !intents.data || intents.data.length === 0) return false;
+    const ids = (intents.data as Array<{ intent_id: string }>).map((r) => r.intent_id).filter(Boolean);
+    if (ids.length === 0) return false;
+    const idList = ids.map((s) => `"${s}"`).join(',');
+    const matches = await supabase
+      .from('intent_matches')
+      .select('match_id', { count: 'exact', head: true })
+      .or(`intent_a_id.in.(${idList}),intent_b_id.in.(${idList})`)
+      .eq('state', 'new');
+    if (matches.error) return false;
+    return (matches.count ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchNextUnlearnedTopic(supabase: SupabaseClient, userId: string): Promise<JourneyTopicInput | null> {
+  try {
+    const state = await supabase
+      .from('user_guided_journey_state')
+      .select('completed_topic_ids, current_session')
+      .eq('user_id', userId)
+      .maybeSingle();
+    const completed = new Set<string>((state.data?.completed_topic_ids as string[] | null | undefined) ?? []);
+    const fromSession = Math.max(1, Number(state.data?.current_session ?? 1) || 1);
+
+    const topics = await supabase
+      .from('journey_checklist_topics')
+      .select('topic_id, title, display_label, short_description, vitana_voice_script, manual_path, session, position')
+      .eq('status', 'published')
+      .eq('enabled', true)
+      .gte('session', fromSession)
+      .order('session', { ascending: true })
+      .order('position', { ascending: true })
+      .limit(50);
+    if (topics.error || !topics.data) return null;
+
+    type Row = {
+      topic_id: string;
+      title: string | null;
+      display_label: string | null;
+      short_description: string | null;
+      vitana_voice_script: string | null;
+      manual_path: string | null;
+      session: number;
+    };
+    const next = (topics.data as Row[]).find((r) => !completed.has(r.topic_id));
+    if (!next) return null;
+    const name = (next.title || next.display_label || '').trim();
+    if (!name) return null;
+    return {
+      topic_id: next.topic_id,
+      name,
+      voice_script: next.vitana_voice_script,
+      short_description: next.short_description,
+      route: next.manual_path,
+      session: next.session,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchSongAvailable(supabase: SupabaseClient): Promise<boolean> {
+  try {
+    const res = await supabase
+      .from('media_uploads')
+      .select('id', { count: 'exact', head: true })
+      .eq('media_type', 'music')
+      .eq('status', 'approved')
+      .eq('is_public', true);
+    if (res.error) return false;
+    return (res.count ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}

--- a/services/gateway/src/services/guide/conversation-flow-v3.ts
+++ b/services/gateway/src/services/guide/conversation-flow-v3.ts
@@ -1,0 +1,284 @@
+/**
+ * Conversation Flow v3 — the unified ORB opener decision engine.
+ *
+ * Replaces the abstract "darf ich dir kurz etwas zeigen?" Teacher invitation
+ * and the scattered opener lineages with ONE pure decision per activation.
+ *
+ * The user's contract (do NOT regress these):
+ *   - Topic offers NAME the feature up front and INTRODUCE it verbally — the
+ *     word "show" is reserved for the SECOND, visual step (offer to open the
+ *     screen) which only comes AFTER the verbal introduction.
+ *   - One topic at a time, always a polite permission ask ("darf ich…?").
+ *   - A new community MATCH outranks teaching and navigates RIGHT AWAY
+ *     (no permission gate) — "Hey Mariia, du hast ein neues Match…".
+ *   - A "play you a song" delight offer: permission-gated, then redirect to
+ *     the Media Hub and autoplay a RANDOM approved track.
+ *   - Teaching content + wording come from the Guided Journey (94 sessions /
+ *     254 topics); only topics NOT yet green-checked are eligible.
+ *
+ * This module is PURE (no DB, no IO) so the decision table is unit-testable.
+ * A thin fetcher supplies the inputs; the renderer turns the decision into a
+ * prompt block + an armed pending action the live session can fire
+ * deterministically on the user's "yes".
+ *
+ * Spec: docs/SPEC-journey-conversation-v2.md (extended) + this file's contract.
+ */
+
+export type FlowFocusKind =
+  | 'community_match'   // top priority, immediate redirect, NOT permission-gated
+  | 'journey_topic'     // name → introduce verbally → offer to open the screen
+  | 'song'              // permission-gated → redirect to Media Hub + autoplay
+  | 'greeting'          // nothing to surface — light greeting / pause
+  | 'defer_to_urgent';  // an urgent reminder/calendar item pre-empts everything
+
+/** A journey topic already filtered to "not yet green-checked" (un-learned). */
+export interface JourneyTopicInput {
+  topic_id: string;
+  /** Human name of the feature/topic, e.g. "Life Compass". */
+  name: string;
+  /** Verbal introduction wording, sourced from the topic content. */
+  voice_script: string | null;
+  /** Short fallback explanation when voice_script is empty. */
+  short_description: string | null;
+  /** The mobile route/overlay this topic opens, e.g. "/memory?open=life_compass". */
+  route: string | null;
+  session: number;
+}
+
+export interface FlowInputs {
+  /** An urgent, time-sensitive reminder/calendar item exists — pre-empts all. */
+  has_urgent: boolean;
+  /** A new, unseen community match. firstName drives "Hey {name}". */
+  new_match: { first_name: string | null } | null;
+  /** Next un-learned Guided Journey topic, or null when all green / none. */
+  next_topic: JourneyTopicInput | null;
+  /** At least one approved track exists in the Media Hub music list. */
+  song_available: boolean;
+  /** Pace/dedupe: nudge_keys already surfaced recently (skip them). */
+  recently_surfaced: Set<string>;
+  /** YYYY-MM-DD for date-stamped, once-per-day nudge keys. */
+  date_key: string;
+}
+
+/** The route + behavior the live session arms and fires on the user's "yes". */
+export interface PendingVisualAction {
+  route: string;
+  /** Fire WITHOUT a permission turn (matches) vs. only after an explicit yes. */
+  immediate: boolean;
+  /** Media Hub autoplay marker — already encoded in the route, surfaced for logs. */
+  autoplay_random?: boolean;
+}
+
+export interface FlowFocus {
+  kind: FlowFocusKind;
+  nudge_key: string;
+  /** The feature/topic/subject name to speak. Empty for greeting/urgent. */
+  name: string;
+  /** Verbal-introduction script (journey topic only). */
+  verbal_script?: string;
+  /** Reason for the LLM (not spoken verbatim). */
+  reason: string;
+  /** The deterministic navigation to fire on consent (null for greeting/urgent). */
+  pending_action: PendingVisualAction | null;
+}
+
+/**
+ * Pick the single conversation focus for this activation.
+ *
+ * Priority (highest first):
+ *   0. urgent reminder/calendar → defer (engine does not override safety/time)
+ *   1. new community match       → immediate redirect
+ *   2. next un-learned topic     → name + introduce + offer to open
+ *   3. song offer                → permission → redirect + autoplay
+ *   4. greeting                  → nothing to surface
+ */
+export function pickFlowFocus(inputs: FlowInputs): FlowFocus {
+  if (inputs.has_urgent) {
+    return {
+      kind: 'defer_to_urgent',
+      nudge_key: 'urgent',
+      name: '',
+      reason: 'an urgent time-sensitive reminder/calendar item pre-empts the opener',
+      pending_action: null,
+    };
+  }
+
+  // 1. New community match — top priority, immediate redirect, no permission ask.
+  if (inputs.new_match) {
+    const key = `match:${inputs.date_key}`;
+    if (!inputs.recently_surfaced.has(key)) {
+      return {
+        kind: 'community_match',
+        nudge_key: key,
+        name: (inputs.new_match.first_name || '').trim(),
+        reason:
+          'a new community match — lead by name and redirect to the matches screen immediately (no permission ask)',
+        pending_action: { route: '/me/matches', immediate: true },
+      };
+    }
+  }
+
+  // 2. Next un-learned Guided Journey topic — name it, introduce verbally,
+  //    THEN offer to open the screen.
+  if (inputs.next_topic) {
+    const t = inputs.next_topic;
+    const key = `topic:${t.topic_id}:${inputs.date_key}`;
+    if (!inputs.recently_surfaced.has(key) && t.name.trim().length > 0) {
+      const script = (t.voice_script || t.short_description || '').trim();
+      return {
+        kind: 'journey_topic',
+        nudge_key: key,
+        name: t.name.trim(),
+        verbal_script: script,
+        reason: `next un-learned Guided Journey topic (session ${t.session}) — name it, introduce it verbally, then offer to open its screen`,
+        // Route may be null when the topic has no screen mapping yet; the
+        // renderer omits the "open screen" offer in that case.
+        pending_action: t.route
+          ? { route: t.route, immediate: false }
+          : null,
+      };
+    }
+  }
+
+  // 3. Song delight offer — permission-gated, then redirect + autoplay random.
+  if (inputs.song_available) {
+    const key = `song:${inputs.date_key}`;
+    if (!inputs.recently_surfaced.has(key)) {
+      return {
+        kind: 'song',
+        nudge_key: key,
+        name: '',
+        reason:
+          'offer to play a song; on consent, redirect to the Media Hub music tab and autoplay a random approved track',
+        pending_action: {
+          route: '/comm/media-hub?tab=music&autoplay=random',
+          immediate: false,
+          autoplay_random: true,
+        },
+      };
+    }
+  }
+
+  // 4. Nothing to surface — light greeting / pause.
+  return {
+    kind: 'greeting',
+    nudge_key: 'greeting',
+    name: '',
+    reason: 'no match, no un-learned topic, no song to offer — keep it to a light greeting',
+    pending_action: null,
+  };
+}
+
+/**
+ * Affirmative detection for the deterministic "yes → fire the pending action"
+ * path. Pure + multilingual (DE/EN/ES/SR + common variants). Conservative:
+ * only matches clear acceptances so we never navigate on an ambiguous turn.
+ *
+ * Word-set + phrase matching (Unicode-safe — ASCII \b breaks after accented
+ * letters like "sí"/"später", so we tokenize on \p{L} with the `u` flag).
+ * Negation always wins.
+ */
+const AFFIRM_WORDS = new Set([
+  'yes', 'yeah', 'yep', 'sure', 'okay', 'ok',
+  'ja', 'jawohl', 'gerne', 'gern', 'klar', 'mach', 'zeig', 'los', 'bitte',
+  'si', 'sí', 'claro', 'vale', 'dale',
+  'da', 'naravno', 'vazi', 'važi', 'hajde', 'molim',
+]);
+const AFFIRM_PHRASES = ['please do', 'go ahead', 'do it', 'show me', 'sounds good', 'na klar', 'por favor', 'adelante'];
+
+const NEG_WORDS = new Set(['no', 'nope', 'nein', 'nee', 'ne', 'skip', 'later', 'lass']);
+const NEG_PHRASES = [
+  'not now', "don't", 'dont',
+  'nicht jetzt', 'später', 'spater',
+  'ahora no', 'más tarde', 'mas tarde', 'para nada',
+  'kasnije', 'preskoči', 'preskoci',
+];
+
+export function detectAffirmative(userText: string): boolean {
+  const raw = (userText || '').toLowerCase().trim();
+  if (raw.length === 0) return false;
+  // Negation anywhere wins (e.g. "no, gerne nicht").
+  if (NEG_PHRASES.some((p) => raw.includes(p))) return false;
+  const words = raw.split(/[^\p{L}]+/u).filter(Boolean);
+  if (words.some((w) => NEG_WORDS.has(w))) return false;
+  if (AFFIRM_PHRASES.some((p) => raw.includes(p))) return true;
+  return words.some((w) => AFFIRM_WORDS.has(w));
+}
+
+/**
+ * Render the focus as a prompt block. Instructions only — the words are
+ * generated in the user's language (the caller injects the language
+ * directive). NEVER contains a sanctioned user-facing sentence to recite.
+ */
+export function renderFlowFocusBlock(focus: FlowFocus): string {
+  switch (focus.kind) {
+    case 'defer_to_urgent':
+      return ''; // urgent path owns turn 1; v3 stays out of the way.
+
+    case 'community_match':
+      return [
+        '=== OPENER: NEW COMMUNITY MATCH (highest priority, immediate) ===',
+        `The user has a new community match.${focus.name ? ` Their first name is "${focus.name}".` : ''}`,
+        'Open warmly BY NAME and tell them you are taking them straight there —',
+        'e.g. "Hey {name}, du hast ein neues Match — ich bringe dich direkt hin."',
+        'This is NOT a permission ask. Do not ask "darf ich"; you are already taking them.',
+        `The app navigates to ${focus.pending_action?.route} immediately. Speak ONE warm sentence.`,
+        "Generate it in the user's language per the language directive. Never English for a non-English user.",
+      ].join('\n');
+
+    case 'journey_topic': {
+      const lines = [
+        '=== OPENER: INTRODUCE ONE GUIDED-JOURNEY FEATURE (named, verbal-first) ===',
+        `The feature to introduce is "${focus.name}". You MUST name it up front — never "may I show you something" abstractly.`,
+        '',
+        'STEP 1 — Ask permission to INTRODUCE it (polite, named, NOT "show"):',
+        `  e.g. "Darf ich dir ${focus.name} kurz vorstellen?" / "May I introduce you to ${focus.name}?"`,
+        '  Wait for the user to say yes.',
+        '',
+        'STEP 2 — On yes, INTRODUCE it VERBALLY (explain how it works, in speech):',
+        focus.verbal_script
+          ? `  Base your explanation on this content (paraphrase naturally, in the user's language):\n  "${truncate(focus.verbal_script, 600)}"`
+          : `  Explain in 2-3 sentences what ${focus.name} is and how it helps.`,
+        '  Do NOT open any screen yet. This step is voice-only.',
+      ];
+      if (focus.pending_action) {
+        lines.push(
+          '',
+          'STEP 3 — ONLY AFTER the verbal introduction, offer the VISUAL:',
+          `  e.g. "Möchtest du, dass ich dir den Bildschirm dazu öffne?" / "Want me to open the screen for it?"`,
+          `  On yes, the app opens ${focus.pending_action.route}.`,
+        );
+      }
+      lines.push(
+        '',
+        'Rules: ONE feature only. "show"/"open the screen" belongs to STEP 3, never STEP 1.',
+        "Generate every line in the user's language per the language directive.",
+        `On decline at any step, accept gracefully and stop (pause nudge_key="${focus.nudge_key}").`,
+      );
+      return lines.join('\n');
+    }
+
+    case 'song':
+      return [
+        '=== OPENER: OFFER TO PLAY A SONG (delight, permission-gated) ===',
+        'Offer, politely, to play the user a song —',
+        '  e.g. "Ich würde dir gern einen Song vorspielen — darf ich?" / "I would love to play you a song — may I?"',
+        `On yes, the app opens ${focus.pending_action?.route} and a random approved track starts right away.`,
+        'Speak ONE short warm line afterwards (e.g. "Ich lege gleich etwas für dich auf.").',
+        "Generate it in the user's language per the language directive.",
+        `On decline, accept gracefully (pause nudge_key="${focus.nudge_key}").`,
+      ].join('\n');
+
+    case 'greeting':
+    default:
+      return [
+        '=== OPENER: LIGHT GREETING ===',
+        'Nothing specific to surface. Greet warmly and briefly by name if known; do not invent an offer.',
+        "Generate it in the user's language per the language directive.",
+      ].join('\n');
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1).trimEnd() + '…';
+}

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -52,6 +52,18 @@ import {
   TEACHER_EXTRA_KEY,
   TEACHER_PROVIDER_KEY,
 } from './assistant-continuation/providers/teacher/feature-discovery-teacher';
+// Conversation Flow v3 (VTID-03307, SAFE rebuild): flag-gated primary turn-1
+// author for community voice — match → un-learned journey topic → song.
+// SPEAK-ONLY opener (benign offer_demo cta, NO navigation at greeting). When
+// the flag is ON it replaces the legacy Teacher (Teacher extra withheld so it
+// suppresses); when OFF it self-suppresses and the legacy ladder is unchanged.
+import { getSystemControl } from './system-controls-service';
+import {
+  makeConversationFlowV3Provider,
+  FLOW_V3_EXTRA_KEY,
+  FLOW_V3_PROVIDER_KEY,
+  FLOW_V3_FLAG,
+} from './assistant-continuation/providers/conversation-flow-v3-provider';
 // VTID-03164: new-day-return provider — fires first session of a new
 // calendar day in user's local TZ. Priority 90 so it beats Teacher (85)
 // and wake-brief (80). Suppresses cleanly when same-day repeat or when
@@ -202,6 +214,11 @@ export function ensureWakeBriefProviderRegistered(): void {
   // first-time-welcome paths.
   if (!defaultProviderRegistry.get(LOGIN_BRIEFING_PROVIDER_KEY)) {
     defaultProviderRegistry.register(makeLoginBriefingProvider());
+  }
+  // VTID-03307 (SAFE rebuild): Conversation Flow v3 at priority 88. Speak-only;
+  // self-suppresses when its flag is off, so registering always is safe.
+  if (!defaultProviderRegistry.get(FLOW_V3_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeConversationFlowV3Provider());
   }
   _registered = true;
 }
@@ -412,9 +429,24 @@ export async function decideWakeBriefForSession(
       decisionContext: args.decisionContext ?? null,
       lang: args.lang,
     };
+    // VTID-03307 (SAFE rebuild): when Conversation Flow v3 is ON it OWNS the
+    // teaching turn — forward its inputs and WITHHOLD the legacy Teacher's
+    // (Teacher → skipped:no_teacher_inputs). When OFF, the legacy ladder is
+    // unchanged. Read once here (cached); the provider re-checks defensively.
+    const flowV3On = !!(await getSystemControl(FLOW_V3_FLAG).catch(() => null))?.enabled;
+
     // VTID-03093 (Teacher PR 3): forward Teacher inputs when identity is
     // known. Anonymous sessions are skipped at the provider level.
     if (args.tenantId && args.userId) {
+      if (flowV3On) {
+        extra[FLOW_V3_EXTRA_KEY] = {
+          supabase: args.supabase,
+          tenantId: args.tenantId,
+          userId: args.userId,
+          lang: args.lang,
+          firstName: args.firstName ?? null,
+        };
+      } else {
       extra[TEACHER_EXTRA_KEY] = {
         supabase: args.supabase,
         tenantId: args.tenantId,
@@ -428,6 +460,7 @@ export async function decideWakeBriefForSession(
         // capability via per-capability dedupe).
         skipReason: greetingDecision.reason,
       };
+      } // end legacy-Teacher branch (flowV3 off)
       // VTID-03164: forward new-day-return inputs. Provider suppresses
       // unless trigger conditions hold (new calendar day in user TZ AND
       // is_first_session=false AND timezone present), so passing the

--- a/services/gateway/test/conversation-flow-v3-provider.test.ts
+++ b/services/gateway/test/conversation-flow-v3-provider.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Conversation Flow v3 provider — SAFE rebuild tests.
+ *
+ * The critical invariants after the breakage:
+ *   - flag gate (off → suppressed)
+ *   - SPEAK-ONLY: cta is benign `offer_demo`, NEVER navigate / ask_permission
+ *     with onYesTool (that fired nav at greeting and killed the audio)
+ *   - RULE 0: lines are proposals, never "what can I do for you?"-style questions
+ *   - privacy: match never speaks a name
+ *   - selection match → topic → song → suppress
+ */
+
+const getSystemControlMock = jest.fn();
+jest.mock('../src/services/system-controls-service', () => ({
+  getSystemControl: (...a: unknown[]) => getSystemControlMock(...a),
+}));
+
+import {
+  makeConversationFlowV3Provider,
+  FLOW_V3_EXTRA_KEY,
+} from '../src/services/assistant-continuation/providers/conversation-flow-v3-provider';
+
+type TableResult = { data?: any; count?: number; error?: any };
+let tables: Record<string, TableResult>;
+function builder(result: TableResult) {
+  const res = { data: result.data ?? null, count: result.count ?? 0, error: result.error ?? null };
+  const b: any = {};
+  for (const m of ['select', 'eq', 'or', 'gte', 'order']) b[m] = jest.fn(() => b);
+  b.limit = jest.fn(() => Promise.resolve(res));
+  b.maybeSingle = jest.fn(() => Promise.resolve({ data: result.data ?? null, error: result.error ?? null }));
+  b.then = (onF: any, onR: any) => Promise.resolve(res).then(onF, onR);
+  return b;
+}
+const supabase: any = { from: (t: string) => builder(tables[t] ?? {}) };
+const ctx = (lang = 'de') => ({
+  extra: { [FLOW_V3_EXTRA_KEY]: { supabase, tenantId: 't1', userId: 'user-1', lang, firstName: 'Mariia' } },
+}) as any;
+const provider = makeConversationFlowV3Provider({ newId: () => 'x', now: () => 0 });
+
+// A passive/preference question pattern the opener must NEVER match (RULE 0).
+const PASSIVE = /(what can i (do|help)|what (do|would) you|wie kann ich dir helfen|was möchtest du|how can i help)/i;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getSystemControlMock.mockResolvedValue({ enabled: true });
+  tables = {
+    user_intents: { data: [] },
+    intent_matches: { count: 0 },
+    user_guided_journey_state: { data: { completed_topic_ids: [], current_session: 1 } },
+    journey_checklist_topics: { data: [] },
+    media_uploads: { count: 0 },
+  };
+});
+
+describe('flag gate', () => {
+  it('suppresses when flag off', async () => {
+    getSystemControlMock.mockResolvedValue({ enabled: false });
+    expect((await provider.produce(ctx())).status).toBe('suppressed');
+  });
+});
+
+describe('SAFE invariants', () => {
+  it('match: SPEAK-ONLY benign cta, no navigation, no name', async () => {
+    tables.user_intents = { data: [{ intent_id: 'i1' }] };
+    tables.intent_matches = { count: 1 };
+    const r = await provider.produce(ctx('de'));
+    expect(r.status).toBe('returned');
+    expect(r.candidate?.cta.type).toBe('offer_demo'); // NOT navigate / ask_permission
+    expect((r.candidate?.cta as any).onYesTool).toBeUndefined();
+    expect(r.candidate?.userFacingLine).not.toContain('Mariia'); // privacy
+    expect(r.candidate?.userFacingLine).not.toMatch(PASSIVE); // RULE 0
+  });
+
+  it('topic: NAMED introduce, benign cta, RULE-0 compliant', async () => {
+    tables.journey_checklist_topics = {
+      data: [{ topic_id: 't1', title: 'Life Compass', display_label: null, short_description: null, vitana_voice_script: 's', manual_path: '/x', session: 1 }],
+    };
+    const r = await provider.produce(ctx('de'));
+    expect(r.candidate?.userFacingLine).toContain('Life Compass');
+    expect(r.candidate?.userFacingLine).toMatch(/vorstellen/i);
+    expect(r.candidate?.cta.type).toBe('offer_demo');
+    expect(r.candidate?.userFacingLine).not.toMatch(PASSIVE);
+  });
+
+  it('song: benign cta, RULE-0 compliant', async () => {
+    tables.media_uploads = { count: 3 };
+    const r = await provider.produce(ctx('de'));
+    expect(r.candidate?.userFacingLine).toMatch(/Song/i);
+    expect(r.candidate?.cta.type).toBe('offer_demo');
+    expect(r.candidate?.userFacingLine).not.toMatch(PASSIVE);
+  });
+
+  it('NO candidate ever carries a navigate/ask_permission cta (audio-kill guard)', async () => {
+    // exercise all three focuses + greeting; none may use a nav-firing cta
+    const scenarios: Array<() => void> = [
+      () => { tables.user_intents = { data: [{ intent_id: 'i' }] }; tables.intent_matches = { count: 1 }; },
+      () => { tables.journey_checklist_topics = { data: [{ topic_id: 't', title: 'X', display_label: null, short_description: null, vitana_voice_script: null, manual_path: '/x', session: 1 }] }; },
+      () => { tables.media_uploads = { count: 1 }; },
+    ];
+    for (const setup of scenarios) {
+      jest.clearAllMocks();
+      getSystemControlMock.mockResolvedValue({ enabled: true });
+      tables = {
+        user_intents: { data: [] }, intent_matches: { count: 0 },
+        user_guided_journey_state: { data: { completed_topic_ids: [], current_session: 1 } },
+        journey_checklist_topics: { data: [] }, media_uploads: { count: 0 },
+      };
+      setup();
+      const r = await provider.produce(ctx('en'));
+      expect(['offer_demo', 'noop']).toContain(r.candidate?.cta.type);
+    }
+  });
+
+  it('match outranks topic and song', async () => {
+    tables.user_intents = { data: [{ intent_id: 'i1' }] };
+    tables.intent_matches = { count: 1 };
+    tables.journey_checklist_topics = { data: [{ topic_id: 't1', title: 'X', display_label: null, short_description: null, vitana_voice_script: null, manual_path: '/x', session: 1 }] };
+    tables.media_uploads = { count: 3 };
+    expect((await provider.produce(ctx())).candidate?.kind).toBe('match_journey_next_move');
+  });
+
+  it('suppresses when nothing to surface', async () => {
+    expect((await provider.produce(ctx())).status).toBe('suppressed');
+  });
+});

--- a/services/gateway/test/conversation-flow-v3.test.ts
+++ b/services/gateway/test/conversation-flow-v3.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Conversation Flow v3 — decision engine tests.
+ *
+ * Locks the user's contract:
+ *   - match > topic > song > greeting; urgent pre-empts all
+ *   - match is immediate (no permission), topic/song are permission-gated
+ *   - topic block NAMES the feature, introduces VERBALLY first, "show/open
+ *     screen" only as a later step
+ *   - song routes to Media Hub music with autoplay=random
+ *   - affirmative/negative detection (multilingual, negation wins)
+ */
+
+import {
+  pickFlowFocus,
+  renderFlowFocusBlock,
+  detectAffirmative,
+  type FlowInputs,
+  type JourneyTopicInput,
+} from '../src/services/guide/conversation-flow-v3';
+
+function inputs(overrides: Partial<FlowInputs> = {}): FlowInputs {
+  return {
+    has_urgent: false,
+    new_match: null,
+    next_topic: null,
+    song_available: false,
+    recently_surfaced: new Set<string>(),
+    date_key: '2026-06-17',
+    ...overrides,
+  };
+}
+
+const topic = (o: Partial<JourneyTopicInput> = {}): JourneyTopicInput => ({
+  topic_id: 't-life-compass',
+  name: 'Life Compass',
+  voice_script: 'Der Life Compass hilft dir, deine wichtigsten Ziele festzulegen.',
+  short_description: null,
+  route: '/memory?open=life_compass',
+  session: 3,
+  ...o,
+});
+
+describe('pickFlowFocus — priority order', () => {
+  it('urgent pre-empts everything', () => {
+    const f = pickFlowFocus(
+      inputs({ has_urgent: true, new_match: { first_name: 'Mariia' }, next_topic: topic(), song_available: true }),
+    );
+    expect(f.kind).toBe('defer_to_urgent');
+    expect(f.pending_action).toBeNull();
+  });
+
+  it('new match outranks topic and song, and is immediate', () => {
+    const f = pickFlowFocus(
+      inputs({ new_match: { first_name: 'Mariia' }, next_topic: topic(), song_available: true }),
+    );
+    expect(f.kind).toBe('community_match');
+    expect(f.name).toBe('Mariia');
+    expect(f.pending_action).toEqual({ route: '/me/matches', immediate: true });
+  });
+
+  it('un-learned topic outranks song when no match', () => {
+    const f = pickFlowFocus(inputs({ next_topic: topic(), song_available: true }));
+    expect(f.kind).toBe('journey_topic');
+    expect(f.name).toBe('Life Compass');
+    expect(f.pending_action).toEqual({ route: '/memory?open=life_compass', immediate: false });
+  });
+
+  it('song offer when no match and no un-learned topic', () => {
+    const f = pickFlowFocus(inputs({ song_available: true }));
+    expect(f.kind).toBe('song');
+    expect(f.pending_action).toEqual({
+      route: '/comm/media-hub?tab=music&autoplay=random',
+      immediate: false,
+      autoplay_random: true,
+    });
+  });
+
+  it('falls back to greeting when nothing to surface', () => {
+    expect(pickFlowFocus(inputs()).kind).toBe('greeting');
+  });
+
+  it('topic with no route still introduces (no open-screen step)', () => {
+    const f = pickFlowFocus(inputs({ next_topic: topic({ route: null }) }));
+    expect(f.kind).toBe('journey_topic');
+    expect(f.pending_action).toBeNull();
+  });
+});
+
+describe('pickFlowFocus — dedupe', () => {
+  it('skips a match already surfaced today and falls to the topic', () => {
+    const f = pickFlowFocus(
+      inputs({
+        new_match: { first_name: 'Mariia' },
+        next_topic: topic(),
+        recently_surfaced: new Set(['match:2026-06-17']),
+      }),
+    );
+    expect(f.kind).toBe('journey_topic');
+  });
+
+  it('skips a topic already surfaced today and falls to the song', () => {
+    const f = pickFlowFocus(
+      inputs({
+        next_topic: topic(),
+        song_available: true,
+        recently_surfaced: new Set(['topic:t-life-compass:2026-06-17']),
+      }),
+    );
+    expect(f.kind).toBe('song');
+  });
+});
+
+describe('renderFlowFocusBlock', () => {
+  it('match block: names the user, immediate, no permission ask', () => {
+    const block = renderFlowFocusBlock(
+      pickFlowFocus(inputs({ new_match: { first_name: 'Mariia' } })),
+    );
+    expect(block).toMatch(/NEW COMMUNITY MATCH/);
+    expect(block).toContain('"Mariia"');
+    expect(block).toMatch(/NOT a permission ask/);
+    expect(block).toContain('/me/matches');
+  });
+
+  it('topic block: NAMES the feature, verbal-first, "show/open" only as step 3', () => {
+    const block = renderFlowFocusBlock(pickFlowFocus(inputs({ next_topic: topic() })));
+    expect(block).toContain('Life Compass');
+    expect(block).toMatch(/Ask permission to INTRODUCE/);
+    expect(block).toMatch(/INTRODUCE it VERBALLY/);
+    // "open the screen" must be step 3, after the verbal intro
+    const step2 = block.indexOf('STEP 2');
+    const step3 = block.indexOf('STEP 3');
+    expect(step2).toBeGreaterThan(-1);
+    expect(step3).toBeGreaterThan(step2);
+    expect(block).toContain('/memory?open=life_compass');
+    // explicitly forbids the old abstract "may I show you something" form
+    expect(block).toMatch(/never .*abstractly/i);
+  });
+
+  it('topic block carries the verbal script content', () => {
+    const block = renderFlowFocusBlock(pickFlowFocus(inputs({ next_topic: topic() })));
+    expect(block).toContain('Der Life Compass hilft dir');
+  });
+
+  it('song block: permission-gated, routes to media hub autoplay', () => {
+    const block = renderFlowFocusBlock(pickFlowFocus(inputs({ song_available: true })));
+    expect(block).toMatch(/OFFER TO PLAY A SONG/);
+    expect(block).toMatch(/darf ich/i);
+    expect(block).toContain('/comm/media-hub?tab=music&autoplay=random');
+  });
+
+  it('every spoken block enforces the language directive', () => {
+    for (const f of [
+      pickFlowFocus(inputs({ new_match: { first_name: 'X' } })),
+      pickFlowFocus(inputs({ next_topic: topic() })),
+      pickFlowFocus(inputs({ song_available: true })),
+      pickFlowFocus(inputs()),
+    ]) {
+      expect(renderFlowFocusBlock(f)).toMatch(/language directive/);
+    }
+  });
+});
+
+describe('detectAffirmative', () => {
+  it('accepts clear yes in multiple languages', () => {
+    for (const t of ['Yes', 'yes please', 'Ja', 'gerne', 'klar', 'sí', 'claro', 'da, naravno', 'go ahead', 'show me']) {
+      expect(detectAffirmative(t)).toBe(true);
+    }
+  });
+
+  it('rejects negatives and negation-wins', () => {
+    for (const t of ['no', 'nein', 'not now', 'später', 'no, gerne nicht', 'nein danke']) {
+      expect(detectAffirmative(t)).toBe(false);
+    }
+  });
+
+  it('rejects empty / ambiguous turns', () => {
+    expect(detectAffirmative('')).toBe(false);
+    expect(detectAffirmative('hmm what is that')).toBe(false);
+  });
+});

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -46,12 +46,19 @@ GENERAL BEHAVIOR:
 - Keep responses concise for voice interaction (2-3 sentences max)
 - Use natural conversational tone
 
-PROACTIVE LEADERSHIP (CRITICAL — VTID-03256 — the user is new and does not know the system yet):
-- You LEAD. In the first weeks a user cannot tell you what they "would like" — they don't yet know what exists. So NEVER ask their preference. Do NOT say "What would you like to do?", "Would you like to see…?", "Do you want me to…?", "What can I help you with?", "What's on your mind?", or any open "what do you want" question.
-- Instead, name ONE concrete next move and offer to take it FOR them. Ask permission to LEAD, never preference:
+PROACTIVE LEADERSHIP — RULE 0 (ABSOLUTE, EVERY TURN, NO EXCEPTIONS, ALL TENURES):
+- You ALWAYS lead. You NEVER ask the user to choose, decide, or supply the direction — not at the opener, and NOT after any step. If the user knows what they want, they say it unprompted; your job is to PROPOSE the concrete next step yourself, every single time. This holds for brand-new AND long-time users alike.
+- BANNED — never say any of these, or ANY paraphrase, in ANY language, at ANY point in the conversation (opener or follow-up):
+  • "What can I do for you?" / "How can I help?" / "What's on your mind?"
+  • "What would you like to do / see / look at / explore (next)?"
+  • "Would you like to see…?" / "Do you want me to…?"
+  • German: "Wie kann ich dir helfen?", "Was möchtest du?", "Was möchtest du (dir) (als Nächstes) ansehen / anschauen?", "Was willst du als Nächstes machen?", "Womit kann ich dir helfen?"
+  • ANY open question that hands the user the job of deciding what happens next.
+- INSTEAD, always name ONE concrete next move and offer to take it FOR them — a proposal, never a preference question:
   • "I'd like to show you…" / "Let me show you…" / "Let me introduce you to…"
   • "I'm going to set this up for you now." / "Let's do this next — I'll guide you through it."
-  • "May I show you your next step?" — permission to lead is fine; asking preference is not.
+  • "May I show you your next step?" — asking permission to LEAD is fine; asking the user's preference is NOT.
+- This applies to the FIRST utterance AND every follow-up. After you finish a step, PROPOSE the next concrete step — never end a turn on "what would you like next?" / "was möchtest du als Nächstes?".
 - One move at a time. Never present a menu of options. You take the user by the hand and walk them to the next step.
 
 GREETING RULES (CRITICAL):
@@ -275,12 +282,19 @@ GENERAL BEHAVIOR:
 - Keep responses concise for voice interaction (2-3 sentences max)
 - Use natural conversational tone
 
-PROACTIVE LEADERSHIP (CRITICAL — VTID-03256 — the user is new and does not know the system yet):
-- You LEAD. In the first weeks a user cannot tell you what they "would like" — they don't yet know what exists. So NEVER ask their preference. Do NOT say "What would you like to do?", "Would you like to see…?", "Do you want me to…?", "What can I help you with?", "What's on your mind?", or any open "what do you want" question.
-- Instead, name ONE concrete next move and offer to take it FOR them. Ask permission to LEAD, never preference:
+PROACTIVE LEADERSHIP — RULE 0 (ABSOLUTE, EVERY TURN, NO EXCEPTIONS, ALL TENURES):
+- You ALWAYS lead. You NEVER ask the user to choose, decide, or supply the direction — not at the opener, and NOT after any step. If the user knows what they want, they say it unprompted; your job is to PROPOSE the concrete next step yourself, every single time. This holds for brand-new AND long-time users alike.
+- BANNED — never say any of these, or ANY paraphrase, in ANY language, at ANY point in the conversation (opener or follow-up):
+  • "What can I do for you?" / "How can I help?" / "What's on your mind?"
+  • "What would you like to do / see / look at / explore (next)?"
+  • "Would you like to see…?" / "Do you want me to…?"
+  • German: "Wie kann ich dir helfen?", "Was möchtest du?", "Was möchtest du (dir) (als Nächstes) ansehen / anschauen?", "Was willst du als Nächstes machen?", "Womit kann ich dir helfen?"
+  • ANY open question that hands the user the job of deciding what happens next.
+- INSTEAD, always name ONE concrete next move and offer to take it FOR them — a proposal, never a preference question:
   • "I'd like to show you…" / "Let me show you…" / "Let me introduce you to…"
   • "I'm going to set this up for you now." / "Let's do this next — I'll guide you through it."
-  • "May I show you your next step?" — permission to lead is fine; asking preference is not.
+  • "May I show you your next step?" — asking permission to LEAD is fine; asking the user's preference is NOT.
+- This applies to the FIRST utterance AND every follow-up. After you finish a step, PROPOSE the next concrete step — never end a turn on "what would you like next?" / "was möchtest du als Nächstes?".
 - One move at a time. Never present a menu of options. You take the user by the hand and walk them to the next step.
 
 GREETING RULES (CRITICAL):
@@ -1550,12 +1564,19 @@ GENERAL BEHAVIOR:
 - Keep responses concise for voice interaction (2-3 sentences max)
 - Use natural conversational tone
 
-PROACTIVE LEADERSHIP (CRITICAL — VTID-03256 — the user is new and does not know the system yet):
-- You LEAD. In the first weeks a user cannot tell you what they "would like" — they don't yet know what exists. So NEVER ask their preference. Do NOT say "What would you like to do?", "Would you like to see…?", "Do you want me to…?", "What can I help you with?", "What's on your mind?", or any open "what do you want" question.
-- Instead, name ONE concrete next move and offer to take it FOR them. Ask permission to LEAD, never preference:
+PROACTIVE LEADERSHIP — RULE 0 (ABSOLUTE, EVERY TURN, NO EXCEPTIONS, ALL TENURES):
+- You ALWAYS lead. You NEVER ask the user to choose, decide, or supply the direction — not at the opener, and NOT after any step. If the user knows what they want, they say it unprompted; your job is to PROPOSE the concrete next step yourself, every single time. This holds for brand-new AND long-time users alike.
+- BANNED — never say any of these, or ANY paraphrase, in ANY language, at ANY point in the conversation (opener or follow-up):
+  • "What can I do for you?" / "How can I help?" / "What's on your mind?"
+  • "What would you like to do / see / look at / explore (next)?"
+  • "Would you like to see…?" / "Do you want me to…?"
+  • German: "Wie kann ich dir helfen?", "Was möchtest du?", "Was möchtest du (dir) (als Nächstes) ansehen / anschauen?", "Was willst du als Nächstes machen?", "Womit kann ich dir helfen?"
+  • ANY open question that hands the user the job of deciding what happens next.
+- INSTEAD, always name ONE concrete next move and offer to take it FOR them — a proposal, never a preference question:
   • "I'd like to show you…" / "Let me show you…" / "Let me introduce you to…"
   • "I'm going to set this up for you now." / "Let's do this next — I'll guide you through it."
-  • "May I show you your next step?" — permission to lead is fine; asking preference is not.
+  • "May I show you your next step?" — asking permission to LEAD is fine; asking the user's preference is NOT.
+- This applies to the FIRST utterance AND every follow-up. After you finish a step, PROPOSE the next concrete step — never end a turn on "what would you like next?" / "was möchtest du als Nächstes?".
 - One move at a time. Never present a menu of options. You take the user by the hand and walk them to the next step.
 
 GREETING RULES (CRITICAL):


### PR DESCRIPTION
## RULE 0 fix — ban passive "what would you like next?" openers

During staging voice testing, Vitana asked *"was möchtest du dir als nächstes ansehen?"* — a passive preference question, which is the **#1 forbidden behavior** (Vitana must always lead and propose, never ask the user to pick the direction).

**Root cause:** the `PROACTIVE LEADERSHIP` block in `live-system-instruction.ts` already forbade passive openers, but (1) it was framed as *"in the first weeks a user cannot tell you…"* — tenure-scoped, so the model treated it as optional for established users, and (2) it enumerated specific phrases but **not** the *"what would you like to look at next"* / German *"was möchtest du … ansehen"* framing the model used.

**Fix (prompt-text only — no control-flow / audio / navigation change):** rewrote it as an **ABSOLUTE, every-turn, all-tenures RULE 0** that categorically bans any open "what do you want / would you like to see / look at / do next" question (EN + DE, including the exact failure phrase), and requires Vitana to always **propose the concrete next step itself** — at the opener AND after every step.

This is global (not flag-gated) — RULE 0 applies to all sessions.

### Verification
- `tsc --noEmit` clean, full `npm run build` clean
- **686 orb/live tests green**; 3 intentional characterization snapshots updated to the new wording
- Confirmed the offending phrase exists nowhere in code (LLM-improvised), so the fix belongs in the system instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_