### PR TITLE
feat(notifications): post_like / post_comment author notifications

### DIFF
--- a/services/gateway/src/i18n/catalog.ts
+++ b/services/gateway/src/i18n/catalog.ts
@@ -40,6 +40,11 @@ export type GatewayI18nKey =
   // Live room goes live → notify everyone who tapped "Notify me" on the scheduled session.
   | 'notif.live_going_live.title'
   | 'notif.live_going_live.body'
+  // Social: someone liked or commented on your post (community feed + profile)
+  | 'notif.post_like.title'
+  | 'notif.post_like.body'
+  | 'notif.post_comment.title'
+  | 'notif.post_comment.body'
   // Daily pace check (claude/daily-pace-notifications)
   | 'notif.daily_pace.on_track.title'
   | 'notif.daily_pace.on_track.body'
@@ -122,6 +127,10 @@ const DE: LocaleCatalog = {
   'notif.fallback_app_name': 'Vitana',
   'notif.live_going_live.title': '🔴 Jetzt live!',
   'notif.live_going_live.body': '„{title}" hat gerade begonnen. Schau jetzt rein.',
+  'notif.post_like.title': 'Neues Like',
+  'notif.post_like.body': '{name} gefällt dein Beitrag.',
+  'notif.post_comment.title': 'Neuer Kommentar',
+  'notif.post_comment.body': '{name} hat deinen Beitrag kommentiert.',
   // Daily pace check
   'notif.daily_pace.on_track.title': 'Auf Kurs ✨',
   'notif.daily_pace.on_track.body': 'Du bist auf einem guten Weg. Schließ heute noch deinen Tagesplan ab — dein Ziel kommt näher.',
@@ -200,6 +209,10 @@ const EN: LocaleCatalog = {
   'notif.fallback_app_name': 'Vitana',
   'notif.live_going_live.title': '🔴 Now live!',
   'notif.live_going_live.body': '"{title}" just started. Tune in now.',
+  'notif.post_like.title': 'New like',
+  'notif.post_like.body': '{name} liked your post.',
+  'notif.post_comment.title': 'New comment',
+  'notif.post_comment.body': '{name} commented on your post.',
   // Daily pace check
   'notif.daily_pace.on_track.title': 'On track ✨',
   'notif.daily_pace.on_track.body': "You're moving well. Wrap up today's plan — your goal is getting closer.",

--- a/services/gateway/src/routes/community.ts
+++ b/services/gateway/src/routes/community.ts
@@ -29,6 +29,7 @@ import { notifyUserAsync, notifyUsersAsync } from '../services/notification-serv
 import { dispatchEvent } from '../services/automation-executor';
 import { tt } from '../i18n/catalog';
 import { getUserLocale } from '../i18n/server-locale';
+import { requireAuth, type AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
 const router = Router();
 
@@ -1112,9 +1113,12 @@ const INTERACTION_TABLES = {
   media: { parent: 'media_uploads', likes: 'media_upload_likes', comments: 'media_upload_comments', fk: 'upload_id' },
 } as const;
 
-router.post('/interactions/notify', async (req: Request, res: Response) => {
-  const token = getBearerToken(req);
-  if (!token) {
+router.post('/interactions/notify', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  // impact-allow-no-oasis: this endpoint only fans out an author notification
+  // for a like/comment already written client-side; it makes no domain state
+  // transition of its own, so there is nothing OASIS-worthy to record here.
+  const actorId = req.identity?.user_id;
+  if (!actorId) {
     return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
   }
 
@@ -1123,12 +1127,6 @@ router.post('/interactions/notify', async (req: Request, res: Response) => {
     return res.status(400).json({ ok: false, error: 'INVALID_BODY', detail: parsed.error.flatten() });
   }
   const { source, target_id, kind } = parsed.data;
-
-  let actorId = '';
-  try { actorId = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).sub; } catch {}
-  if (!actorId) {
-    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-  }
 
   const supabaseUrl = process.env.SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE;

--- a/services/gateway/src/routes/community.ts
+++ b/services/gateway/src/routes/community.ts
@@ -27,6 +27,8 @@ import { createUserSupabaseClient } from '../lib/supabase-user';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import { notifyUserAsync, notifyUsersAsync } from '../services/notification-service';
 import { dispatchEvent } from '../services/automation-executor';
+import { tt } from '../i18n/catalog';
+import { getUserLocale } from '../i18n/server-locale';
 
 const router = Router();
 
@@ -1081,6 +1083,144 @@ router.get('/health', (_req: Request, res: Response) => {
       'VTID-01078': 'health_brain'
     }
   });
+});
+
+/**
+ * POST /api/v1/community/interactions/notify
+ *
+ * Fire-and-forget notification fan-out for a like/comment that the frontend
+ * already wrote to the DB (client-side, RLS-guarded). The frontend calls this
+ * right after a successful like/comment insert so the post author gets an
+ * in-app + push notification (Instagram/Facebook style) via the canonical
+ * notifyUserAsync path (handles i18n, prefs, DND, inline push).
+ *
+ * Body: { source: 'post'|'media', target_id: uuid, kind: 'like'|'comment' }
+ *
+ * Security: the caller is derived from the JWT; we verify the interaction row
+ * actually exists for this caller (anti-spoof) before notifying, using a
+ * service-role client (needed to insert a notification for a DIFFERENT user —
+ * the recipient — which RLS would block on the user-scoped client).
+ */
+const InteractionNotifySchema = z.object({
+  source: z.enum(['post', 'media']),
+  target_id: z.string().uuid('Invalid target_id'),
+  kind: z.enum(['like', 'comment']),
+});
+
+const INTERACTION_TABLES = {
+  post: { parent: 'profile_posts', likes: 'profile_post_likes', comments: 'profile_post_comments', fk: 'post_id' },
+  media: { parent: 'media_uploads', likes: 'media_upload_likes', comments: 'media_upload_comments', fk: 'upload_id' },
+} as const;
+
+router.post('/interactions/notify', async (req: Request, res: Response) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const parsed = InteractionNotifySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: 'INVALID_BODY', detail: parsed.error.flatten() });
+  }
+  const { source, target_id, kind } = parsed.data;
+
+  let actorId = '';
+  try { actorId = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).sub; } catch {}
+  if (!actorId) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE;
+  if (!supabaseUrl || !serviceKey) {
+    return res.status(503).json({ ok: false, error: 'Gateway misconfigured' });
+  }
+
+  try {
+    const cfg = INTERACTION_TABLES[source];
+    const { createClient } = await import('@supabase/supabase-js');
+    const supa = createClient(supabaseUrl, serviceKey);
+
+    // 1. Resolve the post's author + tenant.
+    const { data: parent } = await supa
+      .from(cfg.parent)
+      .select('user_id, tenant_id')
+      .eq('id', target_id)
+      .maybeSingle();
+    const authorId = (parent as any)?.user_id as string | undefined;
+    const tenantId = (parent as any)?.tenant_id as string | undefined;
+    if (!authorId || !tenantId) {
+      return res.json({ ok: true, skipped: 'target_not_found' });
+    }
+
+    // 2. Skip self-interactions.
+    if (authorId === actorId) {
+      return res.json({ ok: true, skipped: 'self' });
+    }
+
+    // 3. Anti-spoof: verify the interaction row exists for this caller.
+    const intTable = kind === 'like' ? cfg.likes : cfg.comments;
+    const { data: intRow } = await supa
+      .from(intTable)
+      .select('id')
+      .eq(cfg.fk, target_id)
+      .eq('user_id', actorId)
+      .limit(1)
+      .maybeSingle();
+    if (!intRow) {
+      return res.json({ ok: true, skipped: 'no_row' });
+    }
+
+    // 4. Dedup likes (prevents unlike→relike spam). Comments notify per-comment.
+    const type = kind === 'like' ? 'post_like' : 'post_comment';
+    if (kind === 'like') {
+      const { data: existing } = await supa
+        .from('user_notifications')
+        .select('id')
+        .eq('user_id', authorId)
+        .eq('type', 'post_like')
+        .eq('data->>entity_id', target_id)
+        .eq('data->>actor_id', actorId)
+        .limit(1)
+        .maybeSingle();
+      if (existing) {
+        return res.json({ ok: true, skipped: 'duplicate' });
+      }
+    }
+
+    // 5. Resolve actor display name + author locale.
+    const { data: actorProfile } = await supa
+      .from('profiles')
+      .select('display_name')
+      .eq('user_id', actorId)
+      .maybeSingle();
+    const actorName = (actorProfile as any)?.display_name || 'Jemand';
+    const locale = await getUserLocale(supa, authorId);
+
+    // 6. Fire the notification (in-app + inline push, localized, pref/DND-gated).
+    notifyUserAsync(
+      authorId,
+      tenantId,
+      type,
+      {
+        title: tt(`notif.${type}.title` as any, locale, { name: actorName }),
+        body: tt(`notif.${type}.body` as any, locale, { name: actorName }),
+        data: {
+          url: `/u/${authorId}`,
+          entity_id: target_id,
+          actor_id: actorId,
+          source,
+        },
+      },
+      supa,
+    );
+
+    return res.json({ ok: true, notified: true });
+  } catch (err: any) {
+    console.warn(`[${VTID}] interactions/notify error: ${err.message}`);
+    // Never surface to the liker — the like/comment itself already succeeded.
+    return res.json({ ok: true, skipped: 'error' });
+  }
 });
 
 export default router;

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -62,6 +62,8 @@ export const TYPE_META: Record<string, TypeMeta> = {
   new_member_in_group:        { channel: 'inapp',          priority: 'p3', category: 'community' },
   group_milestone_reached:    { channel: 'inapp',          priority: 'p2', category: 'community' },
   group_invitation_received:  { channel: 'push_and_inapp', priority: 'p1', category: 'community' },
+  post_like:                  { channel: 'push_and_inapp', priority: 'p1', category: 'community' },
+  post_comment:               { channel: 'push_and_inapp', priority: 'p1', category: 'community' },
   // Meetups
   meetup_recommended:        { channel: 'push_and_inapp', priority: 'p2', category: 'meetup' },
   meetup_starting_soon:      { channel: 'push_and_inapp', priority: 'p0', category: 'meetup' },


### PR DESCRIPTION
## What & why

Companion to the vitana-v1 PR (same branch). Community-post likes/comments
notified nobody. This adds the gateway pieces so the **post author** gets an
in-app + push notification (Instagram/Facebook style) via the canonical
`notifyUserAsync()` path — which already handles the `user_notifications` row,
inline FCM/Appilix push, recipient locale, notification preferences, and DND.

## Changes

- **`services/gateway/src/services/notification-service.ts`** — register
  `post_like` / `post_comment` in `TYPE_META` (`community` category,
  `push_and_inapp`, `p1`).
- **`services/gateway/src/i18n/catalog.ts`** — add `notif.post_like.*` /
  `notif.post_comment.*` (DE real du-form + EN; ES/SR inherit EN), per the §13b
  no-hardcoded-strings rule.
- **`services/gateway/src/routes/community.ts`** — new
  `POST /api/v1/community/interactions/notify`. Body
  `{ source: 'post'|'media', target_id, kind: 'like'|'comment' }`. With a
  **service-role** client it resolves the post author + tenant, **verifies the
  interaction row exists for the caller** (anti-spoof), skips self-interactions,
  **dedups repeat likes**, localizes via the author's locale, then fires
  `notifyUserAsync`. Best-effort — errors never surface to the caller.

The frontend calls this endpoint after a successful like/comment insert.

## Notes

- `user_notifications.type` is free `TEXT` (the gateway already inserts 100+
  type strings in prod), so no enum migration is needed.
- No new tables.

## Verification

- Project-local `tsc --noEmit` ✅ 0 errors.
- E2E on staging: as B, like/comment A's post → `user_notifications` row for A
  (`type='post_like'`/`post_comment`, localized, `push_sent_at` set) + gateway
  log `[Notifications] post_like → … inapp=true push=…`; self-like and
  unlike→relike produce nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEhYDx6WLD1AJ8yfuNM9aF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEhYDx6WLD1AJ8yfuNM9aF)_