### PR TITLE
ci(impact): conversation-flow changes require a flow test in the same PR (VTID-03349)

### DIFF
--- a/scripts/ci/impact-rules/conversation-flow-change-needs-test.mjs
+++ b/scripts/ci/impact-rules/conversation-flow-change-needs-test.mjs
@@ -1,0 +1,91 @@
+/**
+ * conversation-flow-change-needs-test
+ *
+ * THE RULE (operator request, 2026-06-28): the conversation flow is the product.
+ * Every change to how Vitana decides what to say / which session to surface /
+ * what context she carries MUST ship with a test in the SAME PR — so flow
+ * behaviour can never silently regress again (e.g. "offer session 1 while the
+ * user is on session 10", "I cannot execute").
+ *
+ * Heuristic: if this PR adds/modifies any CONVERSATION-FLOW source file, it must
+ * also add/modify at least one conversation-flow TEST file. If it doesn't, the
+ * check fails (blocker) — mirroring `new-route-needs-test`, but for the flow
+ * surface, and as a hard gate rather than a warning.
+ *
+ * Escape hatch (rare — genuinely behaviour-free edits: a comment, a log line, a
+ * rename): put `flow-test-exempt: <reason>` in a changed flow file (a code
+ * comment is fine). A flow file carrying that marker is excluded from the gate.
+ *
+ * The flow surface and the flow-test set are kept deliberately broad so new flow
+ * modules are covered by default; extend the regexes when a new flow area lands.
+ */
+
+import { readFileAtRepo } from './_shared.mjs';
+
+export const meta = {
+  rule: 'conversation-flow-change-needs-test',
+  category: 'companion',
+  severity: 'blocker',
+};
+
+// Source files that define conversation-flow BEHAVIOUR (what Vitana says / picks
+// / remembers). Test + .d.ts files are excluded below.
+const FLOW_SOURCE_RE = [
+  /^services\/gateway\/src\/services\/conversation\/.+\.(ts|tsx)$/,        // next-best-action, decide-opening, screen-surface
+  /^services\/gateway\/src\/services\/assistant-continuation\/.+\.(ts|tsx)$/, // briefing / continuation providers
+  /^services\/gateway\/src\/services\/guide\/.+\.(ts|tsx)$/,               // temporal bucket / recency
+  /^services\/gateway\/src\/services\/guided-journey\/.+\.(ts|tsx)$/,      // journey state
+  /^services\/gateway\/src\/orb\/live\/instruction\/.+\.(ts|tsx)$/,        // system-instruction builder
+  /^services\/gateway\/src\/orb\/live\/session\/live-session-controller\.ts$/, // bootstrap-context assembly
+  /^services\/gateway\/src\/services\/orb-tools-shared\.ts$/,              // the ORB action/flow tools (narrate, NBA, …)
+];
+
+// A changed test file that counts as covering the flow change. Broad on purpose:
+// the flow suites live under many names (conversation-flow, narrate-guided-session,
+// guided-journey-*, journey-*, greeting-*, wake-*, continuity-*, system-instruction…).
+const FLOW_TEST_RE =
+  /^services\/gateway\/test\/.*(conversation|narrate|guided|journey|greeting|wake|continuity|screen|opening|next-best|decide|instruction|session|nba|recency|temporal).*\.(test|spec)\.(ts|tsx)$/i;
+
+const TEST_OR_DTS_RE = /\.(test|spec)\.(ts|tsx)$|\.d\.ts$/;
+const EXEMPT_RE = /flow-test-exempt/;
+
+export async function check({ changedFiles, repoRoot }) {
+  const flowSource = changedFiles.filter(
+    (f) =>
+      (f.status === 'A' || f.status === 'M') &&
+      !TEST_OR_DTS_RE.test(f.path) &&
+      FLOW_SOURCE_RE.some((re) => re.test(f.path)),
+  );
+  if (flowSource.length === 0) return [];
+
+  // Escape hatch: drop flow files that carry the `flow-test-exempt` marker.
+  const gated = flowSource.filter((f) => {
+    const src = readFileAtRepo(repoRoot, f.path);
+    return !(src && EXEMPT_RE.test(src));
+  });
+  if (gated.length === 0) return [];
+
+  // Did the PR touch a conversation-flow test?
+  const hasFlowTest = changedFiles.some(
+    (f) => (f.status === 'A' || f.status === 'M') && FLOW_TEST_RE.test(f.path),
+  );
+  if (hasFlowTest) return [];
+
+  return [
+    {
+      rule: meta.rule,
+      severity: meta.severity,
+      file_path: gated[0].path,
+      line_number: null,
+      message:
+        `This PR changes conversation-flow code (${gated.length} file(s), e.g. ${gated[0].path}) ` +
+        `but adds/updates no conversation-flow test. Flow behaviour must ship with a test in the same PR.`,
+      suggested_action:
+        `Add or extend a test under services/gateway/test/ that pins the new flow behaviour ` +
+        `(e.g. narrate-guided-session-shared.test.ts, conversation-flow.test.ts, ` +
+        `guided-journey-standing-instruction.test.ts). For a genuinely behaviour-free edit ` +
+        `(comment / log / rename), add \`flow-test-exempt: <reason>\` in a changed flow file.`,
+      raw: { flow_files: gated.map((f) => f.path) },
+    },
+  ];
+}

--- a/scripts/ci/impact-rules/registry.mjs
+++ b/scripts/ci/impact-rules/registry.mjs
@@ -80,6 +80,14 @@ export const IMPACT_RULES = [
     severity: 'warning',
     enabled: true,
   },
