### PR TITLE
fix(orb): make the morning briefing speak the session count + named next session

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
@@ -168,13 +168,15 @@ export interface OverviewPayload {
   guided_journey: {
     /** Curriculum sessions the user has completed (current_session - 1). */
     sessions_completed: number;
+    /** Curriculum TOPICS the user has marked complete (completed_topic_ids). */
+    topics_learned: number;
     /** Total topics in the published curriculum, or null when unknown. */
-    sessions_total: number | null;
-    /** Title of the session the user is about to do next. */
+    topics_total: number | null;
+    /** Title of the session the user is about to do next (named, never generic). */
     next_session_title: string | null;
     /** The REAL last topic the user opened — the "where we left off" thread to
-     *  continue. Falls back to the just-completed session title; null when the
-     *  user has not started the curriculum yet. */
+     *  continue. Falls back to the next-session title when the last-opened topic
+     *  is unknown; null when the user has not started the curriculum yet. */
     last_session_recall: string | null;
   } | null;
 
@@ -680,16 +682,18 @@ async function fetchGuidedJourney(
     if (!js) return null;
     const currentSession = Number.isFinite(js.currentSession) ? Math.max(1, js.currentSession) : 1;
     const sessionsCompleted = Math.max(0, currentSession - 1);
+    const topicsLearned = Array.isArray(js.completedTopicIds) ? js.completedTopicIds.length : 0;
     const cur = await resolveCurriculumFacts(sb, lang, currentSession, {
       completedTopicIds: js.completedTopicIds ?? [],
       lastOpenedTopicId: js.lastOpenedTopicId ?? null,
     });
     // "Where we left off" = the real last-opened topic; fall back to the
-    // just-completed session title once the user has done at least one session.
+    // current session title once the user has done at least one session.
     const recall = cur.lastOpenedTitle ?? (sessionsCompleted > 0 ? cur.title : null);
     return {
       sessions_completed: sessionsCompleted,
-      sessions_total: cur.totalTopics,
+      topics_learned: topicsLearned,
+      topics_total: cur.totalTopics,
       next_session_title: cur.title,
       last_session_recall: recall,
     };

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
@@ -289,9 +289,10 @@ greetings are forbidden.
 Use every payload key that has data OR has a setup gap. Weave them
 into the two paragraphs:
   a. journey                    → P1: day + wave name (Rule 2)
-  a2. guided_journey            → P1: "X of N sessions learned, last time we did
-                                  Z, your next session is Y" — learning momentum +
-                                  where-we-left-off continuity + named next session
+  a2. guided_journey            → P1: BOTH the session COUNT ("du hast schon X
+                                  Sessions geschafft") AND the NAMED next session
+                                  ("deine nächste Session ist Y") + where-we-left-off
+                                  continuity. Never collapse to a generic "next step".
   b. vitana_index (state=ok)    → P1: number + meaning + pillar (Rule 3)
   c. vitana_index (not_set_up)  → P2: invitation to set up (Rule 6)
   d. life_compass (state=set)   → P1: woven anchor (Rule 4)
@@ -374,19 +375,24 @@ function buildCoverageChecklist(p: OverviewPayload): string {
   if (
     p.guided_journey &&
     (p.guided_journey.sessions_completed > 0 ||
+      p.guided_journey.topics_learned > 0 ||
       p.guided_journey.next_session_title ||
       p.guided_journey.last_session_recall)
   ) {
     const g = p.guided_journey;
-    const total = g.sessions_total != null ? ` of ${g.sessions_total}` : '';
+    const topicsClause =
+      g.topics_total != null ? `${g.topics_learned} of ${g.topics_total} topics` : `${g.topics_learned} topics`;
     const recallHint = g.last_session_recall
-      ? ` Last time you worked on "${g.last_session_recall}" — pick that thread back up (continuity, not a status line).`
+      ? ` Last time the thread was "${g.last_session_recall}" — continue it (continuity, not a status line). If it equals the next session, frame as "let's carry on with it".`
       : '';
-    const nextHint = g.next_session_title
-      ? ` Recommend the next session by name: "${g.next_session_title}".`
-      : '';
+    const nextClause = g.next_session_title
+      ? `Their next session is "${g.next_session_title}".`
+      : 'Offer the next session.';
     items.push(
-      `- [ ] ADDRESS (guided journey): ${g.sessions_completed}${total} guided sessions completed so far.${nextHint}${recallHint} (Weave learning momentum + "where we left off" + the next session into the journey anchor — this is what makes the briefing feel personal and continuous.)`,
+      `- [ ] ADDRESS (guided journey — speak BOTH of these, do not drop them):\n` +
+        `    • MOMENTUM: the user has completed ${g.sessions_completed} guided sessions (${topicsClause}). Say this concretely as a NUMBER — e.g. "du hast schon ${g.sessions_completed} Sessions geschafft".\n` +
+        `    • NEXT SESSION (named, never generic "next step"): ${nextClause} Name it and offer to do it together.${recallHint}\n` +
+        `    (This learning beat is what makes the briefing feel like a continuing journey — it is NOT optional when the user is in the guided curriculum.)`,
     );
   }
 
@@ -508,6 +514,7 @@ function compactPayloadForPrompt(p: OverviewPayload): Record<string, unknown> {
   if (
     p.guided_journey &&
     (p.guided_journey.sessions_completed > 0 ||
+      p.guided_journey.topics_learned > 0 ||
       p.guided_journey.next_session_title ||
       p.guided_journey.last_session_recall)
   ) {


### PR DESCRIPTION
## Why

Follow-up to #2795. Live staging test: the briefing now recalls *"wir hatten uns zuletzt den Bereich 'Vitana Index' angesehen — machen wir da weiter"* ✅, but still **dropped two beats the user asked for**: the **count of completed sessions** and the **named next session** (it said a generic "den nächsten Schritt").

The data was all present — `current_session=9` → **8 sessions completed, 18 topics, next session "Vitana Index"** — so this was the prompt under-surfacing it, plus a units bug.

## What

- **Payload**: split the conflated field. `sessions_total` actually held the *topic* count, so "8 of N sessions" would mix units. Now: `sessions_completed` (count) + `topics_learned` + `topics_total`. `next_session_title` / `last_session_recall` unchanged.
- **Prompt**: the guided-journey coverage item is now **imperative and split** — the model MUST (a) state the completed-session count as a number, and (b) name the next session (never a generic "next step"). Coverage-order entry updated to match.

## Verification
- `tsc --noEmit` clean; provider suites pass (45/45).
- Post-merge staging: reset the user's briefing flag, open ORB → expect *"…du hast schon 8 Sessions geschafft … deine nächste Session ist 'Vitana Index'…"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_