### PR TITLE
feat(orb): carry guided-journey progress into the live system instruction every turn (VTID-03348)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -891,6 +891,25 @@ export async function handleLiveSessionStart(
           console.log(`[LANG-PREF] No client lang — using stored preference: ${finalLang} for user=${bootstrapIdentity.user_id.substring(0, 8)}...`);
         }
 
+        // GUIDED JOURNEY standing awareness: append the user's LIVE journey
+        // progress (sessions completed, current session + title, where they left
+        // off) to the STANDING bootstrap context — so Vitana knows the user is on
+        // e.g. session 10 on EVERY turn, not only at the greeting. Without this she
+        // defaults to "the first lesson" mid-conversation. Best-effort; the block
+        // is empty for brand-new users and any failure never blocks bootstrap.
+        try {
+          const { getSupabase } = await import('../../../lib/supabase');
+          const supaGj = getSupabase() ?? undefined;
+          if (supaGj && bootstrapIdentity.user_id) {
+            const { fetchGuidedJourney, buildGuidedJourneyStandingInstruction } = await import(
+              '../../../services/assistant-continuation/providers/new-day-overview-payload'
+            );
+            const gj = await fetchGuidedJourney(supaGj, bootstrapIdentity.user_id, finalLang);
+            const journeyBlock = buildGuidedJourneyStandingInstruction(gj);
+            if (journeyBlock) finalContext = finalContext ? `${finalContext}${journeyBlock}` : journeyBlock.trimStart();
+          }
+        } catch { /* non-blocking — journey awareness is additive */ }
+
         session.active_role = resolvedRole;
         session.lastSessionInfo = fetchedSessionInfo;
         session.contextInstruction = finalContext;

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -1607,9 +1607,26 @@ router.get(
       // back to a "I'll note it for the team" no-op when faced with a
       // bug-report flow (2026-05-17 user-reported regression).
       const vitanaBehavioralRule = buildPersonaBehavioralRule('vitana');
-      const vitanaContextInstruction = bootstrapContext
+      // GUIDED JOURNEY standing awareness (parity with the Vertex/SSE path in
+      // live-session-controller): append the user's live journey progress so
+      // LiveKit Vitana also knows the user's current session every turn and never
+      // defaults to "the first lesson". Best-effort; empty for brand-new users.
+      let journeyStandingBlock = '';
+      try {
+        const gjSb = getSupabase();
+        const gjUser = req.identity?.user_id;
+        if (gjSb && gjUser) {
+          const { fetchGuidedJourney, buildGuidedJourneyStandingInstruction } = await import(
+            '../services/assistant-continuation/providers/new-day-overview-payload'
+          );
+          journeyStandingBlock = buildGuidedJourneyStandingInstruction(
+            await fetchGuidedJourney(gjSb, gjUser, lang),
+          );
+        }
+      } catch { /* non-blocking — journey awareness is additive */ }
+      const vitanaContextInstruction = (bootstrapContext
         ? `${bootstrapContext}\n\n${vitanaBehavioralRule}`
-        : vitanaBehavioralRule;
+        : vitanaBehavioralRule) + journeyStandingBlock;
       systemInstruction = buildLiveSystemInstruction(
         lang,
         voiceStyle,

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
@@ -674,7 +674,7 @@ async function fetchRemindersToday(
  * proactive opener never disagree. Best-effort: any failure → null (the briefing
  * simply omits the guided-journey beat).
  */
-async function fetchGuidedJourney(
+export async function fetchGuidedJourney(
   sb: SupabaseClient, userId: string, lang: string,
 ): Promise<OverviewPayload['guided_journey']> {
   try {
@@ -700,6 +700,35 @@ async function fetchGuidedJourney(
   } catch {
     return null;
   }
+}
+
+/**
+ * Render the user's guided-journey progress as a STANDING system-instruction
+ * block (English; the model emits the user's language). Unlike the greeting
+ * briefing — which only reaches the model on the first turn — this is meant to
+ * be appended to the persistent bootstrap context so Vitana knows the user's
+ * current session on EVERY turn and never defaults to "the first lesson".
+ *
+ * Returns '' for users without meaningful progress (brand-new / session 1 with
+ * nothing completed) — those are handled by the NEW-USER bias and should not be
+ * told "you are on session 1".
+ */
+export function buildGuidedJourneyStandingInstruction(
+  gj: OverviewPayload['guided_journey'],
+): string {
+  if (!gj || !(gj.sessions_completed > 0)) return '';
+  const currentSession = gj.sessions_completed + 1;
+  const lines: string[] = [];
+  lines.push('## GUIDED JOURNEY — LIVE PROGRESS (authoritative; do not contradict)');
+  lines.push('The user is ACTIVELY progressing through the Vitanaland Guided Journey.');
+  lines.push(`- Sessions completed: ${gj.sessions_completed}`);
+  lines.push(`- Current session: ${currentSession}${gj.next_session_title ? ` — "${gj.next_session_title}"` : ''}`);
+  if (gj.last_session_recall) lines.push(`- Where you left off: "${gj.last_session_recall}"`);
+  lines.push('');
+  lines.push(
+    `When the user asks what to do next in the journey — or you proactively guide them there — refer to their CURRENT session (${currentSession}) and continue FORWARD. NEVER restart at session 1 or call it "the first lesson". If they agree to continue, calling narrate_guided_session with NO session number resumes at their current session automatically. Mention the session number/title naturally so the user feels you know exactly where they are.`,
+  );
+  return '\n\n' + lines.join('\n');
 }
 
 async function fetchDiaryLast7Days(sb: SupabaseClient, userId: string, now: Date): Promise<number> {

--- a/services/gateway/test/guided-journey-standing-instruction.test.ts
+++ b/services/gateway/test/guided-journey-standing-instruction.test.ts
@@ -1,0 +1,62 @@
+/**
+ * buildGuidedJourneyStandingInstruction — the STANDING system-instruction block
+ * that makes Vitana aware of the user's current guided-journey session on EVERY
+ * turn (not just the greeting), so she never defaults to "the first lesson"
+ * mid-conversation.
+ *
+ * Pins the contract:
+ *   1. A user with real progress (session 10) → block names session 10 + title,
+ *      and explicitly forbids restarting at session 1.
+ *   2. A brand-new user (session 1, nothing completed) → empty string (handled
+ *      by the NEW-USER bias; must not be told "you are on session 1").
+ *   3. null progress → empty string.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { buildGuidedJourneyStandingInstruction } from '../src/services/assistant-continuation/providers/new-day-overview-payload';
+
+describe('buildGuidedJourneyStandingInstruction', () => {
+  it('user on session 10 → standing block names the current session and forbids restarting at 1', () => {
+    const block = buildGuidedJourneyStandingInstruction({
+      sessions_completed: 9,
+      topics_learned: 12,
+      topics_total: 254,
+      next_session_title: 'Schlaf optimieren',
+      last_session_recall: 'Atemübungen für besseren Schlaf',
+    });
+    expect(block).toContain('Current session: 10');
+    expect(block).toContain('Schlaf optimieren');
+    expect(block).toContain('Sessions completed: 9');
+    expect(block).toContain('Where you left off: "Atemübungen für besseren Schlaf"');
+    expect(block).toMatch(/NEVER restart at session 1/i);
+  });
+
+  it('brand-new user (session 1, nothing completed) → empty (handled by NEW-USER bias)', () => {
+    const block = buildGuidedJourneyStandingInstruction({
+      sessions_completed: 0,
+      topics_learned: 0,
+      topics_total: 254,
+      next_session_title: 'Starte deine Longevity-Reise',
+      last_session_recall: null,
+    });
+    expect(block).toBe('');
+  });
+
+  it('null progress → empty string (never blocks / never fabricates)', () => {
+    expect(buildGuidedJourneyStandingInstruction(null)).toBe('');
+  });
+
+  it('derives the current session as sessions_completed + 1', () => {
+    const block = buildGuidedJourneyStandingInstruction({
+      sessions_completed: 4,
+      topics_learned: 5,
+      topics_total: 254,
+      next_session_title: null,
+      last_session_recall: null,
+    });
+    expect(block).toContain('Current session: 5');
+    // No title/recall available → those lines are omitted, but the session line stays.
+    expect(block).not.toContain('Where you left off');
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03348` · **Layer:** AGTL (ORB live instruction) · **Priority:** P1

VALIDATION_PROFILE: gateway_backend

---

## 📋 Summary

Follow-up to #2804. That PR fixed the **tool** (`narrate_guided_session` now returns the user's current session). But the live ORB **system instruction** only learned the user's journey progress at the **greeting** (the login briefing) — so mid-conversation the model lost that context and could still talk about "the first lesson."

This injects the user's **live journey progress** into the **standing** bootstrap context, so Vitana knows the user is on e.g. Session 10 on **every** turn — not just the first.

---

## ✅ Changes

SCOPE_ALLOWLIST: services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts, services/gateway/src/orb/live/session/live-session-controller.ts, services/gateway/src/routes/orb-livekit.ts, services/gateway/test/guided-journey-standing-instruction.test.ts

- `new-day-overview-payload.ts`: export `fetchGuidedJourney`; add `buildGuidedJourneyStandingInstruction()` — renders `sessions_completed`, current session + title, and "where you left off" as a standing block with an explicit **"NEVER restart at session 1"** directive. Returns empty for brand-new users (session 1, nothing completed) so they aren't told "you are on session 1."
- `live-session-controller.ts` (Vertex/SSE path): append the standing block to the bootstrap `contextInstruction`. Best-effort; never blocks bootstrap.
- `orb-livekit.ts` (LiveKit path): same, for parity on the main Vitana path (the wake-brief path already carried a journey-guide block).

No new positional param on `buildLiveSystemInstruction` — the block is appended to the existing bootstrap-context string, so the 14-arg builder and its other callers are untouched.

---

## 🧪 Testing

ACCEPTANCE:
- AC-1: User on session 10 → standing block names session 10 + title and forbids restarting at 1. TEST: `guided-journey-standing-instruction.test.ts`
- AC-2: Brand-new user (session 1, nothing completed) → empty block (NEW-USER bias handles it). TEST: same
- AC-3: null progress → empty (never fabricates). TEST: same

- New renderer suite (4) + existing narrate suite (24) = **28 green**; **595** assistant-continuation / provider tests still pass; `tsc --noEmit` clean.

---

## 🚨 Breaking Changes

None. Purely additive context; both injections are best-effort and empty for users without progress. No schema change, no new route, no signature change to the instruction builder.

---

## 📌 Additional Notes

MERGE_PAYLOAD_PREVIEW: backend-only (`services/gateway/src/**`) + one unit test; no migration.

OASIS_IMPACT: none.

Together with #2804 this closes the loop the user raised: Vitana both **picks** the right session and **knows** which session the user is on before she's asked — no more "die erste Lektion" when you're on Session 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_