### PR TITLE
docs(conversation): v2 build-handoff for the Command Hub "Conversation" section (per-tenant)

### DIFF
--- a/docs/CONVERSATION_FLOW_HANDOFF.md
+++ b/docs/CONVERSATION_FLOW_HANDOFF.md
@@ -1,271 +1,361 @@
-# Conversation Flow — Handoff for the Command Hub "Conversation" section
+# Conversation Flow — Build Handoff for the Command Hub "Conversation" section (v2)
 
 **Audience:** the next session's agent, tasked with building a new **"Conversation"**
-section in the Command Hub that visualises and configures the conversation-flow
-engine described here.
+section in the Command Hub to **design, test, and maintain** Vitana's conversation
+flow — **per tenant**.
 
-**Status:** the engine below is built and live on the gateway (Vertex ORB path).
-This doc is the contract the Command Hub UI should mirror — read it as the source
-of truth for what the "Conversation" section must show and let an operator tune.
+**Status (2026-06-28):** the conversation-flow engine is built and live on the
+gateway (Vertex ORB path) and hardened over several rounds (see §1). It is **global
+and code-driven today**. This section's job is to give operators a UI to *see, tune,
+test, and per-tenant customise* it. This doc is the source of truth for what to build.
+
+> Placement requested by the operator: **sidebar order = … Assistant → `Conversation` → Voice …**
+> Per-tenant: **each tenant designs its own flow on the same engine/tools, with its own
+> overrides, logic and copy.**
 
 ---
 
-## 1. The mental model (what we built)
+## 0. TL;DR — what to build
 
