### PR TITLE
feat(orb): offer_action tool — record the proposed action (invariant #10, produce side)

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -4656,6 +4656,62 @@ export async function tool_narrate_guided_session(
   }
 }
 
+/**
+ * NAV_CONTINUATION_BIND — offer_action (design invariant #10, PRODUCE side).
+ *
+ * Vitana calls this the moment she PROPOSES an action and will wait for a
+ * yes/no ("Soll ich dir zeigen, wo du in deinem Guided Journey stehst?"). It
+ * records the EXACT canonical action as the session's `pending_cta`, so when
+ * the user then says "Ja", the acceptance gate (acceptance-gate.ts) executes
+ * THIS action instead of re-interpreting the bare yes as a fresh navigation /
+ * search request (the invariant-#10 bug).
+ *
+ * Args: { tool: string (required, must be a real ORB tool), payload?: object,
+ *         ttl_minutes?: number (1..30, default 5) }
+ *
+ * Flag-gated: with NAV_CONTINUATION_BIND off it is an inert success (so a
+ * stray model call never surfaces an error to the user).
+ */
+export async function tool_offer_action(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (process.env.NAV_CONTINUATION_BIND !== 'true') {
+    return { ok: true, result: { stored: false, reason: 'flag_off' } };
+  }
+  const tool = String(args.tool ?? '').trim();
+  if (!tool) return { ok: false, error: 'offer_action requires a non-empty `tool`.' };
+  // The offered action must be dispatchable on acceptance — reject unknown tools
+  // (and offer_action itself, to avoid a self-referential pending_cta).
+  if (tool === 'offer_action' || !ORB_TOOL_REGISTRY[tool]) {
+    return { ok: false, error: `offer_action: '${tool}' is not a dispatchable ORB tool.` };
+  }
+  if (!id.user_id) return { ok: false, error: 'offer_action requires an authenticated user.' };
+  const payload =
+    args.payload && typeof args.payload === 'object' && !Array.isArray(args.payload)
+      ? (args.payload as Record<string, unknown>)
+      : {};
+  const ttlRaw = Number(args.ttl_minutes);
+  const ttl = Number.isFinite(ttlRaw) && ttlRaw > 0 && ttlRaw <= 30 ? ttlRaw : 5;
+  const { writeOrbSessionState } = await import('./orb/orb-session-state');
+  const res = await writeOrbSessionState(
+    sb,
+    id.user_id,
+    'pending_cta',
+    { tool, payload, offered_at: new Date().toISOString() },
+    ttl,
+  );
+  if (!res.ok) return { ok: false, error: res.reason ?? 'offer_action: failed to store pending action.' };
+  return {
+    ok: true,
+    result: { stored: true, tool },
+    // LLM-facing guidance (not user-visible): ask the yes/no and wait — the
+    // offered action fires automatically on acceptance, so don't re-resolve it.
+    text: 'OFFER_REGISTERED: Ask your yes/no question naturally and wait. If the user accepts, the offered action runs automatically — do not re-resolve or re-search it.',
+  };
+}
+
 type OrbToolHandler = (
   args: OrbToolArgs,
   identity: OrbToolIdentity,
@@ -4730,6 +4786,9 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   // fact (life_compass goal / economy stance / focus / teacher ack), re-verifies,
   // and returns the next move. Reachable from Vertex, LiveKit, and /api/v1/orb/tool.
   record_journey_answer: tool_record_journey_answer,
+  // NAV_CONTINUATION_BIND — offer_action: Vitana records the exact action she is
+  // proposing so a later "Ja" executes it deterministically (invariant #10).
+  offer_action: tool_offer_action,
 };
 
 export const ORB_TOOL_NAMES = Object.keys(ORB_TOOL_REGISTRY);

