### PR TITLE
Fix ORB language flip on guided-session narration (English session → German on "continue")

### DIFF
--- a/services/gateway/src/orb/live/instruction/greeting-gate.ts
+++ b/services/gateway/src/orb/live/instruction/greeting-gate.ts
@@ -1,0 +1,67 @@
+/**
+ * BOOTSTRAP-ORB-GREETING-LANG-FIRSTTIME — greeting-gate decisions.
+ *
+ * Small, pure helpers that encapsulate two session-start greeting decisions so
+ * they can be unit-pinned independently of the large live-session controller /
+ * orb-live handler that consume them:
+ *
+ *   1. deriveHasPriorSession  — has this user talked to Vitana before?
+ *   2. shouldFireFirstTimeWelcome — does the FULL one-time first-session welcome
+ *      fire, or should the user fall through to the returning-user register?
+ *   3. resolveGreetingLang    — which language does the spoken greeting use?
+ *
+ * Why these exist as a unit: the first-time welcome previously fired on the
+ * "needs onboarding" signal alone (0 completed guided-journey topics + not
+ * opted out), so a user who simply never finished onboarding was re-introduced
+ * from scratch on EVERY session — the robotic "first-time user every time" bug.
+ * Gating on `hasPriorSession` fixes it; pinning that here keeps it from
+ * regressing.
+ */
+
+/** The persisted user_journey fields that prove prior interaction. */
+export interface PriorSessionRow {
+  last_session_date?: string | null;
+  is_first_session?: boolean | null;
+}
+
+/**
+ * A user "has a prior session" once they have a recorded `last_session_date` OR
+ * their `is_first_session` flag has already been cleared. Either proves they
+ * have talked to Vitana before. No row at all → no prior session.
+ */
+export function deriveHasPriorSession(row: PriorSessionRow | null | undefined): boolean {
+  if (!row) return false;
+  return row.last_session_date != null || row.is_first_session === false;
+}
+
+export interface FirstTimeWelcomeGateInput {
+  /** The user has talked to Vitana before (see deriveHasPriorSession). */
+  hasPriorSession: boolean;
+  /** 0 completed guided-journey topics AND not opted out of onboarding. */
+  needsOnboarding: boolean;
+  /** user_journey.is_first_session — true only on the genuine first session. */
+  isFirstSession: boolean;
+}
+
+/**
+ * The full one-time first-session welcome fires ONLY when there is no prior
+ * session on record. A returning user who simply never completed guided
+ * onboarding (`needsOnboarding === true`) must NOT be re-introduced from
+ * scratch — they fall through to the returning-user resume register.
+ */
+export function shouldFireFirstTimeWelcome(input: FirstTimeWelcomeGateInput): boolean {
+  if (input.hasPriorSession) return false;
+  return input.needsOnboarding === true || input.isFirstSession === true;
+}
+
+/**
+ * Resolve the language the spoken greeting should use. Prefer the session
+ * language (resolved from the user's stored preference during the greeting-facts
+ * pre-fetch) and fall back to the value captured at session start. This keeps
+ * turn 1 (the greeting) in the SAME language as the rest of the conversation,
+ * which reads `session.lang` — otherwise the greeting speaks the default and the
+ * conversation flips to the stored preference on turn 2.
+ */
+export function resolveGreetingLang(sessionLang: unknown, fallback: string): string {
+  return typeof sessionLang === 'string' && sessionLang.length > 0 ? sessionLang : fallback;
+}

--- a/services/gateway/src/orb/live/instruction/guided-topic-narration-prompt.ts
+++ b/services/gateway/src/orb/live/instruction/guided-topic-narration-prompt.ts
@@ -134,11 +134,16 @@ export function buildGuidedTopicNarrationBlock(
     ].join('\n');
   }
 
