### PR TITLE
fix(ci): orb-tools-lift scanner anchors on registry definition (false 0-tools parse)

### DIFF
--- a/scripts/orb-tools-lift-scanner.mjs
+++ b/scripts/orb-tools-lift-scanner.mjs
@@ -47,8 +47,15 @@ function readSource(path) {
 // ---------------------------------------------------------------------------
 
 function extractRegistry(src) {
-  // Find the `ORB_TOOL_REGISTRY` block and pull each `tool_name:` key.
-  const idx = src.indexOf('ORB_TOOL_REGISTRY');
+  // Find the `ORB_TOOL_REGISTRY` object-literal DEFINITION and pull each
+  // `tool_name:` key. Anchor on the `const ... = {` definition, NOT the first
+  // textual occurrence — usages like `!ORB_TOOL_REGISTRY[tool]` now appear
+  // BEFORE the definition, and anchoring on those made the brace-matcher capture
+  // an unrelated block and parse 0 tools (→ every delegating Vertex case was
+  // falsely flagged as "registry has no entry").
+  let idx = src.search(/\bORB_TOOL_REGISTRY\s*:\s*Record/);
+  if (idx < 0) idx = src.search(/\bconst\s+ORB_TOOL_REGISTRY\b/);
+  if (idx < 0) idx = src.indexOf('ORB_TOOL_REGISTRY'); // last-resort fallback
   if (idx < 0) {
     console.error('[parity] could not find ORB_TOOL_REGISTRY in shared module');
     process.exit(3);
@@ -202,6 +209,8 @@ const SHARED_ONLY_INTENTIONAL = new Set([
   'navigate',             // Vertex: handleNavigate at orb-live.ts (PR 1.B-4)
   'navigate_to_screen',   // Vertex: handleNavigateToScreen (PR 1.B-5)
   'get_current_screen',   // Vertex: handleGetCurrentScreen (PR 1.B-3)
+  'offer_action',         // LiveKit-only (#2751): registry entry for tools.py;
+                          // Vertex never declares/routes it, so no `case` arm.
 ]);
 const intentionalInline = [];
 


### PR DESCRIPTION
## Why the `scan (orb-tools-lift)` check is red on `main` for everyone

The parity scanner's `extractRegistry()` anchored on the **first textual occurrence** of `ORB_TOOL_REGISTRY` in `orb-tools-shared.ts`. Once `offer_action` was added (#2751), the first occurrence became a **usage** site — `if (tool === 'offer_action' || !ORB_TOOL_REGISTRY[tool])` at `orb-tools-shared.ts:4713` — which sits *before* the actual definition (`ORB_TOOL_REGISTRY: Record<...>` at line 4747).

The parser then read the wrong block, found **0 tools** in the registry, and consequently flagged **every** Vertex `case` that delegates to `dispatchOrbToolForVertex` as a `BROKEN-DELEGATION` (36 false positives). Under the gate (`ORB_TOOLS_PARITY_GATE=1`, set in `ORB-TOOLS-LIFT-SCANNER.yml`) that exits non-zero → the check goes red on every PR and on `main`.

## Fix

1. **Anchor `extractRegistry()` on the definition**, not the first occurrence:
   - first try the typed declaration `ORB_TOOL_REGISTRY: Record<...>`
   - fall back to `const ORB_TOOL_REGISTRY`
   - last-resort fall back to the first textual occurrence (with a hard error if nothing is found)
2. **Allowlist `offer_action` in `SHARED_ONLY_INTENTIONAL`.** It is a LiveKit-only registry entry (so `tools.py` doesn't 404); Vertex never declares or routes it, so it correctly has no `switch` case. Without the allowlist it tripped the `shared-only` warning (exit 1).

## Verification

```
ORB_TOOLS_PARITY_GATE=1 node scripts/orb-tools-lift-scanner.mjs
→ Shared registry: **42 tools** in ORB_TOOL_REGISTRY.
→ ### ✅ no drift detected
→ EXIT=0
```

Source files unchanged — this only fixes the scanner's parse and allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_