### PR TITLE
feat(vcaop): Awin product feed discovery + one-step activation

### DIFF
--- a/docs/AWIN_PRODUCT_ACTIVATION_RUNBOOK.md
+++ b/docs/AWIN_PRODUCT_ACTIVATION_RUNBOOK.md
@@ -1,0 +1,110 @@
+# Awin Product Activation Runbook
+
+**How real affiliate products get onto `/discover` — and what gates it.**
+
+This is the affiliate-first path: members browse real merchant products, click
+through, buy on the merchant's site, Vitana earns commission. No owned
+inventory required.
+
+---
+
+## The two gates
+
+| Gate | In our control? | What it is |
+|------|-----------------|------------|
+| **1. Advertiser approval** | ❌ External (Awin + the merchant) | A product datafeed only exists for advertisers you are **joined/approved** with. Approvals are applied for in the Awin dashboard and granted by each merchant. |
+| **2. Feed configuration** | ✅ Ours | Each approved advertiser's `feed_id` must be saved into an Awin source config. The discovery endpoint below removes the manual lookup. |
+
+> As of this writing only **ROCKBROS** (cycling gear) is a joined Awin
+> advertiser. A real *health* catalog depends on Gate 1 — approvals for
+> DocMorris, Shop Apotheke, MyProtein, Sunday Natural, Otto, etc. There is no
+> code path that bypasses an advertiser approval.
+
+---
+
+## One-time prerequisite: the datafeed API key
+
+Awin product-feed downloads authenticate with a **publisher datafeed API key**
+(stamped into the `productdata.awin.com` URL path — this is *not* the OAuth
+Bearer token used by the programme harvest). Find it in the Awin dashboard
+under **Toolbox → Create-a-Feed / Product Feeds**, or **My Account → API
+Credentials**.
+
+Provide it one of three ways (checked in this order by the discovery endpoint):
+1. `?api_key=` query parameter, or
+2. an already-saved Awin source (`marketplace_sources_config.config.api_key`), or
+3. the `AWIN_DATAFEED_API_KEY` env var on the gateway (falls back to
+   `AWIN_API_TOKEN` as a last resort).
+
+---
+
+## Activation steps
+
+### 1. Discover available feeds (no manual feed_id lookup)
+
+```
+GET /api/v1/admin/marketplace/awin/feeds?joined_only=true&api_key=<DATAFEED_KEY>
+```
+(tenant-admin auth required)
+
+Returns every product feed your key can download, plus a ready-to-save
+`suggested_config`:
+
+```json
+{
+  "ok": true,
+  "count": 1,
+  "feeds": [
+    { "feed_id": "12345", "advertiser_id": "67890",
+      "advertiser_name": "ROCKBROS", "primary_region": "DE",
+      "membership_status": "joined", "product_count": 480 }
+  ],
+  "suggested_config": {
+    "api_key": "<DATAFEED_KEY>",
+    "publisher_id": "<SID>",
+    "feeds": [{ "feed_id": "12345", "advertiser_id": "67890", "advertiser_name": "ROCKBROS" }],
+    "max_products_per_feed": 500
+  }
+}
+```
+
+### 2. Save the source
+
+POST the `suggested_config` (trim feeds to the advertisers you want):
+
+```
+POST /api/v1/admin/marketplace/sources
+{ "source_network": "awin", "display_name": "Awin (DE health)",
+  "config": <suggested_config>, "is_active": true }
+```
+
+Or use the Command Hub **Add source → Awin** form (same provider schema).
+
+### 3. Sync products into the catalog
+
+```
+POST /api/v1/admin/marketplace/sync/awin
+```
+Or wait for the daily `MARKETPLACE-SYNC-CRON.yml` run at 03:00 UTC. Products
+land in `products` with `source_network='awin'`.
+
+### 4. Verify on `/discover`
+
+A row is feed-eligible (see `discover-feed.ts`) when:
+`is_active=TRUE`, `availability='in_stock'`, ships to the member's
+country/region, and the origin passes their scope. Products flagged
+`requires_admin_review` wait in the moderation queue
+(`/api/v1/admin/marketplace/products?requires_admin_review=true`).
+
+---
+
+## Where the code lives
+
+| Piece | File |
+|-------|------|
+| Feed discovery (`listAwinFeeds`) | `services/gateway/src/services/marketplace-sync/awin-sync.ts` |
+| Discovery endpoint | `services/gateway/src/routes/admin-marketplace.ts` (`GET /awin/feeds`) |
+| Product feed sync (`runAwinSync`) | `services/gateway/src/services/marketplace-sync/awin-sync.ts` |
+| Provider registration | `services/gateway/src/services/marketplace-sync/providers/awin.ts` |
+| Programme harvest (joined → `affiliate_program`) | `services/gateway/src/services/awin-sync.ts` |
+| Discover feed query | `services/gateway/src/routes/discover-feed.ts` |

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -66,6 +66,13 @@ AWIN_API_TOKEN=
 AWIN_API_BASE=https://api.awin.com
 AWIN_SYNC_INTERVAL_MS=3600000
 
