### PR TITLE
fix(nav): resolve named-person profiles via the member directory (no invented IDs)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -69,6 +69,14 @@ FEATURE_ORB_GREETING_PREBUFFER_ENV=off
 # Enable on staging first to verify desktop resolution via the admin simulator.
 NAV_PLATFORM_AWARE=false
 
+# NAV-ENTITY-RESOLVE (Navigation Route Integrity) — named-person profile safety.
+# When 'true', navigate_to_screen will NOT dispatch a model-supplied identifier
+# for a person-profile route (/u/:identifier). Instead it resolves the name via
+# the canonical member directory (findCommunityMember): unique → that member's
+# profile; not found → the members directory + a spoken "couldn't find them"
+# (never a broken /u/<invented-slug> page). Default OFF = previous behaviour.
+NAV_ENTITY_RESOLVE=false
+
 # DEV-COMHU-0513 — upper bound (ms) on waiting for session.contextReadyPromise
 # before sending the Gemini setup message / greeting. Safety net so a slow or
 # hung context build (notably when FEATURE_ORB_FAST_START_ENV defers wake-brief/

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -2705,6 +2705,7 @@ export async function tool_respond_to_match(
 export async function tool_navigate_to_screen(
   args: OrbToolArgs,
   id: OrbToolIdentity,
+  sb?: SupabaseClient,
 ): Promise<OrbToolResult> {
   const screenIdArg = String(args.screen_id ?? args.target ?? '').trim();
   if (!screenIdArg) return { ok: false, error: 'screen_id (or legacy target) is required' };
@@ -2906,6 +2907,61 @@ export async function tool_navigate_to_screen(
         ok: false,
         error: `Screen '${entry.screen_id}' is only available on ${entry.viewport_only}. Suggest a different screen or stay in voice.`,
       };
+    }
+  }
+
+  // NAV-ENTITY-RESOLVE: a person-profile route (/u/:identifier) must NEVER
+  // dispatch a model-supplied identifier — the model invents slugs like
+  // "maria-maksina" that 404 ("Benutzer nicht gefunden"). Resolve the name
+  // through the canonical member directory instead (design invariants #1/#5/#7).
+  // Flag-gated; verify on staging. Only triggers when the identifier looks like
+  // a de-slugged NAME (has a separator) or an explicit name/query was supplied
+  // — a concrete @vitana_id handle still passes straight through.
+  if (
+    process.env.NAV_ENTITY_RESOLVE === 'true' &&
+    sb &&
+    entry.screen_id === 'PROFILE.PUBLIC' &&
+    id.user_id && id.tenant_id
+  ) {
+    const rawId = String(args.identifier ?? args.target ?? '').trim();
+    const explicitName = String(args.name ?? args.query ?? args.reason ?? '').trim();
+    const nameQuery = explicitName || rawId.replace(/[-_]+/g, ' ').trim();
+    const looksLikeName = !!explicitName || /[-_\s]/.test(rawId);
+    if (nameQuery && looksLikeName) {
+      emitOasisEvent({
+        vtid: 'VTID-NAV-01',
+        type: 'orb.navigator.blocked',
+        source: 'orb-tools-shared',
+        status: 'info',
+        message: `Profile-by-name '${nameQuery}' routed through member resolver (not trusting model identifier '${rawId}')`,
+        payload: {
+          session_id: sessionId,
+          attempted_screen_id: screenIdArg,
+          entity_query: nameQuery.slice(0, 120),
+          error_kind: 'entity_resolve',
+        },
+      }).catch(() => {});
+      const memberRes = await tool_find_community_member({ query: nameQuery }, id, sb);
+      if (memberRes.ok === false) return memberRes;
+      // Adapt the resolver's result to the navigate_to_screen contract so BOTH
+      // pipelines dispatch it (Vertex reads top-level screen_id/route/title;
+      // LiveKit reads result.directive). The resolver already built the correct
+      // profile directive (its own route + search_id for the match card).
+      const d = (memberRes.result as { directive?: { screen_id?: string; route?: string; title?: string } } | undefined)?.directive;
+      if (d && d.route) {
+        return {
+          ok: true,
+          result: {
+            screen_id: d.screen_id || 'profile_with_match',
+            route: d.route,
+            title: d.title || 'Profile',
+            entry_kind: 'route',
+            directive: d,
+          },
+          text: memberRes.text,
+        };
+      }
+      return memberRes;
     }
   }
 
@@ -4516,7 +4572,7 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   scan_existing_matches: tool_scan_existing_matches,
   share_intent_post: tool_share_intent_post,
   respond_to_match: tool_respond_to_match,
-  navigate_to_screen: (args, id) => tool_navigate_to_screen(args, id),
+  navigate_to_screen: (args, id, sb) => tool_navigate_to_screen(args, id, sb),
   // VTID-NAV-UNIFIED — free-text navigate (PR 1.B-4). Runs consultNavigator's
   // 8-step resolution and constructs the redirect directive.
   navigate: tool_navigate,

