### PR TITLE
DEV-COMHU-0513: new-day personalized greeting on the fast path

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -86,6 +86,9 @@ import {
 } from '../instruction/wake-decision-snapshot';
 // VTID-03248 (R1 slice 1): single canonical spoken-first-name resolver.
 import { resolveSpokenFirstName } from '../../../services/awareness-unified-context';
+// DEV-COMHU-0513 (new-day): gate the fast greeting-facts pre-fetch on the
+// EXISTING ORB_SAFE_FAST_GREETING feature flag (no new flag).
+import { isFeatureLive } from '../../../services/feature-flags';
 import { recordAgentHeartbeat } from '../../../routes/agents-registry';
 import {
   fetchAdminBriefingBlock,
@@ -712,6 +715,19 @@ export async function handleLiveSessionStart(
   // awaited by connectToLiveAPI's ws.on('open') handler.
   let contextReadyPromise: Promise<void> | undefined;
 
+  // DEV-COMHU-0513 (new-day): FAST greeting-facts pre-fetch. Independent of the
+  // heavy bootstrapWork above so the new-day personalized opener has a spoken
+  // first name + last-session info ready at greeting time even under fast-start
+  // (where the heavy block has NOT resolved yet). Populated only for authed,
+  // non-anon, non-guided sessions AND only when FEATURE_ORB_SAFE_FAST_GREETING
+  // is live. Resolved values are copied onto the session after it is created
+  // (the session object is constructed further below). Fail-open: any error
+  // leaves greetingFirstName null and the greeting builder falls through to the
+  // existing generic opener.
+  let greetingFirstName: string | null = null;
+  let greetingEarlyLastSessionInfo: { time: string; wasFailure: boolean } | null = null;
+  let greetingFactsReady: Promise<void> | undefined;
+
   // VTID-03294: a Guided-Journey topic tap needs ZERO context — Vitana just
   // picks up the KB lesson and speaks it. Detect it here so we can skip the
   // heavy Brain/memory/history/admin bootstrap (the 7-10s first-audio delay).
@@ -874,6 +890,70 @@ export async function handleLiveSessionStart(
       .catch((err) => {
         console.warn(`[BOOTSTRAP-ORB-CRITICAL-PATH] Context build rejected for ${sessionId}, proceeding with empty context:`, err?.message || err);
       });
+
+    // DEV-COMHU-0513 (new-day): kick off a FAST, parallel pre-fetch of the two
+    // facts the new-day personalized opener needs — the spoken first name and
+    // the last-session timestamp — so they are ready at greeting time even when
+    // the heavy bootstrapWork above has not resolved yet (fast-start). This runs
+    // independently of bootstrapWork and never blocks session start. Gated on
+    // the EXISTING FEATURE_ORB_SAFE_FAST_GREETING flag — a no-op when off, so
+    // default behavior is 100% unchanged. Fail-open: every fetch failure leaves
+    // greetingFirstName null (→ generic opener). The name-resolution mirrors the
+    // canonical block (~memory_facts.user_name → app_users.display_name → email
+    // via resolveSpokenFirstName); setting lastSessionInfo early is idempotent
+    // with the heavy block, which sets the same field later.
+    if (isFeatureLive('ORB_SAFE_FAST_GREETING')) {
+      const _ndIdentity = bootstrapIdentity;
+      greetingFactsReady = (async () => {
+        try {
+          const { getSupabase } = await import('../../../lib/supabase');
+          const supa = getSupabase() ?? undefined;
+          const [lastInfo, factResult, profileResult] = await Promise.allSettled([
+            deps.fetchLastSessionInfo(_ndIdentity.user_id),
+            supa
+              ? supa
+                  .from('memory_facts')
+                  .select('fact_value')
+                  .eq('user_id', _ndIdentity.user_id)
+                  .eq('fact_key', 'user_name')
+                  .maybeSingle()
+              : Promise.resolve(null as any),
+            supa
+              ? supa
+                  .from('app_users')
+                  .select('display_name')
+                  .eq('user_id', _ndIdentity.user_id)
+                  .maybeSingle()
+              : Promise.resolve(null as any),
+          ]);
+
+          if (lastInfo.status === 'fulfilled') {
+            greetingEarlyLastSessionInfo = lastInfo.value;
+          }
+
+          const factValue =
+            factResult.status === 'fulfilled' && factResult.value && !factResult.value.error
+              ? (factResult.value.data as { fact_value?: string | null } | null)?.fact_value ?? null
+              : null;
+          const profileValue =
+            profileResult.status === 'fulfilled' && profileResult.value && !profileResult.value.error
+              ? (profileResult.value.data as { display_name?: string | null } | null)?.display_name ?? null
+              : null;
+          const resolved = resolveSpokenFirstName({
+            memoryFactUserName: factValue,
+            displayName: profileValue,
+            email: _ndIdentity.email ?? null,
+          });
+          greetingFirstName = resolved.firstName;
+          console.log(
+            `[GREETING-FACTS-PREFETCH] session ${sessionId} resolved firstName=${greetingFirstName ? '<set>' : 'null'} lastSession=${greetingEarlyLastSessionInfo ? 'yes' : 'no'}`,
+          );
+        } catch (err: any) {
+          // Fail-open to nulls — never reject.
+          console.warn(`[GREETING-FACTS-PREFETCH] session ${sessionId} pre-fetch failed (non-fatal): ${err?.message || err}`);
+        }
+      })();
+    }
   } else {
     contextBootstrapSkippedReason = 'no_identity';
     console.log(`[VTID-01224] Skipping context bootstrap for ${sessionId}: no identity`);
@@ -966,6 +1046,27 @@ export async function handleLiveSessionStart(
 
   // Store session
   liveSessions.set(sessionId, session);
+
+  // DEV-COMHU-0513 (new-day): expose the fast greeting-facts pre-fetch on the
+  // session so the greeting builder (sendGreetingPromptToLiveAPI) can do a
+  // bounded wait for the spoken first name + last-session info under fast-start.
+  // greetingFactsReady is undefined when FEATURE_ORB_SAFE_FAST_GREETING is off
+  // (default → builder treats it as immediately ready and uses the generic
+  // opener, i.e. behavior unchanged). When it resolves, copy the resolved facts
+  // onto the session. Also seed from any value that already resolved.
+  if (greetingFactsReady) {
+    (session as any).greetingFirstName = greetingFirstName;
+    if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
+      session.lastSessionInfo = greetingEarlyLastSessionInfo;
+    }
+    (session as any).greetingFactsReady = greetingFactsReady.then(() => {
+      (session as any).greetingFirstName = greetingFirstName;
+      // Idempotent with the heavy bootstrap block, which also sets this later.
+      if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
+        session.lastSessionInfo = greetingEarlyLastSessionInfo;
+      }
+    });
+  }
 
   // VTID-03107: arm the per-minute voice meter for authenticated sessions
   // whose quota gate is in 'allow' or 'degrade' state. 'deferred' sessions

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7412,27 +7412,139 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
     );
     emitDiag(session, 'greeting_context_pending', { lang, safe_fast_greeting: _safeFastLive });
     if (_safeFastLive && ws.readyState === WebSocket.OPEN) {
-      const _menu = pickShortGapGreetings(lang, 6).map((p) => `"${p}"`).join(', ');
-      const _safePrompt =
-        `Open with EXACTLY ONE short phrase, picked from this menu and used VERBATIM ` +
-        `(already in the user's language): ${_menu}. Do NOT say "Hello" or the user's name. ` +
-        `Do NOT introduce yourself. NEVER use two-part sentences. Speak it as audio.`;
-      ws.send(
-        JSON.stringify({
-          client_content: { turns: [{ role: 'user', parts: [{ text: _safePrompt }] }], turn_complete: true },
-        }),
-      );
-      session.greetingSent = true;
-      session.greetingTurnIndex = session.turn_count;
-      _sm.markOpeningDelivered();
-      emitDiag(session, 'greeting_sent', {
-        lang,
-        prompt_len: _safePrompt.length,
-        wake_opener: 'safe_fast_pending_context',
-      });
-      startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
-      console.log(`[GREETING-SAFE-FAST] session ${session.sessionId} sent short audio-safe opener (context still pending)`);
-      return true;
+      // DEV-COMHU-0513 (new-day): when this fast-greeting fires on a genuine
+      // NEW-DAY return, speak a short personalized "Good <tod>, <Name>." instead
+      // of the generic opener — while staying fast. The greeting-facts pre-fetch
+      // (live-session-controller) resolves the spoken first name + last-session
+      // info independently of the heavy bootstrap; here we do a BOUNDED wait for
+      // it so we don't lose the speed, then check the temporal bucket. Same-day
+      // reconnects ('reconnect'|'recent'|'same_day') and missing names fall
+      // through to the EXISTING generic opener below (unchanged). This whole
+      // branch is reachable only under FEATURE_ORB_SAFE_FAST_GREETING.
+      //
+      // The bounded wait + send runs in an async IIFE so the synchronous
+      // function signature (and all its fire-and-forget call sites) stay
+      // unchanged; greetingSent is claimed synchronously to prevent a duplicate
+      // greeting while the wait is in flight.
+      {
+        const _greetingFactsReady: Promise<void> | undefined = (session as any).greetingFactsReady;
+        // Mark sent synchronously so no other path emits a second greeting while
+        // we await the bounded facts wait below.
+        session.greetingSent = true;
+        session.greetingTurnIndex = session.turn_count;
+        _sm.markOpeningDelivered();
+        void (async () => {
+          try {
+            await Promise.race([
+              _greetingFactsReady ?? Promise.resolve(),
+              new Promise<void>((r) => setTimeout(r, Number(process.env.ORB_GREETING_FACTS_WAIT_MS || 700))),
+            ]);
+            if (ws.readyState !== WebSocket.OPEN) return;
+
+            const temporal = describeTimeSince((session as any).lastSessionInfo);
+            const firstName = (session as any).greetingFirstName;
+            const isNewDay =
+              temporal.bucket === 'today' ||
+              temporal.bucket === 'yesterday' ||
+              temporal.bucket === 'week' ||
+              temporal.bucket === 'long';
+
+            if (isNewDay && typeof firstName === 'string' && firstName.trim().length > 0) {
+              const name = firstName.trim();
+              // Map time-of-day → greeting; 'night' → evening (avoid "good night"
+              // farewell), default 'day'.
+              const tod =
+                session.clientContext?.timeOfDay === 'night'
+                  ? 'evening'
+                  : session.clientContext?.timeOfDay || 'day';
+              // Localized "Good <tod>, <Name>." — en + de are real; other langs
+              // get an easy localized good-<tod> where known, else the en line.
+              const greetingByLang: Record<string, string> = {
+                en:
+                  tod === 'morning'
+                    ? `Good morning, ${name}.`
+                    : tod === 'afternoon'
+                      ? `Good afternoon, ${name}.`
+                      : tod === 'evening'
+                        ? `Good evening, ${name}.`
+                        : `Hello, ${name}.`,
+                de:
+                  tod === 'morning'
+                    ? `Guten Morgen, ${name}.`
+                    : tod === 'evening'
+                      ? `Guten Abend, ${name}.`
+                      : `Guten Tag, ${name}.`,
+                es:
+                  tod === 'morning'
+                    ? `Buenos días, ${name}.`
+                    : tod === 'evening'
+                      ? `Buenas noches, ${name}.`
+                      : `Buenas tardes, ${name}.`,
+                fr:
+                  tod === 'evening'
+                    ? `Bonsoir, ${name}.`
+                    : `Bonjour, ${name}.`,
+                sr:
+                  tod === 'morning'
+                    ? `Добро јутро, ${name}.`
+                    : tod === 'evening'
+                      ? `Добро вече, ${name}.`
+                      : `Добар дан, ${name}.`,
+              };
+              const langKey = (lang || 'en').slice(0, 2).toLowerCase();
+              const spoken = greetingByLang[langKey] || greetingByLang.en;
+              const safe = spoken.replace(/"/g, '\\"');
+              // Mirror the existing `Say exactly: "..."` shape used elsewhere in
+              // this function — keep it SHORT so Gemini reliably emits audio.
+              const newDayPrompt =
+                `Say exactly: "${safe}" — ONE short utterance only. Do NOT add anything before or after. Do NOT paraphrase. Speak it as audio.`;
+              ws.send(
+                JSON.stringify({
+                  client_content: { turns: [{ role: 'user', parts: [{ text: newDayPrompt }] }], turn_complete: true },
+                }),
+              );
+              emitDiag(session, 'greeting_sent', {
+                lang,
+                prompt_len: newDayPrompt.length,
+                wake_opener: 'safe_fast_newday',
+                bucket: temporal.bucket,
+              });
+              startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
+              console.log(
+                `[GREETING-SAFE-FAST-NEWDAY] session ${session.sessionId} sent personalized new-day opener (bucket=${temporal.bucket}, lang=${lang})`,
+              );
+              return;
+            }
+
+            // ELSE — fall through to the EXISTING generic opener (unchanged
+            // behavior). Same-day reconnects and no-name sessions take this path.
+            const _menu = pickShortGapGreetings(lang, 6).map((p) => `"${p}"`).join(', ');
+            const _safePrompt =
+              `Open with EXACTLY ONE short phrase, picked from this menu and used VERBATIM ` +
+              `(already in the user's language): ${_menu}. Do NOT say "Hello" or the user's name. ` +
+              `Do NOT introduce yourself. NEVER use two-part sentences. Speak it as audio.`;
+            ws.send(
+              JSON.stringify({
+                client_content: { turns: [{ role: 'user', parts: [{ text: _safePrompt }] }], turn_complete: true },
+              }),
+            );
+            emitDiag(session, 'greeting_sent', {
+              lang,
+              prompt_len: _safePrompt.length,
+              wake_opener: 'safe_fast_pending_context',
+            });
+            startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
+            console.log(
+              `[GREETING-SAFE-FAST] session ${session.sessionId} sent short audio-safe opener (context still pending)`,
+            );
+          } catch (err: any) {
+            console.warn(
+              `[GREETING-SAFE-FAST-NEWDAY] session ${session.sessionId} bounded greeting send failed (non-fatal): ${err?.message || err}`,
+            );
+          }
+        })();
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
## DEV-COMHU-0513 — new-day personalized greeting on the fast path

**Problem:** the fast greeting (`FEATURE_ORB_SAFE_FAST_GREETING` + 300ms context cap) speaks a *generic* opener because the user's name + last-visit time live in the **slow** deferred context block — so "Good morning, Dragan" never fires on a new day.

**Hybrid fix** (gated on the **existing** `FEATURE_ORB_SAFE_FAST_GREETING`; flag off → behavior 100% unchanged):
- **`live-session-controller.ts`** — a FAST parallel pre-fetch (independent of the heavy bootstrap) resolves the spoken first name (`memory_facts.user_name` → `app_users.display_name` → `resolveSpokenFirstName`) + last-session info, exposed as `session.greetingFactsReady` / `greetingFirstName`. Fail-open to nulls; never blocks session start.
- **`sendGreetingPromptToLiveAPI`** — in the safe-fast branch: claim the greeting synchronously (dup-guard), bounded-wait (`ORB_GREETING_FACTS_WAIT_MS`, default 700ms) for those facts, then if the temporal bucket is a genuine new-day (`today`/`yesterday`/`week`/`long`) **and** a name resolved → speak a short localized **"Good `<tod>`, `<Name>`."** (en/de/es/fr/sr). Otherwise → the existing generic opener (same-day reconnects unchanged).

The pre-fetch overlaps session start, so the ~2s speed is preserved; new-day returns gain warmth. Type-checks clean (built in an isolated worktree, reviewed, re-applied to a fresh base).

### Note on verification
The new-day branch only triggers on a genuine new-day return; the e2e test user has recent sessions (same-day bucket) so the probe will show the generic opener + confirm no regression/latency. The "Good morning, <Name>" path is best confirmed by a real new-day open (which is exactly the case you hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B85fhJm5pGBLxzqt4Jva8r)_