### PR TITLE
Fix ORB greeting: stop re-welcoming returning users + greeting/conversation language flip

### DIFF
--- a/services/gateway/src/orb/live/instruction/greeting-gate.ts
+++ b/services/gateway/src/orb/live/instruction/greeting-gate.ts
@@ -1,0 +1,67 @@
+/**
+ * BOOTSTRAP-ORB-GREETING-LANG-FIRSTTIME — greeting-gate decisions.
+ *
+ * Small, pure helpers that encapsulate two session-start greeting decisions so
+ * they can be unit-pinned independently of the large live-session controller /
+ * orb-live handler that consume them:
+ *
+ *   1. deriveHasPriorSession  — has this user talked to Vitana before?
+ *   2. shouldFireFirstTimeWelcome — does the FULL one-time first-session welcome
+ *      fire, or should the user fall through to the returning-user register?
+ *   3. resolveGreetingLang    — which language does the spoken greeting use?
+ *
+ * Why these exist as a unit: the first-time welcome previously fired on the
+ * "needs onboarding" signal alone (0 completed guided-journey topics + not
+ * opted out), so a user who simply never finished onboarding was re-introduced
+ * from scratch on EVERY session — the robotic "first-time user every time" bug.
+ * Gating on `hasPriorSession` fixes it; pinning that here keeps it from
+ * regressing.
+ */
+
+/** The persisted user_journey fields that prove prior interaction. */
+export interface PriorSessionRow {
+  last_session_date?: string | null;
+  is_first_session?: boolean | null;
+}
+
+/**
+ * A user "has a prior session" once they have a recorded `last_session_date` OR
+ * their `is_first_session` flag has already been cleared. Either proves they
+ * have talked to Vitana before. No row at all → no prior session.
+ */
+export function deriveHasPriorSession(row: PriorSessionRow | null | undefined): boolean {
+  if (!row) return false;
+  return row.last_session_date != null || row.is_first_session === false;
+}
+
+export interface FirstTimeWelcomeGateInput {
+  /** The user has talked to Vitana before (see deriveHasPriorSession). */
+  hasPriorSession: boolean;
+  /** 0 completed guided-journey topics AND not opted out of onboarding. */
+  needsOnboarding: boolean;
+  /** user_journey.is_first_session — true only on the genuine first session. */
+  isFirstSession: boolean;
+}
+
+/**
+ * The full one-time first-session welcome fires ONLY when there is no prior
+ * session on record. A returning user who simply never completed guided
+ * onboarding (`needsOnboarding === true`) must NOT be re-introduced from
+ * scratch — they fall through to the returning-user resume register.
+ */
+export function shouldFireFirstTimeWelcome(input: FirstTimeWelcomeGateInput): boolean {
+  if (input.hasPriorSession) return false;
+  return input.needsOnboarding === true || input.isFirstSession === true;
+}
+
+/**
+ * Resolve the language the spoken greeting should use. Prefer the session
+ * language (resolved from the user's stored preference during the greeting-facts
+ * pre-fetch) and fall back to the value captured at session start. This keeps
+ * turn 1 (the greeting) in the SAME language as the rest of the conversation,
+ * which reads `session.lang` — otherwise the greeting speaks the default and the
+ * conversation flips to the stored preference on turn 2.
+ */
+export function resolveGreetingLang(sessionLang: unknown, fallback: string): string {
+  return typeof sessionLang === 'string' && sessionLang.length > 0 ? sessionLang : fallback;
+}

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -751,6 +751,18 @@ export async function handleLiveSessionStart(
   // most-recent last) from user_journey.recent_nbas. Lets the resume opener
   // ADVANCE past what it already suggested instead of repeating it.
   let greetingRecentNbaKeys: string[] = [];
+  // BOOTSTRAP-ORB-GREETING-LANG: the user's STORED language preference, resolved
+  // in the fast greeting-facts pre-fetch so the spoken greeting can use the SAME
+  // language the rest of the conversation will use (buildLiveSystemInstruction
+  // reads session.lang). Without this the greeting speaks the default ('en') and
+  // the conversation flips to the stored preference ('de') on turn 2. null = not
+  // resolved / no client-independent preference on record.
+  let greetingResolvedLang: string | null = null;
+  // BOOTSTRAP-ORB-GREETING-FIRSTTIME: does the user have a prior session on
+  // record (user_journey.last_session_date set, OR is_first_session already
+  // cleared)? A returning user must NOT get the one-time first-session welcome
+  // again just because they never completed guided onboarding. null = unknown.
+  let greetingHasPriorSession: boolean | null = null;
 
   // VTID-03294: a Guided-Journey topic tap needs ZERO context — Vitana just
   // picks up the KB lesson and speaks it. Detect it here so we can skip the
@@ -951,7 +963,7 @@ export async function handleLiveSessionStart(
         try {
           const { getSupabase } = await import('../../../lib/supabase');
           const supa = getSupabase() ?? undefined;
-          const [lastInfo, factResult, profileResult, firstSessionResult, journeyStateResult] = await Promise.allSettled([
+          const [lastInfo, factResult, profileResult, firstSessionResult, journeyStateResult, langPrefResult] = await Promise.allSettled([
             deps.fetchLastSessionInfo(_ndIdentity.user_id, clientContext?.timezone),
             supa
               ? supa
@@ -974,7 +986,7 @@ export async function handleLiveSessionStart(
             supa
               ? supa
                   .from('user_journey')
-                  .select('is_first_session, last_full_briefing_date, recent_nbas')
+                  .select('is_first_session, last_session_date, last_full_briefing_date, recent_nbas')
                   .eq('user_id', _ndIdentity.user_id)
                   .maybeSingle()
               : Promise.resolve(null as any),
@@ -989,6 +1001,16 @@ export async function handleLiveSessionStart(
                   .eq('user_id', _ndIdentity.user_id)
                   .maybeSingle()
               : Promise.resolve(null as any),
+            // BOOTSTRAP-ORB-GREETING-LANG: the STORED language preference, in the
+            // SAME parallel batch (no added latency). Drives the spoken greeting's
+            // language so it matches the system-instruction language and does not
+            // flip from 'en' to the stored 'de' on turn 2. Skipped (→ null) when
+            // the client already requested a language explicitly — that wins.
+            !clientRequestedLang && _ndIdentity.tenant_id
+              ? deps
+                  .getStoredLanguagePreference(_ndIdentity.tenant_id, _ndIdentity.user_id)
+                  .catch(() => null)
+              : Promise.resolve(null),
           ]);
 
           if (lastInfo.status === 'fulfilled') {
@@ -1001,11 +1023,20 @@ export async function handleLiveSessionStart(
           ) {
             const _fsRow = firstSessionResult.value.data as {
               is_first_session?: boolean | null;
+              last_session_date?: string | null;
               last_full_briefing_date?: string | null;
               recent_nbas?: unknown;
             } | null;
             // No row at all → user has never had a journey row → treat as first-time.
             greetingIsFirstSession = _fsRow ? _fsRow.is_first_session === true : true;
+            // BOOTSTRAP-ORB-GREETING-FIRSTTIME: a user "has a prior session" once
+            // they have a recorded last_session_date OR their is_first_session flag
+            // has already been cleared. Either proves they have talked to Vitana
+            // before, so the one-time welcome must NOT fire again — even if they
+            // never completed guided onboarding. No row at all → no prior session.
+            greetingHasPriorSession = _fsRow
+              ? _fsRow.last_session_date != null || _fsRow.is_first_session === false
+              : false;
             // Durable once-per-day briefing flag (null when never delivered or
             // column absent → briefing is due).
             greetingLastFullBriefingDate = _fsRow?.last_full_briefing_date ?? null;
@@ -1038,6 +1069,17 @@ export async function handleLiveSessionStart(
               _jsRow?.mode === 'full';
             greetingNeedsOnboarding = !_jsRow ? true : _completed === 0 && !_optedOut;
           }
+          // BOOTSTRAP-ORB-GREETING-LANG: resolve the stored language preference so
+          // the greeting builder speaks it (matching the system instruction). Only
+          // when the client did not request a language explicitly.
+          if (
+            !clientRequestedLang &&
+            langPrefResult.status === 'fulfilled' &&
+            typeof langPrefResult.value === 'string' &&
+            langPrefResult.value.length > 0
+          ) {
+            greetingResolvedLang = deps.normalizeLang(langPrefResult.value);
+          }
 
           const factValue =
             factResult.status === 'fulfilled' && factResult.value && !factResult.value.error
@@ -1064,7 +1106,10 @@ export async function handleLiveSessionStart(
             greetingProactiveLine = await computeFastProactiveOpener({
               supabase: supa,
               userId: _ndIdentity.user_id,
-              lang,
+              // BOOTSTRAP-ORB-GREETING-LANG: render the proactive opener in the
+              // resolved stored language, not the default 'en', so this verbatim
+              // line matches the rest of the conversation.
+              lang: greetingResolvedLang || lang,
               firstName: greetingFirstName,
               timezone: clientContext?.timezone ?? null,
               nowMs: Date.now(),
@@ -1188,6 +1233,7 @@ export async function handleLiveSessionStart(
     (session as any).greetingProactiveLine = greetingProactiveLine;
     (session as any).greetingIsFirstTime = greetingIsFirstSession;
     (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
+    (session as any).greetingHasPriorSession = greetingHasPriorSession;
     (session as any).lastFullBriefingDate = greetingLastFullBriefingDate;
     (session as any).recentNbaKeys = greetingRecentNbaKeys;
     if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
@@ -1200,8 +1246,16 @@ export async function handleLiveSessionStart(
       (session as any).greetingProactiveLine = greetingProactiveLine;
       (session as any).greetingIsFirstTime = greetingIsFirstSession;
       (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
+      (session as any).greetingHasPriorSession = greetingHasPriorSession;
       (session as any).lastFullBriefingDate = greetingLastFullBriefingDate;
       (session as any).recentNbaKeys = greetingRecentNbaKeys;
+      // BOOTSTRAP-ORB-GREETING-LANG: apply the resolved stored language onto the
+      // session BEFORE the greeting builder's bounded wait resolves, so the
+      // spoken greeting uses the same language as buildLiveSystemInstruction.
+      // Only when the client did not request a language explicitly (that wins).
+      if (greetingResolvedLang && !clientRequestedLang) {
+        session.lang = greetingResolvedLang;
+      }
       // Idempotent with the heavy bootstrap block, which also sets this later.
       if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
         session.lastSessionInfo = greetingEarlyLastSessionInfo;
@@ -1631,7 +1685,10 @@ export async function handleLiveSessionStart(
             journey,
             lifeCompassGoalText: lifeCompass?.primary_goal ?? null,
             firstName: nameForGreeting,
-            lang,
+            // BOOTSTRAP-ORB-GREETING-LANG: prefer the resolved session language so
+            // this prompt block's "Speak in <LANG>" matches the conversation
+            // language instead of pinning the default 'en'.
+            lang: (typeof session.lang === 'string' && session.lang.length > 0 ? session.lang : lang),
             todayDateIso,
             nextMove: journeyNextMove,
           });

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -59,6 +59,7 @@ import { recordPaywallEvent } from '../../../services/entitlement-service';
 // ORB-FAST-START Phase 2: defer wake-brief + journey off the session/start
 // response path (flag-gated; default off → legacy inline behavior).
 import { shouldDeferWakeWork, composeContextReady } from './orb-fast-start';
+import { deriveHasPriorSession } from '../instruction/greeting-gate';
 
 // VTID-03107: per-session voice-meter intervals. Keyed by session_id so cleanup
 // in handleLiveSessionStop can tear down without touching GeminiLiveSession's type.
@@ -1033,10 +1034,8 @@ export async function handleLiveSessionStart(
             // they have a recorded last_session_date OR their is_first_session flag
             // has already been cleared. Either proves they have talked to Vitana
             // before, so the one-time welcome must NOT fire again — even if they
-            // never completed guided onboarding. No row at all → no prior session.
-            greetingHasPriorSession = _fsRow
-              ? _fsRow.last_session_date != null || _fsRow.is_first_session === false
-              : false;
+            // never completed guided onboarding. (Pinned in greeting-gate.test.ts.)
+            greetingHasPriorSession = deriveHasPriorSession(_fsRow);
             // Durable once-per-day briefing flag (null when never delivered or
             // column absent → briefing is due).
             greetingLastFullBriefingDate = _fsRow?.last_full_briefing_date ?? null;

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1641,7 +1641,7 @@ export async function handleLiveSessionStart(
       const supa = getSupa();
       if (supa) {
         const [
-          { getJourneyState, updateSessionEndState },
+          { getJourneyState, updateSessionEndState, ensureUserJourneyRow },
           { buildJourneyGreetingBlock, todayInTimezone },
           { fetchLifeCompass },
         ] = await Promise.all([
@@ -1651,6 +1651,23 @@ export async function handleLiveSessionStart(
         ]);
         const journey = await getJourneyState(supa, orbIdentity.user_id);
         if (journey) {
+          // BOOTSTRAP-ORB-GREETING-FIRSTTIME: if getJourneyState fell back to the
+          // math path, the user has NO user_journey row — so the
+          // updateSessionEndState below would update zero rows and
+          // last_session_date would never persist, making the greeting re-fire
+          // every session. Seed a real row (idempotently) so this session's
+          // last_session_date actually lands and the welcome converges. We mark
+          // is_first_session=false: a user reaching a live session without a row
+          // is an existing user the backfill missed, not a first-ever signup.
+          if (journey.fallback_used) {
+            await ensureUserJourneyRow(supa, orbIdentity.user_id, {
+              tenant_id: orbIdentity.tenant_id ?? null,
+              started_at: journey.started_at,
+              is_first_session: false,
+            }).catch((err: any) =>
+              console.warn(`[VTID-03154] ensureUserJourneyRow (fallback seed) failed (non-fatal): ${err?.message}`),
+            );
+          }
           const lifeCompass = await fetchLifeCompass(supa, orbIdentity.user_id).catch(() => null);
           const tz = (session as any).clientContext?.timezone ?? null;
           const todayDateIso = todayInTimezone(new Date(), tz);

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1372,6 +1372,7 @@ export { buildLiveApiTools } from '../orb/live/tools/live-tool-catalog';
 // tools rather than a TS-side state machine.
 import { buildTeacherModeBlock } from '../orb/teacher/teacher-mode-prompt';
 // VTID-03257 (Fix-1): GUIDE MODE block — Vitana leads the Foundation checklist.
+import { shouldFireFirstTimeWelcome, resolveGreetingLang } from '../orb/live/instruction/greeting-gate';
 import { buildJourneyGuideBlock } from '../orb/live/instruction/journey-guide-prompt';
 import { buildGuidedTopicNarrationBlock } from '../orb/live/instruction/guided-topic-narration-prompt';
 // A6.2 (orb-live-refactor): SessionContext + SessionMutator + first
@@ -7611,10 +7612,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
             // default ('en') and then flip to the stored 'de' on turn 2 (the system
             // instruction reads session.lang). Re-reading here keeps turn 1 and the
             // rest of the conversation in one language.
-            const greetLang =
-              typeof (session as any).lang === 'string' && (session as any).lang.length > 0
-                ? ((session as any).lang as string)
-                : lang;
+            const greetLang = resolveGreetingLang((session as any).lang, lang);
             // BOOTSTRAP-ORB-GREETING-FIRSTTIME: a user who has a prior session on
             // record must never get the one-time first-session welcome again, even
             // if they never finished guided onboarding.
@@ -7810,8 +7808,11 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               // must NOT be re-introduced from scratch every session — they fall
               // through to the returning-user resume register below. This is what
               // made Vitana feel robotic: greeting every visit as a first-timer.
-              const _isFirstTime =
-                !_hasPriorSession && (_needsOnboarding === true || _ift === true);
+              const _isFirstTime = shouldFireFirstTimeWelcome({
+                hasPriorSession: _hasPriorSession,
+                needsOnboarding: _needsOnboarding === true,
+                isFirstSession: _ift === true,
+              });
               if (_isFirstTime) {
                 const _welcome = buildFirstTimeWelcomeLine(greetLang, (session as any).greetingFirstName ?? null);
                 const _safeWel = _welcome.replace(/"/g, '\\"');
@@ -7851,10 +7852,11 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               // returning never-onboarded user reaches the resume register (soft
               // "welcome back / let's continue") instead of being treated as a
               // first-timer and skipping it.
-              const _isFirstTimeR =
-                !_hasPriorSession &&
-                ((session as any).greetingNeedsOnboarding === true ||
-                  (session as any).greetingIsFirstTime === true);
+              const _isFirstTimeR = shouldFireFirstTimeWelcome({
+                hasPriorSession: _hasPriorSession,
+                needsOnboarding: (session as any).greetingNeedsOnboarding === true,
+                isFirstSession: (session as any).greetingIsFirstTime === true,
+              });
               const _uidR = session.identity?.user_id;
               const _supaR = getSupabase();
               const _langKeyR = (greetLang || 'en').slice(0, 2).toLowerCase();

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7604,6 +7604,22 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               }
             }
 
+            // BOOTSTRAP-ORB-GREETING-LANG: re-read the language AFTER the bounded
+            // facts wait. `lang` was captured at function entry (above), before the
+            // greeting-facts pre-fetch resolved the user's stored preference onto
+            // session.lang. Using the stale capture would speak the greeting in the
+            // default ('en') and then flip to the stored 'de' on turn 2 (the system
+            // instruction reads session.lang). Re-reading here keeps turn 1 and the
+            // rest of the conversation in one language.
+            const greetLang =
+              typeof (session as any).lang === 'string' && (session as any).lang.length > 0
+                ? ((session as any).lang as string)
+                : lang;
+            // BOOTSTRAP-ORB-GREETING-FIRSTTIME: a user who has a prior session on
+            // record must never get the one-time first-session welcome again, even
+            // if they never finished guided onboarding.
+            const _hasPriorSession = (session as any).greetingHasPriorSession === true;
+
             // NEW-DAY OVERVIEW (rich summary owns turn 1). On a genuine new-day
             // return we speak the FULL multi-clause morning overview (what passed
             // since last session, today's next event, Index direction, Life
@@ -7685,7 +7701,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                     userId: _uidNd,
                     now: _nowNd,
                     timezone: _tzNd,
-                    lang,
+                    lang: greetLang,
                     lastSessionDateUserTz: _lastSessDateTz,
                     // Precise cutoff for "events since we last spoke" — avoids
                     // briefing the user about events that happened BEFORE their
@@ -7714,7 +7730,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                 if (_overview && _hasContent) {
                   const _block = buildNewDayOverviewBlock({
                     payload: _overview,
-                    lang,
+                    lang: greetLang,
                     firstName: _firstNameNd.trim(),
                     localHour: localHourInTimezone(_nowNd, _tzNd),
                     timezone: _tzNd,
@@ -7788,9 +7804,16 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               // (0 completed journey topics and not graduated/opted-out — survives
               // the eager is_first_session clear) OR is_first_session still true.
               // Unknown → fall through to the normal proactive/name/menu ladder.
-              const _isFirstTime = _needsOnboarding === true || _ift === true;
+              // BOOTSTRAP-ORB-GREETING-FIRSTTIME: the full one-time welcome fires
+              // ONLY when there is no prior session on record. A returning user who
+              // simply never completed guided onboarding (_needsOnboarding===true)
+              // must NOT be re-introduced from scratch every session — they fall
+              // through to the returning-user resume register below. This is what
+              // made Vitana feel robotic: greeting every visit as a first-timer.
+              const _isFirstTime =
+                !_hasPriorSession && (_needsOnboarding === true || _ift === true);
               if (_isFirstTime) {
-                const _welcome = buildFirstTimeWelcomeLine(lang, (session as any).greetingFirstName ?? null);
+                const _welcome = buildFirstTimeWelcomeLine(greetLang, (session as any).greetingFirstName ?? null);
                 const _safeWel = _welcome.replace(/"/g, '\\"');
                 const _welPrompt = `Say exactly: "${_safeWel}" — speak it verbatim as audio, as ONE warm greeting. Do NOT add, paraphrase, or split it.`;
                 ws.send(
@@ -7799,14 +7822,14 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                   }),
                 );
                 emitDiag(session, 'greeting_sent', {
-                  lang,
+                  lang: greetLang,
                   prompt_len: _welPrompt.length,
                   wake_opener: 'safe_fast_first_time_welcome',
                   is_first_session: _ift === true,
                 });
                 startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
                 console.log(
-                  `[GREETING-SAFE-FAST-FIRST-TIME] session ${session.sessionId} sent first-time welcome (is_first_session=${String(_ift)}, needs_onboarding=${String(_needsOnboarding)}, lang=${lang})`,
+                  `[GREETING-SAFE-FAST-FIRST-TIME] session ${session.sessionId} sent first-time welcome (is_first_session=${String(_ift)}, needs_onboarding=${String(_needsOnboarding)}, has_prior=${String(_hasPriorSession)}, lang=${greetLang})`,
                 );
                 return;
               }
@@ -7824,12 +7847,17 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
             // payload could not be gathered in budget. See
             // docs/CONVERSATION_FLOW_HANDOFF.md.
             {
+              // BOOTSTRAP-ORB-GREETING-FIRSTTIME: mirror the prior-session guard so a
+              // returning never-onboarded user reaches the resume register (soft
+              // "welcome back / let's continue") instead of being treated as a
+              // first-timer and skipping it.
               const _isFirstTimeR =
-                (session as any).greetingNeedsOnboarding === true ||
-                (session as any).greetingIsFirstTime === true;
+                !_hasPriorSession &&
+                ((session as any).greetingNeedsOnboarding === true ||
+                  (session as any).greetingIsFirstTime === true);
               const _uidR = session.identity?.user_id;
               const _supaR = getSupabase();
-              const _langKeyR = (lang || 'en').slice(0, 2).toLowerCase();
+              const _langKeyR = (greetLang || 'en').slice(0, 2).toLowerCase();
               const _langOkR = _langKeyR === 'de' || _langKeyR === 'en';
               if (_langOkR && !_isFirstTimeR && _uidR && _supaR) {
                 try {
@@ -7858,7 +7886,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                         userId: _uidR,
                         now: _nowR,
                         timezone: _tzR,
-                        lang,
+                        lang: greetLang,
                         lastSessionDateUserTz: _lastSessDateR,
                         lastSessionAtIso: _lastSessIsoR,
                       }),
@@ -7872,7 +7900,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                       register: _registerR,
                       payload: _payloadR,
                       firstName: (session as any).greetingFirstName ?? null,
-                      lang,
+                      lang: greetLang,
                       timeAgo: _lastIxR.timeAgo,
                       rotationSeed: _seedR,
                       recentNbaKeys: _recentNbaKeysR as any,
@@ -8023,7 +8051,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                       ? `Добро вече, ${name}.`
                       : `Добар дан, ${name}.`,
               };
-              const langKey = (lang || 'en').slice(0, 2).toLowerCase();
+              const langKey = (greetLang || 'en').slice(0, 2).toLowerCase();
               const spoken = greetingByLang[langKey] || greetingByLang.en;
               const safe = spoken.replace(/"/g, '\\"');
               // Mirror the existing `Say exactly: "..."` shape used elsewhere in
@@ -8050,7 +8078,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
 
             // ELSE — fall through to the EXISTING generic opener (unchanged
             // behavior). Same-day reconnects and no-name sessions take this path.
-            const _menu = pickShortGapGreetings(lang, 6).map((p) => `"${p}"`).join(', ');
+            const _menu = pickShortGapGreetings(greetLang, 6).map((p) => `"${p}"`).join(', ');
             const _safePrompt =
               `Open with EXACTLY ONE short phrase, picked from this menu and used VERBATIM ` +
               `(already in the user's language): ${_menu}. Do NOT say "Hello" or the user's name. ` +

--- a/services/gateway/src/services/journey/user-journey-service.ts
+++ b/services/gateway/src/services/journey/user-journey-service.ts
@@ -194,7 +194,7 @@ export async function getJourneyState(
 export async function ensureUserJourneyRow(
   client: SupabaseClient,
   userId: string,
-  opts: { tenant_id?: string | null; started_at?: string | Date } = {},
+  opts: { tenant_id?: string | null; started_at?: string | Date; is_first_session?: boolean } = {},
 ): Promise<boolean> {
   try {
     const startedAtIso =
@@ -207,7 +207,12 @@ export async function ensureUserJourneyRow(
         user_id: userId,
         tenant_id: opts.tenant_id ?? null,
         started_at: startedAtIso,
-        is_first_session: true,
+        // Defaults to true so the /me seeding path (brand-new users) is
+        // unchanged. The session-start backfill passes false: a user reaching
+        // a live session WITHOUT a row is an existing user the backfill missed,
+        // not a first-ever signup — seeding them as first_session would (re)play
+        // the one-time welcome on the legacy continuation path.
+        is_first_session: opts.is_first_session ?? true,
       })
       .select('user_id')
       .maybeSingle();

--- a/services/gateway/test/greeting-gate.test.ts
+++ b/services/gateway/test/greeting-gate.test.ts
@@ -1,0 +1,89 @@
+/**
+ * greeting-gate — pins the session-start greeting decisions changed by
+ * BOOTSTRAP-ORB-GREETING-LANG-FIRSTTIME.
+ *
+ * Regression context: the ORB greeted returning users as first-timers on EVERY
+ * session (the full one-time welcome fired on the "needs onboarding" signal
+ * alone), and the spoken greeting could be in a different language than the
+ * rest of the conversation. These tests lock the corrected behaviour:
+ *
+ *   1. A user with ANY prior session never gets the full first-time welcome,
+ *      even when they never finished guided onboarding.
+ *   2. A genuine first-ever user DOES get it.
+ *   3. The greeting language prefers the resolved session language so turn 1
+ *      matches turn 2.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import {
+  deriveHasPriorSession,
+  shouldFireFirstTimeWelcome,
+  resolveGreetingLang,
+} from '../src/orb/live/instruction/greeting-gate';
+
+describe('deriveHasPriorSession', () => {
+  it('no row → no prior session', () => {
+    expect(deriveHasPriorSession(null)).toBe(false);
+    expect(deriveHasPriorSession(undefined)).toBe(false);
+  });
+
+  it('genuine first session (is_first_session=true, no last_session_date) → no prior session', () => {
+    expect(deriveHasPriorSession({ is_first_session: true, last_session_date: null })).toBe(false);
+  });
+
+  it('last_session_date set → has prior session', () => {
+    expect(deriveHasPriorSession({ is_first_session: true, last_session_date: '2026-06-28' })).toBe(true);
+  });
+
+  it('is_first_session already cleared → has prior session even without a date', () => {
+    expect(deriveHasPriorSession({ is_first_session: false, last_session_date: null })).toBe(true);
+  });
+});
+
+describe('shouldFireFirstTimeWelcome', () => {
+  it('genuine first-ever session → fires', () => {
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: false, needsOnboarding: true, isFirstSession: true }),
+    ).toBe(true);
+  });
+
+  it('first-ever session by is_first_session only (onboarding already satisfied) → fires', () => {
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: false, needsOnboarding: false, isFirstSession: true }),
+    ).toBe(true);
+  });
+
+  it('REGRESSION: returning user who never finished onboarding → does NOT fire', () => {
+    // This is the exact bug: needsOnboarding=true used to force the welcome on
+    // every session. With a prior session on record it must NOT re-introduce.
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: true, needsOnboarding: true, isFirstSession: false }),
+    ).toBe(false);
+  });
+
+  it('returning, fully onboarded user → does NOT fire', () => {
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: true, needsOnboarding: false, isFirstSession: false }),
+    ).toBe(false);
+  });
+
+  it('no prior session and no first-time signals → does NOT fire', () => {
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: false, needsOnboarding: false, isFirstSession: false }),
+    ).toBe(false);
+  });
+});
+
+describe('resolveGreetingLang', () => {
+  it('prefers a non-empty session language over the fallback', () => {
+    expect(resolveGreetingLang('de', 'en')).toBe('de');
+  });
+
+  it('falls back when session language is missing/empty/non-string', () => {
+    expect(resolveGreetingLang(undefined, 'en')).toBe('en');
+    expect(resolveGreetingLang('', 'de')).toBe('de');
+    expect(resolveGreetingLang(null, 'fr')).toBe('fr');
+    expect(resolveGreetingLang(42 as unknown, 'es')).toBe('es');
+  });
+});

--- a/services/gateway/test/user-journey-service.test.ts
+++ b/services/gateway/test/user-journey-service.test.ts
@@ -1,0 +1,73 @@
+/**
+ * user-journey-service.ensureUserJourneyRow — seeding semantics.
+ *
+ * Pins BOOTSTRAP-ORB-GREETING-FIRSTTIME: the session-start backfill seeds a
+ * MISSING user_journey row with is_first_session=false (an existing user the
+ * backfill missed must not replay the one-time welcome), while the default
+ * /me seeding path stays is_first_session=true. Idempotent on conflict.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { ensureUserJourneyRow } from '../src/services/journey/user-journey-service';
+
+/** Minimal fake supporting `.from(t).insert(p).select('user_id').maybeSingle()`.
+ *  Captures the inserted payload and simulates a unique-violation when the
+ *  user_id is already present. */
+function makeFakeSupabase(existingIds: string[] = []) {
+  const ids = new Set(existingIds);
+  const inserts: any[] = [];
+  const client: any = {
+    __inserts: inserts,
+    from(_table: string) {
+      let payload: any = null;
+      const builder: any = {
+        insert(p: any) {
+          payload = p;
+          inserts.push(p);
+          return builder;
+        },
+        select() { return builder; },
+        maybeSingle() {
+          if (ids.has(payload.user_id)) {
+            return Promise.resolve({ data: null, error: { code: '23505', message: 'duplicate key' } });
+          }
+          ids.add(payload.user_id);
+          return Promise.resolve({ data: { user_id: payload.user_id }, error: null });
+        },
+      };
+      return builder;
+    },
+  };
+  return client;
+}
+
+describe('ensureUserJourneyRow', () => {
+  it('defaults to is_first_session=true (the /me signup seeding path)', async () => {
+    const sb = makeFakeSupabase();
+    const created = await ensureUserJourneyRow(sb, 'user-new');
+    expect(created).toBe(true);
+    expect(sb.__inserts).toHaveLength(1);
+    expect(sb.__inserts[0].is_first_session).toBe(true);
+    expect(sb.__inserts[0].user_id).toBe('user-new');
+  });
+
+  it('seeds is_first_session=false when explicitly requested (session-start backfill)', async () => {
+    const sb = makeFakeSupabase();
+    const created = await ensureUserJourneyRow(sb, 'user-existing', {
+      tenant_id: 'tenant-1',
+      started_at: '2026-01-01T00:00:00.000Z',
+      is_first_session: false,
+    });
+    expect(created).toBe(true);
+    expect(sb.__inserts[0].is_first_session).toBe(false);
+    expect(sb.__inserts[0].tenant_id).toBe('tenant-1');
+    expect(sb.__inserts[0].started_at).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('is idempotent: a duplicate (existing row) resolves false, never throws', async () => {
+    const sb = makeFakeSupabase(['user-existing']);
+    const created = await ensureUserJourneyRow(sb, 'user-existing', { is_first_session: false });
+    expect(created).toBe(false);
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-ORB-GREETING-LANG-FIRSTTIME` _(no governed VTID allocated; user-reported ORB UX defect)_

**Layer:** AGTL (ORB / gateway live-session)

**Priority:** P2

---

## 📋 Summary

Fixes two defects behind the "robotic, greets me as a first-time user every
session, then suddenly switches to German" ORB experience. Both live in the
fast-start greeting assembly (`live-session-controller.ts` pre-fetch +
`orb-live.ts` `sendGreetingPromptToLiveAPI`).

**1. Always greeted as a first-timer.** The SAFE-FAST first-time welcome fired
on `greetingNeedsOnboarding`, a signal derived purely from Guided-Journey
progress (0 completed topics + not opted out) — independent of how many real
sessions the user has had. A user who never completed a guided-journey topic
got the one-time onboarding welcome on **every** session; clearing
`is_first_session` didn't help because this branch re-triggered it on its own.

**2. Greeting in English, conversation in German on turn 2.** `session.lang` is
initialized to the default (`'en'`) and the stored preference (`'de'`) only
resolves later in the heavy bootstrap. The greeting was spoken with the stale
value, while `buildLiveSystemInstruction` used the resolved one — so turn 1
spoke English and turn 2+ obeyed "Respond ONLY in German".

---

## ✅ Changes

- [x] Resolve a durable **"has a prior session"** signal from
  `user_journey.last_session_date` / `is_first_session`; gate the full first-time
  welcome on `!hasPriorSession`. Returning never-onboarded users now fall through
  to the returning-user **resume register** (soft "welcome back / let's
  continue"). Same guard mirrored in the resume-register gate so they reach it.
- [x] Resolve the **stored language preference** inside the fast greeting-facts
  pre-fetch (same parallel batch — no added latency); apply it onto
  `session.lang` before the greeting builder's bounded wait resolves.
- [x] Re-read the resolved language (`greetLang`) **after** the bounded wait in
  every spoken greeting path (first-time welcome, new-day overview, resume
  register, generic opener) plus the pre-rendered proactive line and the
  journey-greeting prompt block.
- [x] Behavior unchanged when the client requests a language explicitly (that
  wins) and when `FEATURE_ORB_SAFE_FAST_GREETING` is off (the
  continuation-provider path already gates correctly on `is_first_session`).

---

## 🧪 Testing

- [x] `tsc --noEmit` on the gateway: 0 errors.
- [ ] Manual ORB verification on staging: confirm (a) a returning user with no
  completed onboarding gets a "welcome back" continuation rather than the
  first-time intro, and (b) the spoken greeting and turn-2 reply are in the same
  language for a `de`-preference user.
- [ ] Verified in staging/dev environment

---

## 🚨 Breaking Changes

None. Net-new read of one extra column (`last_session_date`) in an existing
parallel batch and one extra preference read gated on no explicit client lang.

---

## 📌 Additional Notes

- The fix targets the `FEATURE_ORB_SAFE_FAST_GREETING` greeting path, which is
  the one that exhibited the bug. Users with **no** `user_journey` row at all
  (predating the backfill / never hit `/me`) still depend on row seeding
  elsewhere; this PR converges the common case (any user with a journey row).
- On a slow DB read where `greetingFactsReady` times out, `hasPriorSession`
  reads as unknown → the welcome may still fire — strictly no worse than the
  prior behavior (which always fired), and the same accepted edge as the
  existing `greetingNeedsOnboarding` signal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVuVKDQEnJkGwiUuKtR5vr)_