### PR TITLE
feat(gateway): news-feed top-performer spotlight endpoint (VTID-03319)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -199,6 +199,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const longevityRouter = require('./routes/longevity').default;
   // VTID-01900: Longevity News Feed — curated RSS sources
   const longevityNewsRouter = require('./routes/longevity-news').default;
+  // VTID-03319: News Feed — consent-gated community spotlight (most improved)
+  const newsFeedRouter = require('./routes/news-feed').default;
   // VTID-01120: D28 Emotional & Cognitive Signal Interpretation Engine
   const emotionalCognitiveRouter = require('./routes/emotional-cognitive').default;
   // VTID-01084: Community Personalization v1 - longevity-focused groups/meetups
@@ -1049,6 +1051,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // VTID-01900: Longevity News Feed — curated RSS sources
   mountRouterSync(app, '/api/v1/longevity-news', longevityNewsRouter, { owner: 'longevity-news' });
+
+  // VTID-03319: News Feed — consent-gated community spotlight
+  mountRouterSync(app, '/api/v1/news-feed', newsFeedRouter, { owner: 'news-feed' });
 
   // VTID-01120: D28 Emotional & Cognitive Signal Interpretation Engine
   mountRouterSync(app, '/api/v1/signals', emotionalCognitiveRouter, { owner: 'emotional-cognitive' });

--- a/services/gateway/src/routes/news-feed.ts
+++ b/services/gateway/src/routes/news-feed.ts
@@ -1,0 +1,114 @@
+/**
+ * VTID-03319: News Feed — server-trusted endpoints.
+ *
+ * The unified "All News" feed is assembled client-side under RLS (member posts,
+ * approved public videos, follows, matches, public news). The ONE read that
+ * needs server-side trust is the consent-gated community spotlight: it crosses
+ * user boundaries and reads the Vitana Index, neither of which a client may do.
+ *
+ *   GET /api/v1/news-feed/top-performer
+ *     → { ok: true, performer: { user_id, display_name, avatar_url,
+ *                                improvement, computed_at } | null }
+ *
+ * "Most improved", not "highest score": we rank by the per-user delta in
+ * score_total over a trailing window, restricted to members who explicitly
+ * opted in (profiles.index_spotlight_consent = true). Exact scores are never
+ * returned — only the improvement delta. Degrades to `performer: null` whenever
+ * data or consent is missing, so the feed simply omits the spotlight.
+ */
+
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+
+const router = Router();
+const VTID = 'VTID-03319';
+
+// Trailing window over which "improvement" is measured.
+const WINDOW_DAYS = 30;
+
+interface ScoreRow {
+  user_id: string;
+  date: string;
+  score_total: number;
+}
+
+router.get('/top-performer', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const supabase = getSupabase();
+    if (!supabase) {
+      return res.status(500).json({ ok: false, error: 'supabase_not_configured' });
+    }
+
+    const tenantId = req.identity?.tenant_id || null;
+
+    // 1. Members who opted in to the spotlight.
+    let consentQuery = supabase
+      .from('profiles')
+      .select('user_id, display_name, avatar_url')
+      .eq('index_spotlight_consent', true);
+    const { data: consented, error: consentErr } = await consentQuery;
+    if (consentErr || !consented || consented.length === 0) {
+      return res.json({ ok: true, vtid: VTID, performer: null });
+    }
+    const consentedIds = consented.map((p: any) => p.user_id);
+
+    // 2. Index history for those members over the trailing window.
+    const since = new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    let scoresQuery = supabase
+      .from('vitana_index_scores')
+      .select('user_id, date, score_total')
+      .in('user_id', consentedIds)
+      .gte('date', since)
+      .order('date', { ascending: true });
+    if (tenantId) scoresQuery = scoresQuery.eq('tenant_id', tenantId);
+    const { data: scores, error: scoresErr } = await scoresQuery;
+    if (scoresErr || !scores || scores.length === 0) {
+      return res.json({ ok: true, vtid: VTID, performer: null });
+    }
+
+    // 3. Per-user improvement = latest score - earliest score in the window.
+    //    Needs at least two data points to be a real "improvement".
+    const byUser = new Map<string, ScoreRow[]>();
+    for (const row of scores as ScoreRow[]) {
+      const arr = byUser.get(row.user_id) || [];
+      arr.push(row);
+      byUser.set(row.user_id, arr);
+    }
+
+    let best: { user_id: string; improvement: number } | null = null;
+    for (const [userId, rows] of byUser) {
+      if (rows.length < 2) continue; // rows are date-ascending from the query
+      const improvement = rows[rows.length - 1].score_total - rows[0].score_total;
+      if (improvement <= 0) continue;
+      if (!best || improvement > best.improvement || (improvement === best.improvement && userId < best.user_id)) {
+        best = { user_id: userId, improvement };
+      }
+    }
+
+    if (!best) {
+      return res.json({ ok: true, vtid: VTID, performer: null });
+    }
+
+    const profile = consented.find((p: any) => p.user_id === best!.user_id);
+    return res.json({
+      ok: true,
+      vtid: VTID,
+      performer: {
+        user_id: best.user_id,
+        display_name: profile?.display_name || null,
+        avatar_url: profile?.avatar_url || null,
+        improvement: best.improvement,
+        computed_at: new Date().toISOString(),
+      },
+    });
+  } catch (err: any) {
+    // Never break the feed — degrade to no spotlight.
+    console.error(`[${VTID}] top-performer error:`, err?.message || err);
+    return res.json({ ok: true, vtid: VTID, performer: null });
+  }
+});
+
+export default router;

