### PR TITLE
feat(orb): continuation acceptance gate — bind "yes" to the offered action (invariant #10)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/acceptance-gate.ts
+++ b/services/gateway/src/services/assistant-continuation/acceptance-gate.ts
@@ -1,0 +1,153 @@
+/**
+ * NAV_CONTINUATION_BIND — design invariant #10: continuation acceptance binding.
+ *
+ * When Vitana OFFERS an action ("Soll ich dir zeigen, wo du in deinem Guided
+ * Journey stehst?") and the user ACCEPTS ("Ja", "zeig mir", "mach das"), the
+ * system must execute the EXACT action Vitana offered — the stored canonical
+ * `pending_cta` — instead of re-interpreting the bare "yes" as a fresh
+ * navigation/search request (which is what misfires today: "Ja" goes straight
+ * to the LLM as a new turn and gets resolved wrongly).
+ *
+ * This module is the PURE decision core:
+ *   1. detectAcceptance(text)        — is this utterance an affirmation?
+ *   2. maybeBindAcceptance(...)      — affirmation + a live pending_cta → the
+ *                                       exact { tool, payload } to execute.
+ *
+ * It is transport-agnostic (Vertex Live + LiveKit) and has NO realtime
+ * dependencies, so it is fully unit-testable. The turn-loop wiring that calls
+ * maybeBindAcceptance() — and on a hit, dispatches the stored tool instead of
+ * forwarding "yes" to the LLM — lives in the upstream message handler, behind
+ * the NAV_CONTINUATION_BIND flag. The pending_cta itself is produced by the
+ * continuation layer (wake-brief-wiring.ts today; mid-conversation offers next)
+ * via writeOrbSessionState(userId, 'pending_cta', { tool, payload, offered_at }).
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  readOrbSessionState,
+  clearOrbSessionState,
+} from '../orb/orb-session-state';
+
+/** The shape stored under orb_session_state.key='pending_cta' (see wake-brief-wiring.ts). */
+export interface PendingCtaValue {
+  tool: string;
+  payload?: Record<string, unknown>;
+  offered_at?: string;
+}
+
+/** What an accepted continuation resolves to — the exact action to execute. */
+export interface BoundAcceptance {
+  tool: string;
+  payload: Record<string, unknown>;
+  source: 'pending_cta';
+}
+
+// ---------------------------------------------------------------------------
+// Affirmation detection (DE + EN), with negation / redirect guards.
+// ---------------------------------------------------------------------------
+
+// Whole-word affirmation tokens. Kept deliberately tight: a continuation
+// acceptance is a SHORT confirming utterance, not a fresh request that merely
+// happens to contain "ja".
+const AFFIRM = [
+  // German
+  'ja', 'jo', 'joa', 'jepp', 'jap', 'klar', 'na klar', 'klaro', 'gerne', 'gern',
+  'sicher', 'okay', 'ok', 'oki', 'passt', 'einverstanden', 'mach', 'machs',
+  'mach das', 'mach es', 'tu das', 'tu es', 'zeig', 'zeig mir', 'zeig es',
+  'zeig es mir', 'zeig mal', 'leg los', 'los', 'bitte', 'jawohl', 'auf jeden',
+  'auf jeden fall', 'unbedingt', 'perfekt',
+  // English
+  'yes', 'yeah', 'yep', 'yup', 'sure', 'okay', 'ok', 'please', 'please do',
+  'go ahead', 'do it', 'show me', 'show it', "let's go", 'lets go', 'sounds good',
+  'sound good', 'perfect', 'absolutely', 'definitely', 'go for it',
+];
+
+// If any of these appear, it is NOT a clean acceptance: an explicit refusal,
+// or a redirect ("ja, aber zeig mir lieber X" → user is steering elsewhere).
+const NEGATE_OR_REDIRECT =
+  /\b(nein|nee|n[öo]|nope|no|not now|nicht jetzt|nicht|kein|keine|stop|stopp|abbrechen|cancel|sp[äa]ter|warte|aber|lieber|stattdessen|eigentlich|doch lieber|instead|rather)\b/;
+
+const AFFIRM_RE = new RegExp(
+  `(^|\\b)(${AFFIRM.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+')).join('|')})(\\b|$)`,
+  'i',
+);
+
+const WORD = /\S+/g;
+
+/**
+ * True when `text` is a clean affirmation accepting the prior offer.
+ *
+ * Guards (in order):
+ *  - empty → false
+ *  - contains a negation OR redirect word → false ("nein", "aber", "lieber")
+ *  - longer than 6 words → false (a real sentence is a fresh request, not a
+ *    bare "yes" — even if it contains "zeig mir")
+ *  - contains an affirmation token as a whole word → true
+ */
+export function detectAcceptance(text: string | null | undefined): boolean {
+  if (!text) return false;
+  const norm = text.toLowerCase().replace(/[.!,;:¿?]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!norm) return false;
+  if (NEGATE_OR_REDIRECT.test(norm)) return false;
+  const wordCount = norm.match(WORD)?.length ?? 0;
+  if (wordCount > 6) return false;
+  return AFFIRM_RE.test(norm);
+}
+
+// ---------------------------------------------------------------------------
+// Pending-CTA resolution (one-shot).
+// ---------------------------------------------------------------------------
+
+/** Indirection so the gate is unit-testable without a live Supabase chain. */
+export interface AcceptanceGateDeps {
+  readPendingCta: (userId: string, now: number) => Promise<PendingCtaValue | null>;
+  clearPendingCta: (userId: string) => Promise<void>;
+}
+
+/** Real deps backed by orb_session_state. The reader already drops expired rows. */
+export function makeSupabaseAcceptanceDeps(supabase: SupabaseClient): AcceptanceGateDeps {
+  return {
+    readPendingCta: async (userId, now) => {
+      const rec = await readOrbSessionState<PendingCtaValue>(supabase, userId, 'pending_cta', now);
+      const v = rec?.value;
+      if (!v || typeof v.tool !== 'string' || v.tool.trim() === '') return null;
+      return v;
+    },
+    clearPendingCta: async (userId) => {
+      await clearOrbSessionState(supabase, userId, 'pending_cta');
+    },
+  };
+}
+
+export interface MaybeBindInput {
+  /** The user's latest utterance / transcript for this turn. */
+  userText: string | null | undefined;
+  userId: string | null | undefined;
+  now?: number;
+}
+
+/**
+ * The keystone: if `userText` is an acceptance AND a live pending_cta exists,
+ * return the exact stored action to execute (and consume it, so a second "ja"
+ * can't re-fire). Otherwise null — the caller proceeds normally (LLM turn).
+ *
+ * Fails open: any error → null (never blocks the conversation).
+ */
+export async function maybeBindAcceptance(
+  input: MaybeBindInput,
+  deps: AcceptanceGateDeps,
+): Promise<BoundAcceptance | null> {
+  const { userText, userId } = input;
+  if (!userId) return null;
+  if (!detectAcceptance(userText)) return null;
+  try {
+    const cta = await deps.readPendingCta(userId, input.now ?? Date.now());
+    if (!cta) return null;
+    // One-shot: consume before returning so the acceptance can't double-execute
+    // (e.g. user says "ja" twice while the action is already running).
+    await deps.clearPendingCta(userId);
+    return { tool: cta.tool, payload: cta.payload ?? {}, source: 'pending_cta' };
+  } catch {
+    return null;
+  }
+}

--- a/services/gateway/test/acceptance-gate.test.ts
+++ b/services/gateway/test/acceptance-gate.test.ts
@@ -1,0 +1,140 @@
+/**
+ * NAV_CONTINUATION_BIND — unit tests for the continuation acceptance gate
+ * (design invariant #10). Pure decision core: affirmation detection + one-shot
+ * pending_cta resolution. No realtime / Supabase dependency (deps injected).
+ */
+import {
+  detectAcceptance,
+  maybeBindAcceptance,
+  type AcceptanceGateDeps,
+  type PendingCtaValue,
+} from '../src/services/assistant-continuation/acceptance-gate';
+
+describe('detectAcceptance', () => {
+  test.each([
+    'Ja',
+    'ja',
+    'Ja!',
+    'ja, zeig mir',
+    'zeig mir',
+    'zeig es mir',
+    'mach das',
+    'mach es',
+    'klar',
+    'na klar',
+    'gerne',
+    'okay',
+    'ok',
+    'perfekt',
+    'yes',
+    'yes please',
+    'yeah, go for it',
+    'sure',
+    'show me',
+    "let's go",
+    'absolutely',
+  ])('accepts affirmation: %p', (s) => {
+    expect(detectAcceptance(s)).toBe(true);
+  });
+
+  test.each([
+    '',
+    '   ',
+    null,
+    undefined,
+    'nein',
+    'nein danke',
+    'no',
+    'nope',
+    'nicht jetzt',
+    'stop',
+    'abbrechen',
+    // redirect — "yes, but rather show me X" is steering elsewhere, NOT a clean accept
+    'ja, aber lieber meine Termine',
+    'ja, zeig mir lieber meine Nachrichten',
+    'no, show me the calendar instead',
+    // a real fresh request that happens to contain an affirmation word but is long
+    'kannst du mir bitte zeigen wo meine termine heute sind',
+    // substring, not whole word
+    'willst du jagen gehen',
+  ])('rejects non-acceptance: %p', (s) => {
+    expect(detectAcceptance(s as string)).toBe(false);
+  });
+});
+
+describe('maybeBindAcceptance', () => {
+  const pending: PendingCtaValue = {
+    tool: 'navigate_to_screen',
+    payload: { screen_id: 'AUTOPILOT.MY_JOURNEY' },
+    offered_at: new Date().toISOString(),
+  };
+
+  function makeDeps(cta: PendingCtaValue | null) {
+    const calls = { read: 0, clear: 0 };
+    const deps: AcceptanceGateDeps = {
+      readPendingCta: async () => {
+        calls.read++;
+        return cta;
+      },
+      clearPendingCta: async () => {
+        calls.clear++;
+      },
+    };
+    return { deps, calls };
+  }
+
+  test('acceptance + live pending_cta → returns the exact stored action and consumes it', async () => {
+    const { deps, calls } = makeDeps(pending);
+    const r = await maybeBindAcceptance({ userText: 'ja, zeig mir', userId: 'u-1' }, deps);
+    expect(r).toEqual({
+      tool: 'navigate_to_screen',
+      payload: { screen_id: 'AUTOPILOT.MY_JOURNEY' },
+      source: 'pending_cta',
+    });
+    expect(calls.read).toBe(1);
+    expect(calls.clear).toBe(1); // one-shot consume
+  });
+
+  test('acceptance but NO pending_cta → null, nothing consumed', async () => {
+    const { deps, calls } = makeDeps(null);
+    const r = await maybeBindAcceptance({ userText: 'ja', userId: 'u-1' }, deps);
+    expect(r).toBeNull();
+    expect(calls.read).toBe(1);
+    expect(calls.clear).toBe(0);
+  });
+
+  test('non-acceptance short-circuits BEFORE reading state (no fresh-search override)', async () => {
+    const { deps, calls } = makeDeps(pending);
+    const r = await maybeBindAcceptance(
+      { userText: 'zeig mir lieber meine nachrichten', userId: 'u-1' },
+      deps,
+    );
+    expect(r).toBeNull();
+    expect(calls.read).toBe(0); // never even looked at pending_cta
+    expect(calls.clear).toBe(0);
+  });
+
+  test('missing userId → null', async () => {
+    const { deps, calls } = makeDeps(pending);
+    const r = await maybeBindAcceptance({ userText: 'ja', userId: null }, deps);
+    expect(r).toBeNull();
+    expect(calls.read).toBe(0);
+  });
+
+  test('payload defaults to {} when stored cta has none', async () => {
+    const { deps } = makeDeps({ tool: 'open_autopilot' });
+    const r = await maybeBindAcceptance({ userText: 'yes', userId: 'u-1' }, deps);
+    expect(r).toEqual({ tool: 'open_autopilot', payload: {}, source: 'pending_cta' });
+  });
+
+  test('fails open: reader throws → null (never blocks the turn)', async () => {
+    const deps: AcceptanceGateDeps = {
+      readPendingCta: async () => {
+        throw new Error('db down');
+      },
+      clearPendingCta: async () => {},
+    };
+    const r = await maybeBindAcceptance({ userText: 'ja', userId: 'u-1' }, deps);
+    expect(r).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Keystone for **design invariant #10** — *continuation acceptance binding*. The problem you hit: Vitana offers something ("Soll ich dir zeigen, wo du in deinem Guided Journey stehst?"), you say **"Ja"**, and instead of executing the **exact action she offered**, the bare "yes" goes straight to the LLM as a fresh turn and gets re-interpreted as a new navigation/search — resolving wrongly.

This PR lands the **pure decision core** (transport-agnostic, fully unit-tested, **called by nothing yet** → zero runtime risk):

- **`detectAcceptance(text)`** — DE+EN affirmations (`ja`, `zeig mir`, `mach das`, `yes`, `show me`, …) with:
  - **negation/redirect guards** — `nein`, `nicht jetzt`, and crucially *"ja, aber lieber meine Termine"* (steering elsewhere → **not** a clean accept);
  - a **6-word length guard** — a real sentence is a fresh request, not a bare yes.
- **`maybeBindAcceptance()`** — affirmation **+** a live `pending_cta` → the exact `{ tool, payload }` to execute; **one-shot consume** so a second "ja" can't re-fire; **fails open** (any error → null, never blocks the turn).
- Reuses the existing `orb_session_state` **`pending_cta`** store (5-min TTL, already written by `wake-brief-wiring.ts`) + its read/clear helpers; deps injected so it's testable without Supabase.

### Why land it alone
It's the riskiest feature to ship blind because the *consumer* lives in the real-time audio turn loop. Landing the tested core first keeps that next PR small and reviewable.

### Next PR (separate)
Wire `maybeBindAcceptance()` into the turn loop (`upstream-message-handler`, Vertex + LiveKit) behind **`NAV_CONTINUATION_BIND`** — on a hit, dispatch the stored tool instead of forwarding "yes" to the LLM — **plus** mid-conversation offer storage (so offers Vitana makes *during* a chat get a `pending_cta` to bind to). That one you'll verify on a live staging voice session.

### Verification
- `acceptance-gate` — **43/43 green** (21 affirmations, 16 rejections incl. negation/redirect/length/substring, 6 binding cases).
- `tsc --noEmit` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_