### PR TITLE
feat(vcaop): Admitad product catalog sync (Products API → /discover)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -50,6 +50,20 @@ SHOPIFY_SYNC_INTERVAL_MS=3600000
 # (Tools -> Postback URL). Bind it as a gateway Cloud Run env / Secret Manager value.
 ADMITAD_POSTBACK_KEY=
 
+# VCAOP Admitad product catalog sync (Products API, OAuth client_credentials).
+# Pulls product data for joined Admitad advertiser campaigns into `products` so
+# items render on /discover. Config lives in the marketplace_sources_config table
+# (source_network='admitad'); these env vars are the credential FALLBACK when the
+# config row omits client_id/client_secret — reuse the same secrets bound for the
+# postback flow. Trigger: POST /api/v1/internal/sync/admitad (or the daily cron).
+# VCAOP_ADMITAD_CLIENT_ID / VCAOP_ADMITAD_CLIENT_SECRET: OAuth app credentials.
+# VCAOP_ADMITAD_BASE64_HEADER: optional pre-built base64("id:secret") Basic header.
+# ADMITAD_API_BASE: defaults to https://api.admitad.com.
+VCAOP_ADMITAD_CLIENT_ID=
+VCAOP_ADMITAD_CLIENT_SECRET=
+VCAOP_ADMITAD_BASE64_HEADER=
+ADMITAD_API_BASE=https://api.admitad.com
+
 # VCAOP Awin joined-programme sync.
 # Harvests the programmes this publisher has JOINED (Awin Publisher API) into
 # affiliate_program rows (cashback=true; Awin cread.php deeplink + clickref SubID),

