### PR TITLE
fix(orb): pre-login orb stuck on "listening" — skip authenticated wake-brief for anonymous sessions

### DIFF
--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -17,7 +17,7 @@
     "validate:dev-frontend-spec": "node ./scripts/validate-dev-frontend-spec.mjs",
     "nav:sync": "tsx scripts/sync-nav-catalog-from-manifest.ts",
     "nav:check": "tsx scripts/sync-nav-catalog-from-manifest.ts --check",
-    "smoke:orb-widget": "node ./scripts/orb-widget-stop-regression.mjs && node ./scripts/orb-widget-audio-playback-regression.mjs && node ./scripts/orb-widget-speaking-watchdog-regression.mjs && node ./scripts/orb-widget-greeting-unlock-regression.mjs"
+    "smoke:orb-widget": "node ./scripts/orb-widget-stop-regression.mjs && node ./scripts/orb-widget-audio-playback-regression.mjs && node ./scripts/orb-widget-speaking-watchdog-regression.mjs && node ./scripts/orb-widget-greeting-unlock-regression.mjs && node ./scripts/orb-anon-wake-skip-regression.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",

--- a/services/gateway/scripts/orb-anon-wake-skip-regression.mjs
+++ b/services/gateway/scripts/orb-anon-wake-skip-regression.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Regression: anonymous (pre-login) ORB sessions must NOT run the authenticated
+ * wake-brief / journey / decision-context pipeline on the session-start critical
+ * path.
+ *
+ * The bug (production pre-login regression): `handleLiveSessionStart` ran
+ * `assembleWakeBriefAndJourney()` INLINE (awaited before the HTTP response) for
+ * every non-fast-start session — including anonymous ones. `shouldDeferWakeWork`
+ * returns false for anonymous, so the fast-start defer never applied to them, and
+ * authenticated sessions (which DO defer) stayed fast — hence "post-login works,
+ * pre-login is broken". The wake-brief result is discarded for anonymous sessions
+ * anyway (every consumer in orb-live.ts is gated behind `!session.isAnonymous`),
+ * but running it inline piled Supabase round-trips + an emission write onto the
+ * pre-login path (session/start observed at ~4.5s), pushing slow/mobile clients
+ * past the orb-widget's 8s session-start timeout. The orb opened, flipped to
+ * "listening", and never received the greeting.
+ *
+ * The fix gates the inline call behind `!isAnonymousSession`. This guard fails if
+ * that gate is removed and anonymous sessions start awaiting the wake-brief
+ * assembly inline again.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const sourcePath = resolve(
+  repoRoot,
+  'services/gateway/src/orb/live/session/live-session-controller.ts',
+);
+const source = readFileSync(sourcePath, 'utf8');
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`[orb-anon-wake-skip-regression] FAIL: ${message}`);
+    process.exit(1);
+  }
+}
+
+const callIdx = source.indexOf('await assembleWakeBriefAndJourney()');
+assert(callIdx >= 0, 'expected an inline `await assembleWakeBriefAndJourney()` call site.');
+
+// The inline call must be guarded so it only runs for NON-anonymous sessions.
+// We look at the branch keyword immediately preceding the call.
+const preceding = source.slice(Math.max(0, callIdx - 400), callIdx);
+assert(
+  /else if \(!isAnonymousSession\)\s*\{[^}]*$/.test(preceding) ||
+    preceding.includes('} else if (!isAnonymousSession) {'),
+  'the inline wake-brief assembly MUST be gated behind `else if (!isAnonymousSession)` ' +
+    'so anonymous (pre-login) sessions never await it on the session-start critical path.',
+);
+
+// And there must be exactly one inline call site (the guarded one).
+const occurrences = source.split('await assembleWakeBriefAndJourney()').length - 1;
+assert(
+  occurrences === 1,
+  `expected exactly 1 inline wake-brief call site, found ${occurrences}.`,
+);
+
+console.log('[orb-anon-wake-skip-regression] PASS: anonymous sessions skip inline wake-brief assembly.');

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1609,11 +1609,26 @@ export async function handleLiveSessionStart(
     console.log(
       `[ORB-FAST-START] session ${sessionId}: wake-brief + journey deferred onto contextReadyPromise (fast session/start)`,
     );
-  } else {
+  } else if (!isAnonymousSession) {
     // Legacy inline path: assign the return value so TS control-flow analysis
     // sees wakeBriefDecision populated for the response meta below.
     wakeBriefDecision = await assembleWakeBriefAndJourney();
   }
