### PR TITLE
DEV-COMHU-0513: remove instant wake-cue TTS (different-voice "Ich bin da")

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -702,15 +702,17 @@
     return _cfg.transport === 'ws';
   }
 
-  // ORB-FAST-START Phase 4: should the cached wake cue play on tap? localStorage
-  // 'vtorb.wakecue' wins (per-browser staging verification), else init() config.
+  // ORB-FAST-START Phase 4: should the cached wake cue play on tap?
+  // DEV-COMHU-0513: DISABLED per product decision. The instant cached "Ich bin
+  // da."/"I'm here." clip is a DIFFERENT voice from the real Live (voice-to-
+  // voice) greeting, so it lands as jarring/irritating rather than helpful — and
+  // with the fast-greeting work the real greeting now arrives in ~2s anyway, so
+  // the stop-gap cue is no longer needed. Hard-off here (ignores init({wakeCue})
+  // and any leftover localStorage 'vtorb.wakecue'='on') so it never plays on any
+  // surface. The chime (tone, not speech) is unaffected. To re-enable, restore
+  // the original flag check below.
   function _useWakeCue() {
-    try {
-      var o = window.localStorage && localStorage.getItem('vtorb.wakecue');
-      if (o === 'on') return true;
-      if (o === 'off') return false;
-    } catch (e) { /* storage blocked — fall through to config */ }
-    return _cfg.wakeCue === true;
+    return false;
   }
 
   // BOOTSTRAP-ORB-LATENCY-PHASE3: tear down the WS transport (idempotent).


### PR DESCRIPTION
## DEV-COMHU-0513 — remove the instant wake-cue TTS

The cached instant **"Ich bin da."/"I'm here."** clip (`wakeCue`, ORB-FAST-START Phase 4) plays in a **different voice** from the real Live (voice-to-voice) greeting, so it lands as jarring/irritating rather than helpful. With the fast-greeting work the real greeting now arrives in **~2s**, so this stop-gap is obsolete.

**Change:** hard-disable `_useWakeCue()` in `orb-widget.js` so the cue never plays on any surface — ignores `init({wakeCue})` and any leftover `localStorage 'vtorb.wakecue'='on'` (which is what was triggering it on the test browser). The activation **chime** (a tone, not speech) is unaffected. One-line revert restores the flag.

Auto-deploys to `gateway-staging`; `preview.vitanaland.com` picks up the widget fresh (gateway serves it `no-cache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B85fhJm5pGBLxzqt4Jva8r)_