### PR TITLE
feat(vcaop): Awin conversion crediting worker (Phase 2, pull-based)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -66,6 +66,20 @@ AWIN_API_TOKEN=
 AWIN_API_BASE=https://api.awin.com
 AWIN_SYNC_INTERVAL_MS=3600000
 
+# VCAOP Awin conversion crediting (Phase 2 — pull-based, no postback).
+# Pulls the Awin Publisher Transactions API, reverse-attributes each by clickRef
+# (the per-member SubID) via subid_map, and credits the rewards ledger
+# (pending -> confirmed/reversed). Reuses AWIN_PUBLISHER_ID / AWIN_API_TOKEN above.
+# AWIN_CONVERSIONS_ENABLED: set "true" to run the background worker on boot.
+# AWIN_CONVERSIONS_LOOKBACK_DAYS: pull window in days (default 30, capped at 31 by Awin).
+# AWIN_CONVERSIONS_INTERVAL_MS: worker interval (default 3600000 = 1h, min 60000).
+# AWIN_MEMBER_SHARE: member share of gross commission (0..1, default 0.5).
+# The admin trigger POST /api/v1/vcaop/awin/conversions/sync works regardless of the flag.
+AWIN_CONVERSIONS_ENABLED=false
+AWIN_CONVERSIONS_LOOKBACK_DAYS=30
+AWIN_CONVERSIONS_INTERVAL_MS=3600000
+AWIN_MEMBER_SHARE=0.5
+
 # --- DEV-COMHU-0513: ORB first-greeting latency ---
 # Greeting pre-buffer (WebSocket path). When live, the greeting prompt is
 # dispatched to the model as soon as the upstream Live API socket opens (so

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1607,6 +1607,16 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
         console.warn('⚠️ Awin sync worker initialization failed (non-fatal):', error);
       }
 
+      // VCAOP: Awin conversion crediting (Phase 2). Opt-in (AWIN_CONVERSIONS_ENABLED=true
+      // + AWIN_PUBLISHER_ID + AWIN_API_TOKEN). Pulls transactions on an interval and
+      // credits attributed conversions into the rewards ledger (no postback).
+      try {
+        const { startAwinConversionWorker } = require('./services/awin-conversions');
+        startAwinConversionWorker();
+      } catch (error) {
+        console.warn('⚠️ Awin conversion worker initialization failed (non-fatal):', error);
+      }
+
       // Dev Autopilot background executor (cooling→running→ci loop).
       // Disabled when DEV_AUTOPILOT_EXECUTOR_ENABLED=false.
       try {

--- a/services/gateway/src/routes/awin-sync.ts
+++ b/services/gateway/src/routes/awin-sync.ts
@@ -1,16 +1,17 @@
 /**
- * Admin endpoint: harvest joined Awin programmes into affiliate_program.
- *   POST /api/v1/vcaop/awin/sync   (exafy_admin only)
+ * Admin endpoints for the Awin integration (exafy_admin only):
+ *   POST /api/v1/vcaop/awin/sync               harvest joined programmes
+ *   POST /api/v1/vcaop/awin/conversions/sync   pull + credit conversions (Phase 2)
  *
- * On-demand twin of the background worker in services/awin-sync. Uses the Awin
- * Publisher API to pull joined programmes and upsert them (cashback=true, with
- * the Awin cread.php deeplink base + clickref SubID).
+ * On-demand twins of the background workers in services/awin-sync and
+ * services/awin-conversions.
  */
 import { Router, Request, Response } from 'express';
 import { randomUUID } from 'crypto';
 import { getSupabase } from '../lib/supabase';
 import { requireAuth } from '../middleware/auth-supabase-jwt';
 import { resolveAwinConfig, syncAwinProgrammes } from '../services/awin-sync';
+import { resolveAwinTxConfig, creditAwinConversions } from '../services/awin-conversions';
 
 const router = Router();
 router.use(requireAuth as any);
@@ -34,6 +35,31 @@ router.post('/sync', async (req: Request, res: Response) => {
         metadata: result, created_at: new Date().toISOString(),
       });
     } catch { /* never block the sync response on the audit write */ }
