### PR TITLE
feat(orb): wire acceptance gate at turn_complete — bind "Ja" to pending nav offer (invariant #10)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -459,6 +459,70 @@ export function createUpstreamLiveMessageHandler(
                 });
               }
 
+              // NAV_CONTINUATION_BIND — invariant #10 (consume side). Fire-and-
+              // forget, exactly like the identity-intent intercept above: if the
+              // user just ACCEPTED ("Ja"/"yes"/"mach das") and a navigation offer
+              // is pending in orb_session_state, dispatch that exact target. The
+              // acceptance gate consumes the offer one-shot, ignores negations/
+              // redirects/long sentences, and fails open (any error → no-op).
+              //
+              // Guarded by !pendingNavigation && !navigationDispatched so the
+              // LLM's OWN fresh navigation this turn always wins — we never
+              // override it; we only step in when Gemini answered "Ja" with words
+              // but failed to actually navigate (the bug this closes). The
+              // dispatch may land a beat after Vitana's spoken reply; that late
+              // directive still corrects course, and the one-shot consume stops
+              // any re-fire on a second "ja".
+              if (
+                process.env.NAV_CONTINUATION_BIND === 'true' &&
+                !session.pendingNavigation &&
+                !session.navigationDispatched &&
+                session.identity?.user_id
+              ) {
+                const _accSb = getSupabase();
+                const _accUser = session.identity.user_id;
+                if (_accSb) {
+                  import('../../../services/assistant-continuation/acceptance-gate')
+                    .then(({ maybeBindAcceptance, makeSupabaseAcceptanceDeps }) =>
+                      maybeBindAcceptance(
+                        { userText, userId: _accUser },
+                        makeSupabaseAcceptanceDeps(_accSb),
+                      ),
+                    )
+                    .then((bound) => {
+                      if (!bound || bound.tool !== 'navigate_to_screen') return;
+                      const p = bound.payload as { screen_id?: string; route?: string; title?: string };
+                      if (!p.screen_id || !p.route) return;
+                      // Re-check at dispatch time: if the LLM navigated while the
+                      // async read was in flight, defer to it (no double-nav).
+                      if (session.pendingNavigation || session.navigationDispatched) return;
+                      const directive = {
+                        type: 'orb_directive',
+                        directive: 'navigate',
+                        screen_id: p.screen_id,
+                        route: p.route,
+                        title: p.title || p.screen_id,
+                        reason: 'continuation_accept',
+                        vtid: 'VTID-NAV-01',
+                      };
+                      if (session.sseResponse) writeSseEvent(session.sseResponse, directive);
+                      if ((session as any).clientWs && (session as any).clientWs.readyState === WebSocket.OPEN) {
+                        try { ctx.deps.sendWsMessage((session as any).clientWs, directive); } catch (_e) { /* WS closed */ }
+                      }
+                      session.navigationDispatched = true;
+                      console.log(
+                        `[NAV-CONTINUATION-BIND] accepted pending offer → ${p.screen_id} (${p.route}) — session=${session.sessionId}`,
+                      );
+                    })
+                    .catch((err) =>
+                      console.warn(
+                        '[NAV-CONTINUATION-BIND] acceptance gate failed (non-fatal):',
+                        err instanceof Error ? err.message : err,
+                      ),
+                    );
+                }
+              }
+
               session.transcriptTurns.push({
                 role: 'user',
                 text: userText,


### PR DESCRIPTION
## Summary

The **consume-side wiring** that makes the continuation loop actually fire — the last piece of invariant #10. At `turn_complete`, on the finalized user transcript, it runs `maybeBindAcceptance`: if the user **accepted** ("Ja" / "yes" / "mach das") and a navigation offer is pending in `orb_session_state`, it dispatches that exact target as an `orb_directive` — closing the bug where Vitana says *"Ja, gerne!"* but never navigates.

### How it's wired (safely)
- **Fire-and-forget**, mirroring the VTID-01953 identity-intent intercept right above it (same `getSupabase` + `writeSseEvent` + `sendWsMessage` idiom) — adds **no** Supabase read to the turn hot path. The dispatch lands a beat after the spoken reply and still corrects course.
- **Guarded** by `!pendingNavigation && !navigationDispatched` (re-checked at dispatch time): the LLM's **own** fresh navigation this turn always wins. The gate only steps in when Gemini answered with words but failed to navigate.
- **One-shot consume** stops re-fire on a second "ja"; **fails open** on any error.
- **Flag-gated** by `NAV_CONTINUATION_BIND` — off → the whole block is skipped (so this is inert on merge until you flip the flag).

### ⚠️ This is the one piece I cannot verify — it needs your live check
This is the realtime WebSocket voice turn; it can't be meaningfully unit-tested. Merging only reaches `gateway-staging` (post-cutover) and the flag is off, so it's safe to land — but **please verify on staging before PUBLISH to prod**:

1. On `gateway-staging`, set env `NAV_CONTINUATION_BIND=true` (also enables the producers in #2751/#2753).
2. Open ORB voice on `preview.vitanaland.com`, signed in.
3. Say something that triggers an **either/or nav offer** (e.g. an ambiguous "bring mich zu meinen Matches" that resolves to two screens) — Vitana asks "X oder Y?".
4. Answer **"Ja"**. ✅ Expected: the app navigates to the **top** option (the captured `pending_cta`), even though "Ja" wasn't a screen name.
5. Negative control: say **"Nein"** → no navigation. Say "Ja" again immediately → no second nav (one-shot consume).

Tail the logs for `[NAV-CONTINUATION-BIND] accepted pending offer → …` to confirm the path fired. If anything's off, tell me and I'll fix against the same flag.

### The full invariant-#10 stack (all merged, behind `NAV_CONTINUATION_BIND`)
| PR | Piece |
|----|-------|
| #2749 | acceptance gate (`maybeBindAcceptance`, 43 tests) |
| #2751 | `offer_action` (structured produce) |
| #2753 | auto-capture nav offers (produce) |
| **this** | turn_complete wiring (consume) |

### Regression
`acceptance-gate · nav-guided-journey · offer-action · upstream · continuation · orb-live` → **812/812 across 46 suites**; `tsc --noEmit` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_