### PR TITLE
fix(nav): cross-language brand navigation + regression/contract harness

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -551,6 +551,7 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     category: 'autopilot',
     access: 'authenticated',
     anonymous_safe: false,
+    aliases: ['journey', 'my-journey', 'meine-journey', 'autopilot', 'autopilot-dashboard', 'autopilot-journey', '90-day-journey', '90-day-plan', 'meine-reise'],
     i18n: {
       en: {
         title: 'My Journey',
@@ -3111,6 +3112,21 @@ export function searchCatalog(
     const hintWords = buildWordSet(hintLower);
     const descWords = buildWordSet(descLower);
 
+    // NAV-PHASE: language-agnostic brand PHRASES. A German user says the English
+    // brand name ("Life Compass", "My Journey") even in a German session, but
+    // the active-language i18n content uses the translated term ("Lebenskompass",
+    // "Reise"). The curated multi-word `aliases` carry the canonical brand name;
+    // match them as CONTIGUOUS phrases so distinctive brand navigation works
+    // regardless of UI language. Single-word aliases are intentionally excluded
+    // — generic words ("profile", "results", "matches") would false-positive.
+    const brandPhrases: string[] = [];
+    if (entry.aliases) {
+      for (const a of entry.aliases) {
+        const norm = a.toLowerCase().replace(/[-_]+/g, ' ').trim();
+        if (norm.includes(' ')) brandPhrases.push(norm);
+      }
+    }
+
     let score = 0;
 
     // Direct phrase match (highest signal — query appears verbatim somewhere)
@@ -3160,6 +3176,16 @@ export function searchCatalog(
     // a multi-token query.
     if (effectiveTokens.length > 1 && matchedTokens.size >= effectiveTokens.length) {
       score += effectiveTokens.length * 6;
+    }
+
+    // Language-agnostic brand-phrase RESCUE: only when the active-language
+    // content matched nothing (score still 0). This targets exactly the
+    // cross-language case (English brand name in a German session) without ever
+    // overriding a real content match or perturbing intra-family ranking.
+    if (score === 0 && brandPhrases.length > 0) {
+      for (const ph of brandPhrases) {
+        if (lowerQuery.includes(ph)) { score += 12; break; }
+      }
     }
 
     // Priority boost for promoted destinations (Maxina growth focus).

--- a/services/gateway/test/nav-regression-contract.test.ts
+++ b/services/gateway/test/nav-regression-contract.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Navigation Route Integrity — regression / contract suite.
+ *
+ * Encodes the design doc's PERMANENT regression cases and a subset of the
+ * required contrastive pairs, run against the REAL synchronous scorer
+ * (searchCatalog) over the static catalog. No DB / network — deterministic.
+ *
+ * This is the measurable backbone the design calls for: each case asserts the
+ * top-ranked screen for a phrasing, in EN and DE, and the family-separation
+ * cases assert the wrong family never wins. Entity-resolution and continuation
+ * cases (named-person, "Yes, show me") are intentionally NOT here — they need
+ * the orchestrator/entity registry from later phases and are tracked as TODO.
+ */
+process.env.NODE_ENV = 'test';
+
+import { searchCatalog } from '../src/lib/navigation-catalog';
+
+type Lang = 'en' | 'de';
+interface Case {
+  name: string;
+  lang: Lang;
+  utterance: string;
+  /** Top result must be one of these screen_ids. */
+  expectOneOf: string[];
+  /** Top result must NOT be any of these (wrong-family guard). */
+  expectNotOneOf?: string[];
+}
+
+const CASES: Case[] = [
+  // ── My Journey ─────────────────────────────────────────────────────────
+  { name: 'my journey (EN)', lang: 'en', utterance: 'Open my journey', expectOneOf: ['AUTOPILOT.MY_JOURNEY'], expectNotOneOf: ['LIFE_COMPASS.OVERLAY', 'PROFILE.ME', 'HEALTH.VITANA_INDEX'] },
+  { name: 'my journey (DE)', lang: 'de', utterance: 'Öffne meine Journey', expectOneOf: ['AUTOPILOT.MY_JOURNEY'], expectNotOneOf: ['LIFE_COMPASS.OVERLAY', 'PROFILE.ME'] },
+  // ── Life Compass ───────────────────────────────────────────────────────
+  { name: 'life compass (EN)', lang: 'en', utterance: 'Open my Life Compass', expectOneOf: ['LIFE_COMPASS.OVERLAY'], expectNotOneOf: ['HEALTH.VITANA_INDEX', 'OVERLAY.VITANA_INDEX'] },
+  { name: 'life compass (DE)', lang: 'de', utterance: 'Öffne meinen Life Compass', expectOneOf: ['LIFE_COMPASS.OVERLAY'] },
+  // ── Vitana Index (must NOT degrade to Life Compass) ──────────────────────
+  { name: 'vitana index (EN)', lang: 'en', utterance: 'Open my Vitana Index', expectOneOf: ['HEALTH.VITANA_INDEX', 'OVERLAY.VITANA_INDEX'], expectNotOneOf: ['LIFE_COMPASS.OVERLAY'] },
+  { name: 'vitana index (DE)', lang: 'de', utterance: 'Öffne meinen Vitana Index', expectOneOf: ['HEALTH.VITANA_INDEX', 'OVERLAY.VITANA_INDEX'], expectNotOneOf: ['LIFE_COMPASS.OVERLAY'] },
+  // ── Community events (collection, never a profile) ───────────────────────
+  { name: 'community events (EN)', lang: 'en', utterance: 'Show me community events', expectOneOf: ['COMM.EVENTS', 'COMM.EVENTS_UPCOMING', 'COMM.EVENTS_HOT', 'COMM.EVENTS_TODAY'], expectNotOneOf: ['PROFILE.PUBLIC', 'PROFILE.ME', 'DISCOVER.PROVIDER_PROFILE'] },
+  { name: 'community events (DE)', lang: 'de', utterance: 'Zeig mir Community-Events', expectOneOf: ['COMM.EVENTS', 'COMM.EVENTS_UPCOMING', 'COMM.EVENTS_HOT', 'COMM.EVENTS_TODAY'], expectNotOneOf: ['PROFILE.PUBLIC', 'PROFILE.ME'] },
+];
+
+function topScreen(utterance: string, lang: Lang): { screen_id: string; score: number } | null {
+  const ranked = searchCatalog(utterance, lang);
+  const top = ranked[0];
+  return top ? { screen_id: top.entry.screen_id, score: top.score } : null;
+}
+
+describe('Navigation Route Integrity — regression/contract suite (scorer)', () => {
+  // Emit a human-readable report regardless of pass/fail so CI logs show the
+  // full baseline picture.
+  const report: string[] = [];
+  afterAll(() => {
+    // eslint-disable-next-line no-console
+    console.log('\n=== NAV REGRESSION REPORT (scorer baseline) ===\n' + report.join('\n') + '\n');
+  });
+
+  for (const c of CASES) {
+    it(`${c.name}: "${c.utterance}"`, () => {
+      const top = topScreen(c.utterance, c.lang);
+      const got = top?.screen_id ?? '(none)';
+      const okExpect = !!top && c.expectOneOf.includes(top.screen_id);
+      const okNot = !top || !c.expectNotOneOf || !c.expectNotOneOf.includes(top.screen_id);
+      report.push(`${okExpect && okNot ? 'PASS' : 'FAIL'}  ${c.name.padEnd(22)} got=${got} (score ${top?.score ?? '-'}) expect∈[${c.expectOneOf.join('|')}]`);
+      expect({ case: c.name, top: got }).toEqual({ case: c.name, top: expect.stringMatching(new RegExp(`^(${c.expectOneOf.join('|').replace(/\./g, '\\.')})$`)) });
+      if (c.expectNotOneOf && top) expect(c.expectNotOneOf).not.toContain(top.screen_id);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds the **navigation regression/contract test harness** the design calls for, and uses it to find + fix a real **cross-language navigation bug**.

### 1. New harness — `test/nav-regression-contract.test.ts`
The design doc's **permanent regression cases** (My Journey, Life Compass, Vitana Index, community events), run **EN + DE** against the real synchronous scorer (`searchCatalog`). Deterministic, no DB/network. This is the measurable backbone for "did navigation actually resolve right."

### 2. Fix — German brand-name navigation was broken
The harness immediately caught it: `"Öffne meine Journey"` and `"Öffne meinen Life Compass"` returned **no match**, because `searchCatalog` only scores the *active-language* i18n content (`"Reise"`, `"Lebenskompass"`) and `AUTOPILOT.MY_JOURNEY` had **no aliases at all**. A German user saying the English brand word matched nothing.

- `searchCatalog` now does a language-agnostic **brand-phrase rescue**: a curated *multi-word* alias matched as a contiguous phrase, applied **only when the active-language content scored 0** — so it never overrides a real content match or perturbs intra-family ranking. (Single-word generic aliases are excluded — they false-positive on words like "profile"/"results"/"matches".)
- `AUTOPILOT.MY_JOURNEY` gets its missing aliases.

### Verification
- **Regression harness: 8/8 green** (was 6/8 — the 2 German cases were the bug).
- `navigator | navigation | nav-catalog | nav-redirect | nav-confidence` suites: **all green (290/291)**.
- The 1 remaining failure is the **pre-existing** cross-repo manifest-sync drift gate — it also fails on `main` and **skips in CI** (vitana-v1 isn't checked out there). Not introduced here.
- `tsc --noEmit` ✅. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_