### PR TITLE
feat(orb): capability-gating — guidance that actually EXECUTES (no more "I can't")

### DIFF
--- a/docs/CONVERSATION_FLOW_HANDOFF.md
+++ b/docs/CONVERSATION_FLOW_HANDOFF.md
@@ -123,6 +123,33 @@ Completion mapping (the goal is to FINISH, not navigate):
 **Command-Hub:** the "Conversation" section should show the per-surface completion
 map and let an operator edit the completion offers (ideally policy-backed).
 
+## 3c. Capability-gating — guidance that actually EXECUTES
+
+The opener guides; the user accepts; it must **complete the action**, not stall on
+"Das konnte ich leider nicht umsetzen". Every next-step action is now mapped to
+the **real, registered ORB tool** that executes it (`CAPABILITY_BY_KEY` in
+`next-best-action.ts`, verified against `ORB_TOOL_REGISTRY`):
+
+| Action | Executes via |
+|---|---|
+| reply_messages / connect_community / complete_chat | `send_chat_message` |
+| review_matches | `view_intent_matches` |
+| complete_matches | `respond_to_match` |
+| create_activity | `share_intent_post` |
+| make_post / complete_post | `create_community_post` |
+| diary_entry / complete_diary | `save_diary_entry` |
+| focus_pillar / complete_index | `create_index_improvement_plan` |
+| autopilot_step | `activate_recommendation` |
+| next_session | `narrate_guided_session` |
+| reminder_due, set_goal, complete_profile | _no one-shot tool → GUIDE the user_ |
+
+The resume directive ships `suggested_next_step.execute_with_tool` and a HARD rule:
+on acceptance, **call that tool**; if null, **guide step-by-step** and never promise
+to do it. This stops over-promising and turns guidance into completion. (Most tools
+already existed — the gap was wiring, not capability.) **Follow-up:** build a real
+`update_profile_field` tool (verify `app_users`/`profiles` schema first) so
+`complete_profile` graduates from guide-only to executable.
+
 ## 4. Where everything lives (file map)
 
 | File | Role |

--- a/services/gateway/src/services/conversation/decide-opening.ts
+++ b/services/gateway/src/services/conversation/decide-opening.ts
@@ -153,7 +153,16 @@ export function buildResumeDirective(input: ResumeDirectiveInput): ResumeDirecti
   if (completion) compact.complete_on_current_screen = true;
   if (recall) compact.where_we_left_off = recall;
   if (newBits.length) compact.new_since_last = newBits;
-  if (nba) compact.suggested_next_step = { kind: nba.key, what: nba.detail, why: nba.rationale };
+  if (nba) {
+    compact.suggested_next_step = {
+      kind: nba.key,
+      what: nba.detail,
+      why: nba.rationale,
+      // The REAL ORB tool that executes this when the user accepts. null = no
+      // one-shot tool → guide the user through it, never promise to do it.
+      execute_with_tool: nba.capability ?? null,
+    };
+  }
   if (input.recentNbaKeys && input.recentNbaKeys.length) {
     compact.already_offered_recently = input.recentNbaKeys.slice(-4);
   }
@@ -189,6 +198,13 @@ ${nameLine}
   were just on X" line; lead with what's new and the next step instead.
 - Only mention ${'`new_since_last`'} items that are present; if empty, skip — do not say "nothing new".
 - ALWAYS finish with ${'`suggested_next_step`'} as a guided offer. Never end on a bare "How can I help?".
+- EXECUTION — do not just describe, DO IT: ${'`suggested_next_step.execute_with_tool`'}
+  names the real tool that performs this action. When the user accepts, CALL that
+  tool to actually complete it (e.g. send_chat_message, save_diary_entry,
+  respond_to_match, create_index_improvement_plan). Only promise what that tool
+  does. If ${'`execute_with_tool`'} is null, you have NO one-shot tool — then GUIDE
+  the user through it step by step on the screen; do NOT claim you'll do it
+  yourself. Never say "I couldn't do that" for an action that has a tool — call it.
 - SCREEN AWARENESS: when ${'`current_screen`'} is set, the user is ALREADY on that
   screen. NEVER tell them to open it or go there ("schau dir deine Matches an"
   while they are on the matches screen is forbidden). When

