### PR TITLE
fix(orb): repair intent classifier/extractor so "find a match" voice posts work

### DIFF
--- a/services/gateway/src/services/intent-classifier.ts
+++ b/services/gateway/src/services/intent-classifier.ts
@@ -6,17 +6,32 @@
  * to the kind-specific extractor only when confidence ≥ 0.7; below that,
  * ORB asks a clarifying question.
  *
- * Mirrors the inline-fact-extractor pattern: Vertex AI primary, Gemini API
- * fallback, temperature 0.1 for deterministic classification, low token
- * budget. JSON-mode output.
+ * BOOTSTRAP-FIND-MATCH-CLASSIFY-FIX: the original Vertex call used
+ * gemini-2.0-flash with NO responseMimeType and a system-role
+ * systemInstruction, and its only fallback was gated on
+ * GOOGLE_GEMINI_API_KEY — an env var that is NOT configured on the gateway
+ * (see index.ts). In production that combination returned confidence 0 for
+ * EVERY utterance (verified against textbook examples), so the ORB
+ * "find a match / post an activity" voice flow could never classify an
+ * intent and bailed with "I can't do that right now" before posting.
+ *
+ * This now mirrors the proven-working matchmaker call shape: JSON mode
+ * (responseMimeType), the prompt folded into the user turn (no
+ * system-role systemInstruction), a model fallback chain that ends in the
+ * known-good gemini-2.5-pro, and withGeminiLog telemetry so any future
+ * regression is visible in gemini_call_log instead of silent.
  */
 
 import { VertexAI } from '@google-cloud/vertexai';
+import { withGeminiLog } from './gemini-call-log';
 
-const GOOGLE_GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY;
+// Accept either name — CLAUDE.md documents GEMINI_API_KEY, older code used GOOGLE_GEMINI_API_KEY.
+const GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY || process.env.GEMINI_API_KEY;
 const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
 const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
