### PR TITLE
Add group chat message edit/delete endpoints (VTID-03089)

### DIFF
--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -374,7 +374,7 @@ router.patch('/:id/messages/:messageId', requireAuth, requireTenant, async (req:
     return res.status(400).json({ ok: false, error: 'content is required' });
   }
 
-  // impact-allow-no-oasis: editing one's own chat message is routine user-content
+  // impact-allow-no-oasis: editing your own chat message is routine user-content
   // CRUD, not a governed state transition — consistent with the sibling POST
   // /:id/send handler, which likewise emits no OASIS event.
   const supabase = getSupabase();
@@ -426,7 +426,7 @@ router.delete('/:id/messages/:messageId', requireAuth, requireTenant, async (req
 
   const { id: groupId, messageId } = req.params;
 
-  // impact-allow-no-oasis: deleting one's own chat message (or moderator removal)
+  // impact-allow-no-oasis: deleting your own chat message, or moderator removal,
   // is routine user-content CRUD, not a governed state transition — consistent
   // with the sibling POST /:id/send handler, which likewise emits no OASIS event.
   const supabase = getSupabase();

--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -13,6 +13,8 @@
  *                                    Reactions are written client-side via Supabase RLS on
  *                                    message_reactions (polymorphic on chat_messages.id).
  *   POST   /:id/read               — Mark all group messages read up to "now"
+ *   PATCH  /:id/messages/:messageId — Edit own group message (content)
+ *   DELETE /:id/messages/:messageId — Delete a group message (sender, or owner/admin)
  */
 
 import { Router, Request, Response } from 'express';
@@ -353,6 +355,105 @@ router.post('/:id/read', requireAuth, requireTenant, async (req: Request, res: R
 
   if (error) {
     console.error('[ChatGroups] Mark read error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({ ok: true });
+});
+
+// ── PATCH /:id/messages/:messageId — Edit own group message ────
+
+router.patch('/:id/messages/:messageId', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { id: groupId, messageId } = req.params;
+  const { content } = req.body as { content?: unknown };
+  const trimmed = typeof content === 'string' ? content.trim() : '';
+  if (trimmed.length === 0) {
+    return res.status(400).json({ ok: false, error: 'content is required' });
+  }
+
+  const supabase = getSupabase();
+
+  const membership = await requireMembership(supabase, groupId, identity.user_id);
+  if (!membership) {
+    return res.status(403).json({ ok: false, error: 'not_a_member' });
+  }
+
+  // Only the original sender may edit their message.
+  const { data: existing, error: fetchErr } = await supabase
+    .from('chat_messages')
+    .select('id, sender_id, group_id')
+    .eq('id', messageId)
+    .maybeSingle();
+  if (fetchErr) {
+    console.error('[ChatGroups] Edit lookup error:', fetchErr);
+    return res.status(500).json({ ok: false, error: fetchErr.message });
+  }
+  if (!existing || (existing as any).group_id !== groupId) {
+    return res.status(404).json({ ok: false, error: 'message_not_found' });
+  }
+  if ((existing as any).sender_id !== identity.user_id) {
+    return res.status(403).json({ ok: false, error: 'not_message_owner' });
+  }
+
+  const { data, error } = await supabase
+    .from('chat_messages')
+    .update({ content: trimmed })
+    .eq('id', messageId)
+    .select()
+    .single();
+  if (error) {
+    console.error('[ChatGroups] Edit error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({ ok: true, data });
+});
+
+// ── DELETE /:id/messages/:messageId — Delete a group message ───
+// The original sender may delete their own message; group owners/admins
+// may delete any message (moderation). Mirrors the DM delete capability
+// so the group action sheet's Delete button works (parity with private chat).
+
+router.delete('/:id/messages/:messageId', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { id: groupId, messageId } = req.params;
+  const supabase = getSupabase();
+
+  const membership = await requireMembership(supabase, groupId, identity.user_id);
+  if (!membership) {
+    return res.status(403).json({ ok: false, error: 'not_a_member' });
+  }
+
+  const { data: existing, error: fetchErr } = await supabase
+    .from('chat_messages')
+    .select('id, sender_id, group_id')
+    .eq('id', messageId)
+    .maybeSingle();
+  if (fetchErr) {
+    console.error('[ChatGroups] Delete lookup error:', fetchErr);
+    return res.status(500).json({ ok: false, error: fetchErr.message });
+  }
+  if (!existing || (existing as any).group_id !== groupId) {
+    return res.status(404).json({ ok: false, error: 'message_not_found' });
+  }
+
+  const isOwner = (existing as any).sender_id === identity.user_id;
+  const isModerator = membership.role === 'owner' || membership.role === 'admin';
+  if (!isOwner && !isModerator) {
+    return res.status(403).json({ ok: false, error: 'not_message_owner' });
+  }
+
+  const { error } = await supabase
+    .from('chat_messages')
+    .delete()
+    .eq('id', messageId);
+  if (error) {
+    console.error('[ChatGroups] Delete error:', error);
     return res.status(500).json({ ok: false, error: error.message });
   }
 

--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -374,6 +374,9 @@ router.patch('/:id/messages/:messageId', requireAuth, requireTenant, async (req:
     return res.status(400).json({ ok: false, error: 'content is required' });
   }
 
+  // impact-allow-no-oasis: editing one's own chat message is routine user-content
+  // CRUD, not a governed state transition — consistent with the sibling POST
+  // /:id/send handler, which likewise emits no OASIS event.
   const supabase = getSupabase();
 
   const membership = await requireMembership(supabase, groupId, identity.user_id);
@@ -422,6 +425,10 @@ router.delete('/:id/messages/:messageId', requireAuth, requireTenant, async (req
   if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
 
   const { id: groupId, messageId } = req.params;
+
+  // impact-allow-no-oasis: deleting one's own chat message (or moderator removal)
+  // is routine user-content CRUD, not a governed state transition — consistent
+  // with the sibling POST /:id/send handler, which likewise emits no OASIS event.
   const supabase = getSupabase();
 
   const membership = await requireMembership(supabase, groupId, identity.user_id);


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03089` _(group chat system)_

**Layer:** APIL (Gateway API)

**Priority:** P2

---

## 📋 Summary

The `chat-groups` gateway exposed no way to edit or delete a group message, so the frontend group-chat action sheet's **Delete** and **Edit** buttons were no-ops (private chat worked because it mutates `chat_messages` for DMs). This adds the two missing endpoints so the frontend (companion PR in `exafyltd/vitana-v1`) can wire them up.

---

## ✅ Changes

- [x] `PATCH /api/v1/chat/groups/:id/messages/:messageId` — sender edits their own message `content`
- [x] `DELETE /api/v1/chat/groups/:id/messages/:messageId` — sender deletes own message; group `owner`/`admin` may delete any (moderation)
- [x] Both enforce group membership and verify the message belongs to the group before mutating; updated the route header doc comment

---

## 🧪 Testing

Membership + ownership are enforced server-side; the message is re-fetched and its `group_id` verified before any mutation.

- [x] Manual testing completed — `tsc --noEmit` clean for `chat-groups.ts` (only a pre-existing unrelated tsconfig deprecation warning)
- [ ] Automated tests added/updated
- [ ] Verified in staging/dev environment

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] No workflow files changed

### File Names
- [x] No new files; existing `chat-groups.ts` already kebab-case

### Code Standards
- [x] Event types/kinds use snake_case; status values lowercase; error codes snake_case (`not_a_member`, `message_not_found`, `not_message_owner`)

### Cloud Run Deployments
- [x] No deployment/label changes

### Documentation
- [x] VTID mentioned in commit message

---

## 🚨 Breaking Changes

None — purely additive (two new routes).

---

## 📌 Additional Notes

Frontend companion PR: `exafyltd/vitana-v1#828`. Per the staging-first cutover, merging this deploys to **staging** (`gateway-staging`); production is reached only via the PUBLISH button / escape-hatch.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oHCy4UcbHx5VXeNkaYeVU)_