-Every time a user opens Vitana, ONE decision is made from the **full context**,
-rendered at the right depth, and it **always ends on a guided next step**. No more
-ladder of disconnected greeting rungs.
+1. A new **`Conversation`** Command Hub section (between Assistant and Voice) with
+   sub-tabs: **Overview/Monitor**, **Registers & Recency**, **Next-Best-Action**,
+   **Screen Completion**, **Tool Health**, **Simulator**, **Tenant Settings**.
+2. A **gateway admin API** (`/api/v1/admin/conversation/*`) that (a) exposes the
+   engine's current config + telemetry read models and (b) reads/writes **per-tenant
+   overrides**.
+3. A **per-tenant conversation config** store (mirror `tenant_settings`) + a
+   **resolver** so the engine reads `global defaults ⊕ tenant overrides` instead of
+   today's hardcoded constants.
+
+The engine internals are §2–§5. The multi-tenant design is §6. The concrete build
+recipe (exact files/lines/auth/CSP/build) is §7–§9.
+
+---
+
+## 1. Why this section exists — the recurring failure class
+
+Every ORB UX bug the operator reported this week was the **same root pattern**, not
+isolated bugs:
+
+> A tool **succeeds (or has a graceful answer) but its spoken `text` is unusable** —
+> a navigation announcement that no-ops in a text chat, raw JSON, an empty list, or a
+> fabricated number — so the model has nothing real to say and **improvises a failure
+> ("Das konnte ich leider nicht abschließen") or a hallucination**.
+
+The live model (Vertex path) receives **only the tool result's `text`** (see
+`dispatchOrbToolForVertex` → it sends `r.text`). So **every tool's `text` is a UX
+surface.** Fixes shipped this session, all in this class:
+
+| PR / VTID | Symptom | Fix |
+|---|---|---|
+| #2803 / VTID-03346 | index/nutrition plan "I cannot execute" for admin/staff roles | `toWritableRoleContext()` — session role → constraint-valid `role_context` |
+| #2804 / VTID-03347 | guided journey offered "Lektion 1" while user on session 10 | anchor `narrate_guided_session` on `current_session` |
+| #2807 / VTID-03348 | model lost journey progress mid-conversation | inject `buildGuidedJourneyStandingInstruction()` into the standing system instruction (Vertex + LiveKit) |
+| #2810 / VTID-03350 | "+230 Punkte" fabricated on first diary entry of the day | only state an Index delta when a real same-day baseline exists |
+| #2811 / VTID-03351 | "show my matches" → offer-then-fail | matches tool returns **speakable** content + anti-fake-fail guard; never raw JSON / nav-only |
+| #2813 / VTID-03352 | "how to improve my Index" → couldn't complete; plan written opaquely | `get_index_improvement_suggestions` template fallback + speakable; `create_index_improvement_plan` **names** every scheduled activity |
+| #2809 / VTID-03349 | (process) | **CI guard** `conversation-flow-change-needs-test` — no flow change merges without a flow test |
+
+**The Conversation section is the operator's cockpit to catch this class proactively**
+(see the Tool Health + Simulator tabs) instead of discovering it screenshot-by-screenshot.
+
+**Speakable-tool contract (enforce in review + the new section's docs):** every ORB
+tool's `text` must be (1) presentable content the model can speak, (2) never raw JSON,
+(3) never a bare navigation announcement on a conversational surface, (4) carry an
+explicit "Do NOT say you could not do it" guard on success/handled paths, (5) never
+fabricate a number it didn't compute.
+
+---
+
+## 2. The engine — one decision from full context, always guiding
 
 ```
-            ┌──────────────────────── CONTEXT BUNDLE (assembled once) ───────────────────────┐
-            │ recency (describeTimeSince) · identity+memory · where-we-left-off · journey ·   │
-            │ what's-new (Index move, matches, messages, reminders, calendar) · entry screen  │
-            └───────────────────────────────────┬────────────────────────────────────────────┘
-                                                 ▼
-                                   decideOpeningRegister()              ← recency FIRST
-                                                 ▼
+        ┌──────────── CONTEXT BUNDLE (gatherOverviewPayload, assembled once) ─────────────┐
+        │ recency (describeTimeSince) · identity+memory · where-we-left-off · guided_journey │
+        │ what's-new (Index move, matches, messages, reminders, calendar) · entry screen     │
+        └───────────────────────────────────┬──────────────────────────────────────────────┘
+                                             ▼
+                               decideOpeningRegister()              ← recency FIRST
+                                             ▼
    first_time · daily_briefing · continue · quick_resume · same_day      ← the REGISTER
-                                                 ▼
-                                   selectNextBestAction()                ← the always-guiding step
-                                                 ▼
-                          one composed first-turn directive → the LLM speaks it
+                                             ▼
+                               selectNextBestAction()                ← the always-guiding step
+                                             ▼
+                       one composed first-turn directive → the LLM speaks it
 ```
 
-Two invariants the user insisted on:
-1. **Recency is the primary gate** — a return after 1 minute must never be greeted
-   "Guten Morgen". The register encodes this.
-2. **Vitana always guides** — every register closes on a concrete, real next step
-   (the Next-Best-Action), spanning the two north stars: **community engagement**
-   and **health improvement**.
+Two invariants: **(1) recency is the primary gate** (a return after 1 min is never
+"Guten Morgen"); **(2) Vitana always closes on a concrete next step** spanning the two
+north stars — **community engagement** and **health improvement**.
+
+### Registers (`decideOpeningRegister`)
+| Register | Trigger | Greeting |
+|---|---|---|
+| `first_time` | never onboarded | ✅ welcome |
+| `daily_briefing` | `briefingDue` (first session of a real day; durable flag `user_journey.last_full_briefing_date`) | ✅ time-of-day |
+| `continue` | bucket `reconnect` (<2 min) | ❌ pick the thread back up |
+| `quick_resume` | bucket `recent` (<15 min) | ❌ micro-ack |
+| `same_day` | bucket `same_day`/`today` | ⚠️ light |
+
+Recency buckets: `services/gateway/src/services/guide/temporal-bucket.ts` → `describeTimeSince`
+(8 buckets reconnect/recent/same_day/today/yesterday/week/long/first).
+
+### Next-Best-Action (`next-best-action.ts`) — "always guiding"
+Pure function over `OverviewPayload`. Ranks every **grounded** action (gated on real
+data; never bluffs) by **band = value × timeliness**; rotation via durable
+`user_journey.recent_nbas` (cooldown 3) so it never repeats. Bands 100→26 across
+time-sensitive → continuity → health momentum → community growth → setup. North-star
+mapping + `CAPABILITY_BY_KEY` (each action → the real ORB tool that executes it).
+
+### Screen awareness & completion (`screen-surface.ts`)
+`surfaceForRoute(route)` → surface; `screenCompletionFor(surface)` → completion action
+(band 115, above redirects) + `redirect_key` to suppress. The goal is to **finish the
+action on the screen the user is on**, never redirect to a screen they're already on.
+
+### Capability-gating
+The opener guides → user accepts → it must **execute** via the mapped tool
+(`CAPABILITY_BY_KEY`, verified against `ORB_TOOL_REGISTRY`); if no tool, **guide
+step-by-step**, never over-promise.
 
 ---
 
-## 2. The registers (recency-first decision)
+## 3. Asset inventory (confirmed paths + key exports)
 
-`decideOpeningRegister({ bucket, isFirstTime, briefingDue })` →
-
-| Register | Trigger | Behaviour | Greeting? |
-|---|---|---|---|
-| `first_time` | never onboarded | onboarding welcome | ✅ |
-| `daily_briefing` | `briefingDue` (first session of a real day; any gap length) | full rich briefing, once/day | ✅ time-of-day |
-| `continue` | bucket `reconnect` (<2 min) | no greeting — pick the thread back up + NBA | ❌ |
-| `quick_resume` | bucket `recent` (<15 min) | micro-ack, NO time-of-day, + NBA | ❌ |
-| `same_day` | bucket `same_day`/`today` (hours, same day) | light re-entry + what's-new + NBA | ⚠️ light |
-
-- **Recency buckets** come from `services/guide/temporal-bucket.ts` →
-  `describeTimeSince` (8 buckets: reconnect/recent/same_day/today/yesterday/week/long/first).
-- **`briefingDue`** = the durable once-per-day flag `user_journey.last_full_briefing_date`
-  is stale for today (user tz). Multi-day gaps (yesterday/week/long) always have a
-  stale flag → they resolve to `daily_briefing`.
-
----
-
-## 3. The Next-Best-Action (NBA) engine — "always guiding"
-
-`services/conversation/next-best-action.ts` — pure function over the rich
-`OverviewPayload`. Ranks every **grounded** action (gated on real data; never
-bluffs) by **band = value × timeliness**, then picks the top to lead the close.
-
-| Band | Group | Actions (key) | Source signal |
-|---|---|---|---|
-| 100–92 | time-sensitive / waiting | `reminder_due`, `autopilot_step`, `reply_messages` | reminders_today, autopilot.today_checkpoint, messages_unread |
-| 80 | continuity (journey thread) | `next_session` | guided_journey.next_session_title |
-| 62–58 | health momentum | `diary_entry`, `focus_pillar` | diary_last_7d===0, vitana_index.weakest_pillar |
-| 44 | community growth | `review_matches` | matches_unread |
-| 30 | community growth (always-available, rotated) | `make_post`, `create_activity`, `connect_community` | — (rotation seed = day-of-year) |
-| 26 | setup | `set_goal` | life_compass.state==='not_set' |
-
-**North-star mapping:**
-- **Community engagement:** reply_messages, review_matches, make_post, create_activity, connect_community
-- **Health improvement:** autopilot_step, diary_entry, focus_pillar, next_session, set_goal
-
-**Non-repetition (DONE):** the opener ADVANCES — it never repeats the same
-suggestion two opens in a row. A durable per-user history `user_journey.recent_nbas`
-(jsonb array of action keys, last ~8) is read in the greeting prefetch and passed
-to `selectNextBestAction({ recentKeys, cooldown: 3 })`, which skips the last 3
-suggestions and picks the next-best fresh action; the chosen key is appended after
-speaking. The resume prompt is also told `already_offered_recently` so the model
-explicitly moves the conversation forward. The day-of-year `rotationSeed` still
-varies ties within the always-available community-growth pool.
+| Asset | Path | Key exports |
+|---|---|---|
+| NBA engine | `services/gateway/src/services/conversation/next-best-action.ts` | `rankNextBestActions(p,ctx)` (L119); `selectNextBestAction(p,ctx)` (L228); `CAPABILITY_BY_KEY` (L75); `capabilityForNba(key)` (L95); type `NbaKey` (L30) |
+| Opening register | `services/gateway/src/services/conversation/decide-opening.ts` | `decideOpeningRegister(input)` (L53); `buildResumeDirective(input)` (L102); type `OpeningRegister` (L35) |
+| Screen surface | `services/gateway/src/services/conversation/screen-surface.ts` | `surfaceForRoute(route)` (L39); `screenCompletionFor(surface)` (L70) |
+| Index coach text | `services/gateway/src/services/orb-index-coach-text.ts` | `buildIndexSuggestionsText(pillar,items)` (L18); `buildIndexPlanText(pillar,days,scheduled)` (L45) |
+| Context bundle | `services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts` | `gatherOverviewPayload(args)` (L269); `fetchGuidedJourney(sb,userId,lang)` (L677); `buildGuidedJourneyStandingInstruction(gj)` (L716); iface `OverviewPayload` (L81) |
+| Daily briefing render | `…/providers/new-day-overview-prompt.ts` | `buildNewDayOverviewBlock` |
+| Acceptance gate | `services/gateway/src/services/assistant-continuation/acceptance-gate.ts` | `detectAcceptance(text)` (L87); `maybeBindAcceptance(input,deps)` (L136); `makeSupabaseAcceptanceDeps(sb)` (L108) — **binds wake-brief offers only today** |
+| Provider registry | `services/gateway/src/services/assistant-continuation/provider-registry.ts` | provider registry (single file, not a dir) |
+| Guided journey state | `services/gateway/src/services/guided-journey/guided-journey-state.ts` | `getJourneyState(client,userId)` (L84) → `{ currentSession, completedTopicIds, … }` |
+| Recency | `services/gateway/src/services/guide/temporal-bucket.ts` | `describeTimeSince` |
+| Live system instruction | `services/gateway/src/orb/live/instruction/live-system-instruction.ts` | `buildLiveSystemInstruction(lang,voiceStyle,bootstrapContext?,…,surface?)` (L376) — 4 call sites: orb-livekit.ts ×2, orb-live.ts ×1, voice-lab ×1 |
+| Greeting prefetch + bootstrap context | `services/gateway/src/orb/live/session/live-session-controller.ts` | greeting-facts prefetch; `finalContext` assembly (~L860–896) — where the standing journey block is appended |
+| Integration (Vertex) | `services/gateway/src/routes/orb-live.ts` | `sendGreetingPromptToLiveAPI`; `executeLiveApiTool`; `emitDiag` (L12304) |
+| Shared ORB tools | `services/gateway/src/services/orb-tools-shared.ts` | `ORB_TOOL_REGISTRY`, `dispatchOrbTool`, all the action tools |
+| Self-check harness | `services/gateway/src/routes/orb-tools-selfcheck.ts` | `POST /api/v1/admin/orb-tools/selfcheck {user_id,tools?}` (admin-gated) |
+| CI guard | `scripts/ci/impact-rules/conversation-flow-change-needs-test.mjs` | blocker rule (see §1) |
+| Architecture | `docs/CONVERSATION_FLOW_ARCHITECTURE.md` | "one brain, many mouths" |
 
 ---
 
-## 3b. Screen awareness & action COMPLETION
+## 4. Observability the section must surface (already emitting)
 
-Vitana knows the user's current screen (`session.current_route`, sent by the
-client at session start, kept fresh on navigation) and uses it to **deepen toward
-completing the action**, never to redirect the user to a screen they are already
-on.
+All to `oasis_events`. Read these for the Monitor + Tool Health tabs:
 
