### PR TITLE
feat(orb): advice #3 — wire mutual activity matches to the calendar

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/next-action/sources/match-activity-plan.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/sources/match-activity-plan.ts
@@ -133,7 +133,10 @@ export async function produceMatchActivityPlan(
 
   const { priority, confidence } = bandForStage(top.stage);
   const kindLabel = renderKindLabel(top.row.kind_pairing);
-  const userFacingLine = renderLine(top.stage, kindLabel, ctx.lang);
+  // Advice #3 — a mutual match on a real-world activity is schedulable: the
+  // line proposes a time + calendar entry instead of stopping at "open chat".
+  const schedulable = top.stage === 'mutual_interest' && isSchedulableActivity(top.row.kind_pairing);
+  const userFacingLine = renderLine(top.stage, kindLabel, ctx.lang, schedulable);
 
   const candidate: ScoredCandidate = {
     source: KEY,
@@ -143,13 +146,13 @@ export async function produceMatchActivityPlan(
     reasons: [
       {
         kind: reasonKindFor(top.stage),
-        detail: `match=${top.row.match_id} kind=${top.row.kind_pairing} state=${top.row.state}`,
+        detail: `match=${top.row.match_id} kind=${top.row.kind_pairing} state=${top.row.state}${schedulable ? ' schedulable=1' : ''}`,
       },
     ],
     dedupeKey: `match_activity_plan:${top.row.match_id}:${top.stage}`,
     cta: {
       type: 'ask_permission',
-      payload: { match_id: top.row.match_id, stage: top.stage },
+      payload: { match_id: top.row.match_id, stage: top.stage, propose_schedule: schedulable },
     },
   };
   return { source: KEY, candidate };
@@ -269,39 +272,79 @@ export function renderKindLabel(kindPairing: string | null): string | null {
   return known[left] ?? null;
 }
 
+/**
+ * Activity kinds that map to a real-world meet-up worth putting on a calendar
+ * (advice #3 — make community proactive, add the real-life dimension). A
+ * mutual match on one of these is the moment to propose a TIME, not just a
+ * chat. Keyed on the left token of `kind_pairing` ("hike::hike" → "hike").
+ */
+const SCHEDULABLE_ACTIVITY_KINDS = new Set<string>([
+  'hike',
+  'run',
+  'chess',
+  'language_exchange',
+  'coffee',
+  'activity_seek',
+]);
+
+/** Whether a kind_pairing represents a schedulable real-world activity. */
+export function isSchedulableActivity(kindPairing: string | null): boolean {
+  if (!kindPairing) return false;
+  const left = String(kindPairing).split('::')[0] || '';
+  return SCHEDULABLE_ACTIVITY_KINDS.has(left);
+}
+
+/**
+ * RULE 0 (VTID-03307): every line is a PROPOSAL + lead, never a passive
+ * preference question. (This file previously shipped "Willst du entscheiden,
+ * wie es weitergeht?" / "Want to decide what's next?" — both banned.)
+ *
+ * Advice #3: when a MUTUAL match is on a schedulable real-world activity,
+ * Vitana does not stop at "open the conversation" — it offers to lock in a time
+ * and put it straight in the calendar (the LLM fires create_calendar_event on
+ * the user's yes). `schedulable` is derived from the kind via
+ * isSchedulableActivity in the producer.
+ */
 export function renderLine(
   stage: MatchStage,
   kindLabel: string | null,
   lang: string,
+  schedulable = false,
 ): string {
   const isDe = (lang || 'en').toLowerCase().startsWith('de');
   if (stage === 'pending_user_decision') {
     if (kindLabel) {
       return isDe
-        ? `Es gibt eine Antwort auf deine ${kindLabel}-Anfrage. Willst du entscheiden, wie es weitergeht?`
-        : `Someone has responded to your ${kindLabel} request. Want to decide what's next?`;
+        ? `Es gibt eine Antwort auf deine ${kindLabel}-Anfrage — lass uns gemeinsam den nächsten Schritt entscheiden. Ich führe dich hin.`
+        : `Someone has responded to your ${kindLabel} request — let's decide the next step together. I'll take you there.`;
     }
     return isDe
-      ? `Jemand hat auf deine Anfrage geantwortet. Willst du entscheiden, wie es weitergeht?`
-      : `Someone has responded to your request. Want to decide what's next?`;
+      ? `Jemand hat auf deine Anfrage geantwortet — lass uns gemeinsam den nächsten Schritt entscheiden. Ich führe dich hin.`
+      : `Someone has responded to your request — let's decide the next step together. I'll take you there.`;
   }
   if (stage === 'mutual_interest') {
+    // Advice #3 — schedulable activity → propose a time + calendar entry.
+    if (schedulable && kindLabel) {
+      return isDe
+        ? `Du hast ein gegenseitiges ${kindLabel}-Match — lass uns gleich einen Termin festmachen, ich trage ihn dir direkt in den Kalender ein.`
+        : `You have a mutual ${kindLabel} match — let's lock in a time, and I'll put it straight in your calendar.`;
+    }
     if (kindLabel) {
       return isDe
-        ? `Du hast ein neues gegenseitiges Match auf ${kindLabel}. Sollen wir das Gespräch eröffnen?`
-        : `You have a new mutual ${kindLabel} match. Want to open the conversation?`;
+        ? `Du hast ein neues gegenseitiges ${kindLabel}-Match — lass uns das Gespräch eröffnen, ich bringe dich hin.`
+        : `You have a new mutual ${kindLabel} match — let's open the conversation, I'll take you there.`;
     }
     return isDe
-      ? `Du hast ein neues gegenseitiges Match. Sollen wir das Gespräch eröffnen?`
-      : `You have a new mutual match. Want to open the conversation?`;
+      ? `Du hast ein neues gegenseitiges Match — lass uns das Gespräch eröffnen, ich bringe dich hin.`
+      : `You have a new mutual match — let's open the conversation, I'll take you there.`;
   }
   // stage === 'new'
   if (kindLabel) {
     return isDe
-      ? `Es gibt ein frisches ${kindLabel}-Match für dich. Soll ich es dir vorstellen?`
-      : `You have a fresh ${kindLabel} match. Want me to walk you through it?`;
+      ? `Es gibt ein frisches ${kindLabel}-Match für dich — lass es mich dir kurz vorstellen.`
+      : `You have a fresh ${kindLabel} match — let me walk you through it.`;
   }
   return isDe
-    ? `Es gibt ein frisches Match für dich. Soll ich es dir vorstellen?`
-    : `You have a fresh match. Want me to walk you through it?`;
+    ? `Es gibt ein frisches Match für dich — lass es mich dir kurz vorstellen.`
+    : `You have a fresh match — let me walk you through it.`;
 }

--- a/services/gateway/test/orb/__snapshots__/conversation-flow.contract.test.ts.snap
+++ b/services/gateway/test/orb/__snapshots__/conversation-flow.contract.test.ts.snap
@@ -24,5 +24,7 @@ exports[`Vitana conversation-flow contract — 10 standard scenarios INVARIANT B
 #11 login-briefing/building+weakness (advice #1)
    → "Guten Morgen, Maria. Stark — du hast schon 3 Sessions geschafft. Mir ist aufgefallen: dein Bereich Schlaf ist diese Woche um 6 Punkte gesunken. Weil dir „besser schlafen" wichtig ist, lohnt sich genau hier ein kleiner Schritt. Lass uns das gemeinsam umkehren — ich zeige dir den ersten Schritt."
 #12 login-briefing/momentum+progress (advice #2)
-   → "Guten Morgen, Maria. Schön, dich zu hören. Du bist bei Session 4 — und dein Vitana Index ist diese Woche um 12 Punkte gestiegen. Das ist echte Konstanz. Auf deiner Lernkarte stehen schon 30 von 254 Themen auf grün — das sind 12% deiner Reise. Als Nächstes käme Session 4: „Schlaf-Routine". Lass uns genau da weitermachen — ich führe dich.""
+   → "Guten Morgen, Maria. Schön, dich zu hören. Du bist bei Session 4 — und dein Vitana Index ist diese Woche um 12 Punkte gestiegen. Das ist echte Konstanz. Auf deiner Lernkarte stehen schon 30 von 254 Themen auf grün — das sind 12% deiner Reise. Als Nächstes käme Session 4: „Schlaf-Routine". Lass uns genau da weitermachen — ich führe dich."
+#13 match-activity/mutual+schedulable (advice #3)
+   → "Du hast ein gegenseitiges hike-Match — lass uns gleich einen Termin festmachen, ich trage ihn dir direkt in den Kalender ein.""
 `;

--- a/services/gateway/test/orb/conversation-flow.contract.test.ts
+++ b/services/gateway/test/orb/conversation-flow.contract.test.ts
@@ -32,6 +32,7 @@ import {
   type FlowInputs,
   type JourneyTopicInput,
 } from '../../src/services/guide/conversation-flow-v3';
+import { renderLine as renderMatchLine } from '../../src/services/assistant-continuation/providers/next-action/sources/match-activity-plan';
 import { buildLiveSystemInstruction } from '../../src/orb/live/instruction/live-system-instruction';
 
 // The passive-question gate. Any match in a SPOKEN opener = RULE 0 violation.
@@ -156,6 +157,10 @@ function buildScenarios(): Scenario[] {
     det,
   );
   out.push({ n: 12, label: 'login-briefing/momentum+progress (advice #2)', line: momentumLine, spoken: true });
+
+  // #13 — advice #3: a mutual real-world activity match proposes a time + calendar.
+  const matchScheduleLine = renderMatchLine('mutual_interest', 'hike', 'de', true);
+  out.push({ n: 13, label: 'match-activity/mutual+schedulable (advice #3)', line: matchScheduleLine, spoken: true });
 
   return out;
 }

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/match-activity-plan.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/match-activity-plan.test.ts
@@ -24,6 +24,7 @@ import {
   bandForStage,
   renderKindLabel,
   renderLine,
+  isSchedulableActivity,
 } from '../../../../../src/services/assistant-continuation/providers/next-action/sources/match-activity-plan';
 import type { MatchRow } from '../../../../../src/services/assistant-continuation/providers/next-action/sources/match-activity-plan';
 import type { NextActionSourceContext } from '../../../../../src/services/assistant-continuation/providers/next-action/types';
@@ -92,6 +93,48 @@ function ctxWith(
 // ---------------------------------------------------------------------------
 // Pure helpers
 // ---------------------------------------------------------------------------
+
+// Advice #3 — make community proactive: wire mutual activity matches to the calendar.
+describe('match → calendar scheduling (advice #3)', () => {
+  test('isSchedulableActivity recognizes real-world activity kinds only', () => {
+    expect(isSchedulableActivity('hike::hike')).toBe(true);
+    expect(isSchedulableActivity('coffee::coffee')).toBe(true);
+    expect(isSchedulableActivity('language_exchange::language_exchange')).toBe(true);
+    expect(isSchedulableActivity('partner_seek::partner_seek')).toBe(false);
+    expect(isSchedulableActivity('commercial_buy::product')).toBe(false);
+    expect(isSchedulableActivity(null)).toBe(false);
+  });
+
+  test('mutual + schedulable proposes a time AND a calendar entry', () => {
+    const en = renderLine('mutual_interest', 'hike', 'en', true);
+    const de = renderLine('mutual_interest', 'hike', 'de', true);
+    expect(en).toMatch(/lock in a time/i);
+    expect(en).toMatch(/calendar/i);
+    expect(de).toMatch(/Termin/);
+    expect(de).toMatch(/Kalender/);
+  });
+
+  test('mutual + NON-schedulable falls back to opening the conversation', () => {
+    const en = renderLine('mutual_interest', 'partner', 'en', false);
+    expect(en).toMatch(/open the conversation/i);
+    expect(en).not.toMatch(/calendar/i);
+  });
+
+  test('NO match line in any stage/lang contains a passive RULE 0 question', () => {
+    const PASSIVE = /(möchtest du|willst du|was möchtest|what would you like|want to decide|how can i help)/i;
+    const stages = ['pending_user_decision', 'mutual_interest', 'new'] as const;
+    for (const stage of stages) {
+      for (const lang of ['de', 'en'] as const) {
+        for (const kind of ['hike', 'partner', null]) {
+          for (const sched of [true, false]) {
+            const line = renderLine(stage, kind, lang, sched);
+            expect(line).not.toMatch(PASSIVE);
+          }
+        }
+      }
+    }
+  });
+});
 
 describe('match-activity-plan pure helpers', () => {
   test('renderKindLabel — known kinds get a friendly label, unknown returns null', () => {


### PR DESCRIPTION
## Advice #3 — make community proactive: wire matches to the calendar

Third of the four flow-improvement items.

**Before:** the match next-action source was passive. A mutual match only got "open the conversation", and two of its lines were actual RULE 0 violations — *"Willst du entscheiden, wie es weitergeht?"* / *"Want to decide what's next?"*.

**After:**
- `renderLine` rewritten as **proposal + lead** in every stage/language (the passive forms are gone).
- A mutual match on a **real-world activity** (hike, run, chess, language exchange, coffee, activity-seek) now proposes a **time + calendar entry** instead of stopping at chat:
  > "Du hast ein gegenseitiges hike-Match — lass uns gleich einen Termin festmachen, ich trage ihn dir direkt in den Kalender ein."

  The LLM fires the existing `create_calendar_event` tool on the user's yes; the cta carries `propose_schedule` so the intent is explicit.
- Non-schedulable mutual matches (partner-seek, commercial, …) still fall back to opening the conversation.

## Verification
- `npm run test:flow` ✅ (added scenario #13)
- 4 new scheduling/RULE-0 tests; existing 20 match-source tests still green (30 total) ✅
- `tsc --noEmit` + `npm run build` ✅

Also fixes the latent passive-question regression in this source as a side benefit.

Merging to `main` auto-deploys staging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_