### PR TITLE
fix(orb): new-day greeting speaks the full morning overview, not a bare lead

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -103,6 +103,14 @@ ORB_CONTEXT_READY_GATE_TIMEOUT_MS=4000
 # that is also reliable.
 FEATURE_ORB_SAFE_FAST_GREETING_ENV=off
 
+# Optional tuning for the new-day greeting overview (orb-live.ts): on a new-day
+# return the fast greeting computes the full morning overview (passed events,
+# today's next event, Vitana Index direction, Life Compass goal) via the
+# new-day aggregator and speaks it verbatim instead of a one-line lead. This is
+# the bounded wait for that aggregator fetch; if it exceeds the bound we fall
+# back to the short opener. Optional — defaults to 1500 in code.
+ORB_NEWDAY_OVERVIEW_WAIT_MS=1500
+
 # Env vars read ONLY by the standalone latency probe
 # (services/gateway/scripts/orb-latency-probe.mjs) — never by the running
 # service. Documented here so the impact-scan env-binding check is satisfied.

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7479,6 +7479,78 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
             ]);
             if (ws.readyState !== WebSocket.OPEN) return;
 
+            // NEW-DAY OVERVIEW (rich summary owns turn 1). On a genuine new-day
+            // return we speak the FULL multi-clause morning overview (what passed
+            // since last session, today's next event, Index direction, Life
+            // Compass goal) — the same renderer the heavy new-day-return provider
+            // uses — INSTEAD of the short one-line proactive lead. Deliberate
+            // richness>latency choice: it adds the bounded aggregator fetch, but
+            // restores the summary the fast path had been preempting. Falls
+            // through to the existing ladder (proactive line → name → menu) when
+            // it is not a new day, the name/user is missing, or it can't build.
+            try {
+              const _temporalNd = describeTimeSince((session as any).lastSessionInfo);
+              const _firstNameNd = (session as any).greetingFirstName;
+              const _isNewDayNd =
+                _temporalNd.bucket === 'today' ||
+                _temporalNd.bucket === 'yesterday' ||
+                _temporalNd.bucket === 'week' ||
+                _temporalNd.bucket === 'long';
+              const _uidNd = session.identity?.user_id;
+              const _supaNd = getSupabase();
+              if (_isNewDayNd && typeof _firstNameNd === 'string' && _firstNameNd.trim().length > 0 && _uidNd && _supaNd) {
+                const _tzNd = session.clientContext?.timezone || 'UTC';
+                const _nowNd = new Date();
+                const { aggregateNewDayOverview } = await import('../services/assistant-continuation/providers/new-day-overview-aggregator');
+                const { renderNewDayReturnLineWithOverview, todayInTimezone, pickSalutationKind, localHourInTimezone } = await import('../services/assistant-continuation/providers/new-day-return');
+                const _overview = await Promise.race([
+                  aggregateNewDayOverview({
+                    supabase: _supaNd,
+                    userId: _uidNd,
+                    now: _nowNd,
+                    timezone: _tzNd,
+                    todayDateIso: todayInTimezone(_nowNd, _tzNd),
+                    lastSessionAtIso: (session as any).lastSessionInfo?.time ?? null,
+                  }),
+                  new Promise<null>((r) => setTimeout(() => r(null), Number(process.env.ORB_NEWDAY_OVERVIEW_WAIT_MS || 1500))),
+                ]).catch(() => null);
+                if (_overview) {
+                  const _line = renderNewDayReturnLineWithOverview({
+                    lang,
+                    salutation: pickSalutationKind(localHourInTimezone(_nowNd, _tzNd)),
+                    firstName: _firstNameNd.trim(),
+                    timezone: _tzNd,
+                    payload: _overview,
+                  });
+                  if (_line && _line.trim().length > 0) {
+                    const _safeOv = _line.trim().replace(/"/g, '\\"');
+                    const _ovPrompt =
+                      `Say exactly: "${_safeOv}" — speak it verbatim as audio, as ONE greeting. Do NOT add, paraphrase, or split it.`;
+                    ws.send(
+                      JSON.stringify({
+                        client_content: { turns: [{ role: 'user', parts: [{ text: _ovPrompt }] }], turn_complete: true },
+                      }),
+                    );
+                    emitDiag(session, 'greeting_sent', {
+                      lang,
+                      prompt_len: _ovPrompt.length,
+                      wake_opener: 'safe_fast_newday_overview',
+                      bucket: _temporalNd.bucket,
+                    });
+                    startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
+                    console.log(
+                      `[GREETING-SAFE-FAST-NEWDAY-OVERVIEW] session ${session.sessionId} sent full new-day overview (bucket=${_temporalNd.bucket}, lang=${lang})`,
+                    );
+                    return;
+                  }
+                }
+              }
+            } catch (_ndErr) {
+              console.warn(
+                `[GREETING-SAFE-FAST-NEWDAY-OVERVIEW] non-fatal, falling through: ${_ndErr instanceof Error ? _ndErr.message : String(_ndErr)}`,
+              );
+            }
+
             // DEV-COMHU-0513 (proactive fast greeting): when the fast pre-fetch
             // produced a SHORT proactive opener (name + concrete next step /
             // weakness lead), speak THAT instead of the generic SHORT_GAP phrase

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7498,7 +7498,13 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                 _temporalNd.bucket === 'long';
               const _uidNd = session.identity?.user_id;
               const _supaNd = getSupabase();
-              if (_isNewDayNd && typeof _firstNameNd === 'string' && _firstNameNd.trim().length > 0 && _uidNd && _supaNd) {
+              // The overview renderer only localizes DE/EN; for any other session
+              // language it would emit English clauses. Restrict the overview to
+              // de/en and let the existing localized name-greeting ladder handle
+              // es/fr/sr/etc. (Codex P2).
+              const _langKeyNd = (lang || 'en').slice(0, 2).toLowerCase();
+              const _langOkNd = _langKeyNd === 'de' || _langKeyNd === 'en';
+              if (_langOkNd && _isNewDayNd && typeof _firstNameNd === 'string' && _firstNameNd.trim().length > 0 && _uidNd && _supaNd) {
                 const _tzNd = session.clientContext?.timezone || 'UTC';
                 const _nowNd = new Date();
                 const { aggregateNewDayOverview } = await import('../services/assistant-continuation/providers/new-day-overview-aggregator');
@@ -7514,7 +7520,21 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                   }),
                   new Promise<null>((r) => setTimeout(() => r(null), Number(process.env.ORB_NEWDAY_OVERVIEW_WAIT_MS || 1500))),
                 ]).catch(() => null);