-- `services/conversation/screen-surface.ts` — `surfaceForRoute(route)` maps a
-  route to a `ConversationSurface` (matches / chat / community / diary / index /
-  profile / journey / news / home / other); `screenCompletionFor(surface)` returns
-  the **completion action** (band 115, above every redirect/discovery action) and
-  the `redirect_key` to suppress while on that surface.
-- In `buildResumeDirective`, when the user is on an actionable surface the next
-  step becomes the completion action — e.g. on **/matches**: *pick one and start a
-  joint activity / tell them who a match is / suggest an Index-boosting activity /
-  refine criteria / enrich profile* — and the prompt is told `current_screen` +
-  `complete_on_current_screen` with a HARD rule never to say "open X" while on X.
+- **Greeting decisions** — topic `orb.live.diag`, `metadata.stage='greeting_sent'`:
+  `wake_opener`, `register`, `bucket`, `nba`, `nba_domain`, `briefing_date`,
+  `overview_signals`, `current_route`.
+- **Tool failures** — topic `orb.live.diag`, `metadata.stage='tool_failed'`:
+  `tool`, `soft` (true = handler returned ok:false/reason), `ms`, `detail` (raw error).
+  Fires for HARD (`success===false`) and SOFT failures. (`emitDiag` in orb-live.ts L2390.)
+- **Self-check runs** — topic `orb.tools.selfcheck`: per-tool `ok`, `soft_fail`, `ms`,
+  `detail`, `user_id`.
 