--- a/services/gateway/src/services/conversation/next-best-action.ts
+++ b/services/gateway/src/services/conversation/next-best-action.ts
@@ -58,6 +58,42 @@ export interface NextBestAction {
   detail: string;
   /** Why-now, grounding the model so the suggestion reads as reasoned. */
   rationale: string;
+  /** The EXISTING ORB tool that actually EXECUTES this action when the user
+   *  accepts (capability-gating). Set from CAPABILITY_BY_KEY. When null, Vitana
+   *  has no one-shot tool — it must GUIDE the user through it on the screen
+   *  instead of promising to do it (which is what caused "I can't execute"). */
+  capability?: string | null;
+}
+
+/**
+ * Maps each next-best-action to the REAL, registered ORB tool that executes it
+ * (verified against ORB_TOOL_REGISTRY in services/orb-tools-shared.ts). The
+ * opener tells the model to CALL this tool when the user accepts, so guidance
+ * actually completes the action instead of stalling on "I couldn't do that".
+ * null = no one-shot tool → guide the user through it (don't over-promise).
+ */
+export const CAPABILITY_BY_KEY: Partial<Record<NbaKey, string>> = {
+  autopilot_step: 'activate_recommendation',
+  reply_messages: 'send_chat_message',
+  review_matches: 'view_intent_matches',
+  next_session: 'narrate_guided_session',
+  diary_entry: 'save_diary_entry',
+  focus_pillar: 'create_index_improvement_plan',
+  make_post: 'create_community_post',
+  create_activity: 'share_intent_post',
+  connect_community: 'send_chat_message',
+  // reminder_due, set_goal → no one-shot tool; guide.
+  complete_matches: 'respond_to_match',
+  complete_chat: 'send_chat_message',
+  complete_post: 'create_community_post',
+  complete_diary: 'save_diary_entry',
+  complete_index: 'create_index_improvement_plan',
+  // complete_profile → no verified profile-update tool yet; guide.
+};
+
+/** The executing tool for an action key, or null when only guidance is possible. */
+export function capabilityForNba(key: NbaKey): string | null {
+  return CAPABILITY_BY_KEY[key] ?? null;
 }
 
 export interface NbaContext {
@@ -176,7 +212,9 @@ export function rankNextBestActions(p: OverviewPayload, ctx: NbaContext = {}): N
     });
   }
 
-  // Stable sort by band desc; ties keep insertion order (already priority-ordered).
+  // Attach each action's executing tool (capability-gating), then stable-sort by
+  // band desc; ties keep insertion order (already priority-ordered).
+  for (const a of out) a.capability = capabilityForNba(a.key);
   return out.sort((a, b) => b.band - a.band);
 }
 

--- a/services/gateway/src/services/conversation/screen-surface.ts
+++ b/services/gateway/src/services/conversation/screen-surface.ts
@@ -20,6 +20,7 @@
  */
 
 import type { NextBestAction, NbaKey } from './next-best-action';
+import { capabilityForNba } from './next-best-action';
 
 export type ConversationSurface =
   | 'matches'
