### PR TITLE
fix(orb): 12s budget for community intent voice tools so posts don't false-fail

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2333,9 +2333,19 @@ async function executeLiveApiTool(
   // which can exceed the default 3 s. Replenishment is skipped inline for voice
   // (the popup auto-generates on next open) so these stay bounded.
   const AUTOPILOT_VOICE_TOOLS = new Set(['get_autopilot_recommendations', 'activate_autopilot_recommendations']);
+  // BOOTSTRAP-FIND-MATCH-CLASSIFY-FIX: the community intent tools run TWO
+  // sequential Gemini calls (classify → extract) plus an embed + catalog
+  // search before they can answer. While the classifier was broken it failed
+  // instantly (confidence 0), so it never approached the 3 s cap; with the
+  // corrected gemini-2.5 classifier/extractor the round-trip legitimately runs
+  // ~3-4 s, so the tool timed out at 3000ms and the model apologised ("Das
+  // Posten klappt gerade nicht") even though the row was already inserted in
+  // the background. Give them the same extended budget as the Autopilot tools.
+  const INTENT_VOICE_TOOLS = new Set(['find_match', 'post_intent', 'scan_existing_matches']);
   const TOOL_TIMEOUT_MS =
     toolName === 'consult_external_ai' ? 16_000 :
     AUTOPILOT_VOICE_TOOLS.has(toolName) ? 12_000 :
+    INTENT_VOICE_TOOLS.has(toolName) ? 12_000 :
     3_000;
 
   // BOOTSTRAP-ORB-LATENCY-PHASE2: read-only retrieval tools are cacheable


### PR DESCRIPTION
## Symptom

After the classifier/extractor repair (#2713, #2724), posting still failed via **ORB voice** — the assistant said *"Das Posten klappt gerade nicht. Check the logs"* — even though the REST path worked and the post row was actually being created.

## Root cause

`executeLiveApiTool` (orb-live.ts) races every voice tool against a **3000ms** timeout (`TOOL_TIMEOUT_MS` default; only `consult_external_ai` and the Autopilot tools are excepted). The community intent tools `find_match` / `post_intent` run **two sequential Gemini calls** (classify → extract) plus an embed + catalog search, which legitimately takes ~3-4s on the corrected `gemini-2.5` models. So the tool loses the `Promise.race`, returns `success=false`, and the model apologises — while `executeLiveApiToolInner` keeps running in the background and inserts the `user_intents` row a moment later.

Confirmed in `oasis_events` from the user's session:
```
Tool find_match  executed in 3001ms: failed
Tool post_intent executed in 3003ms: failed
Intent posted with zero matches (cold-start); kind=learning_seek   ← row WAS inserted
```

While the classifier was broken it failed *instantly* (confidence 0), so the 3s cap was never the binding constraint — this only surfaced once posting actually worked.

## Fix

Add `find_match`, `post_intent`, `scan_existing_matches` to a 12s budget, mirroring the existing `AUTOPILOT_VOICE_TOOLS` exception for multi-step voice tools. One-line-of-logic change.

## Verification plan (after staging deploy)
- ORB voice on `preview.vitanaland.com` → "make an activity post / find a match" for a jogging partner → assistant should confirm the post succeeded (no "klappt gerade nicht"), and `oasis_events` should show `Tool post_intent executed in <…>ms: success`.
- ✅ `tsc --noEmit` clean (only the pre-existing tsconfig deprecation warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VBpMkTdZj1HZqqVQ4dHho

---
_Generated by [Claude Code](https://claude.ai/code/session_018VBpMkTdZj1HZqqVQ4dHho)_