-Completion mapping (the goal is to FINISH, not navigate):
-
-| Surface | Completion next step |
-|---|---|
-| matches | pick a match & start a joint activity / who is this person / Index-boosting activity / refine criteria / enrich profile |
-| chat | actually write & send the reply |
-| community | draft & publish the post / create the activity |
-| diary | make today's entry now (lifts the Index) |
-| index | one concrete weakest-pillar action to raise it |
-| profile | add one more profile detail → better matches |
-
-**Telemetry:** `current_route` is now on the `conv_resume` greeting event.
-**Command-Hub:** the "Conversation" section should show the per-surface completion
-map and let an operator edit the completion offers (ideally policy-backed).
-
-## 3c. Capability-gating — guidance that actually EXECUTES
-
-The opener guides; the user accepts; it must **complete the action**, not stall on
-"Das konnte ich leider nicht umsetzen". Every next-step action is now mapped to
-the **real, registered ORB tool** that executes it (`CAPABILITY_BY_KEY` in
-`next-best-action.ts`, verified against `ORB_TOOL_REGISTRY`):
-
-| Action | Executes via |
-|---|---|
-| reply_messages / connect_community / complete_chat | `send_chat_message` |
-| review_matches | `view_intent_matches` |
-| complete_matches | `respond_to_match` |
-| create_activity | `share_intent_post` |
-| make_post / complete_post | `create_community_post` |
-| diary_entry / complete_diary | `save_diary_entry` |
-| focus_pillar / complete_index | `create_index_improvement_plan` |
-| autopilot_step | `activate_recommendation` |
-| next_session | `narrate_guided_session` |
-| reminder_due, set_goal, complete_profile | _no one-shot tool → GUIDE the user_ |
-
-The resume directive ships `suggested_next_step.execute_with_tool` and a HARD rule:
-on acceptance, **call that tool**; if null, **guide step-by-step** and never promise
-to do it. This stops over-promising and turns guidance into completion. (Most tools
-already existed — the gap was wiring, not capability.) **Follow-up:** build a real
-`update_profile_field` tool (verify `app_users`/`profiles` schema first) so
-`complete_profile` graduates from guide-only to executable.
-
-## 3d. Tool-execution observability — telemetry + self-check harness
-
-Guidance can route perfectly and still end in "I couldn't do that" if the
-underlying tool fails. Two pieces make that observable + fixable without a voice
-session:
-
-- **Tool-failure telemetry:** `executeLiveApiTool` (orb-live.ts) now emits an
-  `orb.live.diag` stage `tool_failed` to `oasis_events` for both HARD failures
-  (`success=false`) and SOFT ones (handler returned `ok:false`/a `reason`). Every
-  "I can't" is now queryable: `select metadata->>'tool', metadata->>'detail' from
-  oasis_events where topic='orb.live.diag' and metadata->>'stage'='tool_failed'`.
-- **Self-check harness:** `POST /api/v1/admin/orb-tools/selfcheck { user_id }`
-  (`routes/orb-tools-selfcheck.ts`, admin-gated) runs the capability tools via the
-  SAME dispatcher the voice path uses, against the user's real data, and returns +
-  emits (`orb.tools.selfcheck`) a per-tool pass/fail + exact error. Read tools run
-  live; `create_index_improvement_plan` writes calendar events and is cleaned up.
-- **Diagnosable writes:** `createCalendarEvent` now takes an `onError` sink, so the
-  index-plan tool reports the real PostgREST reason when a calendar write fails
-  (previously swallowed to Cloud Run logs).
-
-The Command-Hub "Conversation" section should surface the `tool_failed` feed and a
-button to run the self-check for a user.
-
-## 4. Where everything lives (file map)
-
-| File | Role |
-|---|---|
-| `services/gateway/src/services/conversation/next-best-action.ts` | NBA engine (ranking + select), pure over OverviewPayload |
-| `services/gateway/src/services/conversation/decide-opening.ts` | register decision + resume-directive composition |
-| `services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts` | `gatherOverviewPayload` — the context bundle (journey, index, life_compass, calendar, autopilot, matches, messages, reminders, diary, guided_journey, recall) |
-| `services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts` | `buildNewDayOverviewBlock` — the rich daily-briefing render |
-| `services/gateway/src/services/guide/temporal-bucket.ts` | `describeTimeSince` — recency buckets + motivation signal |
-| `services/gateway/src/routes/orb-live.ts` (`sendGreetingPromptToLiveAPI`) | integration: register routing for the Vertex SAFE-FAST path |
-| `services/gateway/src/orb/live/session/live-session-controller.ts` | greeting-facts prefetch (name, lastSessionInfo, journey, briefing flag) |
-| `docs/CONVERSATION_FLOW_ARCHITECTURE.md` | the broader "one brain, many mouths" architecture (memory §11, journey §10) |
-
----
-
-## 5. Telemetry the Command Hub should READ
-
-Greeting decisions are emitted to `oasis_events` (topic `orb.live.diag`, stage
-`greeting_sent`) with these fields in `metadata`:
-
-- `wake_opener`: `conv_resume` (new unified resume) | `safe_fast_newday_overview`
-  (daily briefing) | `safe_fast_first_time_welcome` | `safe_fast_proactive`/`safe_fast_newday` (fallbacks)
-- `register`: `continue` | `quick_resume` | `same_day` (on `conv_resume`)
-- `bucket`: the recency bucket
-- `nba` / `nba_domain`: the chosen next-best-action key + domain
-- `briefing_date`: stamped on the daily briefing
-- `overview_signals`: the per-signal inventory on the briefing
-
-**Query example (recent openers):**
+Example (recent tool failures):
 ```sql
-select created_at,
-  coalesce(metadata->>'wake_opener', meta->>'wake_opener') as wake_opener,
-  coalesce(metadata->>'register', meta->>'register')       as register,
-  coalesce(metadata->>'bucket', meta->>'bucket')           as bucket,
-  coalesce(metadata->>'nba', meta->>'nba')                 as nba
+select created_at, metadata->>'tool' as tool, metadata->>'soft' as soft, metadata->>'detail' as detail
 from oasis_events
-where topic='orb.live.diag'
-  and coalesce(metadata->>'stage', meta->>'stage')='greeting_sent'
+where topic='orb.live.diag' and metadata->>'stage'='tool_failed'
 order by created_at desc limit 50;
 ```
 
 ---
 