+  // BOOTSTRAP-ORB-GUIDE-MODE-LANG: name the user's language CONCRETELY. The
+  // teaching material below is authored in German (the KB), and the previous
+  // vague "speak in the user's language" let the German source pull the model
+  // into German for English (and other non-German) users mid-session.
+  const langName = lang === 'es' ? 'Spanish' : lang === 'sr' ? 'Serbian' : lang === 'fr' ? 'French' : 'English';
   return [
     '',
     '## GUIDE MODE (TEACH) — you INTRODUCE this topic and TEACH it',
     '',
-    'LANGUAGE: speak ONLY in the user\'s language — even if earlier instructions contain English. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting/opening rule.',
+    `LANGUAGE: Speak ONLY in ${langName}. The teaching material below may be written in German — translate and deliver everything in ${langName}, and do NOT switch to German (or any other language) at any point in this session. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting/opening rule.`,
     '',
     `The person tapped the topic "${content.topic_title}" in "My Journey" to have you explain it. Introduce it and TEACH it — proactively, in your OWN words.`,
     '',

--- a/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
+++ b/services/gateway/src/orb/live/instruction/journey-guide-prompt.ts
@@ -141,6 +141,11 @@ export function buildJourneyGuideBlock(
   opts?: { wakeBriefOwnsTurn1?: boolean },
 ): string {
   const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  // BOOTSTRAP-ORB-GUIDE-MODE-LANG: the concrete user language, for the non-German
+  // GUIDE-MODE blocks. Journey/step material is authored in German, so a vague
+  // "speak in the user's language" let the model flip to German for English users
+  // mid-session. Naming the language pins it.
+  const langName = lang === 'es' ? 'Spanish' : lang === 'sr' ? 'Serbian' : lang === 'fr' ? 'French' : 'English';
   const done = guide.focus_done === true;
 
   // VTID-03266/03267: lead with the already-localized opener line (beat-B aware
@@ -193,7 +198,7 @@ export function buildJourneyGuideBlock(
       '',
       '## GUIDE MODE (ENRICH) — this person already completed the step and wants to BUILD ON it',
       '',
-      'LANGUAGE: speak ONLY in the user\'s language — even if earlier instructions contain English. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting/opening rule.',
+      `LANGUAGE: Speak ONLY in ${langName}. Any journey/step material below may be written in German — deliver everything in ${langName}, and do NOT switch to German (or any other language) at any point in this session. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting/opening rule.`,
       '',
       `The person has ALREADY completed "${guide.step_title}" and deliberately tapped it to improve it further. Do NOT treat them as a new user and do NOT restart the step from scratch.`,
       '',
@@ -246,7 +251,7 @@ export function buildJourneyGuideBlock(
     '',
     '## GUIDE MODE — you LEAD this person through their journey and DECIDE FOR them',
     '',
-    'LANGUAGE: speak ONLY in the user\'s language — even if earlier instructions contain English. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting/opening rule (including any that apply "for the first turn only" or tell you to say "How can I help?").',
+    `LANGUAGE: Speak ONLY in ${langName}. Any journey/step material below may be written in German — deliver everything in ${langName}, and do NOT switch to German (or any other language) at any point in this session. This GUIDE MODE applies to the WHOLE session and OVERRIDES every generic greeting/opening rule (including any that apply "for the first turn only" or tell you to say "How can I help?").`,
     '',
     'This person is new and does NOT yet know what to do. You decide FOR them. You say "I suggest we do X now" and DO it together.',
     '',

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -751,6 +751,18 @@ export async function handleLiveSessionStart(
   // most-recent last) from user_journey.recent_nbas. Lets the resume opener
   // ADVANCE past what it already suggested instead of repeating it.
   let greetingRecentNbaKeys: string[] = [];
+  // BOOTSTRAP-ORB-GREETING-LANG: the user's STORED language preference, resolved
+  // in the fast greeting-facts pre-fetch so the spoken greeting can use the SAME
+  // language the rest of the conversation will use (buildLiveSystemInstruction
+  // reads session.lang). Without this the greeting speaks the default ('en') and
+  // the conversation flips to the stored preference ('de') on turn 2. null = not
+  // resolved / no client-independent preference on record.
+  let greetingResolvedLang: string | null = null;
+  // BOOTSTRAP-ORB-GREETING-FIRSTTIME: does the user have a prior session on
+  // record (user_journey.last_session_date set, OR is_first_session already
+  // cleared)? A returning user must NOT get the one-time first-session welcome
+  // again just because they never completed guided onboarding. null = unknown.
+  let greetingHasPriorSession: boolean | null = null;
 
   // VTID-03294: a Guided-Journey topic tap needs ZERO context — Vitana just
   // picks up the KB lesson and speaks it. Detect it here so we can skip the
@@ -951,7 +963,7 @@ export async function handleLiveSessionStart(
         try {
           const { getSupabase } = await import('../../../lib/supabase');
           const supa = getSupabase() ?? undefined;
-          const [lastInfo, factResult, profileResult, firstSessionResult, journeyStateResult] = await Promise.allSettled([
+          const [lastInfo, factResult, profileResult, firstSessionResult, journeyStateResult, langPrefResult] = await Promise.allSettled([
             deps.fetchLastSessionInfo(_ndIdentity.user_id, clientContext?.timezone),
             supa
               ? supa
@@ -974,7 +986,7 @@ export async function handleLiveSessionStart(
             supa
               ? supa
                   .from('user_journey')
-                  .select('is_first_session, last_full_briefing_date, recent_nbas')
+                  .select('is_first_session, last_session_date, last_full_briefing_date, recent_nbas')
                   .eq('user_id', _ndIdentity.user_id)
                   .maybeSingle()
               : Promise.resolve(null as any),
@@ -989,6 +1001,16 @@ export async function handleLiveSessionStart(
                   .eq('user_id', _ndIdentity.user_id)
                   .maybeSingle()
               : Promise.resolve(null as any),
+            // BOOTSTRAP-ORB-GREETING-LANG: the STORED language preference, in the
+            // SAME parallel batch (no added latency). Drives the spoken greeting's
+            // language so it matches the system-instruction language and does not
+            // flip from 'en' to the stored 'de' on turn 2. Skipped (→ null) when
+            // the client already requested a language explicitly — that wins.
+            !clientRequestedLang && _ndIdentity.tenant_id
+              ? deps
+                  .getStoredLanguagePreference(_ndIdentity.tenant_id, _ndIdentity.user_id)
+                  .catch(() => null)
+              : Promise.resolve(null),
           ]);
 
           if (lastInfo.status === 'fulfilled') {
@@ -1001,11 +1023,20 @@ export async function handleLiveSessionStart(
           ) {
             const _fsRow = firstSessionResult.value.data as {
               is_first_session?: boolean | null;
+              last_session_date?: string | null;
               last_full_briefing_date?: string | null;
               recent_nbas?: unknown;
             } | null;
             // No row at all → user has never had a journey row → treat as first-time.
             greetingIsFirstSession = _fsRow ? _fsRow.is_first_session === true : true;
+            // BOOTSTRAP-ORB-GREETING-FIRSTTIME: a user "has a prior session" once
+            // they have a recorded last_session_date OR their is_first_session flag
+            // has already been cleared. Either proves they have talked to Vitana
+            // before, so the one-time welcome must NOT fire again — even if they
+            // never completed guided onboarding. No row at all → no prior session.
+            greetingHasPriorSession = _fsRow
+              ? _fsRow.last_session_date != null || _fsRow.is_first_session === false
+              : false;
             // Durable once-per-day briefing flag (null when never delivered or
             // column absent → briefing is due).
             greetingLastFullBriefingDate = _fsRow?.last_full_briefing_date ?? null;
@@ -1038,6 +1069,17 @@ export async function handleLiveSessionStart(
               _jsRow?.mode === 'full';
             greetingNeedsOnboarding = !_jsRow ? true : _completed === 0 && !_optedOut;
           }
+          // BOOTSTRAP-ORB-GREETING-LANG: resolve the stored language preference so
+          // the greeting builder speaks it (matching the system instruction). Only
+          // when the client did not request a language explicitly.
+          if (
+            !clientRequestedLang &&
+            langPrefResult.status === 'fulfilled' &&
+            typeof langPrefResult.value === 'string' &&
+            langPrefResult.value.length > 0
+          ) {
+            greetingResolvedLang = deps.normalizeLang(langPrefResult.value);
+          }
 
           const factValue =
             factResult.status === 'fulfilled' && factResult.value && !factResult.value.error
@@ -1064,7 +1106,10 @@ export async function handleLiveSessionStart(
             greetingProactiveLine = await computeFastProactiveOpener({
               supabase: supa,
               userId: _ndIdentity.user_id,
-              lang,
+              // BOOTSTRAP-ORB-GREETING-LANG: render the proactive opener in the
+              // resolved stored language, not the default 'en', so this verbatim
+              // line matches the rest of the conversation.
+              lang: greetingResolvedLang || lang,
               firstName: greetingFirstName,
               timezone: clientContext?.timezone ?? null,
               nowMs: Date.now(),
@@ -1188,6 +1233,7 @@ export async function handleLiveSessionStart(
     (session as any).greetingProactiveLine = greetingProactiveLine;
     (session as any).greetingIsFirstTime = greetingIsFirstSession;
     (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
+    (session as any).greetingHasPriorSession = greetingHasPriorSession;
     (session as any).lastFullBriefingDate = greetingLastFullBriefingDate;
     (session as any).recentNbaKeys = greetingRecentNbaKeys;
     if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
@@ -1200,8 +1246,16 @@ export async function handleLiveSessionStart(
       (session as any).greetingProactiveLine = greetingProactiveLine;
       (session as any).greetingIsFirstTime = greetingIsFirstSession;
       (session as any).greetingNeedsOnboarding = greetingNeedsOnboarding;
+      (session as any).greetingHasPriorSession = greetingHasPriorSession;
       (session as any).lastFullBriefingDate = greetingLastFullBriefingDate;
       (session as any).recentNbaKeys = greetingRecentNbaKeys;
+      // BOOTSTRAP-ORB-GREETING-LANG: apply the resolved stored language onto the
+      // session BEFORE the greeting builder's bounded wait resolves, so the
+      // spoken greeting uses the same language as buildLiveSystemInstruction.
+      // Only when the client did not request a language explicitly (that wins).
+      if (greetingResolvedLang && !clientRequestedLang) {
+        session.lang = greetingResolvedLang;
+      }
       // Idempotent with the heavy bootstrap block, which also sets this later.
       if (greetingEarlyLastSessionInfo && !session.lastSessionInfo) {
         session.lastSessionInfo = greetingEarlyLastSessionInfo;
@@ -1631,7 +1685,10 @@ export async function handleLiveSessionStart(
             journey,
             lifeCompassGoalText: lifeCompass?.primary_goal ?? null,
             firstName: nameForGreeting,
-            lang,
+            // BOOTSTRAP-ORB-GREETING-LANG: prefer the resolved session language so
+            // this prompt block's "Speak in <LANG>" matches the conversation
+            // language instead of pinning the default 'en'.
+            lang: (typeof session.lang === 'string' && session.lang.length > 0 ? session.lang : lang),
             todayDateIso,
             nextMove: journeyNextMove,
           });

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -59,6 +59,7 @@ import { recordPaywallEvent } from '../../../services/entitlement-service';
 // ORB-FAST-START Phase 2: defer wake-brief + journey off the session/start
 // response path (flag-gated; default off → legacy inline behavior).
 import { shouldDeferWakeWork, composeContextReady } from './orb-fast-start';
+import { deriveHasPriorSession } from '../instruction/greeting-gate';
 
 // VTID-03107: per-session voice-meter intervals. Keyed by session_id so cleanup
 // in handleLiveSessionStop can tear down without touching GeminiLiveSession's type.
@@ -1033,10 +1034,8 @@ export async function handleLiveSessionStart(
             // they have a recorded last_session_date OR their is_first_session flag
             // has already been cleared. Either proves they have talked to Vitana
             // before, so the one-time welcome must NOT fire again — even if they
-            // never completed guided onboarding. No row at all → no prior session.
-            greetingHasPriorSession = _fsRow
-              ? _fsRow.last_session_date != null || _fsRow.is_first_session === false
-              : false;
+            // never completed guided onboarding. (Pinned in greeting-gate.test.ts.)
+            greetingHasPriorSession = deriveHasPriorSession(_fsRow);
             // Durable once-per-day briefing flag (null when never delivered or
             // column absent → briefing is due).
             greetingLastFullBriefingDate = _fsRow?.last_full_briefing_date ?? null;

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -787,16 +787,38 @@ export async function handleLiveSessionStart(
     const minimalGuidedContext = isDe
       ? 'Du bist Vitana — die warme, ruhige Stimme der Vitanaland-Langlebigkeits-Community. Du stellst gerade ein Thema aus der geführten Reise vor und erklärst es. Halte dich an die dir vorgegebene Lektion.'
       : 'You are Vitana — the warm, calm voice of the Vitanaland longevity community. You are introducing and teaching one Guided Journey topic. Stay on the lesson you are given.';
-    contextReadyPromise = Promise.resolve().then(() => {
+    const guidedTopicUserId = bootstrapIdentity.user_id;
+    contextReadyPromise = Promise.resolve().then(async () => {
+      // BOOTSTRAP-ORB-GUIDED-JOURNEY-AWARE: this fast path skips the heavy
+      // bootstrap, so WITHOUT this fetch the model has ZERO awareness of where
+      // the user is in the Guided Journey and defaults to "let's start the first
+      // session" — even for a user on session 10. Inject the SAME authoritative
+      // standing block the heavy path uses (current session + "never restart at
+      // 1"). Correctness-first: we await one indexed read (~20-50ms) so the model
+      // is journey-aware from turn 1. Best-effort: any failure keeps the minimal
+      // persona rather than blocking first audio.
+      let ctx = minimalGuidedContext;
+      try {
+        const { getSupabase } = await import('../../../lib/supabase');
+        const supaGj = getSupabase() ?? undefined;
+        if (supaGj) {
+          const { fetchGuidedJourney, buildGuidedJourneyStandingInstruction } = await import(
+            '../../../services/assistant-continuation/providers/new-day-overview-payload'
+          );
+          const gj = await fetchGuidedJourney(supaGj, guidedTopicUserId, lang);
+          const journeyBlock = buildGuidedJourneyStandingInstruction(gj);
+          if (journeyBlock) ctx = `${ctx}${journeyBlock}`;
+        }
+      } catch { /* keep minimal persona — journey awareness is additive */ }
       session.active_role = 'community';
       session.lastSessionInfo = null;
-      session.contextInstruction = minimalGuidedContext;
+      session.contextInstruction = ctx;
       session.contextPack = undefined;
       session.contextBootstrapLatencyMs = 0;
       session.contextBootstrapSkippedReason = 'guided_topic_minimal';
       session.contextBootstrapBuiltAt = Date.now();
     });
-    console.log(`[VTID-03294] Guided-topic session ${sessionId}: minimal context (skipped heavy bootstrap) for fast first audio`);
+    console.log(`[VTID-03294] Guided-topic session ${sessionId}: minimal context (+journey awareness) for fast first audio`);
   } else if (bootstrapIdentity) {
     const usingDevFallback = bootstrapIdentity.user_id === DEV_IDENTITY.USER_ID;
     console.log(`[VTID-01224] Building bootstrap context for SSE session ${sessionId} user=${bootstrapIdentity.user_id.substring(0, 8)}...${usingDevFallback ? ' (DEV_IDENTITY fallback)' : ''}`);

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1641,7 +1641,7 @@ export async function handleLiveSessionStart(
       const supa = getSupa();
       if (supa) {
         const [
-          { getJourneyState, updateSessionEndState },
+          { getJourneyState, updateSessionEndState, ensureUserJourneyRow },
           { buildJourneyGreetingBlock, todayInTimezone },
           { fetchLifeCompass },
         ] = await Promise.all([
@@ -1651,6 +1651,23 @@ export async function handleLiveSessionStart(
         ]);
         const journey = await getJourneyState(supa, orbIdentity.user_id);
         if (journey) {
+          // BOOTSTRAP-ORB-GREETING-FIRSTTIME: if getJourneyState fell back to the
+          // math path, the user has NO user_journey row — so the
+          // updateSessionEndState below would update zero rows and
+          // last_session_date would never persist, making the greeting re-fire
+          // every session. Seed a real row (idempotently) so this session's
+          // last_session_date actually lands and the welcome converges. We mark
+          // is_first_session=false: a user reaching a live session without a row
+          // is an existing user the backfill missed, not a first-ever signup.
+          if (journey.fallback_used) {
+            await ensureUserJourneyRow(supa, orbIdentity.user_id, {
+              tenant_id: orbIdentity.tenant_id ?? null,
+              started_at: journey.started_at,
+              is_first_session: false,
+            }).catch((err: any) =>
+              console.warn(`[VTID-03154] ensureUserJourneyRow (fallback seed) failed (non-fatal): ${err?.message}`),
+            );
+          }
           const lifeCompass = await fetchLifeCompass(supa, orbIdentity.user_id).catch(() => null);
           const tz = (session as any).clientContext?.timezone ?? null;
           const todayDateIso = todayInTimezone(new Date(), tz);

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4275,6 +4275,12 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            // BOOTSTRAP-ORB-GUIDE-MODE-LANG: pass the session language so
+            // language-sensitive tools (e.g. narrate_guided_session, whose script
+            // is authored in German) instruct the model to TRANSLATE for non-German
+            // users instead of speaking verbatim — which flipped English sessions
+            // into German mid-journey.
+            lang: session.lang ?? null,
           },
           supabase,
         );
@@ -4301,6 +4307,12 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            // BOOTSTRAP-ORB-GUIDE-MODE-LANG: pass the session language so
+            // language-sensitive tools (e.g. narrate_guided_session, whose script
+            // is authored in German) instruct the model to TRANSLATE for non-German
+            // users instead of speaking verbatim — which flipped English sessions
+            // into German mid-journey.
+            lang: session.lang ?? null,
           },
           supabase,
         );
@@ -4330,6 +4342,12 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            // BOOTSTRAP-ORB-GUIDE-MODE-LANG: pass the session language so
+            // language-sensitive tools (e.g. narrate_guided_session, whose script
+            // is authored in German) instruct the model to TRANSLATE for non-German
+            // users instead of speaking verbatim — which flipped English sessions
+            // into German mid-journey.
+            lang: session.lang ?? null,
           },
           supabase,
         );
@@ -4508,6 +4526,12 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            // BOOTSTRAP-ORB-GUIDE-MODE-LANG: pass the session language so
+            // language-sensitive tools (e.g. narrate_guided_session, whose script
+            // is authored in German) instruct the model to TRANSLATE for non-German
+            // users instead of speaking verbatim — which flipped English sessions
+            // into German mid-journey.
+            lang: session.lang ?? null,
           },
           supabase,
         );
@@ -4556,6 +4580,12 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            // BOOTSTRAP-ORB-GUIDE-MODE-LANG: pass the session language so
+            // language-sensitive tools (e.g. narrate_guided_session, whose script
+            // is authored in German) instruct the model to TRANSLATE for non-German
+            // users instead of speaking verbatim — which flipped English sessions
+            // into German mid-journey.
+            lang: session.lang ?? null,
           },
           supabase,
         );
@@ -4738,6 +4768,12 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            // BOOTSTRAP-ORB-GUIDE-MODE-LANG: pass the session language so
+            // language-sensitive tools (e.g. narrate_guided_session, whose script
+            // is authored in German) instruct the model to TRANSLATE for non-German
+            // users instead of speaking verbatim — which flipped English sessions
+            // into German mid-journey.
+            lang: session.lang ?? null,
           },
           supabase,
         );
@@ -5476,6 +5512,12 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            // BOOTSTRAP-ORB-GUIDE-MODE-LANG: pass the session language so
+            // language-sensitive tools (e.g. narrate_guided_session, whose script
+            // is authored in German) instruct the model to TRANSLATE for non-German
+            // users instead of speaking verbatim — which flipped English sessions
+            // into German mid-journey.
+            lang: session.lang ?? null,
           },
           supabase,
         );
@@ -5501,6 +5543,12 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            // BOOTSTRAP-ORB-GUIDE-MODE-LANG: pass the session language so
+            // language-sensitive tools (e.g. narrate_guided_session, whose script
+            // is authored in German) instruct the model to TRANSLATE for non-German
+            // users instead of speaking verbatim — which flipped English sessions
+            // into German mid-journey.
+            lang: session.lang ?? null,
           },
           supabase,
         );
@@ -5526,6 +5574,12 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            // BOOTSTRAP-ORB-GUIDE-MODE-LANG: pass the session language so
+            // language-sensitive tools (e.g. narrate_guided_session, whose script
+            // is authored in German) instruct the model to TRANSLATE for non-German
+            // users instead of speaking verbatim — which flipped English sessions
+            // into German mid-journey.
+            lang: session.lang ?? null,
           },
           supabase,
         );

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1372,6 +1372,7 @@ export { buildLiveApiTools } from '../orb/live/tools/live-tool-catalog';
 // tools rather than a TS-side state machine.
 import { buildTeacherModeBlock } from '../orb/teacher/teacher-mode-prompt';
 // VTID-03257 (Fix-1): GUIDE MODE block — Vitana leads the Foundation checklist.
+import { shouldFireFirstTimeWelcome, resolveGreetingLang } from '../orb/live/instruction/greeting-gate';
 import { buildJourneyGuideBlock } from '../orb/live/instruction/journey-guide-prompt';
 import { buildGuidedTopicNarrationBlock } from '../orb/live/instruction/guided-topic-narration-prompt';
 // A6.2 (orb-live-refactor): SessionContext + SessionMutator + first
@@ -7611,10 +7612,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
             // default ('en') and then flip to the stored 'de' on turn 2 (the system
             // instruction reads session.lang). Re-reading here keeps turn 1 and the
             // rest of the conversation in one language.
-            const greetLang =
-              typeof (session as any).lang === 'string' && (session as any).lang.length > 0
-                ? ((session as any).lang as string)
-                : lang;
+            const greetLang = resolveGreetingLang((session as any).lang, lang);
             // BOOTSTRAP-ORB-GREETING-FIRSTTIME: a user who has a prior session on
             // record must never get the one-time first-session welcome again, even
             // if they never finished guided onboarding.
@@ -7810,8 +7808,11 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               // must NOT be re-introduced from scratch every session — they fall
               // through to the returning-user resume register below. This is what
               // made Vitana feel robotic: greeting every visit as a first-timer.
-              const _isFirstTime =
-                !_hasPriorSession && (_needsOnboarding === true || _ift === true);
+              const _isFirstTime = shouldFireFirstTimeWelcome({
+                hasPriorSession: _hasPriorSession,
+                needsOnboarding: _needsOnboarding === true,
+                isFirstSession: _ift === true,
+              });
               if (_isFirstTime) {
                 const _welcome = buildFirstTimeWelcomeLine(greetLang, (session as any).greetingFirstName ?? null);
                 const _safeWel = _welcome.replace(/"/g, '\\"');
@@ -7851,10 +7852,11 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               // returning never-onboarded user reaches the resume register (soft
               // "welcome back / let's continue") instead of being treated as a
               // first-timer and skipping it.
-              const _isFirstTimeR =
-                !_hasPriorSession &&
-                ((session as any).greetingNeedsOnboarding === true ||
-                  (session as any).greetingIsFirstTime === true);
+              const _isFirstTimeR = shouldFireFirstTimeWelcome({
+                hasPriorSession: _hasPriorSession,
+                needsOnboarding: (session as any).greetingNeedsOnboarding === true,
+                isFirstSession: (session as any).greetingIsFirstTime === true,
+              });
               const _uidR = session.identity?.user_id;
               const _supaR = getSupabase();
               const _langKeyR = (greetLang || 'en').slice(0, 2).toLowerCase();

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7604,6 +7604,22 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               }
             }
 
+            // BOOTSTRAP-ORB-GREETING-LANG: re-read the language AFTER the bounded
+            // facts wait. `lang` was captured at function entry (above), before the
+            // greeting-facts pre-fetch resolved the user's stored preference onto
+            // session.lang. Using the stale capture would speak the greeting in the
+            // default ('en') and then flip to the stored 'de' on turn 2 (the system
+            // instruction reads session.lang). Re-reading here keeps turn 1 and the
+            // rest of the conversation in one language.
+            const greetLang =
+              typeof (session as any).lang === 'string' && (session as any).lang.length > 0
+                ? ((session as any).lang as string)
+                : lang;
+            // BOOTSTRAP-ORB-GREETING-FIRSTTIME: a user who has a prior session on
+            // record must never get the one-time first-session welcome again, even
+            // if they never finished guided onboarding.
+            const _hasPriorSession = (session as any).greetingHasPriorSession === true;
+
             // NEW-DAY OVERVIEW (rich summary owns turn 1). On a genuine new-day
             // return we speak the FULL multi-clause morning overview (what passed
             // since last session, today's next event, Index direction, Life
@@ -7685,7 +7701,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                     userId: _uidNd,
                     now: _nowNd,
                     timezone: _tzNd,
-                    lang,
+                    lang: greetLang,
                     lastSessionDateUserTz: _lastSessDateTz,
                     // Precise cutoff for "events since we last spoke" — avoids
                     // briefing the user about events that happened BEFORE their
@@ -7714,7 +7730,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                 if (_overview && _hasContent) {
                   const _block = buildNewDayOverviewBlock({
                     payload: _overview,
-                    lang,
+                    lang: greetLang,
                     firstName: _firstNameNd.trim(),
                     localHour: localHourInTimezone(_nowNd, _tzNd),
                     timezone: _tzNd,
@@ -7788,9 +7804,16 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
               // (0 completed journey topics and not graduated/opted-out — survives
               // the eager is_first_session clear) OR is_first_session still true.
               // Unknown → fall through to the normal proactive/name/menu ladder.
-              const _isFirstTime = _needsOnboarding === true || _ift === true;
+              // BOOTSTRAP-ORB-GREETING-FIRSTTIME: the full one-time welcome fires
+              // ONLY when there is no prior session on record. A returning user who
+              // simply never completed guided onboarding (_needsOnboarding===true)
+              // must NOT be re-introduced from scratch every session — they fall
+              // through to the returning-user resume register below. This is what
+              // made Vitana feel robotic: greeting every visit as a first-timer.
+              const _isFirstTime =
+                !_hasPriorSession && (_needsOnboarding === true || _ift === true);
               if (_isFirstTime) {
-                const _welcome = buildFirstTimeWelcomeLine(lang, (session as any).greetingFirstName ?? null);
+                const _welcome = buildFirstTimeWelcomeLine(greetLang, (session as any).greetingFirstName ?? null);
                 const _safeWel = _welcome.replace(/"/g, '\\"');
                 const _welPrompt = `Say exactly: "${_safeWel}" — speak it verbatim as audio, as ONE warm greeting. Do NOT add, paraphrase, or split it.`;
                 ws.send(
@@ -7799,14 +7822,14 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                   }),
                 );
                 emitDiag(session, 'greeting_sent', {
-                  lang,
+                  lang: greetLang,
                   prompt_len: _welPrompt.length,
                   wake_opener: 'safe_fast_first_time_welcome',
                   is_first_session: _ift === true,
                 });
                 startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
                 console.log(
-                  `[GREETING-SAFE-FAST-FIRST-TIME] session ${session.sessionId} sent first-time welcome (is_first_session=${String(_ift)}, needs_onboarding=${String(_needsOnboarding)}, lang=${lang})`,
+                  `[GREETING-SAFE-FAST-FIRST-TIME] session ${session.sessionId} sent first-time welcome (is_first_session=${String(_ift)}, needs_onboarding=${String(_needsOnboarding)}, has_prior=${String(_hasPriorSession)}, lang=${greetLang})`,
                 );
                 return;
               }
@@ -7824,12 +7847,17 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
             // payload could not be gathered in budget. See
             // docs/CONVERSATION_FLOW_HANDOFF.md.
             {
+              // BOOTSTRAP-ORB-GREETING-FIRSTTIME: mirror the prior-session guard so a
+              // returning never-onboarded user reaches the resume register (soft
+              // "welcome back / let's continue") instead of being treated as a
+              // first-timer and skipping it.
               const _isFirstTimeR =
-                (session as any).greetingNeedsOnboarding === true ||
-                (session as any).greetingIsFirstTime === true;
+                !_hasPriorSession &&
+                ((session as any).greetingNeedsOnboarding === true ||
+                  (session as any).greetingIsFirstTime === true);
               const _uidR = session.identity?.user_id;
               const _supaR = getSupabase();
-              const _langKeyR = (lang || 'en').slice(0, 2).toLowerCase();
+              const _langKeyR = (greetLang || 'en').slice(0, 2).toLowerCase();
               const _langOkR = _langKeyR === 'de' || _langKeyR === 'en';
               if (_langOkR && !_isFirstTimeR && _uidR && _supaR) {
                 try {
@@ -7858,7 +7886,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                         userId: _uidR,
                         now: _nowR,
                         timezone: _tzR,
-                        lang,
+                        lang: greetLang,
                         lastSessionDateUserTz: _lastSessDateR,
                         lastSessionAtIso: _lastSessIsoR,
                       }),
@@ -7872,7 +7900,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                       register: _registerR,
                       payload: _payloadR,
                       firstName: (session as any).greetingFirstName ?? null,
-                      lang,
+                      lang: greetLang,
                       timeAgo: _lastIxR.timeAgo,
                       rotationSeed: _seedR,
                       recentNbaKeys: _recentNbaKeysR as any,
@@ -8023,7 +8051,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                       ? `Добро вече, ${name}.`
                       : `Добар дан, ${name}.`,
               };
-              const langKey = (lang || 'en').slice(0, 2).toLowerCase();
+              const langKey = (greetLang || 'en').slice(0, 2).toLowerCase();
               const spoken = greetingByLang[langKey] || greetingByLang.en;
               const safe = spoken.replace(/"/g, '\\"');
               // Mirror the existing `Say exactly: "..."` shape used elsewhere in
@@ -8050,7 +8078,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
 
             // ELSE — fall through to the EXISTING generic opener (unchanged
             // behavior). Same-day reconnects and no-name sessions take this path.
-            const _menu = pickShortGapGreetings(lang, 6).map((p) => `"${p}"`).join(', ');
+            const _menu = pickShortGapGreetings(greetLang, 6).map((p) => `"${p}"`).join(', ');
             const _safePrompt =
               `Open with EXACTLY ONE short phrase, picked from this menu and used VERBATIM ` +
               `(already in the user's language): ${_menu}. Do NOT say "Hello" or the user's name. ` +

--- a/services/gateway/src/services/journey/user-journey-service.ts
+++ b/services/gateway/src/services/journey/user-journey-service.ts
@@ -194,7 +194,7 @@ export async function getJourneyState(
 export async function ensureUserJourneyRow(
   client: SupabaseClient,
   userId: string,
-  opts: { tenant_id?: string | null; started_at?: string | Date } = {},
+  opts: { tenant_id?: string | null; started_at?: string | Date; is_first_session?: boolean } = {},
 ): Promise<boolean> {
   try {
     const startedAtIso =
@@ -207,7 +207,12 @@ export async function ensureUserJourneyRow(
         user_id: userId,
         tenant_id: opts.tenant_id ?? null,
         started_at: startedAtIso,
-        is_first_session: true,
+        // Defaults to true so the /me seeding path (brand-new users) is
+        // unchanged. The session-start backfill passes false: a user reaching
+        // a live session WITHOUT a row is an existing user the backfill missed,
+        // not a first-ever signup — seeding them as first_session would (re)play
+        // the one-time welcome on the legacy continuation path.
+        is_first_session: opts.is_first_session ?? true,
       })
       .select('user_id')
       .maybeSingle();

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -4572,6 +4572,37 @@ export async function tool_find_community_member(
  * means the journey content isn't seeded in this environment, so we degrade to
  * "introduce from knowledge" rather than falsely congratulating the user.
  */
+/**
+ * BOOTSTRAP-ORB-GUIDE-MODE-LANG: build the narration directive for the live model.
+ *
+ * The authored `vitana_voice_script` is in German (the curriculum is German).
+ * For a German-speaking user the model speaks it verbatim. For ANY other user
+ * language the directive instructs the model to TRANSLATE the script and speak
+ * it in that language — otherwise the prior "speak it word for word" command
+ * flipped the whole session into German for English (and other) users the moment
+ * narration started (reported: English session → German on "let's continue").
+ *
+ * `lang` defaults to 'de' (the platform default) when absent, preserving the
+ * exact prior verbatim behavior for German users and any caller that doesn't
+ * yet thread the session language.
+ *
+ * Pure — exported for unit tests.
+ */
+export function buildGuidedNarrationDirective(script: string, lang: string | null | undefined): string {
+  const lc = (lang || 'de').toLowerCase();
+  if (lc.startsWith('de')) {
+    return `SPEAK THE TEXT BELOW NOW, as your spoken audio, in full, word for word, exactly as written — it IS the session's real narration, not a summary to describe. Say ONLY the text below: do NOT add an acknowledgement before it, do NOT summarize or shorten it, and do NOT say "we finished" or offer another session until you have spoken every single word of it.\n\n${script}`;
+  }
+  const langName = lc.startsWith('es')
+    ? 'Spanish'
+    : lc.startsWith('sr')
+      ? 'Serbian'
+      : lc.startsWith('fr')
+        ? 'French'
+        : 'English';
+  return `The text below is this session's real narration, authored in German. Deliver it NOW as your spoken audio, but SPOKEN IN ${langName}: translate every sentence faithfully into ${langName} and speak the WHOLE thing — do NOT shorten, summarize, or skip any part, and do NOT speak any German. Say ONLY this narration (no acknowledgement before it, no "we finished" or offer of another session until you have delivered all of it in ${langName}):\n\n${script}`;
+}
+
 export async function tool_narrate_guided_session(
   args: OrbToolArgs,
   identity: OrbToolIdentity,
@@ -4782,9 +4813,8 @@ export async function tool_narrate_guided_session(
     }
     return {
       ok: true,
-      result: { session: target.session, topic_id: target.topic_id, topic_title: title, has_script: true, remaining_in_session: remainingInSession },
-      text:
-        `SPEAK THE TEXT BELOW NOW, as your spoken audio, in full, word for word, exactly as written — it IS the session's real narration, not a summary to describe. Say ONLY the text below: do NOT add an acknowledgement before it, do NOT summarize or shorten it, and do NOT say "we finished" or offer another session until you have spoken every single word of it.\n\n${script}`,
+      result: { session: target.session, topic_id: target.topic_id, topic_title: title, has_script: true, remaining_in_session: remainingInSession, narration_lang: (identity.lang || 'de').toLowerCase() },
+      text: buildGuidedNarrationDirective(script, identity.lang),
     };
   } catch (e: any) {
     console.warn(`[narrate_guided_session] non-fatal: ${e?.message || e}`);

--- a/services/gateway/test/greeting-gate.test.ts
+++ b/services/gateway/test/greeting-gate.test.ts
@@ -1,0 +1,89 @@
+/**
+ * greeting-gate — pins the session-start greeting decisions changed by
+ * BOOTSTRAP-ORB-GREETING-LANG-FIRSTTIME.
+ *
+ * Regression context: the ORB greeted returning users as first-timers on EVERY
+ * session (the full one-time welcome fired on the "needs onboarding" signal
+ * alone), and the spoken greeting could be in a different language than the
+ * rest of the conversation. These tests lock the corrected behaviour:
+ *
+ *   1. A user with ANY prior session never gets the full first-time welcome,
+ *      even when they never finished guided onboarding.
+ *   2. A genuine first-ever user DOES get it.
+ *   3. The greeting language prefers the resolved session language so turn 1
+ *      matches turn 2.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import {
+  deriveHasPriorSession,
+  shouldFireFirstTimeWelcome,
+  resolveGreetingLang,
+} from '../src/orb/live/instruction/greeting-gate';
+
+describe('deriveHasPriorSession', () => {
+  it('no row → no prior session', () => {
+    expect(deriveHasPriorSession(null)).toBe(false);
+    expect(deriveHasPriorSession(undefined)).toBe(false);
+  });
+
+  it('genuine first session (is_first_session=true, no last_session_date) → no prior session', () => {
+    expect(deriveHasPriorSession({ is_first_session: true, last_session_date: null })).toBe(false);
+  });
+
+  it('last_session_date set → has prior session', () => {
+    expect(deriveHasPriorSession({ is_first_session: true, last_session_date: '2026-06-28' })).toBe(true);
+  });
+
+  it('is_first_session already cleared → has prior session even without a date', () => {
+    expect(deriveHasPriorSession({ is_first_session: false, last_session_date: null })).toBe(true);
+  });
+});
+
+describe('shouldFireFirstTimeWelcome', () => {
+  it('genuine first-ever session → fires', () => {
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: false, needsOnboarding: true, isFirstSession: true }),
+    ).toBe(true);
+  });
+
+  it('first-ever session by is_first_session only (onboarding already satisfied) → fires', () => {
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: false, needsOnboarding: false, isFirstSession: true }),
+    ).toBe(true);
+  });
+
+  it('REGRESSION: returning user who never finished onboarding → does NOT fire', () => {
+    // This is the exact bug: needsOnboarding=true used to force the welcome on
+    // every session. With a prior session on record it must NOT re-introduce.
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: true, needsOnboarding: true, isFirstSession: false }),
+    ).toBe(false);
+  });
+
+  it('returning, fully onboarded user → does NOT fire', () => {
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: true, needsOnboarding: false, isFirstSession: false }),
+    ).toBe(false);
+  });
+
+  it('no prior session and no first-time signals → does NOT fire', () => {
+    expect(
+      shouldFireFirstTimeWelcome({ hasPriorSession: false, needsOnboarding: false, isFirstSession: false }),
+    ).toBe(false);
+  });
+});
+
+describe('resolveGreetingLang', () => {
+  it('prefers a non-empty session language over the fallback', () => {
+    expect(resolveGreetingLang('de', 'en')).toBe('de');
+  });
+
+  it('falls back when session language is missing/empty/non-string', () => {
+    expect(resolveGreetingLang(undefined, 'en')).toBe('en');
+    expect(resolveGreetingLang('', 'de')).toBe('de');
+    expect(resolveGreetingLang(null, 'fr')).toBe('fr');
+    expect(resolveGreetingLang(42 as unknown, 'es')).toBe('es');
+  });
+});

--- a/services/gateway/test/guided-journey-standing-instruction.test.ts
+++ b/services/gateway/test/guided-journey-standing-instruction.test.ts
@@ -59,4 +59,24 @@ describe('buildGuidedJourneyStandingInstruction', () => {
     // No title/recall available → those lines are omitted, but the session line stays.
     expect(block).not.toContain('Where you left off');
   });
+
+  // BOOTSTRAP-ORB-GUIDED-JOURNEY-AWARE: reported regression — a real account on
+  // session 10 with 19 completed topics was greeted as if it should "start with
+  // the first session" because the fast guided-topic path skipped this block.
+  // The block itself must (a) name the current session and (b) forbid restarting
+  // at 1; the controller now injects it on the guided-topic path too.
+  it('reported account (session 10, 19 topics done) → names session 10 and forbids restarting at the first lesson', () => {
+    const block = buildGuidedJourneyStandingInstruction({
+      sessions_completed: 9, // currentSession 10 = sessions_completed + 1
+      topics_learned: 19,
+      topics_total: 254,
+      next_session_title: 'Schlaf & Regeneration',
+      last_session_recall: 'Schlaf & Regeneration',
+    });
+    expect(block).not.toBe('');
+    expect(block).toContain('Current session: 10');
+    expect(block).toContain('Sessions completed: 9');
+    expect(block).toMatch(/NEVER restart at session 1/i);
+    expect(block).toMatch(/first lesson/i); // explicitly tells the model not to call it that
+  });
 });

--- a/services/gateway/test/guided-narration-directive.test.ts
+++ b/services/gateway/test/guided-narration-directive.test.ts
@@ -1,0 +1,50 @@
+/**
+ * buildGuidedNarrationDirective — pins the language behaviour of the
+ * narrate_guided_session tool's spoken directive.
+ *
+ * Regression (BOOTSTRAP-ORB-GUIDE-MODE-LANG): the guided-session voice scripts
+ * are authored in German, and the tool told the live model to "speak it word for
+ * word". For an English (or any non-German) user that flipped the whole session
+ * into German the moment narration started ("let's continue" → German). The
+ * directive must now tell the model to TRANSLATE for non-German users, while
+ * keeping verbatim for German users.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { buildGuidedNarrationDirective } from '../src/services/orb-tools-shared';
+
+const SCRIPT = 'Willkommen zu deiner heutigen Sitzung über Schlaf und Regeneration.';
+
+describe('buildGuidedNarrationDirective', () => {
+  it('German user → speak the German script verbatim', () => {
+    const d = buildGuidedNarrationDirective(SCRIPT, 'de');
+    expect(d).toMatch(/word for word/i);
+    expect(d).toContain(SCRIPT);
+    expect(d).not.toMatch(/translate/i);
+  });
+
+  it('defaults to German verbatim when lang is absent (preserves prior behaviour)', () => {
+    for (const lang of [null, undefined, '']) {
+      const d = buildGuidedNarrationDirective(SCRIPT, lang as any);
+      expect(d).toMatch(/word for word/i);
+      expect(d).not.toMatch(/translate/i);
+    }
+  });
+
+  it('REGRESSION: English user → translate the German script into English, never speak German', () => {
+    const d = buildGuidedNarrationDirective(SCRIPT, 'en');
+    expect(d).toMatch(/translate/i);
+    expect(d).toMatch(/SPOKEN IN English/);
+    expect(d).toMatch(/do NOT speak any German/i);
+    expect(d).not.toMatch(/word for word/i);
+    expect(d).toContain(SCRIPT); // the source script is still included for the model to translate from
+  });
+
+  it('names the concrete target language for other non-German locales', () => {
+    expect(buildGuidedNarrationDirective(SCRIPT, 'es')).toMatch(/SPOKEN IN Spanish/);
+    expect(buildGuidedNarrationDirective(SCRIPT, 'sr')).toMatch(/SPOKEN IN Serbian/);
+    expect(buildGuidedNarrationDirective(SCRIPT, 'en-US')).toMatch(/SPOKEN IN English/);
+    expect(buildGuidedNarrationDirective(SCRIPT, 'de-AT')).toMatch(/word for word/i); // de-* stays verbatim
+  });
+});

--- a/services/gateway/test/user-journey-service.test.ts
+++ b/services/gateway/test/user-journey-service.test.ts
@@ -1,0 +1,73 @@
+/**
+ * user-journey-service.ensureUserJourneyRow — seeding semantics.
+ *
+ * Pins BOOTSTRAP-ORB-GREETING-FIRSTTIME: the session-start backfill seeds a
+ * MISSING user_journey row with is_first_session=false (an existing user the
+ * backfill missed must not replay the one-time welcome), while the default
+ * /me seeding path stays is_first_session=true. Idempotent on conflict.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import { ensureUserJourneyRow } from '../src/services/journey/user-journey-service';
+
+/** Minimal fake supporting `.from(t).insert(p).select('user_id').maybeSingle()`.
+ *  Captures the inserted payload and simulates a unique-violation when the
+ *  user_id is already present. */
+function makeFakeSupabase(existingIds: string[] = []) {
+  const ids = new Set(existingIds);
+  const inserts: any[] = [];
+  const client: any = {
+    __inserts: inserts,
+    from(_table: string) {
+      let payload: any = null;
+      const builder: any = {
+        insert(p: any) {
+          payload = p;
+          inserts.push(p);
+          return builder;
+        },
+        select() { return builder; },
+        maybeSingle() {
+          if (ids.has(payload.user_id)) {
+            return Promise.resolve({ data: null, error: { code: '23505', message: 'duplicate key' } });
+          }
+          ids.add(payload.user_id);
+          return Promise.resolve({ data: { user_id: payload.user_id }, error: null });
+        },
+      };
+      return builder;
+    },
+  };
+  return client;
+}
+
+describe('ensureUserJourneyRow', () => {
+  it('defaults to is_first_session=true (the /me signup seeding path)', async () => {
+    const sb = makeFakeSupabase();
+    const created = await ensureUserJourneyRow(sb, 'user-new');
+    expect(created).toBe(true);
+    expect(sb.__inserts).toHaveLength(1);
+    expect(sb.__inserts[0].is_first_session).toBe(true);
+    expect(sb.__inserts[0].user_id).toBe('user-new');
+  });
+
+  it('seeds is_first_session=false when explicitly requested (session-start backfill)', async () => {
+    const sb = makeFakeSupabase();
+    const created = await ensureUserJourneyRow(sb, 'user-existing', {
+      tenant_id: 'tenant-1',
+      started_at: '2026-01-01T00:00:00.000Z',
+      is_first_session: false,
+    });
+    expect(created).toBe(true);
+    expect(sb.__inserts[0].is_first_session).toBe(false);
+    expect(sb.__inserts[0].tenant_id).toBe('tenant-1');
+    expect(sb.__inserts[0].started_at).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('is idempotent: a duplicate (existing row) resolves false, never throws', async () => {
+    const sb = makeFakeSupabase(['user-existing']);
+    const created = await ensureUserJourneyRow(sb, 'user-existing', { is_first_session: false });
+    expect(created).toBe(false);
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-ORB-GUIDE-MODE-LANG` _(follow-up to #2814 / #2816; user-reported ORB UX defect)_

**Layer:** AGTL (ORB / gateway live-session) · **Priority:** P2

---

## 📋 Summary

Reported on staging: an English ORB session **started correctly in English**, but when the user said *"let's continue"* on the Guided Journey, Vitana **switched to German**.

**Root cause (two reinforcing issues):**

1. **The tool spoke German verbatim.** `narrate_guided_session` returns the authored `vitana_voice_script` — which is **German** — wrapped in *"SPEAK THE TEXT BELOW word for word, exactly as written, do NOT summarize."* The tool never received the user's language, so it commanded the live model to speak German verbatim, overriding the session language entirely.
2. **The GUIDE-MODE prompt blocks were asymmetric.** The German branch pinned the language hard (*"Sprich AUSSCHLIESSLICH auf Deutsch"*), but the English/other branch only said the vague *"speak ONLY in the user's language"* — so the German source material pulled the model into German.

---

## ✅ Changes

- [x] Thread `session.lang` into the Vertex tool dispatch (`OrbToolIdentity.lang`) and branch the narration directive: **German user → verbatim** (unchanged); **any other language → "translate this German script into &lt;Language&gt; and speak the whole thing, never speak German."** Extracted as the pure, tested `buildGuidedNarrationDirective(script, lang)`. Defaults to `de`/verbatim when `lang` is absent, preserving prior behavior for German users.
- [x] Strengthen the non-German GUIDE-MODE directives (`guided-topic-narration-prompt.ts`, `journey-guide-prompt.ts`) to **name the concrete language** and state that journey/step material may be in German but must be delivered in the user's language, never switching.
- [x] `guided-narration-directive.test.ts` pins German→verbatim, absent→verbatim, English→translate (never German), and concrete naming for es/sr/en.

---

## 🧪 Testing

- [x] `tsc --noEmit` on the gateway: 0 errors.
- [x] `jest guided-narration-directive.test.ts`: 4/4 green.
- [ ] Manual ORB on staging: in an **English** session, continue a guided session ("let's continue") and confirm the narration is delivered in **English**, in full, with no German.

---

## 🚨 Breaking Changes

None. German users are unchanged (verbatim). The tool defaults to German-verbatim when a caller doesn't pass `lang`.

---

## 📌 Additional Notes

- Covers the **Vertex (web ORB)** path that exhibited the bug. Because the tool defaults to German-verbatim when `lang` isn't threaded, a **LiveKit** non-German user would still need `lang` plumbed at that transport's dispatch — separate path, follow-up if it surfaces.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVuVKDQEnJkGwiUuKtR5vr)_