### PR TITLE
fix(ci): orb-tools parity gate reads 0 tools — anchor on registry definition

### DIFF
--- a/scripts/orb-tools-lift-scanner.mjs
+++ b/scripts/orb-tools-lift-scanner.mjs
@@ -47,8 +47,14 @@ function readSource(path) {
 // ---------------------------------------------------------------------------
 
 function extractRegistry(src) {
-  // Find the `ORB_TOOL_REGISTRY` block and pull each `tool_name:` key.
-  const idx = src.indexOf('ORB_TOOL_REGISTRY');
+  // Find the `ORB_TOOL_REGISTRY` object-literal block and pull each
+  // `tool_name:` key. Anchor on the `const ORB_TOOL_REGISTRY` DEFINITION, not
+  // the first textual mention: the identifier is now used (`!ORB_TOOL_REGISTRY[tool]`)
+  // before it is defined, and a bare indexOf('ORB_TOOL_REGISTRY') would grab
+  // that usage's enclosing `if (...) {` brace, match an empty block, and report
+  // "0 tools" — falsely flagging every delegated tool as broken.
+  let idx = src.indexOf('const ORB_TOOL_REGISTRY');
+  if (idx < 0) idx = src.indexOf('ORB_TOOL_REGISTRY'); // fallback: original behavior
   if (idx < 0) {
     console.error('[parity] could not find ORB_TOOL_REGISTRY in shared module');
     process.exit(3);
@@ -202,6 +208,10 @@ const SHARED_ONLY_INTENTIONAL = new Set([
   'navigate',             // Vertex: handleNavigate at orb-live.ts (PR 1.B-4)
   'navigate_to_screen',   // Vertex: handleNavigateToScreen (PR 1.B-5)
   'get_current_screen',   // Vertex: handleGetCurrentScreen (PR 1.B-3)
+  'offer_action',         // NAV_CONTINUATION_BIND producer (tool_offer_action):
+                          // stores the pending_cta for acceptance binding. Shared-
+                          // only by design — no Vertex case arm; both pipelines
+                          // reach it via the shared dispatcher.
 ]);
 const intentionalInline = [];
 


### PR DESCRIPTION
## Problem

The `scan` CI check (the **orb-tools parity gate**, `scripts/orb-tools-lift-scanner.mjs`) has been failing with exit 2 on **every PR**, reporting:

> Shared registry: **0 tools** in ORB_TOOL_REGISTRY.
> 🔴 BROKEN-DELEGATION — 36 Vertex case(s) call shared for unknown tool

It was not actually finding zero tools — it was misparsing the file.

## Root cause

`extractRegistry()` located the registry with `src.indexOf('ORB_TOOL_REGISTRY')` — the **first textual occurrence**. That occurrence is now a *usage*:

```ts
// orb-tools-shared.ts:4759 (inside tool_offer_action)
if (tool === 'offer_action' || !ORB_TOOL_REGISTRY[tool]) {
```

…which sits **before** the actual definition at line 4793 (`export const ORB_TOOL_REGISTRY = {`). So `indexOf('{', idx)` grabbed the `if (...) {` brace, the brace-matcher closed on an empty block, and the key regex found **0 keys**. With an empty registry, every delegated Vertex tool looked like a broken delegation → exit 2 → gate fails for everyone.

## Fix

1. **Anchor on the definition:** `extractRegistry()` now searches for `const ORB_TOOL_REGISTRY` first, falling back to the original `indexOf` so behavior is unchanged if the definition is ever renamed. It now parses **42 tools**.
2. **Allowlist `offer_action`** in `SHARED_ONLY_INTENTIONAL`: it's `tool_offer_action`, the NAV_CONTINUATION_BIND producer that stores the `pending_cta`. It's shared-only by design (no Vertex `case` arm) — this warning was simply *masked* before by the parse failure.

Gate now exits **0** — "✅ no drift detected".

```
$ ORB_TOOLS_PARITY_GATE=1 node scripts/orb-tools-lift-scanner.mjs; echo $?
Shared registry: 42 tools in ORB_TOOL_REGISTRY.
### ✅ no drift detected
0
```

## Scope

- Single file (`scripts/orb-tools-lift-scanner.mjs`), CI-tooling only — no runtime/gateway code touched.
- Split out from #2759 (the index-recommendation fix) at the maintainer's request; that PR's red `scan` check is this same pre-existing bug and will go green once this lands and it rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXEiPbx6gyx7DojZurEje7)_