-## 6. What the "Conversation" section should DO (build spec)
+## 5. The CI guard (do not regress)
 
-1. **Live decision feed** — stream recent opens with register + recency bucket +
-   chosen NBA + which signals were present (from the telemetry above). Lets an
-   operator see *why* Vitana said what it said.
-2. **Register distribution** — counts of first_time / daily_briefing / continue /
-   quick_resume / same_day over time; flag anomalies (e.g. too many bare fallbacks
-   `safe_fast_newday` → something is mis-gating).
-3. **NBA distribution** — which next steps Vitana is suggesting, split by domain
-   (community vs health), to confirm the engagement/health balance the business wants.
-4. **Action catalog editor** — view/tune the NBA bands and the community-growth
-   rotation pool (see §3). Ideally back this with `decision_policy` keys (see the
-   policy-resolver in `services/decision-contract/`) so changes need no redeploy.
-5. **Register thresholds** — surface the recency thresholds (reconnect <2m, recent
-   <15m, same_day <8h…) and the cooling/absent day boundary (already policy-driven:
-   `SESSION_MOTIVATION_COOLING_TO_ABSENT_DAYS`). Make them viewable, ideally editable.
-6. **Per-user simulator** — given a user_id, show the assembled context bundle, the
-   register that would be chosen, and the NBA — a dry-run of `decideOpeningRegister`
-   + `selectNextBestAction` without speaking. (Expose a gateway debug endpoint that
-   calls the two pure functions over a freshly gathered payload.)
-
-**Suggested gateway support to add for the UI:** a read-only debug route, e.g.
-`GET /api/v1/admin/conversation/preview?user_id=…` returning
-`{ bundle, register, nba, ranked_nbas }` by calling `gatherOverviewPayload` +
-`decideOpeningRegister` + `rankNextBestActions`. (Not built yet — first task for
-the Command-Hub session.)
+`conversation-flow-change-needs-test` (registry.mjs + seed migration) is a **blocker**:
+any change under `conversation/`, `assistant-continuation/`, `guide/`,
+`guided-journey/`, `orb/live/instruction/`, `live-session-controller.ts`, or
+`orb-tools-shared.ts` **must** ship with a matching test under `services/gateway/test/`
+(broad keyword set incl. conversation/narrate/guided/journey/index/match/diary/tool).
+Escape hatch: `flow-test-exempt: <reason>` in a changed flow file. **The Conversation
+section's backend changes will hit this — write the test in the same PR.**
 
 ---
 
-## 7. Open follow-ups (carry into the build)
+## 6. MULTI-TENANT architecture (the new requirement) — DESIGN, build this
 