--- a/services/gateway/src/services/marketplace-sync/admitad-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/admitad-sync.ts
@@ -1,0 +1,470 @@
+/**
+ * VCAOP: Admitad product catalog sync.
+ *
+ * Admitad (Mitgo) is already wired as a rewards/postback network — publisher
+ * account live, "Vitanaland Discover" ad space verified, Alibaba WW joined,
+ * token verified (HTTP 200) against https://api.admitad.com/token/. This module
+ * adds the *catalog* half: pull product data via the Admitad Products API and
+ * upsert it into `products` so items show on /discover.
+ *
+ * AUTH: OAuth2 client_credentials. POST /token/ with HTTP Basic
+ *   (base64(client_id:client_secret)) + grant_type=client_credentials&scope=...
+ * Credentials come from the source config row, falling back to the
+ * Secret-Manager-bound env (VCAOP_ADMITAD_*) used by the existing postback flow.
+ *
+ * PRODUCTS: GET /products/ — paginated ({results, _meta:{count,limit,offset}}).
+ * Admitad's product schema is not pinned from public docs (the API is
+ * account-gated), so normalization is DEFENSIVE: every field tries several
+ * candidate names, the raw item is stored on the row, and the first item of
+ * each campaign is logged so the field mapping can be confirmed live on the
+ * first real sync (activation step). Get a field wrong and you see it in the
+ * sample log / `raw` column rather than silently shipping garbage.
+ *
+ * Config shape (JSON in marketplace_sources_config.config):
+ *   {
+ *     "client_id": "...",            // optional — falls back to VCAOP_ADMITAD_CLIENT_ID
+ *     "client_secret": "...",        // optional — falls back to VCAOP_ADMITAD_CLIENT_SECRET
+ *     "scope": "products",           // optional, default "products"
+ *     "campaign_ids": ["12345"],     // advertiser campaign ids to pull; empty = all connected
+ *     "gotolink_base": "https://rzekl.com/g/.../",  // optional — wraps product url as affiliate link
+ *     "merchant_country": "DE",      // optional fallback
+ *     "max_products": 1000,          // optional, default 1000 (across all campaigns)
+ *     "page_size": 200               // optional, default 200 (Admitad max is typically 500)
+ *   }
+ */
+
+import {
+  startSyncRun,
+  finishSyncRun,
+  upsertMerchant,
+  upsertProducts,
+  type ProductUpsert,
+} from './shared';
+import { inferSupplementAttributes } from './supplement-inference';
+import { getSupabase } from '../../lib/supabase';
+
+const ADMITAD_API_BASE = process.env.ADMITAD_API_BASE || 'https://api.admitad.com';
+
+export interface AdmitadSourceConfig {
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
+  campaign_ids?: string[];
+  gotolink_base?: string;
+  merchant_country?: string;
+  max_products?: number;
+  page_size?: number;
+}
+
+async function loadSourceConfigs(): Promise<AdmitadSourceConfig[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const { data } = await supabase
+    .from('marketplace_sources_config')
+    .select('config')
+    .eq('source_network', 'admitad')
+    .eq('is_active', true);
+  if (!data?.length) return [];
+  return data.map((r) => r.config as AdmitadSourceConfig).filter(Boolean);
+}
+
+// ==================== Auth ====================
+
+function resolveCredentials(cfg: AdmitadSourceConfig): {
+  clientId: string;
+  clientSecret: string;
+  basicHeader: string;
+} | null {
+  const clientId = cfg.client_id || process.env.VCAOP_ADMITAD_CLIENT_ID || '';
+  const clientSecret = cfg.client_secret || process.env.VCAOP_ADMITAD_CLIENT_SECRET || '';
+  // A pre-built base64 "client_id:client_secret" header may be bound in Secret
+  // Manager (VCAOP_ADMITAD_BASE64_HEADER) — prefer it when id/secret absent.
+  const envHeader = process.env.VCAOP_ADMITAD_BASE64_HEADER;
+  if (clientId && clientSecret) {
+    const basicHeader = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+    return { clientId, clientSecret, basicHeader };
+  }
+  if (envHeader) {
+    // Derive client_id from the header so the token body can include it.
+    const decoded = Buffer.from(envHeader, 'base64').toString('utf8');
+    const [id, ...rest] = decoded.split(':');
+    return { clientId: id, clientSecret: rest.join(':'), basicHeader: envHeader };
+  }
+  return null;
+}
+
+async function fetchAccessToken(cfg: AdmitadSourceConfig): Promise<string> {
+  const creds = resolveCredentials(cfg);
+  if (!creds) {
+    throw new Error('Admitad credentials missing (config.client_id/secret or VCAOP_ADMITAD_* env)');
+  }
+  const scope = cfg.scope || 'products';
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: creds.clientId,
+    scope,
+  });
+  const resp = await fetch(`${ADMITAD_API_BASE}/token/`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${creds.basicHeader}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '(no body)');
+    throw new Error(`Admitad token HTTP ${resp.status} ${text.slice(0, 300)}`);
+  }
+  const json = (await resp.json()) as { access_token?: string };
+  if (!json.access_token) throw new Error('Admitad token response missing access_token');
+  return json.access_token;
+}
+
+// ==================== Products fetch ====================
+
+interface AdmitadProductItem {
+  [key: string]: unknown;
+}
+
+interface AdmitadProductsPage {
+  results?: AdmitadProductItem[];
+  _meta?: { count?: number; limit?: number; offset?: number };
+}
+
+/**
+ * Fetch one page of products. `campaignId` filters to a single advertiser
+ * campaign when provided; otherwise the publisher's whole connected catalog.
+ */
+async function fetchProductsPage(
+  token: string,
+  campaignId: string | undefined,
+  limit: number,
+  offset: number
+): Promise<AdmitadProductsPage> {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  if (campaignId) params.set('campaign', campaignId);
+  const url = `${ADMITAD_API_BASE}/products/?${params.toString()}`;
+  const resp = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '(no body)');
+    throw new Error(`Admitad products HTTP ${resp.status} ${text.slice(0, 300)}`);
+  }
+  const json = (await resp.json()) as AdmitadProductsPage | AdmitadProductItem[];
+  if (Array.isArray(json)) return { results: json };
+  return json;
+}
+
+// ==================== Normalization (defensive) ====================
+
+function pick(item: AdmitadProductItem, ...keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = item[k];
+    if (v === null || v === undefined) continue;
+    if (typeof v === 'string' && v.trim()) return v.trim();
+    if (typeof v === 'number') return String(v);
+  }
+  return undefined;
+}
+
+function pickFirstImage(item: AdmitadProductItem): string | undefined {
+  const single = pick(item, 'picture', 'image', 'image_url', 'picture_url', 'imageUrl');
+  if (single) return single;
+  // Some feeds nest images as arrays under various keys.
+  for (const k of ['pictures', 'images', 'image_urls']) {
+    const v = item[k];
+    if (Array.isArray(v) && v.length) {
+      const first = v[0];
+      if (typeof first === 'string' && first.trim()) return first.trim();
+      if (first && typeof first === 'object') {
+        const u = (first as Record<string, unknown>).url ?? (first as Record<string, unknown>).src;
+        if (typeof u === 'string' && u.trim()) return u.trim();
+      }
+    }
+  }
+  return undefined;
+}
+
+function parseCents(amountStr: string | undefined): number | null {
+  if (!amountStr) return null;
+  const n = parseFloat(amountStr.replace(/[^0-9.]/g, ''));
+  return Number.isNaN(n) ? null : Math.round(n * 100);
+}
+
+function parseAvailability(item: AdmitadProductItem): ProductUpsert['availability'] {
+  const raw = item.available ?? item.in_stock ?? item.availability ?? item.is_available;
+  if (raw === true || raw === 1) return 'in_stock';
+  if (raw === false || raw === 0) return 'out_of_stock';
+  const s = String(raw ?? '').toLowerCase();
+  if (!s) return 'unknown';
+  if (s.includes('out')) return 'out_of_stock';
+  if (s.includes('preorder') || s.includes('pre-order')) return 'preorder';
+  if (s.includes('discontinued')) return 'discontinued';
+  if (s === 'true' || s === 'yes' || s === '1' || s.includes('in stock') || s.includes('available')) {
+    return 'in_stock';
+  }
+  return 'unknown';
+}
+
+/** Build the affiliate destination: explicit deeplink wins; else wrap via gotolink_base. */
+function resolveAffiliateUrl(item: AdmitadProductItem, cfg: AdmitadSourceConfig): string {
+  const deeplink = pick(item, 'deeplink', 'gotolink', 'gotourl', 'aw_deep_link', 'affiliate_url');
+  if (deeplink) return deeplink;
+  const productUrl = pick(item, 'url', 'link', 'product_url') ?? '';
+  if (cfg.gotolink_base && productUrl) {
+    const sep = cfg.gotolink_base.includes('?') ? '&' : '?';
+    return `${cfg.gotolink_base}${sep}ulp=${encodeURIComponent(productUrl)}`;
+  }
+  return productUrl;
+}
+
+export function normalizeAdmitadItem(
+  item: AdmitadProductItem,
+  cfg: AdmitadSourceConfig,
+  merchantId: string
+): ProductUpsert | null {
+  const id = pick(item, 'id', 'product_id', 'sku', 'model');
+  if (!id) return null;
+  const title = pick(item, 'name', 'title', 'product_name');
+  if (!title) return null;
+
+  const priceCents = parseCents(pick(item, 'price', 'search_price', 'current_price'));
+  if (priceCents === null) return null;
+  const currency = (pick(item, 'currency', 'currency_code') ?? 'EUR').toUpperCase();
+  const oldCents = parseCents(pick(item, 'oldprice', 'old_price', 'rrp_price', 'compare_at_price'));
+  const compareCents = oldCents && oldCents > priceCents ? oldCents : undefined;
+
+  const description = pick(item, 'description', 'short_description', 'product_short_description');
+  const brand = pick(item, 'vendor', 'brand', 'brand_name', 'manufacturer');
+  const category = pick(item, 'category', 'category_name', 'merchant_category');
+  const gtin = pick(item, 'product_gtin', 'gtin', 'ean', 'upc', 'barcode');
+
+  const images: string[] = [];
+  const img = pickFirstImage(item);
+  if (img) images.push(img);
+
+  const keywords = pick(item, 'keywords', 'tags');
+  const topic_keys: string[] = [];
+  if (keywords) {
+    for (const k of keywords.split(/[,;]/)) {
+      const s = k.trim().toLowerCase();
+      if (s) topic_keys.push(s);
+    }
+  }
+
+  const inferText = [title, description, category, keywords].filter(Boolean).join(' ');
+  const inferred = inferSupplementAttributes(inferText);
+
+  return {
+    merchant_id: merchantId,
+    source_network: 'admitad',
+    source_product_id: String(id),
+    gtin,
+    sku: pick(item, 'sku', 'merchant_product_id'),
+    title,
+    description,
+    brand,
+    category,
+    topic_keys: topic_keys.slice(0, 20),
+    price_cents: priceCents,
+    currency,
+    compare_at_price_cents: compareCents,
+    images,
+    affiliate_url: resolveAffiliateUrl(item, cfg),
+    availability: parseAvailability(item),
+    origin_country: cfg.merchant_country,
+    health_goals: inferred.health_goals,
+    dietary_tags: inferred.dietary_tags,
+    ingredients_primary: inferred.ingredients_primary,
+    form: inferred.form,
+    certifications: inferred.certifications,
+    raw: item as Record<string, unknown>,
+  };
+}
+
+// ==================== Per-campaign sync ====================
+
+interface CampaignStats {
+  inserted: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+  fetched: number;
+  error_sample: unknown[];
+}
+
+const EMPTY_STATS = (): CampaignStats => ({
+  inserted: 0,
+  updated: 0,
+  skipped: 0,
+  errors: 0,
+  fetched: 0,
+  error_sample: [],
+});
+
+async function fetchAllForCampaign(
+  token: string,
+  campaignId: string | undefined,
+  pageSize: number,
+  maxProducts: number
+): Promise<AdmitadProductItem[]> {
+  const out: AdmitadProductItem[] = [];
+  let offset = 0;
+  // Hard page ceiling as a runaway guard independent of _meta correctness.
+  for (let page = 0; page < 100 && out.length < maxProducts; page++) {
+    const limit = Math.min(pageSize, maxProducts - out.length);
+    const data = await fetchProductsPage(token, campaignId, limit, offset);
+    const items = data.results ?? [];
+    if (items.length === 0) break;
+    out.push(...items);
+    offset += items.length;
+    const total = data._meta?.count;
+    if (typeof total === 'number' && offset >= total) break;
+    if (items.length < limit) break;
+  }
+  return out.slice(0, maxProducts);
+}
+
+async function syncOneCampaign(
+  token: string,
+  cfg: AdmitadSourceConfig,
+  campaignId: string | undefined,
+  pageSize: number,
+  maxProducts: number
+): Promise<CampaignStats> {
+  const stats = EMPTY_STATS();
+  const merchantSourceId = campaignId ?? 'admitad-all';
+  const merchantId = await upsertMerchant({
+    source_network: 'admitad',
+    source_merchant_id: merchantSourceId,
+    name: campaignId ? `Admitad Campaign ${campaignId}` : 'Admitad (all connected)',
+    affiliate_network: 'admitad',
+    merchant_country: cfg.merchant_country,
+    quality_score: 65,
+    customs_risk: 'unknown',
+  });
+  if (!merchantId) {
+    stats.errors = 1;
+    stats.error_sample.push({ campaign: merchantSourceId, error: 'merchant upsert failed' });
+    return stats;
+  }
+
+  let items: AdmitadProductItem[];
+  try {
+    items = await fetchAllForCampaign(token, campaignId, pageSize, maxProducts);
+  } catch (err: unknown) {
+    stats.errors = 1;
+    stats.error_sample.push({ campaign: merchantSourceId, error: err instanceof Error ? err.message : String(err) });
+    return stats;
+  }
+  stats.fetched = items.length;
+
+  // Log the first item's keys + a redacted sample so the defensive field
+  // mapping can be confirmed on the first real (activation) sync.
+  if (items.length > 0) {
+    console.log(
+      `[admitad-sync] campaign=${merchantSourceId} fetched=${items.length} sample_keys=` +
+        JSON.stringify(Object.keys(items[0]).slice(0, 40))
+    );
+  }
+
+  const normalized = items
+    .map((i) => normalizeAdmitadItem(i, cfg, merchantId))
+    .filter((p): p is ProductUpsert => p !== null);
+
+  if (normalized.length === 0) return stats;
+
+  const r = await upsertProducts(normalized, 'admitad');
+  stats.inserted = r.inserted;
+  stats.updated = r.updated;
+  stats.skipped = r.skipped_unchanged;
+  stats.errors += r.errors.length;
+  if (r.errors.length) stats.error_sample.push(...r.errors.slice(0, 5));
+  return stats;
+}
+
+// ==================== Entry point ====================
+
+export interface AdmitadSyncResult {
+  ok: boolean;
+  totals: { inserted: number; updated: number; skipped: number; errors: number; fetched: number };
+  campaigns_synced: number;
+  duration_ms: number;
+  per_campaign: Array<{ campaign: string; inserted: number; updated: number; skipped: number; errors: number; fetched: number }>;
+  error?: string;
+}
+
+export async function runAdmitadSync(triggered_by = 'scheduler'): Promise<AdmitadSyncResult> {
+  const startTime = Date.now();
+  const configs = await loadSourceConfigs();
+  if (configs.length === 0) {
+    console.log('[admitad-sync] no active config — skipping');
+    return {
+      ok: true,
+      totals: { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: 0 },
+      campaigns_synced: 0,
+      per_campaign: [],
+      duration_ms: Date.now() - startTime,
+    };
+  }
+
+  const totals = { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: 0 };
+  const per_campaign: AdmitadSyncResult['per_campaign'] = [];
+  const errorSample: unknown[] = [];
+  let campaignCount = 0;
+  let fatalError: string | undefined;
+
+  for (const cfg of configs) {
+    const pageSize = Math.min(Math.max(cfg.page_size ?? 200, 1), 500);
+    const maxProducts = Math.min(Math.max(cfg.max_products ?? 1000, 1), 50000);
+    // Empty/absent campaign_ids → one pass over the whole connected catalog.
+    const campaigns: Array<string | undefined> =
+      Array.isArray(cfg.campaign_ids) && cfg.campaign_ids.length > 0 ? cfg.campaign_ids : [undefined];
+
+    let token: string;
+    try {
+      token = await fetchAccessToken(cfg);
+    } catch (err: unknown) {
+      fatalError = err instanceof Error ? err.message : String(err);
+      totals.errors += 1;
+      errorSample.push({ error: fatalError });
+      continue;
+    }
+
+    const run = await startSyncRun('admitad', triggered_by);
+    for (const campaignId of campaigns) {
+      campaignCount++;
+      const stats = await syncOneCampaign(token, cfg, campaignId, pageSize, maxProducts);
+      per_campaign.push({
+        campaign: campaignId ?? 'all',
+        inserted: stats.inserted,
+        updated: stats.updated,
+        skipped: stats.skipped,
+        errors: stats.errors,
+        fetched: stats.fetched,
+      });
+      totals.inserted += stats.inserted;
+      totals.updated += stats.updated;
+      totals.skipped += stats.skipped;
+      totals.errors += stats.errors;
+      totals.fetched += stats.fetched;
+      if (stats.error_sample.length) errorSample.push(...stats.error_sample);
+    }
+    if (run) await finishSyncRun(run, { ...totals, error_sample: errorSample.slice(0, 10) });
+  }
+
+  const duration_ms = Date.now() - startTime;
+  console.log(
+    `[admitad-sync] done in ${duration_ms}ms — fetched ${totals.fetched}, ` +
+      `${totals.inserted}+ ${totals.updated}~ ${totals.skipped}= ${totals.errors}! across ${campaignCount} campaigns`
+  );
+
+  return {
+    ok: totals.errors === 0,
+    totals,
+    campaigns_synced: campaignCount,
+    per_campaign,
+    duration_ms,
+    error: fatalError,
+  };
+}

