### PR TITLE
feat(orb): screen-aware, completion-driven conversation guidance

### DIFF
--- a/docs/CONVERSATION_FLOW_HANDOFF.md
+++ b/docs/CONVERSATION_FLOW_HANDOFF.md
@@ -90,6 +90,39 @@ varies ties within the always-available community-growth pool.
 
 ---
 
+## 3b. Screen awareness & action COMPLETION
+
+Vitana knows the user's current screen (`session.current_route`, sent by the
+client at session start, kept fresh on navigation) and uses it to **deepen toward
+completing the action**, never to redirect the user to a screen they are already
+on.
+
+- `services/conversation/screen-surface.ts` — `surfaceForRoute(route)` maps a
+  route to a `ConversationSurface` (matches / chat / community / diary / index /
+  profile / journey / news / home / other); `screenCompletionFor(surface)` returns
+  the **completion action** (band 115, above every redirect/discovery action) and
+  the `redirect_key` to suppress while on that surface.
+- In `buildResumeDirective`, when the user is on an actionable surface the next
+  step becomes the completion action — e.g. on **/matches**: *pick one and start a
+  joint activity / tell them who a match is / suggest an Index-boosting activity /
+  refine criteria / enrich profile* — and the prompt is told `current_screen` +
+  `complete_on_current_screen` with a HARD rule never to say "open X" while on X.
+
+Completion mapping (the goal is to FINISH, not navigate):
+
+| Surface | Completion next step |
+|---|---|
+| matches | pick a match & start a joint activity / who is this person / Index-boosting activity / refine criteria / enrich profile |
+| chat | actually write & send the reply |
+| community | draft & publish the post / create the activity |
+| diary | make today's entry now (lifts the Index) |
+| index | one concrete weakest-pillar action to raise it |
+| profile | add one more profile detail → better matches |
+
+**Telemetry:** `current_route` is now on the `conv_resume` greeting event.
+**Command-Hub:** the "Conversation" section should show the per-surface completion
+map and let an operator edit the completion offers (ideally policy-backed).
+
 ## 4. Where everything lives (file map)
 
 | File | Role |

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7859,12 +7859,16 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                       timeAgo: _lastIxR.timeAgo,
                       rotationSeed: _seedR,
                       recentNbaKeys: _recentNbaKeysR as any,
+                      // Screen awareness: deepen toward completing the action on
+                      // the screen the user is already on, never redirect there.
+                      currentScreen: (session as any).current_route ?? null,
                     });
                     // CONTINUE/quick_resume can speak with no payload (pure
                     // thread continuation); same_day needs at least the NBA or a
-                    // recall to be worth speaking, else fall through to proactive.
+                    // recall — but a screen-completion NBA (derived from the
+                    // current screen, no payload needed) also counts.
                     const _worthSpeaking =