+  {
+    rule: 'conversation-flow-change-needs-test',
+    title: 'Conversation-flow change without a flow test',
+    description: 'The conversation flow is the product: any change to how Vitana decides what to say / which guided-journey session to surface / what context she carries (services/gateway/src/services/conversation, assistant-continuation, guide, guided-journey, orb-tools-shared.ts, orb/live/instruction, live-session-controller.ts) MUST ship with a conversation-flow test under services/gateway/test/ in the same PR. Mirrors new-route-needs-test but as a hard gate for the flow surface, so behaviour like "offer session 1 while the user is on session 10" can never silently regress. Escape hatch for behaviour-free edits: `flow-test-exempt: <reason>` in a changed flow file.',
+    category: 'companion',
+    severity: 'blocker',
+    enabled: true,
+  },
 
   // ── conflict rules ───────────────────────────────────────────────────────
   {

--- a/supabase/migrations/20260628120000_conversation_flow_test_impact_rule.sql
+++ b/supabase/migrations/20260628120000_conversation_flow_test_impact_rule.sql
@@ -1,0 +1,25 @@
+-- =============================================================================
+-- Dev Autopilot — register the 'conversation-flow-change-needs-test' impact rule
+-- =============================================================================
+-- Seed row for scripts/ci/impact-rules/conversation-flow-change-needs-test.mjs
+-- (authoritative list: scripts/ci/impact-rules/registry.mjs). Keeps the Command
+-- Hub → Autopilot → Impact Rules tab in sync with the code, per the
+-- new-impact-rule-needs-seed-migration companion rule.
+--
+-- Re-runnable via ON CONFLICT DO UPDATE.
+-- =============================================================================
+
+INSERT INTO public.dev_autopilot_impact_rules
+  (rule, title, description, category, severity, enabled)
+VALUES
+  ('conversation-flow-change-needs-test',
+   'Conversation-flow change without a flow test',
+   'The conversation flow is the product: any change to how Vitana decides what to say / which guided-journey session to surface / what context she carries (services/gateway/src/services/conversation, assistant-continuation, guide, guided-journey, orb-tools-shared.ts, orb/live/instruction, live-session-controller.ts) MUST ship with a conversation-flow test under services/gateway/test/ in the same PR. Mirrors new-route-needs-test but as a hard gate for the flow surface, so behaviour like "offer session 1 while the user is on session 10" can never silently regress. Escape hatch for behaviour-free edits: flow-test-exempt: <reason> in a changed flow file.',
+   'companion', 'blocker', TRUE)
+ON CONFLICT (rule) DO UPDATE SET
+  title       = EXCLUDED.title,
+  description = EXCLUDED.description,
+  category    = EXCLUDED.category,
+  severity    = EXCLUDED.severity,
+  enabled     = EXCLUDED.enabled,
+  updated_at  = NOW();


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03349` · **Layer:** CICDL (governance / CI) · **Priority:** P1

VALIDATION_PROFILE: gateway_backend

---

## 📋 Summary

Makes "test the conversation flow" a **rule**, not a habit. A new **blocker** impact rule fails the **Dev Autopilot Impact Scan** whenever a PR changes conversation-flow code **without** also adding/updating a conversation-flow test. This is the guardrail the operator asked for: no flow change merges without its test, so regressions like *"offer session 1 while the user is on session 10"* or *"I cannot execute"* can never ship silently again.

It mirrors the existing `new-route-needs-test` rule, but scoped to the flow surface and as a **hard gate** rather than a warning.

---

## ✅ Changes

SCOPE_ALLOWLIST: scripts/ci/impact-rules/conversation-flow-change-needs-test.mjs, scripts/ci/impact-rules/registry.mjs, supabase/migrations/20260628120000_conversation_flow_test_impact_rule.sql

- **`conversation-flow-change-needs-test.mjs`** — the rule (auto-discovered by `dev-autopilot-impact-scan.mjs`).
  - **Flow surface (source):** `services/gateway/src/services/{conversation,assistant-continuation,guide,guided-journey}`, `orb-tools-shared.ts`, `orb/live/instruction/**`, `orb/live/session/live-session-controller.ts`.
  - **Required companion:** a changed test under `services/gateway/test/` matching the flow-test set (`conversation|narrate|guided|journey|greeting|wake|instruction|session|…`).
  - **Escape hatch** for genuinely behaviour-free edits (comment / log / rename): `flow-test-exempt: <reason>` in a changed flow file.
- **`registry.mjs`** — register it (companion / **blocker**).
- **Seed migration** — INSERT into `dev_autopilot_impact_rules` so the Command Hub → Autopilot → Impact Rules tab reflects it (satisfies the `new-impact-rule-needs-seed-migration` companion rule).

---

## 🧪 Testing

ACCEPTANCE:
- AC-1: Flow change with NO flow test → rule emits a blocker finding. TEST: node smoke-run (6 scenarios)
- AC-2: Flow change WITH a flow test → no finding. TEST: same
- AC-3: Non-flow change → no finding. TEST: same
- AC-4: An unrelated test name does NOT satisfy the gate. TEST: same

- 6/6 logic scenarios pass; registry + rule modules parse; the existing impact-rule-referencing gateway test still passes.

---

## 🚨 Breaking Changes

None for runtime. **Process change:** future PRs that touch conversation-flow code will be **blocked** by the impact scan until they include a flow test (or an explicit `flow-test-exempt:` marker). That's the intended behaviour. Operators can toggle it from the Command Hub Impact Rules tab (the seed row is `enabled = TRUE`).

---

## 📌 Additional Notes

MERGE_PAYLOAD_PREVIEW: CI tooling + one seed migration; no gateway runtime code. (The `migration-requires-code-touch` rule may warn since this migration is governance-only and doesn't touch `services/gateway/src` — that's expected and non-blocking.)

OASIS_IMPACT: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_