### PR TITLE
feat(vcaop): Awin joined-programme auto-sync into affiliate catalog

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -50,6 +50,22 @@ SHOPIFY_SYNC_INTERVAL_MS=3600000
 # (Tools -> Postback URL). Bind it as a gateway Cloud Run env / Secret Manager value.
 ADMITAD_POSTBACK_KEY=
 
+# VCAOP Awin joined-programme sync.
+# Harvests the programmes this publisher has JOINED (Awin Publisher API) into
+# affiliate_program rows (cashback=true; Awin cread.php deeplink + clickref SubID),
+# so approved advertisers auto-wire into /discover.
+# AWIN_SYNC_ENABLED: set "true" to run the background worker on boot.
+# AWIN_PUBLISHER_ID: e.g. 2938137 (required when enabled).
+# AWIN_API_TOKEN: Awin OAuth2 API token (Secret Manager — required when enabled).
+# AWIN_API_BASE: defaults to https://api.awin.com.
+# AWIN_SYNC_INTERVAL_MS: worker interval (default 3600000 = 1h, min 60000).
+# The admin trigger POST /api/v1/vcaop/awin/sync works regardless of the worker flag.
+AWIN_SYNC_ENABLED=false
+AWIN_PUBLISHER_ID=
+AWIN_API_TOKEN=
+AWIN_API_BASE=https://api.awin.com
+AWIN_SYNC_INTERVAL_MS=3600000
+
 # --- DEV-COMHU-0513: ORB first-greeting latency ---
 # Greeting pre-buffer (WebSocket path). When live, the greeting prompt is
 # dispatched to the model as soon as the upstream Live API socket opens (so

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -301,6 +301,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const vcaopPostbackRouter = require('./routes/vcaop-postback').default;
   // VCAOP: Shopify own-store catalog sync (admin trigger; background worker in services)
   const shopifySyncRouter = require('./routes/shopify-sync').default;
+  // VCAOP: Awin joined-programme sync (admin trigger; background worker in services)
+  const awinSyncRouter = require('./routes/awin-sync').default;
   // VTID-01169: Deploy → Ledger Terminalization (terminalize endpoint + repair job)
   const vtidTerminalizeRouter = require('./routes/vtid-terminalize').default;
   // VTID-01157: Supabase JWT Auth Middleware + /api/v1/auth/me endpoint
@@ -666,6 +668,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/vcaop/postback', vcaopPostbackRouter, { owner: 'vcaop-postback' });
   // VCAOP: Shopify catalog sync — mount before the vcaop router so the sub-path resolves.
   mountRouterSync(app, '/api/v1/vcaop/shopify', shopifySyncRouter, { owner: 'vcaop-shopify' });
+  // VCAOP: Awin programme sync — mount before the vcaop router so the sub-path resolves.
+  mountRouterSync(app, '/api/v1/vcaop/awin', awinSyncRouter, { owner: 'vcaop-awin' });
   // VCAOP: Vitanaland Commerce API — providers/affiliate-programs/shop/wallet/onboarding
   mountRouterSync(app, '/api/v1/vcaop', vcaopRouter, { owner: 'vcaop' });
 
@@ -1592,6 +1596,15 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
         startShopifySyncWorker();
       } catch (error) {
         console.warn('⚠️ Shopify sync worker initialization failed (non-fatal):', error);
+      }
+
+      // VCAOP: Awin joined-programme sync. Opt-in (AWIN_SYNC_ENABLED=true +
+      // AWIN_PUBLISHER_ID + AWIN_API_TOKEN). Harvests joined programmes on an interval.
+      try {
+        const { startAwinSyncWorker } = require('./services/awin-sync');
+        startAwinSyncWorker();
+      } catch (error) {
+        console.warn('⚠️ Awin sync worker initialization failed (non-fatal):', error);
       }
 
       // Dev Autopilot background executor (cooling→running→ci loop).