-const CLASSIFY_MODEL = 'gemini-2.0-flash';
+// Fast model first; fall back to the matchmaker's proven-working Pro model if
+// the fast model throws or returns an empty candidate. Each attempt is logged.
+const CLASSIFY_MODELS = ['gemini-2.0-flash', 'gemini-2.5-pro'];
 
 let vertexAI: VertexAI | null = null;
 try {
@@ -83,16 +98,29 @@ Examples:
 "I teach salsa Tuesday evenings" -> {"intent_kind":"mentor_seek","confidence":0.95,"reasoning":"offering instruction"}
 "What's the weather?" -> {"intent_kind":"NONE","confidence":0.1,"reasoning":"factual question"}`;
 
-function parseClassifierResponse(raw: string): IntentClassification {
-  // Strip code fences if Gemini added them.
+/** Pull the first balanced JSON object out of a model response, tolerating fences/prose. */
+function extractJsonObject(raw: string): string {
   const cleaned = raw.trim().replace(/^```(?:json)?/i, '').replace(/```$/, '').trim();
+  if (cleaned.startsWith('{')) return cleaned;
+  const start = cleaned.indexOf('{');
+  const end = cleaned.lastIndexOf('}');
+  return start >= 0 && end > start ? cleaned.slice(start, end + 1) : cleaned;
+}
+
+/** Confidence may arrive as a number or a stringified number ("0.95"); coerce + clamp. */
+function coerceConfidence(v: unknown): number {
+  const n = typeof v === 'number' ? v : typeof v === 'string' ? parseFloat(v) : NaN;
+  return Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : 0;
+}
+
+function parseClassifierResponse(raw: string): IntentClassification {
   try {
-    const parsed = JSON.parse(cleaned);
+    const parsed = JSON.parse(extractJsonObject(raw));
     const kind = String(parsed.intent_kind || '').toLowerCase();
     const validKinds = ['commercial_buy', 'commercial_sell', 'activity_seek', 'partner_seek', 'social_seek', 'mutual_aid', 'learning_seek', 'mentor_seek'];
     return {
       intent_kind: validKinds.includes(kind) ? (kind as IntentKind) : null,
-      confidence: typeof parsed.confidence === 'number' ? Math.max(0, Math.min(1, parsed.confidence)) : 0,
+      confidence: coerceConfidence(parsed.confidence),
       reasoning: typeof parsed.reasoning === 'string' ? parsed.reasoning.slice(0, 200) : undefined,
     };
   } catch {
@@ -100,51 +128,75 @@ function parseClassifierResponse(raw: string): IntentClassification {
   }
 }
 
+/**
+ * Vertex call with JSON mode + model fallback. Returns the raw JSON text, or
+ * '' when every model failed. Each attempt is recorded in gemini_call_log
+ * (success / error / fallback) so silent breakage like the original
+ * confidence-0 bug surfaces in telemetry.
+ */
+async function runVertexClassify(userText: string): Promise<string> {
+  if (!vertexAI) return '';
+  for (let i = 0; i < CLASSIFY_MODELS.length; i++) {
+    const modelName = CLASSIFY_MODELS[i];
+    try {
+      const raw = await withGeminiLog(
+        { feature: 'classifier', model: modelName },
+        async () => {
+          const model = vertexAI!.getGenerativeModel({
+            model: modelName,
+            generationConfig: { temperature: 0.1, maxOutputTokens: 256, topP: 0.8, responseMimeType: 'application/json' },
+          });
+          const response = await model.generateContent({
+            contents: [{ role: 'user', parts: [{ text: `${CLASSIFIER_SYSTEM_PROMPT}\n\nUtterance to classify:\n${userText}` }] }],
+          });
+          const candidate = response.response?.candidates?.[0];
+          const textPart = candidate?.content?.parts?.find((p: any) => 'text' in p);
+          const text = textPart ? (textPart as any).text : '';
+          if (!text) throw new Error(`empty Vertex response (finishReason=${candidate?.finishReason ?? 'unknown'})`);
+          return text as string;
+        },
+      );
+      if (raw) {
+        if (i > 0) console.warn(`[VTID-01973] classifier fell back to ${modelName}`);
+        return raw;
+      }
+    } catch (err: any) {
+      console.warn(`[VTID-01973] Vertex classifier model ${modelName} failed: ${err?.message}`);
+      // try the next model in the chain
+    }
+  }
+  return '';
+}
+
 export async function classifyIntentKind(utterance: string): Promise<IntentClassification> {
   const trimmed = (utterance || '').trim();
   if (!trimmed) return { intent_kind: null, confidence: 0 };
 
-  // Try Vertex AI first.
-  if (vertexAI) {
-    try {
-      const model = vertexAI.getGenerativeModel({
-        model: CLASSIFY_MODEL,
-        generationConfig: { temperature: 0.1, maxOutputTokens: 200, topP: 0.8 },
-        systemInstruction: { role: 'system', parts: [{ text: CLASSIFIER_SYSTEM_PROMPT }] },
-      });
-      const response = await model.generateContent({
-        contents: [{ role: 'user', parts: [{ text: trimmed }] }],
-      });
-      const textPart = response.response?.candidates?.[0]?.content?.parts?.find((p: any) => 'text' in p);
-      const raw = textPart ? (textPart as any).text : '';
-      if (raw) {
-        const parsed = parseClassifierResponse(raw);
-        if (parsed.intent_kind || parsed.confidence > 0) return parsed;
-      }
-    } catch (err: any) {
-      console.warn(`[VTID-01973] Vertex classifier failed: ${err.message}`);
-    }
+  // Primary: Vertex AI (JSON mode + model fallback chain).
+  const raw = await runVertexClassify(trimmed);
+  if (raw) {
+    const parsed = parseClassifierResponse(raw);
+    if (parsed.intent_kind || parsed.confidence > 0) return parsed;
   }
 
-  // Gemini API fallback.
-  if (GOOGLE_GEMINI_API_KEY) {
+  // Fallback: Gemini API key (only when configured — usually not on the gateway).
+  if (GEMINI_API_KEY) {
     try {
       const response = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/${CLASSIFY_MODEL}:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+        `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            contents: [{ parts: [{ text: trimmed }] }],
-            systemInstruction: { parts: [{ text: CLASSIFIER_SYSTEM_PROMPT }] },
-            generationConfig: { temperature: 0.1, maxOutputTokens: 200 },
+            contents: [{ parts: [{ text: `${CLASSIFIER_SYSTEM_PROMPT}\n\nUtterance to classify:\n${trimmed}` }] }],
+            generationConfig: { temperature: 0.1, maxOutputTokens: 256, responseMimeType: 'application/json' },
           }),
         }
       );
       if (response.ok) {
         const data = await response.json() as any;
-        const raw = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
-        return parseClassifierResponse(raw);
+        const rawApi = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+        if (rawApi) return parseClassifierResponse(rawApi);
       }
     } catch (err: any) {
       console.warn(`[VTID-01973] Gemini API classifier failed: ${err.message}`);

--- a/services/gateway/src/services/intent-extractor.ts
+++ b/services/gateway/src/services/intent-extractor.ts
@@ -14,11 +14,18 @@
 
 import { VertexAI } from '@google-cloud/vertexai';
 import type { IntentKind } from './intent-classifier';
+import { withGeminiLog } from './gemini-call-log';
 
-const GOOGLE_GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY;
+// Accept either name — CLAUDE.md documents GEMINI_API_KEY, older code used GOOGLE_GEMINI_API_KEY.
+const GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY || process.env.GEMINI_API_KEY;
 const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
 const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
-const EXTRACT_MODEL = 'gemini-2.0-flash';
+// BOOTSTRAP-FIND-MATCH-CLASSIFY-FIX: same failure mode as the classifier — the
+// bare gemini-2.0-flash call (no JSON mode) returned empty/unparseable output on
+// the gateway and the only fallback was gated on an unset env var. Use JSON mode
+// + a model fallback chain ending in the proven-working Pro model, and log each
+// attempt so silent breakage surfaces in gemini_call_log.
+const EXTRACT_MODELS = ['gemini-2.0-flash', 'gemini-2.5-pro'];
 
 let vertexAI: VertexAI | null = null;
 try {
@@ -133,11 +140,25 @@ Set "dance" only if the topic is a dance variety; leave the whole "dance" object
 "dance" only when teaching a dance variety. price_cents=null means "free" or "not stated"; the dispatcher confirms free-vs-paid with the user.`,
 };
 
-function parseExtractorResponse(raw: string, kind: IntentKind): ExtractedIntent {
+/** Pull the first balanced JSON object out of a model response, tolerating fences/prose. */
+function extractJsonObject(raw: string): string {
   const cleaned = raw.trim().replace(/^```(?:json)?/i, '').replace(/```$/, '').trim();
+  if (cleaned.startsWith('{')) return cleaned;
+  const start = cleaned.indexOf('{');
+  const end = cleaned.lastIndexOf('}');
+  return start >= 0 && end > start ? cleaned.slice(start, end + 1) : cleaned;
+}
+
+/** Confidence may arrive as a number or a stringified number ("0.9"); coerce + clamp. */
+function coerceConfidence(v: unknown): number {
+  const n = typeof v === 'number' ? v : typeof v === 'string' ? parseFloat(v) : NaN;
+  return Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : 0;
+}
+
+function parseExtractorResponse(raw: string, kind: IntentKind): ExtractedIntent {
   let parsed: any;
   try {
-    parsed = JSON.parse(cleaned);
+    parsed = JSON.parse(extractJsonObject(raw));
   } catch {
     return {
       intent_kind: kind,
@@ -156,7 +177,7 @@ function parseExtractorResponse(raw: string, kind: IntentKind): ExtractedIntent 
     title: typeof parsed.title === 'string' && parsed.title ? parsed.title.slice(0, 140) : null,
     scope: typeof parsed.scope === 'string' && parsed.scope ? parsed.scope.slice(0, 1500) : null,
     kind_payload: typeof parsed.kind_payload === 'object' && parsed.kind_payload ? parsed.kind_payload : {},
-    confidence: typeof parsed.confidence === 'number' ? Math.max(0, Math.min(1, parsed.confidence)) : 0,
+    confidence: coerceConfidence(parsed.confidence),
     missing_critical: [],
   };
 
@@ -188,43 +209,59 @@ export async function extractIntent(utterance: string, kind: IntentKind): Promis
   }
 
   const systemPrompt = SYSTEM_PROMPT_BY_KIND[kind];
+  const prompt = `${systemPrompt}\n\nUtterance to extract from:\n${trimmed}`;
 
+  // Primary: Vertex AI with JSON mode + model fallback chain.
   if (vertexAI) {
-    try {
-      const model = vertexAI.getGenerativeModel({
-        model: EXTRACT_MODEL,
-        generationConfig: { temperature: 0.1, maxOutputTokens: 800, topP: 0.8 },
-        systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] },
-      });
-      const response = await model.generateContent({
-        contents: [{ role: 'user', parts: [{ text: trimmed }] }],
-      });
-      const textPart = response.response?.candidates?.[0]?.content?.parts?.find((p: any) => 'text' in p);
-      const raw = textPart ? (textPart as any).text : '';
-      if (raw) return parseExtractorResponse(raw, kind);
-    } catch (err: any) {
-      console.warn(`[VTID-01973] Vertex extractor failed (kind=${kind}): ${err.message}`);
+    for (let i = 0; i < EXTRACT_MODELS.length; i++) {
+      const modelName = EXTRACT_MODELS[i];
+      try {
+        const raw = await withGeminiLog(
+          { feature: 'extractor', model: modelName },
+          async () => {
+            const model = vertexAI!.getGenerativeModel({
+              model: modelName,
+              generationConfig: { temperature: 0.1, maxOutputTokens: 800, topP: 0.8, responseMimeType: 'application/json' },
+            });
+            const response = await model.generateContent({
+              contents: [{ role: 'user', parts: [{ text: prompt }] }],
+            });
+            const candidate = response.response?.candidates?.[0];
+            const textPart = candidate?.content?.parts?.find((p: any) => 'text' in p);
+            const text = textPart ? (textPart as any).text : '';
+            if (!text) throw new Error(`empty Vertex response (finishReason=${candidate?.finishReason ?? 'unknown'})`);
+            return text as string;
+          },
+        );
+        if (raw) {
+          if (i > 0) console.warn(`[VTID-01973] extractor fell back to ${modelName} (kind=${kind})`);
+          return parseExtractorResponse(raw, kind);
+        }
+      } catch (err: any) {
+        console.warn(`[VTID-01973] Vertex extractor model ${modelName} failed (kind=${kind}): ${err?.message}`);
+        // try the next model in the chain
+      }
     }
   }
 
-  if (GOOGLE_GEMINI_API_KEY) {
+  // Fallback: Gemini API key (only when configured — usually not on the gateway).
+  if (GEMINI_API_KEY) {
     try {
       const response = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/${EXTRACT_MODEL}:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+        `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            contents: [{ parts: [{ text: trimmed }] }],
-            systemInstruction: { parts: [{ text: systemPrompt }] },
-            generationConfig: { temperature: 0.1, maxOutputTokens: 800 },
+            contents: [{ parts: [{ text: prompt }] }],
+            generationConfig: { temperature: 0.1, maxOutputTokens: 800, responseMimeType: 'application/json' },
           }),
         }
       );
       if (response.ok) {
         const data = await response.json() as any;
         const raw = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
-        return parseExtractorResponse(raw, kind);
+        if (raw) return parseExtractorResponse(raw, kind);
       }
     } catch (err: any) {
       console.warn(`[VTID-01973] Gemini API extractor failed (kind=${kind}): ${err.message}`);


### PR DESCRIPTION
## Problem

When a user asks the Vitana Assistant (ORB) to *"make an activity post / find a match"* (e.g. "looking for a jogging partner in Palma Mallorca"), the assistant says it can, collects a title, then fails with **"there is a problem, I can't do that right now."**

## Root cause (verified in production)

The voice tools (`find_match` / `post_intent`) call `classifyIntentKind()` **first**. In production it returned `confidence: 0` for **every** utterance — including the classifier's own textbook examples like `"I need a kitchen contractor"`. With confidence `< 0.7` the tool bails (`CLASSIFY_LOW_CONFIDENCE`) **before** inserting the row, and Gemini apologises to the user.

The post path itself is healthy — an explicit-field `POST /api/v1/intents` for the exact jogging-partner intent returned `201 { ok: true }`.

Why the classifier failed:
- It called `gemini-2.0-flash` with **no** `responseMimeType` and a system-role `systemInstruction`.
- Its only fallback was gated on `GOOGLE_GEMINI_API_KEY` — an env var that `index.ts` itself notes is **not configured on the gateway**.
- That call shape returned empty/unparseable output → `confidence 0` → no working fallback.

By contrast the **matchmaker** calls Vertex with `responseMimeType: 'application/json'` and **succeeds** (confirmed in `gemini_call_log`: only successful rows are `matchmaker` / `gemini-2.5-pro`). The classifier/extractor weren't even logged, so the breakage was invisible.

## Fix

Align `intent-classifier.ts` and `intent-extractor.ts` with the proven matchmaker call shape:
- `responseMimeType: 'application/json'` (JSON mode) on every Vertex call.
- Prompt folded into the user turn (no system-role `systemInstruction`).
- Model fallback chain ending in the known-good `gemini-2.5-pro` when the fast model throws or returns an empty candidate.
- Wrap calls in `withGeminiLog` → outcomes now land in `gemini_call_log` (status `success`/`error` per model), so a regression like this surfaces in telemetry.
- Harden JSON parsing (tolerate fences/prose, coerce stringified confidence) and accept `GEMINI_API_KEY` as well as `GOOGLE_GEMINI_API_KEY` for the REST fallback.

This also repairs the per-kind extractor, which shared the identical broken call shape (so memory-fact / intent extraction was affected too).

## Verification

- ✅ Reproduced the bug live: utterance-only `POST /api/v1/intents` → `CLASSIFY_LOW_CONFIDENCE, classifier_confidence: 0` for jogging-partner **and** textbook examples.
- ✅ Confirmed the post insert path works with explicit fields (`201 ok:true`).
- ✅ `gemini_call_log` shows Vertex + JSON-mode succeeds for `gemini-2.5-pro`.
- ✅ `tsc --noEmit` clean for both changed files (only a pre-existing tsconfig deprecation warning remains).
- ⏳ **End-to-end prod verification pending deploy.** Per staging-first cutover, merge auto-deploys to staging only; production needs the PUBLISH button / escape-hatch. After deploy, re-run the utterance-only POST and expect a classified `201`, and verify the ORB voice flow posts the jogging-partner intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VBpMkTdZj1HZqqVQ4dHho

---
_Generated by [Claude Code](https://claude.ai/code/session_018VBpMkTdZj1HZqqVQ4dHho)_