### PR TITLE
fix(orb): index suggestions never fake-fail; plan names what it scheduled (VTID-03352)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4192,29 +4192,28 @@ async function executeLiveApiToolInner(
             .sort((a: any, b: any) => b._lift - a._lift)
             .slice(0, limit);
 
+          const { buildIndexSuggestionsText } = await import('../services/orb-index-coach-text');
+
           if (ranked.length === 0) {
+            // No queued autopilot recommendations for this pillar — fall back to
+            // the built-in pillar action templates (same source create_index_
+            // improvement_plan uses) so "how do I improve my Index" ALWAYS yields
+            // concrete, speakable suggestions instead of "I couldn't do that".
+            const { PILLAR_ACTION_TEMPLATES } = await import('../lib/vitana-pillars');
+            const templates = (PILLAR_ACTION_TEMPLATES[pillar as keyof typeof PILLAR_ACTION_TEMPLATES] ?? []).slice(0, limit);
             return {
               success: true,
-              result: JSON.stringify({
-                pillar,
-                suggestions: [],
-                message: `No pending recommendations with a positive ${pillar} contribution right now. Completing ANY existing recommendation will trigger the Index engine to propose more.`,
-              }),
+              result: buildIndexSuggestionsText(pillar, templates as Array<{ title?: string | null; description?: string | null }>),
             };
           }
 
+          // SPEAKABLE text (never raw JSON — the live model parrots whatever this is).
           return {
             success: true,
-            result: JSON.stringify({
+            result: buildIndexSuggestionsText(
               pillar,
-              suggestions: ranked.map((r: any) => ({
-                id: r.id,
-                title: r.title,
-                action: r.action_description,
-                lift: r._lift,
-                contribution_vector: r.contribution_vector,
-              })),
-            }),
+              ranked.map((r: any) => ({ title: r.title, description: r.action_description })),
+            ),
           };
         } catch (err: any) {
           console.error('[get_index_improvement_suggestions] error:', err?.message);

--- a/services/gateway/src/services/orb-index-coach-text.ts
+++ b/services/gateway/src/services/orb-index-coach-text.ts
@@ -1,0 +1,64 @@
+/**
+ * Speakable text builders for the ORB "improve my Index" coaching tools.
+ *
+ * The live model is handed ONLY a tool result's spoken text. Two real failures
+ * came from that:
+ *   - get_index_improvement_suggestions returned raw JSON with an empty list when
+ *     the user had no queued autopilot recommendations → the model narrated
+ *     "Das konnte ich nicht abschließen" (offer-then-fail).
+ *   - create_index_improvement_plan wrote 6 calendar events but only said
+ *     "Scheduled 6 actions" → the user had "keine Ahnung" what was added.
+ *
+ * These builders make both tools return concrete, presentable content with an
+ * explicit anti-fake-fail guard, and (for the plan) force the assistant to NAME
+ * exactly what it put on the calendar so nothing happens to the user opaquely.
+ */
+
+/** Suggestions on how to lift a pillar — never empty, never JSON, never a fake-fail. */
+export function buildIndexSuggestionsText(
+  pillar: string,
+  items: Array<{ title?: string | null; description?: string | null }>,
+): string {
+  const lines = items
+    .slice(0, 6)
+    .map((it, i) => {
+      const t = String(it.title ?? '').trim() || 'an action';
+      const d = String(it.description ?? '').trim();
+      return `${i + 1}) ${t}${d ? ` — ${d}` : ''}`;
+    })
+    .join('; ');
+  if (!lines) {
+    return (
+      `HANDLED — no specific ${pillar} suggestions are queued yet. Tell the user warmly that completing ` +
+      `any current recommendation unlocks more, and offer to build a starter ${pillar} plan now. ` +
+      `Do NOT say you could not do it.`
+    );
+  }
+  return (
+    `SUCCESS — concrete ways to lift the user's ${pillar} pillar (their weakest): ${lines}. ` +
+    `Present these warmly as suggestions and offer to build them into a plan on the calendar. ` +
+    `Do NOT say you could not do it.`
+  );
+}
+
+/** Confirmation of a written plan that NAMES each scheduled activity (transparency). */
+export function buildIndexPlanText(
+  pillar: string,
+  days: number,
+  scheduled: Array<{ title?: string | null; start_time?: string | null }>,
+): string {
+  const list = scheduled
+    .slice(0, 8)
+    .map((s, i) => {
+      const t = String(s.title ?? '').trim() || 'an activity';
+      const day = s.start_time ? String(s.start_time).slice(0, 10) : '';
+      return `${i + 1}) ${t}${day ? ` (${day})` : ''}`;
+    })
+    .join('; ');
+  const n = scheduled.length;
+  return (
+    `SUCCESS — ${n} ${pillar} action${n === 1 ? '' : 's'} added to the calendar over the next ${days} days. ` +
+    `Tell the user EXACTLY what was added so they know what is in their calendar — name each one: ${list}. ` +
+    `Then offer to adjust or remove any of them. Do NOT just say "I added some things" — name them.`
+  );
+}

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -1494,10 +1494,13 @@ export async function tool_create_index_improvement_plan(
       last_event: scheduled[scheduled.length - 1],
       all_titles: scheduled.map((s) => s.title),
     };
+    const { buildIndexPlanText } = await import('./orb-index-coach-text');
     return {
       ok: true,
       result: payload,
-      text: `Scheduled ${scheduled.length} ${pillar} actions on your calendar over the next ${days} days.`,
+      // Name EXACTLY what was scheduled so the user is never left wondering what
+      // landed in their calendar ("Ich habe ja keine Ahnung, was du da einträgst").
+      text: buildIndexPlanText(String(pillar), days, scheduled),
     };
   } catch (err: unknown) {
     return { ok: false, error: err instanceof Error ? err.message : 'create_index_improvement_plan error' };

--- a/services/gateway/test/services/conversation/index-coach-text.test.ts
+++ b/services/gateway/test/services/conversation/index-coach-text.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Speakable text for the "improve my Index" coaching tools.
+ *
+ * THE BUGS (operator screenshots):
+ *  - "wie ich meinen Vital-Index verbessern kann" → "Das konnte ich gerade nicht
+ *    abschließen": get_index_improvement_suggestions returned raw JSON with an
+ *    empty list when the user had no queued recommendations.
+ *  - The plan tool wrote 6 calendar events but only said "Scheduled 6 actions",
+ *    leaving the user with "keine Ahnung, was du da einträgst".
+ *
+ * These pin: suggestions are never empty/never JSON/never a fake-fail, and the
+ * plan confirmation NAMES every scheduled activity.
+ */
+
+import {
+  buildIndexSuggestionsText,
+  buildIndexPlanText,
+} from '../../../src/services/orb-index-coach-text';
+
+const ANTI_FAIL = /Do NOT say you could not do it/i;
+
+describe('buildIndexSuggestionsText', () => {
+  it('with items → speakable, enumerated, never raw JSON, anti-fake-fail', () => {
+    const t = buildIndexSuggestionsText('nutrition', [
+      { title: 'Meal planning block', description: '15 minutes to plan balanced meals.' },
+      { title: 'Mindful eating session', description: 'One slow, phone-free meal.' },
+    ]);
+    expect(t).toMatch(/Meal planning block/);
+    expect(t).toMatch(/Mindful eating session/);
+    expect(t).toMatch(/nutrition/);
+    expect(t.trim().startsWith('{')).toBe(false);
+    expect(t).toMatch(ANTI_FAIL);
+  });
+
+  it('with NO items → still positive + actionable, never a fake-fail', () => {
+    const t = buildIndexSuggestionsText('nutrition', []);
+    expect(t).toMatch(/HANDLED/);
+    expect(t).toMatch(/starter nutrition plan/i);
+    expect(t).toMatch(ANTI_FAIL);
+  });
+});
+
+describe('buildIndexPlanText', () => {
+  it('names every scheduled activity with its date (transparency)', () => {
+    const t = buildIndexPlanText('nutrition', 14, [
+      { title: 'Meal planning block', start_time: '2026-06-29T10:00:00.000Z' },
+      { title: 'Mindful eating session', start_time: '2026-07-02T10:00:00.000Z' },
+    ]);
+    expect(t).toMatch(/2 nutrition actions/);
+    expect(t).toMatch(/14 days/);
+    expect(t).toMatch(/Meal planning block \(2026-06-29\)/);
+    expect(t).toMatch(/Mindful eating session \(2026-07-02\)/);
+    expect(t).toMatch(/name each one/i);
+  });
+
+  it('singular wording for a single action', () => {
+    const t = buildIndexPlanText('sleep', 7, [{ title: 'Wind-down routine', start_time: '2026-06-29T20:00:00Z' }]);
+    expect(t).toMatch(/1 sleep action added/);
+    expect(t).not.toMatch(/1 sleep actions/);
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03352` · **Layer:** AGTL (ORB tools) · **Priority:** P1

VALIDATION_PROFILE: gateway_backend

---

## 📋 Summary

Two bad-UX issues from the operator screenshots — same root pattern as the matches bug (a tool's **spoken text** wasn't presentable):

**A. "Das konnte ich gerade nicht abschließen"** when the user asked *"wie ich meinen Vital-Index verbessern kann"*. `get_index_improvement_suggestions` queries `autopilot_recommendations`; when the user has none queued (common), it returned **raw JSON with an empty list** → the model narrated a failure. (The *plan* tool already works in the same situation because it falls back to `PILLAR_ACTION_TEMPLATES`; this tool didn't.)

**B. The plan was written silently.** `create_index_improvement_plan` wrote 6 calendar events but only said *"Scheduled 6 actions"* — so the user had *"keine Ahnung, was du da einträgst"*. It now **names every scheduled activity** so nothing lands in the calendar opaquely.

---

## ✅ Changes

SCOPE_ALLOWLIST: services/gateway/src/services/orb-index-coach-text.ts, services/gateway/src/services/orb-tools-shared.ts, services/gateway/src/routes/orb-live.ts, services/gateway/test/services/conversation/index-coach-text.test.ts

- New `orb-index-coach-text.ts` with two pure, speakable, anti-fake-fail builders: `buildIndexSuggestionsText()` and `buildIndexPlanText()`.
- `get_index_improvement_suggestions` (orb-live.ts): falls back to `PILLAR_ACTION_TEMPLATES` when no recommendations are queued (so it can't come up empty) and returns speakable text instead of raw JSON.
- `create_index_improvement_plan` (orb-tools-shared.ts): the confirmation now names each scheduled activity (title + date), with a directive to NOT say "I added some things" — name them.

---

## 🧪 Testing

ACCEPTANCE:
- AC-1: Suggestions with items → enumerated, not JSON, anti-fake-fail. TEST: `index-coach-text.test.ts`
- AC-2: Suggestions with NO items → still positive + actionable (never "couldn't"). TEST: same
- AC-3: Plan text names every activity with its date. TEST: same
- AC-4: Singular wording ("1 action", not "1 actions"). TEST: same

- 4/4 new tests pass; existing `tool-failure-grace` + `conversation-flow` suites still green (14); `tsc --noEmit` clean.

---

## 🚨 Breaking Changes

None. Only the spoken text of two coaching tools changed (toward concrete, presentable content). Structured `result` payloads and calendar-write behaviour are unchanged.

---

## 📌 Additional Notes

MERGE_PAYLOAD_PREVIEW: backend-only + one new flow test; no migration, no route.

OASIS_IMPACT: none.

This addresses transparency + the suggestions fake-fail. The broader follow-up remains: **confirm-before-commit** for consequential writes (the user's *"du musst doch erst mit mir…"* — present the plan and get agreement before writing it), and binding **every** mid-conversation offer on accept. Both are intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_