+    res.json({ ok: true, data: result });
+  } catch (e: any) {
+    res.status(502).json({ ok: false, error: String((e && e.message) || e) });
+  }
+});
+
+router.post('/conversions/sync', async (req: Request, res: Response) => {
+  // impact-allow-no-oasis: creditAwinConversions records reward.<state> OASIS rows
+  // via a direct oasis_events insert (same pattern as emitEvent in vcaop.ts), not
+  // via the emitOasisEvent helper the scanner greps for.
+  if (!(req as any).identity?.exafy_admin) { res.status(403).json({ ok: false, error: 'forbidden' }); return; }
+  const supabase = getSupabase();
+  if (!supabase) { res.status(503).json({ ok: false, error: 'database unavailable' }); return; }
+  const cfg = resolveAwinTxConfig();
+  if (!cfg) { res.status(400).json({ ok: false, error: 'AWIN_PUBLISHER_ID / AWIN_API_TOKEN not configured' }); return; }
+  try {
+    const result = await creditAwinConversions(supabase, cfg);
+    try {
+      await supabase.from('oasis_events').insert({
+        id: randomUUID(), service: 'vcaop', source: 'vcaop',
+        topic: 'vcaop.awin.conversions_synced',
+        status: 'success', message: `awin conversions ${result.credited} credited / ${result.attributed} attributed / ${result.fetched} pulled`,
+        metadata: result, created_at: new Date().toISOString(),
+      });
+    } catch { /* never block the response on the audit write */ }
     res.json({ ok: true, data: result });
   } catch (e: any) {
     res.status(502).json({ ok: false, error: String((e && e.message) || e) });

--- a/services/gateway/src/services/awin-conversions.ts
+++ b/services/gateway/src/services/awin-conversions.ts
@@ -1,0 +1,239 @@
+/**
+ * VCAOP Awin conversion crediting (Phase 2 — pull-based, no postback).
+ *
+ * Unlike Admitad (which calls our public postback), Awin reports conversions via
+ * its Publisher Transactions API. This worker periodically pulls transactions,
+ * reverse-attributes each by its `clickRef` (= the per-member SubID we minted at
+ * affiliate-link time) back to a member via `subid_map`, and idempotently moves
+ * the rewards_ledger entry through pending -> confirmed (approved) | reversed
+ * (declined/deleted) — exactly mirroring the Admitad postback's ledger semantics.
+ *
+ * Idempotent: each credit gets a deterministic id keyed on the Awin transaction
+ * id + SubID, so re-pulls upsert the same rows (no double-credit) and status
+ * changes (pending -> approved, later reversed) just overwrite in place. The pull
+ * runs over two date windows — `transaction` (catches new sales) and `validation`
+ * (catches later status changes) — and dedupes by transaction id.
+ */
+import { createHash } from 'crypto';
+import { getSupabase } from '../lib/supabase';
+import { resolveAwinConfig } from './awin-sync';
+
+/** Member share of the gross commission (mirrors the /shop + postback 50% split). */
+const DEFAULT_MEMBER_SHARE = 0.5;
+/** Awin caps a single transactions query at a 31-day range. */
+const MAX_LOOKBACK_DAYS = 31;
+
+export interface AwinTxConfig {
+  publisherId: string;
+  apiToken: string;
+  apiBase: string;
+  lookbackDays: number;
+  memberShare: number;
+}
+
+export interface AwinTransaction {
+  id: number | string;
+  advertiserId?: number | string;
+  commissionStatus?: string;          // pending | approved | declined | deleted
+  clickRef?: string;                  // our per-member SubID (sub_...)
+  commissionAmount?: { amount?: number; currency?: string };
+  saleAmount?: { amount?: number; currency?: string };
+}
+
+export interface AwinConversionResult {
+  ok: boolean;
+  fetched: number;       // unique transactions pulled
+  attributed: number;    // matched to a member via subid_map
+  credited: number;      // rows whose state actually changed (upserted + emitted)
+  unattributed: number;  // clickRefs not found in subid_map (organic / other)
+}
+
+/** A normalized credit intent derived from one Awin transaction. */
+export interface AwinCredit {
+  txId: string;
+  subId: string;
+  advertiserId: string;
+  gross: number;
+  currency: string;
+  state: 'pending' | 'confirmed' | 'reversed';
+}
+
+/** Build the conversion-pull config from env, or null if Awin isn't configured. */
+export function resolveAwinTxConfig(): AwinTxConfig | null {
+  const base = resolveAwinConfig();
+  if (!base) return null;
+  const lookbackDays = Math.min(
+    MAX_LOOKBACK_DAYS,
+    Math.max(1, Number(process.env.AWIN_CONVERSIONS_LOOKBACK_DAYS) || 30),
+  );
+  const rawShare = Number(process.env.AWIN_MEMBER_SHARE);
+  const memberShare = Number.isFinite(rawShare) && rawShare > 0 && rawShare <= 1 ? rawShare : DEFAULT_MEMBER_SHARE;
+  return { ...base, lookbackDays, memberShare };
+}
+
+/** Map an Awin commissionStatus to our ledger state. */
+export function mapAwinTxStatus(raw: string): 'pending' | 'confirmed' | 'reversed' {
+  const s = (raw || '').toLowerCase().trim();
+  if (['approved', 'confirmed', 'paid'].includes(s)) return 'confirmed';
+  if (['declined', 'rejected', 'deleted', 'reversed', 'cancelled', 'canceled'].includes(s)) return 'reversed';
+  return 'pending';
+}
+
+/** Awin transactions API date param: `YYYY-MM-DDTHH:mm:ss` (no milliseconds/Z). */
+export function awinDateParam(d: Date): string {
+  return d.toISOString().slice(0, 19);
+}
+
+/** Deterministic credit ids so re-pulls upsert in place (no double-credit). */
+export function awinCreditIds(txId: string, subId: string): { commissionId: string; rewardId: string } {
+  const fp = createHash('sha256').update(`awin:${txId}:${subId}`).digest('hex');
+  return { commissionId: 'cm_' + fp.slice(0, 24), rewardId: 'rw_' + fp.slice(0, 24) };
+}
+
+/** Normalize one Awin transaction into a credit intent, or null if unusable. */
+export function mapAwinTransaction(tx: AwinTransaction): AwinCredit | null {
+  if (!tx || tx.id === undefined || tx.id === null) return null;
+  const subId = String(tx.clickRef || '').trim();
+  if (!subId) return null; // no SubID -> can't attribute to a member
+  const gross = Number(tx.commissionAmount?.amount ?? 0) || 0;
+  const currency = String(tx.commissionAmount?.currency || tx.saleAmount?.currency || 'EUR').toUpperCase().slice(0, 8);
+  return {
+    txId: String(tx.id),
+    subId,
+    advertiserId: String(tx.advertiserId ?? ''),
+    gross: +gross.toFixed(4),
+    currency,
+    state: mapAwinTxStatus(String(tx.commissionStatus || '')),
+  };
+}
+
+async function fetchTransactions(cfg: AwinTxConfig, dateType: 'transaction' | 'validation', startIso: string, endIso: string): Promise<AwinTransaction[]> {
+  const url = `${cfg.apiBase}/publishers/${cfg.publisherId}/transactions/`
+    + `?startDate=${encodeURIComponent(startIso)}&endDate=${encodeURIComponent(endIso)}`
+    + `&timezone=UTC&dateType=${dateType}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${cfg.apiToken}` } });
+  if (!res.ok) throw new Error(`awin transactions (${dateType}) HTTP ${res.status}`);
+  const data = (await res.json()) as AwinTransaction[] | { transactions?: AwinTransaction[] };
+  return Array.isArray(data) ? data : (data.transactions || []);
+}
+
+/** Pull both date windows and dedupe by transaction id (validation wins — freshest status). */
+async function pullUniqueTransactions(cfg: AwinTxConfig, now: Date): Promise<AwinTransaction[]> {
+  const start = awinDateParam(new Date(now.getTime() - cfg.lookbackDays * 86_400_000));
+  const end = awinDateParam(now);
+  const byTx = new Map<string, AwinTransaction>();
+  for (const dateType of ['transaction', 'validation'] as const) {
+    let list: AwinTransaction[] = [];
+    try {
+      list = await fetchTransactions(cfg, dateType, start, end);
+    } catch (e) {
+      // A failure on one window shouldn't drop the other; surface but continue.
+      console.warn(`⚠️ Awin transactions pull (${dateType}) failed:`, e);
+    }
+    for (const tx of list) {
+      if (tx && tx.id !== undefined && tx.id !== null) byTx.set(String(tx.id), tx);
+    }
+  }
+  return [...byTx.values()];
+}
+
+async function emitOasis(supabase: any, topic: string, status: string, message: string, metadata: Record<string, unknown>): Promise<void> {
+  // Uses only columns present on oasis_events (no `type`), so the audit row persists.
+  try {
+    await supabase.from('oasis_events').insert({
+      id: createHash('sha256').update(`${topic}:${message}:${JSON.stringify(metadata)}`).digest('hex').replace(
+        /^(.{8})(.{4})(.{3})(.{3})(.{12}).*$/, '$1-$2-4$3-8$4-$5',
+      ),
+      service: 'vcaop', source: 'vcaop', topic, status, message,
+      metadata, created_at: new Date().toISOString(),
+    });
+  } catch { /* never block crediting on the audit write */ }
+}
+
+/**
+ * Pull Awin transactions and credit attributed conversions into the ledger.
+ * Only writes when a commission's state actually changes (quiet on steady state).
+ */
+export async function creditAwinConversions(supabase: any, cfg: AwinTxConfig): Promise<AwinConversionResult> {
+  const now = new Date();
+  const txns = await pullUniqueTransactions(cfg, now);
+
+  // Preload Awin program merchant names (id `awin_<advertiserId>` -> merchant) so
+  // commission rows carry a human merchant label without a per-tx query.
+  const merchantById = new Map<string, string>();
+  try {
+    const { data: progs } = await supabase.from('affiliate_program').select('id,merchant').eq('network', 'awin');
+    for (const p of progs || []) merchantById.set(String(p.id), String(p.merchant || ''));
+  } catch { /* enrichment is best-effort */ }
+
+  let attributed = 0, credited = 0, unattributed = 0;
+  for (const tx of txns) {
+    const credit = mapAwinTransaction(tx);
+    if (!credit) continue;
+
+    const { data: map } = await supabase
+      .from('subid_map')
+      .select('user_id, affiliate_program_id, network')
+      .eq('sub_id', credit.subId)
+      .maybeSingle();
+    if (!map) { unattributed++; continue; }
+    attributed++;
+
+    const programId = String(map.affiliate_program_id || (credit.advertiserId ? `awin_${credit.advertiserId}` : 'awin'));
+    const merchant = merchantById.get(programId) || `awin_${credit.advertiserId || 'unknown'}`;
+    const { commissionId, rewardId } = awinCreditIds(credit.txId, credit.subId);
+    const nowIso = now.toISOString();
+
+    // Skip the write when nothing changed (idempotent, quiet re-pulls).
+    const { data: existing } = await supabase
+      .from('commission_event').select('status').eq('id', commissionId).maybeSingle();
+    if (existing && existing.status === credit.state) continue;
+
+    const reward = +(credit.gross * cfg.memberShare).toFixed(4);
+    await supabase.from('commission_event').upsert({
+      id: commissionId, affiliate_program_id: programId, sub_id: credit.subId, user_id: map.user_id,
+      merchant, order_ref: credit.txId, gross_commission: credit.gross, currency: credit.currency,
+      status: credit.state, postback_ref: credit.txId, updated_at: nowIso,
+    }, { onConflict: 'id' });
+    await supabase.from('rewards_ledger').upsert({
+      id: rewardId, user_id: map.user_id, commission_event_id: commissionId,
+      amount: reward, currency: credit.currency, state: credit.state, updated_at: nowIso,
+    }, { onConflict: 'id' });
+    await emitOasis(supabase, `vcaop.reward.${credit.state}`, credit.state === 'reversed' ? 'warning' : 'success',
+      `awin conversion ${credit.state}`,
+      { commissionId, txId: credit.txId, subId: credit.subId, userId: map.user_id, gross: credit.gross, reward, state: credit.state });
+    credited++;
+  }
+
+  return { ok: true, fetched: txns.length, attributed, credited, unattributed };
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/** Env-gated background worker: periodically pulls + credits Awin conversions. */
+export function startAwinConversionWorker(): void {
+  if (process.env.AWIN_CONVERSIONS_ENABLED !== 'true') {
+    console.log('⏸️ Awin conversion worker disabled (set AWIN_CONVERSIONS_ENABLED=true to enable)');
+    return;
+  }
+  const cfg = resolveAwinTxConfig();
+  if (!cfg) {
+    console.warn('⚠️ Awin conversions enabled but AWIN_PUBLISHER_ID / AWIN_API_TOKEN not set — skipping');
+    return;
+  }
+  const intervalMs = Math.max(60_000, Number(process.env.AWIN_CONVERSIONS_INTERVAL_MS) || 3_600_000);
+  const run = async () => {
+    try {
+      const supabase = getSupabase();
+      if (!supabase) return;
+      const r = await creditAwinConversions(supabase, cfg);
+      console.log(`💸 Awin conversions: ${r.credited} credited / ${r.attributed} attributed / ${r.fetched} pulled (${r.unattributed} unattributed)`);
+    } catch (e) {
+      console.warn('⚠️ Awin conversion run failed (non-fatal):', e);
+    }
+  };
+  if (timer) clearInterval(timer);
+  void run();
+  timer = setInterval(() => void run(), intervalMs);
+  console.log(`💸 Awin conversion worker started (every ${Math.round(intervalMs / 60000)}m) for publisher ${cfg.publisherId}`);
+}

--- a/services/gateway/test/routes/awin-conversions.test.ts
+++ b/services/gateway/test/routes/awin-conversions.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for Awin conversion crediting (the pure logic behind
+ * POST /api/v1/vcaop/awin/conversions/sync and the background worker).
+ */
+import {
+  mapAwinTxStatus,
+  mapAwinTransaction,
+  resolveAwinTxConfig,
+  awinDateParam,
+  awinCreditIds,
+  type AwinTransaction,
+} from '../../src/services/awin-conversions';
+
+describe('mapAwinTxStatus', () => {
+  test('approved/paid -> confirmed', () => {
+    expect(mapAwinTxStatus('approved')).toBe('confirmed');
+    expect(mapAwinTxStatus('PAID')).toBe('confirmed');
+  });
+  test('declined/deleted -> reversed', () => {
+    expect(mapAwinTxStatus('declined')).toBe('reversed');
+    expect(mapAwinTxStatus('deleted')).toBe('reversed');
+  });
+  test('pending / unknown -> pending', () => {
+    expect(mapAwinTxStatus('pending')).toBe('pending');
+    expect(mapAwinTxStatus('')).toBe('pending');
+    expect(mapAwinTxStatus('whatever')).toBe('pending');
+  });
+});
+
+describe('mapAwinTransaction', () => {
+  const tx: AwinTransaction = {
+    id: 998877,
+    advertiserId: 122456,
+    commissionStatus: 'approved',
+    clickRef: 'sub_abc123def456',
+    commissionAmount: { amount: 4.0, currency: 'eur' },
+    saleAmount: { amount: 40, currency: 'EUR' },
+  };
+
+  test('normalizes a transaction into a credit intent', () => {
+    const c = mapAwinTransaction(tx)!;
+    expect(c.txId).toBe('998877');
+    expect(c.subId).toBe('sub_abc123def456');
+    expect(c.advertiserId).toBe('122456');
+    expect(c.gross).toBe(4.0);
+    expect(c.currency).toBe('EUR'); // upper-cased
+    expect(c.state).toBe('confirmed');
+  });
+
+  test('returns null when there is no clickRef (cannot attribute)', () => {
+    expect(mapAwinTransaction({ ...tx, clickRef: '' })).toBeNull();
+    expect(mapAwinTransaction({ ...tx, clickRef: undefined })).toBeNull();
+  });
+
+  test('returns null for a transaction with no id', () => {
+    expect(mapAwinTransaction({ id: undefined as any, clickRef: 'sub_x' })).toBeNull();
+  });
+
+  test('falls back to EUR and zero gross when amounts are missing', () => {
+    const c = mapAwinTransaction({ id: 1, clickRef: 'sub_x', commissionStatus: 'pending' })!;
+    expect(c.gross).toBe(0);
+    expect(c.currency).toBe('EUR');
+    expect(c.state).toBe('pending');
+  });
+});
+
+describe('awinCreditIds', () => {
+  test('deterministic + prefixed ids, stable across calls', () => {
+    const a = awinCreditIds('998877', 'sub_abc');
+    const b = awinCreditIds('998877', 'sub_abc');
+    expect(a.commissionId).toBe(b.commissionId);
+    expect(a.rewardId).toBe(b.rewardId);
+    expect(a.commissionId.startsWith('cm_')).toBe(true);
+    expect(a.rewardId.startsWith('rw_')).toBe(true);
+  });
+  test('different tx/sub combos produce different ids', () => {
+    expect(awinCreditIds('1', 'sub_a').commissionId).not.toBe(awinCreditIds('2', 'sub_a').commissionId);
+    expect(awinCreditIds('1', 'sub_a').commissionId).not.toBe(awinCreditIds('1', 'sub_b').commissionId);
+  });
+});
+
+describe('awinDateParam', () => {
+  test('formats as YYYY-MM-DDTHH:mm:ss (no ms / Z)', () => {
+    expect(awinDateParam(new Date('2026-06-25T08:28:17.588Z'))).toBe('2026-06-25T08:28:17');
+  });
+});
+
+describe('resolveAwinTxConfig', () => {
+  const OLD = {
+    id: process.env.AWIN_PUBLISHER_ID, tok: process.env.AWIN_API_TOKEN,
+    look: process.env.AWIN_CONVERSIONS_LOOKBACK_DAYS, share: process.env.AWIN_MEMBER_SHARE,
+  };
+  afterAll(() => {
+    process.env.AWIN_PUBLISHER_ID = OLD.id ?? '';
+    process.env.AWIN_API_TOKEN = OLD.tok ?? '';
+    if (OLD.look === undefined) delete process.env.AWIN_CONVERSIONS_LOOKBACK_DAYS; else process.env.AWIN_CONVERSIONS_LOOKBACK_DAYS = OLD.look;
+    if (OLD.share === undefined) delete process.env.AWIN_MEMBER_SHARE; else process.env.AWIN_MEMBER_SHARE = OLD.share;
+    if (OLD.id === undefined) delete process.env.AWIN_PUBLISHER_ID;
+    if (OLD.tok === undefined) delete process.env.AWIN_API_TOKEN;
+  });
+
+  test('null when Awin credentials are missing', () => {
+    delete process.env.AWIN_PUBLISHER_ID;
+    delete process.env.AWIN_API_TOKEN;
+    expect(resolveAwinTxConfig()).toBeNull();
+  });
+
+  test('builds config with defaults', () => {
+    process.env.AWIN_PUBLISHER_ID = '2938137';
+    process.env.AWIN_API_TOKEN = 'tok';
+    delete process.env.AWIN_CONVERSIONS_LOOKBACK_DAYS;
+    delete process.env.AWIN_MEMBER_SHARE;
+    const c = resolveAwinTxConfig()!;
+    expect(c.publisherId).toBe('2938137');
+    expect(c.lookbackDays).toBe(30);
+    expect(c.memberShare).toBe(0.5);
+  });
+
+  test('caps lookback at 31 days and clamps an invalid member share to the default', () => {
+    process.env.AWIN_PUBLISHER_ID = '2938137';
+    process.env.AWIN_API_TOKEN = 'tok';
+    process.env.AWIN_CONVERSIONS_LOOKBACK_DAYS = '90';
+    process.env.AWIN_MEMBER_SHARE = '5';
+    const c = resolveAwinTxConfig()!;
+    expect(c.lookbackDays).toBe(31);
+    expect(c.memberShare).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## What & why

Closes the last open piece of the VCAOP rewards loop: **Awin conversion crediting**.

Admitad calls our public postback when a sale converts. **Awin doesn't** — it reports conversions via its **Publisher Transactions API**, so conversions must be *pulled*. This adds that pull-based worker, mirroring the Admitad postback's ledger semantics exactly.

## How it works

`services/gateway/src/services/awin-conversions.ts`:
1. **Pulls** transactions over **two** date windows — `transaction` (catches new sales) and `validation` (catches later status flips: pending→approved, approved→declined) — and **dedupes by transaction id** (validation wins, freshest status).
2. **Reverse-attributes** each transaction by its `clickRef` (the per-member SubID we mint at `/affiliate-link` time) → member via `subid_map`. Same scheme the Admitad postback uses.
3. **Credits idempotently**: deterministic ids keyed on `awin:<txId>:<subId>` so re-pulls upsert in place (no double-credit). Moves `rewards_ledger` `pending → confirmed` (approved) / `reversed` (declined/deleted). 50% member share (matches `/shop` + postback).
4. **Quiet on steady state**: skips the write when a commission's status hasn't changed; unattributed clickRefs (organic Awin traffic) are counted, not spammed.

## Surface

- **Worker** — env-gated `AWIN_CONVERSIONS_ENABLED=true` (reuses `AWIN_PUBLISHER_ID`/`AWIN_API_TOKEN`), started on boot alongside the existing Awin programme sync.
- **Admin trigger** — `POST /api/v1/vcaop/awin/conversions/sync` (exafy_admin), added to the existing awin route file.
- **Config** — `AWIN_CONVERSIONS_LOOKBACK_DAYS` (default 30, capped 31 per Awin), `AWIN_CONVERSIONS_INTERVAL_MS` (default 1h), `AWIN_MEMBER_SHARE` (default 0.5). All documented in `.env.example`.

## Quality

- `tsc` clean · 19/19 Awin tests pass (13 new: status mapping, transaction normalization, deterministic ids, date formatting, config defaults/caps/clamping) · impact-scan **0 findings**.
- OASIS audit rows use only columns that exist on `oasis_events` (`topic`, not `type`), so reward events actually persist.

## Activation (after merge → staging → PUBLISH)

Set on the prod gateway when ready to go live:
```
AWIN_CONVERSIONS_ENABLED=true   # AWIN_PUBLISHER_ID / AWIN_API_TOKEN already set
```
Until then it's inert (flag off). The admin trigger works regardless of the flag for a manual first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK)_