### PR TITLE
feat(nav): guided/full journey switch both ways + Vitana explains the difference

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3260,25 +3260,33 @@ export async function tool_navigate(
     const entry = lookupScreen(consultResult.primary.screen_id);
     if (entry) {
       // NAV-GUIDED-JOURNEY: "Guided Journey" is NOT a separate screen — it's the
-      // durable GUIDED mode of My Journey (GuidedModeProvider, VTID-03279). The
-      // Navigator can only emit /autopilot, which renders in the user's current
-      // mode (defaults Full). So when the user asks for their GUIDED journey,
-      // flip the durable mode to 'guided' BEFORE opening the screen, so they
-      // land in the guided view instead of the full app. Flag-gated; reuses the
+      // durable GUIDED vs FULL mode of My Journey (GuidedModeProvider, VTID-03279;
+      // the Einführung/Vollversion toggle). The Navigator can only emit /autopilot,
+      // which renders in the user's current durable mode. So when the user asks for
+      // their GUIDED journey (or the FULL app), flip the durable mode to match
+      // BEFORE opening the screen, so they land in the right view. We also tell
+      // Vitana to explain the difference + how to switch. Flag-gated; reuses the
       // existing journey-mode service.
+      let journeyModeSwitched: 'guided' | 'full' | null = null;
       if (
         process.env.NAV_GUIDED_JOURNEY === 'true' &&
         sb && id.user_id &&
-        entry.screen_id === 'AUTOPILOT.MY_JOURNEY' &&
-        /guided|gef[üu]hrt|einf[üu]hrung|guided[\s-]?journey|guided[\s-]?mode/i.test(`${question} ${transcriptExcerpt}`)
+        entry.screen_id === 'AUTOPILOT.MY_JOURNEY'
       ) {
-        try {
-          const { setJourneyMode } = await import('./guided-journey/guided-journey-state');
-          await setJourneyMode(sb, id.user_id, 'guided');
-          console.log(`[NAV-GUIDED-JOURNEY] set journey mode = guided for ${id.user_id} before opening My Journey`);
-        } catch (e) {
-          // Don't block navigation — the screen is still correct, just in Full mode.
-          console.error('[NAV-GUIDED-JOURNEY] setJourneyMode failed:', e instanceof Error ? e.message : e);
+        const intentText = `${question} ${transcriptExcerpt}`.toLowerCase();
+        const wantsGuided = /guided|gef[üu]hrt|einf[üu]hrung/.test(intentText);
+        const wantsFull = /full[\s-]?app|full[\s-]?version|full[\s-]?mode|vollversion|volle\s+version|komplette\s+app|kompletten?\s+app/.test(intentText);
+        const targetMode: 'guided' | 'full' | null = wantsGuided ? 'guided' : wantsFull ? 'full' : null;
+        if (targetMode) {
+          try {
+            const { setJourneyMode } = await import('./guided-journey/guided-journey-state');
+            await setJourneyMode(sb, id.user_id, targetMode);
+            journeyModeSwitched = targetMode;
+            console.log(`[NAV-GUIDED-JOURNEY] set journey mode = ${targetMode} for ${id.user_id} before opening My Journey`);
+          } catch (e) {
+            // Don't block navigation — the screen is still correct, just in the prior mode.
+            console.error('[NAV-GUIDED-JOURNEY] setJourneyMode failed:', e instanceof Error ? e.message : e);
+          }
         }
       }
 
@@ -3353,6 +3361,22 @@ export async function tool_navigate(
       lines.push('explain the feature, tell them what they can do on that screen,');
       lines.push('and let them know you are taking them there. The redirect happens');
       lines.push('automatically when you finish speaking.');
+      if (journeyModeSwitched === 'guided') {
+        lines.push('');
+        lines.push('MODE_SWITCH: You switched the user into the GUIDED JOURNEY — the');
+        lines.push('step-by-step guided experience that walks them through one focused');
+        lines.push('move at a time. Briefly explain how this differs from the FULL app');
+        lines.push('(the complete version with everything available at once), and tell');
+        lines.push('them they can switch back anytime with the Einführung/Vollversion');
+        lines.push('toggle at the top of this screen — or just ask you to switch.');
+      } else if (journeyModeSwitched === 'full') {
+        lines.push('');
+        lines.push('MODE_SWITCH: You switched the user into the FULL app — the complete');
+        lines.push('version with everything available at once. Briefly explain how this');
+        lines.push('differs from the GUIDED Journey (the step-by-step guided experience),');
+        lines.push('and tell them they can switch back anytime with the');
+        lines.push('Einführung/Vollversion toggle at the top of this screen — or just ask you.');
+      }
 
       return {
         ok: true,

--- a/services/gateway/test/nav-guided-journey.test.ts
+++ b/services/gateway/test/nav-guided-journey.test.ts
@@ -52,6 +52,18 @@ describe('NAV-GUIDED-JOURNEY', () => {
     expect(mockSetMode.mock.calls[0]).toEqual([sbStub, 'u-1', 'guided']);
     expect(r.ok).toBe(true);
     expect(r.result.route).toBe('/autopilot');
+    // Vitana is told to explain the difference + how to switch.
+    expect(r.text).toContain('GUIDED JOURNEY');
+    expect(r.text).toContain('Einführung/Vollversion');
+  });
+
+  test('full-app intent → flips durable mode to full + explains the difference', async () => {
+    process.env.NAV_GUIDED_JOURNEY = 'true';
+    const r: any = await tool_navigate({ question: 'show me the full app version' }, authedId, sbStub);
+    expect(mockSetMode).toHaveBeenCalledTimes(1);
+    expect(mockSetMode.mock.calls[0]).toEqual([sbStub, 'u-1', 'full']);
+    expect(r.text).toContain('FULL app');
+    expect(r.text).toContain('Einführung/Vollversion');
   });
 
   test('German "geführte" / "Einführung" intent also flips the mode', async () => {


### PR DESCRIPTION
## Summary

Follow-up to the Guided Journey fix (#2744), per your guidance:

1. **Switch both ways** — not just guided. *"show me my guided journey"* → **guided** mode; *"show me the full app / die Vollversion"* → **full** mode (before opening `/autopilot`). So you can ask Vitana to show either.
2. **Vitana explains the difference** — when she switches the mode, she's now instructed to briefly explain how the **Guided Journey** (step-by-step, one focused move at a time) differs from the **Full app** (everything available at once), and to tell you that you can switch anytime via the **Einführung/Vollversion** toggle — or just by asking her.

Same `NAV_GUIDED_JOURNEY` flag (default OFF). The explanation is LLM-facing guidance (Vitana speaks it in the user's language), so no hardcoded user string.

### Verification
- `nav-guided-journey` — **5/5** (guided + full switch, EN + DE intent, explanation text present, flag-off + plain "my journey" untouched).
- `navigator | navigation | nav-catalog | nav-redirect | nav-confidence | orb-tools | entity | regression` — **301/301 green**.
- `tsc --noEmit` ✅. Live on staging with `NAV_GUIDED_JOURNEY=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_