### PR TITLE
feat(orb): shared session-end memory-commit endpoint for LiveKit parity (§11)

### DIFF
--- a/scripts/ci/impact-rules/new-route-without-auth-middleware.mjs
+++ b/scripts/ci/impact-rules/new-route-without-auth-middleware.mjs
@@ -24,6 +24,9 @@ const AUTH_NAMES = [
   'requireAuth', 'requireAdmin', 'requireDevRole', 'requirePlatformAdmin',
   'optionalAuth', 'requireTenant', 'requireTenantAdmin', 'requireAuthOptional',
   'requireServiceRole', 'requireApiKey', 'requireScanToken',
+  // requireAuthWithTenant: authenticated + tenant-scoped middleware used across
+  // orb-livekit.ts (voice-config, commit-memory). It IS auth — was missing here.
+  'requireAuthWithTenant',
 ];
 const ROUTE_PREFIX_RE = /^\s*router\.(get|post|put|patch|delete)\s*\(/;
 

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -848,6 +848,30 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     model_turns_counter = {"n": 0}
     stall_count = {"n": 0}
 
+    # §11 conversation-flow memory: accumulate the conversation transcript so
+    # _teardown can POST it to the gateway's /api/v1/orb/session/commit-memory
+    # endpoint, which runs the SAME extraction (Cognee + deduplicated facts) the
+    # Vertex path runs at session stop. Before this, the LiveKit agent extracted
+    # NOTHING and every conversation was heard and thrown away (no cross-session
+    # memory). User lines come from the proven user_input_transcribed hook;
+    # assistant lines from conversation_item_added (best-effort). See
+    # docs/CONVERSATION_FLOW_ARCHITECTURE.md §11.
+    mem_transcript: list[str] = []
+    MEM_TRANSCRIPT_MAX_CHARS = 20000
+
+    def _mem_append(role: str, text: Any) -> None:
+        try:
+            if isinstance(text, (list, tuple)):
+                text = " ".join(str(p) for p in text)
+            t = (text or "").strip() if isinstance(text, str) else ""
+            if not t:
+                return
+            if sum(len(x) for x in mem_transcript) > MEM_TRANSCRIPT_MAX_CHARS:
+                return
+            mem_transcript.append(f"{role}: {t}")
+        except Exception:  # noqa: BLE001
+            pass
+
     # VTID-03076 (P0-C): activeContinuation voice state.
     #
     # When the agent speaks a wake-brief (proactive opener at orb_wake),
@@ -1028,6 +1052,38 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("session.stop oasis emit failed: %s", exc)
+        # §11 conversation-flow memory: commit the session transcript so the
+        # SAME extraction the Vertex path runs also runs for LiveKit. Runs
+        # BEFORE gw.aclose() (it uses gw). Fire-and-forget — extraction must
+        # never block teardown. The gateway emits orb.live.memory.committed so
+        # we can VERIFY transcript_chars > 0 on staging (the "proven" leg of the
+        # done ritual). See docs/CONVERSATION_FLOW_ARCHITECTURE.md §11.
+        try:
+            _mem_text = "\n".join(mem_transcript)
+            if identity.user_id and identity.tenant_id and len(_mem_text) > 50:
+                await gw.post(
+                    "/api/v1/orb/session/commit-memory",
+                    {
+                        "transcript": _mem_text,
+                        "session_id": orb_session_id,
+                        "active_role": identity.role or "community",
+                    },
+                )
+                logger.info(
+                    "§11 committed session memory: %d chars, %d lines (session=%s)",
+                    len(_mem_text),
+                    len(mem_transcript),
+                    orb_session_id,
+                )
+            else:
+                logger.info(
+                    "§11 skip memory commit: chars=%d user=%s (session=%s)",
+                    len(_mem_text),
+                    bool(identity.user_id),
+                    orb_session_id,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("§11 commit-memory POST failed (non-fatal): %s", exc)
         try:
             await gw.aclose()
         except Exception:  # noqa: BLE001
@@ -1414,6 +1470,7 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                 # orb.turn.responded with the voice-tool-routing signal
                 # (consent/PII-gated server-side at /api/v1/oasis/emit).
                 turn_state["user_text"] = t
+                _mem_append("User", t)  # §11: accrue for session-end memory commit
         except Exception:  # noqa: BLE001
             pass
         turn_state["user_text_len"] = text_len
@@ -1437,6 +1494,32 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         session.on("user_input_transcribed")(_on_user_transcribed)  # type: ignore[misc]
     except Exception as exc:  # noqa: BLE001
         logger.debug("could not hook user_input_transcribed: %s", exc)
+
+    # §11: capture ASSISTANT lines for the session-end memory transcript.
+    # Best-effort — the event/attribute names vary across livekit-agents
+    # versions, so read defensively and never raise. User lines already come
+    # from the proven user_input_transcribed hook above, so even if this hook
+    # captures nothing the user's shared facts are still committed.
+    def _on_conversation_item(_ev: Any = None) -> None:
+        try:
+            item = getattr(_ev, "item", None) or _ev
+            role = getattr(item, "role", None)
+            if role != "assistant":
+                return
+            text = (
+                getattr(item, "text_content", None)
+                or getattr(item, "content", None)
+                or getattr(item, "text", None)
+                or ""
+            )
+            _mem_append("Assistant", text)
+        except Exception:  # noqa: BLE001
+            pass
+
+    try:
+        session.on("conversation_item_added")(_on_conversation_item)  # type: ignore[misc]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("could not hook conversation_item_added: %s", exc)
 
     # VTID-03076 (P0-C): activeContinuation accept/dismiss intercept.
     #

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -1061,13 +1061,20 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         try:
             _mem_text = "\n".join(mem_transcript)
             if identity.user_id and identity.tenant_id and len(_mem_text) > 50:
-                await gw.post(
-                    "/api/v1/orb/session/commit-memory",
-                    {
-                        "transcript": _mem_text,
-                        "session_id": orb_session_id,
-                        "active_role": identity.role or "community",
-                    },
+                # Bound the POST so a slow/unreachable gateway can never stall
+                # teardown (the GatewayClient default timeout is 30s; the
+                # endpoint queues extraction async, so the agent need not wait
+                # for the response) — Codex P2.
+                await asyncio.wait_for(
+                    gw.post(
+                        "/api/v1/orb/session/commit-memory",
+                        {
+                            "transcript": _mem_text,
+                            "session_id": orb_session_id,
+                            "active_role": identity.role or "community",
+                        },
+                    ),
+                    timeout=5.0,
                 )
                 logger.info(
                     "§11 committed session memory: %d chars, %d lines (session=%s)",
@@ -1082,6 +1089,8 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                     bool(identity.user_id),
                     orb_session_id,
                 )
+        except asyncio.TimeoutError:
+            logger.warning("§11 commit-memory POST timed out (non-fatal); teardown continues")
         except Exception as exc:  # noqa: BLE001
             logger.warning("§11 commit-memory POST failed (non-fatal): %s", exc)
         try:
@@ -1470,7 +1479,12 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                 # orb.turn.responded with the voice-tool-routing signal
                 # (consent/PII-gated server-side at /api/v1/oasis/emit).
                 turn_state["user_text"] = t
-                _mem_append("User", t)  # §11: accrue for session-end memory commit
+                # §11: only persist FINAL transcripts — skip interim STT
+                # hypotheses so partial/misrecognized text can't corrupt durable
+                # memory facts (Codex P2). Defaults to persist when the flag is
+                # absent (older livekit-agents versions).
+                if getattr(_ev, "is_final", True):
+                    _mem_append("User", t)  # §11: accrue for session-end memory commit
         except Exception:  # noqa: BLE001
             pass
         turn_state["user_text_len"] = text_len

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -37,6 +37,10 @@ import { randomUUID } from 'crypto';
 import { AccessToken } from 'livekit-server-sdk';
 import * as jose from 'jose';
 import { emitOasisEvent } from '../services/oasis-event-service';
+// §11 conversation-flow architecture: the single session-end memory-commit step.
+// The LiveKit agent POSTs its transcript here on teardown so the SAME extraction
+// the Vertex path runs also runs for LiveKit (it ran NOTHING before).
+import { commitSessionMemory } from '../services/session-memory-commit';
 import { getSupabase } from '../lib/supabase';
 // VTID-03210: single structured turn-1 wake-decision snapshot — emitted
 // identically on Vertex (live-session-controller) and here on LiveKit so
@@ -2140,6 +2144,74 @@ router.get(
       });
     }
     res.json({ ok: true, agent_id: id, config: data ?? null, vtid: VTID });
+  },
+);
+
+// §11 — session-end memory commit (LiveKit parity with Vertex). The agent owns
+// the transcript (the conversation runs in the agent process), so it POSTs it
+// here on teardown. This runs the SAME extraction (Cognee + deduplicated inline
+// facts) the Vertex path runs at session stop. Without it, LiveKit conversations
+// were heard and thrown away → no cross-session memory. Fire-and-forget;
+// extraction never blocks the agent's teardown. See
+// docs/CONVERSATION_FLOW_ARCHITECTURE.md §11.
+router.post(
+  '/orb/session/commit-memory',
+  requireAuthWithTenant,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const tenantId = req.identity?.tenant_id ?? null;
+      const userId = req.identity?.user_id ?? null;
+      if (!tenantId || !userId) {
+        return res.status(401).json({ ok: false, error: 'auth_required', vtid: VTID });
+      }
+      const body = (req.body ?? {}) as {
+        transcript?: unknown;
+        session_id?: unknown;
+        active_role?: unknown;
+      };
+      const transcript = typeof body.transcript === 'string' ? body.transcript : '';
+      const sessionId =
+        typeof body.session_id === 'string' && body.session_id.length > 0
+          ? body.session_id
+          : `livekit-${userId.slice(0, 8)}`;
+      const activeRole = typeof body.active_role === 'string' ? body.active_role : null;
+
+      const result = commitSessionMemory({
+        transcript,
+        tenantId,
+        userId,
+        sessionId,
+        activeRole,
+      });
+
+      // Telemetry so "did this session persist memory?" is QUERYABLE (§4/§11),
+      // not assumed. Mirrors the memory_hits goal on the read side.
+      emitOasisEvent({
+        vtid: VTID,
+        type: 'orb.live.memory.committed',
+        source: 'gateway',
+        status: result.committed ? 'info' : 'warning',
+        message: `LiveKit session memory commit: ${result.committed ? 'queued' : result.reason}`,
+        payload: {
+          service: 'gateway',
+          component: 'orb-livekit',
+          transport: 'livekit',
+          session_id: sessionId,
+          user_id: userId,
+          committed: result.committed,
+          cognee_queued: result.cognee_queued,
+          reason: result.reason ?? null,
+          transcript_chars: transcript.length,
+        },
+      }).catch(() => {});
+
+      return res.json({ ok: true, ...result, vtid: VTID });
+    } catch (err) {
+      console.error(
+        `[orb/session/commit-memory] failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return res.status(500).json({ ok: false, error: 'commit_failed', vtid: VTID });
+    }
   },
 );
 

--- a/services/gateway/src/services/session-memory-commit.ts
+++ b/services/gateway/src/services/session-memory-commit.ts
@@ -1,0 +1,90 @@
+/**
+ * Session-end memory commit — the SINGLE place a voice conversation is turned
+ * into durable memory (extraction → memory_facts / memory_items /
+ * relationship_nodes).
+ *
+ * Both voice transports MUST route here so extraction can never fork again:
+ *   - Vertex (orb-live.ts / live-session-controller) calls it inline at session
+ *     stop (it already holds the transcript).
+ *   - LiveKit (services/agents/orb-agent) has the transcript in the agent
+ *     process, so it POSTs it to `POST /api/v1/orb/session/commit-memory`
+ *     (orb-livekit.ts) on teardown, which calls this function.
+ *
+ * Before this existed, the LiveKit agent's teardown extracted NOTHING — every
+ * LiveKit conversation was heard and thrown away, so cross-session memory never
+ * accumulated on the pipeline real users are on. See
+ * docs/CONVERSATION_FLOW_ARCHITECTURE.md §11.
+ */
+
+import { cogneeExtractorClient } from './cognee-extractor-client';
+import { deduplicatedExtract } from './extraction-dedup-manager';
+
+/** Minimum transcript length (chars) worth extracting from. Mirrors the Vertex
+ *  session-stop guard so both transports behave identically. */
+export const MIN_COMMIT_TRANSCRIPT_CHARS = 50;
+
+export interface CommitSessionMemoryArgs {
+  transcript: string;
+  tenantId: string;
+  userId: string;
+  sessionId: string;
+  activeRole?: string | null;
+}
+
+export interface CommitSessionMemoryResult {
+  /** True when at least the deduplicated extractor was fired. */
+  committed: boolean;
+  /** True when the Cognee extractor was also queued (it is gated by a flag). */
+  cognee_queued: boolean;
+  reason?: string;
+}
+
+/**
+ * Fire-and-forget the session-end extraction (Cognee + deduplicated inline
+ * facts). Never throws — extraction failures must never block the session-stop
+ * path. Returns what was fired so callers can record telemetry.
+ */
+export function commitSessionMemory(args: CommitSessionMemoryArgs): CommitSessionMemoryResult {
+  const transcript = (args.transcript || '').trim();
+  if (transcript.length <= MIN_COMMIT_TRANSCRIPT_CHARS) {
+    return { committed: false, cognee_queued: false, reason: 'transcript_too_short' };
+  }
+  if (!args.tenantId || !args.userId) {
+    return { committed: false, cognee_queued: false, reason: 'missing_identity' };
+  }
+
+  let cogneeQueued = false;
+  try {
+    if (cogneeExtractorClient.isEnabled()) {
+      cogneeExtractorClient.extractAsync({
+        transcript,
+        tenant_id: args.tenantId,
+        user_id: args.userId,
+        session_id: args.sessionId,
+        active_role: args.activeRole || 'community',
+      });
+      cogneeQueued = true;
+    }
+  } catch (err) {
+    console.warn(
+      `[session-memory-commit] cognee extractAsync threw (non-fatal) for ${args.userId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  try {
+    // VTID-01230: deduplicated inline-fact extraction (force on session end).
+    deduplicatedExtract({
+      conversationText: transcript,
+      tenant_id: args.tenantId,
+      user_id: args.userId,
+      session_id: args.sessionId,
+      force: true,
+    });
+  } catch (err) {
+    console.warn(
+      `[session-memory-commit] deduplicatedExtract threw (non-fatal) for ${args.userId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return { committed: true, cognee_queued: cogneeQueued };
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -604,6 +604,8 @@ export type CicdEventType =
   | 'livekit.stt.recovery'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
+  // Conversation-flow §11: session-end memory commit (LiveKit parity).
+  | 'orb.live.memory.committed'
   // VTID-FALLBACK: Chat-TTS fallback events
   | 'orb.live.fallback_used'
   | 'orb.live.fallback_error'


### PR DESCRIPTION
## §11 of the conversation-flow architecture — the LiveKit memory write (both halves)

**The break (investigated):** memory READ works on both transports, but the WRITE (extraction → durable facts) ran **only on Vertex**. The LiveKit agent's teardown extracted *nothing* — so every LiveKit conversation was **heard and thrown away**; cross-session memory never accumulated on the pipeline real users are on. That's the "Vitana forgets me" amnesia.

This PR closes it end-to-end — **one** shared extraction step, both transports route to it.

### Gateway (auto-deploys to staging on merge)
- **`services/session-memory-commit.ts`** — shared `commitSessionMemory()`: runs the **same** extraction the Vertex path runs (`cogneeExtractorClient.extractAsync` + `deduplicatedExtract`, force-on-end), fire-and-forget, never throws.
- **`POST /api/v1/orb/session/commit-memory`** (`orb-livekit.ts`, `requireAuthWithTenant`).
- **`orb.live.memory.committed`** OASIS event → *"did this session persist memory?"* is **queryable, not assumed**.

### Agent (`orb-agent` — needs its own governed deploy to take effect)
- Accumulates the conversation transcript (`mem_transcript`): **user** lines from the proven `user_input_transcribed` hook, **assistant** lines from `conversation_item_added` (best-effort, defensive).
- `_teardown()` POSTs the transcript to the endpoint **before** `gw.aclose()` — fire-and-forget, never blocks teardown.

### CI
- `tsc` build clean; Python `py_compile` clean.
- Also fixes the impact-rule's auth-middleware list to recognize `requireAuthWithTenant` (the route *is* authed — was a false-positive warning).

## The "done" ritual (how we prove it, not assume it)
1. Merge → gateway endpoint live on staging; **deploy `orb-agent`** (separate workflow).
2. Real LiveKit staging session → gateway emits `orb.live.memory.committed` with **`transcript_chars > 0`**.
3. **Next** session recalls a fact you shared. That's "done."

Tracked follow-ups: route the Vertex inline block through `commitSessionMemory` (one literal impl); per-turn memory consideration + `memory_hits` on the read side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)