### PR TITLE
BOOTSTRAP-MEMORY-ORCHESTRATOR-MANDATORY: hotfix — real oasis_events/life_compass column names

### DIFF
--- a/services/gateway/src/routes/admin-memory-orchestrator.ts
+++ b/services/gateway/src/routes/admin-memory-orchestrator.ts
@@ -56,10 +56,13 @@ router.get('/admin/memory-orchestrator/status', async (req: AuthenticatedRequest
 
   try {
     const since = new Date(Date.now() - windowHours * 3600 * 1000).toISOString();
+    // oasis_events stores the event type in `topic` and the payload in
+    // `metadata` (see oasis-event-service emit mapping) — verified against
+    // production data 2026-07-03; `type`/`payload` columns do not exist.
     const { data, error } = await supabase
       .from('oasis_events')
-      .select('type, status, payload, created_at')
-      .in('type', [
+      .select('topic, status, metadata, created_at')
+      .in('topic', [
         MEMORY_ORCHESTRATOR_EVENT_TYPES.TURN,
         MEMORY_ORCHESTRATOR_EVENT_TYPES.CONTEXT_BUILT,
         MEMORY_ORCHESTRATOR_EVENT_TYPES.BYPASS_DETECTED,
@@ -73,9 +76,9 @@ router.get('/admin/memory-orchestrator/status', async (req: AuthenticatedRequest
     }
 
     const events = data || [];
-    const turns = events.filter((e) => e.type === MEMORY_ORCHESTRATOR_EVENT_TYPES.TURN);
-    const built = events.filter((e) => e.type === MEMORY_ORCHESTRATOR_EVENT_TYPES.CONTEXT_BUILT);
-    const bypasses = events.filter((e) => e.type === MEMORY_ORCHESTRATOR_EVENT_TYPES.BYPASS_DETECTED);
+    const turns = events.filter((e) => e.topic === MEMORY_ORCHESTRATOR_EVENT_TYPES.TURN);
+    const built = events.filter((e) => e.topic === MEMORY_ORCHESTRATOR_EVENT_TYPES.CONTEXT_BUILT);
+    const bypasses = events.filter((e) => e.topic === MEMORY_ORCHESTRATOR_EVENT_TYPES.BYPASS_DETECTED);
 
     let injected = 0;
     let retrieved = 0;
@@ -86,7 +89,7 @@ router.get('/admin/memory-orchestrator/status', async (req: AuthenticatedRequest
     let prefsSum = 0;
     const perChannel: Record<string, { turns: number; injected: number }> = {};
     for (const e of turns) {
-      const p = (e.payload || {}) as TurnPayload;
+      const p = (e.metadata || {}) as TurnPayload;
       if (p.memory_injected_to_prompt) injected++;
       if ((p.memory_hits ?? 0) > 0) retrieved++;
       if (p.assistant_used_memory) used++;
@@ -101,12 +104,12 @@ router.get('/admin/memory-orchestrator/status', async (req: AuthenticatedRequest
     }
 
     const degradedBuilds = built.filter(
-      (e) => Array.isArray((e.payload as any)?.degraded_sources) && (e.payload as any).degraded_sources.length > 0,
+      (e) => Array.isArray((e.metadata as any)?.degraded_sources) && (e.metadata as any).degraded_sources.length > 0,
     ).length;
-    const enforcedBypasses = bypasses.filter((e) => (e.payload as any)?.enforced === true).length;
+    const enforcedBypasses = bypasses.filter((e) => (e.metadata as any)?.enforced === true).length;
     const softBypasses = bypasses.length - enforcedBypasses;
     const bypassCallers = Array.from(
-      new Set(bypasses.map((e) => String((e.payload as any)?.caller || 'unknown'))),
+      new Set(bypasses.map((e) => String((e.metadata as any)?.caller || 'unknown'))),
     ).slice(0, 10);
 
     const injectedRate = turns.length > 0 ? injected / turns.length : 0;

--- a/services/gateway/src/services/memory-orchestrator.ts
+++ b/services/gateway/src/services/memory-orchestrator.ts
@@ -204,17 +204,21 @@ async function fetchActiveGoals(userId: string): Promise<ActiveGoal[]> {
   const supabase = getSupabase();
   if (!supabase) return [];
   try {
-    const { data } = await supabase
+    // Column set mirrors buildLifeCompassGoalBlock exactly — the live
+    // life_compass table has NO is_system_seeded column, and selecting a
+    // missing column makes PostgREST return an error (silently mapped to
+    // zero goals). Verified against production data 2026-07-03.
+    const { data, error } = await supabase
       .from('life_compass')
-      .select('primary_goal, category, is_system_seeded')
+      .select('primary_goal, category')
       .eq('user_id', userId)
       .eq('is_active', true)
       .order('created_at', { ascending: false })
       .limit(3);
+    if (error) throw new Error(error.message);
     return (data || []).map((r: any) => ({
       primary_goal: r.primary_goal,
       category: r.category,
-      is_system_seeded: r.is_system_seeded === true,
     }));
   } catch (err: any) {
     console.warn(`${LOG_PREFIX} fetchActiveGoals failed: ${err.message}`);

--- a/services/gateway/test/admin-memory-orchestrator.test.ts
+++ b/services/gateway/test/admin-memory-orchestrator.test.ts
@@ -49,8 +49,9 @@ function makeFakeSupabase(result: { data: any[] | null; error: { message: string
   };
 }
 
-function turnEvent(payload: Record<string, unknown>, createdAt = new Date().toISOString()) {
-  return { type: 'memory.orchestrator.turn', status: 'success', payload, created_at: createdAt };
+// oasis_events stores the event type in `topic` and the payload in `metadata`
+function turnEvent(metadata: Record<string, unknown>, createdAt = new Date().toISOString()) {
+  return { topic: 'memory.orchestrator.turn', status: 'success', metadata, created_at: createdAt };
 }
 
 const HEALTHY_TURN = {
@@ -128,9 +129,9 @@ describe('GET /api/v1/admin/memory-orchestrator/status — verdict', () => {
       data: [
         turnEvent(HEALTHY_TURN),
         {
-          type: 'memory.orchestrator.bypass_detected',
+          topic: 'memory.orchestrator.bypass_detected',
           status: 'warning',
-          payload: { caller: 'processWithGemini', enforced: false },
+          metadata: { caller: 'processWithGemini', enforced: false },
           created_at: new Date().toISOString(),
         },
       ],
@@ -164,9 +165,9 @@ describe('GET /api/v1/admin/memory-orchestrator/status — verdict', () => {
       data: [
         turnEvent(HEALTHY_TURN),
         {
-          type: 'memory.orchestrator.bypass_detected',
+          topic: 'memory.orchestrator.bypass_detected',
           status: 'error',
-          payload: { caller: 'routes/conversation.turn', enforced: true },
+          metadata: { caller: 'routes/conversation.turn', enforced: true },
           created_at: new Date().toISOString(),
         },
       ],


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-MEMORY-ORCHESTRATOR-MANDATORY` (hotfix follow-up to #2830)

**Layer:** AGTL

**Priority:** P1

---

## 📋 Summary

Live staging verification of #2830 (3 real conversation turns against `gateway-staging-00430`) exposed two schema mismatches that mocked tests could not catch. Both are one-line-class fixes verified against production data.

---

## ✅ Changes

- [x] `admin-memory-orchestrator.ts`: the status route queried `oasis_events` by `type`/`payload`, but `emitOasisEvent` writes `topic`/`metadata` — the endpoint 500ed on real data. Now queries `topic`/`metadata`; tests updated to the real column names.
- [x] `memory-orchestrator.ts` `fetchActiveGoals`: selected `life_compass.is_system_seeded`, which does not exist in the live table — PostgREST errored and goals silently loaded as 0 (`goals_loaded=0` in telemetry despite an active goal). Now selects only `primary_goal, category` (mirroring `buildLifeCompassGoalBlock`) and surfaces query errors as degraded telemetry instead of swallowing them.

---

## 🧪 Testing

- [x] Automated tests updated/passing — 31 tests across `memory-orchestrator.test.ts` + `admin-memory-orchestrator.test.ts`
- [x] `tsc --noEmit` clean
- [x] Root cause verified against live staging telemetry: 3/3 turns `memory_injected_to_prompt=true`, hits 11–13, `goals_loaded=0` reproduced pre-fix
- [ ] Verify on staging post-merge: `goals_loaded=1` for a user with an active Life Compass goal; status endpoint returns JSON verdict for exafy_admin

---

## 📝 Phase 2B Naming Compliance Checklist

- [x] No workflow changes; no new files; kebab-case respected; event topics unchanged

---

## 🚨 Breaking Changes

None.

---

## 👀 Reviewers

@exafyltd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDeWcwo8qwBnCdr2h48Fy9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDeWcwo8qwBnCdr2h48Fy9)_