+  // ANON-WAKE-SKIP: anonymous (pre-login) sessions deliberately do NOT run the
+  // authenticated wake-brief / journey / decision-context pipeline. Its result
+  // is discarded for anonymous sessions anyway — every greeting-builder branch
+  // that consumes wakeBriefDecision is gated behind `!session.isAnonymous`
+  // (orb-live.ts: wake-override speak, cadence-silence, context-pending), and the
+  // pre-login intro speech is driven by buildAnonymousSystemInstruction's own
+  // verbatim-speech path. Running it inline only piled Supabase round-trips +
+  // emission writes onto the pre-login critical path (session/start observed at
+  // ~4.5s), pushing slow/mobile clients past the orb-widget's 8s session-start
+  // timeout — so the orb opened, flipped to "listening", and never received the
+  // greeting (the "pre-login speech doesn't start / doesn't react to input"
+  // report). The fast-start path already defers this work for authenticated
+  // users (shouldDeferWakeWork), which is why post-login was unaffected.
+  // wakeBriefDecision stays null → response meta reports wake_brief:null, which
+  // the widget does not depend on for anonymous sessions.
 
   // Emit OASIS event with identity context.
   // ORB-FAST-START Phase 1a: fire-and-forget. session.start IS a real state


### PR DESCRIPTION
## Symptom

Pressing the **pre-login (anonymous)** orb opened the overlay, flipped to **"listening"**, but never spoke the intro greeting and didn't react to voice input. **Post-login was unaffected** ("after login works well").

## Root cause

`handleLiveSessionStart` ran `assembleWakeBriefAndJourney()` **inline** (awaited before the HTTP `session/start` response) for anonymous sessions.

- `shouldDeferWakeWork()` returns `false` for anonymous, so the **fast-start defer** that keeps *authenticated* `session/start` fast never applied to pre-login — exactly why post-login works but pre-login stalled.
- The wake-brief result is **discarded** for anonymous sessions anyway: every consumer in `orb-live.ts` is gated behind `!session.isAnonymous` (wake-override speak, cadence-silence, context-pending). The pre-login speech itself is driven by `buildAnonymousSystemInstruction`'s own verbatim-speech path.
- Running it inline only piled Supabase round-trips + an emission write onto the pre-login critical path. **Anonymous `session/start` was observed at up to ~4.5s against prod** — enough for slow/mobile clients to blow past the orb-widget's **8s session-start timeout**, leaving the orb in "listening" with no greeting and no working session.

## Fix

Gate the inline wake-brief assembly behind `!isAnonymousSession` so anonymous sessions skip it entirely. `wakeBriefDecision` stays `null` → `meta.wake_brief:null`, which the widget does not depend on for anonymous sessions.

## Verification

- Reproduced the slow anonymous `session/start` against prod (`gateway.vitanaland.com`) — up to ~4.5s.
- Confirmed the anonymous greeting still streams **end-to-end** against **both prod and staging** gateways, over **WS and SSE** transports — full ~45s intro speech ("Hello from … My name is Vitana …").
- Added `scripts/orb-anon-wake-skip-regression.mjs`, wired into `npm run smoke:orb-widget` (all 5 checks pass), to lock the gate in.

## Notes

Staging-first: this auto-deploys to staging on merge — verify on `preview.vitanaland.com` (mobile), then PUBLISH to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVbdhr94uc6bHAnJXrLCB2)_