### PR TITLE
feat(orb): unified, recency-aware, always-guiding conversation opener (Phase 1)

### DIFF
--- a/docs/CONVERSATION_FLOW_HANDOFF.md
+++ b/docs/CONVERSATION_FLOW_HANDOFF.md
@@ -1,0 +1,184 @@
+# Conversation Flow — Handoff for the Command Hub "Conversation" section
+
+**Audience:** the next session's agent, tasked with building a new **"Conversation"**
+section in the Command Hub that visualises and configures the conversation-flow
+engine described here.
+
+**Status:** the engine below is built and live on the gateway (Vertex ORB path).
+This doc is the contract the Command Hub UI should mirror — read it as the source
+of truth for what the "Conversation" section must show and let an operator tune.
+
+---
+
+## 1. The mental model (what we built)
+
+Every time a user opens Vitana, ONE decision is made from the **full context**,
+rendered at the right depth, and it **always ends on a guided next step**. No more
+ladder of disconnected greeting rungs.
+
+```
+            ┌──────────────────────── CONTEXT BUNDLE (assembled once) ───────────────────────┐
+            │ recency (describeTimeSince) · identity+memory · where-we-left-off · journey ·   │
+            │ what's-new (Index move, matches, messages, reminders, calendar) · entry screen  │
+            └───────────────────────────────────┬────────────────────────────────────────────┘
+                                                 ▼
+                                   decideOpeningRegister()              ← recency FIRST
+                                                 ▼
+   first_time · daily_briefing · continue · quick_resume · same_day      ← the REGISTER
+                                                 ▼
+                                   selectNextBestAction()                ← the always-guiding step
+                                                 ▼
+                          one composed first-turn directive → the LLM speaks it
+```
+
+Two invariants the user insisted on:
+1. **Recency is the primary gate** — a return after 1 minute must never be greeted
+   "Guten Morgen". The register encodes this.
+2. **Vitana always guides** — every register closes on a concrete, real next step
+   (the Next-Best-Action), spanning the two north stars: **community engagement**
+   and **health improvement**.
+
+---
+
+## 2. The registers (recency-first decision)
+
+`decideOpeningRegister({ bucket, isFirstTime, briefingDue })` →
+
+| Register | Trigger | Behaviour | Greeting? |
+|---|---|---|---|
+| `first_time` | never onboarded | onboarding welcome | ✅ |
+| `daily_briefing` | `briefingDue` (first session of a real day; any gap length) | full rich briefing, once/day | ✅ time-of-day |
+| `continue` | bucket `reconnect` (<2 min) | no greeting — pick the thread back up + NBA | ❌ |
+| `quick_resume` | bucket `recent` (<15 min) | micro-ack, NO time-of-day, + NBA | ❌ |
+| `same_day` | bucket `same_day`/`today` (hours, same day) | light re-entry + what's-new + NBA | ⚠️ light |
+
+- **Recency buckets** come from `services/guide/temporal-bucket.ts` →
+  `describeTimeSince` (8 buckets: reconnect/recent/same_day/today/yesterday/week/long/first).
+- **`briefingDue`** = the durable once-per-day flag `user_journey.last_full_briefing_date`
+  is stale for today (user tz). Multi-day gaps (yesterday/week/long) always have a
+  stale flag → they resolve to `daily_briefing`.
+
+---
+
+## 3. The Next-Best-Action (NBA) engine — "always guiding"
+
+`services/conversation/next-best-action.ts` — pure function over the rich
+`OverviewPayload`. Ranks every **grounded** action (gated on real data; never
+bluffs) by **band = value × timeliness**, then picks the top to lead the close.
+
+| Band | Group | Actions (key) | Source signal |
+|---|---|---|---|
+| 100–92 | time-sensitive / waiting | `reminder_due`, `autopilot_step`, `reply_messages` | reminders_today, autopilot.today_checkpoint, messages_unread |
+| 80 | continuity (journey thread) | `next_session` | guided_journey.next_session_title |
+| 62–58 | health momentum | `diary_entry`, `focus_pillar` | diary_last_7d===0, vitana_index.weakest_pillar |
+| 44 | community growth | `review_matches` | matches_unread |
+| 30 | community growth (always-available, rotated) | `make_post`, `create_activity`, `connect_community` | — (rotation seed = day-of-year) |
+| 26 | setup | `set_goal` | life_compass.state==='not_set' |
+
+**North-star mapping:**
+- **Community engagement:** reply_messages, review_matches, make_post, create_activity, connect_community
+- **Health improvement:** autopilot_step, diary_entry, focus_pillar, next_session, set_goal
+
+**Known follow-up:** rotation is currently a day-of-year seed (varies daily). True
+"don't repeat the same suggestion two opens in a row" needs per-user NBA history —
+add a `last_nba_key` + timestamp (e.g. on `user_journey` or a small `nba_log`
+table) and pass it into `rankNextBestActions` to demote the just-suggested action.
+
+---
+
+## 4. Where everything lives (file map)
+
+| File | Role |
+|---|---|
+| `services/gateway/src/services/conversation/next-best-action.ts` | NBA engine (ranking + select), pure over OverviewPayload |
+| `services/gateway/src/services/conversation/decide-opening.ts` | register decision + resume-directive composition |
+| `services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts` | `gatherOverviewPayload` — the context bundle (journey, index, life_compass, calendar, autopilot, matches, messages, reminders, diary, guided_journey, recall) |
+| `services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts` | `buildNewDayOverviewBlock` — the rich daily-briefing render |
+| `services/gateway/src/services/guide/temporal-bucket.ts` | `describeTimeSince` — recency buckets + motivation signal |
+| `services/gateway/src/routes/orb-live.ts` (`sendGreetingPromptToLiveAPI`) | integration: register routing for the Vertex SAFE-FAST path |
+| `services/gateway/src/orb/live/session/live-session-controller.ts` | greeting-facts prefetch (name, lastSessionInfo, journey, briefing flag) |
+| `docs/CONVERSATION_FLOW_ARCHITECTURE.md` | the broader "one brain, many mouths" architecture (memory §11, journey §10) |
+
+---
+
+## 5. Telemetry the Command Hub should READ
+
+Greeting decisions are emitted to `oasis_events` (topic `orb.live.diag`, stage
+`greeting_sent`) with these fields in `metadata`:
+
+- `wake_opener`: `conv_resume` (new unified resume) | `safe_fast_newday_overview`
+  (daily briefing) | `safe_fast_first_time_welcome` | `safe_fast_proactive`/`safe_fast_newday` (fallbacks)
+- `register`: `continue` | `quick_resume` | `same_day` (on `conv_resume`)
+- `bucket`: the recency bucket
+- `nba` / `nba_domain`: the chosen next-best-action key + domain
+- `briefing_date`: stamped on the daily briefing
+- `overview_signals`: the per-signal inventory on the briefing
+
+**Query example (recent openers):**
+```sql
+select created_at,
+  coalesce(metadata->>'wake_opener', meta->>'wake_opener') as wake_opener,
+  coalesce(metadata->>'register', meta->>'register')       as register,
+  coalesce(metadata->>'bucket', meta->>'bucket')           as bucket,
+  coalesce(metadata->>'nba', meta->>'nba')                 as nba
+from oasis_events
+where topic='orb.live.diag'
+  and coalesce(metadata->>'stage', meta->>'stage')='greeting_sent'
+order by created_at desc limit 50;
+```
+
+---
+
+## 6. What the "Conversation" section should DO (build spec)
+
+1. **Live decision feed** — stream recent opens with register + recency bucket +
+   chosen NBA + which signals were present (from the telemetry above). Lets an
+   operator see *why* Vitana said what it said.
+2. **Register distribution** — counts of first_time / daily_briefing / continue /
+   quick_resume / same_day over time; flag anomalies (e.g. too many bare fallbacks
+   `safe_fast_newday` → something is mis-gating).
+3. **NBA distribution** — which next steps Vitana is suggesting, split by domain
+   (community vs health), to confirm the engagement/health balance the business wants.
+4. **Action catalog editor** — view/tune the NBA bands and the community-growth
+   rotation pool (see §3). Ideally back this with `decision_policy` keys (see the
+   policy-resolver in `services/decision-contract/`) so changes need no redeploy.
+5. **Register thresholds** — surface the recency thresholds (reconnect <2m, recent
+   <15m, same_day <8h…) and the cooling/absent day boundary (already policy-driven:
+   `SESSION_MOTIVATION_COOLING_TO_ABSENT_DAYS`). Make them viewable, ideally editable.
+6. **Per-user simulator** — given a user_id, show the assembled context bundle, the
+   register that would be chosen, and the NBA — a dry-run of `decideOpeningRegister`
+   + `selectNextBestAction` without speaking. (Expose a gateway debug endpoint that
+   calls the two pure functions over a freshly gathered payload.)
+
+**Suggested gateway support to add for the UI:** a read-only debug route, e.g.
+`GET /api/v1/admin/conversation/preview?user_id=…` returning
+`{ bundle, register, nba, ranked_nbas }` by calling `gatherOverviewPayload` +
+`decideOpeningRegister` + `rankNextBestActions`. (Not built yet — first task for
+the Command-Hub session.)
+
+---
+
+## 7. Open follow-ups (carry into the build)
+
+- [ ] Per-user NBA rotation history (§3) so suggestions don't repeat.
+- [ ] Multi-day `welcome_back` warmth: today multi-day gaps fold into
+  `daily_briefing`; consider passing `motivation_signal` into the briefing render
+  so a 10-days-away open explicitly acknowledges the absence.
+- [ ] Optimise the resume path: it gathers `gatherOverviewPayload` at greeting
+  time (bounded 1800ms). Move it into the existing greeting-facts prefetch so the
+  reopen is instant.
+- [ ] Converge transports: LiveKit / the 3rd provider should call the SAME
+  `decideOpeningRegister` + NBA (the "one brain, many mouths" goal in
+  `CONVERSATION_FLOW_ARCHITECTURE.md`). Vertex is wired first.
+- [ ] Standing-instruction guidance: keep the chosen NBA + memory in the system
+  instruction for turns 2+, so Vitana keeps nudging the next step mid-conversation,
+  not just at the open.
+- [ ] Debug preview endpoint (§6) for the simulator.
+
+---
+
+## 8. Change log
+
+| Date | Change |
+|---|---|
+| 2026-06-27 | Phase 1: unified opening decision (registers, recency-first) + Next-Best-Action engine wired into the Vertex SAFE-FAST path; durable once-per-day briefing flag; this handoff authored for the Command-Hub "Conversation" section. |

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -154,6 +154,13 @@ ORB_GREETING_FACTS_WAIT_MS=700
 # already resolved are unaffected. Optional — defaults to 2200 in code.
 ORB_NEWDAY_FACTS_WAIT_MS=2200
 
