### PR TITLE
fix(orb): use proven gemini-2.5 family + larger token budget for intent classify/extract

### DIFF
--- a/services/gateway/src/services/intent-classifier.ts
+++ b/services/gateway/src/services/intent-classifier.ts
@@ -29,9 +29,14 @@ import { withGeminiLog } from './gemini-call-log';
 const GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY || process.env.GEMINI_API_KEY;
 const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
 const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
-// Fast model first; fall back to the matchmaker's proven-working Pro model if
-// the fast model throws or returns an empty candidate. Each attempt is logged.
-const CLASSIFY_MODELS = ['gemini-2.0-flash', 'gemini-2.5-pro'];
+// Use the model family proven to work on this Vertex project. The matchmaker
+// succeeds on gemini-2.5-pro; gemini-2.0-flash is never actually exercised
+// there (no fallback rows) and returned empty/errored for the classifier, so
+// we lead with 2.5-flash and fall back to the proven 2.5-pro. Both are
+// "thinking" models, so maxOutputTokens must leave room for reasoning BEFORE
+// the JSON (a 256-token budget made 2.5-pro emit an empty candidate).
+const CLASSIFY_MODELS = ['gemini-2.5-flash', 'gemini-2.5-pro'];
+const CLASSIFY_MAX_OUTPUT_TOKENS = 2048;
 
 let vertexAI: VertexAI | null = null;
 try {
@@ -144,7 +149,7 @@ async function runVertexClassify(userText: string): Promise<string> {
         async () => {
           const model = vertexAI!.getGenerativeModel({
             model: modelName,
-            generationConfig: { temperature: 0.1, maxOutputTokens: 256, topP: 0.8, responseMimeType: 'application/json' },
+            generationConfig: { temperature: 0.1, maxOutputTokens: CLASSIFY_MAX_OUTPUT_TOKENS, topP: 0.8, responseMimeType: 'application/json' },
           });
           const response = await model.generateContent({
             contents: [{ role: 'user', parts: [{ text: `${CLASSIFIER_SYSTEM_PROMPT}\n\nUtterance to classify:\n${userText}` }] }],
@@ -189,7 +194,7 @@ export async function classifyIntentKind(utterance: string): Promise<IntentClass
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             contents: [{ parts: [{ text: `${CLASSIFIER_SYSTEM_PROMPT}\n\nUtterance to classify:\n${trimmed}` }] }],
-            generationConfig: { temperature: 0.1, maxOutputTokens: 256, responseMimeType: 'application/json' },
+            generationConfig: { temperature: 0.1, maxOutputTokens: CLASSIFY_MAX_OUTPUT_TOKENS, responseMimeType: 'application/json' },
           }),
         }
       );

--- a/services/gateway/src/services/intent-extractor.ts
+++ b/services/gateway/src/services/intent-extractor.ts
@@ -23,9 +23,12 @@ const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
 // BOOTSTRAP-FIND-MATCH-CLASSIFY-FIX: same failure mode as the classifier — the
 // bare gemini-2.0-flash call (no JSON mode) returned empty/unparseable output on
 // the gateway and the only fallback was gated on an unset env var. Use JSON mode
-// + a model fallback chain ending in the proven-working Pro model, and log each
-// attempt so silent breakage surfaces in gemini_call_log.
-const EXTRACT_MODELS = ['gemini-2.0-flash', 'gemini-2.5-pro'];
+// + the model family proven to work on this Vertex project (2.5-flash → the
+// matchmaker-proven 2.5-pro), and log each attempt so silent breakage surfaces
+// in gemini_call_log. Both are "thinking" models, so the token budget must leave
+// room for reasoning before the JSON payload.
+const EXTRACT_MODELS = ['gemini-2.5-flash', 'gemini-2.5-pro'];
+const EXTRACT_MAX_OUTPUT_TOKENS = 2048;
 
 let vertexAI: VertexAI | null = null;
 try {
@@ -221,7 +224,7 @@ export async function extractIntent(utterance: string, kind: IntentKind): Promis
           async () => {
             const model = vertexAI!.getGenerativeModel({
               model: modelName,
-              generationConfig: { temperature: 0.1, maxOutputTokens: 800, topP: 0.8, responseMimeType: 'application/json' },
+              generationConfig: { temperature: 0.1, maxOutputTokens: EXTRACT_MAX_OUTPUT_TOKENS, topP: 0.8, responseMimeType: 'application/json' },
             });
             const response = await model.generateContent({
               contents: [{ role: 'user', parts: [{ text: prompt }] }],
@@ -254,7 +257,7 @@ export async function extractIntent(utterance: string, kind: IntentKind): Promis
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             contents: [{ parts: [{ text: prompt }] }],
-            generationConfig: { temperature: 0.1, maxOutputTokens: 800, responseMimeType: 'application/json' },
+            generationConfig: { temperature: 0.1, maxOutputTokens: EXTRACT_MAX_OUTPUT_TOKENS, responseMimeType: 'application/json' },
           }),
         }
       );


### PR DESCRIPTION
## Follow-up to #2713

#2713 deployed to staging but the classifier **still** returned `classifier_confidence: 0`. I verified on `gateway-staging`:
- The deploy succeeded and my code is live (revision `00342`, built from the merge commit).
- **Vertex works on staging** — the matchmaker returns LLM-scored candidates with natural-language reasons on `gemini-2.5-pro`.

So the call shape was still wrong. Two compounding causes:

1. **`gemini-2.0-flash` is effectively unavailable on this Vertex project.** The matchmaker never exercises it (all its successes are `gemini-2.5-pro`, no fallback rows), and it returned empty/errored for classify/extract.
2. **The `gemini-2.5-pro` fallback was capped at 256 output tokens.** `gemini-2.5-pro` is a *thinking* model — reasoning consumed the whole budget before any JSON was emitted, so the candidate came back empty and confidence fell to 0. The matchmaker works because it gives 2.5-pro 4096 tokens.

## Fix
- Lead with `gemini-2.5-flash`, fall back to the matchmaker-proven `gemini-2.5-pro` (drop the unavailable `gemini-2.0-flash`).
- Raise `maxOutputTokens` to **2048** so thinking models have room to emit the JSON payload.

Diff vs `main` is only the model list + token budget; the JSON-mode / prompt-folding / `withGeminiLog` telemetry changes already landed in #2713.

## Verification plan (after staging deploy)
- Re-run utterance-only `POST /api/v1/intents {"utterance":"...jogging partner in Palma Mallorca"}` on `preview-gateway.vitanaland.com` → expect `201` with `intent_id` (not `CLASSIFY_LOW_CONFIDENCE`).
- ✅ `tsc --noEmit` clean for both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VBpMkTdZj1HZqqVQ4dHho

---
_Generated by [Claude Code](https://claude.ai/code/session_018VBpMkTdZj1HZqqVQ4dHho)_