### PR TITLE
feat(orb): teach Vitana the two My Journey views (Guided/Einführung vs Full/Vollversion)

### DIFF
--- a/services/gateway/src/orb/live/instruction/journey-modes-prompt.ts
+++ b/services/gateway/src/orb/live/instruction/journey-modes-prompt.ts
@@ -1,0 +1,62 @@
+/**
+ * NAV_GUIDED_JOURNEY — "My Journey has two views" knowledge block.
+ *
+ * Teaches Vitana the DECLARATIVE distinction between the two presentations of
+ * the user's longevity journey (the /autopilot "My Journey" screen):
+ *   • GUIDED JOURNEY  — German "Einführung" / "geführte Journey"
+ *   • FULL APP        — German "Vollversion"
+ *
+ * Why this exists: the guided-journey *content* system (narrate_guided_session,
+ * journey-guide openers, 254 topics) teaches Vitana how to RUN the journey, but
+ * nothing told it WHAT the two views are. So on a plain "what's the difference
+ * between the guided journey and the full app?" Vitana had no answer — it could
+ * switch modes (via the navigate tool's MODE_SWITCH hint) but couldn't explain
+ * the distinction in open conversation. This block fills that gap.
+ *
+ * Injected for the whole session, gated by NAV_GUIDED_JOURNEY (same flag that
+ * powers the navigate-path mode switch), so knowledge and capability stay in
+ * lockstep. English block for EN sessions, German for DE (the user base) — the
+ * German labels Einführung/Vollversion appear in BOTH because they are the
+ * exact words the UI toggle and the user use.
+ */
+export function buildJourneyModesSection(lang: string): string {
+  const isDe = lang.startsWith('de');
+  if (isDe) {
+    return `
+
+=== MY JOURNEY — ZWEI ANSICHTEN (Geführt vs. Vollversion) ===
+Die "Longevity Journey" des Nutzers (der Bildschirm "My Journey" / Autopilot)
+kann in ZWEI Ansichten angezeigt werden. Es ist DIESELBE Journey in zwei
+Darstellungen — KEINE zwei verschiedenen Funktionen. Der Nutzer kann jederzeit
+zwischen ihnen wechseln:
+  • GEFÜHRTE JOURNEY ("Einführung") — die Schritt-für-Schritt geführte Ansicht,
+    die den Nutzer durch EINEN fokussierten Schritt nach dem anderen führt. Ideal
+    zum Einstieg und für alle, die geführt werden möchten.
+  • VOLLVERSION (die volle App) — die komplette Ansicht mit allem auf einmal
+    verfügbar. Ideal für erfahrene Nutzer, die volle Kontrolle wollen.
+Gewechselt wird über den Einführung/Vollversion-Umschalter oben auf dem
+My-Journey-Bildschirm — ODER indem der Nutzer dich einfach bittet ("wechsle zur
+geführten Journey", "zeig mir die Vollversion"); dann navigierst du und die
+Ansicht klappt um.
+WENN DER NUTZER NACH DEM UNTERSCHIED FRAGT ("was ist der Unterschied zwischen
+geführter Journey und Vollversion?"), ERKLÄRE ihn mit den obigen Punkten in
+seiner Sprache. Sage NIEMALS, dass du den Unterschied nicht kennst.`;
+  }
+  return `
+
+=== MY JOURNEY — TWO VIEWS (Guided vs Full App) ===
+The user's longevity journey (the "My Journey" / Autopilot screen) can be shown
+in TWO views. It is the SAME journey in two presentations — NOT two different
+features. The user can switch between them at any time:
+  • GUIDED JOURNEY (German: "Einführung" / "geführte Journey") — the
+    step-by-step guided view that walks the user through ONE focused move at a
+    time. Best for getting started and for anyone who wants to be led.
+  • FULL APP (German: "Vollversion") — the complete view with everything
+    available at once. Best for established users who want full control.
+Switching is done with the Einführung/Vollversion toggle at the top of the
+My Journey screen — OR by the user simply asking you ("switch me to the guided
+journey", "show me the full version"); you then navigate and the view flips.
+WHEN THE USER ASKS WHAT THE DIFFERENCE IS ("what's the difference between the
+guided journey and the full app?"), EXPLAIN it in their language using the
+points above. NEVER say you don't know the difference.`;
+}

