### PR TITLE
fix(orb): guided journey recommends the user's current session, not session 1 (VTID-03347)

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -4552,10 +4552,18 @@ export async function tool_narrate_guided_session(
   try {
     const state = await sb
       .from('user_guided_journey_state')
-      .select('completed_topic_ids')
+      .select('completed_topic_ids, current_session')
       .eq('user_id', identity.user_id)
       .maybeSingle();
     const completed = new Set<string>((state.data?.completed_topic_ids as string[] | null | undefined) ?? []);
+    // The session the user is actually ON. The frontend Longevity-Reise advances
+    // current_session as the user clicks through, but completed_topic_ids is only
+    // written by the voice narrator — so a user on session 10 can have an empty
+    // completed set. Without this anchor the default "what's next" search below
+    // returned the first un-heard topic across the WHOLE curriculum (session 1,
+    // "Starte deine Longevity-Reise"), making Vitana look unaware of real progress.
+    const curRaw = (state.data as { current_session?: unknown } | null | undefined)?.current_session;
+    const currentSession = Number.isFinite(Number(curRaw)) && Number(curRaw) >= 1 ? Math.floor(Number(curRaw)) : 1;
 
     // ALL published topics, ordered — NO session floor (the floor caused a false
     // "you completed everything" once current_session advanced past the rows).
@@ -4633,7 +4641,17 @@ export async function tool_narrate_guided_session(
       target = inSession.find((r) => !completed.has(r.topic_id)) ?? inSession[0]; // all heard → replay from the top
       remainingInSession = inSession.filter((r) => !completed.has(r.topic_id) && r.topic_id !== target!.topic_id).length;
     } else {
-      target = rows.find((r) => !completed.has(r.topic_id));
+      // DEFAULT "what's next" — anchor on the user's CURRENT session, not the
+      // global first un-heard topic. Clamp the floor to the curriculum so an
+      // over-advanced current_session can't false-complete the journey, then pick
+      // the first un-heard topic AT OR AFTER it (rows are ordered session,position).
+      // Only if nothing remains from the current session onward do we fall back to
+      // any earlier skipped topic — so a user on session 10 is offered session 10,
+      // never session 1.
+      const floor = Math.min(Math.max(1, currentSession), maxSession);
+      target =
+        rows.find((r) => r.session >= floor && !completed.has(r.topic_id)) ??
+        rows.find((r) => !completed.has(r.topic_id));
       if (!target) {
         return {
           ok: true,

--- a/services/gateway/test/narrate-guided-session-shared.test.ts
+++ b/services/gateway/test/narrate-guided-session-shared.test.ts
@@ -79,6 +79,43 @@ describe('tool_narrate_guided_session', () => {
     expect(r.text).not.toContain(TOPICS[0].vitana_voice_script);
   });
 
+  // REGRESSION: the user is on session 10 (frontend advanced current_session) but
+  // completed_topic_ids is empty because only the voice narrator writes it. The
+  // default "what's next" must anchor on current_session and offer session 10 —
+  // NOT the first topic of the whole curriculum (session 1, "Starte deine Reise").
+  const JOURNEY_1_TO_10 = Array.from({ length: 10 }, (_, i) => ({
+    topic_id: `s${i + 1}`,
+    title: `Session ${i + 1} Titel`,
+    display_label: null,
+    short_description: '',
+    vitana_voice_script: `Das ist die Narration von Session ${i + 1}.`,
+    session: i + 1,
+    position: 1,
+  }));
+
+  it('REGRESSION: user on session 10 with empty completed set → offers session 10, not session 1', async () => {
+    const sb = makeSb({ stateData: { completed_topic_ids: [], current_session: 10 }, topics: JOURNEY_1_TO_10 });
+    const r = await tool_narrate_guided_session({} as any, IDENT, sb);
+    expect((r as any).result.session).toBe(10);
+    expect(r.text).toContain('Das ist die Narration von Session 10.');
+    expect(r.text).not.toContain('Session 1 Titel');
+  });
+
+  it('current session fully heard → rolls forward to the next session, never back to 1', async () => {
+    const sb = makeSb({ stateData: { completed_topic_ids: ['s9'], current_session: 9 }, topics: JOURNEY_1_TO_10 });
+    const r = await tool_narrate_guided_session({} as any, IDENT, sb);
+    expect((r as any).result.session).toBe(10); // s9 heard → next is session 10
+  });
+
+  it('over-advanced current_session (beyond curriculum) does NOT false-complete — falls back to remaining work', async () => {
+    // current_session=99 but only 10 sessions exist; nothing is completed. Must still
+    // offer real content (floor clamps to maxSession), not claim "journey complete".
+    const sb = makeSb({ stateData: { completed_topic_ids: [], current_session: 99 }, topics: JOURNEY_1_TO_10 });
+    const r = await tool_narrate_guided_session({} as any, IDENT, sb);
+    expect((r as any).result.done).toBeUndefined();
+    expect((r as any).result.session).toBe(10); // clamps to the last session with work
+  });
+
   it('journey complete → done:true, congratulate, no script', async () => {
     const sb = makeSb({ stateData: { completed_topic_ids: ['t1', 't2'], current_session: 1 }, topics: TOPICS });
     const r = await tool_narrate_guided_session({} as any, IDENT, sb);


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03347` · **Layer:** AGTL (ORB tools) · **Priority:** P1

VALIDATION_PROFILE: gateway_backend

---

## 📋 Summary

In the ORB voice assistant, when the user asked what to do next in the **Guided Journey / Longevity-Reise**, Vitana offered **Lektion 1** ("Starte deine Longevity-Reise") even though the user had completed 9 sessions and was on **Session 10** — looking unaware and incompetent.

**Root cause:** `tool_narrate_guided_session` read only `completed_topic_ids` from `user_guided_journey_state` and, when called with no explicit session, picked the first un-heard topic across the **entire** 254-topic curriculum. The frontend journey advances `current_session` as the user clicks through, but `completed_topic_ids` is written **only by the voice narrator** — so a user on Session 10 can have an empty completed set, and the global search fell back to Session 1.

---

## ✅ Changes

SCOPE_ALLOWLIST: services/gateway/src/services/orb-tools-shared.ts, services/gateway/test/narrate-guided-session-shared.test.ts

- Read `current_session` alongside `completed_topic_ids`.
- Anchor the default "what's next" selection on `current_session`:
  - Clamp the floor to the curriculum (`min(current_session, maxSession)`) so an over-advanced `current_session` can't false-complete the journey.
  - Pick the first un-heard topic **at or after** the floor (rows are ordered session, position).
  - Only fall back to an earlier skipped topic if nothing remains ahead.
- Explicit `session_number` / `topic_query` / `info_only` paths are unchanged.

---

## 🧪 Testing

ACCEPTANCE:
- AC-1: User on session 10 with empty completed set → offered session 10, not session 1. TEST: `narrate-guided-session-shared.test.ts`
- AC-2: Current session fully heard → rolls forward to the next session (never back to 1). TEST: same
- AC-3: Over-advanced `current_session` (beyond curriculum) → does NOT false-complete; offers the last session with work. TEST: same

- All 24 tests in `narrate-guided-session-shared.test.ts` pass (21 existing + 3 new regression). `tsc --noEmit` clean.

---

## 🚨 Breaking Changes

None. No schema change. Existing explicit-session / named-topic / info-only behaviour is byte-for-byte unchanged; only the no-argument "next session" default is corrected.

---

## 📌 Additional Notes

MERGE_PAYLOAD_PREVIEW: backend-only (`services/gateway/src/**`) + its existing unit test; no migration, no new route.

OASIS_IMPACT: none.

Follow-up (not in this PR): also surface `sessions_completed` / next-session in the live ORB system instruction so the model has progress context even before it calls the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_