### PR TITLE
feat(orb): give the text brain the journey-modes knowledge (voice/text parity, part 1)

### DIFF
--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -36,6 +36,7 @@ import { computeRetrievalRouterDecision } from './retrieval-router';
 import { ContextLens, createContextLens } from '../types/context-lens';
 import { ConversationChannel, ContextPack } from '../types/conversation';
 import { getPersonalityConfigSync } from './ai-personality-service';
+import { buildJourneyModesSection } from '../orb/live/instruction/journey-modes-prompt';
 import { emitOasisEvent } from './oasis-event-service';
 import { getSupabase } from '../lib/supabase';
 // Proactive Guide Phase 0.5 + Companion Awareness Phase A (VTID-01927)
@@ -395,6 +396,13 @@ export async function buildBrainSystemInstruction(input: {
   const preferredLanguage = extractLanguageFromContextPack(contextPack);
   const languageDirective = buildLanguageDirective(preferredLanguage);
 
+  // NAV_GUIDED_JOURNEY — give the TEXT brain the same declarative knowledge the
+  // voice brain has (live-system-instruction.ts): what the two My Journey views
+  // (Guided/Einführung vs Full/Vollversion) are, so it can EXPLAIN the
+  // difference on demand instead of drawing a blank. Voice/text parity.
+  const journeyModesBlock =
+    process.env.NAV_GUIDED_JOURNEY === 'true' ? buildJourneyModesSection(preferredLanguage || 'de') : '';
+
   const ucConfig = getPersonalityConfigSync('unified_conversation') as Record<string, any>;
   const baseInstruction = input.channel === 'orb'
     ? (ucConfig.orb_instruction || 'You are Vitana, an intelligent voice assistant. Keep responses concise and conversational for voice interaction.')
@@ -414,6 +422,7 @@ ${languageDirective}
 ${identityGuardrailBlock}
 ${contextForLLM}
 ${lifeCompassBlock}
+${journeyModesBlock}
 
 Current conversation channel: ${input.channel}
 User's role: ${input.role}


### PR DESCRIPTION
## Summary

Voice/text parity, **part 1 (knowledge)**. The in-app text chat (`conversation.ts → vitana-brain`) is a separate pipeline from ORB voice and never got the guided/full journey work — which is why your staging chat saw Vitana offer "die Vollversion" then fail to explain or act. The journey-modes knowledge block (#2777) was injected **only** into the voice system instruction.

This injects the same `buildJourneyModesSection` block into **`vitana-brain`'s** system prompt (the text brain), gated by `NAV_GUIDED_JOURNEY` (already on staging), in the user's language. The text brain can now **explain** the Guided/Einführung vs Full/Vollversion difference on demand — matching voice.

## Scope (the parity is staged)
- ✅ **Resolution** ("Vollversion" → My Journey, both paths) — shipped shared in #2789.
- ✅ **Knowledge** (explain the difference in text) — **this PR**.
- ⏳ **Mode flip** in text (`setJourneyMode`) — remaining. The text LLM's navigate executes through the shared `orb-tools-shared` dispatcher; whether it carries the guided/full intent there needs live tracing of the text tool path. Tracked as the focused next step — I didn't want to push a speculative change into the text tool-execution pipeline I can't verify live.

## Verification
- `journey-modes-prompt` 3/3; `tsc --noEmit` ✅.
- Verify on staging (text): *"was ist der Unterschied zwischen der geführten Journey und der Vollversion?"* → Vitana explains both views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQdEpdQBd6xyVF5e9bLfbS)_