-                      _registerR !== 'same_day' || !!_payloadR;
+                      _registerR !== 'same_day' || !!_payloadR || !!_nbaR;
                     if (_dirR && _dirR.trim().length > 0 && _worthSpeaking) {
                       ws.send(
                         JSON.stringify({
@@ -7891,6 +7895,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                         bucket: _lastIxR.bucket,
                         nba: _nbaR?.key ?? null,
                         nba_domain: _nbaR?.domain ?? null,
+                        current_route: (session as any).current_route ?? null,
                       });
                       startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
                       console.log(

--- a/services/gateway/src/services/conversation/decide-opening.ts
+++ b/services/gateway/src/services/conversation/decide-opening.ts
@@ -30,6 +30,7 @@ import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../../orb/live/instruction/wa
 import type { OverviewPayload } from '../assistant-continuation/providers/new-day-overview-payload';
 import type { TemporalBucket } from '../guide/temporal-bucket';
 import { selectNextBestAction, type NextBestAction, type NbaKey } from './next-best-action';
+import { surfaceForRoute, screenCompletionFor } from './screen-surface';
 
 export type OpeningRegister =
   | 'first_time'
@@ -80,6 +81,10 @@ export interface ResumeDirectiveInput {
    *  last). The opener ADVANCES past these so it never repeats the same
    *  suggestion two opens in a row. */
   recentNbaKeys?: NbaKey[];
+  /** The client route the user is currently on (session.current_route). When it
+   *  maps to an actionable surface, the next step DEEPENS toward completing the
+   *  action there instead of redirecting the user away. */
+  currentScreen?: string | null;
 }
 
 export interface ResumeDirective {
@@ -96,13 +101,23 @@ export interface ResumeDirective {
  */
 export function buildResumeDirective(input: ResumeDirectiveInput): ResumeDirective {
   const { register, payload, lang } = input;
-  const nba = payload
-    ? selectNextBestAction(payload, {
-        rotationSeed: input.rotationSeed,
-        recentKeys: input.recentNbaKeys,
-        cooldown: 3,
-      })
-    : null;
+
+  // SCREEN AWARENESS. If the user is already on an actionable screen, the next
+  // step must DEEPEN toward completing the action here — never redirect them to
+  // a screen they are already on. The screen completion overrides the
+  // value-ranked pick; its `detail` lists several on-screen moves and the model
+  // picks one, so it stays fresh across reopens on the same screen.
+  const surface = surfaceForRoute(input.currentScreen);
+  const completion = screenCompletionFor(surface);
+  const nba = completion
+    ? completion.action
+    : payload
+      ? selectNextBestAction(payload, {
+          rotationSeed: input.rotationSeed,
+          recentKeys: input.recentNbaKeys,
+          cooldown: 3,
+        })
+      : null;
 
   // "Where we left off" is only REAL when it is an actual last-opened topic.
   // The payload falls back to the next-session title when the last-opened topic
@@ -134,6 +149,8 @@ export function buildResumeDirective(input: ResumeDirectiveInput): ResumeDirecti
           `- Mention what is new since earlier, reconnect to the thread, then the suggested next step.`;
 
   const compact: Record<string, unknown> = {};
+  if (surface !== 'other' && surface !== 'home') compact.current_screen = surface;
+  if (completion) compact.complete_on_current_screen = true;
   if (recall) compact.where_we_left_off = recall;
   if (newBits.length) compact.new_since_last = newBits;
   if (nba) compact.suggested_next_step = { kind: nba.key, what: nba.detail, why: nba.rationale };
@@ -172,6 +189,14 @@ ${nameLine}
   were just on X" line; lead with what's new and the next step instead.
 - Only mention ${'`new_since_last`'} items that are present; if empty, skip — do not say "nothing new".
 - ALWAYS finish with ${'`suggested_next_step`'} as a guided offer. Never end on a bare "How can I help?".
+- SCREEN AWARENESS: when ${'`current_screen`'} is set, the user is ALREADY on that
+  screen. NEVER tell them to open it or go there ("schau dir deine Matches an"
+  while they are on the matches screen is forbidden). When
+  ${'`complete_on_current_screen`'} is true, the ${'`suggested_next_step`'} is a
+  DEEPER move to COMPLETE the action here — pick ONE concrete option from its
+  ${'`what`'} and propose doing it together right now (e.g. on matches: "lass uns
+  einen davon auswählen und eine gemeinsame Aktivität starten", or tell them who
+  one match is). The goal is to FINISH the action, not to navigate.
 - Nothing here is hardcoded wording — compose it; but never invent data not in the payload.
 
 ## STRUCTURED PAYLOAD

--- a/services/gateway/src/services/conversation/next-best-action.ts
+++ b/services/gateway/src/services/conversation/next-best-action.ts
@@ -38,7 +38,15 @@ export type NbaKey =
   | 'make_post'
   | 'create_activity'
   | 'connect_community'
-  | 'set_goal';
+  | 'set_goal'
+  // Screen-aware COMPLETION actions — chosen when the user is already on the
+  // relevant screen, to deepen toward finishing the action instead of redirecting.
+  | 'complete_matches'
+  | 'complete_chat'
+  | 'complete_post'
+  | 'complete_diary'
+  | 'complete_index'
+  | 'complete_profile';
 
 export interface NextBestAction {
   key: NbaKey;

--- a/services/gateway/src/services/conversation/screen-surface.ts
+++ b/services/gateway/src/services/conversation/screen-surface.ts
@@ -1,0 +1,144 @@
+/**
+ * Conversation Flow — screen awareness & action completion.
+ *
+ * Vitana must know WHICH screen the user is on before it speaks, and once the
+ * user is on a screen (especially one Vitana just sent them to), the next step
+ * must go DEEPER toward COMPLETING the action there — never bounce the user
+ * elsewhere or re-suggest "go look at X" while they are already on X.
+ *
+ *   on /matches  → pick a match & start a joint activity / explain who one is /
+ *                  suggest an activity for their Vitana Index / refine match
+ *                  criteria / enrich the profile for better matches
+ *   on /chat     → actually send the reply
+ *   on compose   → actually write & publish the post / activity
+ *   on /diary    → make today's entry now (it lifts the Index)
+ *   on /index    → the concrete action to raise it (weakest pillar)
+ *
+ * The current screen comes from `session.current_route` (sent by the client at
+ * session start and kept fresh on navigation). This module maps a route to a
+ * coarse ConversationSurface and supplies the screen's completion action.
+ */
+
+import type { NextBestAction, NbaKey } from './next-best-action';
+
+export type ConversationSurface =
+  | 'matches'
+  | 'community'
+  | 'chat'
+  | 'diary'
+  | 'index'
+  | 'profile'
+  | 'journey'
+  | 'news'
+  | 'home'
+  | 'other';
+
+/** Map a client route to a coarse conversation surface. Best-effort substring
+ *  matching against the community-app route names; unknown → 'other'. */
+export function surfaceForRoute(route: string | null | undefined): ConversationSurface {
+  const r = (route || '').toLowerCase();
+  if (!r) return 'other';
+  // Order matters — check the more specific routes first.
+  if (/(^|\/)(matches|matchmaker|discover-matches)\b/.test(r)) return 'matches';
+  if (/(^|\/)(chat|messages|inbox|dm)\b/.test(r)) return 'chat';
+  if (/(^|\/)(diary|journal)\b/.test(r)) return 'diary';
+  if (/(^|\/)(vitana-index|longevity-index|health-index|index|pillars)\b/.test(r)) return 'index';
+  if (/(^|\/)(profile|my-profile|account)\b/.test(r)) return 'profile';
+  if (/(^|\/)(my-journey|journey|sessions|guided)\b/.test(r)) return 'journey';
+  if (/(^|\/)(news|longevity-news|feed)\b/.test(r)) return 'news';
+  if (/(^|\/)(community|posts?|activities|activity|create-post|compose)\b/.test(r)) return 'community';
+  if (r === '/' || /(^|\/)(home|dashboard|overview)\b/.test(r)) return 'home';
+  return 'other';
+}
+
+/**
+ * The DEEPER, completion-oriented next step when the user is already on a given
+ * surface. The `detail` lists the concrete on-screen moves the model can offer
+ * (it should pick ONE and propose it as the next step), and `redirect_key` is
+ * the "go to this screen" NBA that must be SUPPRESSED while the user is already
+ * here (so Vitana never says "let's look at your matches" on the matches screen).
+ */
+export interface ScreenCompletion {
+  action: NextBestAction;
+  /** The redirect-style NBA key to drop while on this surface (already here). */
+  redirect_key: NbaKey | null;
+}
+
+const COMPLETION_BAND = 115; // above every redirect/discovery action
+
+export function screenCompletionFor(surface: ConversationSurface): ScreenCompletion | null {
+  switch (surface) {
+    case 'matches':
+      return {
+        redirect_key: 'review_matches',
+        action: {
+          key: 'complete_matches',
+          domain: 'community',
+          band: COMPLETION_BAND,
+          detail:
+            'pick ONE of the matches and start a joint activity, OR tell the user who one match is, OR suggest an activity that also helps their Vitana Index, OR refine the match criteria, OR add info to the profile for better matches',
+          rationale:
+            'The user is ON the matches screen — help them ACT on a specific match (start an activity / learn about a person / refine search / enrich profile), never tell them to "open matches".',
+        },
+      };
+    case 'chat':
+      return {
+        redirect_key: 'reply_messages',
+        action: {
+          key: 'complete_chat',
+          domain: 'community',
+          band: COMPLETION_BAND,
+          detail: 'help the user actually write and send a reply in the open conversation',
+          rationale: 'The user is ON the chat screen — help them compose and send the message, not navigate to it.',
+        },
+      };
+    case 'community':
+      return {
+        redirect_key: 'make_post',
+        action: {
+          key: 'complete_post',
+          domain: 'community',
+          band: COMPLETION_BAND,
+          detail: 'help the user draft and publish a post or create an activity others can join, right now',
+          rationale: 'The user is ON the community/compose screen — help them finish and publish, not navigate to it.',
+        },
+      };
+    case 'diary':
+      return {
+        redirect_key: 'diary_entry',
+        action: {
+          key: 'complete_diary',
+          domain: 'health',
+          band: COMPLETION_BAND,
+          detail: 'help the user make today’s diary entry now (a quick note lifts the Vitana Index)',
+          rationale: 'The user is ON the diary screen — help them capture an entry, not navigate to it.',
+        },
+      };
+    case 'index':
+      return {
+        redirect_key: 'focus_pillar',
+        action: {
+          key: 'complete_index',
+          domain: 'health',
+          band: COMPLETION_BAND,
+          detail: 'propose ONE concrete action on the weakest pillar that will raise the Vitana Index, and offer to set it up',
+          rationale: 'The user is ON the Index screen — propose a concrete action to raise it, not navigate to it.',
+        },
+      };
+    case 'profile':
+      return {
+        redirect_key: null,
+        action: {
+          key: 'complete_profile',
+          domain: 'community',
+          band: COMPLETION_BAND,
+          detail: 'help the user add one more piece of profile info so others see more of them and matches improve',
+          rationale: 'The user is ON the profile screen — help them enrich it, which improves match quality.',
+        },
+      };
+    // journey / news / home / other → no specific on-screen completion; the
+    // normal value-ranked next step applies.
+    default:
+      return null;
+  }
+}

--- a/services/gateway/test/services/conversation/conversation-flow.test.ts
+++ b/services/gateway/test/services/conversation/conversation-flow.test.ts
@@ -8,8 +8,9 @@
  *     and always grounded in real data.
  */
 
-import { decideOpeningRegister } from '../../../src/services/conversation/decide-opening';
+import { decideOpeningRegister, buildResumeDirective } from '../../../src/services/conversation/decide-opening';
 import { rankNextBestActions, selectNextBestAction } from '../../../src/services/conversation/next-best-action';
+import { surfaceForRoute, screenCompletionFor } from '../../../src/services/conversation/screen-surface';
 import type { OverviewPayload } from '../../../src/services/assistant-continuation/providers/new-day-overview-payload';
 
 function emptyPayload(over: Partial<OverviewPayload> = {}): OverviewPayload {
@@ -81,6 +82,34 @@ describe('rankNextBestActions — value × timeliness, always grounded', () => {
     const p = emptyPayload({ diary_last_7d: 0 });
     const keys = rankNextBestActions(p).map((a) => a.key);
     expect(keys).toContain('diary_entry');
+  });
+
+  it('SCREEN AWARENESS: on the matches screen, the next step COMPLETES the action, never redirects there', () => {
+    const p = emptyPayload({ matches_unread: 15, messages_unread: 26 });
+    // Off-screen (home): the value-ranked redirect-style action is fine.
+    const off = buildResumeDirective({
+      register: 'same_day', payload: p, firstName: 'Dragan', lang: 'de', timeAgo: 'earlier today', currentScreen: '/home',
+    });
+    expect(off.nba!.key).not.toBe('complete_matches');
+    // On the matches screen: deepen to complete_matches, suppress review_matches.
+    const on = buildResumeDirective({
+      register: 'same_day', payload: p, firstName: 'Dragan', lang: 'de', timeAgo: 'earlier today', currentScreen: '/matches',
+    });
+    expect(on.nba!.key).toBe('complete_matches');
+    // The directive tells the model the user is already on the screen + to complete.
+    expect(on.text).toContain('current_screen');
+    expect(on.text).toContain('complete_on_current_screen');
+  });
+
+  it('surfaceForRoute maps the key screens; screenCompletionFor deepens + suppresses the redirect', () => {
+    expect(surfaceForRoute('/matches')).toBe('matches');
+    expect(surfaceForRoute('/chat/123')).toBe('chat');
+    expect(surfaceForRoute('/diary')).toBe('diary');
+    expect(surfaceForRoute('/vitana-index')).toBe('index');
+    expect(surfaceForRoute('/longevity-news')).toBe('news');
+    expect(screenCompletionFor('matches')!.action.key).toBe('complete_matches');
+    expect(screenCompletionFor('matches')!.redirect_key).toBe('review_matches');
+    expect(screenCompletionFor('news')).toBeNull();
   });
 
   it('ADVANCES, never repeats: recently-suggested actions are skipped for the next-best fresh one', () => {


### PR DESCRIPTION
## Why

Vitana was **screen-blind and redirect-happy**: it suggested "look at your matches", redirected to `/matches`, and when the user clicked the ORB **on the matches screen** it said *"Let's look at your 15 matches"* again — unaware it had already suggested that and already sent them there. The goal must be to **complete the action**, not bounce the user around.

## What

Vitana now knows the user's current screen (`session.current_route`, sent at session start) and **deepens toward completing the action there**:

- **`screen-surface.ts`** — `surfaceForRoute(route)` → surface (matches / chat / community / diary / index / profile / journey / news / home); `screenCompletionFor(surface)` → the **completion action** (band 115, above redirects) + the redirect-style key to **suppress** while on that surface.
- **`decide-opening.ts`** — on an actionable surface, the next step becomes the completion action, and the prompt gets `current_screen` + `complete_on_current_screen` with a **HARD rule**: never say "open X" while already on X; pick ONE concrete on-screen move and propose finishing it together.
- **`orb-live.ts`** — passes `session.current_route` into the resume rung; logs `current_route` in telemetry.

### Completion map (FINISH, don't navigate)
| Surface | Next step |
|---|---|
| matches | pick one & start a joint activity / who is this person / Index-boosting activity / refine criteria / enrich profile |
| chat | write & send the reply |
| community | draft & publish the post / create the activity |
| diary | make today's entry now (lifts the Index) |
| index | one weakest-pillar action to raise it |
| profile | add a detail → better matches |

## Verification
- `tsc` + full build clean; conversation suite **9/9** (new screen-awareness tests: on `/matches` → `complete_matches`, suppresses `review_matches`, prompt carries `current_screen`).
- Post-merge staging: redirect to matches, click the ORB on the matches screen → Vitana proposes **acting on a match** (start an activity / who is this / refine), not "open your matches".

Handoff §3b updated for the Command Hub "Conversation" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_