### PR TITLE
feat(orb): tool-execution observability — failure telemetry + self-check harness

### DIFF
--- a/docs/CONVERSATION_FLOW_HANDOFF.md
+++ b/docs/CONVERSATION_FLOW_HANDOFF.md
@@ -150,6 +150,29 @@ already existed — the gap was wiring, not capability.) **Follow-up:** build a 
 `update_profile_field` tool (verify `app_users`/`profiles` schema first) so
 `complete_profile` graduates from guide-only to executable.
 
+## 3d. Tool-execution observability — telemetry + self-check harness
+
+Guidance can route perfectly and still end in "I couldn't do that" if the
+underlying tool fails. Two pieces make that observable + fixable without a voice
+session:
+
+- **Tool-failure telemetry:** `executeLiveApiTool` (orb-live.ts) now emits an
+  `orb.live.diag` stage `tool_failed` to `oasis_events` for both HARD failures
+  (`success=false`) and SOFT ones (handler returned `ok:false`/a `reason`). Every
+  "I can't" is now queryable: `select metadata->>'tool', metadata->>'detail' from
+  oasis_events where topic='orb.live.diag' and metadata->>'stage'='tool_failed'`.
+- **Self-check harness:** `POST /api/v1/admin/orb-tools/selfcheck { user_id }`
+  (`routes/orb-tools-selfcheck.ts`, admin-gated) runs the capability tools via the
+  SAME dispatcher the voice path uses, against the user's real data, and returns +
+  emits (`orb.tools.selfcheck`) a per-tool pass/fail + exact error. Read tools run
+  live; `create_index_improvement_plan` writes calendar events and is cleaned up.
+- **Diagnosable writes:** `createCalendarEvent` now takes an `onError` sink, so the
+  index-plan tool reports the real PostgREST reason when a calendar write fails
+  (previously swallowed to Cloud Run logs).
+
+The Command-Hub "Conversation" section should surface the `tool_failed` feed and a
+button to run the self-check for a user.
+
 ## 4. Where everything lives (file map)
 
 | File | Role |

--- a/scripts/ci/impact-rules/new-route-without-auth-middleware.mjs
+++ b/scripts/ci/impact-rules/new-route-without-auth-middleware.mjs
@@ -27,6 +27,9 @@ const AUTH_NAMES = [
   // requireAuthWithTenant: authenticated + tenant-scoped middleware used across
   // orb-livekit.ts (voice-config, commit-memory). It IS auth — was missing here.
   'requireAuthWithTenant',
+  // requireExafyAdmin: admin-role gate (middleware/auth-supabase-jwt) used by the
+  // admin routes (notifications, orb-tools selfcheck). It IS auth.
+  'requireExafyAdmin',
 ];
 const ROUTE_PREFIX_RE = /^\s*router\.(get|post|put|patch|delete)\s*\(/;
 

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -390,6 +390,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const intentsShareRouter = intentEngineEnabled ? require('./routes/intents-share').default : null;
   // Admin: Signup Funnel Tracking & Outreach
   const adminSignupsRouter = require('./routes/admin-signups').default;
+  // Admin: ORB tool self-check harness (verify execution tools without a voice session)
+  const orbToolsSelfcheckRouter = require('./routes/orb-tools-selfcheck').default;
   // Admin: Notification Compose & Tracking
   const adminNotificationsRouter = require('./routes/admin-notifications').default;
   // Admin: Notification Category Management (CRUD + Test)
@@ -1133,6 +1135,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/admin/signups', adminSignupsRouter, { owner: 'admin-signups' });
 
   // Admin: Notification Compose & Tracking
+  mountRouterSync(app, '/api/v1/admin/orb-tools', orbToolsSelfcheckRouter, { owner: 'orb-tools-selfcheck' });
   mountRouterSync(app, '/api/v1/admin/notifications', adminNotificationsRouter, { owner: 'admin-notifications' });
 
   // Admin: Notification Category Management

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2387,6 +2387,24 @@ async function executeLiveApiTool(
   const elapsed = Date.now() - startTime;
   // Phase 1 W2: tool returned — close the tool_dispatch→tool_response interval.
   markVoiceLatency(session, 'tool_response', { tool: toolName, ms: elapsed, success: result.success });
+  // TOOL-EXEC TELEMETRY: surface tool failures to oasis_events (orb.live.diag) so
+  // every "I couldn't do that" is self-diagnosing — the exact tool + reason is
+  // queryable, instead of guessing. Captures BOTH hard failures (success=false)
+  // and SOFT failures (success=true but the result carries ok:false / a reason —
+  // e.g. create_index_improvement_plan returning no_index_data / no_actions),
+  // because the model speaks both as "I can't". Truncated; no args/PII.
+  try {
+    const _softFail =
+      result.success && /"ok"\s*:\s*false|"reason"\s*:|"stage"\s*:\s*"awaiting/.test(result.result || '');
+    if (!result.success || _softFail) {
+      emitDiag(session, 'tool_failed', {
+        tool: toolName,
+        soft: !!_softFail,
+        ms: elapsed,
+        detail: (!result.success ? (result.error || 'unknown') : (result.result || '')).slice(0, 400),
+      });
+    }
+  } catch { /* telemetry is best-effort */ }
   // BOOTSTRAP-PRODUCT-ANALYTICS: tool-call outcome for the /admin/insights
   // dashboards. Metadata only (tool name + latency + error code) — args and
   // results never leave this function. Fire-and-forget.

--- a/services/gateway/src/routes/orb-tools-selfcheck.ts
+++ b/services/gateway/src/routes/orb-tools-selfcheck.ts
@@ -150,6 +150,10 @@ router.post('/selfcheck', requireAuth, requireExafyAdmin, async (req: Authentica
     results,
     not_auto_run: NEEDS_ARGS.map((tool) => ({ tool, reason: 'needs user-dictated args' })),
   });
+  // impact-allow-no-oasis: diagnostic endpoint — already records each tool result
+  // to oasis_events (topic 'orb.tools.selfcheck') above; the only write is the
+  // idempotent cleanup of calendar events it itself created. (Placed here, after
+  // the inner arrow callbacks, so the scanner's handler-body extraction sees it.)
 });
 
 export default router;

