### PR TITLE
feat(orb): auto-capture navigation offers as pending_cta (invariant #10)

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3240,6 +3240,32 @@ export async function tool_navigate(
     lines.push('Then call navigate_to_screen with the chosen screen_id directly —');
     lines.push('do not call navigate again unless the user rephrases their request.');
 
+    // NAV_CONTINUATION_BIND — invariant #10 (auto-capture nav offers): this is a
+    // navigation OFFER (Vitana asks an either/or instead of auto-navigating) and
+    // the navigator has already resolved the top candidate. Record the TOP one
+    // as the session's pending_cta so a bare "Ja" deterministically opens it
+    // (the acceptance gate consumes it) rather than re-resolving the ambiguous
+    // phrase from scratch. Naming a specific candidate still routes through the
+    // LLM → navigate_to_screen, and that fresh confident nav supersedes this.
+    if (process.env.NAV_CONTINUATION_BIND === 'true' && sb && id.user_id) {
+      try {
+        const { writeOrbSessionState } = await import('./orb/orb-session-state');
+        await writeOrbSessionState(
+          sb,
+          id.user_id,
+          'pending_cta',
+          {
+            tool: 'navigate_to_screen',
+            payload: { screen_id: top.screen_id, route: top.route, title: top.title },
+            offered_at: new Date().toISOString(),
+          },
+          5,
+        );
+      } catch (e) {
+        console.error('[NAV-CONTINUATION-BIND] pending_cta write failed:', e instanceof Error ? e.message : e);
+      }
+    }
+
     return {
       ok: true,
       result: {

--- a/services/gateway/test/nav-guided-journey.test.ts
+++ b/services/gateway/test/nav-guided-journey.test.ts
@@ -83,3 +83,53 @@ describe('NAV-GUIDED-JOURNEY', () => {
     expect(mockSetMode).not.toHaveBeenCalled();
   });
 });
+
+// NAV_CONTINUATION_BIND — auto-capture nav offers (invariant #10, produce side):
+// when the navigator OFFERS (confirmation_needed, two resolved targets) instead
+// of auto-navigating, record the PRIMARY as pending_cta so a later "Ja" binds.
+describe('NAV-CONTINUATION-BIND auto-capture (navigator confirmation offer)', () => {
+  function makeSb() {
+    const upserts: any[] = [];
+    const sb: any = {
+      from: () => ({ upsert: (row: any) => { upserts.push(row); return Promise.resolve({ error: null }); } }),
+    };
+    return { sb, upserts };
+  }
+  function confirmationNeeded() {
+    // Live disambiguation shape: decision='ambiguous' with ≥2 alternatives.
+    mockConsult.mockResolvedValue({
+      decision: 'ambiguous',
+      primary: { screen_id: 'COMM.FIND_PARTNER', route: '/comm/find-partner', title: 'Find a Partner' },
+      alternatives: [
+        { screen_id: 'COMM.FIND_PARTNER', route: '/comm/find-partner', title: 'Find a Partner' },
+        { screen_id: 'COMM.EVENTS', route: '/comm/events', title: 'Events' },
+      ],
+      suggested_question: 'Find a Partner or Events?',
+      confidence: 'low', explanation: '', kb_excerpts: [], kb_excerpt_count: 0,
+      memory_hint_count: 0, ms_elapsed: 1,
+    });
+  }
+
+  afterEach(() => { delete process.env.NAV_CONTINUATION_BIND; });
+
+  test('flag ON → writes pending_cta for the PRIMARY resolved target', async () => {
+    process.env.NAV_CONTINUATION_BIND = 'true';
+    confirmationNeeded();
+    const { sb, upserts } = makeSb();
+    const r: any = await tool_navigate({ question: 'find me something' }, authedId, sb);
+    expect(r.result.decision).toBe('ambiguous'); // still asks the user
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0].key).toBe('pending_cta');
+    expect(upserts[0].value.tool).toBe('navigate_to_screen');
+    expect(upserts[0].value.payload).toEqual({
+      screen_id: 'COMM.FIND_PARTNER', route: '/comm/find-partner', title: 'Find a Partner',
+    });
+  });
+
+  test('flag OFF → no pending_cta written', async () => {
+    confirmationNeeded();
+    const { sb, upserts } = makeSb();
+    await tool_navigate({ question: 'find me something' }, authedId, sb);
+    expect(upserts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

The **offer-storage** half you chose (*auto-capture nav offers*). When the navigator **offers an either/or** ("Find a Partner or Events?") instead of auto-navigating — the live `decision === 'ambiguous'` branch with ≥2 alternatives — it now records the **top candidate** as the session's `pending_cta`. A later bare **"Ja"** then deterministically opens it (via the merged acceptance gate), instead of re-resolving the ambiguous phrase from scratch — the invariant-#10 bug.

Naming a specific candidate still routes through the LLM → `navigate_to_screen`, and that fresh confident nav supersedes the stored offer.

- **No LLM/prompt change**, no characterization-snapshot churn — pure server-side capture on the existing consult path; reuses the `orb_session_state` `pending_cta` store (5-min TTL).
- **Flag-gated** by `NAV_CONTINUATION_BIND` (off → no write).

This pairs with the merged **acceptance gate** (#2749, consume) and **`offer_action`** (#2751, structured produce). 

### The one remaining piece
The realtime `turn_complete` wiring that actually *calls* the acceptance gate on the finalized user transcript (force-dispatch the stored action on "Ja"). That's the only part touching the real-time audio turn loop, so it lands separately and is verified on a live staging voice session.

### Verification
- `nav-guided-journey` auto-capture — **2/2** (flag-on writes the top candidate as `pending_cta`; flag-off no-op).
- `nav-guided-journey | acceptance-gate | offer-action | navigator | navigation | nav-redirect | nav-confidence | nav-catalog | orb-tools` — **347/347 green**.
- `tsc --noEmit` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_