--- a/services/gateway/src/routes/awin-sync.ts
+++ b/services/gateway/src/routes/awin-sync.ts
@@ -1,0 +1,43 @@
+/**
+ * Admin endpoint: harvest joined Awin programmes into affiliate_program.
+ *   POST /api/v1/vcaop/awin/sync   (exafy_admin only)
+ *
+ * On-demand twin of the background worker in services/awin-sync. Uses the Awin
+ * Publisher API to pull joined programmes and upsert them (cashback=true, with
+ * the Awin cread.php deeplink base + clickref SubID).
+ */
+import { Router, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { getSupabase } from '../lib/supabase';
+import { requireAuth } from '../middleware/auth-supabase-jwt';
+import { resolveAwinConfig, syncAwinProgrammes } from '../services/awin-sync';
+
+const router = Router();
+router.use(requireAuth as any);
+
+router.post('/sync', async (req: Request, res: Response) => {
+  // impact-allow-no-oasis: this handler records an OASIS event via the direct
+  // oasis_events insert below (same pattern as emitEvent in vcaop.ts), not via
+  // the emitOasisEvent helper the scanner greps for.
+  if (!(req as any).identity?.exafy_admin) { res.status(403).json({ ok: false, error: 'forbidden' }); return; }
+  const supabase = getSupabase();
+  if (!supabase) { res.status(503).json({ ok: false, error: 'database unavailable' }); return; }
+  const cfg = resolveAwinConfig();
+  if (!cfg) { res.status(400).json({ ok: false, error: 'AWIN_PUBLISHER_ID / AWIN_API_TOKEN not configured' }); return; }
+  try {
+    const result = await syncAwinProgrammes(supabase, cfg);
+    try {
+      await supabase.from('oasis_events').insert({
+        id: randomUUID(), service: 'vcaop', source: 'vcaop',
+        type: 'vcaop.awin.synced', topic: 'vcaop.awin.synced',
+        status: 'success', message: `awin sync ${result.upserted}/${result.fetched} programmes`,
+        metadata: result, created_at: new Date().toISOString(),
+      });
+    } catch { /* never block the sync response on the audit write */ }
+    res.json({ ok: true, data: result });
+  } catch (e: any) {
+    res.status(502).json({ ok: false, error: String((e && e.message) || e) });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/awin-sync.ts
+++ b/services/gateway/src/services/awin-sync.ts
@@ -1,0 +1,118 @@
+/**
+ * VCAOP Awin programme sync (affiliate rewards network).
+ *
+ * Uses the Awin Publisher API to list the programmes this publisher has JOINED
+ * and upserts each as an affiliate_program row (cashback=true) with an Awin
+ * cread.php deeplink base + `clickref` SubID — which plugs straight into the
+ * existing /affiliate-link endpoint. As advertiser approvals land, they auto-wire.
+ *
+ * Conversion crediting (Awin transactions -> rewards) is a separate pull-based
+ * worker (Phase 2) — Awin reports conversions via its API, not a postback.
+ */
+import { getSupabase } from '../lib/supabase';
+
+export interface AwinSyncConfig {
+  publisherId: string;
+  apiToken: string;
+  apiBase: string;
+}
+
+export interface AwinSyncResult { ok: boolean; fetched: number; upserted: number }
+
+export interface AwinProgramme {
+  id: number;
+  name: string;
+  primarySector?: string;
+  currencyCode?: string;
+  status?: string;
+  primaryRegion?: { countryCode?: string };
+}
+
+/** Build the sync config from env, or null if not configured. */
+export function resolveAwinConfig(): AwinSyncConfig | null {
+  const publisherId = process.env.AWIN_PUBLISHER_ID || '';
+  const apiToken = process.env.AWIN_API_TOKEN || '';
+  if (!publisherId || !apiToken) return null;
+  return { publisherId, apiToken, apiBase: process.env.AWIN_API_BASE || 'https://api.awin.com' };
+}
+
+/** Map an Awin joined-programme onto an affiliate_program row. */
+export function mapAwinProgramme(p: AwinProgramme, cfg: AwinSyncConfig): Record<string, unknown> | null {
+  if (!p || !p.id || !p.name) return null;
+  return {
+    id: `awin_${p.id}`,
+    network: 'awin',
+    merchant: p.name,
+    commission_terms: {
+      market: p.primaryRegion?.countryCode ?? null,
+      sector: p.primarySector ?? null,
+      currency: p.currencyCode ?? null,
+      awin_mid: String(p.id),
+    },
+    affiliate_cashback_allowed: true,
+    policy: {
+      affiliate_cashback_allowed: true,
+      gotolink: `https://www.awin1.com/cread.php?awinmid=${p.id}&awinaffid=${cfg.publisherId}`,
+      subid_param: 'clickref',
+      deeplink_param: 'ued',
+      notes: `Awin publisher ${cfg.publisherId}. ${p.primarySector ?? 'general'} / ${p.primaryRegion?.countryCode ?? 'XX'}.`,
+    },
+    source: 'aggregator',
+    updated_at: new Date().toISOString(),
+  };
+}
+
+async function fetchJoinedProgrammes(cfg: AwinSyncConfig): Promise<AwinProgramme[]> {
+  const url = `${cfg.apiBase}/publishers/${cfg.publisherId}/programmes?relationship=joined`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${cfg.apiToken}` } });
+  if (!res.ok) throw new Error(`awin programmes HTTP ${res.status}`);
+  const data = (await res.json()) as AwinProgramme[] | { programmes?: AwinProgramme[] };
+  return Array.isArray(data) ? data : (data.programmes || []);
+}
+
+/** Harvest joined programmes and upsert them as affiliate_program rows. */
+export async function syncAwinProgrammes(supabase: any, cfg: AwinSyncConfig): Promise<AwinSyncResult> {
+  const programmes = await fetchJoinedProgrammes(cfg);
+  const rows = programmes
+    .map((p) => mapAwinProgramme(p, cfg))
+    .filter((r): r is Record<string, unknown> => r !== null);
+
+  let upserted = 0;
+  for (let i = 0; i < rows.length; i += 100) {
+    const chunk = rows.slice(i, i + 100);
+    const { error } = await supabase.from('affiliate_program').upsert(chunk, { onConflict: 'id' });
+    if (error) throw new Error(error.message);
+    upserted += chunk.length;
+  }
+  return { ok: true, fetched: programmes.length, upserted };
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/** Env-gated background worker: periodically harvests joined Awin programmes. */
+export function startAwinSyncWorker(): void {
+  if (process.env.AWIN_SYNC_ENABLED !== 'true') {
+    console.log('⏸️ Awin sync worker disabled (set AWIN_SYNC_ENABLED=true to enable)');
+    return;
+  }
+  const cfg = resolveAwinConfig();
+  if (!cfg) {
+    console.warn('⚠️ Awin sync enabled but AWIN_PUBLISHER_ID / AWIN_API_TOKEN not set — skipping');
+    return;
+  }
+  const intervalMs = Math.max(60_000, Number(process.env.AWIN_SYNC_INTERVAL_MS) || 3_600_000);
+  const run = async () => {
+    try {
+      const supabase = getSupabase();
+      if (!supabase) return;
+      const r = await syncAwinProgrammes(supabase, cfg);
+      console.log(`🔗 Awin sync: ${r.upserted}/${r.fetched} joined programmes (publisher ${cfg.publisherId})`);
+    } catch (e) {
+      console.warn('⚠️ Awin sync run failed (non-fatal):', e);
+    }
+  };
+  if (timer) clearInterval(timer);
+  void run();
+  timer = setInterval(() => void run(), intervalMs);
+  console.log(`🔗 Awin sync worker started (every ${Math.round(intervalMs / 60000)}m) for publisher ${cfg.publisherId}`);
+}

--- a/services/gateway/test/routes/awin-sync.test.ts
+++ b/services/gateway/test/routes/awin-sync.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the Awin programme sync mapping + config resolution
+ * (behind POST /api/v1/vcaop/awin/sync and the background worker).
+ */
+import {
+  mapAwinProgramme,
+  resolveAwinConfig,
+  type AwinSyncConfig,
+  type AwinProgramme,
+} from '../../src/services/awin-sync';
+
+const cfg: AwinSyncConfig = {
+  publisherId: '2938137',
+  apiToken: 'tok',
+  apiBase: 'https://api.awin.com',
+};
+
+describe('mapAwinProgramme', () => {
+  const prog: AwinProgramme = {
+    id: 122456,
+    name: 'ROCKBROS',
+    primarySector: 'Sports Equipment',
+    currencyCode: 'EUR',
+    status: 'Active',
+    primaryRegion: { countryCode: 'DE' },
+  };
+
+  test('maps to an affiliate_program row with the Awin deeplink + clickref', () => {
+    const row = mapAwinProgramme(prog, cfg)!;
+    expect(row.id).toBe('awin_122456');
+    expect(row.network).toBe('awin');
+    expect(row.merchant).toBe('ROCKBROS');
+    expect(row.affiliate_cashback_allowed).toBe(true);
+    expect(row.source).toBe('aggregator');
+    const policy = row.policy as Record<string, unknown>;
+    expect(policy.gotolink).toBe('https://www.awin1.com/cread.php?awinmid=122456&awinaffid=2938137');
+    expect(policy.subid_param).toBe('clickref');
+    expect(policy.deeplink_param).toBe('ued');
+    const terms = row.commission_terms as Record<string, unknown>;
+    expect(terms.awin_mid).toBe('122456');
+    expect(terms.market).toBe('DE');
+  });
+
+  test('deterministic id is stable across syncs (idempotent upsert key)', () => {
+    expect(mapAwinProgramme(prog, cfg)!.id).toBe(mapAwinProgramme(prog, cfg)!.id);
+  });
+
+  test('returns null for an invalid programme (no id/name)', () => {
+    expect(mapAwinProgramme({ id: 0, name: '' } as AwinProgramme, cfg)).toBeNull();
+  });
+
+  test('tolerates missing optional fields', () => {
+    const row = mapAwinProgramme({ id: 999, name: 'X' } as AwinProgramme, cfg)!;
+    expect(row.id).toBe('awin_999');
+    expect((row.commission_terms as Record<string, unknown>).market).toBeNull();
+  });
+});
+
+describe('resolveAwinConfig', () => {
+  const OLD_ID = process.env.AWIN_PUBLISHER_ID;
+  const OLD_TOK = process.env.AWIN_API_TOKEN;
+  afterAll(() => {
+    if (OLD_ID === undefined) delete process.env.AWIN_PUBLISHER_ID; else process.env.AWIN_PUBLISHER_ID = OLD_ID;
+    if (OLD_TOK === undefined) delete process.env.AWIN_API_TOKEN; else process.env.AWIN_API_TOKEN = OLD_TOK;
+  });
+
+  test('null when publisher id or token is missing', () => {
+    delete process.env.AWIN_PUBLISHER_ID;
+    delete process.env.AWIN_API_TOKEN;
+    expect(resolveAwinConfig()).toBeNull();
+    process.env.AWIN_PUBLISHER_ID = '2938137';
+    expect(resolveAwinConfig()).toBeNull(); // still no token
+  });
+
+  test('builds config when both are set', () => {
+    process.env.AWIN_PUBLISHER_ID = '2938137';
+    process.env.AWIN_API_TOKEN = 'abc';
+    const c = resolveAwinConfig()!;
+    expect(c.publisherId).toBe('2938137');
+    expect(c.apiBase).toBe('https://api.awin.com');
+  });
+});


### PR DESCRIPTION
## What

Auto-harvests the Awin programmes this publisher (`2938137`) has **joined** into the affiliate catalog, so approved advertisers (DocMorris, Shop Apotheke, MyProtein, etc.) wire into `/discover` with no manual step — same pattern as the Shopify sync (#2691).

### `services/awin-sync.ts`
- Lists **joined** programmes via the Awin Publisher API (`/publishers/{id}/programmes?relationship=joined`).
- Maps each → `affiliate_program` row: `id = awin_<advertiserId>` (idempotent upsert), `network=awin`, `cashback=true`, and an Awin **`cread.php` deeplink base + `clickref` SubID** — which plugs straight into the existing `/affiliate-link` endpoint (no new link logic needed).
- **Env-gated background worker** (`AWIN_SYNC_ENABLED`) on an interval, mirroring the other gateway scheduled jobs.

### `routes/awin-sync.ts`
- `POST /api/v1/vcaop/awin/sync` (exafy_admin) — on-demand harvest; mounted before the vcaop router.

### Config (`.env.example`)
`AWIN_SYNC_ENABLED`, `AWIN_PUBLISHER_ID`, `AWIN_API_TOKEN` (Secret Manager), `AWIN_API_BASE`, `AWIN_SYNC_INTERVAL_MS`.

## Scope
- **This PR = programme harvest** (links + attribution). **Conversion crediting (Awin transactions → member rewards) is Phase 2** — Awin reports conversions via its API (pull), not a postback, so it's a separate worker.
- Provider/account rows + ROCKBROS already wired in Supabase out-of-band.

## Tests / safety
- 6 unit tests: programme mapping (deeplink, clickref, terms), idempotent id, invalid/missing fields, config resolution.
- `tsc --noEmit` clean; Dev-Autopilot impact scan **0 findings**.
- Worker opt-in + fail-soft; admin endpoint auth-gated.

https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK)_