### PR TITLE
fix(orb): new-day morning overview owns turn 1 of the day

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -138,8 +138,21 @@ FEATURE_ORB_SAFE_FAST_GREETING_ENV=off
 # today's next event, Vitana Index direction, Life Compass goal) via the
 # new-day aggregator and speaks it verbatim instead of a one-line lead. This is
 # the bounded wait for that aggregator fetch; if it exceeds the bound we fall
-# back to the short opener. Optional — defaults to 1500 in code.
-ORB_NEWDAY_OVERVIEW_WAIT_MS=1500
+# back to the short opener. Optional — defaults to 3000 in code (the first
+# greeting of the day is allowed a longer budget so the full summary lands).
+ORB_NEWDAY_OVERVIEW_WAIT_MS=3000
+
+# Bounded wait for the fast greeting-facts pre-fetch (spoken name, last-session
+# info, proactive line) before the opener is chosen (orb-live.ts). Short by
+# design so same-day reopenings stay snappy. Optional — defaults to 700 in code.
+ORB_GREETING_FACTS_WAIT_MS=700
+
+# First-greeting-of-the-day extension: when the facts pre-fetch is still pending
+# after ORB_GREETING_FACTS_WAIT_MS, the fast greeting waits once more up to this
+# larger budget so the new-day morning overview can own turn 1 instead of
+# falling through to a bare next-step lead. Same-day reconnects whose facts
+# already resolved are unaffected. Optional — defaults to 2200 in code.
+ORB_NEWDAY_FACTS_WAIT_MS=2200
 
 # Env vars read ONLY by the standalone latency probe
 # (services/gateway/scripts/orb-latency-probe.mjs) — never by the running

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7564,6 +7564,29 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
             ]);
             if (ws.readyState !== WebSocket.OPEN) return;
 
+            // FIRST-GREETING-OF-THE-DAY budget. The first session of a new day
+            // is allowed to take a beat longer so Vitana can open with the FULL
+            // morning overview instead of a bare next-step lead (product
+            // decision: richness > latency for turn 1 of the day). The fast
+            // facts pre-fetch (spoken name + last-session info + proactive line)
+            // may not have resolved within the short ORB_GREETING_FACTS_WAIT_MS
+            // cap above — and until last-session info lands we cannot even tell
+            // whether this IS a new-day return. So when facts are still pending,
+            // wait once more up to a larger new-day budget. Same-day reconnects
+            // whose facts already resolved skip this entirely and stay fast.
+            if (_greetingFactsReady && !(session as any).lastSessionInfo) {
+              const _firstWaitMs = Number(process.env.ORB_GREETING_FACTS_WAIT_MS || 700);
+              const _ndFactsWaitMs = Number(process.env.ORB_NEWDAY_FACTS_WAIT_MS || 2200);
+              const _extraWaitMs = Math.max(0, _ndFactsWaitMs - _firstWaitMs);
+              if (_extraWaitMs > 0) {
+                await Promise.race([
+                  _greetingFactsReady,
+                  new Promise<void>((r) => setTimeout(r, _extraWaitMs)),
+                ]);
+                if (ws.readyState !== WebSocket.OPEN) return;
+              }
+            }
+
             // NEW-DAY OVERVIEW (rich summary owns turn 1). On a genuine new-day
             // return we speak the FULL multi-clause morning overview (what passed
             // since last session, today's next event, Index direction, Life
@@ -7603,7 +7626,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                     todayDateIso: todayInTimezone(_nowNd, _tzNd),
                     lastSessionAtIso: (session as any).lastSessionInfo?.time ?? null,
                   }),
-                  new Promise<null>((r) => setTimeout(() => r(null), Number(process.env.ORB_NEWDAY_OVERVIEW_WAIT_MS || 1500))),
+                  new Promise<null>((r) => setTimeout(() => r(null), Number(process.env.ORB_NEWDAY_OVERVIEW_WAIT_MS || 3000))),
                 ]).catch(() => null);
                 // The aggregator returns a truthy payload even when EMPTY (no
                 // calendar, no goal, no index move) — rendering that yields just a
