### PR TITLE
feat(nav): Phase 1a — platform as a first-class consult input (flag-gated)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -60,6 +60,15 @@ ADMITAD_POSTBACK_KEY=
 # staging+prod (see services/gateway/src/services/feature-flags.ts).
 FEATURE_ORB_GREETING_PREBUFFER_ENV=off
 
+# NAV-PHASE1 (Navigation Route Integrity) — platform-aware navigation
+# resolution. When 'true', consultNavigator scopes candidate generation,
+# override-trigger matching and scoring to the session's platform (mobile vs
+# desktop) instead of silently defaulting to the mobile/static catalog; a
+# desktop session resolves against the desktop catalog only. Default (unset or
+# anything other than 'true') = OFF = byte-for-byte the previous behaviour.
+# Enable on staging first to verify desktop resolution via the admin simulator.
+NAV_PLATFORM_AWARE=false
+
 # DEV-COMHU-0513 — upper bound (ms) on waiting for session.contextReadyPromise
 # before sending the Gemini setup message / greeting. Safety net so a slow or
 # hung context build (notably when FEATURE_ORB_FAST_START_ENV defers wake-brief/

--- a/services/gateway/src/lib/nav-catalog-db.ts
+++ b/services/gateway/src/lib/nav-catalog-db.ts
@@ -164,11 +164,12 @@ export function getCatalogEntryById(id: string): NavCatalogEntryWithRules | null
 export function findOverrideTriggerMatch(
   utterance: string,
   lang: LangCode,
-  tenantId: string | null | undefined
+  tenantId: string | null | undefined,
+  platform: 'mobile' | 'desktop' = 'mobile'
 ): NavCatalogEntryWithRules | null {
   const normalized = normalizePhrase(utterance);
   if (!normalized) return null;
-  const entries = getCatalogForTenant(tenantId);
+  const entries = getCatalogForTenant(tenantId, platform);
   const langKey = (lang || 'en').slice(0, 2).toLowerCase();
 
   for (const entry of entries) {

--- a/services/gateway/src/routes/admin-navigator.ts
+++ b/services/gateway/src/routes/admin-navigator.ts
@@ -516,7 +516,7 @@ router.post('/catalog/:id/restore/:audit_id', async (req: AuthenticatedRequest, 
 router.post('/simulate', async (req: AuthenticatedRequest, res: Response) => {
   const auth = actorFromReq(req as any);
 
-  const { utterance, lang, current_route, recent_routes, is_anonymous, tenant_id, user_id } = req.body || {};
+  const { utterance, lang, current_route, recent_routes, is_anonymous, tenant_id, user_id, platform } = req.body || {};
   if (typeof utterance !== 'string' || utterance.trim().length === 0) {
     return res.status(400).json({ ok: false, error: 'utterance required' });
   }
@@ -531,6 +531,10 @@ router.post('/simulate', async (req: AuthenticatedRequest, res: Response) => {
       is_anonymous: !!is_anonymous,
       current_route: typeof current_route === 'string' ? current_route : undefined,
       recent_routes: Array.isArray(recent_routes) ? recent_routes : [],
+      // NAV-PHASE1: let the admin simulator exercise platform-aware resolution
+      // exactly as production will (matches the catalog tab the admin is on).
+      platform: platform === 'desktop' ? 'desktop' : platform === 'mobile' ? 'mobile' : undefined,
+      platform_source: 'admin_simulator',
       session_id: `admin-sim-${Date.now()}`,
       turn_number: 0,
       conversation_start: new Date().toISOString(),

--- a/services/gateway/src/services/navigator-consult.ts
+++ b/services/gateway/src/services/navigator-consult.ts
@@ -63,6 +63,14 @@ export interface NavigatorConsultInput {
   current_route?: string;
   recent_routes?: string[];
   transcript_excerpt?: string;
+  // NAV-PHASE1: the application surface this session is bound to. Mobile and
+  // desktop are separate catalogs; when platform-aware resolution is enabled
+  // (NAV_PLATFORM_AWARE), this scopes candidate generation, override-trigger
+  // matching and scoring to the matching catalog instead of silently
+  // defaulting to mobile. `platform_source` is diagnostic only (e.g.
+  // 'session' once host-bound, 'derived_is_mobile' during migration).
+  platform?: 'mobile' | 'desktop';
+  platform_source?: string;
   // Threading metadata for context pack — used for telemetry and caching
   session_id?: string;
   turn_number?: number;
@@ -341,6 +349,22 @@ function staticKbAnchors(entry: NavCatalogEntry | null): string[] {
 // Catalog scoring with memory bias
 // =============================================================================
 
+// NAV-PHASE1: platform-aware resolution is feature-flagged so production
+// behaviour is unchanged until deliberately enabled and verified on staging.
+function navPlatformAware(): boolean {
+  return process.env.NAV_PLATFORM_AWARE === 'true';
+}
+
+// The catalog platform this consult resolves against. Flag OFF ⇒ always
+// 'mobile' (byte-for-byte today's behaviour — every existing caller resolved
+// against the mobile/static catalog). Flag ON ⇒ honour the session platform,
+// defaulting to 'mobile' only when the caller omitted it. Phase 1b makes
+// platform mandatory and fail-closed once all callers send it.
+function effectivePlatform(input: NavigatorConsultInput): 'mobile' | 'desktop' {
+  if (!navPlatformAware()) return 'mobile';
+  return input.platform === 'desktop' ? 'desktop' : 'mobile';
+}
+
 function scoreCatalogWithMemory(
   input: NavigatorConsultInput,
   hints: MemoryHints
@@ -356,7 +380,7 @@ function scoreCatalogWithMemory(
   const baseResults: Array<{ entry: NavCatalogEntry; score: number }> =
     isNavCatalogLoaded()
       ? searchCatalogEntries(
-          getCatalogForTenant(tenantId) as ReadonlyArray<NavCatalogEntry>,
+          getCatalogForTenant(tenantId, effectivePlatform(input)) as ReadonlyArray<NavCatalogEntry>,
           input.question,
           input.lang,
           {
@@ -421,7 +445,7 @@ export async function consultNavigator(
   // for "wrong screen" bugs the scorer can't fix through tuning.
   const tenantIdForOverride = input.identity?.tenant_id || null;
   const overrideMatch = isNavCatalogLoaded()
-    ? findOverrideTriggerMatch(input.question, input.lang, tenantIdForOverride)
+    ? findOverrideTriggerMatch(input.question, input.lang, tenantIdForOverride, effectivePlatform(input))
     : null;
   if (overrideMatch && !input.is_anonymous) {
     const pick = entryToPick(overrideMatch as NavCatalogEntry, input.lang);
@@ -460,11 +484,22 @@ export async function consultNavigator(
   // context actually helps.
   const excludeRoutes: string[] = [];
   if (input.current_route) excludeRoutes.push(input.current_route);
-  const fastScored = searchCatalog(input.question, input.lang, {
-    anonymous_only: input.is_anonymous,
-    exclude_routes: excludeRoutes,
-    role: input.identity?.role || undefined,
-  });
+
+  // NAV-PHASE1: the fast path (searchCatalog) and the semantic path
+  // (semanticSearchCatalog) read the STATIC, mobile-shaped catalog/embeddings.
+  // For a desktop session we must not let them short-circuit or contribute
+  // mobile routes — desktop resolves against the desktop DB catalog only (via
+  // scoreCatalogWithMemory → getCatalogForTenant(tenant, 'desktop')). When the
+  // flag is off, effectivePlatform() is always 'mobile' so this is a no-op.
+  const isDesktop = effectivePlatform(input) === 'desktop';
+
+  const fastScored = isDesktop
+    ? []
+    : searchCatalog(input.question, input.lang, {
+        anonymous_only: input.is_anonymous,
+        exclude_routes: excludeRoutes,
+        role: input.identity?.role || undefined,
+      });
   const fastTop = fastScored[0];
   const fastSecond = fastScored[1];
 
@@ -533,7 +568,7 @@ export async function consultNavigator(
   // confident. This handles synonyms, different languages, and phrasings
   // we never anticipated — "Messenger", "wo kann ich schreiben", etc.
   // Runs in parallel with memory/KB for zero extra latency.
-  const semanticPromise = areCatalogEmbeddingsReady()
+  const semanticPromise = (!isDesktop && areCatalogEmbeddingsReady())
     ? semanticSearchCatalog(input.question, {
         anonymous_only: input.is_anonymous,
         exclude_routes: excludeRoutes,


### PR DESCRIPTION
## Navigation Route Integrity — Phase 1a

First executable slice of the redesign: **make `platform` a first-class input to the resolver**, so desktop and mobile cleanly resolve against their own catalogs instead of the resolver silently defaulting to mobile.

### Problem (verified in code)
`NavigatorConsultInput` has no platform; `getCatalogForTenant()` defaults to `'mobile'`; the fast lexical path (`searchCatalog`) and semantic path read the **static, mobile-shaped** catalog. Net effect: a desktop session can never reach the desktop catalog. (Confirmed: `navigator-consult.ts:58`, `nav-catalog-db.ts:125`.)

### Change (behind `NAV_PLATFORM_AWARE`, default **OFF**)
- `NavigatorConsultInput` gains `platform` + `platform_source` (diagnostic).
- `effectivePlatform(input)`: flag **off ⇒ always `'mobile'`** (byte-for-byte today's behaviour); flag **on ⇒ honour the session platform**.
- `scoreCatalogWithMemory` + `findOverrideTriggerMatch` scope to the session platform's catalog.
- For a **desktop** session, the mobile-shaped **static fast path and static semantic path are skipped** → desktop resolves against the desktop DB catalog only; no mobile routes leak in.
- `/simulate` accepts `platform`, so the admin simulator exercises the exact production path.

Phase 1b makes platform **mandatory + fail-closed** once host sessions send it (invariant #13). **No schema change.**

### Verification
- `tsc --noEmit` ✅
- `jest navigator|navigation|nav-catalog` → **268/268 pass** (proves flag-off is a no-op).
- Once on staging: set `NAV_PLATFORM_AWARE=true` and use the simulator with the **Desktop** tab to confirm desktop utterances resolve to desktop routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_