### PR TITLE
fix(community): resolve author tenant for like/comment notifications (was silently dropping all of them)

### DIFF
--- a/services/gateway/src/routes/community.ts
+++ b/services/gateway/src/routes/community.ts
@@ -1139,15 +1139,15 @@ router.post('/interactions/notify', requireAuth, async (req: AuthenticatedReques
     const { createClient } = await import('@supabase/supabase-js');
     const supa = createClient(supabaseUrl, serviceKey);
 
-    // 1. Resolve the post's author + tenant.
+    // 1. Resolve the post's author. NOTE: profile_posts / media_uploads have
+    // NO tenant_id column — the author's tenant is resolved separately below.
     const { data: parent } = await supa
       .from(cfg.parent)
-      .select('user_id, tenant_id')
+      .select('user_id')
       .eq('id', target_id)
       .maybeSingle();
     const authorId = (parent as any)?.user_id as string | undefined;
-    const tenantId = (parent as any)?.tenant_id as string | undefined;
-    if (!authorId || !tenantId) {
+    if (!authorId) {
       return res.json({ ok: true, skipped: 'target_not_found' });
     }
 
@@ -1156,7 +1156,34 @@ router.post('/interactions/notify', requireAuth, async (req: AuthenticatedReques
       return res.json({ ok: true, skipped: 'self' });
     }
 
-    // 3. Anti-spoof: verify the interaction row exists for this caller.
+    // 3. Resolve the author's tenant (canonical: app_users keyed by user_id,
+    // falling back to profiles). user_notifications, device tokens, and prefs
+    // are all scoped by tenant, so it must be the recipient's own tenant.
+    let tenantId: string | null = null;
+    const { data: authorUser } = await supa
+      .from('app_users')
+      .select('tenant_id')
+      .eq('user_id', authorId)
+      .maybeSingle();
+    tenantId = (authorUser as any)?.tenant_id ?? null;
+    if (!tenantId) {
+      const { data: authorProfile } = await supa
+        .from('profiles')
+        .select('tenant_id')
+        .eq('user_id', authorId)
+        .maybeSingle();
+      tenantId = (authorProfile as any)?.tenant_id ?? null;
+    }
+    // Last resort: the actor's active tenant (same as chat's behavior). In this
+    // single-community deployment author and actor share a tenant.
+    if (!tenantId) {
+      tenantId = req.identity?.tenant_id ?? null;
+    }
+    if (!tenantId) {
+      return res.json({ ok: true, skipped: 'no_tenant' });
+    }
+
+    // 4. Anti-spoof: verify the interaction row exists for this caller.
     const intTable = kind === 'like' ? cfg.likes : cfg.comments;
     const { data: intRow } = await supa
       .from(intTable)
@@ -1169,7 +1196,7 @@ router.post('/interactions/notify', requireAuth, async (req: AuthenticatedReques
       return res.json({ ok: true, skipped: 'no_row' });
     }
 
-    // 4. Dedup likes (prevents unlike→relike spam). Comments notify per-comment.
+    // 5. Dedup likes (prevents unlike→relike spam). Comments notify per-comment.
     const type = kind === 'like' ? 'post_like' : 'post_comment';
     if (kind === 'like') {
       const { data: existing } = await supa
@@ -1186,7 +1213,7 @@ router.post('/interactions/notify', requireAuth, async (req: AuthenticatedReques
       }
     }
 
-    // 5. Resolve actor display name + author locale.
+    // 6. Resolve actor display name + author locale.
     const { data: actorProfile } = await supa
       .from('profiles')
       .select('display_name')
@@ -1195,7 +1222,7 @@ router.post('/interactions/notify', requireAuth, async (req: AuthenticatedReques
     const actorName = (actorProfile as any)?.display_name || 'Jemand';
     const locale = await getUserLocale(supa, authorId);
 
-    // 6. Fire the notification (in-app + inline push, localized, pref/DND-gated).
+    // 7. Fire the notification (in-app + inline push, localized, pref/DND-gated).
     notifyUserAsync(
       authorId,
       tenantId,


### PR DESCRIPTION
## What & why

Live bug: after publishing the like/comment author-notification feature, the post author got **nothing at all** — no in-app bell entry and no push — when someone liked/commented (chat pushes still worked fine).

**Root cause:** the `POST /api/v1/community/interactions/notify` handler resolved the recipient's tenant with `select('user_id, tenant_id')` on `profile_posts` / `media_uploads` — but **those tables have no `tenant_id` column**. The query returned a null tenant, so the handler bailed out with `skipped: 'target_not_found'` on *every* like and comment, and `notifyUser()` was never called. That's why nothing was created (the in-app row is written by `notifyUser`, so its absence explains "no bell either").

## Fix

Resolve the **author's** tenant from `app_users` (canonical, keyed by `user_id` — the same source `getUserLocale` uses), falling back to `profiles.tenant_id`, then to the actor's active tenant (`req.identity.tenant_id`, matching chat's behavior). Only the author's `user_id` is read off the post now. `user_notifications`, device tokens, and preferences are all scoped by this tenant, so it must be the recipient's own tenant.

No frontend change — the client already calls the endpoint correctly.

## Verification

- Project-local `tsc --noEmit` ✅ 0 errors.
- After deploy: as B, like A's post → A gets the in-app bell entry (+ push if A has push enabled); gateway log shows `[Notifications] post_like → … inapp=true`. Previously the handler returned `skipped:'target_not_found'` with no notification.

> Note: if a recipient has **community notifications** disabled in settings, `notifyUser` will still suppress (by design) — that's separate from this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEhYDx6WLD1AJ8yfuNM9aF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEhYDx6WLD1AJ8yfuNM9aF)_