### PR TITLE
fix(orb): fire the morning briefing reliably via a durable once-per-day flag

### DIFF
--- a/docs/CONVERSATION_FLOW_ARCHITECTURE.md
+++ b/docs/CONVERSATION_FLOW_ARCHITECTURE.md
@@ -406,6 +406,29 @@ flag through `decideWakeBriefForSession` so the heavy Vertex path ALSO emits the
 rich block is the tracked Phase-2 follow-up. **The user-facing path (Vertex
 SAFE-FAST) is complete now; the brain-level completion rides Phase 2.**
 
+### Trigger: durable once-per-day flag, NOT the session-start heuristic
+
+> A rich briefing nobody hears is worse than no briefing. The *content* being
+> complete is meaningless if the rung never fires.
+
+The morning briefing originally gated on the most-recent `vtid.live.session.start`
+telemetry (`describeTimeSince` → "first session of a new day"). That heuristic is
+**fragile**: an active user opens many sessions a day and the app auto-creates
+sessions, so any earlier same-day session (or a silent auto-session) flips the
+temporal bucket to "same-day" and the briefing is skipped. In practice it almost
+never fired — which is exactly the "the morning summary disappeared" complaint.
+
+The trigger is now a **durable per-user flag**: `user_journey.last_full_briefing_date`
+(user-tz `YYYY-MM-DD`). The SAFE-FAST rung fires the rich briefing on the FIRST
+session of a day where that date is stale, then stamps today so same-day reopens
+fall through to the short proactive opener (`computeFastProactiveOpener`). This is
+the **"full once/day, short after"** contract. First-time / not-yet-onboarded
+users are excluded (the first-time-welcome rung owns them — never "welcome back").
+
+Rule: **never re-gate the briefing on transient session telemetry.** Whether the
+briefing is due is a function of durable per-user state, not of how many sessions
+or reconnects happened.
+
 ---
 
 ## 11. Memory is a first-class input (read every turn, write every session)

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -741,6 +741,12 @@ export async function handleLiveSessionStart(
   // pre-fetch. null = unknown (read failed).
   let greetingIsFirstSession: boolean | null = null;
   let greetingNeedsOnboarding: boolean | null = null;
+  // Durable "full briefing delivered" date (YYYY-MM-DD, user-tz) from
+  // user_journey.last_full_briefing_date. Drives the once-per-real-day rich
+  // morning briefing independently of the fragile session-start heuristic —
+  // the briefing fires on the first session of a day where this is stale, then
+  // same-day reopens get the short proactive opener.
+  let greetingLastFullBriefingDate: string | null = null;
 
   // VTID-03294: a Guided-Journey topic tap needs ZERO context — Vitana just
   // picks up the KB lesson and speaks it. Detect it here so we can skip the
@@ -945,7 +951,7 @@ export async function handleLiveSessionStart(
             supa
               ? supa
                   .from('user_journey')
-                  .select('is_first_session')
+                  .select('is_first_session, last_full_briefing_date')
                   .eq('user_id', _ndIdentity.user_id)
                   .maybeSingle()
               : Promise.resolve(null as any),
@@ -970,9 +976,12 @@ export async function handleLiveSessionStart(
             firstSessionResult.value &&
             !firstSessionResult.value.error
           ) {
-            const _fsRow = firstSessionResult.value.data as { is_first_session?: boolean | null } | null;
+            const _fsRow = firstSessionResult.value.data as { is_first_session?: boolean | null; last_full_briefing_date?: string | null } | null;
             // No row at all → user has never had a journey row → treat as first-time.
             greetingIsFirstSession = _fsRow ? _fsRow.is_first_session === true : true;
+            // Durable once-per-day briefing flag (null when never delivered or
+            // column absent → briefing is due).
+            greetingLastFullBriefingDate = _fsRow?.last_full_briefing_date ?? null;
           }
           if (
             journeyStateResult.status === 'fulfilled' &&
@@ -1146,6 +1155,7 @@ export async function handleLiveSessionStart(
     (session as any).greetingProactiveLine = greetingProactiveLine;
     (session as any).greetingIsFirstTime = greetingIsFirstSession;
     (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
+    (session as any).lastFullBriefingDate = greetingLastFullBriefingDate;
     if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
       session.lastSessionInfo = greetingEarlyLastSessionInfo;
     }
@@ -1156,6 +1166,7 @@ export async function handleLiveSessionStart(
       (session as any).greetingProactiveLine = greetingProactiveLine;
       (session as any).greetingIsFirstTime = greetingIsFirstSession;
       (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
+      (session as any).lastFullBriefingDate = greetingLastFullBriefingDate;
       // Idempotent with the heavy bootstrap block, which also sets this later.
       if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
         session.lastSessionInfo = greetingEarlyLastSessionInfo;

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7599,22 +7599,43 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
             try {
               const _temporalNd = describeTimeSince((session as any).lastSessionInfo);
               const _firstNameNd = (session as any).greetingFirstName;
-              const _isNewDayNd =
-                _temporalNd.bucket === 'today' ||
-                _temporalNd.bucket === 'yesterday' ||
-                _temporalNd.bucket === 'week' ||
-                _temporalNd.bucket === 'long';
               const _uidNd = session.identity?.user_id;
               const _supaNd = getSupabase();
+              const _tzNd = session.clientContext?.timezone || 'UTC';
+              const _nowNd = new Date();
+              // DURABLE once-per-real-day gate. The old trigger keyed off the
+              // most-recent session-start telemetry (describeTimeSince), which is
+              // fragile: an active user opens many sessions a day and the app
+              // auto-creates sessions, so any earlier same-day session flipped the
+              // bucket to "same-day" and the rich briefing was skipped — it almost
+              // never fired in practice. We now key off
+              // user_journey.last_full_briefing_date (user-tz YYYY-MM-DD): the
+              // briefing fires on the FIRST session of a day where that date is
+              // stale, then we stamp today so same-day reopens fall through to the
+              // short proactive opener. Reliable "full once/day, short after".
+              const _todayNd = (() => {
+                try {
+                  return new Intl.DateTimeFormat('en-CA', {
+                    timeZone: _tzNd, year: 'numeric', month: '2-digit', day: '2-digit',
+                  }).format(_nowNd);
+                } catch {
+                  return _nowNd.toISOString().slice(0, 10);
+                }
+              })();
+              const _lastBriefDateNd = (session as any).lastFullBriefingDate as string | null | undefined;
+              const _briefingDueNd = !(typeof _lastBriefDateNd === 'string' && _lastBriefDateNd >= _todayNd);
+              // Never brief a brand-new / not-yet-onboarded user — the first-time
+              // welcome rung below owns them (never "welcome back" to a newcomer).
+              const _isFirstTimeNd =
+                (session as any).greetingNeedsOnboarding === true ||
+                (session as any).greetingIsFirstTime === true;
               // The overview renderer only localizes DE/EN; for any other session
               // language it would emit English clauses. Restrict the overview to
               // de/en and let the existing localized name-greeting ladder handle
               // es/fr/sr/etc. (Codex P2).
               const _langKeyNd = (lang || 'en').slice(0, 2).toLowerCase();
               const _langOkNd = _langKeyNd === 'de' || _langKeyNd === 'en';
-              if (_langOkNd && _isNewDayNd && typeof _firstNameNd === 'string' && _firstNameNd.trim().length > 0 && _uidNd && _supaNd) {
-                const _tzNd = session.clientContext?.timezone || 'UTC';
-                const _nowNd = new Date();
+              if (_langOkNd && _briefingDueNd && !_isFirstTimeNd && typeof _firstNameNd === 'string' && _firstNameNd.trim().length > 0 && _uidNd && _supaNd) {
                 // VTID-03172 / complete-briefing: use the RICH unified overview
                 // payload (the SAME data the My Journey screen renders, plus
                 // voice-only time-sensitive signals) instead of the narrow
@@ -7686,11 +7707,23 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                         client_content: { turns: [{ role: 'user', parts: [{ text: _block }] }], turn_complete: true },
                       }),
                     );
+                    // Stamp the durable once-per-day flag so same-day reopens get
+                    // the short proactive opener instead of re-briefing. Update by
+                    // user_id (returning users have a journey row); fire-and-forget,
+                    // and mirror onto the session so a second open within this same
+                    // process also sees it as delivered.
+                    (session as any).lastFullBriefingDate = _todayNd;
+                    void _supaNd
+                      .from('user_journey')
+                      .update({ last_full_briefing_date: _todayNd })
+                      .eq('user_id', _uidNd)
+                      .then(() => {}, () => {});
                     emitDiag(session, 'greeting_sent', {
                       lang,
                       prompt_len: _block.length,
                       wake_opener: 'safe_fast_newday_overview',
                       bucket: _temporalNd.bucket,
+                      briefing_date: _todayNd,
                       overview_signals: {
                         journey: !!_overview.journey,
                         index: _overview.vitana_index.state,

--- a/supabase/migrations/20260626220000_add_last_full_briefing_date.sql
+++ b/supabase/migrations/20260626220000_add_last_full_briefing_date.sql
@@ -1,0 +1,15 @@
+-- Durable once-per-real-day flag for the ORB morning briefing.
+--
+-- The rich morning briefing used to be gated on the most-recent
+-- vtid.live.session.start telemetry ("first session of a new day"), which is
+-- fragile: active users open many sessions a day and the app auto-creates
+-- sessions, so any earlier same-day session flipped the temporal bucket to
+-- "same-day" and the briefing was skipped — in practice it almost never fired.
+--
+-- This column lets the gateway record the user-tz date the full briefing was
+-- last delivered. The SAFE-FAST greeting fires the rich briefing on the FIRST
+-- session of a day where this date is stale, then stamps today so same-day
+-- reopens fall through to the short proactive opener ("full once/day, short
+-- after"). NULL = never delivered → briefing is due.
+ALTER TABLE public.user_journey
+  ADD COLUMN IF NOT EXISTS last_full_briefing_date date;


### PR DESCRIPTION
## Why

The rich morning briefing (PR #2793) was **real but unreachable**. It was gated on the most-recent `vtid.live.session.start` telemetry — "first session of a new day." That heuristic is fragile: an active user opens many sessions a day and the app auto-creates sessions, so **any earlier same-day session flipped the bucket to "same-day"** and the briefing rung was skipped. The user kept hearing the short proactive opener (`computeFastProactiveOpener` — *"let me guide you to the next step"*) and concluded the morning summary had disappeared. The #2793 content fix sat **behind** this trigger, so it never showed.

Diagnosed from live telemetry: every session fired `wake_opener: safe_fast_proactive`, never `safe_fast_newday_overview`, because the previous session-start was always earlier the same day.

## What

Replace the trigger with a **durable per-user flag** — "full once/day, short after" (the chosen behavior):

- **New column** `user_journey.last_full_briefing_date` (user-tz `YYYY-MM-DD`). Migration applied to the shared project.
- The SAFE-FAST new-day rung now fires the rich briefing whenever that date is **stale** for a returning, onboarded user — **independent of session count / reconnects** — then **stamps today** on delivery, so same-day reopens fall through to the short proactive opener.
- **First-time / not-yet-onboarded users excluded** — the first-time-welcome rung owns them (never "welcome back" to a newcomer).
- Greeting-facts prefetch (`live-session-controller`) reads the flag in the same parallel batch (zero added latency) and seeds it onto the session.

## Files
- `services/gateway/src/orb/live/session/live-session-controller.ts` — fetch + seed the flag
- `services/gateway/src/routes/orb-live.ts` — durable gate + stamp on delivery
- `supabase/migrations/20260626220000_add_last_full_briefing_date.sql`
- `docs/CONVERSATION_FLOW_ARCHITECTURE.md` — §10: never re-gate on transient session telemetry

## Verification
- `tsc --noEmit` clean; new-day Jest suites pass (31/31).
- DB column added (`ALTER TABLE … ADD COLUMN IF NOT EXISTS`).
- Post-merge staging test: open ORB once → rich briefing fires (telemetry `wake_opener=safe_fast_newday_overview`, `briefing_date=<today>`); open again → short proactive opener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_