### PR TITLE
fix(orb): make "show my matches" speakable so it can't fake-fail (VTID-03351)

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3555,6 +3555,27 @@ const INTENT_MATCH_AUTONAV_GAP = 0.15;
 // single-intent path uses. That screen renders its own graceful empty/error
 // state, so even when there are zero matches (or zero open posts) the offer is
 // fulfilled — we navigate the user there instead of refusing.
+/**
+ * Render match rows as a short, SPEAKABLE summary. The Vertex live path forwards
+ * ONLY a tool result's `text` to the model — so if `text` is "Opening the matches
+ * screen" (a navigation announcement) the model has nothing to actually say on a
+ * conversational surface where no screen opens, and it improvises "I couldn't do
+ * that". Giving it real, presentable content is what prevents the offer-then-fail.
+ */
+function formatMatchesForSpeech(
+  slim: Array<{ score?: number | null; tier?: string | null; kind_pairing?: string | null }>,
+): string {
+  return slim
+    .slice(0, 3)
+    .map((m, i) => {
+      const kind = String(m.kind_pairing ?? 'match').replace(/_/g, ' ');
+      const fit = typeof m.score === 'number' ? `${Math.round(m.score * 100)}% fit` : 'a strong fit';
+      const tier = m.tier ? `, ${m.tier} tier` : '';
+      return `${i + 1}) a ${kind}${tier} — ${fit}`;
+    })
+    .join('; ');
+}
+
 async function viewAllMyMatches(
   args: OrbToolArgs,
   id: OrbToolIdentity,
@@ -3610,8 +3631,9 @@ async function viewAllMyMatches(
           reason: 'no_open_intents',
         },
         text:
-          "I'm opening your matches now — you don't have any open posts yet, " +
-          'so post a wish and I\'ll let you know the moment someone matches.',
+          'HANDLED — the user has no open posts yet, so there are no matches to show. ' +
+          'Warmly invite them to post a wish (what kind of partner or activity they want) and tell ' +
+          'them you will alert them the moment someone matches. Do NOT say you could not do it — guide them to post one now.',
       };
     }
 
@@ -3663,8 +3685,12 @@ async function viewAllMyMatches(
       },
       text:
         slim.length > 0