-- [ ] Per-user NBA rotation history (§3) so suggestions don't repeat.
-- [ ] Multi-day `welcome_back` warmth: today multi-day gaps fold into
-  `daily_briefing`; consider passing `motivation_signal` into the briefing render
-  so a 10-days-away open explicitly acknowledges the absence.
-- [ ] Optimise the resume path: it gathers `gatherOverviewPayload` at greeting
-  time (bounded 1800ms). Move it into the existing greeting-facts prefetch so the
-  reopen is instant.
-- [ ] Converge transports: LiveKit / the 3rd provider should call the SAME
-  `decideOpeningRegister` + NBA (the "one brain, many mouths" goal in
-  `CONVERSATION_FLOW_ARCHITECTURE.md`). Vertex is wired first.
-- [ ] Standing-instruction guidance: keep the chosen NBA + memory in the system
-  instruction for turns 2+, so Vitana keeps nudging the next step mid-conversation,
-  not just at the open.
-- [ ] Debug preview endpoint (§6) for the simulator.
+**Today the flow engine is GLOBAL and hardcoded; only the *data* it reads is
+tenant-scoped.** Specifically:
+- NBA bands/rotation, register thresholds, screen-completion map, the v3 flow
+  priorities (`services/gateway/src/services/guide/conversation-flow-v3.ts`) and the
+  speakable-text builders are **constants in code** — identical for every tenant.
+- Feature flags via `isFeatureLive` (`services/gateway/src/services/feature-flags.ts`)
+  are **global per-process env vars**, NOT per-tenant.
+- The context bundle, journey, matches, diary etc. ARE tenant-scoped (queries filter
+  `.eq('tenant_id', …)`; identity carries `tenant_id` from JWT `app_metadata.active_tenant_id`).
+
+So **per-tenant conversation design is greenfield.** The clean way to add it without a
+rewrite:
+
+### 6.1 Storage — mirror `tenant_settings`, do NOT mirror the global impact-rules table
+`tenant_settings` (`supabase/migrations/20260412300000_tenant_settings.sql`) is the
+canonical per-tenant pattern: `tenant_id UUID PRIMARY KEY REFERENCES tenants(id)` +
+JSONB buckets + RLS (`service_role_all` + `tenant_read` keyed on
+`raw_app_meta_data->>'active_tenant_id'`). **(`dev_autopilot_impact_rules` is the WRONG
+mirror — it is a *global* registry with PK `rule TEXT`, no tenant_id.)**
+
+Create `tenant_conversation_config`:
+```sql
+CREATE TABLE public.tenant_conversation_config (
+  tenant_id   UUID PRIMARY KEY REFERENCES public.tenants(id) ON DELETE CASCADE,
+  enabled     BOOLEAN NOT NULL DEFAULT TRUE,        -- master switch (else pure global defaults)
+  registers   JSONB   NOT NULL DEFAULT '{}'::jsonb, -- recency thresholds, greeting on/off per register
+  nba         JSONB   NOT NULL DEFAULT '{}'::jsonb, -- band overrides, enable/disable actions, rotation pool, cooldown
+  screen      JSONB   NOT NULL DEFAULT '{}'::jsonb, -- per-surface completion offers
+  copy        JSONB   NOT NULL DEFAULT '{}'::jsonb, -- tenant brand-voice overrides for tool text / directives
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by  TEXT
+);
+-- + ENABLE RLS; service_role_all + tenant_read policy copied verbatim from tenant_settings.
+```
+Keep each bucket a **sparse override** — absent keys fall back to the global default.
+
+### 6.2 Resolver — global defaults ⊕ tenant overrides (the keystone)
+Add `services/gateway/src/services/conversation/config-resolver.ts`:
+```ts
+export interface ConversationConfig { registers: …; nba: …; screen: …; copy: …; }
+export const GLOBAL_DEFAULTS: ConversationConfig = /* the current hardcoded constants, extracted */;
+export async function resolveConversationConfig(sb, tenantId: string|null): Promise<ConversationConfig>
+// reads tenant_conversation_config for tenantId, deep-merges over GLOBAL_DEFAULTS (5-min cache).
+```
+Then **thread the resolved config** into the pure engine functions as a parameter:
+`decideOpeningRegister(input, cfg.registers)`, `rankNextBestActions(p, ctx, cfg.nba)`,
+`screenCompletionFor(surface, cfg.screen)`. They stay pure + unit-testable; the only
+new I/O is the resolver call at the integration points (orb-live.ts greeting path,
+live-session-controller bootstrap) where `tenant_id` is already in scope. **Default
+behaviour is unchanged** when a tenant has no row (resolver returns `GLOBAL_DEFAULTS`).
+
+### 6.3 Tenant scoping in the hub — NOTE A GAP
+The Command Hub has **no tenant switcher today**; it operates on the signed-in admin's
+single `state.meContext.tenant_id` (sent as `X-Vitana-Tenant`). The Conversation
+section needs to **design for an arbitrary tenant**, so it must introduce a
+**tenant selector** (dropdown populated from the Admin→Tenants list) that passes a
+`tenant_id`/`tenant_slug` param to the new endpoints. This is a **new pattern** — there
+is one precedent for a tenant-param call (`/api/v1/admin/ai-assistants/policies/:tenantSlug`)
+to mirror, but no global switcher to copy. Gate every write with `requireExafyAdmin`
+AND verify the target tenant is allowed (see `require-tenant-admin.ts` for the
+cross-tenant 403 pattern).
 
 ---
 
