### PR TITLE
ci(staging): enable NAV_GUIDED_JOURNEY + NAV_CONTINUATION_BIND on gateway-staging

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -158,6 +158,17 @@ jobs:
             "FEATURE_ORB_FAST_START_ENV=staging-only"
             "FEATURE_ORB_SAFE_FAST_GREETING_ENV=staging-only"
             "ORB_CONTEXT_READY_GATE_TIMEOUT_MS=300"
+            # NAV continuation / journey-mode experiments — bake into the staging
+            # env so they PERSIST across every STAGE-DEPLOY (--set-env-vars
+            # REPLACES, so a hand-set gcloud flag is wiped on the next push — the
+            # same trap that bit fast-start above). staging-only; prod stays off
+            # until these graduate via the PUBLISH path.
+            #   NAV_GUIDED_JOURNEY    → "guided" vs "full app" durable-mode switch
+            #                           on My Journey (incl. widened phrasing)
+            #   NAV_CONTINUATION_BIND → bind "Ja"/"yes" to a pending nav offer
+            #                           (offer_action + auto-capture + turn_complete)
+            "NAV_GUIDED_JOURNEY=true"
+            "NAV_CONTINUATION_BIND=true"
           )
 
           # Comma-joined for --set-env-vars (replaces, not merges — we want the


### PR DESCRIPTION
## Summary

Turns the two NAV features **on for `gateway-staging`** so they can actually be voice-tested. They were merged and deployed but flag-gated **off**, so they sat dormant.

**Why a workflow change and not a `gcloud` flag:** `STAGE-DEPLOY.yml` deploys with `--set-env-vars`, which **replaces** the env (doesn't merge) on every push — a hand-set flag gets wiped on the next deploy (the exact trap documented for `FEATURE_ORB_FAST_START_ENV` right above this). Baking the flags into the workflow's `ENV_VARS` list is the durable fix, matching the established pattern (`FEATURE_INTENT_ENGINE_A`, `FEATURE_ORB_FAST_START_ENV`, …).

```
NAV_GUIDED_JOURNEY=true     # "guided" vs "full app" durable-mode switch (+ widened phrasing)
NAV_CONTINUATION_BIND=true  # bind "Ja"/"yes" to a pending navigation offer
```

## Scope / safety
- **Staging only.** This is `STAGE-DEPLOY.yml` → `gateway-staging`. Production (`EXEC-DEPLOY.yml`) is **untouched** — these reach prod only via the PUBLISH path once verified.
- **Reversible** — delete the two lines to disable.
- No code change; no test impact.

## After merge
The `STAGE-DEPLOY` run will bake the flags into `gateway-staging`. Then voice-test on `preview.vitanaland.com`:
- *"bring mich zur einfachen Journey"* / *"step by step"* → **guided** mode on My Journey
- *"zeig mir die Vollversion"* / *"show me everything"* → **full** mode
- an ambiguous nav offer → answer **"Ja"** → lands on the offered screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_