--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -45,6 +45,7 @@ import {
 // boundary. The function is pure (lang → string), so the round-trip is
 // safe.
 import { buildNavigatorPolicySection } from '../../../routes/orb-live';
+import { buildJourneyModesSection } from './journey-modes-prompt';
 import {
   BRAIN_OPENER_V2_START,
   BRAIN_OPENER_V2_END,
@@ -726,6 +727,15 @@ ${trimmedHistory}
   // when to consult the navigator, when to navigate directly, and when to
   // simply answer in voice without any tool call.
   instruction += buildNavigatorPolicySection(lang);
+
+  // NAV_GUIDED_JOURNEY — teach Vitana the DECLARATIVE distinction between the
+  // two views of "My Journey" (Guided/Einführung vs Full App/Vollversion) so it
+  // can EXPLAIN the difference in open conversation, not just switch modes on
+  // the navigate path. Gated by the same flag that powers the mode switch, so
+  // knowledge and capability stay in lockstep.
+  if (process.env.NAV_GUIDED_JOURNEY === 'true') {
+    instruction += buildJourneyModesSection(lang);
+  }
 
   // VTID-NAV-TIMEJOURNEY: Append the temporal + journey context block LAST so
   // its greeting policy overrides the generic GREETING RULES higher up. This

--- a/services/gateway/test/journey-modes-prompt.test.ts
+++ b/services/gateway/test/journey-modes-prompt.test.ts
@@ -1,0 +1,35 @@
+/**
+ * NAV_GUIDED_JOURNEY — the "My Journey has two views" knowledge block teaches
+ * Vitana the Guided/Einführung vs Full/Vollversion distinction so it can EXPLAIN
+ * it (not just switch modes). These assert the block carries the right facts in
+ * both languages.
+ */
+import { buildJourneyModesSection } from '../src/orb/live/instruction/journey-modes-prompt';
+
+describe('buildJourneyModesSection', () => {
+  test('EN block names both views + the German toggle labels + the explain directive', () => {
+    const s = buildJourneyModesSection('en');
+    expect(s).toMatch(/GUIDED JOURNEY/);
+    expect(s).toMatch(/FULL APP/);
+    expect(s).toMatch(/Einführung/);
+    expect(s).toMatch(/Vollversion/);
+    expect(s).toMatch(/same journey/i);          // it's one journey, two views
+    expect(s).toMatch(/NEVER say you don't know/i);
+  });
+
+  test('DE block is German and carries the same facts', () => {
+    const s = buildJourneyModesSection('de');
+    expect(s).toMatch(/GEFÜHRTE JOURNEY/);
+    expect(s).toMatch(/VOLLVERSION/);
+    expect(s).toMatch(/Einführung/);
+    expect(s).toMatch(/dieselbe Journey/i);
+    expect(s).toMatch(/NIEMALS/);
+    // no obviously English instruction text leaking into the DE block
+    expect(s).not.toMatch(/the difference between/i);
+  });
+
+  test('de-DE / de-AT region tags still get the German block', () => {
+    expect(buildJourneyModesSection('de-DE')).toMatch(/GEFÜHRTE JOURNEY/);
+    expect(buildJourneyModesSection('de-AT')).toMatch(/GEFÜHRTE JOURNEY/);
+  });
+});


### PR DESCRIPTION
## Summary

You were right: Vitana could **switch** journey modes (the `NAV_GUIDED_JOURNEY` navigate-path work) but had **no declarative knowledge** of what the two views *are* — so when you just talk to it ("what's the difference between the guided journey and the full app?"), it had nothing to say. The existing guided-journey content system (`narrate_guided_session`, 254 topics) teaches it how to **run** the journey, not how to **explain** the two presentations.

This adds a **"MY JOURNEY — TWO VIEWS"** knowledge block to the live system instruction:

- **Guided Journey** (DE *"Einführung" / "geführte Journey"*) — step-by-step, one focused move at a time; best for getting started / being led.
- **Full App** (DE *"Vollversion"*) — everything available at once; best for established users who want full control.
- They're the **same journey, two presentations — not two features**; switch via the Einführung/Vollversion toggle *or* by asking Vitana; **explain on demand in the user's language; never say "I don't know the difference."**

Details:
- **DE + EN** blocks (German labels appear in both — they're the literal UI/toggle words the user says).
- Injected for the whole session, **gated by `NAV_GUIDED_JOURNEY`** so the knowledge and the mode-switch capability stay in lockstep. Already enabled on `gateway-staging`.

## Verification
- `journey-modes-prompt` — **3/3** (EN + DE carry both views, the toggle labels, and the explain directive; `de-DE`/`de-AT` region tags resolve to German).
- `tsc --noEmit` ✅.
- **Voice-verify on staging:** ask Vitana *"was ist der Unterschied zwischen der geführten Journey und der Vollversion?"* — it should now explain both views instead of drawing a blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_