@@ -7706,7 +7729,24 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
             // or the bare "Good <tod>, <Name>". It is kept to ~2 short sentences
             // so Gemini Live reliably emits audio. This is the top of the fast-
             // greeting ladder: proactive line → name greeting → generic opener.
-            const proactiveLine: unknown = (session as any).greetingProactiveLine;
+            // FIRST-GREETING-OF-THE-DAY: on a genuine new-day return the rich
+            // morning overview (the rung above) owns turn 1. If the overview
+            // could not build (e.g. no calendar/goal content yet, or the
+            // aggregator lost its budget), we want the grounded "Good <tod>,
+            // <Name>." new-day opener BELOW — never the bare proactive
+            // next-step lead ("Ich nehme dich mit zum nächsten Schritt"), which
+            // is what made the morning summary feel like it disappeared. So
+            // suppress the proactive opener on a genuine new-day return; it
+            // still fires for same-day reopenings (reconnect/recent/same_day).
+            const _ladderTemporal = describeTimeSince((session as any).lastSessionInfo);
+            const _ladderIsNewDay =
+              _ladderTemporal.bucket === 'today' ||
+              _ladderTemporal.bucket === 'yesterday' ||
+              _ladderTemporal.bucket === 'week' ||
+              _ladderTemporal.bucket === 'long';
+            const proactiveLine: unknown = _ladderIsNewDay
+              ? null
+              : (session as any).greetingProactiveLine;
             if (typeof proactiveLine === 'string' && proactiveLine.trim().length > 0) {
               const safeProactive = proactiveLine.trim().replace(/"/g, '\\"');
               const proactivePrompt =


### PR DESCRIPTION
## Problem

The rich **new-day morning overview** (the summary that recaps what passed since last session, today's next event, Index direction, and the Life Compass goal) almost never reached users. In `oasis_events` greeting telemetry over 6 days it fired **~4 times out of several hundred greetings**. Instead, users heard a bare next-step lead — *"Ich nehme dich mit zum nächsten Schritt"* / "I'll take you to the next step" — or a generic menu.

### Root cause

In the SAFE-FAST greeting ladder (`sendGreetingPromptToLiveAPI`):

1. The overview rung sits at the top but must win a **tight double race**: the facts pre-fetch (spoken name + last-session info) within `ORB_GREETING_FACTS_WAIT_MS` (700ms) **and** the aggregator within `ORB_NEWDAY_OVERVIEW_WAIT_MS` (1500ms). Whenever it lost, the lower **proactive next-step opener** (#2752) — which has *no* new-day gate — caught the turn and spoke a bare lead.
2. When the facts pre-fetch missed the 700ms cap, the generic `safe_fast_pending_context` menu fired instead. That's the **dominant** opener in telemetry.

It was never a data problem — affected users have a Life Compass goal and calendar events, so the overview's content gate would pass. It just kept losing the race.

## Fix

Per product direction, **the first greeting of the day may take a beat longer** so Vitana can deliver the full summary:

- **Extend the facts wait** when the pre-fetch is still pending, up to a new-day budget (`ORB_NEWDAY_FACTS_WAIT_MS`, default **2200ms**). Until last-session info lands we can't even tell it's a new-day return — so we wait for it. Same-day reconnects whose facts already resolved skip this and stay fast.
- **Raise the overview aggregator budget** default `1500ms → 3000ms` so a cold/slow read doesn't cost the summary its turn.
- **Suppress the proactive next-step opener on a genuine new-day return** (`today`/`yesterday`/`week`/`long`). The overview owns turn 1; if it genuinely can't build, the fallback is the grounded *"Good &lt;tod&gt;, &lt;Name&gt;."* opener — never the bare next-step lead. Same-day reopenings keep the proactive opener unchanged.

All thresholds are env-tunable.

## Verification

- `npm run build` (tsc) passes.
- Related suites green: `new-day-return`, `new-day-overview-aggregator`, `opening-contract` (57 tests).
- Behavior is gated on the existing gap buckets (`describeTimeSince`): new-day = ≥8h since last session.

After merge this auto-deploys to **staging** (`gateway-staging` / `preview-gateway.vitanaland.com`); verify by opening the ORB on a genuine first-of-day session and confirming `wake_opener=safe_fast_newday_overview` in `oasis_events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_