+# Bounded wait for the same-day RESUME registers (continue / quick_resume /
+# same_day) to gather the rich overview payload that grounds the recency-aware,
+# always-guiding re-entry line (orb-live.ts conversation-flow resume rung). Kept
+# short so a reopen stays fast; on timeout we compose a minimal continuity line
+# or fall through to the proactive opener. Optional — defaults to 1800 in code.
+ORB_RESUME_OVERVIEW_WAIT_MS=1800
+
 # Env vars read ONLY by the standalone latency probe
 # (services/gateway/scripts/orb-latency-probe.mjs) — never by the running
 # service. Documented here so the impact-scan env-binding check is satisfied.

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7795,30 +7795,124 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               }
             }
 
+            // CONVERSATION-FLOW RESUME REGISTER. Reaching here means: not a
+            // first-timer, and the full morning briefing did NOT fire this turn
+            // (already delivered today, or it could not build) — i.e. a SAME-DAY
+            // reopen. The unified decision picks a recency-appropriate register
+            // (continue / quick_resume / same_day) so a return after a minute is
+            // NEVER greeted with "good morning", and ALWAYS closes on a concrete
+            // guided next step (the Next-Best-Action engine). This replaces the
+            // old "proactive line, suppressed on a temporal new-day check" rung;
+            // the proactive/name rungs below remain only as a fallback when the
+            // payload could not be gathered in budget. See
+            // docs/CONVERSATION_FLOW_HANDOFF.md.
+            {
+              const _isFirstTimeR =
+                (session as any).greetingNeedsOnboarding === true ||
+                (session as any).greetingIsFirstTime === true;
+              const _uidR = session.identity?.user_id;
+              const _supaR = getSupabase();
+              const _langKeyR = (lang || 'en').slice(0, 2).toLowerCase();
+              const _langOkR = _langKeyR === 'de' || _langKeyR === 'en';
+              if (_langOkR && !_isFirstTimeR && _uidR && _supaR) {
+                try {
+                  const _lastIxR = describeTimeSince((session as any).lastSessionInfo);
+                  const { decideOpeningRegister, buildResumeDirective } = await import('../services/conversation/decide-opening');
+                  const _registerR = decideOpeningRegister({
+                    bucket: _lastIxR.bucket,
+                    isFirstTime: false,
+                    briefingDue: false,
+                  });
+                  if (_registerR === 'continue' || _registerR === 'quick_resume' || _registerR === 'same_day') {
+                    const _tzR = session.clientContext?.timezone || 'UTC';
+                    const _nowR = new Date();
+                    const { gatherOverviewPayload } = await import('../services/assistant-continuation/providers/new-day-overview-payload');
+                    const { todayInTimezone } = await import('../services/assistant-continuation/providers/new-day-return');
+                    const _lastSessIsoR = (session as any).lastSessionInfo?.time ?? null;
+                    const _lastSessDateR =
+                      typeof _lastSessIsoR === 'string' && _lastSessIsoR.length > 0
+                        ? todayInTimezone(new Date(_lastSessIsoR), _tzR)
+                        : null;
+                    // Bounded — a reopen must stay fast; on timeout we still
+                    // compose a minimal continuity line, else fall through.
+                    const _payloadR = await Promise.race([
+                      gatherOverviewPayload({
+                        supabase: _supaR,
+                        userId: _uidR,
+                        now: _nowR,
+                        timezone: _tzR,
+                        lang,
+                        lastSessionDateUserTz: _lastSessDateR,
+                        lastSessionAtIso: _lastSessIsoR,
+                      }),
+                      new Promise<null>((r) => setTimeout(() => r(null), Number(process.env.ORB_RESUME_OVERVIEW_WAIT_MS || 1800))),
+                    ]).catch(() => null);
+                    const _seedR = Math.floor((_nowR.getTime() - Date.UTC(_nowR.getUTCFullYear(), 0, 0)) / 86_400_000);
+                    const { text: _dirR, nba: _nbaR } = buildResumeDirective({
+                      register: _registerR,
+                      payload: _payloadR,
+                      firstName: (session as any).greetingFirstName ?? null,
+                      lang,
+                      timeAgo: _lastIxR.timeAgo,
+                      rotationSeed: _seedR,
+                    });
+                    // CONTINUE/quick_resume can speak with no payload (pure
+                    // thread continuation); same_day needs at least the NBA or a
+                    // recall to be worth speaking, else fall through to proactive.
+                    const _worthSpeaking =
+                      _registerR !== 'same_day' || !!_payloadR;
+                    if (_dirR && _dirR.trim().length > 0 && _worthSpeaking) {
+                      ws.send(
+                        JSON.stringify({
+                          client_content: { turns: [{ role: 'user', parts: [{ text: _dirR }] }], turn_complete: true },
+                        }),
+                      );
+                      emitDiag(session, 'greeting_sent', {
+                        lang,
+                        wake_opener: 'conv_resume',
+                        register: _registerR,
+                        bucket: _lastIxR.bucket,
+                        nba: _nbaR?.key ?? null,
+                        nba_domain: _nbaR?.domain ?? null,
+                      });
+                      startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
+                      console.log(
+                        `[GREETING-CONV-RESUME] session ${session.sessionId} register=${_registerR} bucket=${_lastIxR.bucket} nba=${_nbaR?.key ?? 'none'} lang=${lang}`,
+                      );
+                      return;
+                    }
+                  }
+                } catch (_resumeErr) {
+                  console.warn(
+                    `[GREETING-CONV-RESUME] non-fatal, falling through: ${_resumeErr instanceof Error ? _resumeErr.message : String(_resumeErr)}`,
+                  );
+                }
+              }
+            }
+
             // DEV-COMHU-0513 (proactive fast greeting): when the fast pre-fetch
             // produced a SHORT proactive opener (name + concrete next step /
             // weakness lead), speak THAT instead of the generic SHORT_GAP phrase
             // or the bare "Good <tod>, <Name>". It is kept to ~2 short sentences
             // so Gemini Live reliably emits audio. This is the top of the fast-
             // greeting ladder: proactive line → name greeting → generic opener.
