### PR TITLE
fix(orb): index-improvement plan valid role_context for all session roles (VTID-03346)

### DIFF
--- a/services/gateway/src/routes/orb-tools-selfcheck.ts
+++ b/services/gateway/src/routes/orb-tools-selfcheck.ts
@@ -70,14 +70,18 @@ router.post('/selfcheck', requireAuth, requireExafyAdmin, async (req: Authentica
   let role: string | null = null;
   let vitanaId: string | null = null;
   try {
+    // NOTE: app_users has no `role` column — selecting it 400s and nulls the
+    // whole row. Role is carried on the session/JWT, not this table; for the
+    // harness 'community' is a safe stand-in (the tools that gate on role_context
+    // now map any role to a valid value), and tenant_id/vitana_id come from here.
     const { data } = await sb
       .from('app_users')
-      .select('tenant_id, role, vitana_id')
+      .select('tenant_id, vitana_id')
       .eq('user_id', userId)
       .maybeSingle();
-    const row = data as { tenant_id?: string; role?: string; vitana_id?: string } | null;
+    const row = data as { tenant_id?: string; vitana_id?: string } | null;
     tenantId = row?.tenant_id ?? null;
-    role = row?.role ?? 'community';
+    role = 'community';
     vitanaId = row?.vitana_id ?? null;
   } catch { /* identity backfill is best-effort */ }
 

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -1339,6 +1339,7 @@ export async function tool_create_index_improvement_plan(
   try {
     const { PILLAR_TAGS, PILLAR_ACTION_TEMPLATES } = await import('../lib/vitana-pillars');
     const { createCalendarEvent } = await import('./calendar-service');
+    const { toWritableRoleContext } = await import('../types/calendar');
 
     let pillar: string | undefined = resolvePillarKey(args.pillar as string | undefined);
     if (!pillar) {
@@ -1442,8 +1443,13 @@ export async function tool_create_index_improvement_plan(
           event_type: 'health' as any,
           status: 'confirmed',
           priority: 'medium',
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          role_context: ((id.role || 'community') as any),
+          // role_context is constrained by the `valid_role_context` CHECK to
+          // exactly {community, admin, developer, personal}. The session role
+          // (id.role) can be super_admin / staff / dev / patient / professional,
+          // none of which pass — writing it raw made EVERY calendar insert fail
+          // with a 400 (the swallowed error behind "I cannot execute"). Coerce to
+          // a valid context.
+          role_context: toWritableRoleContext(id.role),
           source_type: 'assistant',
           source_ref_type:
             item.source === 'autopilot' ? 'autopilot_recommendation' : 'pillar_template',

--- a/services/gateway/src/types/calendar.ts
+++ b/services/gateway/src/types/calendar.ts
@@ -43,6 +43,31 @@ export function getVisibleContexts(role: string | null): CalendarRoleContext[] |
   return ROLE_TO_CONTEXTS[role] ?? ROLE_TO_CONTEXTS.community;
 }
 
+/**
+ * Coerce an arbitrary session role into a CalendarRoleContext that satisfies the
+ * `valid_role_context` CHECK on calendar_events ({community, admin, developer,
+ * personal}). The session role (e.g. super_admin, staff, dev, patient,
+ * professional) is NOT itself a valid role_context — writing it raw makes the
+ * INSERT fail with a 400. Use this for the role_context of any event we write on
+ * the user's behalf so the write never violates the constraint.
+ */
+export function toWritableRoleContext(role: string | null | undefined): CalendarRoleContext {
+  switch (role) {
+    case 'developer':
+    case 'infra':
+    case 'dev':
+    case 'DEV':
+      return 'developer';
+    case 'admin':
+    case 'super_admin':
+    case 'staff':
+      return 'admin';
+    default:
+      // community, patient, professional, null, unknown → community
+      return 'community';
+  }
+}
+
 // =============================================================================
 // Vitana Pillars (calendar → Index linkage)
 // =============================================================================

--- a/services/gateway/test/services/calendar-role-context.test.ts
+++ b/services/gateway/test/services/calendar-role-context.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression: role_context written to calendar_events MUST satisfy the DB
+ * `valid_role_context` CHECK ({community, admin, developer, personal}).
+ *
+ * The ORB index-improvement-plan tool previously wrote the raw SESSION role
+ * (id.role) as role_context. Session roles include super_admin / staff / dev /
+ * patient / professional — none of which are valid role_context values — so the
+ * calendar INSERT failed with a 400 for those users and the plan silently
+ * produced zero events ("I cannot execute"). `toWritableRoleContext` coerces any
+ * session role into a constraint-valid context. This test pins that contract.
+ */
+
+import { toWritableRoleContext, CalendarRoleContext } from '../../src/types/calendar';
+
+// Mirror of the DB CHECK constraint `valid_role_context`.
+const VALID: ReadonlySet<string> = new Set(['community', 'admin', 'developer', 'personal']);
+
+describe('toWritableRoleContext — calendar role_context coercion', () => {
+  // Every role the gateway may carry on a session, plus edge cases.
+  const SESSION_ROLES = [
+    'community', 'admin', 'developer', 'personal',
+    'super_admin', 'staff', 'dev', 'DEV', 'infra', 'patient', 'professional',
+    'totally_unknown_role', '', null, undefined,
+  ];
+
+  it('always returns a value that satisfies the valid_role_context CHECK', () => {
+    for (const role of SESSION_ROLES) {
+      const ctx = toWritableRoleContext(role as string | null | undefined);
+      expect(VALID.has(ctx)).toBe(true);
+    }
+  });
+
+  it('maps the roles that previously broke the calendar INSERT to a valid context', () => {
+    // These are exactly the session roles NOT present in valid_role_context —
+    // the ones that used to 400 the insert.
+    expect(toWritableRoleContext('super_admin')).toBe('admin');
+    expect(toWritableRoleContext('staff')).toBe('admin');
+    expect(toWritableRoleContext('dev')).toBe('developer');
+    expect(toWritableRoleContext('DEV')).toBe('developer');
+    expect(toWritableRoleContext('infra')).toBe('developer');
+    expect(toWritableRoleContext('patient')).toBe('community');
+    expect(toWritableRoleContext('professional')).toBe('community');
+  });
+
+  it('passes through already-valid contexts unchanged', () => {
+    expect(toWritableRoleContext('admin')).toBe('admin');
+    expect(toWritableRoleContext('developer')).toBe('developer');
+    expect(toWritableRoleContext('community')).toBe('community');
+  });
+
+  it('defaults unknown / empty / nullish roles to community', () => {
+    const fallbacks: Array<string | null | undefined> = ['', 'mystery', null, undefined];
+    for (const r of fallbacks) {
+      const ctx: CalendarRoleContext = toWritableRoleContext(r);
+      expect(ctx).toBe('community');
+    }
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03346` _(allocated + registered in `vtid_ledger`: layer `AGTL`, module `ORB`, `spec_status=approved`, terminal `success`)_

**Layer:** AGTL (ORB agent / tool execution)

**Priority:** P1

VALIDATION_PROFILE: gateway_backend

---

## 📋 Summary

The ORB `create_index_improvement_plan` tool gave the user a personalized plan but never wrote any calendar events for non-community users — they heard *"I cannot execute."* Root cause: the tool wrote the **raw session role** (`id.role`) as the calendar event's `role_context`. The `valid_role_context` CHECK on `calendar_events` only permits `{community, admin, developer, personal}`, but a session role can be `super_admin` / `staff` / `dev` / `patient` / `professional` — none of which pass. Every `INSERT` for those users `400`'d, the plan produced zero events, and the failure was swallowed (PR #2802's `onError` sink is what finally surfaced it).

Builds directly on the tool-observability work from #2802 — that error telemetry is what let me pin this down.

---

## ✅ Changes

SCOPE_ALLOWLIST: services/gateway/src/types/calendar.ts, services/gateway/src/services/orb-tools-shared.ts, services/gateway/src/routes/orb-tools-selfcheck.ts, services/gateway/test/services/calendar-role-context.test.ts

- [x] Add `toWritableRoleContext(role)` in `types/calendar.ts` — single source of truth coercing any session role to a constraint-valid `CalendarRoleContext`.
- [x] `create_index_improvement_plan` uses it for `role_context` instead of the raw role.
- [x] Fix the self-check harness identity backfill, which selected a non-existent `app_users.role` column (that query `400`'d and nulled `tenant_id`/`vitana_id` too).
- [x] Add a regression test pinning the coercion contract for every session role.

---

## 🧪 Testing

ACCEPTANCE:
- AC-1: `toWritableRoleContext` returns a value in `{community,admin,developer,personal}` for every session role. TEST: `test/services/calendar-role-context.test.ts`
- AC-2: Roles that previously broke the INSERT (`super_admin`,`staff`,`dev`,`patient`,`professional`) map to a valid context. TEST: `test/services/calendar-role-context.test.ts`
- AC-3: `create_index_improvement_plan` writes events instead of 400ing for an admin/founder session. TEST: live DB reproduction of the `valid_role_context` CHECK (raw `super_admin` rejected; coerced value inserts).

- [x] Automated tests added — `calendar-role-context.test.ts` (4) + existing `orb-tools-selfcheck.test.ts` (4): 8/8 green. `tsc --noEmit` clean. CI `unit` + `Gateway CI` green.
- [x] Manual/DB verification — reproduced against the live `valid_role_context` CHECK; test rows cleaned up (0 leftover).
- [ ] Staging verification — after merge → `gateway-staging` (`preview-gateway.vitanaland.com`).

---

## 🚨 Breaking Changes

None. Pure bug fix; no schema change. Community-role behaviour unchanged (still → `community`).

---

## 📌 Additional Notes

MERGE_PAYLOAD_PREVIEW: backend-only (services/gateway/src/**) + one gateway unit test; no schema/migration, no route added (only an identity-select fix inside the existing `orb-tools-selfcheck` route from #2802).

OASIS_IMPACT: none — no new OASIS event types or state transitions; tool failures continue to surface via the existing `orb.live.diag` / `orb.tools.selfcheck` telemetry from #2802.

Only `orb-tools-shared.ts` wrote a raw role; every other calendar writer already mapped/hardcoded a valid context, so the fix is localized but the new helper is reusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh