### PR TITLE
fix(orb): unlock AudioContext before continuity await — first greeting silent on mobile

### DIFF
--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -17,7 +17,7 @@
     "validate:dev-frontend-spec": "node ./scripts/validate-dev-frontend-spec.mjs",
     "nav:sync": "tsx scripts/sync-nav-catalog-from-manifest.ts",
     "nav:check": "tsx scripts/sync-nav-catalog-from-manifest.ts --check",
-    "smoke:orb-widget": "node ./scripts/orb-widget-stop-regression.mjs && node ./scripts/orb-widget-audio-playback-regression.mjs && node ./scripts/orb-widget-speaking-watchdog-regression.mjs"
+    "smoke:orb-widget": "node ./scripts/orb-widget-stop-regression.mjs && node ./scripts/orb-widget-audio-playback-regression.mjs && node ./scripts/orb-widget-speaking-watchdog-regression.mjs && node ./scripts/orb-widget-greeting-unlock-regression.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",

--- a/services/gateway/scripts/orb-widget-greeting-unlock-regression.mjs
+++ b/services/gateway/scripts/orb-widget-greeting-unlock-regression.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Regression: the ORB playback AudioContext must be unlocked (1-sample silent
+ * buffer + resume) SYNCHRONOUSLY, before the first `await` in `_sessionStart()`.
+ *
+ * The bug (production first-greeting silence on mobile): `_sessionStart()` did
+ * `await fetch(/orb/session/continuity)` BEFORE the silent-buffer unlock +
+ * resume(). On iOS/Android the user-gesture activation token is consumed by the
+ * first await, so the unlock landed outside the gesture window, the context
+ * stayed suspended, and the FIRST greeting's PCM was dropped (the second press
+ * worked because the context was already running). The fix hoists the unlock
+ * above the continuity fetch. This guard fails if anything reorders an await
+ * (the continuity fetch in particular) ahead of the unlock again.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const sourcePath = resolve(repoRoot, 'services/gateway/src/frontend/command-hub/orb-widget.js');
+const source = readFileSync(sourcePath, 'utf8');
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`[orb-widget-greeting-unlock-regression] FAIL: ${message}`);
+    process.exit(1);
+  }
+}
+
+function extractFunctionBody(signature) {
+  const sigIdx = source.indexOf(signature);
+  assert(sigIdx >= 0, `missing function signature: ${signature}`);
+  const openIdx = source.indexOf('{', sigIdx);
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    if (c === '}') depth--;
+    if (depth === 0) return source.slice(openIdx + 1, i);
+  }
+  throw new Error(`unclosed function body: ${signature}`);
+}
+
+const body = extractFunctionBody('async function _sessionStart()');
+
+const unlockIdx = body.indexOf('createBuffer(1, 1, 22050)');
+const resumeIdx = body.indexOf('playbackCtx.resume(');
+const continuityIdx = body.indexOf('/orb/session/continuity');
+// Match the first REAL awaited call (an `await fetch(`), not the word "await"
+// that appears in explanatory comments above the unlock block.
+const firstAwaitIdx = body.search(/await\s+fetch\s*\(/);
+
+assert(unlockIdx >= 0, '_sessionStart must create the 1-sample silent unlock buffer.');
+assert(resumeIdx >= 0, '_sessionStart must call playbackCtx.resume().');
+assert(continuityIdx >= 0, '_sessionStart must still perform the continuity hydrate fetch.');
+assert(firstAwaitIdx >= 0, '_sessionStart is expected to contain at least one awaited fetch.');
+
+assert(
+  unlockIdx < continuityIdx,
+  'the silent-buffer AudioContext unlock MUST appear before the continuity fetch (gesture window).',
+);
+assert(
+  resumeIdx < continuityIdx,
+  'playbackCtx.resume() MUST run before the continuity fetch (gesture window).',
+);
+assert(
+  unlockIdx < firstAwaitIdx && resumeIdx < firstAwaitIdx,
+  'the AudioContext unlock + resume() MUST run before the FIRST await in _sessionStart.',
+);
+
+console.log('[orb-widget-greeting-unlock-regression] OK: audio unlock runs in-gesture, before the first await.');

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1167,6 +1167,33 @@
     // acks its new session_id, forcing the greeting gate to the 3s timeout.
     _s._audioReadySignaled = false;
 
+    // DEV-COMHU-ORB-AUDIO-FIRST-GREETING: unlock the playback AudioContext
+    // SYNCHRONOUSLY, before ANY await in this function. On mobile (iOS/Android)
+    // the user-gesture activation token is consumed by the first await — and the
+    // continuity fetch below awaited BEFORE this unlock, so the silent-buffer
+    // unlock + resume() landed OUTSIDE the gesture window, the context stayed
+    // suspended, and the FIRST greeting's PCM was dropped (the second press
+    // worked because the context was already running). Creating + unlocking here,
+    // ahead of the fetch, restores the in-gesture guarantee. Idempotent: reuses
+    // an existing, non-closed context on later presses.
+    if (!_s.playbackCtx || _s.playbackCtx.state === 'closed') {
+      _s.playbackCtx = new (window.AudioContext || window.webkitAudioContext)();
+    }
+    try {
+      var _silentUnlock = _s.playbackCtx.createBuffer(1, 1, 22050);
+      var _silentUnlockSrc = _s.playbackCtx.createBufferSource();
+      _silentUnlockSrc.buffer = _silentUnlock;
+      _silentUnlockSrc.connect(_s.playbackCtx.destination);
+      _silentUnlockSrc.start(0);
+    } catch (e) {
+      console.warn('[VTOrb] silent-buffer iOS unlock failed:', e && e.message);
+    }
+    if (_s.playbackCtx.state === 'suspended') {
+      _s.playbackCtx.resume().catch(function (e) {
+        console.warn('[VTOrb] playbackCtx resume rejected at session start:', e && e.message);
+      });
+    }
+
     // DEV-COMHU-0503 (review fix): hydrate persisted continuity on a fresh
     // reopen. _hide() persisted continuity then _sessionStop cleared the
     // in-memory fields, so without this the reconnect-context builder below
@@ -1218,31 +1245,11 @@
     _s.navigationPending = false;
     _s.signupClosing = false;
 
-    // BOOTSTRAP-ORB-IOS-UNLOCK: Create playback AudioContext inside the user
-    // gesture (critical for iOS — creating later or resuming later is
-    // unreliable across awaits). Also play a 1-sample silent buffer
-    // immediately: this is the canonical iOS unlock primitive. The chime
-    // below used to be the de-facto unlock but it fires *after* the fetch
-    // below on slower devices, losing the gesture window.
-    if (!_s.playbackCtx || _s.playbackCtx.state === 'closed') {
-      _s.playbackCtx = new (window.AudioContext || window.webkitAudioContext)();
-    }
-    try {
-      var _silent = _s.playbackCtx.createBuffer(1, 1, 22050);
-      var _silentSrc = _s.playbackCtx.createBufferSource();
-      _silentSrc.buffer = _silent;
-      _silentSrc.connect(_s.playbackCtx.destination);
-      _silentSrc.start(0);
-    } catch (e) {
-      console.warn('[VTOrb] silent-buffer iOS unlock failed:', e && e.message);
-    }
-    if (_s.playbackCtx.state === 'suspended') {
-      _s.playbackCtx.resume().catch(function (e) {
-        console.warn('[VTOrb] playbackCtx resume rejected at session start:', e && e.message);
-      });
-    }
-
-    // Play activation chime immediately
+    // BOOTSTRAP-ORB-IOS-UNLOCK: the playback AudioContext create + 1-sample
+    // silent-buffer unlock + resume() was MOVED UP to before the continuity
+    // fetch above (DEV-COMHU-ORB-AUDIO-FIRST-GREETING) — it MUST run before any
+    // await so the mobile gesture window is not lost. The ctx is already unlocked
+    // by here; just play the activation chime into it.
     _playChime(_s.playbackCtx);
 
     // ORB-FAST-START Phase 4: instant cached wake cue. Right after the chime,


### PR DESCRIPTION
## Production incident: first ORB greeting silent on mobile (Android + iPhone)

**Symptom:** first orb press → no greeting audio; close + press again → Vitana speaks. Appeared right after the staging→prod publish.

**Root cause (client-side, definitive):** in `orb-widget.js` `_sessionStart()`, the continuity hydrate `await fetch(/orb/session/continuity)` ran **before** the playback-AudioContext silent-buffer unlock + `resume()`. On iOS/Android the user-gesture activation token is consumed by the first `await`, so the unlock landed **outside the gesture window** → context stayed suspended → the first greeting's PCM was dropped. The second press reused the now-running context, so it worked. The recent fast-start latency reordering is what moved the await ahead of the unlock.

**Fix:** hoist the AudioContext create + 1-sample silent-buffer unlock + `resume()` to the **top of `_sessionStart()`**, before any `await`. The chime now plays into the already-unlocked context. Minimal, no behavior change beyond ordering.

## Verification
- New regression guard `scripts/orb-widget-greeting-unlock-regression.mjs` asserts the unlock + `resume()` precede the first awaited fetch in `_sessionStart` — wired into `npm run smoke:orb-widget`.
- Full `smoke:orb-widget` suite green (stop / audio-playback / speaking-watchdog / **greeting-unlock**).
- `node --check` clean; `npm run build` ok.

## Notes
- The server-side #2716 path (deferred greeting / new-day branch) is a *secondary* candidate but is gated behind `FEATURE_ORB_SAFE_FAST_GREETING`, which defaults **off** in prod — so the client ordering above is the primary, unconditional fix. If first-greeting silence persists after this ships with that flag confirmed on, I'll address the #2716 deferred-send `return`-on-WS-closed path next.
- Gateway serves `orb-widget.js` with `no-cache`, so no cache-bust needed.

**Deploy:** merges to staging → verify on `preview.vitanaland.com` (mobile), then **PUBLISH** to prod to fix production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_