### PR TITLE
fix(orb): honor negation in guided/full journey-mode detection

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3303,7 +3303,6 @@ export async function tool_navigate(
         // Keyword detection for the GUIDED vs FULL durable mode. Deliberately
         // broad — people don't say "guided journey" verbatim; they say "the
         // simple one", "step by step", "der Anfänger-Modus", "show me everything".
-        // GUIDED is checked first, so it wins if a phrase somehow hits both.
         // EN: guided / step-by-step / beginner / intro(duction) / tutorial /
         //     onboarding / walk me through / simple(r) / basic / easy mode.
         // DE: geführt / Einführung / Schritt für Schritt / Anfänger / einfach(e/r) /
@@ -3320,7 +3319,25 @@ export async function tool_navigate(
           /full[\s-]?(?:app|version|mode|experience)|vollversion|volle\s+version|komplette?n?\s*app|\bkomplett(?:e[rsn]?)?\b|\bcomplete\b|advanced|fortgeschritten|erweitert|all[\s-]?features|alle\s+funktionen|\balles\b|everything|pro[\s-]?(?:mode|modus)|profi[\s-]?modus/.test(
             intentText,
           );
-        const targetMode: 'guided' | 'full' | null = wantsGuided ? 'guided' : wantsFull ? 'full' : null;
+        // NEGATION GUARD: "the FULL app, NOT the guided journey" must NOT switch
+        // to guided just because the word "guided" appears. Detect a negation
+        // token within ~3 words before a mode NAME and discount that side, so the
+        // explicitly-rejected mode never wins. Targets the named modes (the words
+        // people actually contrast); broad synonyms aren't negated in practice.
+        const negatedGuided =
+          /(?:not|n['’]?t|nicht|kein[a-z]*|rather than|instead of|statt|anstatt|ohne)\b(?:\W+\w+){0,3}?\W+(?:guided|gef[üu]hrt|einf[üu]hrung)/.test(
+            intentText,
+          );
+        const negatedFull =
+          /(?:not|n['’]?t|nicht|kein[a-z]*|rather than|instead of|statt|anstatt|ohne)\b(?:\W+\w+){0,3}?\W+(?:full|vollversion|volle|komplett|complete)/.test(
+            intentText,
+          );
+        const pickGuided = wantsGuided && !negatedGuided;
+        const pickFull = wantsFull && !negatedFull;
+        // Guided wins ties only among modes that were actually requested (i.e.
+        // not negated). "full not guided" → guided negated → full; "guided not
+        // full" → full negated → guided.
+        const targetMode: 'guided' | 'full' | null = pickGuided ? 'guided' : pickFull ? 'full' : null;
         if (targetMode) {
           try {
             const { setJourneyMode } = await import('./guided-journey/guided-journey-state');

--- a/services/gateway/test/nav-guided-journey.test.ts
+++ b/services/gateway/test/nav-guided-journey.test.ts
@@ -128,6 +128,24 @@ describe('NAV-GUIDED-JOURNEY', () => {
       expect(mockSetMode).not.toHaveBeenCalled();
     });
   });
+
+  // NEGATION: "the FULL app, NOT the guided journey" must resolve to FULL even
+  // though the word "guided" appears — the rejected mode must never win.
+  describe('negation handling (X not Y)', () => {
+    const CASES: Array<[string, 'guided' | 'full']> = [
+      ['navigate me to my longevity journey, the full app not the guided journey', 'full'],
+      ['the guided journey, not the full app', 'guided'],
+      ['bring mich zur Vollversion, nicht zur geführten Journey', 'full'],
+      ['zeig mir die geführte Journey, nicht die Vollversion', 'guided'],
+      ['I don’t want the guided journey, give me the full app', 'full'],
+    ];
+    test.each(CASES)('"%s" → %s', async (q, expected) => {
+      process.env.NAV_GUIDED_JOURNEY = 'true';
+      await tool_navigate({ question: q }, authedId, sbStub);
+      expect(mockSetMode).toHaveBeenCalledTimes(1);
+      expect(mockSetMode.mock.calls[0][2]).toBe(expected);
+    });
+  });
 });
 
 // NAV_CONTINUATION_BIND — auto-capture nav offers (invariant #10, produce side):


### PR DESCRIPTION
## Summary

Your test found a real bug. Asking *"navigate me to My Longevity Journey, the **full app**, **not** the guided journey"* switched the user to **Guided** — the exact opposite. I confirmed it by running your phrase through the live detection logic:

```
wantsGuided: true   (matches "guided journey")
wantsFull:   true   (matches "full app")
=> targetMode: guided   ← WRONG (guided checked first, no negation handling)
```

Root cause: the rejected mode ("not the guided journey") still counted as wanting guided, and guided wins ties.

## Fix — negation guard
Detect a negation token (`not` / `n't` / `nicht` / `kein*` / `rather than` / `instead of` / `statt` / `anstatt` / `ohne`) within ~3 words before a mode **name**, and discount that side. Guided still wins ties, **but only among modes that were actually requested (not negated):**

| Phrase | Result |
|--------|--------|
| "full app **not** the guided journey" | **full** ✅ |
| "guided journey, **not** the full app" | **guided** ✅ |
| "Vollversion, **nicht** die geführte Journey" | **full** ✅ |
| "geführte Journey, **nicht** die Vollversion" | **guided** ✅ |
| "I **don't want** the guided … give me the full app" | **full** ✅ |

Plain single-mode phrases ("show me the full version") and neutral "open my journey" are unchanged.

## Verification
- `nav-guided-journey` — **30/30**, incl. **5 new negation cases** (EN + DE, both directions) + the existing widened-phrasing/auto-capture suites.
- `tsc --noEmit` ✅.
- Flag-gated by `NAV_GUIDED_JOURNEY` (already on `gateway-staging`). After merge, voice-test the exact phrase → should land on **full**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_