--- a/services/gateway/test/offer-action.test.ts
+++ b/services/gateway/test/offer-action.test.ts
@@ -1,0 +1,96 @@
+/**
+ * NAV_CONTINUATION_BIND — unit tests for the offer_action tool (invariant #10,
+ * PRODUCE side). Vitana records the exact action she proposes as pending_cta;
+ * the acceptance gate consumes it on "Ja". Tests the handler + registry wiring.
+ */
+import {
+  tool_offer_action,
+  ORB_TOOL_NAMES,
+  type OrbToolIdentity,
+} from '../src/services/orb-tools-shared';
+
+const ID: OrbToolIdentity = { user_id: 'u-1', tenant_id: 't-1', role: 'community' };
+
+/** Minimal Supabase stub capturing the orb_session_state upsert row. */
+function makeSbStub() {
+  const upserts: any[] = [];
+  const sb: any = {
+    from: (_table: string) => ({
+      upsert: (row: any) => {
+        upserts.push(row);
+        return Promise.resolve({ error: null });
+      },
+    }),
+  };
+  return { sb, upserts };
+}
+
+const FLAG = 'NAV_CONTINUATION_BIND';
+afterEach(() => {
+  delete process.env[FLAG];
+});
+
+test('offer_action is registered in the shared tool registry', () => {
+  expect(ORB_TOOL_NAMES).toContain('offer_action');
+});
+
+test('flag ON: stores the exact offered action as pending_cta', async () => {
+  process.env[FLAG] = 'true';
+  const { sb, upserts } = makeSbStub();
+  const r: any = await tool_offer_action(
+    { tool: 'navigate_to_screen', payload: { screen_id: 'AUTOPILOT.MY_JOURNEY' } },
+    ID,
+    sb,
+  );
+  expect(r.ok).toBe(true);
+  expect(r.result.stored).toBe(true);
+  expect(upserts).toHaveLength(1);
+  expect(upserts[0].key).toBe('pending_cta');
+  expect(upserts[0].user_id).toBe('u-1');
+  expect(upserts[0].value.tool).toBe('navigate_to_screen');
+  expect(upserts[0].value.payload).toEqual({ screen_id: 'AUTOPILOT.MY_JOURNEY' });
+  expect(typeof upserts[0].value.offered_at).toBe('string');
+});
+
+test('flag OFF: inert success, nothing written', async () => {
+  const { sb, upserts } = makeSbStub();
+  const r: any = await tool_offer_action({ tool: 'navigate_to_screen' }, ID, sb);
+  expect(r.ok).toBe(true);
+  expect(r.result.stored).toBe(false);
+  expect(upserts).toHaveLength(0);
+});
+
+test('rejects an unknown / non-dispatchable tool', async () => {
+  process.env[FLAG] = 'true';
+  const { sb, upserts } = makeSbStub();
+  const r: any = await tool_offer_action({ tool: 'definitely_not_a_tool' }, ID, sb);
+  expect(r.ok).toBe(false);
+  expect(upserts).toHaveLength(0);
+});
+
+test('rejects self-referential offer_action', async () => {
+  process.env[FLAG] = 'true';
+  const { sb } = makeSbStub();
+  const r: any = await tool_offer_action({ tool: 'offer_action' }, ID, sb);
+  expect(r.ok).toBe(false);
+});
+
+test('rejects a missing tool arg', async () => {
+  process.env[FLAG] = 'true';
+  const { sb } = makeSbStub();
+  const r: any = await tool_offer_action({}, ID, sb);
+  expect(r.ok).toBe(false);
+});
+
+test('clamps ttl_minutes into 1..30 (default 5 when out of range)', async () => {
+  process.env[FLAG] = 'true';
+  const { sb, upserts } = makeSbStub();
+  // 999 is out of range → handler falls back to 5 min; assert the row expires
+  // ~5 min out, not ~999.
+  const before = Date.now();
+  await tool_offer_action({ tool: 'navigate', ttl_minutes: 999 }, ID, sb);
+  const expiresAt = Date.parse(upserts[0].expires_at);
+  const minutesOut = (expiresAt - before) / 60_000;
+  expect(minutesOut).toBeGreaterThan(4);
+  expect(minutesOut).toBeLessThan(6);
+});


### PR DESCRIPTION
## Summary

**Produce side** of continuation binding (invariant #10). The consume side — the acceptance gate that runs the stored action on "Ja" — is already merged (#2749). This adds the half that *records* what Vitana offered.

`offer_action` is a new shared-registry tool Vitana calls the moment she **proposes** an action and will wait for yes/no ("Soll ich dir zeigen, wo du in deinem Guided Journey stehst?"). It writes the **exact canonical action** as the session's `pending_cta` (reusing the existing `orb_session_state` store, TTL 1–30 min, default 5). So when the user says "Ja", the acceptance gate executes **that** action instead of re-interpreting the bare yes as a fresh navigation/search — which is the invariant-#10 bug you hit.

- Reachable from Vertex, LiveKit, and `/api/v1/orb/tool` (shared registry).
- **Validates** the offered tool is a real, dispatchable ORB tool (rejects unknown tools + self-referential `offer_action`).
- **Flag-gated** by `NAV_CONTINUATION_BIND`: off → inert success (a stray model call never surfaces a user-visible error).

### Not in this PR (the final, live-verified step)
Declaring `offer_action` to the LLM (tool declarations + a short system-instruction nudge so Vitana calls it) **and** wiring the consume side at `turn_complete` to force-dispatch the stored action on acceptance. That's the only part that touches the real-time turn loop, so it lands separately and you verify it on a live staging voice session.

### Verification
- `offer-action` — **7/7** (registry wiring, stored shape, flag-off inert, unknown/self/missing-tool rejects, ttl clamp).
- `acceptance-gate | navigator | orb-tools | nav-guided` — **77/77 green**.
- `tsc --noEmit` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_