### PR TITLE
feat(orb): add guided-journey progress + "where we left off" to the morning briefing

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7668,6 +7668,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                     userId: _uidNd,
                     now: _nowNd,
                     timezone: _tzNd,
+                    lang,
                     lastSessionDateUserTz: _lastSessDateTz,
                     // Precise cutoff for "events since we last spoke" — avoids
                     // briefing the user about events that happened BEFORE their

--- a/services/gateway/src/services/assistant-continuation/providers/login-briefing.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/login-briefing.ts
@@ -477,7 +477,7 @@ function checklistLocale(lang: string): 'de' | 'en' {
  * the "N" in "X of N topics"). Best-effort: any failure degrades to nulls so the
  * briefing still renders ("your next session is ready", no progress beat).
  */
-async function resolveCurriculumFacts(
+export async function resolveCurriculumFacts(
   supabase: SupabaseClient,
   lang: string,
   nextSessionNumber: number,

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
@@ -32,6 +32,13 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { getJourneyState, type JourneyState } from '../../journey/user-journey-service';
 import { fetchLifeCompass, fetchVitanaIndexForProfiler } from '../../user-context-profiler';
+// Guided-journey learning progress ("X of N sessions") + the real "where we
+// left off" recall — sourced from the SAME helpers the login-briefing provider
+// uses, so voice and the briefing agree. getJourneyState here is the GUIDED
+// curriculum pointer (distinct from the longevity-journey getJourneyState
+// imported above), hence the alias.
+import { getJourneyState as getGuidedJourneyState } from '../../guided-journey/guided-journey-state';
+import { resolveCurriculumFacts } from './login-briefing';
 
 // ---------------------------------------------------------------------------
 // Type definitions
@@ -157,6 +164,20 @@ export interface OverviewPayload {
   // -- DIARY (voice-only, streak proxy) --
   diary_last_7d: number;
 
+  // -- GUIDED JOURNEY (learning progress + "where we left off") --
+  guided_journey: {
+    /** Curriculum sessions the user has completed (current_session - 1). */
+    sessions_completed: number;
+    /** Total topics in the published curriculum, or null when unknown. */
+    sessions_total: number | null;
+    /** Title of the session the user is about to do next. */
+    next_session_title: string | null;
+    /** The REAL last topic the user opened — the "where we left off" thread to
+     *  continue. Falls back to the just-completed session title; null when the
+     *  user has not started the curriculum yet. */
+    last_session_recall: string | null;
+  } | null;
+
   // -- META --
   last_session_date_user_tz: string | null;
 }
@@ -166,6 +187,9 @@ export interface AggregateArgs {
   userId: string;
   timezone: string;
   now: Date;
+  /** Session language — selects the curriculum-checklist locale for the
+   *  guided-journey session titles. Defaults to 'en'. */
+  lang?: string;
   lastSessionDateUserTz: string | null;
   /**
    * Precise last-session timestamp (ISO). When provided it is the EXACT cutoff
@@ -261,6 +285,7 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     msgsUnread,
     remindersToday,
     diary7d,
+    guidedJourney,
   ] = await Promise.all([
     getJourneyState(args.supabase, args.userId).catch(() => null),
     fetchVitanaIndexForProfiler(args.supabase, args.userId).catch(() => null),
@@ -273,6 +298,7 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     fetchMessagesUnread(args.supabase, args.userId),
     fetchRemindersToday(args.supabase, args.userId, startUtc, endUtc),
     fetchDiaryLast7Days(args.supabase, args.userId, args.now),
+    fetchGuidedJourney(args.supabase, args.userId, args.lang ?? 'en'),
   ]);
 
   const lifeCompass = projectLifeCompass(lcSnapshot);
@@ -287,6 +313,7 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     messages_unread: msgsUnread,
     reminders_today: remindersToday,
     diary_last_7d: diary7d,
+    guided_journey: guidedJourney,
     last_session_date_user_tz: args.lastSessionDateUserTz,
   };
 }
@@ -635,6 +662,39 @@ async function fetchRemindersToday(
     };
   } catch {
     return { count: 0, next: null };
+  }
+}
+
+/**
+ * Guided-journey learning progress + the real "where we left off" recall.
+ * Reuses the login-briefing provider's exact sources (getJourneyState curriculum
+ * pointer + resolveCurriculumFacts checklist read) so the briefing and the
+ * proactive opener never disagree. Best-effort: any failure → null (the briefing
+ * simply omits the guided-journey beat).
+ */
+async function fetchGuidedJourney(
+  sb: SupabaseClient, userId: string, lang: string,
+): Promise<OverviewPayload['guided_journey']> {
+  try {
+    const js = await getGuidedJourneyState(sb, userId).catch(() => null);
+    if (!js) return null;
+    const currentSession = Number.isFinite(js.currentSession) ? Math.max(1, js.currentSession) : 1;
+    const sessionsCompleted = Math.max(0, currentSession - 1);
+    const cur = await resolveCurriculumFacts(sb, lang, currentSession, {
+      completedTopicIds: js.completedTopicIds ?? [],
+      lastOpenedTopicId: js.lastOpenedTopicId ?? null,
+    });
+    // "Where we left off" = the real last-opened topic; fall back to the
+    // just-completed session title once the user has done at least one session.
+    const recall = cur.lastOpenedTitle ?? (sessionsCompleted > 0 ? cur.title : null);
+    return {
+      sessions_completed: sessionsCompleted,
+      sessions_total: cur.totalTopics,
+      next_session_title: cur.title,
+      last_session_recall: recall,
+    };
+  } catch {
+    return null;
   }
 }
 

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
@@ -289,6 +289,9 @@ greetings are forbidden.
 Use every payload key that has data OR has a setup gap. Weave them
 into the two paragraphs:
   a. journey                    → P1: day + wave name (Rule 2)
+  a2. guided_journey            → P1: "X of N sessions learned, last time we did
+                                  Z, your next session is Y" — learning momentum +
+                                  where-we-left-off continuity + named next session
   b. vitana_index (state=ok)    → P1: number + meaning + pillar (Rule 3)
   c. vitana_index (not_set_up)  → P2: invitation to set up (Rule 6)
   d. life_compass (state=set)   → P1: woven anchor (Rule 4)
@@ -366,6 +369,25 @@ function buildCoverageChecklist(p: OverviewPayload): string {
         : '';
       items.push(`- [ ] ADDRESS (Rule 2, plan_phase='default_active'): Day ${j.day_in_journey} of ${j.default_plan_total_days} in the starter plan${waveHint}.`);
     }
+  }
+
+  if (
+    p.guided_journey &&
+    (p.guided_journey.sessions_completed > 0 ||
+      p.guided_journey.next_session_title ||
+      p.guided_journey.last_session_recall)
+  ) {
+    const g = p.guided_journey;
+    const total = g.sessions_total != null ? ` of ${g.sessions_total}` : '';
+    const recallHint = g.last_session_recall
+      ? ` Last time you worked on "${g.last_session_recall}" — pick that thread back up (continuity, not a status line).`
+      : '';
+    const nextHint = g.next_session_title
+      ? ` Recommend the next session by name: "${g.next_session_title}".`
+      : '';
+    items.push(
+      `- [ ] ADDRESS (guided journey): ${g.sessions_completed}${total} guided sessions completed so far.${nextHint}${recallHint} (Weave learning momentum + "where we left off" + the next session into the journey anchor — this is what makes the briefing feel personal and continuous.)`,
+    );
   }
 
   if (p.vitana_index.state === 'ok' && p.vitana_index.today !== null) {
@@ -483,6 +505,14 @@ function compactPayloadForPrompt(p: OverviewPayload): Record<string, unknown> {
   if (p.matches_unread > 0) out.matches_unread = p.matches_unread;
   if (p.messages_unread > 0) out.messages_unread = p.messages_unread;
   if (p.reminders_today.count > 0 || p.reminders_today.next) out.reminders_today = p.reminders_today;
+  if (
+    p.guided_journey &&
+    (p.guided_journey.sessions_completed > 0 ||
+      p.guided_journey.next_session_title ||
+      p.guided_journey.last_session_recall)
+  ) {
+    out.guided_journey = p.guided_journey;
+  }
   out.diary_last_7d = p.diary_last_7d;
   if (p.last_session_date_user_tz) out.last_session_date_user_tz = p.last_session_date_user_tz;
   return out;

--- a/services/gateway/test/services/assistant-continuation/providers/new-day-overview-plan-phase.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/new-day-overview-plan-phase.test.ts
@@ -57,6 +57,7 @@ function makePayload(journey: OverviewPayload['journey']): OverviewPayload {
     messages_unread: 0,
     reminders_today: { count: 0, next: null },
     diary_last_7d: 0,
+    guided_journey: null,
     last_session_date_user_tz: '2026-05-31',
   };
 }


### PR DESCRIPTION
## Why

After the durable trigger (#2794) made the morning briefing actually fire, the user flagged two missing beats:
1. **Guided-journey progress** — how many sessions they've completed and what the next session is.
2. **"Where we left off"** — recall of the last conversation's thread, so the briefing *continues* the journey instead of just reporting status. This is the bit that makes it feel personal.

Both data points already exist (they power the proactive opener's `Letztes Mal ging es um „…"` recall) but weren't in the rich briefing payload.

## What

Add a `guided_journey` block to `gatherOverviewPayload`, sourced from the **same helpers the `login_briefing` provider uses** — `getJourneyState` (curriculum pointer) + `resolveCurriculumFacts` (checklist read) — so the briefing and the opener never disagree:

- `sessions_completed` / `sessions_total` → "X of N sessions learned"
- `next_session_title` → named next session to recommend
- `last_session_recall` → the real last-opened topic = "where we left off"

`resolveCurriculumFacts` is now **exported** from `login-briefing.ts` for reuse (no logic duplication). The prompt (`buildNewDayOverviewBlock`) gains a coverage-checklist item + coverage-order entry so the model weaves learning momentum + where-we-left-off continuity + the named next session into the journey anchor.

## Constraints
- Wording stays 100% model-composed; **every field gates on real data** — null → the beat is omitted, never invented.
- Sourced identically to the existing opener, so no new "source of truth."

## Verification
- `tsc --noEmit` + full `npm run build` clean.
- Provider suites pass (72/72), incl. login-briefing + plan-phase.
- Post-merge staging: open ORB (first of day) → briefing now includes "X von N Sessions … letztes Mal ging es um Z … als Nächstes Y".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_