-          ? `Opening your matches — you have ${slim.length} to look through.`
-          : "I'm opening your matches now. None have come in yet, but your posts are live — I'll flag the moment someone matches.",
+          ? `SUCCESS — the user has ${slim.length} match${slim.length === 1 ? '' : 'es'}. ` +
+            `Present them now, warmly and conversationally, then offer to open the top one for details. ` +
+            `Do NOT say you could not do it. Matches: ${formatMatchesForSpeech(slim)}.`
+          : 'HANDLED — the user has live posts but no matches have arrived yet. Tell them warmly that ' +
+            'nothing has come in yet, their posts are active, and you will flag the moment someone matches; ' +
+            'then suggest a next step (refine a post or explore the community). Do NOT say you could not complete it — there is simply nothing to show yet.',
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : 'unknown';
@@ -3768,7 +3794,14 @@ export async function tool_view_intent_matches(
     return {
       ok: true,
       result: { ok: true, matches: slim, decision: 'list_only' },
-      text: JSON.stringify({ ok: true, matches: slim }),
+      // SPEAKABLE text (never raw JSON — the live model parrots whatever this is).
+      text:
+        slim.length > 0
+          ? `SUCCESS — ${slim.length} match${slim.length === 1 ? '' : 'es'} for this post. ` +
+            `Present them now, then offer to open one for details. Do NOT say you could not do it. ` +
+            `Matches: ${formatMatchesForSpeech(slim)}.`
+          : 'HANDLED — no matches have arrived for this post yet. Tell the user warmly that none have ' +
+            'come in yet but the post is live, and offer to refine it or look at the wider community. Do NOT say you could not do it.',
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : 'unknown';

--- a/services/gateway/test/services/conversation/intent-matches-speakable.test.ts
+++ b/services/gateway/test/services/conversation/intent-matches-speakable.test.ts
@@ -1,0 +1,102 @@
+/**
+ * view_intent_matches — the result text the live model speaks must be PRESENTABLE
+ * content, never a navigation announcement or raw JSON, and must never invite a
+ * "couldn't complete" narration.
+ *
+ * THE BUG (operator report): Vitana offered "soll ich dir die Matches zeigen?",
+ * the user said "Ja", and she answered "Das konnte ich leider nicht abschließen."
+ * On a conversational surface the matches tool's old text was "Opening your
+ * matches screen" (a no-op there) or raw JSON — so the model had nothing real to
+ * say and improvised a failure. These tests pin that every branch now returns
+ * speakable content and explicitly forbids the fake-fail.
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SUPABASE_URL = 'http://supabase.test';
+process.env.SUPABASE_SERVICE_ROLE = 'test-service-role';
+
+// viewAllMyMatches builds its own client; mock the user_intents query chain.
+let MOCK_INTENTS: Array<{ intent_id: string }> = [];
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => {
+      const chain: Record<string, unknown> = {};
+      chain.select = () => chain;
+      chain.eq = () => chain;
+      chain.in = () => chain;
+      chain.order = () => chain;
+      chain.limit = () => Promise.resolve({ data: MOCK_INTENTS, error: null });
+      return chain;
+    },
+  }),
+}));
+
+let MOCK_MATCHES: Array<Record<string, unknown>> = [];
+jest.mock('../../../src/services/intent-matcher', () => ({
+  surfaceTopMatches: jest.fn(async () => MOCK_MATCHES),
+}));
+jest.mock('../../../src/services/intent-mutual-reveal', () => ({
+  redactMatchForReader: jest.fn(async (m: unknown) => m),
+}));
+
+import { tool_view_intent_matches } from '../../../src/services/orb-tools-shared';
+
+const id = { user_id: 'u1', tenant_id: 't1', role: 'community', session_id: 's1' } as never;
+// Every branch frames the result positively (SUCCESS/HANDLED) and carries the
+// explicit guard telling the model NOT to claim it couldn't do it.
+const POSITIVE = /SUCCESS|HANDLED/;
+const ANTI_FAIL_GUARD = /Do NOT say you could not|Do NOT say you could not complete/i;
+
+beforeEach(() => {
+  MOCK_INTENTS = [];
+  MOCK_MATCHES = [];
+});
+
+describe('view_intent_matches — speakable, never a fake-fail', () => {
+  it('aggregate (no intent_id) with matches → speakable list, fit %, no "couldn\'t"', async () => {
+    MOCK_INTENTS = [{ intent_id: 'i1' }];
+    MOCK_MATCHES = [
+      { match_id: 'm1', vitana_id_b: null, score: 0.82, kind_pairing: 'partner_seek', state: 'new', redacted: true, match_reasons: { tier: 'gold' } },
+      { match_id: 'm2', vitana_id_b: null, score: 0.61, kind_pairing: 'activity', state: 'new', redacted: true, match_reasons: { tier: 'silver' } },
+    ];
+    const r = await tool_view_intent_matches({}, id);
+    expect(r.ok).toBe(true);
+    expect(r.text).toMatch(/2 matches/);
+    expect(r.text).toMatch(/82% fit/);
+    expect(r.text).toMatch(/Present them/i);
+    expect(r.text).toMatch(POSITIVE);
+    expect(r.text).toMatch(ANTI_FAIL_GUARD);
+    expect(r.text!.trim().startsWith('{')).toBe(false); // never raw JSON
+  });
+
+  it('aggregate with OPEN posts but zero matches → "nothing yet", not a failure', async () => {
+    MOCK_INTENTS = [{ intent_id: 'i1' }];
+    MOCK_MATCHES = [];
+    const r = await tool_view_intent_matches({}, id);
+    expect(r.ok).toBe(true);
+    expect(r.text).toMatch(/nothing has come in yet|no matches/i);
+    expect(r.text).toMatch(POSITIVE);
+  });
+
+  it('aggregate with NO open posts → invite to post a wish, not a failure', async () => {
+    MOCK_INTENTS = [];
+    const r = await tool_view_intent_matches({}, id);
+    expect(r.ok).toBe(true);
+    expect(r.text).toMatch(/post a wish/i);
+    expect(r.text).toMatch(POSITIVE);
+  });
+
+  it('single-intent list_only → speakable summary, never raw JSON, no fake-fail', async () => {
+    // Two near-tied scores → not "dominant", so it stays list_only (the branch
+    // that used to return JSON.stringify as the spoken text).
+    MOCK_MATCHES = [
+      { match_id: 'm1', vitana_id_b: null, score: 0.80, kind_pairing: 'partner_seek', state: 'new', redacted: true, match_reasons: { tier: 'gold' } },
+      { match_id: 'm2', vitana_id_b: null, score: 0.79, kind_pairing: 'partner_seek', state: 'new', redacted: true, match_reasons: { tier: 'gold' } },
+    ];
+    const r = await tool_view_intent_matches({ intent_id: 'i1' }, id);
+    expect(r.ok).toBe(true);
+    expect(r.text!.trim().startsWith('{')).toBe(false);
+    expect(r.text).toMatch(/Present them|for this post/i);
+    expect(r.text).toMatch(ANTI_FAIL_GUARD);
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03351` · **Layer:** AGTL (ORB tools) · **Priority:** P1

VALIDATION_PROFILE: gateway_backend

---

## 📋 Summary

The offer-then-fail from the screenshot: Vitana offered *"soll ich dir die Matches zeigen?"*, the user said *"Ja"*, and she answered *"Das konnte ich leider nicht abschließen"* — with **no `tool_failed` telemetry** (confirmed: the query returned zero rows), because the tool didn't actually error.

**Root cause:** the Vertex live path forwards **only** a tool result's `text` to the model. `view_intent_matches` returned either a **navigation announcement** ("Opening your matches screen" — a no-op on a conversational surface where no screen opens) or, in the `list_only` branch, **raw `JSON.stringify(...)`**. With nothing real to say, the model improvised a failure.

This is the user-chosen fix: make matches **speakable** and make a successful tool result impossible to narrate as "couldn't complete."

---

## ✅ Changes

SCOPE_ALLOWLIST: services/gateway/src/services/orb-tools-shared.ts, services/gateway/test/services/conversation/intent-matches-speakable.test.ts

- New `formatMatchesForSpeech()` helper → "1) a partner seek, gold tier — 82% fit; …".
- Every `view_intent_matches` / `viewAllMyMatches` branch now returns presentable content with an explicit **"Do NOT say you could not do it"** guard:
  - matches present → speakable list + offer to open the top one;
  - open posts but no matches → "nothing has come in yet …";
  - no open posts → invite to post a wish;
  - single-intent `list_only` → readable summary instead of `JSON.stringify`.
- The `navigate` directive is **retained** for full-app surfaces (unchanged there).

---

## 🧪 Testing

ACCEPTANCE:
- AC-1: Aggregate with matches → text contains the count + fit % + "Present them", is not raw JSON. TEST: `intent-matches-speakable.test.ts`
- AC-2: Open posts, zero matches → "nothing yet", positive framing, not a failure. TEST: same
- AC-3: No open posts → invite to post a wish. TEST: same
- AC-4: Single-intent `list_only` → speakable summary, never raw JSON. TEST: same

- 4/4 new tests pass; `tsc --noEmit` clean. The characterization snapshots are unaffected (the "Opening your matches" string they contain is a system-instruction voice-cue, not the tool's result text).

---

## 🚨 Breaking Changes

None. Only the spoken `text` of the matches tool changed (toward presentable content). Structured `result` fields, the `navigate` directive, and app-surface behaviour are unchanged.

---

## 📌 Additional Notes

MERGE_PAYLOAD_PREVIEW: backend-only + one new flow test; no migration, no route.

OASIS_IMPACT: none.

This addresses the *matches* offer-then-fail specifically. The broader fix — binding **every** mid-conversation offer so "Ja" always executes the exact offered action (the acceptance gate only binds wake-brief offers today) — is the deeper follow-up we discussed and is intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_