### PR TITLE
fix(orb): stop the SAFE-FAST greeting re-greeting on every orb reopen

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -111,6 +111,15 @@ FEATURE_ORB_SAFE_FAST_GREETING_ENV=off
 # back to the short opener. Optional — defaults to 1500 in code.
 ORB_NEWDAY_OVERVIEW_WAIT_MS=1500
 
+# BOOTSTRAP-ORB-FAST-GREETING-CADENCE — kill-switch for the greet-once / recent-turn
+# cap on the SAFE-FAST greeting path. The fast greeting ladder previously emitted a
+# greeting on EVERY orb reopen (it ran before the cadence-silence check); it now
+# honors the same decideGreetingPolicy 'skip' (greeted < 15 min ago / turn < 5 min
+# ago) and stays silent on a quick reopen. Set to "false" to revert to the legacy
+# always-greet behavior. Optional — defaults to enabled (any value other than
+# "false") in code; fail-open if the cadence prefetch errors.
+ORB_FAST_GREETING_CADENCE_SKIP_ENABLED=true
+
 # Env vars read ONLY by the standalone latency probe
 # (services/gateway/scripts/orb-latency-probe.mjs) — never by the running
 # service. Documented here so the impact-scan env-binding check is satisfied.

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -740,6 +740,13 @@ export async function handleLiveSessionStart(
   // pre-fetch. null = unknown (read failed).
   let greetingIsFirstSession: boolean | null = null;
   let greetingNeedsOnboarding: boolean | null = null;
+  // BOOTSTRAP-ORB-FAST-GREETING-CADENCE: when true, the SAFE-FAST greeting
+  // ladder must stay SILENT — the user was greeted within the greet-once
+  // window (or had a turn within the recent-turn window), so decideGreetingPolicy
+  // resolved to 'skip'. Computed in the fast greeting-facts prefetch below and
+  // copied onto the session so sendGreetingPromptToLiveAPI can honor it on the
+  // fast path (which previously re-greeted on every reopen). Fail-open → false.
+  let greetingCadenceSkip = false;
 
   // VTID-03294: a Guided-Journey topic tap needs ZERO context — Vitana just
   // picks up the KB lesson and speaks it. Detect it here so we can skip the
@@ -1031,8 +1038,34 @@ export async function handleLiveSessionStart(
               lastSessionInfo: greetingEarlyLastSessionInfo,
             });
           }
