### PR TITLE
fix(orb): never dead-end "improve my Index" — degrade to plan + Autopilot offer

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -1463,7 +1463,41 @@ export async function tool_create_index_improvement_plan(
     }
 
     if (scheduled.length === 0) {
-      return { ok: false, error: 'No events could be scheduled (calendar write failed).' };
+      // CALENDAR WRITE FAILED — but we already computed a real, ranked plan
+      // (autopilot recs or pillar templates). The user asked how to improve
+      // their Index; we must NOT throw that answer away just because the
+      // calendar side-effect failed. Returning ok:false here is what makes the
+      // model abandon the topic and pivot to an unrelated screen — the
+      // "Das konnte ich gerade nicht abschließen. Soll ich dir deinen Life
+      // Compass zeigen?" failure the user reported. Instead, degrade to SHOWING
+      // the computed plan and OFFERING to run it on Autopilot on the user's
+      // behalf (the on-yes path), so the next step still gets done.
+      const top = source.slice(0, Math.max(3, perWeek));
+      const recommendations = top.map((s) => ({
+        title: s.title,
+        description: s.description,
+        source: s.source,
+        source_ref_id: s.source_ref_id,
+      }));
+      const bullets = top.map((s) => `• ${s.title}`).join('\n');
+      return {
+        ok: true,
+        result: {
+          ok: false,
+          reason: 'calendar_unavailable',
+          degraded: true,
+          pillar,
+          recommendations,
+          offer_autopilot: true,
+        },
+        text:
+          `A real ${pillar} improvement plan WAS computed, but writing it to the ` +
+          `user's calendar did not go through just now. Do NOT say you failed and ` +
+          `do NOT switch to an unrelated screen. Tell the user concretely how to ` +
+          `lift their ${pillar} pillar with these steps:\n${bullets}\n\n` +
+          `Then OFFER to set them up automatically on Autopilot so they happen ` +
+          `without manual work — if the user agrees, that is the next action to run.`,
+      };
     }
 
     const payload = {
@@ -1485,7 +1519,19 @@ export async function tool_create_index_improvement_plan(
       text: `Scheduled ${scheduled.length} ${pillar} actions on your calendar over the next ${days} days.`,
     };
   } catch (err: unknown) {
-    return { ok: false, error: err instanceof Error ? err.message : 'create_index_improvement_plan error' };
+    // Never dead-end the "how do I improve my Index?" intent. A hard ok:false
+    // makes the model give up and pivot to an unrelated offer. Degrade to a
+    // graceful, on-topic recovery that still moves the user forward.
+    const detail = err instanceof Error ? err.message : 'create_index_improvement_plan error';
+    return {
+      ok: true,
+      result: { ok: false, reason: 'errored', degraded: true, detail },
+      text:
+        `Building the Index improvement plan ran into a problem just now. Do NOT ` +
+        `say it failed and do NOT switch to an unrelated screen. Give the user one ` +
+        `or two concrete, general next steps for their weakest pillar, then offer ` +
+        `to try setting up the plan again or to put it on Autopilot for them.`,
+    };
   }
 }
 


### PR DESCRIPTION
## The reported bug

In chat, Vitana offered: *"Soll ich dir zeigen, wie du deinen Index verbessern kannst?"* The user said *"Ja"* and got back:

> **"Das konnte ich gerade nicht abschließen. Soll ich dir deinen Life Compass zeigen?"**

So the index-improvement recommendation silently failed and pivoted to an unrelated screen.

## Root cause

When the user accepts, the model calls `tool_create_index_improvement_plan` (`services/gateway/src/services/orb-tools-shared.ts`). That tool:

1. **Computes a real, ranked plan** — top autopilot recommendations for the weakest pillar, falling back to `PILLAR_ACTION_TEMPLATES`. ✅ This part succeeds.
2. **Then tries to write calendar events** for each plan item.

If every `createCalendarEvent` call fails (per-event errors are swallowed), `scheduled.length === 0` and the tool returned a hard `{ ok: false, error: 'No events could be scheduled (calendar write failed).' }` — **discarding the plan it had already computed**.

The model sees a failed tool with no recoverable content, can't fulfil the request, emits graceful filler (*"Das konnte ich gerade nicht abschließen"* — this string is **not** in the codebase; it's the model improvising) and pivots to the next-best offer (Life Compass). The recommendation existed the whole time; the calendar **side-effect** killed it.

The failure phrase appears nowhere in either repo, confirming it is LLM-generated graceful degradation — there is no coded recovery path for this tool.

## The fix

Follow the existing degradation pattern already used by `tool_narrate_guided_session` (return `ok: true` + an instructive `text` that tells the model *not* to say it failed):

- **On calendar-write failure:** return `ok: true` carrying the computed `recommendations`, and instruct the model to **show the plan** and **offer to run it on Autopilot on the user's behalf** — instead of abandoning the topic.
- **Outer catch hardened:** any unexpected error now degrades to an on-topic recovery (one or two concrete next steps + offer to retry / automate) rather than a dead-end `ok: false`.

A failed side-effect becomes an **offer to do the work**, not a dead end.

## Scope / verification

- Single-file, low-risk change to one tool handler; matches existing conventions in the same file.
- `tsc --noEmit` clean (no new type errors).
- Staging-first: merging to `main` deploys to `gateway-staging`; verify on `preview-gateway.vitanaland.com` before PUBLISH.

## Follow-up (not in this PR — see chat)

This fixes the one action. The broader ask — *make **every** "next step" offer executable, and have Vitana do the work via Autopilot* — is a framework-level change (a standard `NextActionResult` contract: answer / execution-outcome / recovery-offer, coded localized recovery instead of LLM improvisation, and on-yes wiring to Autopilot execution). Proposed roadmap is in the chat thread for scoping before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXEiPbx6gyx7DojZurEje7)_