### PR TITLE
fix(chat-groups): add edit/delete endpoints for group chat messages

### DIFF
--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -28,8 +28,13 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { notifyUserAsync } from '../services/notification-service';
 import { VITANA_BOT_USER_ID, isVitanaBot } from '../lib/vitana-bot';
 import { processConversationTurn } from '../services/conversation-client';
+import { emitOasisEvent } from '../services/oasis-event-service';
 
 const router = Router();
+
+// Chat groups feature VTID (VTID-03089) — reused for OASIS events emitted by
+// this route file, matching the @vitana mention handler below.
+const VTID = 'VTID-03089';
 
 function getSupabase(): SupabaseClient {
   return createClient(
@@ -401,6 +406,19 @@ router.patch('/:id/messages/:messageId', requireAuth, requireTenant, async (req:
     return res.status(500).json({ ok: false, error: error.message });
   }
 
+  // Fire-and-forget OASIS event; failure here must not block the response.
+  emitOasisEvent({
+    vtid: VTID,
+    type: 'chat_group.message.edited' as any,
+    source: 'chat-groups-gateway',
+    status: 'info',
+    message: `Group message ${messageId} edited`,
+    payload: { group_id: groupId, message_id: messageId },
+    actor_id: identity.user_id,
+    actor_role: 'user',
+    surface: 'api',
+  }).catch(err => console.warn(`[${VTID}] OASIS emit failed:`, err?.message));
+
   return res.json({ ok: true, data });
 });
 
@@ -435,6 +453,19 @@ router.delete('/:id/messages/:messageId', requireAuth, requireTenant, async (req
     console.error('[ChatGroups] Delete message error:', error);
     return res.status(500).json({ ok: false, error: error.message });
   }
+
+  // Fire-and-forget OASIS event; failure here must not block the response.
+  emitOasisEvent({
+    vtid: VTID,
+    type: 'chat_group.message.deleted' as any,
+    source: 'chat-groups-gateway',
+    status: 'info',
+    message: `Group message ${messageId} deleted`,
+    payload: { group_id: groupId, message_id: messageId },
+    actor_id: identity.user_id,
+    actor_role: 'user',
+    surface: 'api',
+  }).catch(err => console.warn(`[${VTID}] OASIS emit failed:`, err?.message));
 
   return res.json({ ok: true });
 });

--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -36,6 +36,14 @@ const router = Router();
 // this route file, matching the @vitana mention handler below.
 const VTID = 'VTID-03089';
 
+// Named (non-arrow) catch handler for fire-and-forget emitOasisEvent calls.
+// Keeping this out of the route handler bodies avoids a second `=>` inside
+// those bodies, which the impact-scan `new-mutation-without-oasis-emit`
+// static parser's lastIndexOf('=>') handler-body extraction mis-locates.
+function warnOasisEmitFailed(err: any): void {
+  console.warn(`[${VTID}] OASIS emit failed:`, err?.message);
+}
+
 function getSupabase(): SupabaseClient {
   return createClient(
     process.env.SUPABASE_URL!,
@@ -417,7 +425,7 @@ router.patch('/:id/messages/:messageId', requireAuth, requireTenant, async (req:
     actor_id: identity.user_id,
     actor_role: 'user',
     surface: 'api',
-  }).catch(err => console.warn(`[${VTID}] OASIS emit failed:`, err?.message));
+  }).catch(warnOasisEmitFailed);
 
   return res.json({ ok: true, data });
 });
@@ -465,7 +473,7 @@ router.delete('/:id/messages/:messageId', requireAuth, requireTenant, async (req
     actor_id: identity.user_id,
     actor_role: 'user',
     surface: 'api',
-  }).catch(err => console.warn(`[${VTID}] OASIS emit failed:`, err?.message));
+  }).catch(warnOasisEmitFailed);
 
   return res.json({ ok: true });
 });

--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -13,6 +13,8 @@
  *                                    Reactions are written client-side via Supabase RLS on
  *                                    message_reactions (polymorphic on chat_messages.id).
  *   POST   /:id/read               — Mark all group messages read up to "now"
+ *   PATCH  /:id/messages/:messageId — Edit a message (sender only)
+ *   DELETE /:id/messages/:messageId — Delete a message (sender only)
  */
 
 import { Router, Request, Response } from 'express';
@@ -359,7 +361,101 @@ router.post('/:id/read', requireAuth, requireTenant, async (req: Request, res: R
   return res.json({ ok: true });
 });
 
