### PR TITLE
Fix duplicate like/comment push (one opens the post, one crashes the WebView)

### DIFF
--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -997,7 +997,20 @@ router.post('/push-dispatch', async (req: Request, res: Response) => {
         }
       }
 
-      // Send FCM web push + Appilix native push
+      // Send push. Mirror notifyUser()'s dispatch policy
+      // (notification-service.ts): notifications WITH a deep-link URL must go
+      // Appilix-FIRST — an FCM-delivered notification tapped inside the Appilix
+      // WebView crashes it ("Something went wrong") because FCM doesn't pass the
+      // URL to Appilix's native tap handler. Only fall back to FCM if Appilix
+      // didn't deliver. Without a URL, FCM-first with Appilix fallback.
+      //
+      // Previously this cron fired BOTH channels unconditionally, so a user with
+      // both an FCM token and an Appilix identity received the SAME notification
+      // twice — once via Appilix (deep-links correctly) and once via FCM (opens
+      // the WebView crash screen). That is the like/comment "double notification,
+      // one opens Try Again" bug.
+      const hasDeepLink =
+        typeof notif.data === 'object' && notif.data !== null && !!(notif.data as any).url;
       const pushPayload = {
         title: notif.title || 'Vitana',
         body: notif.body || '',
@@ -1005,8 +1018,19 @@ router.post('/push-dispatch', async (req: Request, res: Response) => {
           ? Object.fromEntries(Object.entries(notif.data).map(([k, v]) => [k, String(v)]))
           : undefined,
       };
-      const sent = await sendPushToUser(notif.user_id, notif.tenant_id, pushPayload, supa);
-      const appilixSent = await sendAppilixPush(notif.user_id, pushPayload);
+      let sent = 0;
+      let appilixSent = false;
+      if (hasDeepLink) {
+        appilixSent = await sendAppilixPush(notif.user_id, pushPayload);
+        if (!appilixSent) {
+          sent = await sendPushToUser(notif.user_id, notif.tenant_id, pushPayload, supa);
+        }
+      } else {
+        sent = await sendPushToUser(notif.user_id, notif.tenant_id, pushPayload, supa);
+        if (sent === 0) {
+          appilixSent = await sendAppilixPush(notif.user_id, pushPayload);
+        }
+      }
 
       // Mark as dispatched
       await supa.from('user_notifications')


### PR DESCRIPTION
## Problem

A like/comment now produces **two** lock-screen notifications:
- one **deep-links correctly** to `/post/<source>/<id>` ✅
- one **opens the black "Something went wrong / Try Again"** screen ❌

## Root cause

The `/push-dispatch` cron (`scheduled-notifications.ts`) — which picks up DB-trigger-created notifications and sends their push — fired **both** channels **unconditionally**:

```ts
const sent = await sendPushToUser(...);        // FCM
const appilixSent = await sendAppilixPush(...); // Appilix native
```

A user with **both** an FCM token and an Appilix identity therefore receives the **same notification twice**:
- **Appilix** honours `open_link_url` → deep-links to the post correctly.
- **FCM** delivered into the Appilix WebView **crashes it** with "Something went wrong" — FCM doesn't pass the URL to Appilix's native tap handler (documented in `notification-service.ts` and `pushNotifications.ts`).

This is why **chat** never had the bug: chat goes through the canonical `notifyUser()` path, which for deep-link URLs is **Appilix-first, FCM only as fallback**. The cron never got that logic.

## Fix

Make the cron mirror `notifyUser()`'s dispatch policy:
- **With a deep-link URL** → Appilix-first; fall back to FCM only if Appilix didn't deliver (web-only users with no Appilix device still get FCM).
- **Without a URL** → FCM-first with Appilix fallback (unchanged).

One push per notification, no WebView crash.

## Verification

- `npm run typecheck` passes.
- Behaviour now matches the chat path the user already confirmed works.

## Deploy note

Gateway change → auto-deploys to **staging** on merge; reaches **production** via the **PUBLISH** button (or escape-hatch). The duplicate will persist in prod until promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEhYDx6WLD1AJ8yfuNM9aF)_