@@ -67,6 +68,14 @@ export interface ScreenCompletion {
 const COMPLETION_BAND = 115; // above every redirect/discovery action
 
 export function screenCompletionFor(surface: ConversationSurface): ScreenCompletion | null {
+  const comp = _rawScreenCompletion(surface);
+  // Attach the executing tool (capability-gating) so the opener tells the model
+  // to CALL it on acceptance — completing the action, not just describing it.
+  if (comp) comp.action.capability = capabilityForNba(comp.action.key);
+  return comp;
+}
+
+function _rawScreenCompletion(surface: ConversationSurface): ScreenCompletion | null {
   switch (surface) {
     case 'matches':
       return {

--- a/services/gateway/test/services/conversation/conversation-flow.test.ts
+++ b/services/gateway/test/services/conversation/conversation-flow.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { decideOpeningRegister, buildResumeDirective } from '../../../src/services/conversation/decide-opening';
-import { rankNextBestActions, selectNextBestAction } from '../../../src/services/conversation/next-best-action';
+import { rankNextBestActions, selectNextBestAction, capabilityForNba } from '../../../src/services/conversation/next-best-action';
 import { surfaceForRoute, screenCompletionFor } from '../../../src/services/conversation/screen-surface';
 import type { OverviewPayload } from '../../../src/services/assistant-continuation/providers/new-day-overview-payload';
 
@@ -99,6 +99,25 @@ describe('rankNextBestActions — value × timeliness, always grounded', () => {
     // The directive tells the model the user is already on the screen + to complete.
     expect(on.text).toContain('current_screen');
     expect(on.text).toContain('complete_on_current_screen');
+  });
+
+  it('CAPABILITY-GATING: actions carry the real executing tool; gap actions are guide-only (null)', () => {
+    // Executable actions route to a real, registered ORB tool.
+    expect(capabilityForNba('reply_messages')).toBe('send_chat_message');
+    expect(capabilityForNba('complete_diary')).toBe('save_diary_entry');
+    expect(capabilityForNba('complete_matches')).toBe('respond_to_match');
+    expect(capabilityForNba('complete_index')).toBe('create_index_improvement_plan');
+    // No one-shot tool → guide-only (never over-promise execution).
+    expect(capabilityForNba('complete_profile')).toBeNull();
+    expect(capabilityForNba('set_goal')).toBeNull();
+    // Ranked actions carry their capability + the resume directive ships execute_with_tool.
+    const p = emptyPayload({ messages_unread: 26 });
+    expect(rankNextBestActions(p).find((a) => a.key === 'reply_messages')!.capability).toBe('send_chat_message');
+    const dir = buildResumeDirective({
+      register: 'same_day', payload: p, firstName: 'Dragan', lang: 'de', timeAgo: 'earlier today', currentScreen: '/chat',
+    });
+    expect(dir.text).toContain('execute_with_tool');
+    expect(dir.nba!.capability).toBe('send_chat_message');
   });
 
   it('surfaceForRoute maps the key screens; screenCompletionFor deepens + suppresses the redirect', () => {


### PR DESCRIPTION
## Why

Vitana would recommend an action, you'd accept, and it stalled with *"Das konnte ich leider gerade nicht umsetzen."* The guidance layer (which we just built) had outrun its hands.

**Root cause (verified against `ORB_TOOL_REGISTRY`):** the tools mostly **already exist** — `send_chat_message`, `save_diary_entry`, `respond_to_match`, `view_intent_matches`, `share_intent_post`, `create_community_post`, `create_index_improvement_plan`, `activate_recommendation`, `narrate_guided_session`, … The gap was that the **suggestions weren't wired to the tools**, so the model didn't reliably call the right one and sometimes promised actions no tool backed.

## What — capability-gating + tool-routing

- **`CAPABILITY_BY_KEY`** maps every next-step action → the real executing tool; `rankNextBestActions` + `screenCompletionFor` attach it to each action.
- The resume directive ships `suggested_next_step.execute_with_tool` + a **HARD rule**: on acceptance, **CALL that tool** to complete the action; if `null` (no one-shot tool — `reminder_due` / `set_goal` / `complete_profile`), **GUIDE** the user step-by-step and never over-promise. *"I couldn't do that"* for an action that **has** a tool is now forbidden.

| Action | Executes via |
|---|---|
| reply/connect/complete_chat | `send_chat_message` |
| review_matches | `view_intent_matches` |
| complete_matches | `respond_to_match` |
| create_activity | `share_intent_post` |
| make_post/complete_post | `create_community_post` |
| diary/complete_diary | `save_diary_entry` |
| focus_pillar/complete_index | `create_index_improvement_plan` |
| autopilot_step | `activate_recommendation` |
| next_session | `narrate_guided_session` |
| reminder_due, set_goal, complete_profile | _guide-only (no one-shot tool)_ |

## Honesty note
I did **not** ship new tools against unverified schema (the `messages`-table lesson). `complete_profile` stays guide-only until a real `update_profile_field` tool is built on a verified table — captured as the follow-up in the handoff doc.

## Verification
- `tsc` + full build clean; conversation suite **10/10** (new capability-gating test: actions carry the real tool; gaps are guide-only).
- Post-merge staging: accept a suggestion (e.g. on chat → reply) → Vitana **calls the tool and completes it**, no "I can't".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_