--- a/services/gateway/test/nav-entity-resolve.test.ts
+++ b/services/gateway/test/nav-entity-resolve.test.ts
@@ -1,0 +1,101 @@
+/**
+ * NAV-ENTITY-RESOLVE — named-person profile resolution guard.
+ *
+ * Proves that navigate_to_screen, for a person-profile route, does NOT trust a
+ * model-invented identifier. With the flag ON it resolves the NAME through the
+ * canonical member directory; with the flag OFF it keeps the old behaviour.
+ * The member ranker + supabase are mocked so this is deterministic and never
+ * touches a DB.
+ */
+process.env.NODE_ENV = 'test';
+process.env.SUPABASE_URL = 'http://localhost:54321';
+process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+
+jest.mock('../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+const mockFindCommunityMember = jest.fn();
+jest.mock('../src/services/voice-tools/community-member-ranker', () => ({
+  findCommunityMember: (...a: any[]) => mockFindCommunityMember(...a),
+  hashQuery: () => 'hash',
+}));
+
+import { tool_navigate_to_screen } from '../src/services/orb-tools-shared';
+
+// Minimal supabase stub: only community_search_history insert is exercised.
+const sbStub: any = {
+  from: () => ({
+    insert: () => ({ select: () => ({ maybeSingle: async () => ({ data: { search_id: 'sid-1' } }) }) }),
+  }),
+};
+
+const authedId = {
+  user_id: 'u-1',
+  tenant_id: 't-1',
+  vitana_id: 'viewer',
+  role: 'community',
+  lang: 'en',
+  session_id: 's-1',
+  is_anonymous: false,
+  is_mobile: false,
+} as any;
+
+beforeEach(() => {
+  mockFindCommunityMember.mockReset();
+  delete process.env.NAV_ENTITY_RESOLVE;
+});
+
+describe('NAV-ENTITY-RESOLVE — profile-by-name', () => {
+  test('flag ON: a model-invented identifier is resolved via the member directory', async () => {
+    process.env.NAV_ENTITY_RESOLVE = 'true';
+    mockFindCommunityMember.mockResolvedValue({
+      tier: 1, lane: 'name', winnerUserId: 'maria-user',
+      result: {
+        ok: true,
+        vitana_id: 'maria_m',
+        display_name: 'Maria Maksina',
+        voice_summary: 'Here is Maria Maksina.',
+        match_recipe: {},
+        redirect: { screen: 'profile_with_match', route: '/u/maria_m' },
+      },
+    });
+
+    const r: any = await tool_navigate_to_screen(
+      { screen_id: 'PROFILE.PUBLIC', identifier: 'maria-maksina' },
+      authedId,
+      sbStub,
+    );
+
+    expect(mockFindCommunityMember).toHaveBeenCalledTimes(1);
+    // It searched the NAME, not the invented slug.
+    expect(mockFindCommunityMember.mock.calls[0][1]).toMatchObject({ query: 'maria maksina' });
+    expect(r.ok).toBe(true);
+    // The dispatched route is the resolved member's real route — never /u/maria-maksina.
+    expect(r.result.route).toContain('maria_m');
+    expect(r.result.route).not.toContain('maria-maksina');
+    expect(r.text).toBe('Here is Maria Maksina.');
+  });
+
+  test('flag OFF: behaviour unchanged — the identifier is used as given', async () => {
+    const r: any = await tool_navigate_to_screen(
+      { screen_id: 'PROFILE.PUBLIC', identifier: 'maria-maksina' },
+      authedId,
+      sbStub,
+    );
+    expect(mockFindCommunityMember).not.toHaveBeenCalled();
+    expect(r.ok).toBe(true);
+    expect(r.result.route).toContain('maria-maksina');
+  });
+
+  test('flag ON but a concrete @handle (no separators) passes straight through', async () => {
+    process.env.NAV_ENTITY_RESOLVE = 'true';
+    const r: any = await tool_navigate_to_screen(
+      { screen_id: 'PROFILE.PUBLIC', identifier: 'mariamaksina' },
+      authedId,
+      sbStub,
+    );
+    expect(mockFindCommunityMember).not.toHaveBeenCalled();
+    expect(r.result.route).toContain('mariamaksina');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the live failure you hit: **"show me the profile of Maria Maksina" → "Benutzer nicht gefunden."**

### Root cause
The model chose `navigate_to_screen('PROFILE.PUBLIC', identifier='maria-maksina')` instead of the **existing** `find_community_member` resolver, and the dispatcher **trusted the invented identifier** — dropping a guessed slug into `/u/:identifier`, which 404s. This is the design's headline bug (invariants **#1/#5/#7**: the model must never supply a trusted entity id; an entity route can't dispatch until the entity is uniquely resolved).

### Fix — behind `NAV_ENTITY_RESOLVE` (default OFF)
For a person-profile route, `navigate_to_screen` now resolves the **name** through the canonical member directory (`findCommunityMember`) instead of trusting the model's identifier:
- **unique match →** that member's real profile (works on **Vertex *and* LiveKit** — the resolver result is adapted to the `navigate_to_screen` contract so both pipelines dispatch it);
- **not found →** the members directory + a spoken *"I couldn't find them"* — never a broken `/u/<invented-slug>` page;
- a concrete `@handle` (no separators) still passes straight through.

`navigate_to_screen` now receives the request-scoped supabase client (the registry wrapper passes it; the param is optional so existing callers are unaffected).

### Verification
- **New `test/nav-entity-resolve.test.ts` — 3/3** (resolves the name not the slug; flag-off unchanged; `@handle` pass-through).
- `navigator | navigation | nav-catalog | nav-redirect | nav-confidence | orb-tools` — **290/290 green**.
- `tsc --noEmit` ✅.
- **Live confirmation needs staging** with `NAV_ENTITY_RESOLVE=true`. Since Maria is a real member, the resolver should open her profile; if it still can't find her, that points to a directory-search gap (the next thing to look at).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_