### PR TITLE
fix(orb): make the conversation opener ADVANCE — stateful, non-repeating next steps

### DIFF
--- a/docs/CONVERSATION_FLOW_HANDOFF.md
+++ b/docs/CONVERSATION_FLOW_HANDOFF.md
@@ -79,10 +79,14 @@ bluffs) by **band = value × timeliness**, then picks the top to lead the close.
 - **Community engagement:** reply_messages, review_matches, make_post, create_activity, connect_community
 - **Health improvement:** autopilot_step, diary_entry, focus_pillar, next_session, set_goal
 
-**Known follow-up:** rotation is currently a day-of-year seed (varies daily). True
-"don't repeat the same suggestion two opens in a row" needs per-user NBA history —
-add a `last_nba_key` + timestamp (e.g. on `user_journey` or a small `nba_log`
-table) and pass it into `rankNextBestActions` to demote the just-suggested action.
+**Non-repetition (DONE):** the opener ADVANCES — it never repeats the same
+suggestion two opens in a row. A durable per-user history `user_journey.recent_nbas`
+(jsonb array of action keys, last ~8) is read in the greeting prefetch and passed
+to `selectNextBestAction({ recentKeys, cooldown: 3 })`, which skips the last 3
+suggestions and picks the next-best fresh action; the chosen key is appended after
+speaking. The resume prompt is also told `already_offered_recently` so the model
+explicitly moves the conversation forward. The day-of-year `rotationSeed` still
+varies ties within the always-available community-growth pool.
 
 ---
 

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -747,6 +747,10 @@ export async function handleLiveSessionStart(
   // the briefing fires on the first session of a day where this is stale, then
   // same-day reopens get the short proactive opener.
   let greetingLastFullBriefingDate: string | null = null;
+  // Durable per-user history of recently-suggested next-best-actions (keys,
+  // most-recent last) from user_journey.recent_nbas. Lets the resume opener
+  // ADVANCE past what it already suggested instead of repeating it.
+  let greetingRecentNbaKeys: string[] = [];
 
   // VTID-03294: a Guided-Journey topic tap needs ZERO context — Vitana just
   // picks up the KB lesson and speaks it. Detect it here so we can skip the
@@ -951,7 +955,7 @@ export async function handleLiveSessionStart(
             supa
               ? supa
                   .from('user_journey')
-                  .select('is_first_session, last_full_briefing_date')
+                  .select('is_first_session, last_full_briefing_date, recent_nbas')
                   .eq('user_id', _ndIdentity.user_id)
                   .maybeSingle()
               : Promise.resolve(null as any),
@@ -976,12 +980,22 @@ export async function handleLiveSessionStart(
             firstSessionResult.value &&
             !firstSessionResult.value.error
           ) {
-            const _fsRow = firstSessionResult.value.data as { is_first_session?: boolean | null; last_full_briefing_date?: string | null } | null;
+            const _fsRow = firstSessionResult.value.data as {
+              is_first_session?: boolean | null;
+              last_full_briefing_date?: string | null;
+              recent_nbas?: unknown;
+            } | null;
             // No row at all → user has never had a journey row → treat as first-time.
             greetingIsFirstSession = _fsRow ? _fsRow.is_first_session === true : true;
             // Durable once-per-day briefing flag (null when never delivered or
             // column absent → briefing is due).
             greetingLastFullBriefingDate = _fsRow?.last_full_briefing_date ?? null;
+            // Recent NBA history → keys (defensive: accept string[] or {key}[]).
+            if (Array.isArray(_fsRow?.recent_nbas)) {
+              greetingRecentNbaKeys = (_fsRow!.recent_nbas as unknown[])
+                .map((e) => (typeof e === 'string' ? e : (e as { key?: unknown })?.key))
+                .filter((k): k is string => typeof k === 'string' && k.length > 0);
+            }
           }
           if (
             journeyStateResult.status === 'fulfilled' &&
@@ -1156,6 +1170,7 @@ export async function handleLiveSessionStart(
     (session as any).greetingIsFirstTime = greetingIsFirstSession;
     (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
     (session as any).lastFullBriefingDate = greetingLastFullBriefingDate;
+    (session as any).recentNbaKeys = greetingRecentNbaKeys;
     if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
       session.lastSessionInfo = greetingEarlyLastSessionInfo;
     }
@@ -1167,6 +1182,7 @@ export async function handleLiveSessionStart(
       (session as any).greetingIsFirstTime = greetingIsFirstSession;
       (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
       (session as any).lastFullBriefingDate = greetingLastFullBriefingDate;
+      (session as any).recentNbaKeys = greetingRecentNbaKeys;
       // Idempotent with the heavy bootstrap block, which also sets this later.
       if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
         session.lastSessionInfo = greetingEarlyLastSessionInfo;

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7848,6 +7848,9 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                       new Promise<null>((r) => setTimeout(() => r(null), Number(process.env.ORB_RESUME_OVERVIEW_WAIT_MS || 1800))),
                     ]).catch(() => null);
                     const _seedR = Math.floor((_nowR.getTime() - Date.UTC(_nowR.getUTCFullYear(), 0, 0)) / 86_400_000);
+                    const _recentNbaKeysR = Array.isArray((session as any).recentNbaKeys)
+                      ? ((session as any).recentNbaKeys as string[])
+                      : [];
                     const { text: _dirR, nba: _nbaR } = buildResumeDirective({
                       register: _registerR,
                       payload: _payloadR,
@@ -7855,6 +7858,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                       lang,
                       timeAgo: _lastIxR.timeAgo,
                       rotationSeed: _seedR,
+                      recentNbaKeys: _recentNbaKeysR as any,
                     });
                     // CONTINUE/quick_resume can speak with no payload (pure
                     // thread continuation); same_day needs at least the NBA or a
@@ -7867,6 +7871,19 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                           client_content: { turns: [{ role: 'user', parts: [{ text: _dirR }] }], turn_complete: true },
                         }),
                       );
+                      // Record the suggested action in the durable per-user
+                      // history so the NEXT open advances past it instead of
+                      // repeating. Keep the last 8; fire-and-forget; mirror onto
+                      // the session for same-process re-opens.
+                      if (_nbaR?.key) {
+                        const _updatedNbas = [..._recentNbaKeysR, _nbaR.key].slice(-8);
+                        (session as any).recentNbaKeys = _updatedNbas;
+                        void _supaR
+                          .from('user_journey')
+                          .update({ recent_nbas: _updatedNbas })
+                          .eq('user_id', _uidR)
+                          .then(() => {}, () => {});
+                      }
                       emitDiag(session, 'greeting_sent', {
                         lang,
                         wake_opener: 'conv_resume',

--- a/services/gateway/src/services/conversation/decide-opening.ts
+++ b/services/gateway/src/services/conversation/decide-opening.ts
@@ -29,7 +29,7 @@
 import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../../orb/live/instruction/wake-brief-marker';
 import type { OverviewPayload } from '../assistant-continuation/providers/new-day-overview-payload';
 import type { TemporalBucket } from '../guide/temporal-bucket';
-import { selectNextBestAction, type NextBestAction } from './next-best-action';
+import { selectNextBestAction, type NextBestAction, type NbaKey } from './next-best-action';
 
 export type OpeningRegister =
   | 'first_time'
@@ -76,6 +76,10 @@ export interface ResumeDirectiveInput {
   timeAgo: string;
   /** Rotation seed (day-of-year) so the guided nudge varies. */
   rotationSeed?: number;
+  /** Durable per-user history of recently-suggested next steps (most-recent
+   *  last). The opener ADVANCES past these so it never repeats the same
+   *  suggestion two opens in a row. */
+  recentNbaKeys?: NbaKey[];
 }
 
 export interface ResumeDirective {
@@ -92,9 +96,22 @@ export interface ResumeDirective {
  */
 export function buildResumeDirective(input: ResumeDirectiveInput): ResumeDirective {
   const { register, payload, lang } = input;
-  const nba = payload ? selectNextBestAction(payload, { rotationSeed: input.rotationSeed }) : null;
+  const nba = payload
+    ? selectNextBestAction(payload, {
+        rotationSeed: input.rotationSeed,
+        recentKeys: input.recentNbaKeys,
+        cooldown: 3,
+      })
+    : null;
 
-  const recall = payload?.guided_journey?.last_session_recall ?? null;
+  // "Where we left off" is only REAL when it is an actual last-opened topic.
+  // The payload falls back to the next-session title when the last-opened topic
+  // is unknown — asserting that as "we were just on X" every open is the stale
+  // copy-paste the user called out, so we suppress it and let the (rotating)
+  // next step carry the re-entry instead.
+  const rawRecall = payload?.guided_journey?.last_session_recall ?? null;
+  const nextSessionTitle = payload?.guided_journey?.next_session_title ?? null;
+  const recall = rawRecall && rawRecall !== nextSessionTitle ? rawRecall : null;
   const newBits: string[] = [];
   if (payload) {
     if (payload.matches_unread > 0) newBits.push(`${payload.matches_unread} new match(es)`);
@@ -120,6 +137,9 @@ export function buildResumeDirective(input: ResumeDirectiveInput): ResumeDirecti
   if (recall) compact.where_we_left_off = recall;
   if (newBits.length) compact.new_since_last = newBits;
   if (nba) compact.suggested_next_step = { kind: nba.key, what: nba.detail, why: nba.rationale };
+  if (input.recentNbaKeys && input.recentNbaKeys.length) {
+    compact.already_offered_recently = input.recentNbaKeys.slice(-4);
+  }
 
   const nameLine = input.firstName
     ? `User first name: ${input.firstName}`
@@ -143,7 +163,13 @@ ${nameLine}
 
 ## RULES
 - ONE to TWO short sentences. This is a re-entry, not a report.
-- ${'`where_we_left_off`'} is the thread to continue — reference it naturally, never as a database row.
+- THIS IS A FRESH TURN — do NOT reuse the wording of a previous opener, and do
+  NOT re-offer anything in ${'`already_offered_recently`'}. Move the conversation
+  FORWARD to the new ${'`suggested_next_step`'}. Repeating the same suggestion is
+  forbidden — the user has heard it.
+- ${'`where_we_left_off`'}, when present, is a real thread to continue — reference
+  it naturally, never as a database row. When it is ABSENT, do NOT invent a "we
+  were just on X" line; lead with what's new and the next step instead.
 - Only mention ${'`new_since_last`'} items that are present; if empty, skip — do not say "nothing new".
 - ALWAYS finish with ${'`suggested_next_step`'} as a guided offer. Never end on a bare "How can I help?".
 - Nothing here is hardcoded wording — compose it; but never invent data not in the payload.

--- a/services/gateway/src/services/conversation/next-best-action.ts
+++ b/services/gateway/src/services/conversation/next-best-action.ts
@@ -55,6 +55,13 @@ export interface NextBestAction {
 export interface NbaContext {
   /** Day-of-year (user tz) — varies tie-broken picks so the nudge rotates. */
   rotationSeed?: number;
+  /** Keys Vitana already suggested recently (most-recent last), from the
+   *  durable per-user history. The selector skips these so each open ADVANCES
+   *  to the next-best fresh action instead of repeating the same suggestion. */
+  recentKeys?: NbaKey[];
+  /** How many of the most-recent suggestions to treat as "on cooldown".
+   *  Default 3 — cycles through the top handful before any can repeat. */
+  cooldown?: number;
 }
 
 /**
@@ -165,10 +172,18 @@ export function rankNextBestActions(p: OverviewPayload, ctx: NbaContext = {}): N
   return out.sort((a, b) => b.band - a.band);
 }
 
-/** The single next-best-action to lead the always-guiding close. Null only when
- *  the user has literally nothing actionable (the growth pool guarantees at
- *  least one, so this is effectively never null for a real user). */
+/** The single next-best-action to lead the always-guiding close — ADVANCING,
+ *  not repeating. Picks the highest-value action whose key was NOT among the
+ *  last `cooldown` suggestions, so each open moves to a fresh next step and only
+ *  revisits an action after cycling through the others. Falls back to the
+ *  top-ranked action when everything is on cooldown (small action sets). Null
+ *  only when there is literally nothing actionable (effectively never, thanks to
+ *  the always-available community-growth pool). */
 export function selectNextBestAction(p: OverviewPayload, ctx: NbaContext = {}): NextBestAction | null {
   const ranked = rankNextBestActions(p, ctx);
-  return ranked.length > 0 ? ranked[0] : null;
+  if (ranked.length === 0) return null;
+  const cooldown = Number.isFinite(ctx.cooldown) ? (ctx.cooldown as number) : 3;
+  const recent = new Set((ctx.recentKeys ?? []).slice(-cooldown));
+  const fresh = ranked.find((a) => !recent.has(a.key));
+  return fresh ?? ranked[0];
 }

--- a/services/gateway/test/services/conversation/conversation-flow.test.ts
+++ b/services/gateway/test/services/conversation/conversation-flow.test.ts
@@ -82,4 +82,22 @@ describe('rankNextBestActions — value × timeliness, always grounded', () => {
     const keys = rankNextBestActions(p).map((a) => a.key);
     expect(keys).toContain('diary_entry');
   });
+
+  it('ADVANCES, never repeats: recently-suggested actions are skipped for the next-best fresh one', () => {
+    const p = emptyPayload({
+      messages_unread: 26,
+      matches_unread: 15,
+      diary_last_7d: 0,
+      guided_journey: { sessions_completed: 8, topics_learned: 18, topics_total: 90, next_session_title: 'Vitana Index', last_session_recall: 'Vitana Index' },
+    });
+    // Open 1: top action (messages).
+    const a1 = selectNextBestAction(p, { recentKeys: [] })!;
+    expect(a1.key).toBe('reply_messages');
+    // Open 2: messages on cooldown → advances to the next-best (next_session).
+    const a2 = selectNextBestAction(p, { recentKeys: ['reply_messages'] })!;
+    expect(a2.key).not.toBe('reply_messages');
+    // Open 3: both prior on cooldown → advances again, still not repeating.
+    const a3 = selectNextBestAction(p, { recentKeys: ['reply_messages', a2.key as any] })!;
+    expect([a1.key, a2.key]).not.toContain(a3.key);
+  });
 });

--- a/supabase/migrations/20260627100000_add_recent_nbas.sql
+++ b/supabase/migrations/20260627100000_add_recent_nbas.sql
@@ -1,0 +1,10 @@
+-- Per-user history of the next-best-actions Vitana has already suggested, so the
+-- conversation opener ADVANCES instead of repeating the same suggestion every
+-- open. The Next-Best-Action engine reads this to demote recently-suggested
+-- actions and pick the next-best fresh one; the opener appends the chosen action
+-- after speaking it.
+--
+-- Shape: a JSON array of { key, at } objects, most-recent last, capped in code
+-- (~8 entries). Empty array = nothing suggested yet.
+ALTER TABLE public.user_journey
+  ADD COLUMN IF NOT EXISTS recent_nbas jsonb NOT NULL DEFAULT '[]'::jsonb;


### PR DESCRIPTION
## Why

The resume opener was **stateless** — it re-derived the same top action every open ("26 unread → answer your messages") and asserted the same static curriculum pointer ("wir waren bei Vitana Index") every time. Robotic copy-paste, not intelligence. As the user put it: real intelligence remembers what it suggested and advances to the **next** thing.

## What

**It now advances and remembers:**
- **Durable per-user history** `user_journey.recent_nbas` (new jsonb column). The greeting prefetch reads it; `selectNextBestAction({ recentKeys, cooldown: 3 })` skips the last 3 suggestions and picks the next-best **fresh** action; the chosen key is appended after speaking. So opens cycle — **messages → next session → diary → matches → …** — and only revisit an action after cycling the others, never back-to-back.
- **Prompt advances explicitly:** the resume directive receives `already_offered_recently` and is told to move the conversation **forward** and never reuse a prior opener's wording.
- **"Where we left off" only when real:** the next-session-title fallback (which caused the repeated "wir waren bei Vitana Index") is suppressed; the rotating next step carries the re-entry instead.

## Files
- `migration … add_recent_nbas` (applied to shared project)
- `services/conversation/next-best-action.ts` — rotation-aware select (recentKeys + cooldown)
- `services/conversation/decide-opening.ts` — real-recall gate + "advance, don't repeat" rules
- `orb/live/session/live-session-controller.ts` — read `recent_nbas` in prefetch
- `routes/orb-live.ts` — pass history + append chosen action after speaking
- `docs/CONVERSATION_FLOW_HANDOFF.md` — non-repetition marked DONE

## Verification
- `tsc` + full build clean; conversation suite **7/7** incl. a new *"advances, never repeats"* test.
- Post-merge staging: reopen the ORB several times in a row → each open suggests a **different** next step, no repeated "wir waren bei Vitana Index".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_