--- a/services/gateway/test/news-feed.test.ts
+++ b/services/gateway/test/news-feed.test.ts
@@ -1,0 +1,108 @@
+/**
+ * VTID-03319 — news-feed top-performer endpoint tests.
+ *
+ * Covers: auth gate (401), happy path (most-improved consented member, no exact
+ * score leaked), no-consent → null, and insufficient history → null.
+ */
+import request from 'supertest';
+import express from 'express';
+
+// --- Mocks (must be declared before requiring the router) ---
+let tableData: Record<string, any[]>;
+
+jest.mock('../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (req.headers.authorization === 'Bearer user') {
+      req.identity = { user_id: 'viewer-1', tenant_id: null };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'unauthenticated' });
+  },
+}));
+
+// Minimal chainable, awaitable query builder — filters are no-ops; the route's
+// logic is driven entirely by the rows we seed per table.
+function builder(rows: any[]) {
+  const b: any = {
+    select: () => b,
+    eq: () => b,
+    in: () => b,
+    gte: () => b,
+    order: () => b,
+    then: (resolve: any) => resolve({ data: rows, error: null }),
+  };
+  return b;
+}
+jest.mock('../src/lib/supabase', () => ({
+  getSupabase: () => ({ from: (table: string) => builder(tableData[table] || []) }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const newsFeedRouter = require('../src/routes/news-feed').default;
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/news-feed', newsFeedRouter);
+  return app;
+}
+
+describe('GET /api/v1/news-feed/top-performer', () => {
+  beforeEach(() => {
+    tableData = {};
+  });
+
+  it('401s without auth', async () => {
+    const res = await request(makeApp()).get('/api/v1/news-feed/top-performer');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the most-improved consented member (no exact score leaked)', async () => {
+    tableData = {
+      profiles: [
+        { user_id: 'a', display_name: 'Ada', avatar_url: null },
+        { user_id: 'b', display_name: 'Ben', avatar_url: null },
+      ],
+      // date-ascending, as the route's .order('date') guarantees
+      vitana_index_scores: [
+        { user_id: 'a', date: '2026-06-01', score_total: 500 },
+        { user_id: 'a', date: '2026-06-18', score_total: 540 }, // +40
+        { user_id: 'b', date: '2026-06-01', score_total: 600 },
+        { user_id: 'b', date: '2026-06-18', score_total: 610 }, // +10
+      ],
+    };
+    const res = await request(makeApp())
+      .get('/api/v1/news-feed/top-performer')
+      .set('authorization', 'Bearer user');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.performer.user_id).toBe('a'); // bigger delta wins
+    expect(res.body.performer.improvement).toBe(40);
+    // Exact Index scores must never be exposed.
+    expect(JSON.stringify(res.body)).not.toContain('540');
+    expect(JSON.stringify(res.body)).not.toContain('score_total');
+  });
+
+  it('returns null when nobody opted in', async () => {
+    tableData = { profiles: [], vitana_index_scores: [] };
+    const res = await request(makeApp())
+      .get('/api/v1/news-feed/top-performer')
+      .set('authorization', 'Bearer user');
+    expect(res.status).toBe(200);
+    expect(res.body.performer).toBeNull();
+  });
+
+  it('returns null when there is no real improvement (single data point / non-positive delta)', async () => {
+    tableData = {
+      profiles: [{ user_id: 'a', display_name: 'Ada', avatar_url: null }],
+      vitana_index_scores: [
+        { user_id: 'a', date: '2026-06-01', score_total: 500 }, // only one point
+      ],
+    };
+    const res = await request(makeApp())
+      .get('/api/v1/news-feed/top-performer')
+      .set('authorization', 'Bearer user');
+    expect(res.status).toBe(200);
+    expect(res.body.performer).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Backend half of the **News Screen v2** rework (VTID-03319). Adds the single server-trusted read the unified "All News" feed needs — the consent-gated community spotlight. Everything else in the feed is loaded client-side under RLS.

## What changed

- **`GET /api/v1/news-feed/top-performer`** (`services/gateway/src/routes/news-feed.ts`), mounted under `/api/v1/news-feed`, behind `requireAuth`.
- Returns the **"most improved"** opted-in member: the delta of `vitana_index_scores.score_total` over a trailing 30-day window, restricted to `profiles.index_spotlight_consent = true`, tenant-scoped when available.
- **Most-improved, not highest-score** (per the approved design — avoids a permanent leaderboard feel). Never returns exact Index values, only the improvement delta.
- **Degrades to `performer: null`** on any missing data / no consent / error, so the feed simply omits the spotlight. Never throws.

## Consent column

The frontend repo (`exafyltd/vitana-v1`, PR #763) adds the opt-in toggle and the migration `profiles.index_spotlight_consent boolean default false`. That column has already been applied to the shared Supabase project, so this endpoint works as soon as it's deployed.

## Verification

- `npm run build` (gateway) — passes; `dist/routes/news-feed.js` emitted.
- No hard dependency ordering with the frontend: if the frontend ships first, `fetchTopPerformer` just gets a 404 → null.

## Deploy

Per staging-first: merging to `main` auto-deploys **`gateway-staging`** (verify on `preview-gateway.vitanaland.com`); production is a separate PUBLISH-button action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuRXgM9XNrwKrSefyZi7Td

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuRXgM9XNrwKrSefyZi7Td)_