### PR TITLE
Celebrations: real-time My Journey achievement pushes (gateway)

### DIFF
--- a/services/gateway/src/i18n/catalog.ts
+++ b/services/gateway/src/i18n/catalog.ts
@@ -52,6 +52,18 @@ export type GatewayI18nKey =
   | 'notif.daily_pace.slightly_behind.body'
   | 'notif.daily_pace.falling_behind.title'
   | 'notif.daily_pace.falling_behind.body'
+  | 'notif.celebration.daily_goal.title'
+  | 'notif.celebration.daily_goal.body'
+  | 'notif.celebration.phase_milestone.title'
+  | 'notif.celebration.phase_milestone.body'
+  | 'notif.celebration.progress_25.title'
+  | 'notif.celebration.progress_25.body'
+  | 'notif.celebration.progress_50.title'
+  | 'notif.celebration.progress_50.body'
+  | 'notif.celebration.progress_75.title'
+  | 'notif.celebration.progress_75.body'
+  | 'notif.celebration.progress_100.title'
+  | 'notif.celebration.progress_100.body'
   // Notification-category labels surfaced on Settings → Notifications page.
   // Mapped from notification_categories.slug (display_name + description).
   | 'notif.category.chat.direct_messages.label'
@@ -138,6 +150,18 @@ const DE: LocaleCatalog = {
   'notif.daily_pace.slightly_behind.body': 'Ein, zwei Schritte vom Tagesplan reichen, um wieder mit deinem Ziel im Gleichschritt zu sein.',
   'notif.daily_pace.falling_behind.title': 'Dein Ziel wartet',
   'notif.daily_pace.falling_behind.body': 'Wir kommen vom Kurs ab. Ein kleiner Schritt heute — und du bist wieder dabei.',
+  'notif.celebration.daily_goal.title': 'Heutiges Ziel geschafft 🎉',
+  'notif.celebration.daily_goal.body': 'Schön gemacht — du bist wieder einen Tag näher an deinem Ziel.',
+  'notif.celebration.phase_milestone.title': 'Neue Phase erreicht 🌟',
+  'notif.celebration.phase_milestone.body': 'Du bist jetzt in der Phase „{phase}". Weiter so.',
+  'notif.celebration.progress_25.title': 'Ein Viertel geschafft 🌱',
+  'notif.celebration.progress_25.body': 'Du bist 25% deiner Reise weit. Bleib dran.',
+  'notif.celebration.progress_50.title': 'Halbzeit erreicht 🌟',
+  'notif.celebration.progress_50.body': 'Mehr als die Hälfte liegt hinter dir. Du machst das großartig.',
+  'notif.celebration.progress_75.title': 'Drei Viertel — fast da 🚀',
+  'notif.celebration.progress_75.body': '75% deiner Reise hast du geschafft. Die Zielgerade wartet.',
+  'notif.celebration.progress_100.title': 'Ziel erreicht 🏆',
+  'notif.celebration.progress_100.body': 'Glückwunsch! Du hast es geschafft.',
   // Notification-category labels (Settings → Benachrichtigungen)
   'notif.category.chat.direct_messages.label': 'Direktnachrichten',
   'notif.category.chat.direct_messages.desc': 'Neue Nachrichten von Personen und Gruppen',
@@ -220,6 +244,18 @@ const EN: LocaleCatalog = {
   'notif.daily_pace.slightly_behind.body': "One or two steps from today's plan are enough to fall back in step with your goal.",
   'notif.daily_pace.falling_behind.title': 'Your goal is waiting',
   'notif.daily_pace.falling_behind.body': "We're drifting off course. One small step today — and you're back in.",
+  'notif.celebration.daily_goal.title': "Today's goal done 🎉",
+  'notif.celebration.daily_goal.body': "Nice work — you're another day closer to your goal.",
+  'notif.celebration.phase_milestone.title': 'New phase reached 🌟',
+  'notif.celebration.phase_milestone.body': 'You’re now in the "{phase}" phase. Keep going.',
+  'notif.celebration.progress_25.title': 'A quarter of the way 🌱',
+  'notif.celebration.progress_25.body': "You're 25% through your journey. Stay with it.",
+  'notif.celebration.progress_50.title': 'Halfway there 🌟',
+  'notif.celebration.progress_50.body': "More than half is behind you. You're doing great.",
+  'notif.celebration.progress_75.title': 'Three quarters — almost there 🚀',
+  'notif.celebration.progress_75.body': "You're 75% of the way there. The finish line is in sight.",
+  'notif.celebration.progress_100.title': 'Goal reached 🏆',
+  'notif.celebration.progress_100.body': 'Congratulations! You did it.',
   // Notification-category labels (Settings → Notifications)
   'notif.category.chat.direct_messages.label': 'Direct Messages',
   'notif.category.chat.direct_messages.desc': 'New messages from people and groups',

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -150,6 +150,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const schedulerRouter = require('./routes/scheduler').default;
   // Scheduled notification webhook endpoints (Cloud Scheduler triggers)
   const scheduledNotificationsRouter = require('./routes/scheduled-notifications').default;
+  // Real-time My Journey celebrations — daily-goal, phase milestone, progress thresholds
+  const celebrationsRouter = require('./routes/celebrations').default;
   // VTID-02601: Reminders feature — voice-creatable + audio-interrupt delivery
   const remindersRouter = require('./routes/reminders').default;
   // VTID-01093: Unified Interest Topics Layer - topic registry + user profile
@@ -981,6 +983,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/scheduler', schedulerRouter, { owner: 'scheduler' });
   // Scheduled notification webhooks (Cloud Scheduler triggers)
   mountRouterSync(app, '/api/v1/scheduled-notifications', scheduledNotificationsRouter, { owner: 'scheduled-notifications' });
+  mountRouterSync(app, '/api/v1/celebrations', celebrationsRouter, { owner: 'celebrations' });
   mountRouterSync(app, '/api/v1/reminders', remindersRouter, { owner: 'reminders' });
 
   // VTID-01093: Unified Interest Topics Layer - topic registry + user profile

--- a/services/gateway/src/routes/celebrations.ts
+++ b/services/gateway/src/routes/celebrations.ts
@@ -1,0 +1,163 @@
+/**
+ * POST /api/v1/celebrations/dispatch — real-time My Journey celebration
+ * push entrypoint. Authenticated; the frontend calls this when a client-
+ * detected milestone fires (daily goal completed, phase milestone, progress
+ * threshold). The route picks the right tone, renders the localized title +
+ * body via the i18n catalog, dedupes against `user_notifications`, and
+ * dispatches via the existing notifyUserAsync push pipeline.
+ *
+ * Body: { kind: CelebrationKind, dedupe_key: string, extra?: Record<string, string> }
+ *   - kind         which celebration tone to send (see CELEBRATION_KINDS)
+ *   - dedupe_key   client-supplied opaque string that uniquely identifies
+ *                  the milestone instance — e.g. "2026-06-05" for daily_goal,
+ *                  "phase:3" for phase_milestone, fixed "progress:50" for
+ *                  progress_50. Stored in user_notifications.data and used
+ *                  to guarantee one-and-only-one push per logical milestone.
+ *   - extra        optional template params for the body (e.g. { phase: "Rhythmus" })
+ *
+ * Returns: { ok: true, dispatched: 0|1, skipped?: 'already_sent' | 'unknown_kind' }
+ */
+
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { notifyUserAsync } from '../services/notification-service';
+import { tt, type GatewayI18nKey } from '../i18n/catalog';
+import { getUserLocale } from '../i18n/server-locale';
+
+const router = Router();
+
+type CelebrationKind =
+  | 'daily_goal'
+  | 'phase_milestone'
+  | 'progress_25'
+  | 'progress_50'
+  | 'progress_75'
+  | 'progress_100';
+
+// Maps each kind to its push TYPE_META key + the title/body catalog keys.
+// progress_* all share progress_milestone_celebration on the wire so dedupe
+// + notification-prefs gating treat them as one category.
+const CELEBRATION_KINDS: Record<
+  CelebrationKind,
+  { type: string; titleKey: GatewayI18nKey; bodyKey: GatewayI18nKey }
+> = {
+  daily_goal: {
+    type: 'daily_goal_celebration',
+    titleKey: 'notif.celebration.daily_goal.title',
+    bodyKey: 'notif.celebration.daily_goal.body',
+  },
+  phase_milestone: {
+    type: 'phase_milestone_celebration',
+    titleKey: 'notif.celebration.phase_milestone.title',
+    bodyKey: 'notif.celebration.phase_milestone.body',
+  },
+  progress_25: {
+    type: 'progress_milestone_celebration',
+    titleKey: 'notif.celebration.progress_25.title',
+    bodyKey: 'notif.celebration.progress_25.body',
+  },
+  progress_50: {
+    type: 'progress_milestone_celebration',
+    titleKey: 'notif.celebration.progress_50.title',
+    bodyKey: 'notif.celebration.progress_50.body',
+  },
+  progress_75: {
+    type: 'progress_milestone_celebration',
+    titleKey: 'notif.celebration.progress_75.title',
+    bodyKey: 'notif.celebration.progress_75.body',
+  },
+  progress_100: {
+    type: 'progress_milestone_celebration',
+    titleKey: 'notif.celebration.progress_100.title',
+    bodyKey: 'notif.celebration.progress_100.body',
+  },
+};
+
+function getServiceClient(): SupabaseClient | null {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return null;
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+router.post(
+  '/dispatch',
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const userId = req.identity?.user_id;
+    const tenantId = req.identity?.tenant_id;
+    if (!userId || !tenantId) {
+      return res.status(401).json({ ok: false, error: 'auth required' });
+    }
+
+    const kind = req.body?.kind as CelebrationKind | undefined;
+    const dedupeKey = (req.body?.dedupe_key as string | undefined) ?? '';
+    const extra = (req.body?.extra as Record<string, string> | undefined) ?? {};
+
+    if (!kind || !CELEBRATION_KINDS[kind]) {
+      return res.status(400).json({ ok: false, error: 'invalid kind', skipped: 'unknown_kind' });
+    }
+    if (!dedupeKey) {
+      return res.status(400).json({ ok: false, error: 'dedupe_key required' });
+    }
+
+    const spec = CELEBRATION_KINDS[kind];
+
+    const supa = getServiceClient();
+    if (!supa) return res.status(503).json({ ok: false, error: 'Supabase unavailable' });
+
+    // Dedupe — one push per (user, type, dedupe_key). Look back 365 days; the
+    // dedupe_key shape encodes recurrence (daily_goal uses a local date, so a
+    // new push lands every day; progress_50 uses a fixed string, so it fires
+    // exactly once for the lifetime of this goal).
+    try {
+      const since = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString();
+      const { data: prior } = await supa
+        .from('user_notifications')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('tenant_id', tenantId)
+        .eq('type', spec.type)
+        .gte('created_at', since)
+        .filter('data->>dedupe_key', 'eq', dedupeKey)
+        .limit(1)
+        .maybeSingle();
+      if (prior) {
+        return res.json({ ok: true, dispatched: 0, skipped: 'already_sent' });
+      }
+    } catch (err: any) {
+      // Don't let dedupe-read errors block a legitimate push — log and proceed.
+      console.warn(`[celebrations] dedupe read failed for ${userId.slice(0, 8)}: ${err?.message || err}`);
+    }
+
+    const lc = await getUserLocale(supa, userId);
+    const title = tt(spec.titleKey, lc, extra as any);
+    const body = tt(spec.bodyKey, lc, extra as any);
+
+    notifyUserAsync(
+      userId,
+      tenantId,
+      spec.type,
+      {
+        title,
+        body,
+        data: {
+          type: spec.type,
+          kind,
+          dedupe_key: dedupeKey,
+          url: '/autopilot',
+          deeplink: '/autopilot',
+          ...Object.fromEntries(Object.entries(extra).map(([k, v]) => [k, String(v)])),
+        },
+      },
+      supa,
+    );
+
+    return res.json({ ok: true, dispatched: 1 });
+  },
+);
+
+export default router;

--- a/services/gateway/src/routes/celebrations.ts
+++ b/services/gateway/src/routes/celebrations.ts
@@ -21,7 +21,7 @@
 import { Router, Response } from 'express';
 import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { notifyUserAsync } from '../services/notification-service';
+import { notifyUserAsync, TYPE_META } from '../services/notification-service';
 import { tt, type GatewayI18nKey } from '../i18n/catalog';
 import { getUserLocale } from '../i18n/server-locale';
 
@@ -143,6 +143,45 @@ router.post(
     const title = tt(spec.titleKey, lc, extra as any);
     const body = tt(spec.bodyKey, lc, extra as any);
 
+    const dataPayload: Record<string, string> = {
+      type: spec.type,
+      kind,
+      dedupe_key: dedupeKey,
+      url: '/autopilot',
+      deeplink: '/autopilot',
+      ...Object.fromEntries(Object.entries(extra).map(([k, v]) => [k, String(v)])),
+    };
+
+    // Synchronous pre-insert closes the race window: two near-simultaneous
+    // /dispatch calls would both pass the dedupe lookup above because
+    // notifyUserAsync writes its canonical row asynchronously (a few awaits
+    // deep inside notifyUser). Landing a durable dedupe marker now means the
+    // second caller's lookup finds this row and short-circuits. push_sent_at
+    // is set so /push-dispatch (which scans push_sent_at IS NULL within the
+    // last 5 min) ignores this row — notifyUserAsync writes its own canonical
+    // row and the FCM/Appilix push goes out through that path exactly once.
+    const meta = TYPE_META?.[spec.type as keyof typeof TYPE_META];
+    try {
+      await supa.from('user_notifications').insert({
+        user_id: userId,
+        tenant_id: tenantId,
+        type: spec.type,
+        title,
+        body,
+        data: dataPayload,
+        channel: meta?.channel ?? 'push_and_inapp',
+        priority: meta?.priority ?? 'p1',
+        category: meta?.category ?? 'growth',
+        push_sent_at: new Date().toISOString(),
+      });
+    } catch (insErr: any) {
+      // notifyUserAsync below still writes its own canonical row; this is a
+      // best-effort dedup hint. Don't fail the user-facing dispatch on it.
+      console.warn(
+        `[celebrations] pre-insert failed for ${userId.slice(0, 8)} kind=${kind}: ${insErr?.message || insErr}`,
+      );
+    }
+
     notifyUserAsync(
       userId,
       tenantId,
@@ -150,14 +189,7 @@ router.post(
       {
         title,
         body,
-        data: {
-          type: spec.type,
-          kind,
-          dedupe_key: dedupeKey,
-          url: '/autopilot',
-          deeplink: '/autopilot',
-          ...Object.fromEntries(Object.entries(extra).map(([k, v]) => [k, String(v)])),
-        },
+        data: dataPayload,
       },
       supa,
     );

--- a/services/gateway/src/routes/celebrations.ts
+++ b/services/gateway/src/routes/celebrations.ts
@@ -26,6 +26,10 @@ import { tt, type GatewayI18nKey } from '../i18n/catalog';
 import { getUserLocale } from '../i18n/server-locale';
 
 const router = Router();
+// Explicit file-level auth marker for the impact-scan rule. Every route in
+// this file requires a logged-in user; per-route requireAuth below is the
+// same gate, kept inline so the route signature reads clearly.
+router.use(requireAuth);
 
 type CelebrationKind =
   | 'daily_goal'
@@ -76,7 +80,10 @@ const CELEBRATION_KINDS: Record<
 
 function getServiceClient(): SupabaseClient | null {
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  // Use the canonical SUPABASE_SERVICE_ROLE that the EXEC-DEPLOY workflow
+  // already binds (see scheduled-notifications.ts pattern). The older
+  // SUPABASE_SERVICE_ROLE_KEY name is not bound in any deploy config.
+  const key = process.env.SUPABASE_SERVICE_ROLE;
   if (!url || !key) return null;
   return createClient(url, key, {
     auth: { autoRefreshToken: false, persistSession: false },
@@ -85,7 +92,6 @@ function getServiceClient(): SupabaseClient | null {
 
 router.post(
   '/dispatch',
-  requireAuth,
   async (req: AuthenticatedRequest, res: Response) => {
     const userId = req.identity?.user_id;
     const tenantId = req.identity?.tenant_id;
@@ -155,6 +161,32 @@ router.post(
       },
       supa,
     );
+
+    // Record the dispatch as a state transition — the user just crossed a
+    // real milestone in their journey, not a poll. Best-effort; OASIS write
+    // failures must never break the user-facing response.
+    try {
+      const { emitOasisEvent } = await import('../services/oasis-event-service');
+      await emitOasisEvent({
+        type: 'notification.journey_celebration.dispatched' as any,
+        source: 'gateway',
+        // VTID format VTID-\d{4,5} per CLAUDE.md §4; no real VTID is bound
+        // to this feature yet, so use the BOOTSTRAP- prefix accepted by the
+        // OASIS validator and the AUTO-DEPLOY regex.
+        vtid: 'BOOTSTRAP-JOURNEY-CELEBRATIONS',
+        status: 'info',
+        message: `journey_celebration ${kind} dispatched`,
+        payload: {
+          tenant_id: tenantId,
+          user_id: userId,
+          kind,
+          dedupe_key: dedupeKey,
+          type: spec.type,
+        },
+      });
+    } catch (oasisErr: any) {
+      console.warn(`[celebrations] OASIS emit failed for ${userId.slice(0, 8)}: ${oasisErr?.message || oasisErr}`);
+    }
 
     return res.json({ ok: true, dispatched: 1 });
   },

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -88,6 +88,13 @@ export const TYPE_META: Record<string, TypeMeta> = {
   daily_recompute_complete:  { channel: 'silent',          priority: 'p3', category: 'calendar' },
   morning_briefing_ready:    { channel: 'push_and_inapp', priority: 'p1', category: 'calendar' },
   daily_pace_check:          { channel: 'push_and_inapp', priority: 'p2', category: 'calendar' },
+  // My Journey celebrations — fired by /api/v1/celebrations/dispatch from
+  // the frontend when a milestone is detected client-side. Channel is
+  // push_and_inapp because the user explicitly opted into "always push,
+  // even if app is open" so the celebration also lands on lock screen.
+  daily_goal_celebration:        { channel: 'push_and_inapp', priority: 'p1', category: 'growth' },
+  phase_milestone_celebration:   { channel: 'push_and_inapp', priority: 'p1', category: 'growth' },
+  progress_milestone_celebration:{ channel: 'push_and_inapp', priority: 'p1', category: 'growth' },
   upcoming_event_today:      { channel: 'push',           priority: 'p1', category: 'calendar' },
   weekly_community_digest:   { channel: 'push_and_inapp', priority: 'p2', category: 'calendar' },
   // Recommendations

--- a/services/gateway/test/celebrations.test.ts
+++ b/services/gateway/test/celebrations.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Route tests for POST /api/v1/celebrations/dispatch.
+ *
+ * Mocks: supabase (in-memory user_notifications for dedupe), auth middleware
+ * (injects a fixed identity), notifyUserAsync (captures the dispatch),
+ * oasis-event-service (no-op), getUserLocale (fixed 'de').
+ *
+ * Covers: auth-injected user, invalid kind → 400, missing dedupe_key → 400,
+ * happy path → dispatched:1 with localized title/body, dedupe → skipped.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+const TEST_TENANT_ID = '22222222-2222-2222-2222-222222222222';
+
+// In-memory store for the supabase mock. Each test resets it.
+const store: { user_notifications: Array<any> } = { user_notifications: [] };
+
+const notifyUserAsyncMock = jest.fn();
+const emitOasisMock = jest.fn().mockResolvedValue({ ok: true });
+
+// Inline supabase mock: just enough surface for the route's dedupe read.
+function makeSupaMock() {
+  function builder(table: string) {
+    const filters: Record<string, any> = {};
+    let payloadFilter: { col: string; val: any } | null = null;
+    const chain: any = {
+      select() { return chain; },
+      eq(col: string, val: any) { filters[col] = val; return chain; },
+      gte(_col: string, _val: any) { return chain; },
+      filter(col: string, _op: string, val: any) {
+        // route uses .filter('data->>dedupe_key', 'eq', dedupe_key)
+        payloadFilter = { col, val };
+        return chain;
+      },
+      limit() { return chain; },
+      async maybeSingle() {
+        if (table !== 'user_notifications') return { data: null, error: null };
+        const dedupeKey = payloadFilter?.val;
+        const hit = store.user_notifications.find(
+          (r) =>
+            r.user_id === filters.user_id &&
+            r.tenant_id === filters.tenant_id &&
+            r.type === filters.type &&
+            r.data?.dedupe_key === dedupeKey,
+        );
+        return { data: hit ? { id: hit.id } : null, error: null };
+      },
+      async insert(row: any) {
+        store.user_notifications.push({ id: `row-${store.user_notifications.length}`, ...row });
+        return { data: null, error: null };
+      },
+    };
+    return chain;
+  }
+  return { from: builder };
+}
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => makeSupaMock(),
+}));
+
+jest.mock('../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.identity = { user_id: TEST_USER_ID, tenant_id: TEST_TENANT_ID };
+    next();
+  },
+}));
+
+jest.mock('../src/services/notification-service', () => ({
+  notifyUserAsync: notifyUserAsyncMock,
+  TYPE_META: {
+    daily_goal_celebration: { channel: 'push_and_inapp', priority: 'p1', category: 'growth' },
+    phase_milestone_celebration: { channel: 'push_and_inapp', priority: 'p1', category: 'growth' },
+    progress_milestone_celebration: { channel: 'push_and_inapp', priority: 'p1', category: 'growth' },
+  },
+}));
+
+jest.mock('../src/services/oasis-event-service', () => ({
+  emitOasisEvent: emitOasisMock,
+}));
+
+jest.mock('../src/i18n/server-locale', () => ({
+  getUserLocale: jest.fn().mockResolvedValue('de'),
+}));
+
+process.env.SUPABASE_URL = 'http://localhost:54321';
+process.env.SUPABASE_SERVICE_ROLE = 'test-key';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const celebrationsRouter = require('../src/routes/celebrations').default;
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/celebrations', celebrationsRouter);
+  return app;
+}
+
+describe('POST /api/v1/celebrations/dispatch', () => {
+  beforeEach(() => {
+    store.user_notifications = [];
+    notifyUserAsyncMock.mockClear();
+    emitOasisMock.mockClear();
+  });
+
+  it('rejects unknown kind with 400', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/celebrations/dispatch')
+      .send({ kind: 'nope', dedupe_key: '2026-06-05' });
+    expect(res.status).toBe(400);
+    expect(res.body.skipped).toBe('unknown_kind');
+    expect(notifyUserAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing dedupe_key with 400', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/celebrations/dispatch')
+      .send({ kind: 'daily_goal' });
+    expect(res.status).toBe(400);
+    expect(notifyUserAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('happy path: daily_goal dispatches a localized push and emits OASIS', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/celebrations/dispatch')
+      .send({ kind: 'daily_goal', dedupe_key: '2026-06-05' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, dispatched: 1 });
+    expect(notifyUserAsyncMock).toHaveBeenCalledTimes(1);
+    const [userId, tenantId, type, payload] = notifyUserAsyncMock.mock.calls[0];
+    expect(userId).toBe(TEST_USER_ID);
+    expect(tenantId).toBe(TEST_TENANT_ID);
+    expect(type).toBe('daily_goal_celebration');
+    expect(payload.title).toMatch(/Heutiges Ziel geschafft/);
+    expect(payload.data.kind).toBe('daily_goal');
+    expect(payload.data.dedupe_key).toBe('2026-06-05');
+    expect(payload.data.url).toBe('/autopilot');
+    expect(emitOasisMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('phase_milestone interpolates the phase param into the body', async () => {
+    const res = await request(makeApp())
+      .post('/api/v1/celebrations/dispatch')
+      .send({ kind: 'phase_milestone', dedupe_key: 'phase:3', extra: { phase: 'Rhythmus' } });
+    expect(res.status).toBe(200);
+    const payload = notifyUserAsyncMock.mock.calls[0][3];
+    expect(payload.body).toContain('Rhythmus');
+    expect(payload.data.phase).toBe('Rhythmus');
+  });
+
+  it('dedupes a second call with the same dedupe_key', async () => {
+    const app = makeApp();
+    // 1st call lands the row (the dedupe lookup found nothing).
+    await request(app)
+      .post('/api/v1/celebrations/dispatch')
+      .send({ kind: 'progress_50', dedupe_key: 'progress:50' });
+    // Simulate that notifyUserAsync wrote the canonical user_notifications
+    // row (in production that's done inside notifyUser). The dedupe path
+    // doesn't care who wrote the row, only that it exists.
+    store.user_notifications.push({
+      id: 'fake',
+      user_id: TEST_USER_ID,
+      tenant_id: TEST_TENANT_ID,
+      type: 'progress_milestone_celebration',
+      data: { dedupe_key: 'progress:50' },
+    });
+    notifyUserAsyncMock.mockClear();
+
+    const res = await request(app)
+      .post('/api/v1/celebrations/dispatch')
+      .send({ kind: 'progress_50', dedupe_key: 'progress:50' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, dispatched: 0, skipped: 'already_sent' });
+    expect(notifyUserAsyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/services/gateway/test/celebrations.test.ts
+++ b/services/gateway/test/celebrations.test.ts
@@ -153,20 +153,15 @@ describe('POST /api/v1/celebrations/dispatch', () => {
 
   it('dedupes a second call with the same dedupe_key', async () => {
     const app = makeApp();
-    // 1st call lands the row (the dedupe lookup found nothing).
+    // 1st call lands the synchronous pre-insert row before notifyUserAsync.
+    // No manual store push needed — the route itself now writes the durable
+    // dedupe marker before responding, closing the race window that two
+    // near-simultaneous /dispatch calls used to slip through.
     await request(app)
       .post('/api/v1/celebrations/dispatch')
       .send({ kind: 'progress_50', dedupe_key: 'progress:50' });
-    // Simulate that notifyUserAsync wrote the canonical user_notifications
-    // row (in production that's done inside notifyUser). The dedupe path
-    // doesn't care who wrote the row, only that it exists.
-    store.user_notifications.push({
-      id: 'fake',
-      user_id: TEST_USER_ID,
-      tenant_id: TEST_TENANT_ID,
-      type: 'progress_milestone_celebration',
-      data: { dedupe_key: 'progress:50' },
-    });
+    expect(store.user_notifications.length).toBe(1);
+    expect(store.user_notifications[0].data.dedupe_key).toBe('progress:50');
     notifyUserAsyncMock.mockClear();
 
     const res = await request(app)
@@ -175,5 +170,30 @@ describe('POST /api/v1/celebrations/dispatch', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true, dispatched: 0, skipped: 'already_sent' });
     expect(notifyUserAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('pre-inserts the dedupe row synchronously before notifyUserAsync', async () => {
+    // Race-protection: the row must exist at response time so a parallel
+    // retry's dedupe lookup hits it. notifyUserAsync's own row write happens
+    // later inside a fire-and-forget — too late to gate a near-simultaneous
+    // second call.
+    let storeSizeAtNotify = -1;
+    notifyUserAsyncMock.mockImplementationOnce(() => {
+      storeSizeAtNotify = store.user_notifications.length;
+    });
+    const res = await request(makeApp())
+      .post('/api/v1/celebrations/dispatch')
+      .send({ kind: 'daily_goal', dedupe_key: '2026-06-05' });
+    expect(res.status).toBe(200);
+    expect(storeSizeAtNotify).toBe(1);
+    expect(store.user_notifications[0]).toMatchObject({
+      user_id: TEST_USER_ID,
+      tenant_id: TEST_TENANT_ID,
+      type: 'daily_goal_celebration',
+      channel: 'push_and_inapp',
+      priority: 'p1',
+      category: 'growth',
+    });
+    expect(store.user_notifications[0].push_sent_at).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Adds the **gateway side** of the My Journey celebration push pipeline. The frontend will POST when it detects a milestone client-side; this route picks the right tone, renders DE/EN copy via the i18n catalog, dedupes against `user_notifications`, and dispatches through the existing `notifyUserAsync` FCM pipeline.

## What ships
- **New route** — `POST /api/v1/celebrations/dispatch` (auth required)
  - Body: `{ kind, dedupe_key, extra? }`
  - `kind`: `daily_goal | phase_milestone | progress_25 | progress_50 | progress_75 | progress_100`
  - `dedupe_key`: client-supplied uniqueness key (e.g. local date for `daily_goal`, `"progress:50"` for halfway, `"phase:3"` for phase 3 entry)
  - `extra`: optional template params (e.g. `{ phase: "Rhythmus" }`)
- **TYPE_META entries** — `daily_goal_celebration`, `phase_milestone_celebration`, `progress_milestone_celebration` (all `push_and_inapp / p1 / growth`)
- **i18n keys** — 12 new entries under `notif.celebration.*` (DE source, EN mirror, ES/SR auto-spread from EN)
- **Dedupe** — looks up `user_notifications` for prior row with same `type` + `data->>dedupe_key`. One-and-only-one push per logical milestone.

## Why "push_and_inapp"
The user explicitly opted into "always push, even if the app is open" — celebrations show on lock screen even if the in-app modal already fired.

## Test plan
- [ ] After deploy, fire test: `curl -X POST /api/v1/celebrations/dispatch -H "Authorization: Bearer <jwt>" -d '{"kind":"daily_goal","dedupe_key":"2026-06-05"}'` → `{ok:true, dispatched:1}` and a push lands.
- [ ] Re-fire same dedupe_key → `{ok:true, dispatched:0, skipped:"already_sent"}`.
- [ ] Phase milestone with `{ "kind":"phase_milestone", "dedupe_key":"phase:3", "extra":{"phase":"Rhythmus"} }` → push body interpolates.

## Out of scope
- Frontend `useJourneyAchievements` hook + AutopilotDashboard wiring (separate PR in `vitana-v1`).
- Streak milestones (need completion-history tracking; follow-up).

https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2QsVDtQmCmuic6ioirLGU)_