--- a/services/gateway/src/services/marketplace-sync/providers/admitad.ts
+++ b/services/gateway/src/services/marketplace-sync/providers/admitad.ts
@@ -1,0 +1,115 @@
+/**
+ * VCAOP: Admitad provider registration.
+ *
+ * Admitad (Mitgo) — already live as a rewards/postback network (publisher
+ * account verified, Alibaba WW joined). This registers its *catalog* side so
+ * an admin can add an Admitad product source and have it sync into `products`.
+ *
+ * Credentials are optional in the form: if omitted, the sync falls back to the
+ * Secret-Manager-bound VCAOP_ADMITAD_* env already used by the postback flow.
+ *
+ * Sync logic: ../admitad-sync.ts.
+ */
+
+import type { MarketplaceProvider, ProviderSyncResult } from '../provider';
+import { runAdmitadSync } from '../admitad-sync';
+
+export const admitadProvider: MarketplaceProvider = {
+  key: 'admitad',
+  displayName: 'Admitad',
+  description:
+    'Admitad product catalog via the Products API (OAuth client_credentials). Already wired for rewards/postbacks; this pulls product data for joined advertiser campaigns. Leave credentials blank to use the VCAOP_ADMITAD_* secrets bound to the gateway.',
+  configSchema: [
+    {
+      key: 'client_id',
+      label: 'Admitad client_id (optional — falls back to VCAOP_ADMITAD_CLIENT_ID)',
+      type: 'password',
+    },
+    {
+      key: 'client_secret',
+      label: 'Admitad client_secret (optional — falls back to VCAOP_ADMITAD_CLIENT_SECRET)',
+      type: 'password',
+    },
+    {
+      key: 'campaign_ids',
+      label: 'Advertiser campaign IDs (comma-separated; blank = all connected)',
+      type: 'text',
+      list: true,
+      placeholder: '12345, 67890',
+      help: 'Admitad advertiser campaign IDs you have joined. Leave blank to pull the whole connected catalog.',
+    },
+    {
+      key: 'gotolink_base',
+      label: 'Gotolink base (optional — wraps product URLs as affiliate links)',
+      type: 'text',
+      placeholder: 'https://rzekl.com/g/xxxxxxxx/',
+      help: 'If the Products API does not return per-item deeplinks, product URLs are wrapped as {base}?ulp={url}. Per-user subid is added later by the affiliate-link layer.',
+    },
+    {
+      key: 'scope',
+      label: 'OAuth scope (default "products")',
+      type: 'text',
+      placeholder: 'products',
+    },
+    {
+      key: 'max_products',
+      label: 'Max products total (default 1000)',
+      type: 'number',
+      placeholder: '1000',
+    },
+    {
+      key: 'page_size',
+      label: 'Page size (default 200, max 500)',
+      type: 'number',
+      placeholder: '200',
+    },
+    {
+      key: 'merchant_country',
+      label: 'Fallback merchant country (ISO-2, optional)',
+      type: 'text',
+      placeholder: 'DE',
+    },
+  ],
+  validateConfig(cfg) {
+    if (!cfg || typeof cfg !== 'object') return { ok: false, error: 'config must be an object' };
+
+    // campaign_ids may arrive as an array (list:true parsed) or a string.
+    let campaignIds = cfg.campaign_ids;
+    if (typeof campaignIds === 'string') {
+      campaignIds = campaignIds.split(',').map((s) => s.trim()).filter(Boolean);
+    }
+    if (campaignIds !== undefined && !Array.isArray(campaignIds)) {
+      return { ok: false, error: 'campaign_ids must be a list' };
+    }
+    if (Array.isArray(campaignIds)) cfg.campaign_ids = campaignIds;
+
+    if (cfg.max_products !== undefined) {
+      const n = Number(cfg.max_products);
+      if (!Number.isFinite(n) || n < 1 || n > 50000) {
+        return { ok: false, error: 'max_products must be between 1 and 50000' };
+      }
+    }
+    if (cfg.page_size !== undefined) {
+      const n = Number(cfg.page_size);
+      if (!Number.isFinite(n) || n < 1 || n > 500) {
+        return { ok: false, error: 'page_size must be between 1 and 500' };
+      }
+    }
+    return { ok: true };
+  },
+  async runSync(triggered_by: string): Promise<ProviderSyncResult> {
+    const r = await runAdmitadSync(triggered_by);
+    return {
+      ok: r.ok,
+      totals: {
+        inserted: r.totals.inserted,
+        updated: r.totals.updated,
+        skipped: r.totals.skipped,
+        errors: r.totals.errors,
+      },
+      duration_ms: r.duration_ms,
+      details: { fetched: r.totals.fetched, campaigns_synced: r.campaigns_synced, per_campaign: r.per_campaign },
+      error: r.error,
+    };
+  },
+};

