### PR TITLE
feat(orb): advice #2 — visible-momentum progress beat

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/login-briefing.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/login-briefing.ts
@@ -129,6 +129,14 @@ export interface BriefingFacts {
    * matters ("because 'more energy' matters to you …"). Null when unset.
    */
   primaryGoalLabel?: string | null;
+  /**
+   * Advice #2 — visible momentum. How many curriculum topics the user has
+   * green-checked and the total in the published journey. Drives the
+   * "X of N topics in green — that's P% of your journey" progress beat.
+   * Optional → degrades to "no beat" when unknown.
+   */
+  topicsLearned?: number | null;
+  topicsTotal?: number | null;
 }
 
 /** Pick the state purely from the gathered facts. Exported for tests. */
@@ -222,6 +230,28 @@ export function buildWeaknessRider(lang: string, f: BriefingFacts): string {
     : `I noticed your ${pillar} dropped ${d} points this week.${why} Let's turn it around together — I'll show you the first step.`;
 }
 
+/**
+ * Advice #2 — the "visible momentum" progress beat. Turns the flat topic
+ * checklist into a felt sense of progress: "X of N topics in green — that's P%
+ * of your journey", with a special celebration at 100%. Earned-only (empty when
+ * nothing is learned yet) and RULE 0 safe (a statement, never a question).
+ */
+export function buildProgressBeat(lang: string, f: BriefingFacts): string {
+  const learned = f.topicsLearned ?? 0;
+  const total = f.topicsTotal ?? 0;
+  if (learned <= 0 || total <= 0) return '';
+  const de = lang === 'de';
+  if (learned >= total) {
+    return de
+      ? `Und das Größte: du hast alle ${total} Themen gemeistert — das schaffen die wenigsten.`
+      : `And the big one: you've mastered all ${total} topics — almost no one gets there.`;
+  }
+  const pct = Math.max(1, Math.round((learned / total) * 100));
+  return de
+    ? `Auf deiner Lernkarte stehen schon ${learned} von ${total} Themen auf grün — das sind ${pct}% deiner Reise.`
+    : `Your learning map already shows ${learned} of ${total} topics in green — that's ${pct}% of your journey.`;
+}
+
 interface RenderArgs {
   lang: string;
   salutation: SalutationKind;
@@ -279,8 +309,11 @@ export function renderBriefingLine(args: RenderArgs, rng: () => number = Math.ra
       // the single next move — keep the briefing to ONE clear lead.
       const rider = buildWeaknessRider(args.lang, f);
       if (rider) return [prefix, praise, rider].filter(Boolean).join(' ');
+      // Advice #2: visible momentum — show how far through the curriculum the
+      // user is as an earned compliment, before the next-session lead.
+      const beat = buildProgressBeat(args.lang, f);
       const nudge = buildNudge(args.lang, f);
-      return [prefix, praise, nextClause, nudge, lead].filter(Boolean).join(' ');
+      return [prefix, praise, beat, nextClause, nudge, lead].filter(Boolean).join(' ');
     }
 
     case 'momentum': {
@@ -288,8 +321,9 @@ export function renderBriefingLine(args: RenderArgs, rng: () => number = Math.ra
       const praise = de
         ? `Schön, dich zu hören. Du bist bei Session ${f.nextSessionNumber} — und dein Vitana Index ist diese Woche um ${delta} Punkte gestiegen. Das ist echte Konstanz.`
         : `Good to hear you. You are on Session ${f.nextSessionNumber} — and your Vitana Index is up ${delta} points this week. That is real consistency.`;
+      const beat = buildProgressBeat(args.lang, f); // Advice #2
       const nudge = buildNudge(args.lang, f);
-      return [prefix, praise, nextClause, nudge, lead].filter(Boolean).join(' ');
+      return [prefix, praise, beat, nextClause, nudge, lead].filter(Boolean).join(' ');
     }
 
     case 'returning': {
@@ -313,10 +347,11 @@ export function renderBriefingLine(args: RenderArgs, rng: () => number = Math.ra
           : de
             ? 'Du hast deine Onboarding-Journey gemeistert. Jetzt geht es um Tiefe.'
             : 'You have mastered your onboarding journey. Now it is about depth.';
+      const beat = buildProgressBeat(args.lang, f); // Advice #2
       const lead2 = de
         ? 'Lass uns gleich eine Stufe tiefer gehen — ich zeige dir den ersten Schritt.'
         : "Let's go one level deeper — I'll show you the first step.";
-      return [prefix, body, lead2].filter(Boolean).join(' ');
+      return [prefix, body, beat, lead2].filter(Boolean).join(' ');
     }
   }
 }
@@ -365,24 +400,28 @@ function checklistLocale(lang: string): 'de' | 'en' {
 }
 
 /**
- * Resolve the title of the session the user is about to do (the lowest-position
- * topic whose `session` equals `nextSessionNumber`). Best-effort: returns null
- * on any failure so the briefing degrades to "your next session is ready".
+ * Resolve, from a single published-checklist read: the title of the session the
+ * user is about to do (lowest-position topic whose `session` equals
+ * `nextSessionNumber`) AND the total topic count in the curriculum (advice #2,
+ * the "N" in "X of N topics"). Best-effort: any failure degrades to nulls so the
+ * briefing still renders ("your next session is ready", no progress beat).
  */
-async function resolveNextSessionTitle(
+async function resolveCurriculumFacts(
   supabase: SupabaseClient,
   lang: string,
   nextSessionNumber: number,
-): Promise<string | null> {
+): Promise<{ title: string | null; totalTopics: number | null }> {
   try {
     const checklist = await getPublishedChecklist(supabase, 'v2', checklistLocale(lang));
     const inSession = checklist.topics
       .filter((t) => t.session === nextSessionNumber)
       .sort((a, b) => a.position - b.position);
-    const title = inSession[0]?.displayLabel;
-    return typeof title === 'string' && title.trim().length > 0 ? title.trim() : null;
+    const rawTitle = inSession[0]?.displayLabel;
+    const title = typeof rawTitle === 'string' && rawTitle.trim().length > 0 ? rawTitle.trim() : null;
+    const totalTopics = Array.isArray(checklist.topics) && checklist.topics.length > 0 ? checklist.topics.length : null;
+    return { title, totalTopics };
   } catch {
-    return null;
+    return { title: null, totalTopics: null };
   }
 }
 
@@ -454,11 +493,16 @@ export function makeLoginBriefingProvider(
         journeyState?.onboardingStatus === 'qualified' ||
         journeyState?.onboardingStatus === 'completed';
 
-      const nextSessionTitle = await resolveNextSessionTitle(
+      const { title: nextSessionTitle, totalTopics } = await resolveCurriculumFacts(
         inputs.supabase,
         inputs.lang,
         currentSession,
       );
+
+      // Advice #2 — visible momentum: count of green-checked curriculum topics.
+      const topicsLearned = Array.isArray(journeyState?.completedTopicIds)
+        ? journeyState.completedTopicIds.length
+        : 0;
 
       const trend = readIndexTrend(indexSnap);
       const indexDeltaUp = trend !== null && trend >= MATERIAL_INDEX_DELTA ? trend : null;
@@ -486,6 +530,9 @@ export function makeLoginBriefingProvider(
         // signal is absent.
         weakestPillarDrop: readWeakestPillarDrop(indexSnap),
         primaryGoalLabel,
+        // Advice #2 — visible momentum: progress through the curriculum.
+        topicsLearned,
+        topicsTotal: totalTopics,
       };
 
       const localHour = localHourInTimezone(nowDate, inputs.timezone);

--- a/services/gateway/test/orb/__snapshots__/conversation-flow.contract.test.ts.snap
+++ b/services/gateway/test/orb/__snapshots__/conversation-flow.contract.test.ts.snap
@@ -22,5 +22,7 @@ exports[`Vitana conversation-flow contract — 10 standard scenarios INVARIANT B
 #10 flow-v3/community_match (all-three→match-wins)
    → "Du hast ein neues Match! Lass es uns gemeinsam anschauen — ich führe dich gleich hin."
 #11 login-briefing/building+weakness (advice #1)
-   → "Guten Morgen, Maria. Stark — du hast schon 3 Sessions geschafft. Mir ist aufgefallen: dein Bereich Schlaf ist diese Woche um 6 Punkte gesunken. Weil dir „besser schlafen" wichtig ist, lohnt sich genau hier ein kleiner Schritt. Lass uns das gemeinsam umkehren — ich zeige dir den ersten Schritt.""
+   → "Guten Morgen, Maria. Stark — du hast schon 3 Sessions geschafft. Mir ist aufgefallen: dein Bereich Schlaf ist diese Woche um 6 Punkte gesunken. Weil dir „besser schlafen" wichtig ist, lohnt sich genau hier ein kleiner Schritt. Lass uns das gemeinsam umkehren — ich zeige dir den ersten Schritt."
+#12 login-briefing/momentum+progress (advice #2)
+   → "Guten Morgen, Maria. Schön, dich zu hören. Du bist bei Session 4 — und dein Vitana Index ist diese Woche um 12 Punkte gestiegen. Das ist echte Konstanz. Auf deiner Lernkarte stehen schon 30 von 254 Themen auf grün — das sind 12% deiner Reise. Als Nächstes käme Session 4: „Schlaf-Routine". Lass uns genau da weitermachen — ich führe dich.""
 `;

--- a/services/gateway/test/orb/conversation-flow.contract.test.ts
+++ b/services/gateway/test/orb/conversation-flow.contract.test.ts
@@ -145,6 +145,18 @@ function buildScenarios(): Scenario[] {
   );
   out.push({ n: 11, label: 'login-briefing/building+weakness (advice #1)', line: weaknessLine, spoken: true });
 
+  // #12 — advice #2: visible momentum progress beat in the momentum state.
+  const momentumLine = renderBriefingLine(
+    {
+      lang: 'de',
+      salutation: 'morning',
+      firstName: 'Maria',
+      facts: { ...BASE, indexDeltaUp: 12, daysSinceLastSession: 1, topicsLearned: 30, topicsTotal: 254 },
+    },
+    det,
+  );
+  out.push({ n: 12, label: 'login-briefing/momentum+progress (advice #2)', line: momentumLine, spoken: true });
+
   return out;
 }
 

--- a/services/gateway/test/services/assistant-continuation/providers/login-briefing.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/login-briefing.test.ts
@@ -18,6 +18,7 @@ import {
   pickBriefingState,
   renderBriefingLine,
   buildWeaknessRider,
+  buildProgressBeat,
   type BriefingFacts,
 } from '../../../../src/services/assistant-continuation/providers/login-briefing';
 
@@ -208,6 +209,55 @@ describe('buildWeaknessRider (advice #1)', () => {
     expect(pickBriefingState({ ...BASE_FACTS, indexDeltaUp: null, daysSinceLastSession: 1 })).toBe('building');
     expect(line).toContain('Schlaf ist diese Woche um 6 Punkte gesunken');
     expect(line).toContain('„besser schlafen"');
+  });
+});
+
+// Advice #2 — "visible momentum": progress beat.
+describe('buildProgressBeat (advice #2)', () => {
+  it('returns empty when nothing is learned or total is unknown', () => {
+    expect(buildProgressBeat('de', { ...BASE_FACTS })).toBe('');
+    expect(buildProgressBeat('de', { ...BASE_FACTS, topicsLearned: 0, topicsTotal: 254 })).toBe('');
+    expect(buildProgressBeat('de', { ...BASE_FACTS, topicsLearned: 12, topicsTotal: 0 })).toBe('');
+  });
+
+  it('states X of N green-checked topics + the percentage of the journey', () => {
+    const line = buildProgressBeat('de', { ...BASE_FACTS, topicsLearned: 12, topicsTotal: 254 });
+    expect(line).toContain('12 von 254');
+    expect(line).toContain('auf grün');
+    expect(line).toContain('5%'); // round(12/254*100)
+  });
+
+  it('celebrates the 100% completion case specially', () => {
+    const line = buildProgressBeat('de', { ...BASE_FACTS, topicsLearned: 254, topicsTotal: 254 });
+    expect(line).toContain('alle 254 Themen gemeistert');
+    expect(line).not.toContain('%');
+  });
+
+  it('floors the percentage at 1% so a single topic still reads as progress', () => {
+    const line = buildProgressBeat('en', { ...BASE_FACTS, topicsLearned: 1, topicsTotal: 254 });
+    expect(line).toContain('1 of 254');
+    expect(line).toContain('1%');
+  });
+
+  it('NEVER contains a passive RULE 0 question', () => {
+    const PASSIVE = /(möchtest du|willst du|what would you like|how can i help)/i;
+    for (const lang of ['de', 'en'] as const) {
+      const line = buildProgressBeat(lang, { ...BASE_FACTS, topicsLearned: 40, topicsTotal: 254 });
+      expect(line).not.toMatch(PASSIVE);
+    }
+  });
+
+  it('appears in the building state as an earned compliment', () => {
+    const line = renderBriefingLine(
+      {
+        lang: 'de',
+        salutation: 'morning',
+        firstName: 'Maria',
+        facts: { ...BASE_FACTS, indexDeltaUp: null, daysSinceLastSession: 1, topicsLearned: 30, topicsTotal: 254 },
+      },
+      () => 0,
+    );
+    expect(line).toContain('30 von 254');
   });
 });
 


### PR DESCRIPTION
## Advice #2 — turn feature-learning into visible momentum

Second of the four flow-improvement items.

**Before:** the guided journey was a flat checklist; nothing told the user how far they'd come, so learning felt like a treadmill.

**After:** the briefing now carries an earned progress beat — *"Auf deiner Lernkarte stehen schon 30 von 254 Themen auf grün — das sind 12% deiner Reise."* — with a special 100% celebration.

Example (contract scenario #12, momentum state):
> "Guten Morgen, Maria. Schön, dich zu hören. Du bist bei Session 4 — und dein Vitana Index ist diese Woche um 12 Punkte gestiegen. Das ist echte Konstanz. Auf deiner Lernkarte stehen schon 30 von 254 Themen auf grün — das sind 12% deiner Reise. Als Nächstes käme Session 4: „Schlaf-Routine". Lass uns genau da weitermachen — ich führe dich."

## Notes
- `topicsTotal` is resolved in the **same** published-checklist read that already fetches the next-session title — no extra DB round-trip.
- Earned-only and RULE 0 safe; floors at 1% so a single topic still reads as progress.
- Yields to the advice #1 weakness rider — when a pillar slipped, the problem still leads.
- **Deferred (honest scope):** the "+N this week" weekly delta and spaced-repetition reinforcement both need a per-topic completion timestamp that `user_guided_journey_state` doesn't store yet. Building those means a schema column first; not fabricated here.

## Verification
- `npm run test:flow` ✅ (added scenario #12)
- 6 new `buildProgressBeat` unit tests ✅
- `tsc --noEmit` + `npm run build` ✅

Merging to `main` auto-deploys staging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_