-## 8. Change log
+## 7. Command Hub build recipe (exact, verified)
+
+**Editable source ONLY:** `services/gateway/src/frontend/command-hub/`. `dist/…` is
+build output (`npm run build` → `tsc && cp -r src/frontend/command-hub/* dist/…`). Never
+hand-edit dist. **`navigation-config.js` is stale & auto-generated — do NOT edit it;
+the real nav is in `app.js`.**
+
+Four edits in `services/gateway/src/frontend/command-hub/app.js`:
+
+1. **Nav entry** — insert a section object **between the Assistant object (ends ~L2751)
+   and the Voice object (`// VTID-02856` ~L2752)** inside `NAVIGATION_CONFIG`:
+   ```js
+   {
+     "section": "conversation",
+     "basePath": "/command-hub/conversation/",
+     "tabs": [
+       { "key": "monitor",   "label": "Monitor",          "path": "/command-hub/conversation/monitor/" },
+       { "key": "registers", "label": "Registers",        "path": "/command-hub/conversation/registers/" },
+       { "key": "nba",       "label": "Next-Best-Action",  "path": "/command-hub/conversation/nba/" },
+       { "key": "screens",   "label": "Screen Completion", "path": "/command-hub/conversation/screens/" },
+       { "key": "tools",     "label": "Tool Health",       "path": "/command-hub/conversation/tools/" },
+       { "key": "simulator", "label": "Simulator",         "path": "/command-hub/conversation/simulator/" },
+       { "key": "tenant",    "label": "Tenant Settings",   "path": "/command-hub/conversation/tenant/" }
+     ]
+   },
+   ```
+2. **`SECTION_LABELS`** (~L2968): add `'conversation': 'Conversation',` between
+   `'assistant'` and `'voice'`.
+3. **`renderModuleContent(moduleKey, tab)`** (~L6968; Assistant block ~L7002–7016):
+   add `else if (moduleKey === 'conversation' && tab === '…') { container.appendChild(renderConversation<Tab>View()); }`
+   branches **after the Assistant block, before Voice**.
+4. **View builders + state + fetch:** add `renderConversation<Tab>View()` fns (DOM-imperative,
+   mirror `renderAssistantOverviewView()` at L51524), a `state.conversation` slice
+   (mirror `state.assistantOverview` at L3943), and `fetchConversation*()` fns that call
+   the new endpoints with `buildContextHeaders(...)` (L635 — attaches Bearer token +
+   `X-Vitana-Tenant`; for the tenant selector, pass the chosen tenant explicitly).
+
+Deep-links work automatically once the nav entry exists (`getRouteFromPath` L10619).
+
+**CSP** (set in `routes/command-hub.ts` L71): `script-src 'self'` → **no inline JS**
+(external/bundled only); inline `style=`/`el.style.cssText` is allowed. New API hosts
+must be added to `connect-src` (currently self + livekit) — your endpoints are
+same-origin so no change needed.
+
+**Cache-bust:** bump `?v=` on the `app.js`/`styles.css` links in
+`src/frontend/command-hub/index.html` (L25/L33).
+
+**Deploy:** merge to `main` → STAGING only (`gateway-staging`, `preview-gateway.vitanaland.com`);
+prod via PUBLISH button. (Per CLAUDE.md §16 staging-first.)
+
+---
+
+## 8. The Conversation section — sub-tabs (build spec)
+
+| Tab | Shows | Reads / Writes |
+|---|---|---|
+| **Monitor** | Live decision feed: recent opens with register + recency bucket + chosen NBA + present signals + `current_route`. Register & NBA distributions (community vs health balance). Flag anomalies (too many bare `safe_fast_newday` fallbacks). | `oasis_events` greeting_sent (§4) |
+| **Registers** | The 5 registers + recency thresholds (reconnect <2m, recent <15m, same_day <8h…), greeting on/off per register. Editable per tenant. | resolver defaults + `tenant_conversation_config.registers` |
+| **Next-Best-Action** | The band table, the community-growth rotation pool, cooldown; enable/disable actions; `CAPABILITY_BY_KEY` (action → tool). Editable per tenant. | defaults + `…nba` |
+| **Screen Completion** | The per-surface completion map (§2). Editable per tenant. | defaults + `…screen` |
+| **Tool Health** | The `tool_failed` feed (tool, soft/hard, detail) + a **"Run self-check for user_id"** button calling `POST /api/v1/admin/orb-tools/selfcheck`. This is the proactive catch for the §1 failure class. | `oasis_events` tool_failed + selfcheck endpoint |
+| **Simulator** | Given a `user_id` (+ optional tenant), dry-run the decision: show assembled bundle, chosen register, ranked NBAs, the composed directive — **without speaking**. | new preview endpoint (§9) |
+| **Tenant Settings** | Tenant selector + master `enabled` switch + brand-voice `copy` overrides; diff vs global defaults. | `tenant_conversation_config` |
+
+---
+
+## 9. Gateway endpoints to add (new `src/routes/conversation-hub.ts`, admin-gated)
+
+Mount at `/api/v1/admin/conversation`, `router.use(requireAuth, requireExafyAdmin)`.
+This route file will trip the CI flow-test guard → ship a test in the same PR.
+
+- `GET  /config?tenant_id=…` → resolved config (defaults ⊕ tenant overrides) + the raw
+  override row, for the editor tabs.
+- `PUT  /config?tenant_id=…` → upsert `tenant_conversation_config` (validate with Zod;
+  record `updated_by`).
+- `GET  /preview?user_id=…&tenant_id=…` → `{ bundle, register, nba, ranked_nbas, directive }`
+  by calling `gatherOverviewPayload` + `resolveConversationConfig` + `decideOpeningRegister`
+  + `rankNextBestActions` (read-only; never speaks). Powers the Simulator.
+- `GET  /decisions?limit=…&tenant_id=…` → read model over `oasis_events` greeting_sent.
+- `GET  /tool-failures?limit=…` → read model over `oasis_events` tool_failed.
+- `POST /selfcheck` → proxy/call the existing `orb-tools/selfcheck` (or just have the UI
+  call that endpoint directly).
+- `GET  /tenants` → list tenants for the selector (or reuse the Admin→Tenants source).
+
+---
+
+## 10. Open follow-ups (the real "endless loop" enders — carry these in)
+
+These two close the failure **class**, not instances:
+
+- [ ] **Confirm-before-consequential-write.** Today `create_index_improvement_plan`
+  writes 6 calendar events then describes them; the user wanted to approve the concrete
+  plan first ("du musst doch erst mit mir…"). Add a propose→confirm step for
+  consequential writes (present the plan, gate the write on acceptance). Ties into the
+  acceptance gate below.
+- [ ] **Bind every mid-conversation offer.** `acceptance-gate.ts` only binds offers that
+  wrote a `pending_cta` (wake-brief today). When Vitana improvises an offer mid-chat and
+  the user says "Ja", there is no binding → the model free-interprets and can fail. Make
+  every offer Vitana makes write a `pending_cta` so acceptance always executes the exact
+  offered action. **This is the structural end of the offer-then-fail class.**
+
+Engine follow-ups:
+- [ ] Build a real `update_profile_field` tool so `complete_profile` graduates from guide-only.
+- [ ] Converge transports: LiveKit / 3rd provider should call the SAME
+  `decideOpeningRegister` + NBA (Vertex wired first).
+- [ ] Move `gatherOverviewPayload` into the greeting-facts prefetch so reopen is instant.
+
+---
+
+## 11. Change log
 
 | Date | Change |
 |---|---|