--- a/services/gateway/src/services/marketplace-sync/providers/index.ts
+++ b/services/gateway/src/services/marketplace-sync/providers/index.ts
@@ -13,6 +13,7 @@ import { cjProvider } from './cj';
 import { amazonProvider } from './amazon';
 import { rakutenProvider } from './rakuten';
 import { awinProvider } from './awin';
+import { admitadProvider } from './admitad';
 
 /** Order here == display order in the admin UI dropdown. */
 const PROVIDERS: readonly MarketplaceProvider[] = [
@@ -21,6 +22,7 @@ const PROVIDERS: readonly MarketplaceProvider[] = [
   amazonProvider,
   rakutenProvider,
   awinProvider,
+  admitadProvider,
 ];
 
 const BY_KEY = new Map<string, MarketplaceProvider>(PROVIDERS.map((p) => [p.key, p]));

--- a/services/gateway/test/services/admitad-sync-normalize.test.ts
+++ b/services/gateway/test/services/admitad-sync-normalize.test.ts
@@ -1,0 +1,97 @@
+/**
+ * VCAOP: unit tests for the Admitad product normalizer.
+ *
+ * Admitad's product schema is not pinned from public docs, so normalization is
+ * deliberately defensive (multiple candidate field names per attribute). These
+ * tests lock the candidate mapping so a future field rename / contract drift is
+ * caught locally rather than silently shipping null-filled rows to /discover.
+ */
+
+import { normalizeAdmitadItem, type AdmitadSourceConfig } from '../../src/services/marketplace-sync/admitad-sync';
+
+const MERCHANT = 'merchant-uuid-1';
+const baseCfg: AdmitadSourceConfig = { merchant_country: 'DE' };
+
+describe('normalizeAdmitadItem', () => {
+  it('maps a canonical Admitad-style product item', () => {
+    const p = normalizeAdmitadItem(
+      {
+        id: 'A123',
+        name: 'Vitamin D3 2000 IU',
+        description: 'High-strength vitamin D supplement',
+        price: '19.99',
+        oldprice: '24.99',
+        currency: 'eur',
+        picture: 'https://img.example/d3.jpg',
+        deeplink: 'https://rzekl.com/g/abc/?ulp=https%3A%2F%2Fshop%2Fd3',
+        available: true,
+        category: 'Supplements',
+        vendor: 'Acme Health',
+        product_gtin: '4012345678901',
+      },
+      baseCfg,
+      MERCHANT
+    );
+    expect(p).not.toBeNull();
+    expect(p!.source_network).toBe('admitad');
+    expect(p!.merchant_id).toBe(MERCHANT);
+    expect(p!.source_product_id).toBe('A123');
+    expect(p!.title).toBe('Vitamin D3 2000 IU');
+    expect(p!.price_cents).toBe(1999);
+    expect(p!.compare_at_price_cents).toBe(2499);
+    expect(p!.currency).toBe('EUR');
+    expect(p!.images).toEqual(['https://img.example/d3.jpg']);
+    expect(p!.affiliate_url).toContain('rzekl.com');
+    expect(p!.availability).toBe('in_stock');
+    expect(p!.brand).toBe('Acme Health');
+    expect(p!.gtin).toBe('4012345678901');
+    expect(p!.origin_country).toBe('DE');
+  });
+
+  it('falls back across alternate field names (title/search_price/image_url/url)', () => {
+    const p = normalizeAdmitadItem(
+      {
+        product_id: 'B9',
+        title: 'Omega 3',
+        search_price: '12.50',
+        currency_code: 'USD',
+        image_url: 'https://img/o3.png',
+        url: 'https://shop/omega3',
+        in_stock: 'yes',
+      },
+      { ...baseCfg, gotolink_base: 'https://go.example/g/xyz/' },
+      MERCHANT
+    );
+    expect(p).not.toBeNull();
+    expect(p!.source_product_id).toBe('B9');
+    expect(p!.title).toBe('Omega 3');
+    expect(p!.price_cents).toBe(1250);
+    expect(p!.currency).toBe('USD');
+    expect(p!.availability).toBe('in_stock');
+    // No deeplink on item → wrapped via gotolink_base with the product url as ulp.
+    expect(p!.affiliate_url).toBe('https://go.example/g/xyz/?ulp=' + encodeURIComponent('https://shop/omega3'));
+  });
+
+  it('drops items missing an id, title, or parseable price', () => {
+    expect(normalizeAdmitadItem({ name: 'x', price: '1.00' }, baseCfg, MERCHANT)).toBeNull();
+    expect(normalizeAdmitadItem({ id: '1', price: '1.00' }, baseCfg, MERCHANT)).toBeNull();
+    expect(normalizeAdmitadItem({ id: '1', name: 'x' }, baseCfg, MERCHANT)).toBeNull();
+  });
+
+  it('reads availability from boolean, numeric, and string forms', () => {
+    const mk = (available: unknown) =>
+      normalizeAdmitadItem({ id: '1', name: 'x', price: '1.00', available }, baseCfg, MERCHANT)!.availability;
+    expect(mk(false)).toBe('out_of_stock');
+    expect(mk(0)).toBe('out_of_stock');
+    expect(mk('out of stock')).toBe('out_of_stock');
+    expect(mk('preorder')).toBe('preorder');
+    expect(mk(true)).toBe('in_stock');
+    expect(mk('')).toBe('unknown');
+  });
+
+  it('preserves the raw item for activation-time verification', () => {
+    const item = { id: '1', name: 'x', price: '1.00', some_unknown_field: 'keepme' };
+    const p = normalizeAdmitadItem(item, baseCfg, MERCHANT);
+    expect(p!.raw).toEqual(item);
+  });
+});

--- a/supabase/migrations/20260625130000_admitad_marketplace_source.sql
+++ b/supabase/migrations/20260625130000_admitad_marketplace_source.sql
@@ -1,0 +1,16 @@
+-- VCAOP: allow 'admitad' as a marketplace catalog source.
+--
+-- marketplace_sources_config originally constrained source_network to
+-- ('shopify','cj','amazon','awin','rakuten','manual'). Admitad was wired as a
+-- conversion/postback network only (rewards crediting) and never had a product
+-- catalog source. Adding Admitad product-feed ingestion (admitad-sync.ts) needs
+-- 'admitad' to be an accepted source_network so an admin can store its config row.
+--
+-- Idempotent: drops the auto-named CHECK if present and re-adds it with admitad.
+
+ALTER TABLE public.marketplace_sources_config
+  DROP CONSTRAINT IF EXISTS marketplace_sources_config_source_network_check;
+
+ALTER TABLE public.marketplace_sources_config
+  ADD CONSTRAINT marketplace_sources_config_source_network_check
+  CHECK (source_network IN ('shopify','cj','amazon','awin','rakuten','admitad','manual'));

--- a/vcaop/ACTIVATION-RUNWAY.md
+++ b/vcaop/ACTIVATION-RUNWAY.md
@@ -1,0 +1,174 @@
+# VCAOP — Affiliate Catalog Activation Runway
+
+> **Goal:** real, buyable affiliate products on `/discover`.
+> **Audience:** operator (you). These are the steps Claude **cannot** do — they
+> need Secret-Manager access, the Admitad/Awin panels, and advertiser approvals.
+> **Status as of 2026-06-25:** code is in place (Admitad PR #2786, Awin #2784);
+> `/discover` still shows only Shopify (26) + demo-seed (10). Zero affiliate
+> products until the steps below run.
+
+The two halves of "products on /discover":
+1. **Catalog ingestion** (code — done): pulls products into the `products` table.
+2. **Activation** (operator — this doc): credentials + an approved advertiser
+   with a feed + a verified first sync.
+
+---
+
+## 0. Prerequisites (one-time)
+
+- [ ] **Merge + deploy the catalog code.** #2786 (Admitad) and #2784 (Awin
+      discovery) merge to `main` → auto-deploy to **staging**; then **PUBLISH**
+      in the Command Hub to reach prod. (Per CLAUDE.md §16 — push never reaches
+      prod directly post-cutover.)
+- [ ] **`MARKETPLACE_SYNC_SECRET`** is set on the gateway (Cloud Run env /
+      Secret Manager). Required to trigger a manual sync. Confirm:
+      `gcloud run services describe gateway --region=us-central1 --project=lovable-vitana-vers1 --format='value(spec.template.spec.containers[0].env)' | tr ',' '\n' | grep MARKETPLACE_SYNC_SECRET`
+
+Prod gateway base URL: `https://gateway-86804897789.us-central1.run.app`
+(staging: `https://preview-gateway.vitanaland.com`). Resolve dynamically if unsure
+(CLAUDE.md §11).
+
+---
+
+## 1. ADMITAD — closest to live
+
+**Already joined (rewards-allowed) advertisers** (`affiliate_program`):
+
+| id | merchant | fit | gotolink |
+|----|----------|-----|----------|
+| `admitad_bodylab24_de` | **Bodylab24 DE** | ★ German sports nutrition / supplements — best /discover fit | `https://ad.admitad.com/g/q51r4zfcu5…` |
+| `admitad_alibaba_ww` | Alibaba WW | general marketplace | `https://rzekl.com/g/pm1aev55cl…` |
+| `admitad_aliexpress` | AliExpress | general marketplace | `https://rzekl.com/g/1e8d114494…` |
+
+### Step 1.1 — Confirm Admitad Products API access
+The Products API (scope `products`) is **account-gated** on Admitad — on some
+publisher tiers it must be explicitly enabled/requested. Verify before anything else:
+- In the Admitad panel, confirm the Products/Product-feeds product is enabled for
+  the publisher account, **or** test the token mints with `scope=products`:
+  ```bash
+  curl -s -X POST https://api.admitad.com/token/ \
+    -H "Authorization: Basic $VCAOP_ADMITAD_BASE64_HEADER" \
+    -d "grant_type=client_credentials&client_id=<CLIENT_ID>&scope=products"
+  # Expect: {"access_token":"…"}. If it errors on scope → request Products API access first.
+  ```
+> ⚠️ **If `scope=products` is not granted, Admitad catalog ingestion cannot run**
+> regardless of code. This is the single biggest unknown — check it first.
+
+### Step 1.2 — Bind credentials (if not already on the gateway)
+Secrets already exist in Secret Manager as `VCAOP_ADMITAD_*`. Ensure they're
+exposed to the **gateway** service as env:
+`VCAOP_ADMITAD_CLIENT_ID`, `VCAOP_ADMITAD_CLIENT_SECRET` (or `VCAOP_ADMITAD_BASE64_HEADER`).
+
+### Step 1.3 — Get the numeric campaign IDs
+The Products API filters by **numeric campaign (advertiser) id** — the
+`affiliate_program` rows store gotolinks, not the numeric ids. From the Admitad
+panel (Programs → joined) note the campaign id for **Bodylab24 DE** (and any
+others you want). *(Or skip filtering — see Step 1.4 note.)*
+
+### Step 1.4 — Create the source config row
+```sql
+insert into marketplace_sources_config (source_network, display_name, config, is_active)
+values (
+  'admitad',
+  'Admitad — Bodylab24 DE',
+  '{
+     "campaign_ids": ["<BODYLAB24_CAMPAIGN_ID>"],
+     "gotolink_base": "https://ad.admitad.com/g/q51r4zfcu52fafe74eabfad1369401/",
+     "merchant_country": "DE",
+     "max_products": 1000,
+     "page_size": 200
+   }'::jsonb,
+  true
+);
+```
+- Omit `client_id`/`client_secret` → falls back to the `VCAOP_ADMITAD_*` env.
+- **`campaign_ids` blank** → pulls the whole connected catalog (all advertisers).
+  In that case prefer per-product deeplinks from the API; a single `gotolink_base`
+  only attributes one advertiser, so use **one config row per advertiser** when
+  mixing networks/gotolinks.
+
+### Step 1.5 — Run the first sync + VERIFY (critical)
+```bash
+curl -s -X POST "$GW/api/v1/internal/sync/admitad" \
+  -H "X-Scheduler-Secret: $MARKETPLACE_SYNC_SECRET" | jq .
+```
+Then **verify the field mapping** (the Admitad product schema is defensively
+mapped but unverified live):
+1. **Sample-key log** — in gateway logs find:
+   `[admitad-sync] campaign=<id> fetched=<n> sample_keys=[...]`
+   Confirm the real field names line up with the normalizer's candidates
+   (`name/title`, `price/search_price`, `picture/image_url`, `deeplink/gotolink`,
+   `available/in_stock`, `vendor/brand`, …). If they differ → tell Claude the
+   `sample_keys` and a sample row; the normalizer candidates get adjusted + redeployed.
+2. **Spot-check the rows**:
+   ```sql
+   select count(*) from products where source_network='admitad';
+   select title, price_cents, currency, availability, affiliate_url,
+          (raw->>'name') as raw_name
+   from products where source_network='admitad' limit 5;
+   ```
+   - Titles/prices populated? `affiliate_url` a real deeplink? `availability='in_stock'`?
+   - If `affiliate_url` is just the bare product URL (no gotolink), the API didn't
+     return per-product deeplinks → set/verify `gotolink_base`.
+
+### Step 1.6 — Confirm on /discover
+Products appear when `is_active=true` AND `availability='in_stock'` AND they pass
+the shipping/region + health-limitation filters (discover-feed.ts). Check a DE user.
+
+---
+
+## 2. AWIN — code ready (#2784), needs a feed
+
+Only **ROCKBROS** is joined on Awin today (not wellness). Awin needs a per-advertiser
+**product feed** (feed_id + advertiser_id), unlike Admitad.
+
+### Step 2.1 — Datafeed API key
+Awin My Account → API Credentials → the **product-feed** key (distinct from the
+publisher API token). Bind as `AWIN_DATAFEED_API_KEY` (per #2784) or put `api_key`
+in the config row.
+
+### Step 2.2 — Discover available feeds
+#2784 adds feed discovery — list the feeds this publisher can download
+(advertisers you're joined to that offer a datafeed) to get `feed_id` + `advertiser_id`.
+
+### Step 2.3 — Source config row
+```sql
+insert into marketplace_sources_config (source_network, display_name, config, is_active)
+values ('awin','Awin',
+  '{"api_key":"<DATAFEED_KEY>","publisher_id":"<SID>",
+    "feeds":[{"feed_id":"<FID>","advertiser_id":"<MID>","advertiser_name":"<name>"}],
+    "merchant_country":"DE","max_products_per_feed":500}'::jsonb, true);
+```
+
+### Step 2.4 — Sync + verify
+```bash
+curl -s -X POST "$GW/api/v1/internal/sync/awin" -H "X-Scheduler-Secret: $MARKETPLACE_SYNC_SECRET" | jq .
+```
+Same verification as Admitad (counts + sample rows in `products`).
+
+### Step 2.5 — Approvals (the real bottleneck)
+Apply on Awin to wellness/German advertisers with datafeeds (DocMorris, Shop
+Apotheke, MyProtein, Sunday Natural, Otto, …). As each approval lands, add its
+`{feed_id, advertiser_id}` to the config `feeds` array.
+
+---
+
+## 3. Go-live (both networks)
+
+- [ ] First manual sync verified (Step 1.5 / 2.4) — rows present, mapping correct.
+- [ ] `/discover` shows the products for a matching-region user.
+- [ ] The **daily cron** (`MARKETPLACE-SYNC-CRON.yml`, 03:00 UTC) runs all
+      providers — once a network verifies, it stays fresh automatically.
+- [ ] Per-user rewards: the existing `/api/v1/vcaop/affiliate-link` layer wraps the
+      catalog deeplink with the member SubID at click time (already built); Admitad
+      postback (#earlier) and Awin conversion worker (#2774) credit the ledger.
+
+---
+
+## Biggest risks / unknowns (call these out first)
+
+1. **Admitad Products API scope access** (Step 1.1) — gated; may need requesting.
+2. **Admitad product field names** — defensively mapped, **unverified live**;
+   confirm via the sample-key log on first sync.
+3. **Awin advertiser approvals** — only ROCKBROS joined; wellness advertisers are
+   applications-in-flight, the true gate on useful Awin inventory.


### PR DESCRIPTION
## What

Adds **Admitad** as a marketplace **catalog** source. Admitad was previously wired as a rewards/postback network only (conversion crediting); it had no product ingestion. This adds the catalog half so joined advertiser-campaign products land in `products` and render on `/discover`, mirroring the existing Awin product-feed sync.

## Why

`/discover` currently shows only Shopify (26) + demo-seed (10) products — zero affiliate inventory. Admitad is the closest-to-live network (publisher account verified, Alibaba WW joined, token verified HTTP 200 against `/token/`), and its Products API returns products across **all** connected campaigns via OAuth — no per-advertiser feed-ID discovery needed (unlike Awin).

## Changes

- **`admitad-sync.ts`** — OAuth `client_credentials` (POST `/token/`, HTTP Basic) + paginated Products API fetch + **defensive normalization**: every field tries several candidate names, the raw item is stored on the row, and the first item per campaign is logged. The Admitad product schema isn't pinned from public docs (API is account-gated), so the mapping is confirmed **live on the first activation sync** per the deploy-verification protocol — get a field wrong and it shows in the sample log / `raw` column rather than silently shipping null rows.
- **`providers/admitad.ts`** + registry registration — makes `admitad` a first-class source. `POST /api/v1/internal/sync/admitad` auto-wires via the dynamic provider registry (no route edits).
- **migration** `20260625130000_admitad_marketplace_source.sql` — adds `admitad` to the `marketplace_sources_config.source_network` CHECK constraint (idempotent).
- **`.env.example`** — documents `VCAOP_ADMITAD_*` credential fallback (reuses the Secret-Manager secrets already bound for the postback flow).
- **5 unit tests** locking the defensive field mapping (canonical + alternate names, availability coercion, drop-on-missing, raw preservation).

`tsc` clean; `jest` for the new suite green (5/5).

## Activation (operator steps — not code)

This ships the **plumbing**. Real products on `/discover` still require, in the live gateway:
1. Admitad credentials bound (`VCAOP_ADMITAD_*`, or in the config row).
2. An active `marketplace_sources_config` row (`source_network='admitad'`) with joined `campaign_ids`.
3. First sync via `POST /api/v1/internal/sync/admitad` → **verify the sample-key log + a few `products` rows** before trusting the feed.

A full activation runway (Awin + Admitad) is being drafted separately.

## Verify-at-activation note

The Admitad product field names are defensively mapped but **unverified against a live response**. First real sync must be smoke-tested (sample log + spot-check `products` rows / `raw`) before enabling the daily cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfkEeZCo1sTJFmc1FSRnnK)_