### PR TITLE
feat(orb): complete daily voice briefing on the Vertex new-day path

### DIFF
--- a/docs/CONVERSATION_FLOW_ARCHITECTURE.md
+++ b/docs/CONVERSATION_FLOW_ARCHITECTURE.md
@@ -351,6 +351,61 @@ journey-maturity model that already exists (`login_briefing`'s
   relates back to the journey and nudges the next session. The provider and the
   standing instruction read the SAME journey context, so they can never disagree.
 
+### Completeness: the briefing carries EVERY signal, not just journey + calendar
+
+> A morning briefing that names the journey day and today's calendar but omits
+> the Vitana Index move, new community matches, unread messages, due reminders,
+> and the autopilot/proactive next step is **half-baked**. The first turn of the
+> day is the one moment the user is most receptive to the full picture — it must
+> be the *complete* picture.
+
+The complete signal set is the **rich** `gatherOverviewPayload`
+(`new-day-overview-payload.ts`), which reads the SAME sources the My Journey
+screen renders **plus** the voice-only time-sensitive signals:
+
+- journey (day-in-journey, plan_phase, wave / goal arc)
+- Vitana Index **with pillar + 7-day-trend interpretation** (never a bare number)
+- Life Compass goal (verbatim, as the North Star)
+- calendar today + passed-since-last-session
+- **autopilot `today_checkpoint`** — the proactive next step, which OWNS the
+  named close (this is the proactive-assistant layer surfacing in voice)
+- **new community matches** (`matches_unread`)
+- **unread messages** (`messages_unread`, count only)
+- reminders due today
+- diary streak (7-day)
+
+The narrow `aggregateNewDayOverview` (calendar + Index + goal only) is **not**
+sufficient for the opener — wiring it into the spoken turn drops seven signals
+and is what produced the half-baked briefing (the PR #2790 regression).
+
+### One brain, MANY MOUTHS — the rendering differs by transport, the payload does not
+
+The single-rich-payload is the **brain**. The mistake was forcing ONE
+*rendering* (a single server-composed line) onto BOTH transports: a deterministic
+line cannot carry nine signals without reading like a dashboard (the exact tone
+the briefing prompt forbids). So the mouths differ by capability:
+
+- **Vertex (LLM mouth):** hand the model the full structured block
+  `buildNewDayOverviewBlock` (carries the wake-brief override marker + a
+  per-payload coverage checklist). The model composes the natural two-paragraph
+  briefing that covers every applicable signal. **Wording is 100% model-composed
+  from the payload — nothing is hardcoded, and the block is language-agnostic
+  (`Respond in {lang}`), so German is first-class.** This is what the Vertex
+  SAFE-FAST new-day rung now sends (`orb-live.ts`, `wake_opener:
+  safe_fast_newday_overview`) — the path real users are on today.
+- **LiveKit (deterministic `say()` mouth):** has no LLM to compose the opener, so
+  it speaks `userFacingLine` verbatim. It gets a **bounded** composed line. A
+  fully-rich deterministic line is a separate renderer; until LiveKit is actually
+  activated (Vertex-only today) it keeps the bounded line.
+
+**Therefore:** the `new_day_return` provider must carry the rich payload, and the
+render step is chosen per transport — LLM transports get the structured block,
+deterministic transports get the bounded line. The provider is transport-agnostic
+today (no transport flag in `ContinuationDecisionContext`), so threading that
+flag through `decideWakeBriefForSession` so the heavy Vertex path ALSO emits the
+rich block is the tracked Phase-2 follow-up. **The user-facing path (Vertex
+SAFE-FAST) is complete now; the brain-level completion rides Phase 2.**
+
 ---
 
 ## 11. Memory is a first-class input (read every turn, write every session)

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7648,6 +7648,10 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                     now: _nowNd,
                     timezone: _tzNd,
                     lastSessionDateUserTz: _lastSessDateTz,
+                    // Precise cutoff for "events since we last spoke" — avoids
+                    // briefing the user about events that happened BEFORE their
+                    // prior same-day session (Codex P2).
+                    lastSessionAtIso: _lastSessIso,
                   }),
                   new Promise<null>((r) => setTimeout(() => r(null), Number(process.env.ORB_NEWDAY_OVERVIEW_WAIT_MS || 3000))),
                 ]).catch(() => null);

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7615,59 +7615,93 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               if (_langOkNd && _isNewDayNd && typeof _firstNameNd === 'string' && _firstNameNd.trim().length > 0 && _uidNd && _supaNd) {
                 const _tzNd = session.clientContext?.timezone || 'UTC';
                 const _nowNd = new Date();
-                const { aggregateNewDayOverview } = await import('../services/assistant-continuation/providers/new-day-overview-aggregator');
-                const { renderNewDayReturnLineWithOverview, todayInTimezone, pickSalutationKind, localHourInTimezone } = await import('../services/assistant-continuation/providers/new-day-return');
+                // VTID-03172 / complete-briefing: use the RICH unified overview
+                // payload (the SAME data the My Journey screen renders, plus
+                // voice-only time-sensitive signals) instead of the narrow
+                // calendar+goal aggregator. This restores the Vitana Index
+                // (with pillar + trend interpretation), new community matches,
+                // unread messages, reminders due today, the autopilot
+                // today-checkpoint, and the diary streak to the FIRST spoken
+                // turn of the day — the half that the narrow aggregator dropped.
+                // We hand the model the composed structural block (it already
+                // carries the wake-brief override marker + the coverage
+                // checklist) as the first-turn directive, rather than a single
+                // pre-rendered verbatim line, so it speaks the full two-paragraph
+                // journey briefing. Wording stays 100% model-composed from the
+                // payload — nothing here is hardcoded.
+                const { gatherOverviewPayload } = await import('../services/assistant-continuation/providers/new-day-overview-payload');
+                const { buildNewDayOverviewBlock } = await import('../services/assistant-continuation/providers/new-day-overview-prompt');
+                const { todayInTimezone, localHourInTimezone } = await import('../services/assistant-continuation/providers/new-day-return');
+                // Last session's LOCAL date (YYYY-MM-DD) bounds the "since last
+                // session" calendar lookback. Derive it from the pre-fetched
+                // last-session timestamp; null falls back to a 24h window inside
+                // the aggregator.
+                const _lastSessIso = (session as any).lastSessionInfo?.time ?? null;
+                const _lastSessDateTz =
+                  typeof _lastSessIso === 'string' && _lastSessIso.length > 0
+                    ? todayInTimezone(new Date(_lastSessIso), _tzNd)
+                    : null;
                 const _overview = await Promise.race([
-                  aggregateNewDayOverview({
+                  gatherOverviewPayload({
                     supabase: _supaNd,
                     userId: _uidNd,
                     now: _nowNd,
                     timezone: _tzNd,
-                    todayDateIso: todayInTimezone(_nowNd, _tzNd),
-                    lastSessionAtIso: (session as any).lastSessionInfo?.time ?? null,
+                    lastSessionDateUserTz: _lastSessDateTz,
                   }),
                   new Promise<null>((r) => setTimeout(() => r(null), Number(process.env.ORB_NEWDAY_OVERVIEW_WAIT_MS || 3000))),
                 ]).catch(() => null);
-                // The aggregator returns a truthy payload even when EMPTY (no
-                // calendar, no goal, no index move) — rendering that yields just a
-                // bare "Good morning … let's get started", which would preempt a
-                // genuine concrete proactive opener. Only take the overview when
-                // it has REAL content (a calendar event or the Life Compass goal);
-                // an index-only move is handled by the proactive ladder below.
-                // Otherwise fall through (Codex P2).
-                const _overviewHasContent =
+                // Take the rich overview when it has ANY substantive content. For
+                // a genuine onboarded new-day return `journey` is virtually always
+                // present (day_in_journey is monotonic), so this fires; the guard
+                // exists only so a fully-empty payload (no journey, every signal
+                // un-set, nothing scheduled, no inbox) falls through to the
+                // proactive ladder rather than speaking an empty briefing.
+                const _hasContent =
                   !!_overview &&
-                  (_overview.calendar_passed_notable != null ||
-                    _overview.calendar_passed_count > 0 ||
-                    _overview.calendar_today_next != null ||
-                    _overview.calendar_today_count > 0 ||
-                    !!(_overview.life_compass_goal && String(_overview.life_compass_goal).trim().length > 0));
-                if (_overview && _overviewHasContent) {
-                  const _line = renderNewDayReturnLineWithOverview({
-                    lang,
-                    salutation: pickSalutationKind(localHourInTimezone(_nowNd, _tzNd)),
-                    firstName: _firstNameNd.trim(),
-                    timezone: _tzNd,
+                  (!!_overview.journey ||
+                    _overview.vitana_index.state === 'ok' ||
+                    _overview.life_compass.state === 'set' ||
+                    _overview.calendar_today.count > 0 ||
+                    _overview.calendar_passed.count > 0 ||
+                    (_overview.autopilot.state === 'has_actions' && !!_overview.autopilot.today_checkpoint) ||
+                    _overview.matches_unread > 0 ||
+                    _overview.messages_unread > 0 ||
+                    _overview.reminders_today.count > 0);
+                if (_overview && _hasContent) {
+                  const _block = buildNewDayOverviewBlock({
                     payload: _overview,
+                    lang,
+                    firstName: _firstNameNd.trim(),
+                    localHour: localHourInTimezone(_nowNd, _tzNd),
+                    timezone: _tzNd,
                   });
-                  if (_line && _line.trim().length > 0) {
-                    const _safeOv = _line.trim().replace(/"/g, '\\"');
-                    const _ovPrompt =
-                      `Say exactly: "${_safeOv}" — speak it verbatim as audio, as ONE greeting. Do NOT add, paraphrase, or split it.`;
+                  if (_block && _block.trim().length > 0) {
                     ws.send(
                       JSON.stringify({
-                        client_content: { turns: [{ role: 'user', parts: [{ text: _ovPrompt }] }], turn_complete: true },
+                        client_content: { turns: [{ role: 'user', parts: [{ text: _block }] }], turn_complete: true },
                       }),
                     );
                     emitDiag(session, 'greeting_sent', {
                       lang,
-                      prompt_len: _ovPrompt.length,
+                      prompt_len: _block.length,
                       wake_opener: 'safe_fast_newday_overview',
                       bucket: _temporalNd.bucket,
+                      overview_signals: {
+                        journey: !!_overview.journey,
+                        index: _overview.vitana_index.state,
+                        life_compass: _overview.life_compass.state,
+                        calendar_today: _overview.calendar_today.count,
+                        autopilot: _overview.autopilot.state,
+                        matches_unread: _overview.matches_unread,
+                        messages_unread: _overview.messages_unread,
+                        reminders_today: _overview.reminders_today.count,
+                        diary_last_7d: _overview.diary_last_7d,
+                      },
                     });
                     startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
                     console.log(
-                      `[GREETING-SAFE-FAST-NEWDAY-OVERVIEW] session ${session.sessionId} sent full new-day overview (bucket=${_temporalNd.bucket}, lang=${lang})`,
+                      `[GREETING-SAFE-FAST-NEWDAY-OVERVIEW] session ${session.sessionId} sent RICH new-day briefing (bucket=${_temporalNd.bucket}, lang=${lang}, matches=${_overview.matches_unread}, msgs=${_overview.messages_unread}, autopilot=${_overview.autopilot.state}, index=${_overview.vitana_index.state})`,
                     );
                     return;
                   }

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
@@ -167,6 +167,13 @@ export interface AggregateArgs {
   timezone: string;
   now: Date;
   lastSessionDateUserTz: string | null;
+  /**
+   * Precise last-session timestamp (ISO). When provided it is the EXACT cutoff
+   * for "calendar events since we last spoke", so a user who spoke at 8pm is
+   * not briefed the next morning about that same day's earlier events. Falls
+   * back to local-midnight of `lastSessionDateUserTz`, then to 24h ago.
+   */
+  lastSessionAtIso?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -236,9 +243,11 @@ export { dayWindowUtcIso };
 export async function gatherOverviewPayload(args: AggregateArgs): Promise<OverviewPayload> {
   const { startUtc, endUtc } = dayWindowUtcIso(args.now, args.timezone);
   const nowIso = args.now.toISOString();
-  const lookbackIso = args.lastSessionDateUserTz
-    ? new Date(`${args.lastSessionDateUserTz}T00:00:00Z`).toISOString()
-    : new Date(args.now.getTime() - 24 * 3600 * 1000).toISOString();
+  const lookbackIso = args.lastSessionAtIso
+    ? args.lastSessionAtIso
+    : args.lastSessionDateUserTz
+      ? new Date(`${args.lastSessionDateUserTz}T00:00:00Z`).toISOString()
+      : new Date(args.now.getTime() - 24 * 3600 * 1000).toISOString();
 
   const [
     journeyState,
@@ -559,12 +568,28 @@ async function fetchAutopilotForVoice(
 }
 
 async function fetchMatchesUnread(sb: SupabaseClient, userId: string): Promise<number> {
+  // Matches live in `intent_matches`, reached via the user's `user_intents`
+  // (requester_user_id) — the SAME source the match-activity-plan next-action
+  // provider uses. There is no `match_notifications` table, so the prior query
+  // always errored → silently returned 0 and the briefing omitted matches.
+  // "Unread/new" here means a match in one of the live stages (not closed).
   try {
+    const { data: intentRows, error: intentErr } = await sb
+      .from('user_intents')
+      .select('intent_id')
+      .eq('requester_user_id', userId)
+      .limit(200);
+    if (intentErr) return 0;
+    const intentIds = (intentRows ?? [])
+      .map((r) => (r as { intent_id: string }).intent_id)
+      .filter(Boolean);
+    if (intentIds.length === 0) return 0;
+    const idList = intentIds.map((s) => `"${s}"`).join(',');
     const { count, error } = await sb
-      .from('match_notifications')
-      .select('id', { head: true, count: 'exact' })
-      .eq('user_id', userId)
-      .eq('is_read', false);
+      .from('intent_matches')
+      .select('match_id', { head: true, count: 'exact' })
+      .or(`intent_a_id.in.(${idList}),intent_b_id.in.(${idList})`)
+      .in('state', ['new', 'responded_by_a', 'responded_by_b', 'mutual_interest']);
     if (error) return 0;
     return Number(count ?? 0);
   } catch {
@@ -573,11 +598,14 @@ async function fetchMatchesUnread(sb: SupabaseClient, userId: string): Promise<n
 }
 
 async function fetchMessagesUnread(sb: SupabaseClient, userId: string): Promise<number> {
+  // DMs live in `chat_messages` (receiver_id / read_at) — mirrors the canonical
+  // unread query in routes/chat.ts. There is no `messages` table, so the prior
+  // query always errored → silently returned 0 and the briefing omitted DMs.
   try {
     const { count, error } = await sb
-      .from('messages')
-      .select('id', { head: true, count: 'exact' })
-      .eq('recipient_id', userId)
+      .from('chat_messages')
+      .select('*', { head: true, count: 'exact' })
+      .eq('receiver_id', userId)
       .is('read_at', null);
     if (error) return 0;
     return Number(count ?? 0);


### PR DESCRIPTION
## Why

The first spoken turn of a new day was **half-baked**. It named the journey day and today's calendar but **dropped**:

- the **Vitana Index** move (with pillar + 7-day trend interpretation)
- **new community matches**
- **unread messages**
- **reminders due today**
- the **diary streak**
- and — most importantly — the **autopilot / proactive next step** (the proactive-assistant layer never reached voice)

PR #2790 had narrowed the spoken overview from the rich `gatherOverviewPayload` to the calendar+Index+goal-only `aggregateNewDayOverview`, losing seven signals. This restores the **complete** briefing on the path real users hear.

## What

The Vertex **SAFE-FAST** new-day rung (`orb-live.ts`, `wake_opener: safe_fast_newday_overview`) — the path Vertex users are on today:

- **swap** `aggregateNewDayOverview` (narrow) → `gatherOverviewPayload` (rich): journey + Index-with-pillar/trend + Life Compass + calendar today/passed + **autopilot `today_checkpoint`** + matches + messages + reminders + diary streak — the same sources the My Journey screen renders, plus voice-only time-sensitive signals.
- **hand the model the full `buildNewDayOverviewBlock` structured block** (with its per-payload coverage checklist) instead of a single pre-rendered line, so it composes the natural two-paragraph briefing covering every applicable signal.
- **content gate** now fires for any onboarded returning user (journey present), and the per-signal inventory is logged in greeting diagnostics.

### Constraints honored
- **No hardcoded greeting wording** — 100% model-composed from the payload.
- **German is first-class** — the block is language-agnostic (`Respond in {lang}`).
- **Never "welcome back" to non-onboarded users** — first-timers are handled by the separate first-time-welcome branch; this rung only fires on a genuine new-day *return*.
- **Never invent memory** — every clause is gated on real payload data.

## Architecture (one brain, MANY mouths)

The rich payload is the **brain**. The #2790 mistake was forcing ONE rendering (a single deterministic line) onto BOTH transports — a deterministic line can't carry nine signals without sounding like a dashboard. So the mouths differ by capability:

- **Vertex (LLM mouth):** full `buildNewDayOverviewBlock` structured block → natural multi-signal briefing. ✅ shipped here.
- **LiveKit (`say()` mouth):** no LLM to compose; keeps its bounded composed line (provider stays untouched so the LiveKit canary isn't broken).

Threading a transport flag through `decideWakeBriefForSession` so the **heavy** Vertex path / provider also emits the rich block is the tracked **Phase-2** follow-up. Recorded in §10 of `CONVERSATION_FLOW_ARCHITECTURE.md`.

## Verification
- `tsc --noEmit` clean.
- `new-day-return` + `new-day-overview-aggregator` Jest suites: **43 passed**.
- Provider/heavy-path contract unchanged (no transport regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_