+          // BOOTSTRAP-ORB-FAST-GREETING-CADENCE: compute the greet-once / recent-turn
+          // skip in the SAME fast window the greeting builder awaits, reusing the
+          // canonical decideGreetingPolicy (the authority the slower wake-brief path
+          // already uses). Previously the fast ladder never saw this, so a quick orb
+          // re-open re-greeted ("Guten Morgen, <Name>.") seconds apart. Fail-open:
+          // any error leaves greetingCadenceSkip=false → unchanged behavior.
+          if (supa && _ndIdentity.tenant_id && _ndIdentity.user_id) {
+            try {
+              const { fetchWakeCadenceSignals } = await import('../../../services/wake-cadence-signals');
+              const { decideGreetingPolicy } = await import('../instruction/greeting-policy');
+              const cadence = await fetchWakeCadenceSignals({
+                supabase: supa,
+                tenantId: _ndIdentity.tenant_id,
+                userId: _ndIdentity.user_id,
+                nowIso: new Date().toISOString(),
+              });
+              const policy = decideGreetingPolicy({
+                bucket: deps.describeTimeSince(greetingEarlyLastSessionInfo).bucket,
+                isReconnect: isReconnectStart,
+                ...cadence,
+              });
+              greetingCadenceSkip = policy === 'skip';
+            } catch {
+              greetingCadenceSkip = false;
+            }
+          }
           console.log(
-            `[GREETING-FACTS-PREFETCH] session ${sessionId} resolved firstName=${greetingFirstName ? '<set>' : 'null'} lastSession=${greetingEarlyLastSessionInfo ? 'yes' : 'no'} proactive=${greetingProactiveLine ? '<set>' : 'null'}`,
+            `[GREETING-FACTS-PREFETCH] session ${sessionId} resolved firstName=${greetingFirstName ? '<set>' : 'null'} lastSession=${greetingEarlyLastSessionInfo ? 'yes' : 'no'} proactive=${greetingProactiveLine ? '<set>' : 'null'} cadenceSkip=${greetingCadenceSkip}`,
           );
         } catch (err: any) {
           // Fail-open to nulls — never reject.
@@ -1145,6 +1178,7 @@ export async function handleLiveSessionStart(
     (session as any).greetingProactiveLine = greetingProactiveLine;
     (session as any).greetingIsFirstTime = greetingIsFirstSession;
     (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
+    (session as any).greetingCadenceSkip = greetingCadenceSkip;
     if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
       session.lastSessionInfo = greetingEarlyLastSessionInfo;
     }
@@ -1155,6 +1189,10 @@ export async function handleLiveSessionStart(
       (session as any).greetingProactiveLine = greetingProactiveLine;
       (session as any).greetingIsFirstTime = greetingIsFirstSession;
       (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
+      // BOOTSTRAP-ORB-FAST-GREETING-CADENCE: the greet-once skip resolves with
+      // the rest of the fast facts; copy it so the builder can stay silent on a
+      // recent reopen instead of re-greeting.
+      (session as any).greetingCadenceSkip = greetingCadenceSkip;
       // Idempotent with the heavy bootstrap block, which also sets this later.
       if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
         session.lastSessionInfo = greetingEarlyLastSessionInfo;

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7564,6 +7564,34 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
             ]);
             if (ws.readyState !== WebSocket.OPEN) return;
 
+            // BOOTSTRAP-ORB-FAST-GREETING-CADENCE: honor the greet-once /
+            // recent-turn cap on the fast path. The greeting-facts prefetch
+            // computed decideGreetingPolicy → 'skip' (greeted < 15 min ago or a
+            // turn < 5 min ago) and stored it on the session. Every SAFE-FAST
+            // sub-branch below (new-day overview / proactive / new-day name /
+            // generic) otherwise emits a greeting UNCONDITIONALLY — that is why a
+            // quick orb reopen re-greeted ("Good morning, <Name>.") seconds apart.
+            // Stay SILENT here instead. greetingSent was claimed synchronously
+            // above (so no late path injects a greeting) and the opening state was
+            // already marked delivered; we do NOT arm the response watchdog —
+            // silence is intended and the user breaks it by speaking, mirroring the
+            // downstream VTID-03108 cadence-silence block. Kill-switch:
+            // ORB_FAST_GREETING_CADENCE_SKIP_ENABLED=false → legacy (always greet).
+            if (
+              process.env.ORB_FAST_GREETING_CADENCE_SKIP_ENABLED !== 'false' &&
+              (session as any).greetingCadenceSkip === true
+            ) {
+              emitDiag(session, 'greeting_sent', {
+                lang,
+                prompt_len: 0,
+                wake_opener: 'safe_fast_silenced_cadence',
+              });
+              console.log(
+                `[GREETING-SAFE-FAST-CADENCE-SKIP] session ${session.sessionId} suppressed re-greeting (recent greeting/turn within cadence window)`,
+              );
+              return;
+            }
+
             // NEW-DAY OVERVIEW (rich summary owns turn 1). On a genuine new-day
             // return we speak the FULL multi-clause morning overview (what passed
             // since last session, today's next event, Index direction, Life

--- a/services/gateway/test/orb/live/regression/fast-greeting-cadence.regression.test.ts
+++ b/services/gateway/test/orb/live/regression/fast-greeting-cadence.regression.test.ts
@@ -1,0 +1,102 @@
+/**
+ * BOOTSTRAP-ORB-FAST-GREETING-CADENCE — regression lock.
+ *
+ * Root cause (confirmed from dragan3's production sessions, 2026-06-23): the
+ * SAFE-FAST greeting ladder in sendGreetingPromptToLiveAPI emitted a greeting
+ * on EVERY session — it never consulted the greet-once / recent-turn cadence
+ * cap that decideGreetingPolicy enforces. A quick orb reopen therefore
+ * re-greeted ("Guten Morgen, <Name>.") seconds apart. The diag stream showed
+ * `wake_opener=safe_fast_*` on ~25 of the last 30 greetings, never silenced.
+ *
+ * The fix wires the fast greeting-facts prefetch through the SAME
+ * decideGreetingPolicy authority and silences the fast path when it returns
+ * 'skip'. This test locks BOTH directions of that contract so a future change
+ * cannot regress it:
+ *
+ *   1. A second press inside the greet-once window MUST resolve to 'skip'
+ *      (no re-greet).
+ *   2. A genuine first / new-day open MUST NOT be silenced (we still greet
+ *      returning + new users — the fix must not over-suppress).
+ *
+ * It asserts on decideGreetingPolicy — the single authority the fast path now
+ * consults (live-session-controller greeting-facts prefetch → session
+ * .greetingCadenceSkip → orb-live.ts SAFE-FAST ladder).
+ */
+
+import {
+  decideGreetingPolicy,
+} from '../../../../src/orb/live/instruction/greeting-policy';
+
+const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+const FIVE_MIN_S = 5 * 60;
+
+describe('fast-greeting cadence regression (greet-once + recent-turn)', () => {
+  describe('MUST suppress — a quick reopen does not re-greet', () => {
+    it('greeted 2 minutes ago today → skip', () => {
+      expect(
+        decideGreetingPolicy({
+          bucket: 'today',
+          time_since_last_greeting_today_ms: 2 * 60 * 1000,
+        }),
+      ).toBe('skip');
+    });
+
+    it('greeted 10 seconds ago (the exact user-reported reopen) → skip', () => {
+      expect(
+        decideGreetingPolicy({
+          bucket: 'reconnect',
+          time_since_last_greeting_today_ms: 10 * 1000,
+        }),
+      ).toBe('skip');
+    });
+
+    it('just under the 15-min greet-once window → skip', () => {
+      expect(
+        decideGreetingPolicy({
+          bucket: 'today',
+          time_since_last_greeting_today_ms: FIFTEEN_MIN_MS - 1000,
+        }),
+      ).toBe('skip');
+    });
+
+    it('a turn happened 30s ago (mid-thread continuation) → skip', () => {
+      expect(
+        decideGreetingPolicy({
+          bucket: 'today',
+          seconds_since_last_turn_anywhere: 30,
+        }),
+      ).toBe('skip');
+    });
+
+    it('transparent/server reconnect → skip', () => {
+      expect(decideGreetingPolicy({ bucket: 'today', isReconnect: true })).toBe('skip');
+    });
+  });
+
+  describe('MUST NOT suppress — legitimate openers still greet', () => {
+    it('first-ever session, no cadence signals → fresh_intro (greets)', () => {
+      expect(decideGreetingPolicy({ bucket: 'first' })).toBe('fresh_intro');
+    });
+
+    it('new-day return after a long gap, no recent greeting → not skip', () => {
+      const policy = decideGreetingPolicy({ bucket: 'long' });
+      expect(policy).not.toBe('skip');
+    });
+
+    it('greeted earlier today but OUTSIDE the 15-min window → not skip', () => {
+      const policy = decideGreetingPolicy({
+        bucket: 'today',
+        time_since_last_greeting_today_ms: FIFTEEN_MIN_MS + 60 * 1000,
+      });
+      expect(policy).not.toBe('skip');
+    });
+
+    it('last turn was 6 minutes ago (outside recent-turn window) → not skip', () => {
+      const policy = decideGreetingPolicy({
+        bucket: 'today',
+        seconds_since_last_turn_anywhere: (FIVE_MIN_S + 60),
+      });
+      expect(policy).not.toBe('skip');
+    });
+  });
+});


### PR DESCRIPTION
## Symptom (reported by dragan3)

Pressing the orb in a fresh conversation says **"Guten Morgen, Dragan."** — then again 10s later, again 30s later. Every reopen re-greets.

## Root cause (confirmed from production data, 2026-06-23)

- The `orb.live.diag` stream shows `wake_opener=safe_fast_*` on **~25 of the last 30 greetings** — never `silenced_on_cadence`.
- `user_assistant_state` holds the correct `wake_cadence:last_greeting_at` (08:41) and `sessions_today=4`, yet sessions kept greeting.

The `SAFE-FAST` greeting ladder in `sendGreetingPromptToLiveAPI` (the `contextReadyResolved === false` fast path, which fires on almost every session) **returns before** the `_openDecision` / `VTID-03108` cadence-silence block ever runs. Every fast sub-branch (new-day overview / proactive / new-day name / generic) emits a greeting **unconditionally** — it never consulted the 15-min greet-once / 5-min recent-turn cap that `decideGreetingPolicy` enforces on the slower wake-brief path. So the smart skip was downstream **dead code** whenever fast-start won the race (nearly always).

This is **not** PR #2760 (unmerged/conflicted), not the missing `orb_session_state` table, and not the OASIS `fetchLastSessionInfo` lookup.

## Fix (minimal, fail-open, kill-switchable)

- **`live-session-controller.ts`** — the fast greeting-facts prefetch now also fetches the wake-cadence signals and runs the **same `decideGreetingPolicy` authority**, storing `greetingCadenceSkip` on the session.
- **`orb-live.ts`** — the SAFE-FAST ladder honors `greetingCadenceSkip` before any branch speaks: it stays **silent** on a recent reopen (`greetingSent` already claimed; no watchdog armed — silence is intended, mirroring the `VTID-03108` cadence-silence path).
- Kill-switch `ORB_FAST_GREETING_CADENCE_SKIP_ENABLED=false` reverts to legacy (always greet). Fail-open: any prefetch error leaves the flag `false` → unchanged behavior.

## Tests

`test/orb/live/regression/fast-greeting-cadence.regression.test.ts` locks **both** directions so this can't regress and can't over-suppress:
- a press within the greet-once / recent-turn window → `skip` (no re-greet);
- a genuine first / new-day open → **not** silenced (returning + new users still greeted).

9/9 green; `tsc --noEmit` clean.

## Verification plan (staging-first)

Merging to `main` deploys **staging only** (`gateway-staging`). After merge I'll verify on staging that a quick reopen produces `wake_opener=safe_fast_silenced_cadence` (no audio greeting) while a fresh/new-day open still greets — then it's promoted to prod via the PUBLISH button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019XQRopj7vu6Xdjydr7bUjJ)_