### PR TITLE
fix(orb): new-day detection falls back to user_journey.last_session_date

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -134,6 +134,7 @@ export interface LiveSessionControllerDeps {
   persistLanguagePreference: (tenantId: string, userId: string, lang: string) => void;
   fetchLastSessionInfo: (
     userId: string,
+    timezone?: string | null,
   ) => Promise<{ time: string; wasFailure: boolean } | null>;
   fetchOnboardingCohortBlock: (
     userId: string | null | undefined,
@@ -812,7 +813,7 @@ export async function handleLiveSessionStart(
       usingDevFallback
         ? Promise.resolve(DEV_IDENTITY.ACTIVE_ROLE)
         : deps.resolveEffectiveRole(bootstrapIdentity.user_id, bootstrapIdentity.tenant_id || ''),
-      deps.fetchLastSessionInfo(bootstrapIdentity.user_id),
+      deps.fetchLastSessionInfo(bootstrapIdentity.user_id, clientContext?.timezone),
       storedLangPromise,
       bootstrapIdentity.tenant_id
         ? fetchAdminBriefingBlock(bootstrapIdentity.tenant_id, 3).catch((err) => {
@@ -922,7 +923,7 @@ export async function handleLiveSessionStart(
           const { getSupabase } = await import('../../../lib/supabase');
           const supa = getSupabase() ?? undefined;
           const [lastInfo, factResult, profileResult, firstSessionResult, journeyStateResult] = await Promise.allSettled([
-            deps.fetchLastSessionInfo(_ndIdentity.user_id),
+            deps.fetchLastSessionInfo(_ndIdentity.user_id, clientContext?.timezone),
             supa
               ? supa
                   .from('memory_facts')

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -11942,7 +11942,7 @@ router.get('/debug/context-bootstrap', async (req: Request, res: Response) => {
  * the same user (independent of start query) and checks turn_count /
  * audio_out_chunks metrics. If no stop event exists, wasFailure is false.
  */
-async function fetchLastSessionInfo(userId: string): Promise<{ time: string; wasFailure: boolean } | null> {
+async function fetchLastSessionInfo(userId: string, timezone?: string | null): Promise<{ time: string; wasFailure: boolean } | null> {
   try {
     const SUPABASE_URL = process.env.SUPABASE_URL;
     const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
@@ -12017,10 +12017,32 @@ async function fetchLastSessionInfo(userId: string): Promise<{ time: string; was
           const ujResp = await fetch(ujUrl, { method: 'GET', headers, signal: controller.signal }).catch(() => null);
           if (ujResp && ujResp.ok) {
             const ujData = await ujResp.json() as Array<{ last_session_date: string | null }>;
-            const lsd = ujData.length > 0 ? ujData[0].last_session_date : null;
-            if (lsd && /^\d{4}-\d{2}-\d{2}/.test(lsd)) {
-              const synthIso = `${lsd.slice(0, 10)}T12:00:00.000Z`;
-              console.log(`[VTID-01224-FIX] fetchLastSessionInfo: no session-start event — using user_journey.last_session_date=${lsd} for user=${userId.substring(0, 8)}...`);
+            const lsdRaw = ujData.length > 0 ? ujData[0].last_session_date : null;
+            if (lsdRaw && /^\d{4}-\d{2}-\d{2}/.test(lsdRaw)) {
+              const lsd = lsdRaw.slice(0, 10);
+              // last_session_date is the user's LOCAL calendar date (stamped via
+              // todayInTimezone). Compare against the user's LOCAL today on the
+              // SAME basis. Only a PRIOR local day is a genuine new-day return;
+              // when the stored date is the current local day (or later) this is
+              // a SAME-DAY reopen and must NOT be treated as new-day — otherwise
+              // a reopen >8h after a synthesized noon would bucket as `today`
+              // (new-day) and wrongly re-fire the morning overview, whereas the
+              // canonical new-day-return provider suppresses last_session_date >=
+              // today (Codex P2). Same-day → return now (short-gap bucket).
+              let todayLocal: string;
+              try {
+                todayLocal = new Intl.DateTimeFormat('en-CA', {
+                  timeZone: timezone || 'UTC', year: 'numeric', month: '2-digit', day: '2-digit',
+                }).format(new Date());
+              } catch {
+                todayLocal = new Date().toISOString().slice(0, 10);
+              }
+              if (lsd >= todayLocal) {
+                console.log(`[VTID-01224-FIX] fetchLastSessionInfo: last_session_date=${lsd} is same-day (today_local=${todayLocal}) — short-gap for user=${userId.substring(0, 8)}...`);
+                return { time: new Date().toISOString(), wasFailure: false };
+              }
+              const synthIso = `${lsd}T12:00:00.000Z`;
+              console.log(`[VTID-01224-FIX] fetchLastSessionInfo: no session-start event — using user_journey.last_session_date=${lsd} (new-day) for user=${userId.substring(0, 8)}...`);
               return { time: synthIso, wasFailure: false };
             }
           }

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -12000,6 +12000,33 @@ async function fetchLastSessionInfo(userId: string): Promise<{ time: string; was
       }
 
       if (!time) {
+        // RELIABLE FALLBACK (new-day detection). The `vtid.live.session.start`
+        // telemetry above has proven fragile — events stop carrying a real
+        // user_id (or stop being written), so this query returns zero rows,
+        // lastSessionInfo becomes null, every session looks like a first
+        // meeting, and the new-day morning overview can NEVER fire. When the
+        // event lookup finds nothing, fall back to the canonical per-user
+        // `user_journey.last_session_date` (stamped on every session, and the
+        // same field the heavy new-day-return provider trusts). We synthesize a
+        // timestamp at noon of that local date; describeTimeSince then buckets a
+        // prior calendar day as yesterday/week/long (→ new-day) and the same
+        // day as same_day/recent (→ not new-day), which is exactly the
+        // first-greeting-of-the-day semantics we want.
+        try {
+          const ujUrl = `${SUPABASE_URL}/rest/v1/user_journey?select=last_session_date&user_id=eq.${userId}&limit=1`;
+          const ujResp = await fetch(ujUrl, { method: 'GET', headers, signal: controller.signal }).catch(() => null);
+          if (ujResp && ujResp.ok) {
+            const ujData = await ujResp.json() as Array<{ last_session_date: string | null }>;
+            const lsd = ujData.length > 0 ? ujData[0].last_session_date : null;
+            if (lsd && /^\d{4}-\d{2}-\d{2}/.test(lsd)) {
+              const synthIso = `${lsd.slice(0, 10)}T12:00:00.000Z`;
+              console.log(`[VTID-01224-FIX] fetchLastSessionInfo: no session-start event — using user_journey.last_session_date=${lsd} for user=${userId.substring(0, 8)}...`);
+              return { time: synthIso, wasFailure: false };
+            }
+          }
+        } catch (_ujErr) {
+          /* fall through to null below */
+        }
         console.log(`[VTID-01224-FIX] fetchLastSessionInfo: no prior session found for user=${userId.substring(0, 8)}...`);
         return null;
       }


### PR DESCRIPTION
## The real root cause

The new-day morning summary never fired because of a broken **input**, not the greeting ladder. `fetchLastSessionInfo` (orb-live.ts) reads the user's last session from `vtid.live.session.start` OASIS events. That telemetry has gone stale/anonymous — the newest such event in the table is **weeks old and tagged `anonymous`**. So the query returns **zero rows**, `lastSessionInfo` is `null`, every session is classified as `first` (never new-day), and the `safe_fast_newday_overview` rung can **never** run. This sits upstream of the priority fix in #2782 and defeats it.

Confirmed with `EXPLAIN ANALYZE` (42 ms, `rows=0`) and a direct check (newest `vtid.live.session.start` = June 9, `user_id='anonymous'`). The function's own header comment even documents this exact failure mode from a prior incident — the "session.start reliably carries user_id" assumption broke again.

## Fix

When the session-start/stop lookup finds nothing, fall back to the **canonical per-user `user_journey.last_session_date`** — stamped on every session by `updateSessionEndState`, and already the source of truth for the *heavy* `new-day-return` provider. We synthesize a noon-of-that-local-date timestamp so `describeTimeSince` buckets:
- a **prior calendar day** → yesterday/week/long → **new-day** (summary fires)
- the **same day** → same_day/recent → not new-day (correct: only the first session of the day gets the summary)

Self-healing and independent of the fragile session-start events.

## Verification

- `npm run build` (tsc) passes.
- Logic only runs as a fallback — when session-start events exist, behavior is unchanged.

After merge → auto-deploys to staging. Note: the fallback needs `user_journey.last_session_date` to be populated for the user; if it's `null` the user is treated as first-time (correct). Separately worth investigating why `vtid.live.session.start` stopped being written with real user_ids, but this fix makes the greeting robust to that regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_