-                if (_overview) {
+                // The aggregator returns a truthy payload even when EMPTY (no
+                // calendar, no goal, no index move) — rendering that yields just a
+                // bare "Good morning … let's get started", which would preempt a
+                // genuine concrete proactive opener. Only take the overview when
+                // it has REAL content (a calendar event or the Life Compass goal);
+                // an index-only move is handled by the proactive ladder below.
+                // Otherwise fall through (Codex P2).
+                const _overviewHasContent =
+                  !!_overview &&
+                  (_overview.calendar_passed_notable != null ||
+                    _overview.calendar_passed_count > 0 ||
+                    _overview.calendar_today_next != null ||
+                    _overview.calendar_today_count > 0 ||
+                    !!(_overview.life_compass_goal && String(_overview.life_compass_goal).trim().length > 0));
+                if (_overview && _overviewHasContent) {
                   const _line = renderNewDayReturnLineWithOverview({
                     lang,
                     salutation: pickSalutationKind(localHourInTimezone(_nowNd, _tzNd)),


### PR DESCRIPTION
## New-day greeting lost its morning summary

### Symptom
On a new day, Vitana opened with a bare *"let me guide you to the next step"* instead of the rich morning overview (what happened since last session, today's next event, Vitana-Index direction, Life-Compass goal).

### Root cause
The **SAFE-FAST greeting path** fires before the heavy context resolves and speaks a deliberately short opener (proactive one-line lead → "Good morning, Name" → generic menu). The rich new-day overview (built by `new-day-overview-aggregator` + `new-day-return`, priority 90) lives on the heavy path, which the fast path **preempts** — and even there, login-briefing (priority 92) outranks it. So the overview never reached turn 1. (Not caused by the recent greeting-recall work — that changed wording only; the preemption came with the fast-start rollout.)

### Fix (richness > latency, per product decision)
In the fast greeting's **new-day rung**, compute and speak the **full overview** via the existing `aggregateNewDayOverview` + `renderNewDayReturnLineWithOverview` — the exact renderer the heavy provider uses — **before** the short proactive line. It:
- runs a **bounded** aggregator fetch (`ORB_NEWDAY_OVERVIEW_WAIT_MS`, default 1500ms) so it can't hang the greeting,
- speaks the line verbatim (`Say exactly: …`),
- **falls through** to the existing ladder (proactive line → name → menu) when it's not a new day, the name/user is missing, or the overview can't be built,
- is the renderer's proven ~3–4 sentence length, so no audio-stall risk.

New log line `[GREETING-SAFE-FAST-NEWDAY-OVERVIEW]` marks when it fires.

### Scope note
This covers the common case (fast path fires because context isn't ready — exactly the reported scenario). The rare fast-context case still goes through the heavy path where login-briefing (92) outranks new-day-return (90); changing that priority is intentionally out of scope here (NEVER-change-priority-ad-hoc).

### Tests
- new-day-return / new-day-overview-aggregator / login-briefing / conversation-flow: 97 passing. Build clean. (The wired functions are already unit-tested; this PR is the wiring into the fast path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_