+// ── PATCH /:id/messages/:messageId — Edit a message (sender only) ─────
+
+router.patch('/:id/messages/:messageId', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { id: groupId, messageId } = req.params;
+  const { content } = req.body as { content?: unknown };
+  const trimmed = typeof content === 'string' ? content.trim() : '';
+  if (trimmed.length === 0) {
+    return res.status(400).json({ ok: false, error: 'content is required' });
+  }
+
+  const supabase = getSupabase();
+
+  const membership = await requireMembership(supabase, groupId, identity.user_id);
+  if (!membership) {
+    return res.status(403).json({ ok: false, error: 'not_a_member' });
+  }
+
+  const owned = await requireOwnMessage(supabase, groupId, messageId, identity.user_id);
+  if (owned === 'not_found') {
+    return res.status(404).json({ ok: false, error: 'message_not_found' });
+  }
+  if (owned === 'forbidden') {
+    return res.status(403).json({ ok: false, error: 'not_the_sender' });
+  }
+
+  const { data, error } = await supabase
+    .from('chat_messages')
+    .update({ content: trimmed })
+    .eq('id', messageId)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('[ChatGroups] Update message error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({ ok: true, data });
+});
+
+// ── DELETE /:id/messages/:messageId — Delete a message (sender only) ──
+
+router.delete('/:id/messages/:messageId', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { id: groupId, messageId } = req.params;
+  const supabase = getSupabase();
+
+  const membership = await requireMembership(supabase, groupId, identity.user_id);
+  if (!membership) {
+    return res.status(403).json({ ok: false, error: 'not_a_member' });
+  }
+
+  const owned = await requireOwnMessage(supabase, groupId, messageId, identity.user_id);
+  if (owned === 'not_found') {
+    return res.status(404).json({ ok: false, error: 'message_not_found' });
+  }
+  if (owned === 'forbidden') {
+    return res.status(403).json({ ok: false, error: 'not_the_sender' });
+  }
+
+  const { error } = await supabase
+    .from('chat_messages')
+    .delete()
+    .eq('id', messageId);
+
+  if (error) {
+    console.error('[ChatGroups] Delete message error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({ ok: true });
+});
+
 // ── helpers ───────────────────────────────────────────────────
+
+async function requireOwnMessage(
+  supabase: SupabaseClient,
+  groupId: string,
+  messageId: string,
+  userId: string,
+): Promise<'ok' | 'not_found' | 'forbidden'> {
+  const { data, error } = await supabase
+    .from('chat_messages')
+    .select('sender_id, group_id')
+    .eq('id', messageId)
+    .maybeSingle();
+  if (error || !data || (data as any).group_id !== groupId) return 'not_found';
+  if ((data as any).sender_id !== userId) return 'forbidden';
+  return 'ok';
+}
 
 async function requireMembership(
   supabase: SupabaseClient,


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** N/A — direct bug fix, no VTID allocated for this hotfix.

**Layer:** APIL (Gateway API)

**Priority:** P1 (user-facing bug — reported on Android and iPhone)

---

## 📋 Summary

Fixes the "Correction" (edit) button in community group chat, which silently did nothing when tapped on both Android and iPhone.

Root cause: the group-chat message edit/delete UI in the frontend (`MessageBubble.tsx`) only works if the caller supplies `onUpdateMessage`/`onDeleteMessage` handlers, and no backend endpoint existed to persist an edit or delete for a `chat_messages` row scoped to a `chat_group`. This PR adds the missing gateway routes; the companion frontend PR (exafyltd/vitana-v1) wires them up.

---

## ✅ Changes

- [x] `PATCH /api/v1/chat/groups/:id/messages/:messageId` — edit a group message's content (sender-only, membership-checked)
- [x] `DELETE /api/v1/chat/groups/:id/messages/:messageId` — delete a group message (sender-only, membership-checked)
- [x] Both routes verify the caller is a member of the group and the original sender of the message before mutating

---

## 🧪 Testing

- [x] `npm run build` (tsc) passes in `services/gateway`
- [ ] Automated tests added/updated (none exist for this route file; followed existing patterns)
- [ ] Verified in staging/dev environment (needs staging deploy + companion frontend PR merged to exercise end-to-end)

---

## 🚨 Breaking Changes

None. New routes only.

---

## 📌 Additional Notes

Companion frontend PR: exafyltd/vitana-v1#TBD (wires `onUpdateMessage`/`onDeleteMessage` into `GroupChat.tsx`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRRwidmtW5eQbMQyiuBSh4)_