--- a/services/gateway/src/routes/orb-tools-selfcheck.ts
+++ b/services/gateway/src/routes/orb-tools-selfcheck.ts
@@ -22,7 +22,7 @@
 
 import { Router, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { requireAuth, requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
 const router = Router();
 
@@ -50,7 +50,14 @@ const DEFAULT_CHECKS: ToolCheck[] = [
 
 const NEEDS_ARGS = ['send_chat_message', 'share_intent_post', 'respond_to_match', 'save_diary_entry', 'create_community_post'];
 
-router.post('/selfcheck', requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
+// requireAuth populates req.identity from the JWT; requireExafyAdmin then gates
+// on the exafy_admin claim. requireExafyAdmin ALONE is not auth — it 401s when
+// identity is unset — so both are required, in this order.
+router.post('/selfcheck', requireAuth, requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  // impact-allow-no-oasis: this is a read-mostly diagnostic; it already records
+  // each tool result directly to oasis_events (topic 'orb.tools.selfcheck'). The
+  // only write is the idempotent cleanup of calendar events the check itself
+  // created — not a user state transition worth a separate emit.
   const body = (req.body ?? {}) as { user_id?: string; tools?: string[] };
   const userId = String(body.user_id ?? '').trim();
   if (!userId) return res.status(400).json({ ok: false, error: 'user_id is required' });

--- a/services/gateway/src/routes/orb-tools-selfcheck.ts
+++ b/services/gateway/src/routes/orb-tools-selfcheck.ts
@@ -1,0 +1,148 @@
+/**
+ * ORB tool self-check harness.
+ *
+ * Answers "are we testing what we build?" for the EXECUTION layer: it invokes
+ * the real ORB action tools against a real user's data — no voice session
+ * needed — and reports per-tool pass/fail + the exact error. The conversation
+ * flow can route perfectly, but if the underlying tool fails the user still
+ * hears "I couldn't do that". This surfaces those failures deterministically.
+ *
+ *   POST /api/v1/admin/orb-tools/selfcheck   body: { user_id, tools?: string[] }
+ *
+ * Each tool is run via the SAME shared dispatcher the voice path uses
+ * (dispatchOrbTool), so a pass here means a pass in production. Results are
+ * returned AND emitted to oasis_events (topic 'orb.tools.selfcheck') so they
+ * are queryable. Read tools run live; the one write tool exercised
+ * (create_index_improvement_plan) cleans up the calendar events it creates.
+ *
+ * Admin-gated. Safe-by-construction: only no/optional-arg tools + the index
+ * plan (with cleanup) are run; tools needing dictated args (send_chat_message,
+ * respond_to_match, …) are reported as 'skipped: needs_args', not failures.
+ */
+
+import { Router, Response } from 'express';
+import { getSupabase } from '../lib/supabase';
+import { requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+interface ToolCheck {
+  tool: string;
+  args: Record<string, unknown>;
+  /** Cleanup tag — tools that write get their rows removed after the check. */
+  cleanup?: 'index_plan';
+}
+
+// Default curated set: the capability tools behind the conversation-flow
+// suggestions. Read-safe tools run live; create_index_improvement_plan writes
+// calendar events and is cleaned up. Tools that require user-dictated content
+// (send_chat_message, share_intent_post, respond_to_match) are intentionally
+// NOT auto-run — they'd need real args — and are reported separately.
+const DEFAULT_CHECKS: ToolCheck[] = [
+  { tool: 'get_vitana_index', args: {} },
+  { tool: 'get_pillar_subscores', args: {} },
+  { tool: 'get_life_compass', args: {} },
+  { tool: 'view_intent_matches', args: {} },
+  { tool: 'scan_existing_matches', args: {} },
+  { tool: 'get_schedule', args: {} },
+  { tool: 'create_index_improvement_plan', args: { days: 7, actions_per_week: 1 }, cleanup: 'index_plan' },
+];
+
+const NEEDS_ARGS = ['send_chat_message', 'share_intent_post', 'respond_to_match', 'save_diary_entry', 'create_community_post'];
+
+router.post('/selfcheck', requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const body = (req.body ?? {}) as { user_id?: string; tools?: string[] };
+  const userId = String(body.user_id ?? '').trim();
+  if (!userId) return res.status(400).json({ ok: false, error: 'user_id is required' });
+
+  const sb = getSupabase();
+  if (!sb) return res.status(503).json({ ok: false, error: 'supabase_not_configured' });
+
+  // Resolve identity for the target user (tenant + role) the way a tool handler expects.
+  let tenantId: string | null = null;
+  let role: string | null = null;
+  let vitanaId: string | null = null;
+  try {
+    const { data } = await sb
+      .from('app_users')
+      .select('tenant_id, role, vitana_id')
+      .eq('user_id', userId)
+      .maybeSingle();
+    const row = data as { tenant_id?: string; role?: string; vitana_id?: string } | null;
+    tenantId = row?.tenant_id ?? null;
+    role = row?.role ?? 'community';
+    vitanaId = row?.vitana_id ?? null;
+  } catch { /* identity backfill is best-effort */ }
+
+  const identity = {
+    user_id: userId,
+    tenant_id: tenantId,
+    role,
+    vitana_id: vitanaId,
+    session_id: `selfcheck:${userId}`,
+  };
+
+  const checks = Array.isArray(body.tools) && body.tools.length > 0
+    ? DEFAULT_CHECKS.filter((c) => body.tools!.includes(c.tool))
+    : DEFAULT_CHECKS;
+
+  const { dispatchOrbTool } = await import('../services/orb-tools-shared');
+
+  const results: Array<{ tool: string; ok: boolean; soft_fail: boolean; ms: number; detail: string }> = [];
+
+  for (const check of checks) {
+    const t0 = Date.now();
+    let ok = false;
+    let soft = false;
+    let detail = '';
+    try {
+      const r = await dispatchOrbTool(check.tool, check.args, identity as any, sb);
+      // OrbToolResult: { ok, result?, error?, text? }
+      const rr = r as { ok?: boolean; error?: string; result?: unknown; text?: string };
+      ok = rr.ok !== false;
+      const resultStr = JSON.stringify(rr.result ?? '') + (rr.text ?? '');
+      // Soft failure: handler returned ok:true but the payload says it couldn't act.
+      soft = ok && /"ok"\s*:\s*false|"reason"\s*:\s*"(no_index_data|no_actions|needs_clarification)"/.test(resultStr);
+      detail = (rr.error ?? rr.text ?? resultStr).slice(0, 400);
+    } catch (e) {
+      ok = false;
+      detail = (e instanceof Error ? e.message : String(e)).slice(0, 400);
+    }
+    const ms = Date.now() - t0;
+    results.push({ tool: check.tool, ok: ok && !soft, soft_fail: soft, ms, detail });
+
+    // Cleanup write side-effects so the harness is idempotent.
+    if (check.cleanup === 'index_plan') {
+      try {
+        await sb
+          .from('calendar_events')
+          .delete()
+          .eq('user_id', userId)
+          .eq('metadata->>plan', 'index_improvement')
+          .gte('created_at', new Date(Date.now() - 5 * 60 * 1000).toISOString());
+      } catch { /* best-effort cleanup */ }
+    }
+
+    // Emit to oasis_events so the report is queryable via SQL/MCP.
+    try {
+      await sb.from('oasis_events').insert({
+        topic: 'orb.tools.selfcheck',
+        source: 'gateway',
+        status: ok && !soft ? 'success' : 'error',
+        message: `selfcheck ${check.tool}: ${ok && !soft ? 'ok' : soft ? 'soft_fail' : 'fail'}`,
+        metadata: { tool: check.tool, user_id: userId, ok: ok && !soft, soft_fail: soft, ms, detail },
+      });
+    } catch { /* best-effort */ }
+  }
+
+  const passed = results.filter((r) => r.ok).length;
+  return res.json({
+    ok: true,
+    user_id: userId,
+    summary: { total: results.length, passed, failed: results.length - passed },
+    results,
+    not_auto_run: NEEDS_ARGS.map((tool) => ({ tool, reason: 'needs user-dictated args' })),
+  });
+});
+
+export default router;

--- a/services/gateway/src/services/calendar-service.ts
+++ b/services/gateway/src/services/calendar-service.ts
@@ -264,9 +264,16 @@ export async function computeNextAvailableSlot(
 export async function createCalendarEvent(
   userId: string,
   input: CreateCalendarEventInput,
+  // Optional error sink — receives the raw PostgREST error body when the insert
+  // fails. Lets callers surface WHY a write failed (previously only console.error'd
+  // to Cloud Run logs) so failures are diagnosable in telemetry / the self-check.
+  onError?: (message: string) => void,
 ): Promise<CalendarEvent | null> {
   const config = getSupabaseConfig();
-  if (!config) return null;
+  if (!config) {
+    if (onError) onError('supabase_config_missing');
+    return null;
+  }
 
   const body = {
     user_id: userId,
@@ -282,6 +289,7 @@ export async function createCalendarEvent(
   if (!resp.ok) {
     const errText = await resp.text();
     console.error(`${LOG_PREFIX} createCalendarEvent failed:`, errText);
+    if (onError) onError(`${resp.status}: ${errText}`.slice(0, 300));
     return null;
   }
 

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -1420,6 +1420,10 @@ export async function tool_create_index_improvement_plan(
     const tags = PILLAR_TAGS[pillar as keyof typeof PILLAR_TAGS];
     const wellnessTags: string[] = tags ? [...tags] : [pillar!];
 
+    // Capture the FIRST calendar-write error so a total failure reports WHY
+    // (the PostgREST reason), instead of an opaque "calendar write failed".
+    let firstCalendarError: string | null = null;
+
     for (let i = 0; i < totalEvents; i++) {
       const item = source[i % source.length];
       const eventDate = new Date(startOfToday);
@@ -1453,17 +1457,22 @@ export async function tool_create_index_improvement_plan(
             plan_source: item.source,
           },
           is_recurring: false,
-        });
+        }, (msg) => { if (!firstCalendarError) firstCalendarError = msg; });
         if (evt) {
           scheduled.push({ title: evt.title, start_time: evt.start_time, source: item.source });
         }
-      } catch {
-        /* per-event failures swallowed; reported as count-mismatch in result */
+      } catch (perEvtErr) {
+        if (!firstCalendarError) {
+          firstCalendarError = perEvtErr instanceof Error ? perEvtErr.message : String(perEvtErr);
+        }
       }
     }
 
     if (scheduled.length === 0) {
-      return { ok: false, error: 'No events could be scheduled (calendar write failed).' };
+      return {
+        ok: false,
+        error: `No events could be scheduled (calendar write failed)${firstCalendarError ? `: ${firstCalendarError}` : ''}`,
+      };
     }
 
     const payload = {

--- a/services/gateway/test/orb-tools-selfcheck.test.ts
+++ b/services/gateway/test/orb-tools-selfcheck.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Admin-gate + validation test for POST /api/v1/admin/orb-tools/selfcheck.
+ *
+ * The self-check runs ORB tools against an arbitrary user's data, so it MUST be
+ * admin-only. This suite mounts the REAL router with the REAL requireExafyAdmin
+ * guard (signing JWTs against a test secret) and asserts the security +
+ * validation contract without dragging in Supabase or the tool dispatcher:
+ *   1. unauthenticated      → 401
+ *   2. authenticated non-admin → 403
+ *   3. admin + missing user_id → 400 (validation, before any DB work)
+ *   4. admin + user_id      → reaches the handler (NOT 401/403)
+ */
+
+import express from 'express';
+import request from 'supertest';
+import * as jose from 'jose';
+
+const TEST_SECRET = 'test-supabase-jwt-secret-for-orb-tools-selfcheck';
+process.env.SUPABASE_JWT_SECRET = TEST_SECRET;
+// Ensure the handler hits its own getSupabase()/validation paths, not a real DB.
+delete process.env.SUPABASE_URL;
+delete process.env.SUPABASE_SERVICE_ROLE;
+delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+import selfcheckRouter from '../src/routes/orb-tools-selfcheck';
+
+async function signToken(opts: { exafyAdmin: boolean }): Promise<string> {
+  const key = new TextEncoder().encode(TEST_SECRET);
+  const now = Math.floor(Date.now() / 1000);
+  return await new jose.SignJWT({
+    aud: 'authenticated',
+    role: 'authenticated',
+    email: 'caller@example.com',
+    app_metadata: {
+      active_tenant_id: '00000000-0000-0000-0000-000000000001',
+      exafy_admin: opts.exafyAdmin,
+    },
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject('11111111-1111-1111-1111-111111111111')
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .sign(key);
+}
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/admin/orb-tools', selfcheckRouter);
+  return app;
+}
+
+describe('POST /api/v1/admin/orb-tools/selfcheck — admin gate + validation', () => {
+  const app = makeApp();
+
+  it('rejects an unauthenticated caller with 401', async () => {
+    const res = await request(app).post('/api/v1/admin/orb-tools/selfcheck').send({ user_id: 'u1' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an authenticated non-admin caller with 403', async () => {
+    const token = await signToken({ exafyAdmin: false });
+    const res = await request(app)
+      .post('/api/v1/admin/orb-tools/selfcheck')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ user_id: 'u1' });
+    expect(res.status).toBe(403);
+  });
+
+  it('admin + missing user_id → 400 (validated before any DB work)', async () => {
+    const token = await signToken({ exafyAdmin: true });
+    const res = await request(app)
+      .post('/api/v1/admin/orb-tools/selfcheck')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/user_id/);
+  });
+
+  it('admin + user_id → passes the guard (reaches handler, not 401/403)', async () => {
+    const token = await signToken({ exafyAdmin: true });
+    const res = await request(app)
+      .post('/api/v1/admin/orb-tools/selfcheck')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ user_id: '22222222-2222-2222-2222-222222222222' });
+    expect([200, 503]).toContain(res.status); // 503 when Supabase isn't configured in the test env
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+  });
+});


### PR DESCRIPTION
## Why

You asked: *"are you testing what you develop?"* — fair. The conversation flow routes to the right tool (your telemetry proved it called `create_index_improvement_plan`), but the tool **failed** and the reason was only `console.error`'d to Cloud Run logs — invisible to me. This PR makes execution failures **observable and fixable without a voice session**, which is the real answer to that question.

## What

1. **Failure telemetry** — `executeLiveApiTool` emits an `orb.live.diag` `tool_failed` event to `oasis_events` for **hard** failures (`success=false`) *and* **soft** ones (handler returned `ok:false`/a `reason`). Every "I can't" is now queryable by tool + reason.
2. **Self-check harness** — `POST /api/v1/admin/orb-tools/selfcheck { user_id }` (admin-gated) runs the capability tools via the **same dispatcher the voice path uses**, against the user's real data, and returns + emits (`orb.tools.selfcheck`) a per-tool pass/fail + exact error. Read tools run live; `create_index_improvement_plan` writes calendar events and is cleaned up.
3. **Diagnosable writes** — `createCalendarEvent` gains an `onError` sink, and the index-plan tool now reports the **real PostgREST reason** when the calendar write fails (the suspected cause of the broken nutrition plan) instead of an opaque "calendar write failed."

## How this finds the nutrition-plan bug
I verified the pillar resolves (`nutrition`) and the DB *accepts* the calendar insert via direct SQL — so the failure is inside the gateway's PostgREST write, whose error was swallowed. After this, the next run (self-check or live ORB) surfaces the exact reason → then I fix it with certainty.

## Verification
- `tsc` + full build clean.
- After merge: run `selfcheck` for the test user (or read `tool_failed` telemetry) → the index-plan's exact error appears → fix follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_