### PR TITLE
feat(news): expand German longevity sources + drop dead feeds

### DIFF
--- a/services/gateway/src/routes/longevity-news.ts
+++ b/services/gateway/src/routes/longevity-news.ts
@@ -54,7 +54,7 @@ async function supabaseQuery(
 router.get('/', async (_req: Request, res: Response) => {
   try {
     const { count, error } = await supabaseQuery('news_items', { select: 'id', limit: '0' });
-    res.json({ ok: true, vtid: VTID, service: 'longevity-news', total_items: count ?? 0, feeds_configured: 27, error: error || undefined });
+    res.json({ ok: true, vtid: VTID, service: 'longevity-news', total_items: count ?? 0, feeds_configured: 25, error: error || undefined });
   } catch (err: any) {
     res.status(500).json({ ok: false, error: err.message });
   }

--- a/services/gateway/src/services/longevity-news-fetcher.ts
+++ b/services/gateway/src/services/longevity-news-fetcher.ts
@@ -48,20 +48,28 @@ const FEEDS: FeedSource[] = [
   { name: 'Rapamycin News', url: 'https://rapamycin.news/feed/', language: 'en' },
   { name: 'Longevity Advice', url: 'https://longevityadvice.com/feed/', language: 'en' },
   { name: 'Mitosynergy', url: 'https://mitosynergy.com/feed/', language: 'en' },
-  // ── German consumer wellness (13) — no medical/pharmacy trade press ──
-  { name: 'Zentrum der Gesundheit', url: 'https://www.zentrum-der-gesundheit.de/rss', language: 'de' },
+  // ── German consumer wellness (11) — no medical/pharmacy trade press ──
+  // Kept: the five sources that have ever produced rows in news_items.
+  { name: 'Brigitte Gesundheit', url: 'https://www.brigitte.de/feed.rss', language: 'de' },
+  { name: 'stern Gesundheit', url: 'https://www.stern.de/feed/standard/gesundheit/', language: 'de' },
   { name: 'Heilpraxis', url: 'https://www.heilpraxisnet.de/feed/', language: 'de' },
   { name: 'Spiegel Gesundheit', url: 'https://www.spiegel.de/gesundheit/index.rss', language: 'de' },
-  { name: "Women's Health DE", url: 'https://www.womenshealth.de/feed/', language: 'de' },
-  { name: "Men's Health DE", url: 'https://www.menshealth.de/feed/', language: 'de' },
-  { name: 'Verbraucherzentrale Gesundheit', url: 'https://www.verbraucherzentrale.de/wissen/gesundheit-pflege/feed', language: 'de' },
-  { name: 'Verbraucherzentrale Lebensmittel', url: 'https://www.verbraucherzentrale.de/wissen/lebensmittel/feed', language: 'de' },
-  { name: 'stern Gesundheit', url: 'https://www.stern.de/feed/standard/gesundheit/', language: 'de' },
-  { name: 'FIT FOR FUN', url: 'https://www.fitforfun.de/fff/XML/rss_fffnews_sport.xml', language: 'de' },
-  { name: 'EAT SMARTER', url: 'https://eatsmarter.de/index.php?type=100', language: 'de' },
-  { name: 'DGE Ernährungsgesellschaft', url: 'https://www.dge.de/rss-feed/', language: 'de' },
   { name: 'Lifeline Gesundheit', url: 'https://www.lifeline.de/rss', language: 'de' },
-  { name: 'Brigitte Gesundheit', url: 'https://www.brigitte.de/feed.rss', language: 'de' },
+  // Added 2026-06-25 — high-frequency, image-rich consumer wellness to break the
+  // single-source (Brigitte) monotony in the German feed. FOCUS/Vital/GEO share
+  // proven image-rich CMSes (Brigitte already runs on the same /feed.rss stack).
+  // Any that yield no images after the first fetch cycle are pruned in a follow-up.
+  { name: 'FOCUS Gesundheit', url: 'https://rss.focus.de/fol/XML/rss_folgesundheit.xml', language: 'de' },
+  { name: 'Vital', url: 'https://www.vital.de/feed.rss', language: 'de' },
+  { name: 'GEO', url: 'https://www.geo.de/feed.rss', language: 'de' },
+  { name: 'Utopia', url: 'https://utopia.de/feed/', language: 'de' },
+  { name: 'Quarks', url: 'https://www.quarks.de/feed/', language: 'de' },
+  { name: 'NetDoktor', url: 'https://www.netdoktor.de/rss/news.xml', language: 'de' },
+  // Removed 2026-06-25 (never produced a single news_items row across months —
+  // dead/blocked RSS that only added failed-fetch noise each cycle):
+  //   Zentrum der Gesundheit, Women's Health DE, Men's Health DE,
+  //   Verbraucherzentrale (Gesundheit + Lebensmittel), FIT FOR FUN,
+  //   EAT SMARTER, DGE Ernährungsgesellschaft.
 ];
 
 const TAG_KEYWORDS: Record<string, string[]> = {


### PR DESCRIPTION
## Problem

The German longevity news feed was effectively **single-source**. Ground truth from `news_items`:

| DE source | items | with image | last successful fetch |
|---|---|---|---|
| Brigitte Gesundheit | 1100 | 1100 | **today** ✅ |
| stern Gesundheit | 300 | 300 | 2026-06-13 (stale) |
| Heilpraxis | 135 | 135 | 2026-06-21 |
| Spiegel Gesundheit | 40 | 40 | 2026-05-21 (stale) |
| Lifeline | 2 | 2 | dead (2019 content) |

And **8 of the 13 configured DE feeds had never produced a single row** — dead/blocked RSS that only emitted failed-fetch OASIS warnings every cycle.

## Change

- **Remove 8 zero-yield feeds:** Zentrum der Gesundheit, Women's Health DE, Men's Health DE, Verbraucherzentrale (Gesundheit + Lebensmittel), FIT FOR FUN, EAT SMARTER, DGE.
- **Add 6 high-frequency, image-rich consumer-wellness sources:** FOCUS Gesundheit, Vital, GEO, Utopia, Quarks, NetDoktor. FOCUS/Vital/GEO run on proven image-rich CMSes (Brigitte already uses the same `/feed.rss` stack).
- Update `feeds_configured` to 25 (14 EN + 11 DE).

## Verification plan

This sandbox's network policy blocks outbound RSS hosts, so feed URLs can't be pre-validated here — the real validation is the gateway's own fetch. After this merges to `main` → staging (`gateway-staging`), the fetcher runs ~60s after boot and writes to the shared `news_items` table. I'll then re-query the DB to confirm which new sources delivered items **with images**, and prune any that didn't in a follow-up.

> Pairs with the frontend ranker change (vitana-v1) that round-robins article sources so the new variety actually surfaces above Brigitte's daily volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYUTVkNSATYeabc9ybEhjq)_