### PR TITLE
fix(vcaop): carry full cookie jar through Shopify storefront-password handshake

### DIFF
--- a/services/gateway/src/services/shopify-sync.ts
+++ b/services/gateway/src/services/shopify-sync.ts
@@ -81,15 +81,43 @@ export function mapShopifyProduct(p: ShopifyProduct, cfg: ShopifySyncConfig): Re
   };
 }
 
+/** Read all Set-Cookie headers off a response (array form when available). */
+function getSetCookies(res: Response): string[] {
+  const h = res.headers as unknown as { getSetCookie?: () => string[] };
+  if (typeof h.getSetCookie === 'function') return h.getSetCookie();
+  const raw = res.headers.get('set-cookie');
+  return raw ? [raw] : [];
+}
+
+/** Fold Set-Cookie strings into a name->value jar (first `name=value` pair only). */
+export function mergeSetCookies(jar: Record<string, string>, setCookies: string[]): Record<string, string> {
+  for (const sc of setCookies) {
+    const first = (sc.split(';')[0] || '').trim();
+    const eq = first.indexOf('=');
+    if (eq > 0) jar[first.slice(0, eq).trim()] = first.slice(eq + 1).trim();
+  }
+  return jar;
+}
+
+/** Serialize a cookie jar into a Cookie request header. */
+export function cookieHeader(jar: Record<string, string>): string {
+  return Object.entries(jar).map(([k, v]) => `${k}=${v}`).join('; ');
+}
+
 async function fetchProductsJson(cfg: ShopifySyncConfig): Promise<ShopifyProduct[]> {
   const base = `https://${cfg.domain}`;
   let res = await fetch(`${base}/products.json?limit=250`);
   // Password-protected storefronts return 401 — do the storefront-password handshake.
+  // Shopify needs BOTH the `_shopify_essential` cookie set by GET /password AND the
+  // `storefront_digest` cookie set by the POST, so we accumulate a single cookie jar
+  // across the whole exchange (mirrors a browser / curl cookie jar). The
+  // authenticity_token is optional here — the cookie jar is what authorizes access.
   if (res.status === 401 && cfg.storefrontPassword) {
+    const jar: Record<string, string> = {};
     const page = await fetch(`${base}/password`);
+    mergeSetCookies(jar, getSetCookies(page));
     const html = await page.text();
     const m = /name="authenticity_token"[^>]*value="([^"]+)"/.exec(html);
-    const cookie = page.headers.get('set-cookie') || '';
     const body = new URLSearchParams({
       form_type: 'storefront_password',
       utf8: '✓',
@@ -98,10 +126,10 @@ async function fetchProductsJson(cfg: ShopifySyncConfig): Promise<ShopifyProduct
     });
     const login = await fetch(`${base}/password`, {
       method: 'POST', redirect: 'manual',
-      headers: { 'content-type': 'application/x-www-form-urlencoded', cookie }, body,
+      headers: { 'content-type': 'application/x-www-form-urlencoded', cookie: cookieHeader(jar) }, body,
     });
-    const authCookie = login.headers.get('set-cookie') || cookie;
-    res = await fetch(`${base}/products.json?limit=250`, { headers: { cookie: authCookie } });
+    mergeSetCookies(jar, getSetCookies(login));
+    res = await fetch(`${base}/products.json?limit=250`, { headers: { cookie: cookieHeader(jar) } });
   }
   if (!res.ok) throw new Error(`products.json HTTP ${res.status}`);
   const data = (await res.json()) as { products?: ShopifyProduct[] };

--- a/services/gateway/test/routes/shopify-sync.test.ts
+++ b/services/gateway/test/routes/shopify-sync.test.ts
@@ -7,6 +7,8 @@ import {
   deterministicUuid,
   mapShopifyProduct,
   resolveShopifyConfig,
+  mergeSetCookies,
+  cookieHeader,
   type ShopifySyncConfig,
   type ShopifyProduct,
 } from '../../src/services/shopify-sync';
@@ -78,6 +80,32 @@ describe('mapShopifyProduct', () => {
 
   test('returns null for an invalid product (no id/title)', () => {
     expect(mapShopifyProduct({ id: 0, title: '', handle: 'x' } as ShopifyProduct, cfg)).toBeNull();
+  });
+});
+
+describe('storefront-password cookie jar', () => {
+  test('accumulates cookies across the handshake (essential + digest)', () => {
+    const jar: Record<string, string> = {};
+    // GET /password sets the essential cookie...
+    mergeSetCookies(jar, ['_shopify_essential=:AABB:; path=/; HttpOnly; SameSite=Lax']);
+    // ...the POST then sets the storefront digest. Both must reach products.json.
+    mergeSetCookies(jar, ['storefront_digest=abc123; path=/; HttpOnly']);
+    const header = cookieHeader(jar);
+    expect(header).toContain('_shopify_essential=:AABB:');
+    expect(header).toContain('storefront_digest=abc123');
+  });
+
+  test('later Set-Cookie for the same name overrides the earlier value', () => {
+    const jar: Record<string, string> = {};
+    mergeSetCookies(jar, ['_shopify_essential=old; path=/']);
+    mergeSetCookies(jar, ['_shopify_essential=new; path=/']);
+    expect(cookieHeader(jar)).toBe('_shopify_essential=new');
+  });
+
+  test('ignores malformed Set-Cookie entries', () => {
+    const jar: Record<string, string> = {};
+    mergeSetCookies(jar, ['', 'no-equals-sign; path=/']);
+    expect(cookieHeader(jar)).toBe('');
   });
 });
 


### PR DESCRIPTION
## Problem

The VCAOP Shopify catalog-sync worker runs on boot (confirmed: merchant row `…0001` refreshed at the deploy timestamp) but **never wrote any product rows** for the password-gated trial store. `/discover` was therefore served only by a stale **manual** Vitamin D3 row.

Root cause: `fetchProductsJson()` did the storefront-password handshake but only forwarded the **POST `/password`** response's `Set-Cookie`, dropping the `_shopify_essential` cookie set by the initial **GET `/password`**. Shopify requires **both** that essential cookie **and** the `storefront_digest` cookie from the POST to authorize `products.json`, so the final fetch 401'd, the sync threw, and the error was swallowed as non-fatal (merchant upsert happens *before* the fetch, which is why the merchant row updated but products didn't).

## Verification (live store)

A cookie-jar handshake against `54n0fa-ir.myshopify.com` confirmed the fix model:
- `token_len=0` — the `authenticity_token` is **not** required.
- `login -> 302`, then `products.json -> 200` returning the real Vitamin D3 feed **only when both cookies are carried** through the chain.

## Fix

Accumulate a single cookie jar across the whole exchange (GET → POST → GET), mirroring a browser/curl cookie jar:
- `getSetCookies()` — reads all `Set-Cookie` headers (uses `Headers.getSetCookie()` when available).
- `mergeSetCookies()` / `cookieHeader()` — fold `name=value` pairs into a jar and serialize a `Cookie` request header.

No new routes/env. Adds 3 unit tests for the jar logic (14 total in the suite, all green). `tsc` clean. Impact scan: 0 findings.

## After merge → staging → PUBLISH

Env is already activated on prod (`SHOPIFY_SYNC_ENABLED=true`, `SHOPIFY_STORE_DOMAIN`, `SHOPIFY_STOREFRONT_PASSWORD` secret). Once this is published, the worker will pull the real product and write its deterministic-id row — at which point the stale manual row `a7e3c1d0-…-0002` should be deleted to avoid a duplicate (tracked as a follow-up; left intact for now so `/discover` keeps serving the product).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK)_