-            // FIRST-GREETING-OF-THE-DAY: on a genuine new-day return the rich
-            // morning overview (the rung above) owns turn 1. If the overview
-            // could not build (e.g. no calendar/goal content yet, or the
-            // aggregator lost its budget), we want the grounded "Good <tod>,
-            // <Name>." new-day opener BELOW — never the bare proactive
-            // next-step lead ("Ich nehme dich mit zum nächsten Schritt"), which
-            // is what made the morning summary feel like it disappeared. So
-            // suppress the proactive opener on a genuine new-day return; it
-            // still fires for same-day reopenings (reconnect/recent/same_day).
-            const _ladderTemporal = describeTimeSince((session as any).lastSessionInfo);
-            const _ladderIsNewDay =
-              _ladderTemporal.bucket === 'today' ||
-              _ladderTemporal.bucket === 'yesterday' ||
-              _ladderTemporal.bucket === 'week' ||
-              _ladderTemporal.bucket === 'long';
-            const proactiveLine: unknown = _ladderIsNewDay
-              ? null
-              : (session as any).greetingProactiveLine;
+            // The rich morning briefing (overview rung above) owns turn 1 on the
+            // FIRST session of a real day and RETURNS when it fires. Reaching this
+            // rung therefore means the briefing did NOT fire this turn — either it
+            // was already delivered today (durable last_full_briefing_date flag),
+            // or it could not build. In BOTH cases the proactive continuity opener
+            // ("letztes Mal ging es um X — machen wir weiter") is exactly the
+            // "short after" we want.
+            //
+            // It used to be suppressed here on a temporal "is it a new day?" check
+            // (describeTimeSince bucket today/yesterday/week/long). That made sense
+            // when the briefing was ALSO gated on that temporal check, but the
+            // briefing is now flag-gated — so the temporal suppression left same-day
+            // reopens with only a bare "Good <tod>, <Name>" (the safe_fast_newday
+            // rung) instead of the continuity line. Use the proactive opener
+            // whenever the prefetch produced one; the overview rung already owns
+            // the genuine briefing-due turn and returned before reaching here.
+            const proactiveLine: unknown = (session as any).greetingProactiveLine;
             if (typeof proactiveLine === 'string' && proactiveLine.trim().length > 0) {
               const safeProactive = proactiveLine.trim().replace(/"/g, '\\"');
               const proactivePrompt =

--- a/services/gateway/src/services/conversation/decide-opening.ts
+++ b/services/gateway/src/services/conversation/decide-opening.ts
@@ -1,0 +1,160 @@
+/**
+ * Conversation Flow — the ONE opening decision.
+ *
+ * Replaces the brittle ladder of independent greeting rungs (temporal bucket →
+ * flag → first-time → proactive → bare-name, each fired/suppressed in isolation)
+ * with a single decision computed from the FULL context bundle. Every register
+ * draws from the same data and ALWAYS closes on a concrete guided next step
+ * (the Next-Best-Action engine) — Vitana never just reports, it always advises.
+ *
+ * Recency decides the register FIRST, so a return after one minute is never
+ * greeted with "good morning":
+ *
+ *   first_time     never onboarded                    → onboarding welcome
+ *   daily_briefing first session of a new real day    → full rich briefing (once/day)
+ *   continue       reconnect (<2 min)                 → no greeting, pick up the thread
+ *   quick_resume   recent (<15 min)                   → micro-ack, NO time-of-day, + NBA
+ *   same_day       hours later, same calendar day     → light re-entry + what's new + NBA
+ *
+ * Multi-day gaps (yesterday/week/long) always have a stale once-per-day flag, so
+ * they resolve to `daily_briefing` — the briefing itself acknowledges the absence.
+ *
+ * This module is transport-agnostic and (apart from delegating the rich-briefing
+ * render) pure: it returns the directive text to hand the LLM as the first-turn
+ * compose instruction, plus telemetry describing WHY it chose. See
+ * docs/CONVERSATION_FLOW_HANDOFF.md for the Command-Hub "Conversation" section
+ * that will visualise/configure all of this.
+ */
+
+import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../../orb/live/instruction/wake-brief-marker';
+import type { OverviewPayload } from '../assistant-continuation/providers/new-day-overview-payload';
+import type { TemporalBucket } from '../guide/temporal-bucket';
+import { selectNextBestAction, type NextBestAction } from './next-best-action';
+
+export type OpeningRegister =
+  | 'first_time'
+  | 'daily_briefing'
+  | 'continue'
+  | 'quick_resume'
+  | 'same_day';
+
+export interface DecideRegisterInput {
+  bucket: TemporalBucket;
+  isFirstTime: boolean;
+  /** Durable once-per-real-day briefing flag is stale → the full briefing is due. */
+  briefingDue: boolean;
+}
+
+/**
+ * Pick the register. Recency-FIRST for same-day reopens; onboarding and the
+ * once-per-day briefing flag take precedence over recency for the big moments.
+ */
+export function decideOpeningRegister(input: DecideRegisterInput): OpeningRegister {
+  if (input.isFirstTime) return 'first_time';
+  // The full briefing owns the first session of a real day (any gap length —
+  // the flag is stale). Multi-day returns land here too.
+  if (input.briefingDue) return 'daily_briefing';
+  // Briefing already delivered today → this is a same-day reopen. Frame by recency.
+  switch (input.bucket) {
+    case 'reconnect':
+      return 'continue';
+    case 'recent':
+      return 'quick_resume';
+    case 'same_day':
+    case 'today':
+    default:
+      return 'same_day';
+  }
+}
+
+export interface ResumeDirectiveInput {
+  register: Exclude<OpeningRegister, 'first_time' | 'daily_briefing'>;
+  payload: OverviewPayload | null;
+  firstName: string | null;
+  lang: string;
+  /** Human "time ago" phrase from describeTimeSince (e.g. "about 3 hours ago"). */
+  timeAgo: string;
+  /** Rotation seed (day-of-year) so the guided nudge varies. */
+  rotationSeed?: number;
+}
+
+export interface ResumeDirective {
+  text: string;
+  nba: NextBestAction | null;
+}
+
+/**
+ * Compose the first-turn directive for a same-day reopen (continue / quick_resume
+ * / same_day). The model composes ONE short, natural line in the user's language
+ * from the structured pieces — recency framing, the where-we-left-off thread,
+ * what is genuinely new, and the guided next step. Nothing is hardcoded; every
+ * field is gated on real data.
+ */
+export function buildResumeDirective(input: ResumeDirectiveInput): ResumeDirective {
+  const { register, payload, lang } = input;
+  const nba = payload ? selectNextBestAction(payload, { rotationSeed: input.rotationSeed }) : null;
+
+  const recall = payload?.guided_journey?.last_session_recall ?? null;
+  const newBits: string[] = [];
+  if (payload) {
+    if (payload.matches_unread > 0) newBits.push(`${payload.matches_unread} new match(es)`);
+    if (payload.messages_unread > 0) newBits.push(`${payload.messages_unread} unread message(s)`);
+    if (payload.reminders_today && payload.reminders_today.count > 0) newBits.push(`${payload.reminders_today.count} reminder(s) due today`);
+  }
+
+  // Register-specific framing rules the model must obey.
+  const framing =
+    register === 'continue'
+      ? `REGISTER: CONTINUE (the user reopened seconds ago — they never really left).\n` +
+        `- Do NOT greet. No "hello", no time-of-day, no name salutation. Just pick the thread back up.\n` +
+        `- One short sentence: carry on from where you were, then the suggested next step.`
+      : register === 'quick_resume'
+        ? `REGISTER: QUICK RESUME (the user reopened a few minutes ago).\n` +
+          `- Do NOT use a time-of-day greeting ("good morning/afternoon"). A bare "${input.firstName ? input.firstName + ', ' : ''}" warm reconnect at most.\n` +
+          `- Acknowledge anything genuinely NEW since they were just here, then the suggested next step.`
+        : `REGISTER: SAME-DAY RETURN (the user is back later the same day, ${input.timeAgo}).\n` +
+          `- A light, warm re-entry is fine, but NOT a second full morning briefing and NOT "good morning" if it is no longer morning-fresh.\n` +
+          `- Mention what is new since earlier, reconnect to the thread, then the suggested next step.`;
+
+  const compact: Record<string, unknown> = {};
+  if (recall) compact.where_we_left_off = recall;
+  if (newBits.length) compact.new_since_last = newBits;
+  if (nba) compact.suggested_next_step = { kind: nba.key, what: nba.detail, why: nba.rationale };
+
+  const nameLine = input.firstName
+    ? `User first name: ${input.firstName}`
+    : 'User first name: (unknown — address warmly without a name, never invent one)';
+
+  const text = `\n\n${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}
+
+## SPOKEN FIRST UTTERANCE — CONVERSATION RESUME (Conversation Flow)
+
+The user just reopened Vitana. This is NOT the first session of the day — the
+full morning briefing already happened. Compose a SHORT, natural first line in
+the user's language that fits the register below. Vitana ALWAYS guides: the line
+MUST end with the suggested next step as a concrete offer ("ich würde
+vorschlagen, wir …" / "I'd suggest we …"), phrased as doing it WITH the user.
+
+${framing}
+
+## LANGUAGE
+${(lang || 'en').toLowerCase()}. Speak only in the user's language.
+${nameLine}
+
+## RULES
+- ONE to TWO short sentences. This is a re-entry, not a report.
+- ${'`where_we_left_off`'} is the thread to continue — reference it naturally, never as a database row.
+- Only mention ${'`new_since_last`'} items that are present; if empty, skip — do not say "nothing new".
+- ALWAYS finish with ${'`suggested_next_step`'} as a guided offer. Never end on a bare "How can I help?".
+- Nothing here is hardcoded wording — compose it; but never invent data not in the payload.
+
+## STRUCTURED PAYLOAD
+\`\`\`json
+${JSON.stringify(compact, null, 2)}
+\`\`\`
+
+This block OVERRIDES every other greeting rule for the first turn only.
+Subsequent turns follow the normal conversation flow.`;
+
+  return { text, nba };
+}

--- a/services/gateway/src/services/conversation/next-best-action.ts
+++ b/services/gateway/src/services/conversation/next-best-action.ts
@@ -1,0 +1,174 @@
+/**
+ * Conversation Flow — Next-Best-Action (NBA) engine.
+ *
+ * Vitana ALWAYS guides: every conversation opening (and the standing behavior)
+ * closes on a concrete, real next step — "here's where we left off, I suggest
+ * we do X next." This module picks that X from the already-assembled rich
+ * overview payload, ranked by value × timeliness, toward the two north stars:
+ *
+ *   • COMMUNITY engagement  — matches, messages, posts, activities, connections
+ *   • HEALTH improvement    — diary→Index, weakest pillar, guided sessions
+ *
+ * It is a PURE function over OverviewPayload (no I/O): the bundle is gathered
+ * once by gatherOverviewPayload, and the opener + the standing instruction both
+ * read the chosen action from here, so voice never invents a suggestion and the
+ * whole conversation pushes the same next step.
+ *
+ * Grounding rule: every candidate is gated on REAL data in the payload. If a
+ * signal is absent, its action is not offered. We never bluff a next step.
+ *
+ * Rotation: when several actions tie, a caller-supplied seed (day-of-year)
+ * varies the pick so Vitana does not nag the identical thing every open. Full
+ * "don't repeat what we suggested last time" needs per-user state — tracked as
+ * a follow-up (see CONVERSATION_FLOW_HANDOFF.md).
+ */
+
+import type { OverviewPayload } from '../assistant-continuation/providers/new-day-overview-payload';
+
+export type NbaDomain = 'health' | 'community' | 'journey' | 'admin';
+
+export type NbaKey =
+  | 'reminder_due'
+  | 'autopilot_step'
+  | 'reply_messages'
+  | 'review_matches'
+  | 'next_session'
+  | 'diary_entry'
+  | 'focus_pillar'
+  | 'make_post'
+  | 'create_activity'
+  | 'connect_community'
+  | 'set_goal';
+
+export interface NextBestAction {
+  key: NbaKey;
+  domain: NbaDomain;
+  /** Priority band (higher = more urgent). For telemetry + tie-breaks. */
+  band: number;
+  /** The concrete thing, with real specifics (titles/counts) for the prompt to
+   *  weave into a natural suggestion. NOT a finished user-facing sentence. */
+  detail: string;
+  /** Why-now, grounding the model so the suggestion reads as reasoned. */
+  rationale: string;
+}
+
+export interface NbaContext {
+  /** Day-of-year (user tz) — varies tie-broken picks so the nudge rotates. */
+  rotationSeed?: number;
+}
+
+/**
+ * Rank every grounded next-best-action for this user, most-valuable first.
+ * Bands (value × timeliness):
+ *   100 time-sensitive / waiting on the user (reminder due, prepared autopilot step, unread DMs)
+ *    80 continuity (the next guided session — the journey thread)
+ *    60 health momentum (diary gap → Index lift, weakest pillar)
+ *    40 community growth (new matches, then post / activity / connect openings)
+ */
+export function rankNextBestActions(p: OverviewPayload, ctx: NbaContext = {}): NextBestAction[] {
+  const out: NextBestAction[] = [];
+
+  // ---- Band 100: time-sensitive / waiting on the user --------------------
+  if (p.reminders_today && p.reminders_today.count > 0 && p.reminders_today.next) {
+    out.push({
+      key: 'reminder_due',
+      domain: 'admin',
+      band: 100,
+      detail: p.reminders_today.next.action_text,
+      rationale: `A reminder is due today (${p.reminders_today.count} total) — act on it before it slips.`,
+    });
+  }
+  if (p.autopilot && p.autopilot.state === 'has_actions' && p.autopilot.today_checkpoint) {
+    out.push({
+      key: 'autopilot_step',
+      domain: 'health',
+      band: 98,
+      detail: p.autopilot.today_checkpoint.title,
+      rationale: 'Autopilot has already prepared the next step — offer to start it.',
+    });
+  }
+  if (p.messages_unread > 0) {
+    out.push({
+      key: 'reply_messages',
+      domain: 'community',
+      band: 92,
+      detail: `${p.messages_unread} unread message(s)`,
+      rationale: 'People are waiting on a reply — responding keeps the community warm.',
+    });
+  }
+
+  // ---- Band 80: continuity (the guided-journey thread) -------------------
+  if (p.guided_journey && p.guided_journey.next_session_title) {
+    out.push({
+      key: 'next_session',
+      domain: 'journey',
+      band: 80,
+      detail: p.guided_journey.next_session_title,
+      rationale: `Continue the guided journey — ${p.guided_journey.sessions_completed} sessions done so far.`,
+    });
+  }
+
+  // ---- Band 60: health momentum ------------------------------------------
+  if (p.diary_last_7d === 0) {
+    out.push({
+      key: 'diary_entry',
+      domain: 'health',
+      band: 62,
+      detail: 'a short diary entry',
+      rationale: 'No diary entry in 7 days — a quick entry nudges the Vitana Index up.',
+    });
+  }
+  if (p.vitana_index && p.vitana_index.state === 'ok' && p.vitana_index.weakest_pillar) {
+    out.push({
+      key: 'focus_pillar',
+      domain: 'health',
+      band: 58,
+      detail: p.vitana_index.weakest_pillar.name,
+      rationale: `Weakest Index pillar is ${p.vitana_index.weakest_pillar.name} (${p.vitana_index.weakest_pillar.score}) — one small move lifts it.`,
+    });
+  }
+
+  // ---- Band 40: community growth -----------------------------------------
+  if (p.matches_unread > 0) {
+    out.push({
+      key: 'review_matches',
+      domain: 'community',
+      band: 44,
+      detail: `${p.matches_unread} new match(es)`,
+      rationale: 'Fresh matches are waiting — looking at them grows real connections.',
+    });
+  }
+  // Always-available community-growth openings (no precondition signal). These
+  // are the lowest band so they only surface when nothing more specific exists,
+  // and the rotation seed varies which one is offered.
+  const growthPool: NextBestAction[] = [
+    { key: 'make_post', domain: 'community', band: 30, detail: 'share a short update with the community', rationale: 'Posting keeps you visible and grows engagement.' },
+    { key: 'create_activity', domain: 'community', band: 30, detail: 'create an activity others can join', rationale: 'Activities turn the community into real-world meetups.' },
+    { key: 'connect_community', domain: 'community', band: 30, detail: 'like or comment on someone’s post', rationale: 'A small interaction strengthens the network.' },
+  ];
+  const seed = Number.isFinite(ctx.rotationSeed) ? (ctx.rotationSeed as number) : 0;
+  out.push(growthPool[((seed % growthPool.length) + growthPool.length) % growthPool.length]);
+
+  // Life Compass not set → a one-time set-goal nudge (low band; the briefing's
+  // own setup-gap handling covers the rich case, this is the NBA fallback).
+  if (p.life_compass && p.life_compass.state === 'not_set') {
+    out.push({
+      key: 'set_goal',
+      domain: 'health',
+      band: 26,
+      detail: 'set your Life Compass goal',
+      rationale: 'No goal set yet — naming one gives the whole journey direction.',
+    });
+  }
+
+  // Stable sort by band desc; ties keep insertion order (already priority-ordered).
+  return out.sort((a, b) => b.band - a.band);
+}
+
+/** The single next-best-action to lead the always-guiding close. Null only when
+ *  the user has literally nothing actionable (the growth pool guarantees at
+ *  least one, so this is effectively never null for a real user). */
+export function selectNextBestAction(p: OverviewPayload, ctx: NbaContext = {}): NextBestAction | null {
+  const ranked = rankNextBestActions(p, ctx);
+  return ranked.length > 0 ? ranked[0] : null;
+}

--- a/services/gateway/test/services/conversation/conversation-flow.test.ts
+++ b/services/gateway/test/services/conversation/conversation-flow.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Conversation Flow — register decision + Next-Best-Action ranking.
+ *
+ * Locks the two behaviours the user explicitly demanded:
+ *  1. Recency decides the register FIRST — a return after a minute is NEVER a
+ *     "good morning" briefing; the briefing owns only the first session of a day.
+ *  2. Every opening has a guided next step (NBA), ranked by value × timeliness,
+ *     and always grounded in real data.
+ */
+
+import { decideOpeningRegister } from '../../../src/services/conversation/decide-opening';
+import { rankNextBestActions, selectNextBestAction } from '../../../src/services/conversation/next-best-action';
+import type { OverviewPayload } from '../../../src/services/assistant-continuation/providers/new-day-overview-payload';
+
+function emptyPayload(over: Partial<OverviewPayload> = {}): OverviewPayload {
+  return {
+    journey: null,
+    vitana_index: {
+      state: 'ok', today: 200, tier: 'Early', tier_framing: null, trend_7d: 0,
+      weakest_pillar: { name: 'nutrition', score: 30 }, strongest_pillar: null,
+      balance_label: 'balanced', pillars: null, projected_day_90: null, projected_day_90_tier: null,
+    },
+    life_compass: {
+      state: 'set', primary_goal: 'longer life', category: null, target_date: null,
+      target_value: null, target_unit: null, starting_value: null, set_at: null,
+      days_to_deadline: null, goal_progress_pct: null,
+    },
+    calendar_today: { count: 0, next: null },
+    calendar_passed: { count: 0, most_recent: null },
+    autopilot: { state: 'none_yet', today_checkpoint: null, this_week: [], pending_total: 0 },
+    matches_unread: 0,
+    messages_unread: 0,
+    reminders_today: { count: 0, next: null },
+    diary_last_7d: 3,
+    guided_journey: null,
+    last_session_date_user_tz: null,
+    ...over,
+  };
+}
+
+describe('decideOpeningRegister — recency-first', () => {
+  it('first-timer → first_time regardless of recency', () => {
+    expect(decideOpeningRegister({ bucket: 'reconnect', isFirstTime: true, briefingDue: true })).toBe('first_time');
+  });
+  it('briefing due (first session of a real day) → daily_briefing, any gap', () => {
+    expect(decideOpeningRegister({ bucket: 'long', isFirstTime: false, briefingDue: true })).toBe('daily_briefing');
+    expect(decideOpeningRegister({ bucket: 'yesterday', isFirstTime: false, briefingDue: true })).toBe('daily_briefing');
+  });
+  it('same-day reopen after the briefing → recency register, NEVER a re-briefing', () => {
+    expect(decideOpeningRegister({ bucket: 'reconnect', isFirstTime: false, briefingDue: false })).toBe('continue');
+    expect(decideOpeningRegister({ bucket: 'recent', isFirstTime: false, briefingDue: false })).toBe('quick_resume');
+    expect(decideOpeningRegister({ bucket: 'same_day', isFirstTime: false, briefingDue: false })).toBe('same_day');
+    expect(decideOpeningRegister({ bucket: 'today', isFirstTime: false, briefingDue: false })).toBe('same_day');
+  });
+});
+
+describe('rankNextBestActions — value × timeliness, always grounded', () => {
+  it('time-sensitive (reminder/autopilot/messages) outrank continuity and community', () => {
+    const p = emptyPayload({
+      reminders_today: { count: 1, next: { action_text: 'take vitamin D', next_fire_at: 'x' } },
+      messages_unread: 5,
+      guided_journey: { sessions_completed: 8, topics_learned: 18, topics_total: 90, next_session_title: 'Vitana Index', last_session_recall: 'Vitana Index' },
+      matches_unread: 15,
+    });
+    const ranked = rankNextBestActions(p, { rotationSeed: 0 });
+    expect(ranked[0].key).toBe('reminder_due');
+    // continuity (next_session) ranks above community growth (matches)
+    const sessionIdx = ranked.findIndex((a) => a.key === 'next_session');
+    const matchesIdx = ranked.findIndex((a) => a.key === 'review_matches');
+    expect(sessionIdx).toBeLessThan(matchesIdx);
+  });
+
+  it('never invents: a payload with no signals still offers a community-growth nudge, nothing fabricated', () => {
+    const p = emptyPayload();
+    const nba = selectNextBestAction(p, { rotationSeed: 1 });
+    expect(nba).not.toBeNull();
+    expect(['make_post', 'create_activity', 'connect_community', 'focus_pillar']).toContain(nba!.key);
+  });
+
+  it('diary gap surfaces a health-momentum entry suggestion', () => {
+    const p = emptyPayload({ diary_last_7d: 0 });
+    const keys = rankNextBestActions(p).map((a) => a.key);
+    expect(keys).toContain('diary_entry');
+  });
+});


### PR DESCRIPTION
## Why

The opener was a **ladder of disconnected rungs** — each added as a separate fix, none sharing one notion of context. Result: a return after one minute still said *"Guten Morgen, Dragan."* with nothing else. That bare greeting was the symptom of the real disease: **no single, context-aware opening decision.**

(Root cause confirmed from telemetry: the briefing was decoupled from the temporal "new day" check — now flag-gated — but the proactive opener was *still* suppressed by that check, so same-day reopens fell through to the bare `safe_fast_newday` name rung.)

## What (the design the user approved)

**One opening decision from the full context, rendered at the right depth, always ending on a guided next step.**

### Recency decides the register FIRST
`decideOpeningRegister` → `first_time` · `daily_briefing` (first session of a real day, once/day) · `continue` (<2 min, **no greeting**) · `quick_resume` (<15 min, **no "good morning"**) · `same_day` (hours later, light re-entry). A 1-minute return is never a "good morning" briefing.

### Vitana ALWAYS guides — Next-Best-Action engine
`next-best-action.ts` ranks **grounded** actions by value × timeliness across the two north stars:
- **Community:** reply messages, review matches, make a post, create an activity, connect
- **Health:** autopilot step, diary→Index, weakest pillar, next guided session, set goal

Never bluffs — absent signal → action not offered. Every register closes on the top pick ("ich würde vorschlagen, wir …").

## Files
- `services/conversation/next-best-action.ts` — NBA engine (pure)
- `services/conversation/decide-opening.ts` — register decision + resume composition
- `routes/orb-live.ts` — recency-aware resume rung wired into the SAFE-FAST path
- `test/services/conversation/conversation-flow.test.ts` — locks recency-first + grounded NBA
- **`docs/CONVERSATION_FLOW_HANDOFF.md`** — full engine spec **+ build spec for the Command Hub "Conversation" section** (next session)

## Verification
- `tsc` + full `npm run build` clean; new suite 6/6.
- Post-merge staging: open ORB (first of day) → full briefing; reopen minutes later → **continuity + guided next step, no "Guten Morgen"**; telemetry shows `register`/`bucket`/`nba`.

## Note for the next session
Per the user: the Command Hub will get a new **"Conversation"** section that visualises/configures this engine. `CONVERSATION_FLOW_HANDOFF.md` §6 is the build spec; everything needed (file map, telemetry fields, register/NBA model, open follow-ups) is captured there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_