-| 2026-06-27 | Phase 1: unified opening decision (registers, recency-first) + Next-Best-Action engine wired into the Vertex SAFE-FAST path; durable once-per-day briefing flag; this handoff authored for the Command-Hub "Conversation" section. |
+| 2026-06-27 | v1: unified opening decision (registers, recency-first) + NBA engine on the Vertex SAFE-FAST path; durable once-per-day briefing flag; initial handoff. |
+| 2026-06-28 | v2: added the speakable-tool failure-class framing (§1) + the 6 fixes shipped (#2803/2804/2807/2810/2811/2813), tool-failure telemetry + self-check + the `conversation-flow-change-needs-test` CI guard (#2809), refreshed asset inventory with exact lines, the **multi-tenant architecture** (`tenant_conversation_config` + resolver, §6), and the **concrete Command Hub build recipe** (exact app.js edits, auth/CSP/build, endpoints, sub-tabs, §7–§9). |


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-CONVERSATION-COMMAND-HUB-HANDOFF` · **Layer:** AGTL/DOCS · **Priority:** P2

VALIDATION_PROFILE: gateway_backend

---

## 📋 Summary

A complete build-instruction for the **next session** to stand up a new **"Conversation"** section in the Command Hub — placed in the sidebar **between Assistant and Voice** — to **design, test, and maintain** Vitana's conversation flow, **per tenant**.

This is the deliverable requested: *"prepare everything from architecture and parts and pieces that you have built and write an instruction for a new session to build the new Command Hub section called Conversation … conversation design has to be separated by tenant."*

---

## ✅ What the doc contains (`docs/CONVERSATION_FLOW_HANDOFF.md`, v2)

- **The failure class** this section exists to kill: a tool succeeds but its spoken `text` is unusable (nav-only / raw JSON / empty / fabricated) → the model improvises a failure or hallucination. Plus the **speakable-tool contract** to enforce.
- **Everything built this session** as the foundation: the 6 fixes (#2803/2804/2807/2810/2811/2813), the tool-failure telemetry, the self-check harness, and the `conversation-flow-change-needs-test` CI guard (#2809).
- **Engine internals** (registers, recency, NBA, screen-completion, capability-gating) + a **refreshed asset inventory** with exact paths/exports/line numbers.
- **Multi-tenant architecture (the new requirement):** the engine is global/hardcoded today and only the *data* is tenant-scoped, so per-tenant design is greenfield. Design = a `tenant_conversation_config` table **mirroring `tenant_settings`** (explicitly **not** the global impact-rules table) + a **config resolver** (`global defaults ⊕ tenant overrides`) threaded into the pure engine functions, with **unchanged default behaviour** when a tenant has no row. Flags the missing hub **tenant-switcher** as new work.
- **Concrete Command Hub build recipe:** the exact 4 edits in `app.js` (`NAVIGATION_CONFIG`, `SECTION_LABELS`, `renderModuleContent` dispatch, render/fetch fns) with line anchors, auth (`requireExafyAdmin` + `buildContextHeaders`/`X-Vitana-Tenant`), CSP (`script-src 'self'`), cache-bust, staging-first deploy.
- **Sub-tabs** (Monitor / Registers / NBA / Screen Completion / Tool Health / Simulator / Tenant Settings) and the **gateway endpoints** to add (`/api/v1/admin/conversation/*`, incl. a read-only Simulator preview).
- **Open follow-ups that end the failure class:** confirm-before-write + binding every mid-conversation offer.

---

## 🧪 Testing

Docs-only — no runtime code, no schema. `tsc`/tests unaffected. (The doc itself specifies the tests the *next* session must write, since the new gateway route will trip the flow-test guard.)

---

## 🚨 Breaking Changes

None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkPcESkKRjt2tcVk7DteEh)_