+# AWIN_DATAFEED_API_KEY (optional): publisher datafeed API key for product feeds
+# (productdata.awin.com path-stamped key — distinct from the OAuth2 AWIN_API_TOKEN).
+# Used only as a fallback by GET /api/v1/admin/marketplace/awin/feeds when no
+# ?api_key= is passed and no Awin source is saved; that endpoint falls back to
+# AWIN_API_TOKEN if this is unset, so it is safe to leave blank.
+AWIN_DATAFEED_API_KEY=
+
 # VCAOP Awin conversion crediting (Phase 2 — pull-based, no postback).
 # Pulls the Awin Publisher Transactions API, reverse-attributes each by clickRef
 # (the per-member SubID) via subid_map, and credits the rewards ledger

--- a/services/gateway/src/routes/admin-marketplace.ts
+++ b/services/gateway/src/routes/admin-marketplace.ts
@@ -297,6 +297,63 @@ router.get('/providers', requireTenantAdmin, async (_req: Request, res: Response
   res.json({ ok: true, providers });
 });
 
+// ==================== Awin feed discovery ====================
+
+// Removes the manual "look up each feed_id in the Awin dashboard" step. Lists
+// every product datafeed the publisher's API key can download and returns a
+// ready-to-save source config (paste into POST /sources, or save in the
+// Command Hub "Add Awin source" form). The moment a health advertiser approval
+// lands, it shows up here and is one save away from flowing onto /discover.
+//
+// Key resolution: ?api_key= query > an existing saved awin source > env
+// (AWIN_DATAFEED_API_KEY, then AWIN_API_TOKEN as a last resort).
+router.get('/awin/feeds', requireTenantAdmin, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  let apiKey = typeof req.query.api_key === 'string' ? req.query.api_key : '';
+  let publisherId =
+    typeof req.query.publisher_id === 'string' && req.query.publisher_id
+      ? req.query.publisher_id
+      : process.env.AWIN_PUBLISHER_ID || '';
+
+  if (!apiKey && supabase) {
+    const { data } = await supabase
+      .from('marketplace_sources_config')
+      .select('config')
+      .eq('source_network', 'awin')
+      .eq('is_active', true)
+      .limit(1);
+    const cfg = data?.[0]?.config as { api_key?: string; publisher_id?: string } | undefined;
+    if (cfg?.api_key) apiKey = cfg.api_key;
+    if (!publisherId && cfg?.publisher_id) publisherId = cfg.publisher_id;
+  }
+  if (!apiKey) apiKey = process.env.AWIN_DATAFEED_API_KEY || process.env.AWIN_API_TOKEN || '';
+  if (!apiKey) {
+    return res.status(400).json({
+      ok: false,
+      error: 'No Awin datafeed API key. Pass ?api_key=, save an Awin source first, or set AWIN_DATAFEED_API_KEY.',
+    });
+  }
+
+  const joinedOnly = req.query.joined_only === 'true' || req.query.joined_only === '1';
+  try {
+    const { listAwinFeeds } = await import('../services/marketplace-sync/awin-sync');
+    const feeds = await listAwinFeeds(apiKey, { joinedOnly });
+    const suggested_config = {
+      api_key: apiKey,
+      publisher_id: publisherId || null,
+      feeds: feeds.map((f) => ({
+        feed_id: f.feed_id,
+        advertiser_id: f.advertiser_id,
+        advertiser_name: f.advertiser_name,
+      })),
+      max_products_per_feed: 500,
+    };
+    res.json({ ok: true, count: feeds.length, feeds, suggested_config });
+  } catch (e: unknown) {
+    res.status(502).json({ ok: false, error: String((e instanceof Error ? e.message : e)) });
+  }
+});
+
 // ==================== VTID-02200: Sources (Shopify + CJ + etc) ====================
 
 router.get('/sources', requireTenantAdmin, async (req: Request, res: Response) => {

--- a/services/gateway/src/services/marketplace-sync/awin-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/awin-sync.ts
@@ -140,6 +140,126 @@ async function fetchAwinFeed(
   return data.products ?? [];
 }
 
+// ==================== Feed discovery ====================
+
+/**
+ * A product feed the publisher account can access, as returned by Awin's
+ * datafeed *list* endpoint. This is what removes the manual "go find the
+ * feed_id in the dashboard" step: call listAwinFeeds() and you get every
+ * feed_id / advertiser_id pair you're entitled to, ready to drop into the
+ * `feeds` array of an Awin source config.
+ */
+export interface AwinAvailableFeed {
+  feed_id: string;
+  advertiser_id: string;
+  advertiser_name: string;
+  primary_region?: string;
+  membership_status?: string;
+  language?: string;
+  vertical?: string;
+  product_count?: number;
+}
+
+/**
+ * Minimal RFC-4180 CSV row parser — handles quoted fields containing commas
+ * and doubled-quote escapes. Awin advertiser names routinely contain commas
+ * ("Acme Health, Inc."), so a naive split() corrupts the columns.
+ */
+function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') { cur += '"'; i++; } // escaped quote
+        else inQuotes = false;
+      } else cur += ch;
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      out.push(cur); cur = '';
+    } else cur += ch;
+  }
+  out.push(cur);
+  return out.map((s) => s.trim());
+}
+
+/**
+ * List every product data feed this publisher's API key can download.
+ *
+ * Awin exposes a CSV catalog of feeds at
+ *   https://productdata.awin.com/datafeed/list/apikey/{key}/
+ * with one row per feed the account is entitled to (joined advertisers that
+ * publish a datafeed). We map the columns we care about by HEADER NAME rather
+ * than position, since Awin has reordered/extended the export over time.
+ *
+ * @param apiKey  the publisher datafeed API key (path-stamped, not Bearer)
+ * @param opts.joinedOnly  keep only rows whose membership status looks joined/active
+ */
+export async function listAwinFeeds(
+  apiKey: string,
+  opts: { joinedOnly?: boolean } = {}
+): Promise<AwinAvailableFeed[]> {
+  if (!apiKey) throw new Error('listAwinFeeds: apiKey required');
+  const url = `https://productdata.awin.com/datafeed/list/apikey/${encodeURIComponent(apiKey)}/`;
+  const resp = await fetch(url, { headers: { Accept: 'text/csv' } });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '(no body)');
+    throw new Error(`Awin feed list HTTP ${resp.status} ${body.slice(0, 300)}`);
+  }
+  const text = await resp.text();
+  const lines = text.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length < 2) return [];
+
+  const header = parseCsvLine(lines[0]).map((h) => h.toLowerCase());
+  const idx = (...names: string[]) => {
+    for (const n of names) {
+      const i = header.indexOf(n);
+      if (i !== -1) return i;
+    }
+    return -1;
+  };
+  const iFeed = idx('feed id', 'feedid', 'feed_id');
+  const iAdv = idx('advertiser id', 'advertiserid', 'advertiser_id');
+  const iName = idx('advertiser name', 'advertisername', 'advertiser_name');
+  const iRegion = idx('primary region', 'region');
+  const iStatus = idx('membership status', 'membership', 'status');
+  const iLang = idx('language', 'languages');
+  const iVertical = idx('vertical', 'sector');
+  const iCount = idx('no of products', 'number of products', 'products');
+
+  if (iFeed === -1 || iAdv === -1) {
+    throw new Error(`Awin feed list: unexpected columns [${header.join(', ')}]`);
+  }
+
+  const feeds: AwinAvailableFeed[] = [];
+  for (let r = 1; r < lines.length; r++) {
+    const cols = parseCsvLine(lines[r]);
+    const feed_id = cols[iFeed];
+    const advertiser_id = cols[iAdv];
+    if (!feed_id || !advertiser_id) continue;
+    const membership_status = iStatus !== -1 ? cols[iStatus] : undefined;
+    if (opts.joinedOnly && membership_status) {
+      const s = membership_status.toLowerCase();
+      if (!(s.includes('join') || s.includes('active') || s.includes('approved'))) continue;
+    }
+    const rawCount = iCount !== -1 ? Number((cols[iCount] || '').replace(/[^0-9]/g, '')) : NaN;
+    feeds.push({
+      feed_id,
+      advertiser_id,
+      advertiser_name: (iName !== -1 ? cols[iName] : '') || `Awin Advertiser ${advertiser_id}`,
+      primary_region: iRegion !== -1 ? cols[iRegion] || undefined : undefined,
+      membership_status,
+      language: iLang !== -1 ? cols[iLang] || undefined : undefined,
+      vertical: iVertical !== -1 ? cols[iVertical] || undefined : undefined,
+      product_count: Number.isFinite(rawCount) ? rawCount : undefined,
+    });
+  }
+  return feeds;
+}
+
 // ==================== Normalization ====================
 
 function parseCents(amountStr: string | undefined): number | null {


### PR DESCRIPTION
## Why

Investigating why `/discover` shows no affiliate products surfaced the real
state of the marketplace:

- `marketplace_sources_config` is **empty** — affiliate product-feed ingestion
  was never configured for any network.
- The `products` table that feeds `/discover` holds only Shopify **demo/mock**
  rows (25× `mock.shop` apparel in CAD + 1 dev-store placeholder) and 10
  `demo_seed` supplement fixtures. **No real sellable catalog on any channel.**
- The affiliate model (browse real merchant products → click → buy on merchant
  site → Vitana earns commission) is the route to real inventory **without
  owning stock**, but it has two gates:
  1. **Advertiser approval** — external; only ROCKBROS is joined today.
  2. **Feed configuration** — ours; each approved advertiser's `feed_id` had to
     be looked up by hand in the Awin dashboard.

The product-feed sync, provider registration, config persistence (`POST
/sources`) and Command Hub UI **already exist**. The only in-our-control
friction was gate 2. This PR removes it.

## What

- **`listAwinFeeds(apiKey)`** (`marketplace-sync/awin-sync.ts`) — lists every
  product datafeed the publisher key can download via Awin's datafeed-list CSV,
  with a quote-aware, header-mapped parser (advertiser names contain commas).
- **`GET /api/v1/admin/marketplace/awin/feeds`** — tenant-admin discovery
  endpoint. Resolves the datafeed key from `?api_key=` → saved Awin source →
  env (`AWIN_DATAFEED_API_KEY`, then `AWIN_API_TOKEN`). Returns the feed list
  plus a ready-to-save `suggested_config`. `?joined_only=true` filters to
  approved advertisers.
- **`docs/AWIN_PRODUCT_ACTIVATION_RUNBOOK.md`** — documents both gates and the
  discover → save → sync → verify flow.

## Activation (once a datafeed key + approvals exist)

```
GET  /api/v1/admin/marketplace/awin/feeds?joined_only=true   # discover
POST /api/v1/admin/marketplace/sources { source_network: "awin", config: <suggested_config> }
POST /api/v1/admin/marketplace/sync/awin                      # ingest
```
Products land in `products` with `source_network='awin'` and appear on
`/discover` once `is_active`, `in_stock`, and shippable to the member.

## Verification

- `npm run build` (gateway) passes.
- The live Awin datafeed call can't be exercised from this environment (network
  policy blocks outbound to external hosts); it runs on the prod gateway. The
  existing `runAwinSync` download path is unchanged.

## Not included (out of our control)

- Health-advertiser approvals (DocMorris, Shop Apotheke, MyProtein, …) — applied
  for in the Awin dashboard.
- The datafeed API key — must be provided by an operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK)_