### PR TITLE
BOOTSTRAP-SOCIAL-MEMORY: Social Memory Intelligence layer for the Maxina community

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -422,6 +422,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const adminMemoryBrokerRouter = require('./routes/admin-memory-broker').default;
   // BOOTSTRAP-MEMORY-ORCHESTRATOR-MANDATORY — Memory Alive/Dead status (exafy_admin only)
   const adminMemoryOrchestratorRouter = require('./routes/admin-memory-orchestrator').default;
+  // BOOTSTRAP-SOCIAL-MEMORY — Social Memory Intelligence endpoints
+  const memorySocialRouter = require('./routes/memory-social').default;
   // Phase F v1: 5 pillar agents (Nutrition/Hydration/Exercise/Sleep/Mental).
   const pillarAgentsRouter = require('./routes/pillar-agents').default;
   // Phase F v2 step 9: per-user integrations + Manual Data Entry.
@@ -1174,6 +1176,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1', adminMemoryBrokerRouter, { owner: 'admin-memory-broker' });
   // BOOTSTRAP-MEMORY-ORCHESTRATOR-MANDATORY Memory Alive/Dead status endpoint
   mountRouterSync(app, '/api/v1', adminMemoryOrchestratorRouter, { owner: 'admin-memory-orchestrator' });
+  // BOOTSTRAP-SOCIAL-MEMORY Social Memory Intelligence layer
+  mountRouterSync(app, '/api/v1/memory/social', memorySocialRouter, { owner: 'memory-social' });
   // Phase F v1: pillar agents framework
   mountRouterSync(app, '/api/v1/pillar-agents', pillarAgentsRouter, { owner: 'pillar-agents' });
   // Phase F v2 step 9: per-user integrations (Manual Data Entry + catalog)

--- a/services/gateway/src/routes/memory-social.ts
+++ b/services/gateway/src/routes/memory-social.ts
@@ -1,0 +1,224 @@
+/**
+ * BOOTSTRAP-SOCIAL-MEMORY — Social Memory Intelligence endpoints.
+ *
+ * Mounted at /api/v1/memory/social. All endpoints are self-scoped: the
+ * acting user comes from the verified JWT (req.identity), NEVER from the
+ * request body/params — a client cannot read another user's social memory.
+ * The only cross-user reads are the privacy-gated person/activity views,
+ * which go through person-context-builder's minimization rules.
+ *
+ * GET  /context/me            — full Social Context Pack for the caller
+ * GET  /following             — who the caller follows
+ * GET  /followers             — who follows the caller
+ * GET  /matches               — matches with scores + reasons
+ * GET  /messages              — recent DM contacts (own conversations only)
+ * GET  /group-chats           — group chats the caller participates in
+ * GET  /interesting-posts     — explainably ranked posts
+ * GET  /interesting-events    — explainably ranked events
+ * GET  /person/:userId        — Person Intelligence (privacy-gated)
+ * GET  /activity/:personId    — a person's recent visible activity
+ * POST /assistant-context     — the assistant-facing aggregate (spec shape)
+ */
+
+import { Router, Response } from 'express';
+import {
+  requireAuth,
+  requireTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { buildSocialContextPack } from '../services/social-memory/social-context-builder';
+import { buildPersonContext } from '../services/social-memory/person-context-builder';
+import {
+  buildPersonActivity,
+} from '../services/social-memory/community-activity-builder';
+import {
+  buildAssistantSocialContext,
+} from '../services/social-memory/social-memory-service';
+import {
+  fetchExclusions,
+  fetchFollowEdges,
+  fetchMatches,
+  fetchRecentMessageContacts,
+  fetchGroupChats,
+} from '../services/social-memory/social-memory-repository';
+
+const router = Router();
+router.use(requireAuth);
+router.use(requireTenant);
+
+function identityOf(req: AuthenticatedRequest): { user_id: string; tenant_id: string } {
+  return {
+    user_id: (req.identity as any).user_id,
+    tenant_id: (req.identity as any).tenant_id,
+  };
+}
+
+router.get('/context/me', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const pack = await buildSocialContextPack({ ...id, question: String(req.query.q || '') });
+    return res.json({ ok: true, ...pack });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/following', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const excl = await fetchExclusions(id.user_id);
+    const { following } = await fetchFollowEdges(id.user_id, excl.blocked);
+    return res.json({ ok: true, following, count: following.length });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/followers', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const excl = await fetchExclusions(id.user_id);
+    const { followers } = await fetchFollowEdges(id.user_id, excl.blocked);
+    return res.json({ ok: true, followers, count: followers.length });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/matches', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const excl = await fetchExclusions(id.user_id);
+    const matches = await fetchMatches(id.user_id, excl.blocked);
+    return res.json({ ok: true, matches, count: matches.length });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/messages', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const excl = await fetchExclusions(id.user_id);
+    const contacts = await fetchRecentMessageContacts(id.user_id, id.tenant_id, excl.blocked);
+    return res.json({ ok: true, contacts, count: contacts.length });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/group-chats', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const groups = await fetchGroupChats(id.user_id, id.tenant_id);
+    return res.json({ ok: true, group_chats: groups, count: groups.length });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/interesting-posts', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const pack = await buildSocialContextPack({ ...id, compact: false });
+    return res.json({ ok: true, posts: pack.interesting_posts });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/interesting-events', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const pack = await buildSocialContextPack({ ...id, compact: false });
+    return res.json({ ok: true, events: pack.interesting_events });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/person/:userId', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const person = await buildPersonContext({
+      ...id,
+      person_id: String(req.params.userId),
+    });
+    if (!person) {
+      return res.status(404).json({ ok: false, error: 'PERSON_NOT_FOUND' });
+    }
+    return res.json({ ok: true, person_context: person });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/activity/:personId', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    // Privacy gate: reuse person context resolution — blocked or
+    // privacy-limited people expose no activity.
+    const person = await buildPersonContext({ ...id, person_id: String(req.params.personId) });
+    if (!person) return res.status(404).json({ ok: false, error: 'PERSON_NOT_FOUND' });
+    if (person.privacy_limited) {
+      return res.json({
+        ok: true,
+        activity: { person: person.person, items: [], window_days: 0 },
+        privacy_limited: true,
+      });
+    }
+    const activity = await buildPersonActivity(person.person.user_id);
+    return res.json({ ok: true, activity });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+/**
+ * The assistant-facing aggregate (spec shape). userId in the body is
+ * accepted only as 'current-user' or the caller's own id — the identity
+ * always comes from the JWT.
+ */
+router.post('/assistant-context', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const id = identityOf(req);
+    const bodyUserId = req.body?.userId;
+    if (bodyUserId && bodyUserId !== 'current-user' && bodyUserId !== id.user_id) {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN_USER_SCOPE' });
+    }
+    const question = String(req.body?.question || '');
+    const surface = req.body?.surface;
+
+    const result = await buildAssistantSocialContext({
+      tenant_id: id.tenant_id,
+      user_id: id.user_id,
+      question,
+      conversation_id: req.body?.conversationId,
+      surface,
+    });
+
+    const p = result.pack;
+    return res.json({
+      ok: true,
+      user: p.user ?? {},
+      relationships: p.relationships,
+      matches: p.matches,
+      messages: p.messages,
+      groupChats: p.group_chats,
+      interestingPosts: p.interesting_posts,
+      interestingEvents: p.interesting_events,
+      personContext: p.person_context ?? {},
+      activityContext: p.activity_context ?? {},
+      memoryHighlights: p.memory_highlights,
+      recommendedActions: p.recommended_actions,
+      assistantSystemHints: p.assistant_system_hints,
+      meta: p.meta,
+      intent: result.intent,
+    });
+  } catch (err: any) {
+    console.error('[memory-social] assistant-context failed:', err.message);
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+export default router;

--- a/services/gateway/src/routes/memory-social.ts
+++ b/services/gateway/src/routes/memory-social.ts
@@ -180,6 +180,10 @@ router.get('/activity/:personId', async (req: AuthenticatedRequest, res: Respons
  * always comes from the JWT.
  */
 router.post('/assistant-context', async (req: AuthenticatedRequest, res: Response) => {
+  // impact-allow-no-oasis — this is a READ aggregate (POST only for the
+  // request body); the retrieval event memory.social.context_built is
+  // emitted inside buildAssistantSocialContext (social-memory-service.ts),
+  // so emitting here would double-count every call.
   try {
     const id = identityOf(req);
     const bodyUserId = req.body?.userId;

--- a/services/gateway/src/services/memory-orchestrator.ts
+++ b/services/gateway/src/services/memory-orchestrator.ts
@@ -107,6 +107,10 @@ export interface DoNotRepeatEntry {
 export interface MemoryTurnTelemetry {
   memory_orchestrator_called: true;
   orchestrator_version: string;
+  /** BOOTSTRAP-SOCIAL-MEMORY: social context injected for this turn. */
+  social_loaded: boolean;
+  /** Social intent kinds detected for this turn (empty = not a social turn). */
+  social_intent_kinds: string[];
   /** Total memory-garden hits in the context pack (facts + episodic + diary). */
   memory_hits: number;
   /** Structured facts (memory_facts / identity core) loaded. */
@@ -417,6 +421,8 @@ export function formatMemoryContextForPrompt(input: {
   goals: ActiveGoal[];
   preferences: PreferenceEntry[];
   do_not_repeat: DoNotRepeatEntry[];
+  /** BOOTSTRAP-SOCIAL-MEMORY: pre-formatted <social_context> section. */
+  social_block?: string;
   skip_goal_section?: boolean;
   user_timezone?: string;
 }): string {
@@ -425,7 +431,7 @@ export function formatMemoryContextForPrompt(input: {
   });
 
   return `${MEMORY_CONTEXT_SENTINEL}
-${packBlock}${buildGoalsSection(input.goals, input.skip_goal_section === true)}${buildPreferencesSection(input.preferences)}${buildDoNotRepeatSection(input.do_not_repeat)}${buildSelfCheckSection()}
+${packBlock}${buildGoalsSection(input.goals, input.skip_goal_section === true)}${buildPreferencesSection(input.preferences)}${input.social_block || ''}${buildDoNotRepeatSection(input.do_not_repeat)}${buildSelfCheckSection()}
 ${MEMORY_CONTEXT_END_SENTINEL}
 `;
 }
@@ -529,11 +535,39 @@ export async function buildAssistantMemoryContext(
   // VTID-03183: Life Compass goals are community prose — never load them
   // for developer/admin surfaces.
   const communityRole = isCommunityRole(input.role);
-  const [packRes, goalsRes, prefsRes, dnrRes] = await Promise.allSettled([
+
+  // BOOTSTRAP-SOCIAL-MEMORY: when the message is about people/community/
+  // matches/posts/events, fetch the live Social Context Pack in parallel
+  // with everything else. Community surfaces only — dev/admin never get
+  // community social context (VTID-03183 spirit).
+  let socialIntent: import('./social-memory/social-memory-types').SocialIntentDecision | null = null;
+  let fetchSocial: Promise<{ prompt_block: string; intent_kinds: string[] } | null> =
+    Promise.resolve(null);
+  if (communityRole && input.message) {
+    fetchSocial = (async () => {
+      const { detectSocialIntent, buildAssistantSocialContext } = await import(
+        './social-memory/social-memory-service'
+      );
+      socialIntent = detectSocialIntent(input.message);
+      if (!socialIntent.is_social) return null;
+      const result = await buildAssistantSocialContext({
+        tenant_id: input.tenant_id,
+        user_id: input.user_id,
+        question: input.message,
+        conversation_id: input.thread_id,
+        surface: 'vitana_assistant',
+        compact: true,
+      });
+      return { prompt_block: result.prompt_block, intent_kinds: result.intent.kinds };
+    })();
+  }
+
+  const [packRes, goalsRes, prefsRes, dnrRes, socialRes] = await Promise.allSettled([
     buildContextPack(contextPackInput),
     communityRole ? fetchActiveGoals(input.user_id) : Promise.resolve([]),
     fetchPreferences(input.user_id),
     fetchDoNotRepeat(input.tenant_id, input.user_id),
+    fetchSocial,
   ]);
 
   if (packRes.status === 'fulfilled') {
@@ -559,6 +593,17 @@ export async function buildAssistantMemoryContext(
     degraded.push('governance');
   }
 
+  // BOOTSTRAP-SOCIAL-MEMORY: social section (null when not a social turn).
+  let socialBlock = '';
+  let socialIntentKinds: string[] = [];
+  if (socialRes.status === 'fulfilled' && socialRes.value) {
+    socialBlock = socialRes.value.prompt_block;
+    socialIntentKinds = socialRes.value.intent_kinds;
+  } else if (socialRes.status === 'rejected') {
+    degraded.push('social');
+    console.warn(`${LOG_PREFIX} social context degraded: ${socialRes.reason?.message}`);
+  }
+
   // Empty-but-valid pack when the builder itself failed, so callers always
   // get a well-formed result and the reply can still be produced (marked
   // degraded, never silently).
@@ -572,6 +617,7 @@ export async function buildAssistantMemoryContext(
     context_pack: pack,
     goals,
     preferences,
+    social_block: socialBlock,
     do_not_repeat: doNotRepeat,
     skip_goal_section: input.skip_goal_section || !communityRole,
     user_timezone: input.user_timezone,
@@ -580,6 +626,8 @@ export async function buildAssistantMemoryContext(
   const telemetry: MemoryTurnTelemetry = {
     memory_orchestrator_called: true,
     orchestrator_version: ORCHESTRATOR_VERSION,
+    social_loaded: socialBlock.length > 0,
+    social_intent_kinds: socialIntentKinds,
     memory_hits: pack.memory_hits.length,
     facts_loaded: factsLoaded,
     episodic_loaded: episodicLoaded,
@@ -838,6 +886,8 @@ export function emitMemoryTurnTelemetry(
       channel: turn.channel,
       model_used: turn.model_used,
       memory_orchestrator_called: t.memory_orchestrator_called,
+      social_loaded: t.social_loaded,
+      social_intent_kinds: t.social_intent_kinds,
       memory_hits: t.memory_hits,
       facts_loaded: t.facts_loaded,
       episodic_loaded: t.episodic_loaded,

--- a/services/gateway/src/services/social-memory/community-activity-builder.ts
+++ b/services/gateway/src/services/social-memory/community-activity-builder.ts
@@ -1,0 +1,159 @@
+/**
+ * BOOTSTRAP-SOCIAL-MEMORY — community activity views.
+ *
+ * Two shapes:
+ *   1. Person activity — "what did Mariia do recently?" — that person's
+ *      recent VISIBLE actions (public posts, events joined/created).
+ *   2. Network digest — "what changed in my community since yesterday?" —
+ *      recent visible actions of the people the viewer follows/matches.
+ *
+ * Privacy: only public posts, only event participation in events the
+ * platform lists publicly. Blocked/muted authors never appear.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { ActivityContext, ActivityItem, SocialPerson } from './social-memory-types';
+import {
+  fetchPersonById,
+  fetchPersonPosts,
+  fetchPeople,
+  fetchEventTitles,
+} from './social-memory-repository';
+
+/** Recent visible activity of ONE person. */
+export async function buildPersonActivity(
+  personId: string,
+  windowDays = 14,
+): Promise<ActivityContext> {
+  const supabase = getSupabase();
+  const person = await fetchPersonById(personId);
+  const items: ActivityItem[] = [];
+  const since = new Date(Date.now() - windowDays * 86400000).toISOString();
+
+  if (supabase && person) {
+    const [posts, participations, groupJoins] = await Promise.all([
+      fetchPersonPosts(personId, 5),
+      supabase
+        .from('global_event_participants')
+        .select('event_id, registered_at')
+        .eq('user_id', personId)
+        .gte('registered_at', since)
+        .order('registered_at', { ascending: false })
+        .limit(5),
+      supabase
+        .from('global_community_group_members')
+        .select('group_id, joined_at')
+        .eq('user_id', personId)
+        .gte('joined_at', since)
+        .order('joined_at', { ascending: false })
+        .limit(5),
+    ]);
+
+    for (const p of posts) {
+      if (Date.parse(p.created_at) < Date.parse(since)) continue;
+      items.push({
+        kind: 'post',
+        at: p.created_at,
+        summary: `Posted: "${(p.content || '').slice(0, 100)}"`,
+        ref_id: p.id,
+      });
+    }
+
+    const eventIds = (participations.data || []).map((r) => r.event_id);
+    const eventTitles = await fetchEventTitles(eventIds);
+    for (const r of participations.data || []) {
+      items.push({
+        kind: 'event_joined',
+        at: r.registered_at,
+        summary: `Joined event: ${eventTitles.get(r.event_id) || 'a community event'}`,
+        ref_id: r.event_id,
+      });
+    }
+
+    if ((groupJoins.data || []).length > 0) {
+      const { data: groups } = await supabase
+        .from('global_community_groups')
+        .select('id, name')
+        .in('id', (groupJoins.data || []).map((g) => g.group_id));
+      const nameById = new Map((groups || []).map((g: any) => [g.id, g.name]));
+      for (const g of groupJoins.data || []) {
+        items.push({
+          kind: 'group_joined',
+          at: g.joined_at,
+          summary: `Joined group: ${nameById.get(g.group_id) || 'a community group'}`,
+          ref_id: g.group_id,
+        });
+      }
+    }
+  }
+
+  items.sort((a, b) => Date.parse(b.at) - Date.parse(a.at));
+  return { person, items: items.slice(0, 10), window_days: windowDays };
+}
+
+/**
+ * Network digest: recent visible posts + event joins from a set of
+ * important people (followed + matched), for "what changed since yesterday".
+ */
+export async function buildNetworkDigest(
+  importantPersonIds: string[],
+  excludeIds: Set<string>,
+  windowDays = 2,
+): Promise<ActivityContext> {
+  const supabase = getSupabase();
+  const items: ActivityItem[] = [];
+  const ids = importantPersonIds.filter((id) => !excludeIds.has(id)).slice(0, 40);
+  const since = new Date(Date.now() - windowDays * 86400000).toISOString();
+
+  if (supabase && ids.length > 0) {
+    const [posts, participations] = await Promise.all([
+      supabase
+        .from('profile_posts')
+        .select('id, user_id, content, created_at')
+        .in('user_id', ids)
+        .eq('is_public', true)
+        .neq('moderation_status', 'rejected')
+        .gte('created_at', since)
+        .order('created_at', { ascending: false })
+        .limit(15),
+      supabase
+        .from('global_event_participants')
+        .select('event_id, user_id, registered_at')
+        .in('user_id', ids)
+        .gte('registered_at', since)
+        .order('registered_at', { ascending: false })
+        .limit(15),
+    ]);
+
+    const authorIds = new Set<string>([
+      ...(posts.data || []).map((p) => p.user_id),
+      ...(participations.data || []).map((p) => p.user_id),
+    ]);
+    const people = await fetchPeople(Array.from(authorIds));
+    const nameOf = (id: string) =>
+      people.get(id)?.display_name || people.get(id)?.handle || 'Someone you follow';
+
+    for (const p of posts.data || []) {
+      items.push({
+        kind: 'post',
+        at: p.created_at,
+        summary: `${nameOf(p.user_id)} posted: "${(p.content || '').slice(0, 80)}"`,
+        ref_id: p.id,
+      });
+    }
+    const eventTitles = await fetchEventTitles(
+      (participations.data || []).map((r) => r.event_id),
+    );
+    for (const r of participations.data || []) {
+      items.push({
+        kind: 'event_joined',
+        at: r.registered_at,
+        summary: `${nameOf(r.user_id)} joined ${eventTitles.get(r.event_id) || 'an event'}`,
+        ref_id: r.event_id,
+      });
+    }
+  }
+
+  items.sort((a, b) => Date.parse(b.at) - Date.parse(a.at));
+  return { person: null, items: items.slice(0, 12), window_days: windowDays };
+}

--- a/services/gateway/src/services/social-memory/person-context-builder.ts
+++ b/services/gateway/src/services/social-memory/person-context-builder.ts
@@ -1,0 +1,197 @@
+/**
+ * BOOTSTRAP-SOCIAL-MEMORY — Person Intelligence.
+ *
+ * For "tell me about X" / "why is X a good match" questions: assembles a
+ * complete, privacy-gated picture of one person relative to the viewer —
+ * relationship flags, match score + reasons, shared interests/groups/
+ * events, latest PUBLIC posts, upcoming events, last chat, and a
+ * recommended next action, plus a speech-ready relevance summary.
+ *
+ * Privacy: blocked people return null (as if not found). Private profiles
+ * with no viewer relationship (no follow / match / chat) are data-minimized
+ * to name-only with privacy_limited=true. Only public posts are ever read.
+ */
+
+import {
+  PersonContext,
+  MatchSummary,
+  SocialPerson,
+} from './social-memory-types';
+import {
+  fetchPersonById,
+  resolvePersonByName,
+  fetchFollowFlags,
+  fetchMatches,
+  fetchExclusions,
+  fetchInterests,
+  fetchGroupsForUsers,
+  fetchEventsForUsers,
+  fetchGroupNames,
+  fetchEventTitles,
+  fetchPersonPosts,
+  fetchLastChatAt,
+} from './social-memory-repository';
+
+export interface BuildPersonContextInput {
+  tenant_id: string;
+  user_id: string;
+  /** Either a concrete user_id... */
+  person_id?: string;
+  /** ...or a fuzzy name/handle hint extracted from the question. */
+  person_hint?: string;
+}
+
+export async function buildPersonContext(
+  input: BuildPersonContextInput,
+): Promise<PersonContext | null> {
+  // Resolve target
+  let person: SocialPerson | null = null;
+  if (input.person_id) {
+    person = await fetchPersonById(input.person_id);
+  } else if (input.person_hint) {
+    person = await resolvePersonByName(input.person_hint);
+  }
+  if (!person || person.user_id === input.user_id) return null;
+
+  const excl = await fetchExclusions(input.user_id);
+  // Blocked people are treated as not found — the assistant must not
+  // resurrect someone the user blocked.
+  if (excl.blocked.has(person.user_id)) return null;
+
+  const [flags, matches, interests, groups, events, posts, lastChatAt] = await Promise.all([
+    fetchFollowFlags(input.user_id, person.user_id),
+    fetchMatches(input.user_id, excl.blocked, 30),
+    fetchInterests([input.user_id, person.user_id]),
+    fetchGroupsForUsers([input.user_id, person.user_id]),
+    fetchEventsForUsers([input.user_id, person.user_id]),
+    fetchPersonPosts(person.user_id, 5),
+    fetchLastChatAt(input.user_id, input.tenant_id, person.user_id),
+  ]);
+
+  const match: MatchSummary | null =
+    matches.find((m) => m.person.user_id === person!.user_id) ?? null;
+
+  const myInterests = new Set(interests.get(input.user_id) || []);
+  const theirInterests = interests.get(person.user_id) || [];
+  const sharedInterests = theirInterests.filter((i) => myInterests.has(i));
+
+  const myGroups = groups.get(input.user_id) || new Set<string>();
+  const theirGroups = groups.get(person.user_id) || new Set<string>();
+  const sharedGroupIds = Array.from(theirGroups).filter((g) => myGroups.has(g));
+
+  const myEvents = events.get(input.user_id) || new Set<string>();
+  const theirEvents = events.get(person.user_id) || new Set<string>();
+  const sharedEventIds = Array.from(theirEvents).filter((e) => myEvents.has(e));
+
+  const [groupNames, eventTitles] = await Promise.all([
+    fetchGroupNames(sharedGroupIds),
+    fetchEventTitles(sharedEventIds),
+  ]);
+
+  // Privacy minimization: private profile + no relationship → name only.
+  const hasRelationship =
+    flags.you_follow || flags.follows_you || !!match || !!lastChatAt;
+  const privacyLimited = person.visibility === 'private' && !hasRelationship;
+
+  const latestPosts = privacyLimited
+    ? []
+    : posts.map((p) => ({
+        post_id: p.id,
+        snippet: (p.content || '').slice(0, 140),
+        created_at: p.created_at,
+        media_type: p.video_url ? 'video' : p.image_url ? 'image' : 'text',
+      }));
+
+  let upcomingEvents: Array<{ event_id: string; title: string; start_time: string }> = [];
+  if (!privacyLimited) {
+    const titles = await fetchEventTitles(Array.from(theirEvents).slice(0, 5));
+    upcomingEvents = Array.from(titles.entries()).map(([event_id, title]) => ({
+      event_id,
+      title,
+      start_time: '',
+    }));
+  }
+
+  const nextAction = recommendNextAction({
+    flags,
+    match,
+    lastChatAt,
+    sharedGroups: sharedGroupIds.length,
+    privacyLimited,
+  });
+
+  const context: PersonContext = {
+    person: privacyLimited
+      ? { ...person, bio: null, city: null, country: null }
+      : person,
+    you_follow: flags.you_follow,
+    follows_you: flags.follows_you,
+    match,
+    shared_interests: privacyLimited ? [] : sharedInterests,
+    shared_groups: Array.from(groupNames.values()),
+    shared_events: Array.from(eventTitles.values()),
+    latest_posts: latestPosts,
+    upcoming_events: upcomingEvents,
+    last_chat_at: lastChatAt,
+    privacy_limited: privacyLimited,
+    recommended_next_action: nextAction,
+    relevance_summary: '',
+  };
+  context.relevance_summary = buildRelevanceSummary(context);
+  return context;
+}
+
+function recommendNextAction(x: {
+  flags: { you_follow: boolean; follows_you: boolean };
+  match: MatchSummary | null;
+  lastChatAt: string | null;
+  sharedGroups: number;
+  privacyLimited: boolean;
+}): string | null {
+  if (x.privacyLimited) return null;
+  if (x.match && !x.match.conversation_started && !x.lastChatAt) {
+    return 'Send a first message — you matched but never talked.';
+  }
+  if (x.lastChatAt) {
+    const daysSince = (Date.now() - Date.parse(x.lastChatAt)) / 86400000;
+    if (daysSince > 7) return 'Reconnect — your last chat was over a week ago.';
+    return 'Continue your conversation.';
+  }
+  if (x.flags.follows_you && !x.flags.you_follow) {
+    return 'They follow you — follow back or open their profile.';
+  }
+  if (x.flags.you_follow) return 'Open their profile to see their latest activity.';
+  if (x.sharedGroups > 0) return 'Say hello in your shared group.';
+  return 'Open their profile to learn more.';
+}
+
+/** One-paragraph, speech-ready relevance summary (English; the LLM localizes). */
+export function buildRelevanceSummary(ctx: PersonContext): string {
+  const name = ctx.person.display_name || ctx.person.handle || 'This member';
+  if (ctx.privacy_limited) {
+    return `${name} keeps their profile private, so only limited information is available.`;
+  }
+  const parts: string[] = [];
+  if (ctx.you_follow && ctx.follows_you) parts.push('you follow each other');
+  else if (ctx.you_follow) parts.push('you follow them');
+  else if (ctx.follows_you) parts.push('they follow you');
+  if (ctx.match?.score != null) {
+    parts.push(`they are a ${ctx.match.score}-point match for you${ctx.match.reasons[0] ? ` (${ctx.match.reasons[0].toLowerCase()})` : ''}`);
+  }
+  if (ctx.shared_interests.length > 0) {
+    parts.push(`you share interests around ${ctx.shared_interests.slice(0, 3).join(', ')}`);
+  }
+  if (ctx.shared_groups.length > 0) {
+    parts.push(`you are both in ${ctx.shared_groups.slice(0, 2).join(' and ')}`);
+  }
+  if (ctx.latest_posts.length > 0) {
+    parts.push('they have been active recently');
+  }
+  const relevance =
+    parts.length > 0
+      ? `${name} is relevant to you because ${parts.join(', ')}.`
+      : `${name} is a member of your Maxina community.`;
+  return ctx.recommended_next_action
+    ? `${relevance} Best next step: ${ctx.recommended_next_action}`
+    : relevance;
+}

--- a/services/gateway/src/services/social-memory/social-context-builder.ts
+++ b/services/gateway/src/services/social-memory/social-context-builder.ts
@@ -1,0 +1,337 @@
+/**
+ * BOOTSTRAP-SOCIAL-MEMORY — Social Context Pack assembly.
+ *
+ * Parallel-fetches the user's live community picture and runs the
+ * explainable rankers. Sections degrade independently (a failing stream
+ * is recorded in meta.degraded_sections, never throws) — same resilience
+ * contract as the memory orchestrator.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import {
+  SocialContextPack,
+  BuildSocialContextInput,
+  RecommendedAction,
+  RelationshipSummary,
+} from './social-memory-types';
+import {
+  fetchExclusions,
+  fetchFollowEdges,
+  fetchMatches,
+  fetchRecentMessageContacts,
+  fetchGroupChats,
+  fetchCandidatePosts,
+  fetchUpcomingEvents,
+  fetchEventParticipants,
+  fetchGroupsForUsers,
+  fetchInterests,
+  fetchPersonById,
+} from './social-memory-repository';
+import {
+  rankInterestingPosts,
+  rankInterestingEvents,
+  extractTerms,
+  buildMatchScoreMap,
+} from './social-memory-ranker';
+import { fetchPeople } from './social-memory-repository';
+import { buildPersonContext } from './person-context-builder';
+import { buildPersonActivity, buildNetworkDigest } from './community-activity-builder';
+import { detectSocialIntent, buildAssistantSystemHints } from './social-memory-prompts';
+
+async function settle<T>(
+  label: string,
+  p: Promise<T>,
+  fallback: T,
+  degraded: string[],
+): Promise<T> {
+  try {
+    return await p;
+  } catch (err: any) {
+    console.warn(`[SOCIAL-MEMORY] section ${label} degraded: ${err?.message}`);
+    degraded.push(label);
+    return fallback;
+  }
+}
+
+export async function buildSocialContextPack(
+  input: BuildSocialContextInput,
+): Promise<SocialContextPack> {
+  const startTime = Date.now();
+  const degraded: string[] = [];
+  const sections: string[] = [];
+  const compact = input.compact === true;
+  const intent = input.intent ?? detectSocialIntent(input.question || '');
+
+  // Exclusions first — every other section depends on them.
+  const excl = await settle(
+    'exclusions',
+    fetchExclusions(input.user_id),
+    { blocked: new Set<string>(), muted: new Set<string>(), hidden_posts: new Set<string>() },
+    degraded,
+  );
+
+  const [user, follows, matches, messages, groupChats] = await Promise.all([
+    settle('user', fetchPersonById(input.user_id), null, degraded),
+    settle(
+      'follows',
+      fetchFollowEdges(input.user_id, excl.blocked, compact ? 20 : 50),
+      { following: [], followers: [] },
+      degraded,
+    ),
+    settle('matches', fetchMatches(input.user_id, excl.blocked, compact ? 10 : 20), [], degraded),
+    settle(
+      'messages',
+      fetchRecentMessageContacts(input.user_id, input.tenant_id, excl.blocked, compact ? 8 : 15),
+      [],
+      degraded,
+    ),
+    settle('group_chats', fetchGroupChats(input.user_id, input.tenant_id), [], degraded),
+  ]);
+  sections.push('relationships', 'matches', 'messages', 'group_chats');
+
+  const followingIds = follows.following.map((f) => f.person.user_id);
+  const followerIds = new Set(follows.followers.map((f) => f.person.user_id));
+  const relationships: RelationshipSummary = {
+    following: follows.following,
+    followers: follows.followers,
+    following_count: follows.following.length,
+    followers_count: follows.followers.length,
+    mutual_ids: followingIds.filter((id) => followerIds.has(id)),
+  };
+
+  // Ranking signals: interests, goal terms, shared groups, location.
+  const matchScores = buildMatchScoreMap(matches);
+  const importantIds = Array.from(
+    new Set([...followingIds, ...matches.map((m) => m.person.user_id)]),
+  );
+
+  const [interestsMap, groupsMap, goalTerms] = await Promise.all([
+    settle('interests', fetchInterests([input.user_id]), new Map(), degraded),
+    settle(
+      'shared_groups',
+      fetchGroupsForUsers([input.user_id, ...importantIds.slice(0, 30)]),
+      new Map(),
+      degraded,
+    ),
+    settle('goal_terms', fetchGoalTerms(input.user_id), [] as string[], degraded),
+  ]);
+
+  const myInterests = interestsMap.get(input.user_id) || [];
+  const myGroups = groupsMap.get(input.user_id) || new Set<string>();
+  const sharedGroupCounts = new Map<string, number>();
+  for (const [uid, set] of groupsMap) {
+    if (uid === input.user_id) continue;
+    let n = 0;
+    for (const g of set) if (myGroups.has(g)) n++;
+    if (n > 0) sharedGroupCounts.set(uid, n);
+  }
+  const locationTerms = [user?.city, user?.country]
+    .filter((x): x is string => !!x)
+    .map((x) => x.toLowerCase());
+
+  // Posts + events with explainable ranking.
+  const [candidatePosts, upcomingEvents] = await Promise.all([
+    settle(
+      'posts',
+      fetchCandidatePosts(input.user_id, followingIds, excl, compact ? 25 : 40),
+      [],
+      degraded,
+    ),
+    settle('events', fetchUpcomingEvents(compact ? 25 : 40), [], degraded),
+  ]);
+  const participants = await settle(
+    'event_participants',
+    fetchEventParticipants(upcomingEvents.map((e) => e.id)),
+    new Map(),
+    degraded,
+  );
+
+  const authorIds = Array.from(new Set(candidatePosts.map((p) => p.user_id)));
+  const attendeeIds = Array.from(new Set(Array.from(participants.values()).flat())).slice(0, 100);
+  const people = await settle(
+    'people',
+    fetchPeople([...authorIds, ...attendeeIds]),
+    new Map(),
+    degraded,
+  );
+
+  const followedSet = new Set(followingIds);
+  const interestingPosts = rankInterestingPosts(
+    candidatePosts,
+    {
+      viewer_id: input.user_id,
+      followed_ids: followedSet,
+      match_scores: matchScores,
+      interests: myInterests,
+      goal_terms: goalTerms,
+      shared_group_counts: sharedGroupCounts,
+      people,
+    },
+    compact ? 5 : 8,
+  );
+  const interestingEvents = rankInterestingEvents(
+    upcomingEvents,
+    {
+      viewer_id: input.user_id,
+      followed_ids: followedSet,
+      match_scores: matchScores,
+      interests: myInterests,
+      goal_terms: goalTerms,
+      location_terms: locationTerms,
+      participants,
+      people,
+    },
+    compact ? 4 : 6,
+  );
+  sections.push('interesting_posts', 'interesting_events');
+
+  // Person / activity context only when the question calls for it.
+  let personContext = null;
+  let activityContext = null;
+  if (input.person_id || intent.person_hint) {
+    personContext = await settle(
+      'person_context',
+      buildPersonContext({
+        tenant_id: input.tenant_id,
+        user_id: input.user_id,
+        person_id: input.person_id,
+        person_hint: intent.person_hint ?? undefined,
+      }),
+      null,
+      degraded,
+    );
+    sections.push('person_context');
+    if (personContext && intent.kinds.includes('person_activity')) {
+      activityContext = await settle(
+        'activity_context',
+        buildPersonActivity(personContext.person.user_id),
+        null,
+        degraded,
+      );
+      sections.push('activity_context');
+    }
+  }
+  if (!activityContext && intent.kinds.includes('community_changes')) {
+    activityContext = await settle(
+      'activity_context',
+      buildNetworkDigest(importantIds, excl.blocked),
+      null,
+      degraded,
+    );
+    sections.push('activity_context');
+  }
+
+  const recommendedActions = buildRecommendedActions({
+    relationships,
+    matches,
+    messages,
+    interestingEvents,
+    personContext,
+  });
+
+  const pack: SocialContextPack = {
+    user,
+    relationships,
+    matches,
+    messages,
+    group_chats: groupChats,
+    interesting_posts: interestingPosts,
+    interesting_events: interestingEvents,
+    person_context: personContext,
+    activity_context: activityContext,
+    memory_highlights: [],
+    recommended_actions: recommendedActions,
+    assistant_system_hints: [],
+    meta: {
+      built_at: new Date().toISOString(),
+      latency_ms: Date.now() - startTime,
+      sections_loaded: sections,
+      degraded_sections: degraded,
+      privacy_filters_applied: [
+        'blocked_authors',
+        'muted_authors',
+        'hidden_posts',
+        'public_posts_only',
+        'private_profile_minimization',
+        'own_conversations_only',
+        'tenant_scope',
+      ],
+    },
+  };
+  pack.assistant_system_hints = buildAssistantSystemHints(pack);
+  return pack;
+}
+
+/** Life Compass goal words for topical boosts (reuses the canonical read). */
+async function fetchGoalTerms(userId: string): Promise<string[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const { data } = await supabase
+    .from('life_compass')
+    .select('primary_goal, category')
+    .eq('user_id', userId)
+    .eq('is_active', true)
+    .order('created_at', { ascending: false })
+    .limit(1);
+  const goal = data?.[0];
+  if (!goal) return [];
+  return extractTerms(`${goal.primary_goal} ${goal.category}`);
+}
+
+function buildRecommendedActions(x: {
+  relationships: RelationshipSummary;
+  matches: SocialContextPack['matches'];
+  messages: SocialContextPack['messages'];
+  interestingEvents: SocialContextPack['interesting_events'];
+  personContext: SocialContextPack['person_context'];
+}): RecommendedAction[] {
+  const actions: RecommendedAction[] = [];
+
+  if (x.personContext?.recommended_next_action) {
+    actions.push({
+      action: x.personContext.recommended_next_action,
+      reason: `About ${x.personContext.person.display_name || 'this member'}`,
+      route: `/profile/${x.personContext.person.user_id}`,
+    });
+  }
+
+  const untouchedMatch = x.matches.find(
+    (m) => m.is_current && !m.conversation_started && m.action !== 'rejected',
+  );
+  if (untouchedMatch) {
+    actions.push({
+      action: `Say hello to ${untouchedMatch.person.display_name || 'your newest match'}`,
+      reason: untouchedMatch.reasons[0] || `Match score ${untouchedMatch.score ?? ''}`.trim(),
+      route: '/matches',
+    });
+  }
+
+  const topEvent = x.interestingEvents[0];
+  if (topEvent && topEvent.score >= 30) {
+    actions.push({
+      action: `Check out "${topEvent.title}"`,
+      reason: topEvent.reason[0] || 'Recommended event',
+      route: topEvent.url,
+    });
+  }
+
+  const staleContact = x.messages.find(
+    (m) => Date.now() - Date.parse(m.last_message_at) > 7 * 86400000,
+  );
+  if (staleContact && actions.length < 3) {
+    actions.push({
+      action: `Reconnect with ${staleContact.person.display_name || 'a recent contact'}`,
+      reason: 'Your last exchange was over a week ago',
+      route: `/messages/${staleContact.person.user_id}`,
+    });
+  }
+
+  if (actions.length === 0 && x.relationships.following_count === 0) {
+    actions.push({
+      action: 'Follow a few members to build your community feed',
+      reason: 'You are not following anyone yet',
+      route: '/community',
+    });
+  }
+  return actions.slice(0, 3);
+}

--- a/services/gateway/src/services/social-memory/social-memory-prompts.ts
+++ b/services/gateway/src/services/social-memory/social-memory-prompts.ts
@@ -1,0 +1,216 @@
+/**
+ * BOOTSTRAP-SOCIAL-MEMORY — intent detection + prompt formatting.
+ *
+ * detectSocialIntent(): cheap keyword classifier (same style as the
+ * retrieval-router) deciding whether a message needs the Social Context
+ * Pack, which sections matter, and whether a specific person was named.
+ *
+ * formatSocialContextForPrompt(): renders the pack as a <social_context>
+ * section for the USER MEMORY CONTEXT block. Written to ENRICH the
+ * existing conversation flow: facts + explainable reasons, no directives
+ * that compete with the proactive-guide layer.
+ */
+
+import {
+  SocialContextPack,
+  SocialIntentDecision,
+  SocialIntentKind,
+} from './social-memory-types';
+
+// EN + DE trigger sets (community is German-first).
+const TRIGGERS: Array<{ kind: SocialIntentKind; patterns: RegExp }> = [
+  { kind: 'follows', patterns: /\b(who (do|am) i follow|wem folge ich|folge ich|my follows|following list)\b/i },
+  { kind: 'followers', patterns: /\b(follows? me|my followers|wer folgt mir|meine follower)\b/i },
+  { kind: 'messages', patterns: /\b(message[ds]?|nachricht(en)?|geschrieben|chat(ted)?|angeschrieben|texted)\b/i },
+  { kind: 'group_chats', patterns: /\b(group ?chats?|gruppenchats?|gruppen(unterhaltung)?|which groups am i)\b/i },
+  { kind: 'matches', patterns: /\b(match(es)?|match-?score|kompatibel|good match|passt zu mir)\b/i },
+  { kind: 'interesting_posts', patterns: /\b(posts?|beitr(a|ä)g(e|en)?|feed|what.?s new|neuigkeiten)\b/i },
+  { kind: 'interesting_events', patterns: /\b(events?|veranstaltung(en)?|meetups?|which events|welche events)\b/i },
+  { kind: 'who_to_contact', patterns: /\b(who should i (contact|message|talk|invite|meet)|wen soll(te)? ich (kontaktieren|anschreiben|einladen|treffen))\b/i },
+  { kind: 'community_changes', patterns: /\b(what changed|since yesterday|was hat sich (getan|geändert)|was ist passiert|what did i miss)\b/i },
+  { kind: 'person_activity', patterns: /\b(latest activit|recent activit|what (did|has) .{2,40} (do|done|been up to)|zuletzt gemacht|letzte[nr]? aktivit)\b/i },
+  { kind: 'general_social', patterns: /\b(community|maxina|freund(e|in)?|friends?|people|leute|wichtige personen|important people|network|netzwerk|mission)\b/i },
+];
+
+// Words that must never be mistaken for a person name.
+const NAME_STOPWORDS = new Set([
+  'Vitana', 'Vitanaland', 'Maxina', 'Community', 'Ich', 'Was', 'Wer', 'Wie',
+  'The', 'What', 'Who', 'How', 'Tell', 'About', 'Erzähl', 'Über', 'Meine',
+  'My', 'Life', 'Compass', 'Index', 'Event', 'Events', 'Match', 'Matches',
+  'Group', 'Groups', 'Gruppe', 'Gruppen', 'Post', 'Posts', 'Heute', 'Today',
+  'Morgen', 'Deutschland', 'Berlin',
+]);
+
+/**
+ * Extract a candidate person name: sequences of 2+ capitalized words
+ * (e.g. "Mariia Maksina"), or a single capitalized word right after
+ * "about/über/von/an/mit/tell me about".
+ */
+export function extractPersonHint(question: string): string | null {
+  if (!question) return null;
+
+  // Multi-word capitalized sequence (most reliable — full names).
+  const multi = question.match(/\b([A-ZÄÖÜ][a-zà-üäöüß]+(?:\s+[A-ZÄÖÜ][a-zà-üäöüß]+)+)\b/g);
+  if (multi) {
+    for (const candidate of multi) {
+      const words = candidate.split(/\s+/);
+      if (words.every((w) => NAME_STOPWORDS.has(w))) continue;
+      const filtered = words.filter((w) => !NAME_STOPWORDS.has(w));
+      if (filtered.length >= 2) return filtered.join(' ');
+      if (filtered.length === 1 && words.length >= 2) return candidate;
+    }
+  }
+
+  // Single name after a preposition ("tell me about Mariia", "über Mariia").
+  // NOTE: no leading \b — JS word boundaries are ASCII-only and fail
+  // before umlauts ("über"), so anchor on whitespace/start instead.
+  const single = question.match(
+    /(?:^|\s)(?:about|über|ueber|von|mit|an|erzähl(?:e)? mir (?:etwas )?(?:über|von))\s+([A-ZÄÖÜ][a-zà-üäöüß]{2,})/,
+  );
+  if (single && !NAME_STOPWORDS.has(single[1])) return single[1];
+
+  return null;
+}
+
+export function detectSocialIntent(question: string): SocialIntentDecision {
+  const kinds: SocialIntentKind[] = [];
+  for (const t of TRIGGERS) {
+    if (t.patterns.test(question)) kinds.push(t.kind);
+  }
+  const personHint = extractPersonHint(question);
+  if (personHint && !kinds.includes('person_query')) kinds.push('person_query');
+
+  return {
+    is_social: kinds.length > 0,
+    kinds,
+    person_hint: personHint,
+  };
+}
+
+// =============================================================================
+// Prompt formatting
+// =============================================================================
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return '';
+  return iso.slice(0, 10);
+}
+
+/**
+ * Render the Social Context Pack as a prompt section. Placed INSIDE the
+ * USER MEMORY CONTEXT block by the memory orchestrator, so the mandatory
+ * memory self-check rules already govern how it is used.
+ */
+export function formatSocialContextForPrompt(pack: SocialContextPack): string {
+  let s = `<social_context>\n`;
+  s += `Live Maxina Community context for this user (already privacy-filtered — blocked/muted/hidden content is excluded; do not speculate about anything not listed):\n\n`;
+
+  const rel = pack.relationships;
+  if (rel.following_count > 0 || rel.followers_count > 0) {
+    const followingNames = rel.following.slice(0, 10).map((f) => f.person.display_name || f.person.handle).filter(Boolean);
+    const followerNames = rel.followers.slice(0, 10).map((f) => f.person.display_name || f.person.handle).filter(Boolean);
+    s += `Follows (${rel.following_count}): ${followingNames.join(', ') || '—'}\n`;
+    s += `Followers (${rel.followers_count}): ${followerNames.join(', ') || '—'}\n`;
+  } else {
+    s += `Follows: none yet. Followers: none yet.\n`;
+  }
+
+  if (pack.matches.length > 0) {
+    s += `\nMatches (best first):\n`;
+    for (const m of pack.matches.slice(0, 6)) {
+      const name = m.person.display_name || m.person.handle || 'A member';
+      s += `- ${name}${m.score != null ? ` (score ${m.score})` : ''}${m.reasons.length ? ` — ${m.reasons.slice(0, 2).join('; ')}` : ''}${m.conversation_started ? ' [chatting]' : ''}${m.action ? ` [${m.action}]` : ''}\n`;
+    }
+  }
+
+  if (pack.messages.length > 0) {
+    s += `\nRecent chat contacts (last 30 days):\n`;
+    for (const c of pack.messages.slice(0, 6)) {
+      const name = c.person.display_name || c.person.handle || 'A member';
+      s += `- ${name} — last ${c.last_direction} ${fmtDate(c.last_message_at)}, ${c.messages_30d} msg(s)\n`;
+    }
+  }
+
+  if (pack.group_chats.length > 0) {
+    s += `\nGroup chats: ${pack.group_chats
+      .map((g) => `${g.name || 'Unnamed'}${g.member_count ? ` (${g.member_count})` : ''}`)
+      .join(', ')}\n`;
+  }
+
+  if (pack.interesting_posts.length > 0) {
+    s += `\nInteresting posts for this user:\n`;
+    for (const p of pack.interesting_posts.slice(0, 5)) {
+      const author = p.author.display_name || p.author.handle || 'A member';
+      s += `- [${p.score}] ${author}: "${p.snippet}" — ${p.reason.slice(0, 2).join('; ')}\n`;
+    }
+  }
+
+  if (pack.interesting_events.length > 0) {
+    s += `\nInteresting events for this user:\n`;
+    for (const e of pack.interesting_events.slice(0, 5)) {
+      s += `- [${e.score}] ${e.title} (${fmtDate(e.start_time)}${e.location ? `, ${e.location}` : ''}) — ${e.reason.slice(0, 2).join('; ')}${e.url ? `\n  Link: ${e.url}` : ''}\n`;
+    }
+  }
+
+  if (pack.person_context) {
+    const pc = pack.person_context;
+    const name = pc.person.display_name || pc.person.handle || 'This member';
+    s += `\nPerson in focus — ${name}:\n`;
+    s += `- ${pc.relevance_summary}\n`;
+    if (pc.privacy_limited) {
+      s += `- PRIVACY: profile is private and the user has no connection — share only the name; do NOT speculate about details.\n`;
+    } else {
+      if (pc.shared_interests.length) s += `- Shared interests: ${pc.shared_interests.join(', ')}\n`;
+      if (pc.shared_groups.length) s += `- Shared groups: ${pc.shared_groups.join(', ')}\n`;
+      if (pc.shared_events.length) s += `- Shared events: ${pc.shared_events.join(', ')}\n`;
+      for (const post of pc.latest_posts.slice(0, 3)) {
+        s += `- Recent post (${fmtDate(post.created_at)}): "${post.snippet}"\n`;
+      }
+      if (pc.last_chat_at) s += `- Last chat with the user: ${fmtDate(pc.last_chat_at)}\n`;
+    }
+  }
+
+  if (pack.activity_context && pack.activity_context.items.length > 0) {
+    const label = pack.activity_context.person
+      ? `Recent activity of ${pack.activity_context.person.display_name || 'this member'}`
+      : `Recent activity in the user's network (last ${pack.activity_context.window_days} day(s))`;
+    s += `\n${label}:\n`;
+    for (const item of pack.activity_context.items.slice(0, 8)) {
+      s += `- ${fmtDate(item.at)}: ${item.summary}\n`;
+    }
+  }
+
+  if (pack.recommended_actions.length > 0) {
+    s += `\nRecommended next actions (offer at most ONE, woven naturally):\n`;
+    for (const a of pack.recommended_actions.slice(0, 3)) {
+      s += `- ${a.action} — ${a.reason}\n`;
+    }
+  }
+
+  if (pack.assistant_system_hints.length > 0) {
+    s += `\nGuidance:\n`;
+    for (const h of pack.assistant_system_hints) s += `- ${h}\n`;
+  }
+
+  s += `</social_context>\n\n`;
+  return s;
+}
+
+/** Standing hints attached to every social pack. */
+export function buildAssistantSystemHints(pack: {
+  person_context: SocialContextPack['person_context'];
+  matches: SocialContextPack['matches'];
+}): string[] {
+  const hints: string[] = [
+    'Answer social questions ONLY from this social context — never invent people, posts, matches, or events.',
+    'When you recommend a post, event, or person, state the reason from the context ("because you follow…", "because it matches…").',
+    'Respect privacy: never reveal message contents of other people, and treat privacy-limited profiles as name-only.',
+  ];
+  if (pack.person_context?.privacy_limited) {
+    hints.push('The person in focus has a private profile — politely say details are limited.');
+  }
+  if (pack.matches.length === 0) {
+    hints.push('The user has no active matches — if asked, say so honestly and suggest exploring the community.');
+  }
+  return hints;
+}

--- a/services/gateway/src/services/social-memory/social-memory-ranker.ts
+++ b/services/gateway/src/services/social-memory/social-memory-ranker.ts
@@ -1,0 +1,234 @@
+/**
+ * BOOTSTRAP-SOCIAL-MEMORY — explainable rankers for posts and events.
+ *
+ * Every score is accompanied by human-readable reasons; the assistant and
+ * the UI surface WHY something was recommended, never a bare number.
+ * Blocked/muted/hidden filtering happens in the repository BEFORE ranking;
+ * the ranker only sees eligible candidates.
+ */
+
+import {
+  RankedPost,
+  RankedEvent,
+  MatchSummary,
+  SocialPerson,
+} from './social-memory-types';
+import { RawPost, RawEvent } from './social-memory-repository';
+
+export interface PostRankSignals {
+  viewer_id: string;
+  followed_ids: Set<string>;
+  /** person_id → match score (0-100) for high-quality-match boosts. */
+  match_scores: Map<string, number>;
+  /** Lowercased interest terms of the viewer (user_interests + memory). */
+  interests: string[];
+  /** Lowercased goal terms (Life Compass primary goal words). */
+  goal_terms: string[];
+  /** person_id → shared community group count with the viewer. */
+  shared_group_counts: Map<string, number>;
+  people: Map<string, SocialPerson>;
+}
+
+const HIGH_QUALITY_MATCH = 75;
+
+function freshnessScore(createdAt: string, halfLifeHours: number): number {
+  const ageHours = Math.max(0, (Date.now() - Date.parse(createdAt)) / 3600000);
+  return Math.exp(-ageHours / halfLifeHours);
+}
+
+function matchTerms(text: string, terms: string[]): string[] {
+  const lower = text.toLowerCase();
+  return terms.filter((t) => t.length >= 3 && lower.includes(t));
+}
+
+export function rankInterestingPosts(
+  candidates: RawPost[],
+  signals: PostRankSignals,
+  topK = 8,
+): RankedPost[] {
+  const ranked: RankedPost[] = [];
+
+  for (const post of candidates) {
+    let score = 0;
+    const reason: string[] = [];
+
+    if (signals.followed_ids.has(post.user_id)) {
+      score += 30;
+      reason.push('You follow this person');
+    }
+    const matchScore = signals.match_scores.get(post.user_id);
+    if (matchScore != null && matchScore >= HIGH_QUALITY_MATCH) {
+      score += 20;
+      reason.push('This author is one of your high-quality matches');
+    } else if (matchScore != null) {
+      score += 10;
+      reason.push('This author is one of your matches');
+    }
+
+    const interestHits = matchTerms(post.content || '', signals.interests);
+    if (interestHits.length > 0) {
+      score += Math.min(20, interestHits.length * 8);
+      reason.push(`Matches your interests: ${interestHits.slice(0, 3).join(', ')}`);
+    }
+    const goalHits = matchTerms(post.content || '', signals.goal_terms);
+    if (goalHits.length > 0) {
+      score += 15;
+      reason.push('This topic connects to your current goal');
+    }
+
+    const sharedGroups = signals.shared_group_counts.get(post.user_id) || 0;
+    if (sharedGroups > 0) {
+      score += Math.min(10, sharedGroups * 5);
+      reason.push(`You share ${sharedGroups} group${sharedGroups === 1 ? '' : 's'} with the author`);
+    }
+
+    // Freshness (48h half-life) + engagement, capped so relationship
+    // signals always dominate raw popularity.
+    score += Math.round(freshnessScore(post.created_at, 48) * 15);
+    const engagement = (post.likes_count || 0) + 2 * (post.comments_count || 0);
+    score += Math.min(10, Math.round(Math.log10(1 + engagement) * 5));
+    if (post.image_url || post.video_url) score += 2;
+
+    if (reason.length === 0) reason.push('Recent public post from the community');
+
+    const author = signals.people.get(post.user_id);
+    ranked.push({
+      post_id: post.id,
+      author: author ?? {
+        user_id: post.user_id,
+        display_name: null,
+        handle: null,
+        vitana_id: null,
+        avatar_url: null,
+        bio: null,
+        city: null,
+        country: null,
+        visibility: null,
+      },
+      snippet: (post.content || '').slice(0, 160),
+      created_at: post.created_at,
+      media_type: post.video_url ? 'video' : post.image_url ? 'image' : 'text',
+      likes_count: post.likes_count || 0,
+      comments_count: post.comments_count || 0,
+      score: Math.min(100, score),
+      reason,
+    });
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+  return ranked.slice(0, topK);
+}
+
+export interface EventRankSignals {
+  viewer_id: string;
+  followed_ids: Set<string>;
+  match_scores: Map<string, number>;
+  interests: string[];
+  goal_terms: string[];
+  /** Viewer's city/country (lowercased) for location affinity. */
+  location_terms: string[];
+  /** event_id → participant user_ids. */
+  participants: Map<string, string[]>;
+  people: Map<string, SocialPerson>;
+}
+
+export function rankInterestingEvents(
+  candidates: RawEvent[],
+  signals: EventRankSignals,
+  topK = 6,
+): RankedEvent[] {
+  const ranked: RankedEvent[] = [];
+
+  for (const ev of candidates) {
+    let score = 0;
+    const reason: string[] = [];
+    const text = `${ev.title || ''} ${ev.description || ''} ${ev.event_type || ''}`;
+
+    const participantIds = signals.participants.get(ev.id) || [];
+    const followedAttending = participantIds.filter((p) => signals.followed_ids.has(p));
+    const matchedAttending = participantIds.filter(
+      (p) => (signals.match_scores.get(p) ?? 0) >= HIGH_QUALITY_MATCH,
+    );
+
+    if (followedAttending.length > 0) {
+      score += Math.min(30, followedAttending.length * 12);
+      reason.push(
+        `${followedAttending.length} ${followedAttending.length === 1 ? 'person you follow is' : 'people you follow are'} attending`,
+      );
+    }
+    if (matchedAttending.length > 0) {
+      score += Math.min(20, matchedAttending.length * 10);
+      reason.push('One of your high-quality matches is attending');
+    }
+
+    const interestHits = matchTerms(text, signals.interests);
+    if (interestHits.length > 0) {
+      score += Math.min(25, interestHits.length * 10);
+      reason.push(`Matches your interests: ${interestHits.slice(0, 3).join(', ')}`);
+    }
+    const goalHits = matchTerms(text, signals.goal_terms);
+    if (goalHits.length > 0) {
+      score += 15;
+      reason.push('It fits your current goal');
+    }
+    const locationHits = matchTerms(`${ev.location || ''}`, signals.location_terms);
+    if (locationHits.length > 0) {
+      score += 10;
+      reason.push('It is near you');
+    }
+
+    // Sooner events surface first (7-day half-life on time-to-start).
+    const daysOut = Math.max(0, (Date.parse(ev.start_time) - Date.now()) / 86400000);
+    score += Math.round(Math.exp(-daysOut / 7) * 15);
+    if ((ev.participant_count || 0) >= 5) score += 5;
+
+    if (reason.length === 0) reason.push('Upcoming community event');
+
+    const followedNames = followedAttending
+      .map((id) => signals.people.get(id)?.display_name)
+      .filter((n): n is string => !!n)
+      .slice(0, 3);
+
+    ranked.push({
+      event_id: ev.id,
+      title: ev.title,
+      event_type: ev.event_type ?? null,
+      start_time: ev.start_time,
+      location: ev.location ?? null,
+      url: ev.slug ? `https://vitanaland.com/e/${ev.slug}` : null,
+      participant_count: ev.participant_count ?? null,
+      followed_attendees: followedNames,
+      matched_attendees: matchedAttending
+        .map((id) => signals.people.get(id)?.display_name)
+        .filter((n): n is string => !!n)
+        .slice(0, 3),
+      score: Math.min(100, score),
+      reason,
+    });
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+  return ranked.slice(0, topK);
+}
+
+/** Extract lowercase significant terms from free text (goals, interests). */
+export function extractTerms(text: string | null | undefined): string[] {
+  if (!text) return [];
+  return Array.from(
+    new Set(
+      text
+        .toLowerCase()
+        .split(/[^a-zà-üäöüß0-9]+/i)
+        .filter((w) => w.length >= 4),
+    ),
+  ).slice(0, 12);
+}
+
+/** Match score lookup map from MatchSummary list. */
+export function buildMatchScoreMap(matches: MatchSummary[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const m of matches) {
+    if (m.score != null) out.set(m.person.user_id, m.score);
+  }
+  return out;
+}

--- a/services/gateway/src/services/social-memory/social-memory-repository.ts
+++ b/services/gateway/src/services/social-memory/social-memory-repository.ts
@@ -1,0 +1,604 @@
+/**
+ * BOOTSTRAP-SOCIAL-MEMORY — repository layer.
+ *
+ * All Supabase reads for the Social Memory Intelligence layer live here.
+ * The gateway uses the service-role client (RLS bypassed), so EVERY read
+ * applies visibility rules explicitly:
+ *
+ *   - blocked authors (user_blocked_authors) are excluded everywhere
+ *   - muted authors (user_muted_authors) are excluded from posts/feeds
+ *   - hidden posts (user_hidden_posts) are excluded from post lists
+ *   - posts: only is_public=true (or the viewer's own), moderation-approved
+ *   - profiles: only public-safe columns are ever selected — email, phone,
+ *     medical fields are never read by this module
+ *   - messages: only conversations the viewer participates in
+ *   - tenant scoping applied where the table carries tenant_id
+ *
+ * Table names verified against the LIVE database (2026-07-03) — several
+ * code-level tables (e.g. matches_daily) do not exist in production; the
+ * populated sources are the ones used here.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import {
+  SocialPerson,
+  FollowEdge,
+  MatchSummary,
+  MessageContact,
+  GroupChatSummary,
+} from './social-memory-types';
+
+const PROFILE_COLS =
+  'user_id, display_name, handle, avatar_url, bio, city, country, account_visibility, vitana_id';
+
+export interface RawPost {
+  id: string;
+  user_id: string;
+  content: string;
+  image_url: string | null;
+  video_url: string | null;
+  likes_count: number;
+  comments_count: number;
+  created_at: string;
+}
+
+export interface RawEvent {
+  id: string;
+  title: string;
+  description: string | null;
+  event_type: string | null;
+  start_time: string;
+  location: string | null;
+  slug: string | null;
+  participant_count: number | null;
+}
+
+function mapPerson(row: any): SocialPerson {
+  return {
+    user_id: row.user_id,
+    display_name: row.display_name ?? null,
+    handle: row.handle ?? null,
+    vitana_id: row.vitana_id ?? null,
+    avatar_url: row.avatar_url ?? null,
+    bio: row.bio ?? null,
+    city: row.city ?? null,
+    country: row.country ?? null,
+    visibility: typeof row.account_visibility === 'string' ? row.account_visibility : null,
+  };
+}
+
+/** Batch-load privacy-safe person cards for a set of user ids. */
+export async function fetchPeople(userIds: string[]): Promise<Map<string, SocialPerson>> {
+  const out = new Map<string, SocialPerson>();
+  const ids = Array.from(new Set(userIds)).filter(Boolean);
+  if (ids.length === 0) return out;
+  const supabase = getSupabase();
+  if (!supabase) return out;
+  const { data } = await supabase.from('profiles').select(PROFILE_COLS).in('user_id', ids.slice(0, 200));
+  for (const row of data || []) out.set(row.user_id, mapPerson(row));
+  return out;
+}
+
+/**
+ * Exclusion sets for the viewer: blocked + muted authors, hidden posts.
+ * Blocked applies everywhere; muted applies to content surfaces.
+ */
+export async function fetchExclusions(userId: string): Promise<{
+  blocked: Set<string>;
+  muted: Set<string>;
+  hidden_posts: Set<string>;
+}> {
+  const supabase = getSupabase();
+  const blocked = new Set<string>();
+  const muted = new Set<string>();
+  const hiddenPosts = new Set<string>();
+  if (!supabase) return { blocked, muted, hidden_posts: hiddenPosts };
+
+  const [b, m, h] = await Promise.all([
+    supabase.from('user_blocked_authors').select('author_id').eq('user_id', userId).limit(500),
+    supabase.from('user_muted_authors').select('author_id').eq('user_id', userId).limit(500),
+    supabase.from('user_hidden_posts').select('post_id').eq('user_id', userId).limit(1000),
+  ]);
+  for (const r of b.data || []) blocked.add(r.author_id);
+  for (const r of m.data || []) muted.add(r.author_id);
+  for (const r of h.data || []) hiddenPosts.add(r.post_id);
+  return { blocked, muted, hidden_posts: hiddenPosts };
+}
+
+/** People the user follows / who follow the user (user_follows). */
+export async function fetchFollowEdges(
+  userId: string,
+  blocked: Set<string>,
+  limit = 50,
+): Promise<{ following: FollowEdge[]; followers: FollowEdge[] }> {
+  const supabase = getSupabase();
+  if (!supabase) return { following: [], followers: [] };
+
+  const [outRes, inRes] = await Promise.all([
+    supabase
+      .from('user_follows')
+      .select('following_id, created_at')
+      .eq('follower_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit),
+    supabase
+      .from('user_follows')
+      .select('follower_id, created_at')
+      .eq('following_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit),
+  ]);
+
+  const outRows = (outRes.data || []).filter((r) => !blocked.has(r.following_id));
+  const inRows = (inRes.data || []).filter((r) => !blocked.has(r.follower_id));
+  const people = await fetchPeople([
+    ...outRows.map((r) => r.following_id),
+    ...inRows.map((r) => r.follower_id),
+  ]);
+
+  const following: FollowEdge[] = outRows
+    .map((r) => ({ person: people.get(r.following_id), since: r.created_at }))
+    .filter((e): e is FollowEdge => !!e.person);
+  const followers: FollowEdge[] = inRows
+    .map((r) => ({ person: people.get(r.follower_id), since: r.created_at }))
+    .filter((e): e is FollowEdge => !!e.person);
+  return { following, followers };
+}
+
+/**
+ * Matches: current daily matches (daily_matches — score + human-readable
+ * reasons) plus historical mutual matches (user_matches).
+ */
+export async function fetchMatches(
+  userId: string,
+  blocked: Set<string>,
+  limit = 20,
+): Promise<MatchSummary[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  const [dailyRes, mutualRes] = await Promise.all([
+    supabase
+      .from('daily_matches')
+      .select('matched_user_id, match_score, match_reasons, action, expires_at, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit),
+    supabase
+      .from('user_matches')
+      .select('user_id_1, user_id_2, compatibility_score, match_reason, matched_at, conversation_started, is_active')
+      .or(`user_id_1.eq.${userId},user_id_2.eq.${userId}`)
+      .order('matched_at', { ascending: false })
+      .limit(limit),
+  ]);
+
+  const now = Date.now();
+  const entries: Array<{ personId: string; summary: Omit<MatchSummary, 'person'> }> = [];
+
+  for (const r of dailyRes.data || []) {
+    if (blocked.has(r.matched_user_id)) continue;
+    entries.push({
+      personId: r.matched_user_id,
+      summary: {
+        score: r.match_score != null ? Math.round(Number(r.match_score)) : null,
+        reasons: Array.isArray(r.match_reasons) ? r.match_reasons.map(String) : [],
+        source: 'daily_match',
+        matched_at: r.created_at,
+        action: r.action ?? null,
+        conversation_started: false,
+        is_current: !r.expires_at || Date.parse(r.expires_at) > now,
+      },
+    });
+  }
+  for (const r of mutualRes.data || []) {
+    const other = r.user_id_1 === userId ? r.user_id_2 : r.user_id_1;
+    if (blocked.has(other)) continue;
+    entries.push({
+      personId: other,
+      summary: {
+        score: r.compatibility_score != null ? Math.round(Number(r.compatibility_score)) : null,
+        reasons: r.match_reason ? [String(r.match_reason)] : [],
+        source: 'user_match',
+        matched_at: r.matched_at,
+        action: null,
+        conversation_started: r.conversation_started === true,
+        is_current: r.is_active === true,
+      },
+    });
+  }
+
+  // Dedupe by person, daily match wins (fresher scores/reasons).
+  const byPerson = new Map<string, Omit<MatchSummary, 'person'>>();
+  for (const e of entries) if (!byPerson.has(e.personId)) byPerson.set(e.personId, e.summary);
+
+  const people = await fetchPeople(Array.from(byPerson.keys()));
+  const out: MatchSummary[] = [];
+  for (const [personId, summary] of byPerson) {
+    const person = people.get(personId);
+    if (person) out.push({ person, ...summary });
+  }
+  out.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+  return out;
+}
+
+/**
+ * Recent DM contacts (chat_messages where the user is sender or receiver,
+ * group messages excluded). Snippets come only from the viewer's OWN
+ * conversations — this never reads anyone else's messages.
+ */
+export async function fetchRecentMessageContacts(
+  userId: string,
+  tenantId: string,
+  blocked: Set<string>,
+  limit = 15,
+): Promise<MessageContact[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  const since = new Date(Date.now() - 30 * 24 * 3600 * 1000).toISOString();
+  const { data } = await supabase
+    .from('chat_messages')
+    .select('sender_id, receiver_id, content, created_at')
+    .eq('tenant_id', tenantId)
+    .is('group_id', null)
+    .or(`sender_id.eq.${userId},receiver_id.eq.${userId}`)
+    .gte('created_at', since)
+    .order('created_at', { ascending: false })
+    .limit(400);
+
+  const byPeer = new Map<
+    string,
+    { last_at: string; last_dir: 'sent' | 'received'; snippet: string; count: number }
+  >();
+  for (const m of data || []) {
+    const peer = m.sender_id === userId ? m.receiver_id : m.sender_id;
+    if (!peer || peer === userId || blocked.has(peer)) continue;
+    const existing = byPeer.get(peer);
+    if (existing) {
+      existing.count++;
+    } else {
+      byPeer.set(peer, {
+        last_at: m.created_at,
+        last_dir: m.sender_id === userId ? 'sent' : 'received',
+        snippet: (m.content || '').slice(0, 120),
+        count: 1,
+      });
+    }
+  }
+
+  const peers = Array.from(byPeer.keys()).slice(0, limit);
+  const people = await fetchPeople(peers);
+  const out: MessageContact[] = [];
+  for (const peer of peers) {
+    const person = people.get(peer);
+    const s = byPeer.get(peer)!;
+    if (!person) continue;
+    out.push({
+      person,
+      last_message_at: s.last_at,
+      last_direction: s.last_dir,
+      last_snippet: s.snippet || null,
+      messages_30d: s.count,
+    });
+  }
+  return out;
+}
+
+/** Group chats the user participates in (chat_group_members → chat_groups). */
+export async function fetchGroupChats(
+  userId: string,
+  tenantId: string,
+  limit = 20,
+): Promise<GroupChatSummary[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  const { data: memberships } = await supabase
+    .from('chat_group_members')
+    .select('group_id, joined_at')
+    .eq('user_id', userId)
+    .eq('tenant_id', tenantId)
+    .limit(limit);
+  const groupIds = (memberships || []).map((m) => m.group_id);
+  if (groupIds.length === 0) return [];
+
+  const [groupsRes, memberCounts, lastMsgs] = await Promise.all([
+    supabase.from('chat_groups').select('id, name, is_system').in('id', groupIds),
+    supabase.from('chat_group_members').select('group_id').in('group_id', groupIds).limit(2000),
+    supabase
+      .from('chat_messages')
+      .select('group_id, created_at')
+      .in('group_id', groupIds)
+      .order('created_at', { ascending: false })
+      .limit(100),
+  ]);
+
+  const countByGroup = new Map<string, number>();
+  for (const r of memberCounts.data || []) {
+    countByGroup.set(r.group_id, (countByGroup.get(r.group_id) || 0) + 1);
+  }
+  const lastByGroup = new Map<string, string>();
+  for (const r of lastMsgs.data || []) {
+    if (!lastByGroup.has(r.group_id)) lastByGroup.set(r.group_id, r.created_at);
+  }
+  const joinedByGroup = new Map<string, string>();
+  for (const m of memberships || []) joinedByGroup.set(m.group_id, m.joined_at);
+
+  return (groupsRes.data || []).map((g) => ({
+    group_id: g.id,
+    name: g.name ?? null,
+    member_count: countByGroup.get(g.id) ?? null,
+    is_system: g.is_system === true,
+    last_message_at: lastByGroup.get(g.id) ?? null,
+    joined_at: joinedByGroup.get(g.id) ?? null,
+  }));
+}
+
+/**
+ * Candidate posts for the interesting-posts ranker: public, approved,
+ * not hidden, authors not blocked/muted. Pulls a wider pool from followed
+ * authors plus recent public posts; the ranker picks the top N.
+ */
+export async function fetchCandidatePosts(
+  userId: string,
+  followedIds: string[],
+  excl: { blocked: Set<string>; muted: Set<string>; hidden_posts: Set<string> },
+  limitPerSource = 40,
+): Promise<RawPost[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const since = new Date(Date.now() - 14 * 24 * 3600 * 1000).toISOString();
+
+  const baseSelect =
+    'id, user_id, content, image_url, video_url, likes_count, comments_count, created_at';
+  const queries: PromiseLike<any>[] = [
+    supabase
+      .from('profile_posts')
+      .select(baseSelect)
+      .eq('is_public', true)
+      .neq('moderation_status', 'rejected')
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
+      .limit(limitPerSource),
+  ];
+  if (followedIds.length > 0) {
+    queries.push(
+      supabase
+        .from('profile_posts')
+        .select(baseSelect)
+        .eq('is_public', true)
+        .neq('moderation_status', 'rejected')
+        .in('user_id', followedIds.slice(0, 100))
+        .order('created_at', { ascending: false })
+        .limit(limitPerSource),
+    );
+  }
+  const results = await Promise.all(queries);
+
+  const seen = new Set<string>();
+  const out: RawPost[] = [];
+  for (const res of results) {
+    for (const p of res.data || []) {
+      if (seen.has(p.id)) continue;
+      seen.add(p.id);
+      if (p.user_id === userId) continue; // own posts are not recommendations
+      if (excl.blocked.has(p.user_id) || excl.muted.has(p.user_id)) continue;
+      if (excl.hidden_posts.has(p.id)) continue;
+      out.push(p as RawPost);
+    }
+  }
+  return out;
+}
+
+/** A specific person's latest PUBLIC posts (privacy: is_public only). */
+export async function fetchPersonPosts(personId: string, limit = 5): Promise<RawPost[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const { data } = await supabase
+    .from('profile_posts')
+    .select('id, user_id, content, image_url, video_url, likes_count, comments_count, created_at')
+    .eq('user_id', personId)
+    .eq('is_public', true)
+    .neq('moderation_status', 'rejected')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  return (data || []) as RawPost[];
+}
+
+/** Upcoming community events (global_community_events). */
+export async function fetchUpcomingEvents(limit = 40): Promise<RawEvent[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const { data } = await supabase
+    .from('global_community_events')
+    .select('id, title, description, event_type, start_time, location, slug, participant_count')
+    .gte('start_time', new Date().toISOString())
+    .order('start_time', { ascending: true })
+    .limit(limit);
+  return (data || []) as RawEvent[];
+}
+
+/** Participant user_ids for a set of events (for "3 people you follow attend"). */
+export async function fetchEventParticipants(
+  eventIds: string[],
+): Promise<Map<string, string[]>> {
+  const out = new Map<string, string[]>();
+  const supabase = getSupabase();
+  if (!supabase || eventIds.length === 0) return out;
+  const { data } = await supabase
+    .from('global_event_participants')
+    .select('event_id, user_id, status')
+    .in('event_id', eventIds.slice(0, 60))
+    .limit(3000);
+  for (const r of data || []) {
+    if (r.status === 'cancelled' || r.status === 'declined') continue;
+    const arr = out.get(r.event_id) || [];
+    arr.push(r.user_id);
+    out.set(r.event_id, arr);
+  }
+  return out;
+}
+
+/** Events a set of users participate in (shared-events computation). */
+export async function fetchEventsForUsers(userIds: string[]): Promise<Map<string, Set<string>>> {
+  const out = new Map<string, Set<string>>();
+  const supabase = getSupabase();
+  if (!supabase || userIds.length === 0) return out;
+  const { data } = await supabase
+    .from('global_event_participants')
+    .select('event_id, user_id')
+    .in('user_id', userIds.slice(0, 50))
+    .limit(2000);
+  for (const r of data || []) {
+    const set = out.get(r.user_id) || new Set<string>();
+    set.add(r.event_id);
+    out.set(r.user_id, set);
+  }
+  return out;
+}
+
+/** Community group memberships for users (shared-groups computation). */
+export async function fetchGroupsForUsers(userIds: string[]): Promise<Map<string, Set<string>>> {
+  const out = new Map<string, Set<string>>();
+  const supabase = getSupabase();
+  if (!supabase || userIds.length === 0) return out;
+  const { data } = await supabase
+    .from('global_community_group_members')
+    .select('group_id, user_id')
+    .in('user_id', userIds.slice(0, 50))
+    .limit(2000);
+  for (const r of data || []) {
+    const set = out.get(r.user_id) || new Set<string>();
+    set.add(r.group_id);
+    out.set(r.user_id, set);
+  }
+  return out;
+}
+
+/** Group names for ids (labels for shared groups). */
+export async function fetchGroupNames(groupIds: string[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  const supabase = getSupabase();
+  if (!supabase || groupIds.length === 0) return out;
+  const { data } = await supabase
+    .from('global_community_groups')
+    .select('id, name')
+    .in('id', groupIds.slice(0, 100));
+  for (const r of data || []) out.set(r.id, r.name);
+  return out;
+}
+
+/** Event titles for ids (labels for shared events). */
+export async function fetchEventTitles(eventIds: string[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  const supabase = getSupabase();
+  if (!supabase || eventIds.length === 0) return out;
+  const { data } = await supabase
+    .from('global_community_events')
+    .select('id, title, start_time')
+    .in('id', eventIds.slice(0, 100));
+  for (const r of data || []) out.set(r.id, r.title);
+  return out;
+}
+
+/** Interests (user_interests) for one or more users. */
+export async function fetchInterests(userIds: string[]): Promise<Map<string, string[]>> {
+  const out = new Map<string, string[]>();
+  const supabase = getSupabase();
+  if (!supabase || userIds.length === 0) return out;
+  const { data } = await supabase
+    .from('user_interests')
+    .select('user_id, interest, confidence_score')
+    .in('user_id', userIds.slice(0, 50))
+    .order('confidence_score', { ascending: false })
+    .limit(500);
+  for (const r of data || []) {
+    const arr = out.get(r.user_id) || [];
+    if (arr.length < 15) arr.push(String(r.interest).toLowerCase());
+    out.set(r.user_id, arr);
+  }
+  return out;
+}
+
+/** Last DM exchange timestamp between viewer and a person (viewer's own thread). */
+export async function fetchLastChatAt(
+  userId: string,
+  tenantId: string,
+  personId: string,
+): Promise<string | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  const { data } = await supabase
+    .from('chat_messages')
+    .select('created_at')
+    .eq('tenant_id', tenantId)
+    .or(
+      `and(sender_id.eq.${userId},receiver_id.eq.${personId}),and(sender_id.eq.${personId},receiver_id.eq.${userId})`,
+    )
+    .order('created_at', { ascending: false })
+    .limit(1);
+  return data?.[0]?.created_at ?? null;
+}
+
+/** Does an active follow edge exist in either direction? */
+export async function fetchFollowFlags(
+  userId: string,
+  personId: string,
+): Promise<{ you_follow: boolean; follows_you: boolean }> {
+  const supabase = getSupabase();
+  if (!supabase) return { you_follow: false, follows_you: false };
+  const [a, b] = await Promise.all([
+    supabase
+      .from('user_follows')
+      .select('id')
+      .eq('follower_id', userId)
+      .eq('following_id', personId)
+      .limit(1),
+    supabase
+      .from('user_follows')
+      .select('id')
+      .eq('follower_id', personId)
+      .eq('following_id', userId)
+      .limit(1),
+  ]);
+  return { you_follow: (a.data || []).length > 0, follows_you: (b.data || []).length > 0 };
+}
+
+/**
+ * Resolve a person by fuzzy name / handle / vitana_id. Only searchable
+ * profiles are considered (profile_privacy_settings.searchable !== false).
+ */
+export async function resolvePersonByName(hint: string): Promise<SocialPerson | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  const term = hint.trim().replace(/[%_]/g, '');
+  if (term.length < 2) return null;
+
+  const { data } = await supabase
+    .from('profiles')
+    .select(`${PROFILE_COLS}, full_name`)
+    .or(`display_name.ilike.%${term}%,full_name.ilike.%${term}%,handle.ilike.%${term}%,vitana_id.ilike.%${term}%`)
+    .limit(5);
+  if (!data || data.length === 0) return null;
+
+  // Prefer exact-ish display_name match, then first hit.
+  const lower = term.toLowerCase();
+  const best =
+    data.find((r: any) => (r.display_name || '').toLowerCase() === lower) ||
+    data.find((r: any) => (r.display_name || '').toLowerCase().includes(lower)) ||
+    data[0];
+
+  const { data: priv } = await supabase
+    .from('profile_privacy_settings')
+    .select('searchable')
+    .eq('user_id', best.user_id)
+    .maybeSingle();
+  if (priv && priv.searchable === false) return null;
+  return mapPerson(best);
+}
+
+/** Load one person by user_id. */
+export async function fetchPersonById(personId: string): Promise<SocialPerson | null> {
+  const people = await fetchPeople([personId]);
+  return people.get(personId) ?? null;
+}

--- a/services/gateway/src/services/social-memory/social-memory-service.ts
+++ b/services/gateway/src/services/social-memory/social-memory-service.ts
@@ -1,0 +1,138 @@
+/**
+ * BOOTSTRAP-SOCIAL-MEMORY — top-level service.
+ *
+ * buildAssistantSocialContext(): the one call the assistant flow and the
+ * POST /assistant-context endpoint use — intent detection, pack assembly,
+ * meaningful-moment memory persistence, and OASIS telemetry.
+ *
+ * Memory persistence is deliberately selective (do NOT store everything):
+ * only person-focus moments (the user asked about a specific person) are
+ * written, via the existing writeMemoryItemWithIdentity path, category
+ * network_relationships — so future turns know who matters to the user.
+ */
+
+import { emitOasisEvent } from '../oasis-event-service';
+import {
+  SocialContextPack,
+  SocialIntentDecision,
+} from './social-memory-types';
+import { buildSocialContextPack } from './social-context-builder';
+import { detectSocialIntent, formatSocialContextForPrompt } from './social-memory-prompts';
+
+const LOG_PREFIX = '[SOCIAL-MEMORY]';
+
+export { detectSocialIntent, formatSocialContextForPrompt };
+
+export interface AssistantSocialContextInput {
+  tenant_id: string;
+  user_id: string;
+  question: string;
+  conversation_id?: string;
+  surface?: 'vitana_assistant' | 'maxina_community' | 'group_chat' | 'profile' | 'feed';
+  compact?: boolean;
+}
+
+export interface AssistantSocialContextResult {
+  ok: boolean;
+  intent: SocialIntentDecision;
+  pack: SocialContextPack;
+  /** Ready-to-inject <social_context> prompt section. */
+  prompt_block: string;
+}
+
+export async function buildAssistantSocialContext(
+  input: AssistantSocialContextInput,
+): Promise<AssistantSocialContextResult> {
+  const intent = detectSocialIntent(input.question || '');
+
+  const pack = await buildSocialContextPack({
+    tenant_id: input.tenant_id,
+    user_id: input.user_id,
+    question: input.question,
+    surface: input.surface,
+    compact: input.compact,
+    intent,
+  });
+
+  // Meaningful-moment memory: the user focused on a specific person.
+  if (pack.person_context && intent.person_hint) {
+    persistPersonFocusMemory(input, pack).catch(() => {});
+  }
+
+  // Telemetry — retrieval + recommendation event, metadata only (counts,
+  // never names/content, so the log cannot leak private data).
+  emitOasisEvent({
+    vtid: 'BOOTSTRAP-SOCIAL-MEMORY',
+    type: 'memory.social.context_built',
+    source: `social-memory-${input.surface || 'vitana_assistant'}`,
+    status: pack.meta.degraded_sections.length > 0 ? 'warning' : 'info',
+    message: `Social context built: ${pack.meta.sections_loaded.length} sections, ${pack.matches.length} matches, ${pack.interesting_posts.length} posts, ${pack.interesting_events.length} events`,
+    payload: {
+      tenant_id: input.tenant_id,
+      user_id: input.user_id,
+      conversation_id: input.conversation_id,
+      surface: input.surface || 'vitana_assistant',
+      intent_kinds: intent.kinds,
+      person_resolved: !!pack.person_context,
+      person_privacy_limited: pack.person_context?.privacy_limited ?? false,
+      following_count: pack.relationships.following_count,
+      followers_count: pack.relationships.followers_count,
+      matches_count: pack.matches.length,
+      message_contacts_count: pack.messages.length,
+      group_chats_count: pack.group_chats.length,
+      interesting_posts_count: pack.interesting_posts.length,
+      interesting_events_count: pack.interesting_events.length,
+      recommended_actions_count: pack.recommended_actions.length,
+      degraded_sections: pack.meta.degraded_sections,
+      latency_ms: pack.meta.latency_ms,
+    },
+  }).catch(() => {});
+
+  console.log(
+    `${LOG_PREFIX} context built in ${pack.meta.latency_ms}ms — intent=[${intent.kinds.join(',')}] ` +
+      `follows=${pack.relationships.following_count}/${pack.relationships.followers_count} ` +
+      `matches=${pack.matches.length} posts=${pack.interesting_posts.length} events=${pack.interesting_events.length} ` +
+      `person=${pack.person_context ? 'yes' : 'no'} degraded=[${pack.meta.degraded_sections.join(',')}]`,
+  );
+
+  return {
+    ok: pack.meta.degraded_sections.length === 0,
+    intent,
+    pack,
+    prompt_block: formatSocialContextForPrompt(pack),
+  };
+}
+
+/**
+ * Durable memory for a meaningful person-focus moment. Uses the existing
+ * memory write path (memory_items via orb-memory-bridge) — never raw SQL.
+ */
+async function persistPersonFocusMemory(
+  input: AssistantSocialContextInput,
+  pack: SocialContextPack,
+): Promise<void> {
+  const pc = pack.person_context!;
+  // Privacy: never memorize details of privacy-limited profiles.
+  if (pc.privacy_limited) return;
+  try {
+    const { writeMemoryItemWithIdentity } = await import('../orb-memory-bridge');
+    const name = pc.person.display_name || pc.person.handle || 'a member';
+    await writeMemoryItemWithIdentity(
+      { user_id: input.user_id, tenant_id: input.tenant_id },
+      {
+        content: `User asked about ${name}${pc.match?.score != null ? ` (match score ${pc.match.score})` : ''} — ${pc.you_follow ? 'follows them' : 'does not follow them yet'}.`,
+        source: 'orb_text',
+        category_key: 'network_relationships',
+        importance: 35,
+        content_json: {
+          direction: 'system',
+          kind: 'person_focus',
+          person_id: pc.person.user_id,
+          surface: input.surface || 'vitana_assistant',
+        },
+      },
+    );
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} person-focus memory write failed: ${err?.message}`);
+  }
+}

--- a/services/gateway/src/services/social-memory/social-memory-types.ts
+++ b/services/gateway/src/services/social-memory/social-memory-types.ts
@@ -1,0 +1,240 @@
+/**
+ * BOOTSTRAP-SOCIAL-MEMORY — Social Memory Intelligence types.
+ *
+ * The Social Context Pack is the assistant's live picture of the user's
+ * Maxina Community life: who they follow, who follows them, who they talk
+ * to, their matches (with scores and reasons), their group chats, ranked
+ * interesting posts/events, and — for person queries — a full Person
+ * Intelligence view.
+ *
+ * Table ground truth (verified against the live database 2026-07-03):
+ *   user_follows(follower_id, following_id, created_at)
+ *   daily_matches(user_id, matched_user_id, match_score, match_reasons,
+ *                 viewed_at, action, expires_at)
+ *   user_matches(user_id_1, user_id_2, compatibility_score, match_reason,
+ *                matched_at, conversation_started, is_active)
+ *   chat_messages(sender_id, receiver_id, group_id, content, created_at)
+ *   chat_groups(id, name, is_system) + chat_group_members(group_id, user_id)
+ *   profile_posts(user_id, content, is_public, likes_count, comments_count,
+ *                 image_url, video_url, moderation_status, created_at)
+ *   global_community_events(id, title, event_type, start_time, location,
+ *                           slug, participant_count)
+ *   global_event_participants(event_id, user_id, status)
+ *   global_community_groups / global_community_group_members
+ *   user_interests(user_id, interest, confidence_score)
+ *   user_blocked_authors / user_muted_authors / user_hidden_posts
+ *   profiles(user_id, display_name, handle, avatar_url, bio, city, country,
+ *            account_visibility, languages, vitana_id, ...)
+ *   profile_privacy_settings(user_id, searchable, show_full_name, ...)
+ */
+
+// =============================================================================
+// People
+// =============================================================================
+
+/** Privacy-safe public view of a person (never exposes email/phone/medical). */
+export interface SocialPerson {
+  user_id: string;
+  display_name: string | null;
+  handle: string | null;
+  vitana_id: string | null;
+  avatar_url: string | null;
+  bio: string | null;
+  city: string | null;
+  country: string | null;
+  /** profiles.account_visibility — 'private' profiles are name-only. */
+  visibility: string | null;
+}
+
+export interface FollowEdge {
+  person: SocialPerson;
+  since: string;
+}
+
+export interface RelationshipSummary {
+  following: FollowEdge[];
+  followers: FollowEdge[];
+  following_count: number;
+  followers_count: number;
+  /** user_ids present in both lists (mutuals). */
+  mutual_ids: string[];
+}
+
+// =============================================================================
+// Matches
+// =============================================================================
+
+export interface MatchSummary {
+  person: SocialPerson;
+  /** 0-100 score (daily_matches.match_score / user_matches.compatibility_score). */
+  score: number | null;
+  reasons: string[];
+  source: 'daily_match' | 'user_match';
+  matched_at: string | null;
+  /** daily_matches.action — accepted / rejected / null etc. */
+  action: string | null;
+  conversation_started: boolean;
+  is_current: boolean;
+}
+
+// =============================================================================
+// Messages / group chats
+// =============================================================================
+
+export interface MessageContact {
+  person: SocialPerson;
+  last_message_at: string;
+  last_direction: 'sent' | 'received';
+  /** Short, consent-gated snippet of the last message (never for other users). */
+  last_snippet: string | null;
+  messages_30d: number;
+}
+
+export interface GroupChatSummary {
+  group_id: string;
+  name: string | null;
+  member_count: number | null;
+  is_system: boolean;
+  last_message_at: string | null;
+  joined_at: string | null;
+}
+
+// =============================================================================
+// Posts / events (explainable ranking)
+// =============================================================================
+
+export interface RankedPost {
+  post_id: string;
+  author: SocialPerson;
+  snippet: string;
+  created_at: string;
+  media_type: 'text' | 'image' | 'video';
+  likes_count: number;
+  comments_count: number;
+  score: number;
+  reason: string[];
+}
+
+export interface RankedEvent {
+  event_id: string;
+  title: string;
+  event_type: string | null;
+  start_time: string;
+  location: string | null;
+  url: string | null;
+  participant_count: number | null;
+  followed_attendees: string[];
+  matched_attendees: string[];
+  score: number;
+  reason: string[];
+}
+
+// =============================================================================
+// Person Intelligence
+// =============================================================================
+
+export interface PersonContext {
+  person: SocialPerson;
+  /** Viewer-relative relationship flags. */
+  you_follow: boolean;
+  follows_you: boolean;
+  match: MatchSummary | null;
+  shared_interests: string[];
+  shared_groups: string[];
+  shared_events: string[];
+  latest_posts: Array<{ post_id: string; snippet: string; created_at: string; media_type: string }>;
+  upcoming_events: Array<{ event_id: string; title: string; start_time: string }>;
+  last_chat_at: string | null;
+  /** True when profile is private and viewer is not connected — data minimized. */
+  privacy_limited: boolean;
+  recommended_next_action: string | null;
+  /** One-paragraph relevance summary suitable for speech. */
+  relevance_summary: string;
+}
+
+export interface ActivityItem {
+  kind: 'post' | 'event_created' | 'event_joined' | 'group_joined' | 'group_post';
+  at: string;
+  summary: string;
+  ref_id: string | null;
+}
+
+export interface ActivityContext {
+  person: SocialPerson | null;
+  items: ActivityItem[];
+  window_days: number;
+}
+
+// =============================================================================
+// The Social Context Pack (assistant-context response shape)
+// =============================================================================
+
+export interface RecommendedAction {
+  action: string;
+  reason: string;
+  /** Optional deep-link route the frontend can navigate to. */
+  route: string | null;
+}
+
+export interface SocialContextPack {
+  user: SocialPerson | null;
+  relationships: RelationshipSummary;
+  matches: MatchSummary[];
+  messages: MessageContact[];
+  group_chats: GroupChatSummary[];
+  interesting_posts: RankedPost[];
+  interesting_events: RankedEvent[];
+  /** Present only when the question referenced a specific person. */
+  person_context: PersonContext | null;
+  /** Present only for "what did X do recently" / "what changed" questions. */
+  activity_context: ActivityContext | null;
+  memory_highlights: string[];
+  recommended_actions: RecommendedAction[];
+  assistant_system_hints: string[];
+  meta: {
+    built_at: string;
+    latency_ms: number;
+    sections_loaded: string[];
+    degraded_sections: string[];
+    privacy_filters_applied: string[];
+  };
+}
+
+// =============================================================================
+// Intent detection
+// =============================================================================
+
+export type SocialIntentKind =
+  | 'follows'
+  | 'followers'
+  | 'messages'
+  | 'group_chats'
+  | 'matches'
+  | 'person_query'
+  | 'person_activity'
+  | 'interesting_posts'
+  | 'interesting_events'
+  | 'who_to_contact'
+  | 'community_changes'
+  | 'general_social';
+
+export interface SocialIntentDecision {
+  is_social: boolean;
+  kinds: SocialIntentKind[];
+  /** Candidate person name extracted from the question, if any. */
+  person_hint: string | null;
+}
+
+export interface BuildSocialContextInput {
+  tenant_id: string;
+  user_id: string;
+  /** The user's question — drives which sections are emphasized. */
+  question?: string;
+  surface?: 'vitana_assistant' | 'maxina_community' | 'group_chat' | 'profile' | 'feed';
+  /** Explicit person target (endpoint /person/:userId). */
+  person_id?: string;
+  /** Compact mode caps list sizes for prompt injection. */
+  compact?: boolean;
+  /** Pre-computed intent (assistant path computes it once). */
+  intent?: SocialIntentDecision;
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -237,6 +237,8 @@ export type CicdEventType =
   | 'memory.orchestrator.context_built'
   | 'memory.orchestrator.turn'
   | 'memory.orchestrator.bypass_detected'
+  // BOOTSTRAP-SOCIAL-MEMORY: social memory intelligence layer
+  | 'memory.social.context_built'
   // VTID-01106: ORB Memory Bridge Events
   | 'orb.memory.context_fetched'
   | 'orb.memory.context_injected'

--- a/services/gateway/test/memory-social.test.ts
+++ b/services/gateway/test/memory-social.test.ts
@@ -1,0 +1,159 @@
+// BOOTSTRAP-SOCIAL-MEMORY — HTTP tests for the /api/v1/memory/social routes.
+//
+// Contract under test:
+//   - auth: 401 without a token on every endpoint
+//   - self-scoping: POST /assistant-context rejects a foreign userId (403)
+//     but accepts 'current-user' and the caller's own id
+//   - happy path: assistant-context returns the spec shape
+//   - person privacy: unknown person → 404
+
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (req.headers.authorization === 'Bearer user') {
+      req.identity = { user_id: 'user-1', tenant_id: 'tenant-1', exafy_admin: false };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'unauthenticated' });
+  },
+  requireTenant: (req: any, res: any, next: any) => {
+    if (!req.identity?.tenant_id) return res.status(400).json({ ok: false, error: 'TENANT_REQUIRED' });
+    return next();
+  },
+}));
+
+const EMPTY_PACK = {
+  user: { user_id: 'user-1', display_name: 'Test' },
+  relationships: { following: [], followers: [], following_count: 0, followers_count: 0, mutual_ids: [] },
+  matches: [],
+  messages: [],
+  group_chats: [],
+  interesting_posts: [],
+  interesting_events: [],
+  person_context: null,
+  activity_context: null,
+  memory_highlights: [],
+  recommended_actions: [],
+  assistant_system_hints: ['hint'],
+  meta: { built_at: '', latency_ms: 1, sections_loaded: [], degraded_sections: [], privacy_filters_applied: [] },
+};
+
+jest.mock('../src/services/social-memory/social-context-builder', () => ({
+  buildSocialContextPack: jest.fn().mockResolvedValue(EMPTY_PACK),
+}));
+jest.mock('../src/services/social-memory/person-context-builder', () => ({
+  buildPersonContext: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../src/services/social-memory/community-activity-builder', () => ({
+  buildPersonActivity: jest.fn().mockResolvedValue({ person: null, items: [], window_days: 14 }),
+}));
+jest.mock('../src/services/social-memory/social-memory-service', () => ({
+  buildAssistantSocialContext: jest.fn().mockResolvedValue({
+    ok: true,
+    intent: { is_social: true, kinds: ['matches'], person_hint: null },
+    pack: EMPTY_PACK,
+    prompt_block: '<social_context></social_context>',
+  }),
+}));
+jest.mock('../src/services/social-memory/social-memory-repository', () => ({
+  fetchExclusions: jest.fn().mockResolvedValue({ blocked: new Set(), muted: new Set(), hidden_posts: new Set() }),
+  fetchFollowEdges: jest.fn().mockResolvedValue({ following: [], followers: [] }),
+  fetchMatches: jest.fn().mockResolvedValue([]),
+  fetchRecentMessageContacts: jest.fn().mockResolvedValue([]),
+  fetchGroupChats: jest.fn().mockResolvedValue([]),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const router = require('../src/routes/memory-social').default;
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/memory/social', router);
+  return app;
+}
+
+describe('/api/v1/memory/social — auth', () => {
+  const endpoints = [
+    '/api/v1/memory/social/context/me',
+    '/api/v1/memory/social/following',
+    '/api/v1/memory/social/followers',
+    '/api/v1/memory/social/matches',
+    '/api/v1/memory/social/messages',
+    '/api/v1/memory/social/group-chats',
+    '/api/v1/memory/social/interesting-posts',
+    '/api/v1/memory/social/interesting-events',
+    '/api/v1/memory/social/person/abc',
+    '/api/v1/memory/social/activity/abc',
+  ];
+
+  it.each(endpoints)('401 without token: %s', async (path) => {
+    const r = await request(makeApp()).get(path);
+    expect(r.status).toBe(401);
+  });
+
+  it('401 without token on POST /assistant-context', async () => {
+    const r = await request(makeApp()).post('/api/v1/memory/social/assistant-context').send({});
+    expect(r.status).toBe(401);
+  });
+});
+
+describe('POST /assistant-context — self-scoping', () => {
+  it('403 for a foreign userId in the body', async () => {
+    const r = await request(makeApp())
+      .post('/api/v1/memory/social/assistant-context')
+      .set('Authorization', 'Bearer user')
+      .send({ userId: 'someone-else', question: 'Who do I follow?' });
+    expect(r.status).toBe(403);
+    expect(r.body.error).toBe('FORBIDDEN_USER_SCOPE');
+  });
+
+  it.each(['current-user', 'user-1', undefined])(
+    'accepts userId=%s and returns the spec shape',
+    async (userId) => {
+      const r = await request(makeApp())
+        .post('/api/v1/memory/social/assistant-context')
+        .set('Authorization', 'Bearer user')
+        .send({ userId, question: 'What matches do I have?', surface: 'vitana_assistant' });
+      expect(r.status).toBe(200);
+      expect(r.body.ok).toBe(true);
+      for (const key of [
+        'user', 'relationships', 'matches', 'messages', 'groupChats',
+        'interestingPosts', 'interestingEvents', 'personContext',
+        'activityContext', 'memoryHighlights', 'recommendedActions',
+        'assistantSystemHints',
+      ]) {
+        expect(r.body).toHaveProperty(key);
+      }
+      expect(r.body.intent.kinds).toContain('matches');
+    },
+  );
+});
+
+describe('GET endpoints — happy + not-found paths', () => {
+  it('GET /matches returns list shape', async () => {
+    const r = await request(makeApp())
+      .get('/api/v1/memory/social/matches')
+      .set('Authorization', 'Bearer user');
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({ ok: true, matches: [], count: 0 });
+  });
+
+  it('GET /person/:userId → 404 when person is unknown/blocked', async () => {
+    const r = await request(makeApp())
+      .get('/api/v1/memory/social/person/nope')
+      .set('Authorization', 'Bearer user');
+    expect(r.status).toBe(404);
+    expect(r.body.error).toBe('PERSON_NOT_FOUND');
+  });
+
+  it('GET /context/me returns the pack', async () => {
+    const r = await request(makeApp())
+      .get('/api/v1/memory/social/context/me')
+      .set('Authorization', 'Bearer user');
+    expect(r.status).toBe(200);
+    expect(r.body.relationships.following_count).toBe(0);
+  });
+});

--- a/services/gateway/test/services/memory-social-integration.test.ts
+++ b/services/gateway/test/services/memory-social-integration.test.ts
@@ -1,0 +1,368 @@
+// BOOTSTRAP-SOCIAL-MEMORY — INTEGRATION tests: memory orchestrator × social
+// context pack working IN COMBINATION.
+//
+// Unlike the unit suites, these tests run the REAL chain
+//   buildAssistantMemoryContext
+//     → detectSocialIntent → buildAssistantSocialContext
+//       → social-memory-repository → builders → rankers → prompt renderer
+//     → formatMemoryContextForPrompt (sentinel block assembly)
+// against a table-aware fake database, and assert on the FINAL prompt block
+// the LLM would receive plus the per-turn telemetry.
+//
+// Covered contracts:
+//   1. Social person question → ONE sentinel block containing BOTH personal
+//      memory sections AND <social_context> with person intelligence,
+//      goals still loaded, self-check last; telemetry social_loaded=true.
+//   2. "Wem folge ich?" / followers / matches questions render the right
+//      social sections with names, scores, and reasons.
+//   3. Non-social question → NO social fetch, telemetry social_loaded=false.
+//   4. Developer role → never receives community social context.
+//   5. Blocked person → person context absent (as if not found).
+//   6. Person-focus queries persist ONE meaningful memory via the existing
+//      write path (writeMemoryItemWithIdentity).
+
+jest.mock('../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+jest.mock('../../src/services/context-pack-builder', () => {
+  const actual = jest.requireActual('../../src/services/context-pack-builder');
+  return { ...actual, buildContextPack: jest.fn() };
+});
+
+jest.mock('../../src/services/memory-broker', () => ({
+  getMemoryContext: jest.fn().mockResolvedValue({
+    ok: true,
+    intent: 'community_intent',
+    blocks: { GOVERNANCE: { kind: 'GOVERNANCE', dismissals: [], pauses: [], source: '', fetched_at: '' } },
+    meta: {},
+  }),
+}));
+
+jest.mock('../../src/services/orb-memory-bridge', () => ({
+  writeMemoryItemWithIdentity: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+import { buildAssistantMemoryContext, MEMORY_CONTEXT_SENTINEL, MEMORY_CONTEXT_END_SENTINEL } from '../../src/services/memory-orchestrator';
+import { buildContextPack } from '../../src/services/context-pack-builder';
+import { getSupabase } from '../../src/lib/supabase';
+import { writeMemoryItemWithIdentity } from '../../src/services/orb-memory-bridge';
+import type { ContextPack } from '../../src/types/conversation';
+
+const mockedBuildContextPack = buildContextPack as jest.MockedFunction<typeof buildContextPack>;
+const mockedGetSupabase = getSupabase as jest.MockedFunction<any>;
+const mockedWriteMemory = writeMemoryItemWithIdentity as jest.MockedFunction<any>;
+
+// ---------------------------------------------------------------------------
+// Fixture identities
+// ---------------------------------------------------------------------------
+
+const ME = 'me-0000';
+const MARIIA = 'mariia-0000';
+const ANNA = 'anna-0000';
+const TENANT = 'tenant-0000';
+
+const PROFILES = [
+  { user_id: ME, display_name: 'Test User', handle: 'test', vitana_id: '@test', avatar_url: null, bio: null, city: 'Berlin', country: 'DE', account_visibility: null, full_name: 'Test User' },
+  { user_id: MARIIA, display_name: 'Mariia Maksina', handle: 'mariia', vitana_id: '@mariia', avatar_url: null, bio: 'Dance & longevity', city: 'Berlin', country: 'DE', account_visibility: null, full_name: 'Mariia Maksina' },
+  { user_id: ANNA, display_name: 'Anna Schmidt', handle: 'anna', vitana_id: '@anna', avatar_url: null, bio: null, city: 'Hamburg', country: 'DE', account_visibility: null, full_name: 'Anna Schmidt' },
+];
+
+/**
+ * Table-aware fake supabase: chainable query builder that records the table
+ * and selected columns, then resolves rows from the handler. Filters are not
+ * evaluated (queries are already user-scoped in the repository); direction-
+ * dependent reads (user_follows) are disambiguated by the SELECT column list.
+ */
+function makeFakeSupabase(overrides: Record<string, (select: string) => any[]> = {}) {
+  const tables: Record<string, (select: string) => any[]> = {
+    profiles: () => PROFILES,
+    profile_privacy_settings: () => [{ searchable: true }],
+    user_follows: (select) =>
+      select.includes('following_id')
+        ? [{ following_id: MARIIA, created_at: '2026-07-01T00:00:00Z', id: 'f1' }]
+        : [{ follower_id: ANNA, created_at: '2026-07-02T00:00:00Z', id: 'f2' }],
+    daily_matches: () => [
+      {
+        matched_user_id: ANNA,
+        match_score: '87.00',
+        match_reasons: ["You're both strong in Sleep"],
+        action: null,
+        expires_at: new Date(Date.now() + 86400000).toISOString(),
+        created_at: new Date().toISOString(),
+      },
+    ],
+    user_matches: () => [],
+    chat_messages: (select) =>
+      select === 'created_at'
+        ? [{ created_at: '2026-07-01T10:00:00Z' }]
+        : [
+            { sender_id: MARIIA, receiver_id: ME, content: 'Hallo! Kommst du zum Dance Event?', created_at: new Date().toISOString() },
+            { sender_id: ME, receiver_id: MARIIA, content: 'Ja, gerne!', created_at: new Date(Date.now() - 3600000).toISOString() },
+          ],
+    chat_group_members: (select) =>
+      select.includes('joined_at')
+        ? [{ group_id: 'g1', joined_at: '2026-06-01T00:00:00Z' }]
+        : [{ group_id: 'g1' }, { group_id: 'g1' }],
+    chat_groups: () => [{ id: 'g1', name: 'Maxina Fitness Chat', is_system: false }],
+    profile_posts: () => [
+      {
+        id: 'p1',
+        user_id: MARIIA,
+        content: 'New dance session for longevity fans this weekend!',
+        image_url: null,
+        video_url: null,
+        likes_count: 12,
+        comments_count: 3,
+        created_at: new Date(Date.now() - 7200000).toISOString(),
+      },
+    ],
+    global_community_events: () => [
+      {
+        id: 'e1',
+        title: 'Dance Night Berlin',
+        description: 'Dance and longevity meetup',
+        event_type: 'meetup',
+        start_time: new Date(Date.now() + 2 * 86400000).toISOString(),
+        location: 'Berlin',
+        slug: 'dance-night-berlin',
+        participant_count: 12,
+      },
+    ],
+    global_event_participants: () => [
+      { event_id: 'e1', user_id: MARIIA, status: 'registered', registered_at: new Date().toISOString() },
+    ],
+    global_community_group_members: () => [
+      { group_id: 'cg1', user_id: ME, joined_at: '2026-06-01T00:00:00Z' },
+      { group_id: 'cg1', user_id: MARIIA, joined_at: '2026-06-02T00:00:00Z' },
+    ],
+    global_community_groups: () => [{ id: 'cg1', name: 'Maxina Fitness' }],
+    user_interests: () => [
+      { user_id: ME, interest: 'dance', confidence_score: 0.9 },
+      { user_id: ME, interest: 'fitness', confidence_score: 0.8 },
+      { user_id: MARIIA, interest: 'dance', confidence_score: 0.9 },
+    ],
+    user_blocked_authors: () => [],
+    user_muted_authors: () => [],
+    user_hidden_posts: () => [],
+    life_compass: () => [{ primary_goal: 'Improve sleep quality', category: 'sleep' }],
+    user_preferences: () => [],
+    user_inferred_preferences: () => [],
+    ...overrides,
+  };
+
+  return {
+    from: (table: string) => {
+      let selectCols = '';
+      const chain: any = {};
+      chain.select = (cols: string) => {
+        selectCols = cols;
+        return chain;
+      };
+      for (const m of ['eq', 'in', 'or', 'gte', 'lt', 'is', 'neq', 'order', 'limit']) {
+        chain[m] = () => chain;
+      }
+      const resolve = () => {
+        const handler = tables[table];
+        return { data: handler ? handler(selectCols) : [], error: null };
+      };
+      chain.maybeSingle = async () => {
+        const r = resolve();
+        return { data: (r.data && r.data[0]) || null, error: null };
+      };
+      chain.then = (res: any, rej: any) => Promise.resolve(resolve()).then(res, rej);
+      return chain;
+    },
+  };
+}
+
+function makePack(): ContextPack {
+  return {
+    pack_id: 'pack-1',
+    pack_hash: 'hash',
+    assembled_at: new Date().toISOString(),
+    assembly_duration_ms: 5,
+    identity: { tenant_id: TENANT, user_id: ME, role: 'community', display_name: 'Test User' },
+    session_state: { thread_id: 't-1', channel: 'operator', turn_number: 1, conversation_start: new Date().toISOString() },
+    memory_hits: [
+      { id: 'f1', category_key: 'fact:self', content: 'preferred_language: German', importance: 95, occurred_at: new Date().toISOString(), source: 'system_observed', relevance_score: 1 },
+    ],
+    knowledge_hits: [],
+    web_hits: [],
+    active_vtids: [],
+    tenant_policies: [],
+    tool_health: [],
+    retrieval_trace: {
+      router_decision: { sources_to_query: ['memory_garden'], query_order: ['memory_garden'], limits: { memory_garden: 8, knowledge_hub: 0, web_search: 0, calendar: 0 }, matched_rule: 'test', decided_at: '', rationale: '' },
+      sources_queried: ['memory_garden'],
+      latencies: { memory_garden: 1, knowledge_hub: 0, web_search: 0, calendar: 0 },
+      hit_counts: { memory_garden: 1, knowledge_hub: 0, web_search: 0, calendar: 0 },
+    },
+    token_budget: { total_budget: 6000, used: 100, remaining: 5900 },
+  } as ContextPack;
+}
+
+const BASE = {
+  tenant_id: TENANT,
+  user_id: ME,
+  role: 'community',
+  channel: 'operator' as const,
+  thread_id: 't-1',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.MEMORY_ORCHESTRATOR_ENFORCEMENT;
+  mockedBuildContextPack.mockResolvedValue(makePack());
+  mockedGetSupabase.mockReturnValue(makeFakeSupabase());
+});
+
+// ---------------------------------------------------------------------------
+
+describe('orchestrator × social — combined prompt block', () => {
+  it('person question: ONE sentinel block with personal memory + social context + person intelligence + goals + self-check', async () => {
+    const result = await buildAssistantMemoryContext({
+      ...BASE,
+      message: 'Erzähl mir mehr über Mariia Maksina.',
+    });
+
+    const block = result.memory_prompt_block;
+    // One coherent block, correctly ordered.
+    expect(block.indexOf(MEMORY_CONTEXT_SENTINEL)).toBeGreaterThanOrEqual(0);
+    expect(block.indexOf('<social_context>')).toBeGreaterThan(block.indexOf(MEMORY_CONTEXT_SENTINEL));
+    expect(block.indexOf('MANDATORY SELF-CHECK')).toBeGreaterThan(block.indexOf('</social_context>'));
+    expect(block.indexOf(MEMORY_CONTEXT_END_SENTINEL)).toBeGreaterThan(block.indexOf('MANDATORY SELF-CHECK'));
+
+    // Personal memory still present alongside social.
+    expect(block).toContain('preferred_language: German');
+    expect(block).toContain('<user_goals>');
+    expect(block).toContain('Improve sleep quality');
+
+    // Person intelligence for Mariia with relationship + shared context.
+    expect(block).toContain('Person in focus — Mariia Maksina');
+    // The fake DB returns follow edges in both directions → mutual follow.
+    expect(block).toContain('you follow each other');
+    expect(block).toContain('Shared interests: dance');
+    expect(block).toContain('Shared groups: Maxina Fitness');
+    expect(block).toContain('New dance session for longevity fans');
+
+    // Telemetry proves the combination ran.
+    expect(result.telemetry.social_loaded).toBe(true);
+    expect(result.telemetry.social_intent_kinds).toContain('person_query');
+    expect(result.telemetry.goals_loaded).toBe(1);
+    expect(result.telemetry.memory_injected_to_prompt).toBe(true);
+  });
+
+  it('"Wem folge ich?" renders the follow list; "Wer folgt mir?" the followers', async () => {
+    const follows = await buildAssistantMemoryContext({ ...BASE, message: 'Wem folge ich eigentlich?' });
+    expect(follows.telemetry.social_loaded).toBe(true);
+    expect(follows.memory_prompt_block).toMatch(/Follows \(1\): Mariia Maksina/);
+
+    const followers = await buildAssistantMemoryContext({ ...BASE, message: 'Wer folgt mir?' });
+    expect(followers.memory_prompt_block).toMatch(/Followers \(1\): Anna Schmidt/);
+  });
+
+  it('matches question renders score + reasons and chat/group/event context', async () => {
+    const result = await buildAssistantMemoryContext({
+      ...BASE,
+      message: 'Welche Matches habe ich und welche Events sollte ich besuchen?',
+    });
+    const block = result.memory_prompt_block;
+    expect(block).toContain('Anna Schmidt (score 87)');
+    expect(block).toContain("You're both strong in Sleep");
+    expect(block).toContain('Dance Night Berlin');
+    expect(block).toContain('person you follow is attending');
+    expect(block).toContain('Link: https://vitanaland.com/e/dance-night-berlin');
+    expect(block).toContain('Maxina Fitness Chat');
+  });
+
+  it('anti-hallucination guidance is always attached to social turns', async () => {
+    const result = await buildAssistantMemoryContext({ ...BASE, message: 'Who should I contact today?' });
+    expect(result.memory_prompt_block).toContain('never invent people');
+    expect(result.memory_prompt_block).toContain('state the reason from the context');
+  });
+});
+
+describe('orchestrator × social — gating', () => {
+  it('non-social question: no social fetch, telemetry social_loaded=false', async () => {
+    const result = await buildAssistantMemoryContext({ ...BASE, message: 'Wie kann ich besser schlafen?' });
+    expect(result.telemetry.social_loaded).toBe(false);
+    expect(result.telemetry.social_intent_kinds).toEqual([]);
+    expect(result.memory_prompt_block).not.toContain('<social_context>');
+    // Personal memory unchanged.
+    expect(result.memory_prompt_block).toContain(MEMORY_CONTEXT_SENTINEL);
+    expect(result.memory_prompt_block).toContain('preferred_language: German');
+  });
+
+  it('developer role never receives community social context, even for social questions', async () => {
+    const result = await buildAssistantMemoryContext({
+      ...BASE,
+      role: 'developer',
+      message: 'Who follows me in the community?',
+    });
+    expect(result.telemetry.social_loaded).toBe(false);
+    expect(result.memory_prompt_block).not.toContain('<social_context>');
+  });
+});
+
+describe('orchestrator × social — privacy', () => {
+  it('blocked person: person context absent, as if not found', async () => {
+    mockedGetSupabase.mockReturnValue(
+      makeFakeSupabase({
+        user_blocked_authors: () => [{ author_id: MARIIA }],
+      }),
+    );
+    const result = await buildAssistantMemoryContext({
+      ...BASE,
+      message: 'Erzähl mir mehr über Mariia Maksina.',
+    });
+    expect(result.memory_prompt_block).not.toContain('Person in focus — Mariia Maksina');
+    // Blocked author's posts must not be recommended either.
+    expect(result.memory_prompt_block).not.toContain('New dance session for longevity fans');
+  });
+
+  it('private profile without relationship: name-only + explicit privacy instruction', async () => {
+    mockedGetSupabase.mockReturnValue(
+      makeFakeSupabase({
+        profiles: () =>
+          PROFILES.map((p) =>
+            p.user_id === MARIIA ? { ...p, account_visibility: 'private' } : p,
+          ),
+        // no follow edges, no matches, no chats → no relationship
+        user_follows: () => [],
+        daily_matches: () => [],
+        chat_messages: () => [],
+      }),
+    );
+    const result = await buildAssistantMemoryContext({
+      ...BASE,
+      message: 'Tell me more about Mariia Maksina.',
+    });
+    expect(result.memory_prompt_block).toContain('PRIVACY: profile is private');
+    expect(result.memory_prompt_block).toContain('do NOT speculate');
+  });
+});
+
+describe('orchestrator × social — meaningful memory persistence', () => {
+  it('person-focus question writes ONE network_relationships memory via the existing path', async () => {
+    await buildAssistantMemoryContext({ ...BASE, message: 'Erzähl mir mehr über Mariia Maksina.' });
+    // fire-and-forget → flush microtasks
+    await new Promise((r) => setImmediate(r));
+    expect(mockedWriteMemory).toHaveBeenCalledTimes(1);
+    const [identity, item] = mockedWriteMemory.mock.calls[0];
+    expect(identity).toEqual({ user_id: ME, tenant_id: TENANT });
+    expect(item.category_key).toBe('network_relationships');
+    expect(item.content).toContain('Mariia Maksina');
+    expect(item.content_json.person_id).toBe(MARIIA);
+  });
+
+  it('generic social questions do NOT write person-focus memory', async () => {
+    await buildAssistantMemoryContext({ ...BASE, message: 'Welche Events sollte ich besuchen?' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockedWriteMemory).not.toHaveBeenCalled();
+  });
+});

--- a/services/gateway/test/services/social-memory.test.ts
+++ b/services/gateway/test/services/social-memory.test.ts
@@ -1,0 +1,357 @@
+// BOOTSTRAP-SOCIAL-MEMORY — unit tests for the Social Memory Intelligence
+// layer: intent detection + person-hint extraction, explainable rankers,
+// prompt formatting (incl. privacy hints), and person-context privacy
+// minimization.
+
+import {
+  detectSocialIntent,
+  extractPersonHint,
+  formatSocialContextForPrompt,
+  buildAssistantSystemHints,
+} from '../../src/services/social-memory/social-memory-prompts';
+import {
+  rankInterestingPosts,
+  rankInterestingEvents,
+  extractTerms,
+  buildMatchScoreMap,
+} from '../../src/services/social-memory/social-memory-ranker';
+import { buildRelevanceSummary } from '../../src/services/social-memory/person-context-builder';
+import type {
+  SocialContextPack,
+  SocialPerson,
+  PersonContext,
+  MatchSummary,
+} from '../../src/services/social-memory/social-memory-types';
+
+function person(id: string, name: string): SocialPerson {
+  return {
+    user_id: id,
+    display_name: name,
+    handle: null,
+    vitana_id: null,
+    avatar_url: null,
+    bio: null,
+    city: null,
+    country: null,
+    visibility: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Intent detection — the acceptance-criteria questions must classify social
+// ---------------------------------------------------------------------------
+
+describe('detectSocialIntent', () => {
+  const socialQuestions: Array<[string, string]> = [
+    ['Who do I follow?', 'follows'],
+    ['Wem folge ich?', 'follows'],
+    ['Who follows me?', 'followers'],
+    ['Wer folgt mir?', 'followers'],
+    ['Who did I message recently?', 'messages'],
+    ['Which group chats am I part of?', 'group_chats'],
+    ['What matches do I have?', 'matches'],
+    ['What posts are interesting for me today?', 'interesting_posts'],
+    ['What events should I join?', 'interesting_events'],
+    ['Who should I contact today?', 'who_to_contact'],
+    ['What changed in my Maxina Community since yesterday?', 'community_changes'],
+  ];
+
+  it.each(socialQuestions)('classifies "%s" as social (%s)', (q, kind) => {
+    const d = detectSocialIntent(q);
+    expect(d.is_social).toBe(true);
+    expect(d.kinds).toContain(kind);
+  });
+
+  it('detects a person query with the person name extracted', () => {
+    const d = detectSocialIntent('Tell me more about Mariia Maksina.');
+    expect(d.is_social).toBe(true);
+    expect(d.kinds).toContain('person_query');
+    expect(d.person_hint).toBe('Mariia Maksina');
+  });
+
+  it('detects person activity queries', () => {
+    const d = detectSocialIntent('What did Mariia Maksina do recently?');
+    expect(d.kinds).toContain('person_activity');
+    expect(d.person_hint).toBe('Mariia Maksina');
+  });
+
+  it('does NOT classify non-social questions as social', () => {
+    for (const q of [
+      'How can I sleep better?',
+      'Was sollte ich heute Abend essen?',
+      'What is my Vitana Index?',
+    ]) {
+      expect(detectSocialIntent(q).is_social).toBe(false);
+    }
+  });
+});
+
+describe('extractPersonHint', () => {
+  it('extracts multi-word capitalized names', () => {
+    expect(extractPersonHint('Talk about Mariia Maksina latest activities')).toBe('Mariia Maksina');
+    expect(extractPersonHint('Erzähl mir etwas über Anna Schmidt bitte')).toBe('Anna Schmidt');
+  });
+
+  it('extracts single names after prepositions', () => {
+    expect(extractPersonHint('tell me about Mariia')).toBe('Mariia');
+    expect(extractPersonHint('was weißt du über Kemal?')).toBe('Kemal');
+  });
+
+  it('never mistakes platform words for names', () => {
+    expect(extractPersonHint('Tell me about Vitana Index')).toBeNull();
+    expect(extractPersonHint('What is the Maxina Community?')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rankers — explainable, relationship-signal-dominated
+// ---------------------------------------------------------------------------
+
+describe('rankInterestingPosts', () => {
+  const people = new Map([
+    ['followed-1', person('followed-1', 'Mariia')],
+    ['match-1', person('match-1', 'Anna')],
+    ['stranger-1', person('stranger-1', 'Random')],
+  ]);
+  const basePost = (id: string, author: string, content: string, hoursAgo = 1) => ({
+    id,
+    user_id: author,
+    content,
+    image_url: null,
+    video_url: null,
+    likes_count: 0,
+    comments_count: 0,
+    created_at: new Date(Date.now() - hoursAgo * 3600000).toISOString(),
+  });
+
+  const signals = {
+    viewer_id: 'me',
+    followed_ids: new Set(['followed-1']),
+    match_scores: new Map([['match-1', 87]]),
+    interests: ['fitness', 'dance'],
+    goal_terms: ['longevity'],
+    shared_group_counts: new Map<string, number>(),
+    people,
+  };
+
+  it('ranks followed authors above strangers and explains why', () => {
+    const ranked = rankInterestingPosts(
+      [
+        basePost('p1', 'stranger-1', 'A generic update'),
+        basePost('p2', 'followed-1', 'Morning walk'),
+      ],
+      signals,
+    );
+    expect(ranked[0].post_id).toBe('p2');
+    expect(ranked[0].reason).toContain('You follow this person');
+  });
+
+  it('boosts high-quality-match authors and interest/goal topics with reasons', () => {
+    const ranked = rankInterestingPosts(
+      [basePost('p3', 'match-1', 'New dance and fitness session for longevity fans')],
+      signals,
+    );
+    const r = ranked[0];
+    expect(r.reason).toEqual(
+      expect.arrayContaining([
+        'This author is one of your high-quality matches',
+        expect.stringContaining('Matches your interests'),
+        'This topic connects to your current goal',
+      ]),
+    );
+    expect(r.score).toBeGreaterThan(50);
+  });
+
+  it('every result carries at least one reason', () => {
+    const ranked = rankInterestingPosts([basePost('p4', 'stranger-1', 'hello world')], signals);
+    expect(ranked[0].reason.length).toBeGreaterThan(0);
+  });
+});
+
+describe('rankInterestingEvents', () => {
+  const people = new Map([['followed-1', person('followed-1', 'Mariia')]]);
+  const ev = (id: string, title: string, daysOut = 2) => ({
+    id,
+    title,
+    description: null,
+    event_type: null,
+    start_time: new Date(Date.now() + daysOut * 86400000).toISOString(),
+    location: 'Berlin',
+    slug: 'test-event',
+    participant_count: 10,
+  });
+
+  it('boosts events attended by followed people, with attendee names', () => {
+    const ranked = rankInterestingEvents([ev('e1', 'Dance Night')], {
+      viewer_id: 'me',
+      followed_ids: new Set(['followed-1']),
+      match_scores: new Map(),
+      interests: ['dance'],
+      goal_terms: [],
+      location_terms: ['berlin'],
+      participants: new Map([['e1', ['followed-1', 'other']]]),
+      people,
+    });
+    const r = ranked[0];
+    expect(r.reason).toEqual(
+      expect.arrayContaining([
+        '1 person you follow is attending',
+        expect.stringContaining('Matches your interests'),
+        'It is near you',
+      ]),
+    );
+    expect(r.followed_attendees).toEqual(['Mariia']);
+    expect(r.url).toBe('https://vitanaland.com/e/test-event');
+  });
+});
+
+describe('helpers', () => {
+  it('extractTerms produces lowercase significant words', () => {
+    expect(extractTerms('Improve Sleep Quality')).toEqual(
+      expect.arrayContaining(['improve', 'sleep', 'quality']),
+    );
+    expect(extractTerms(null)).toEqual([]);
+  });
+
+  it('buildMatchScoreMap maps person → score', () => {
+    const matches: MatchSummary[] = [
+      {
+        person: person('a', 'A'),
+        score: 87,
+        reasons: [],
+        source: 'daily_match',
+        matched_at: null,
+        action: null,
+        conversation_started: false,
+        is_current: true,
+      },
+    ];
+    expect(buildMatchScoreMap(matches).get('a')).toBe(87);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt formatting + privacy
+// ---------------------------------------------------------------------------
+
+function makePack(overrides: Partial<SocialContextPack> = {}): SocialContextPack {
+  return {
+    user: person('me', 'Test User'),
+    relationships: {
+      following: [{ person: person('f1', 'Mariia Maksina'), since: '2026-07-01' }],
+      followers: [],
+      following_count: 1,
+      followers_count: 0,
+      mutual_ids: [],
+    },
+    matches: [
+      {
+        person: person('m1', 'Anna'),
+        score: 87,
+        reasons: ["You're both strong in Sleep"],
+        source: 'daily_match',
+        matched_at: null,
+        action: null,
+        conversation_started: false,
+        is_current: true,
+      },
+    ],
+    messages: [],
+    group_chats: [],
+    interesting_posts: [],
+    interesting_events: [],
+    person_context: null,
+    activity_context: null,
+    memory_highlights: [],
+    recommended_actions: [
+      { action: 'Say hello to Anna', reason: 'Match score 87', route: '/matches' },
+    ],
+    assistant_system_hints: [],
+    meta: {
+      built_at: new Date().toISOString(),
+      latency_ms: 5,
+      sections_loaded: [],
+      degraded_sections: [],
+      privacy_filters_applied: [],
+    },
+    ...overrides,
+  };
+}
+
+describe('formatSocialContextForPrompt', () => {
+  it('renders follows, matches with scores/reasons, and recommended actions', () => {
+    const pack = makePack();
+    pack.assistant_system_hints = buildAssistantSystemHints(pack);
+    const block = formatSocialContextForPrompt(pack);
+    expect(block).toContain('<social_context>');
+    expect(block).toContain('Mariia Maksina');
+    expect(block).toContain('Anna (score 87)');
+    expect(block).toContain("You're both strong in Sleep");
+    expect(block).toContain('Say hello to Anna');
+    expect(block).toContain('never invent people');
+  });
+
+  it('emits a hard privacy instruction for privacy-limited person context', () => {
+    const pc: PersonContext = {
+      person: person('p1', 'Private Person'),
+      you_follow: false,
+      follows_you: false,
+      match: null,
+      shared_interests: [],
+      shared_groups: [],
+      shared_events: [],
+      latest_posts: [],
+      upcoming_events: [],
+      last_chat_at: null,
+      privacy_limited: true,
+      recommended_next_action: null,
+      relevance_summary: 'Private Person keeps their profile private, so only limited information is available.',
+    };
+    const block = formatSocialContextForPrompt(makePack({ person_context: pc }));
+    expect(block).toContain('PRIVACY: profile is private');
+    expect(block).toContain('do NOT speculate');
+  });
+});
+
+describe('buildRelevanceSummary', () => {
+  const baseCtx = (over: Partial<PersonContext>): PersonContext => ({
+    person: person('p1', 'Mariia Maksina'),
+    you_follow: true,
+    follows_you: false,
+    match: {
+      person: person('p1', 'Mariia Maksina'),
+      score: 87,
+      reasons: ["You're both strong in Sleep"],
+      source: 'daily_match',
+      matched_at: null,
+      action: null,
+      conversation_started: false,
+      is_current: true,
+    },
+    shared_interests: ['fitness', 'dance'],
+    shared_groups: ['Maxina Fitness'],
+    shared_events: [],
+    latest_posts: [{ post_id: 'x', snippet: 'hi', created_at: '2026-07-01', media_type: 'text' }],
+    upcoming_events: [],
+    last_chat_at: null,
+    privacy_limited: false,
+    recommended_next_action: 'Open her profile.',
+    relevance_summary: '',
+    ...over,
+  });
+
+  it('produces the spec-style relevance narrative with next action', () => {
+    const s = buildRelevanceSummary(baseCtx({}));
+    expect(s).toContain('Mariia Maksina is relevant to you because');
+    expect(s).toContain('you follow them');
+    expect(s).toContain('87-point match');
+    expect(s).toContain('fitness, dance');
+    expect(s).toContain('Best next step: Open her profile.');
+  });
+
+  it('says details are limited for private profiles', () => {
+    const s = buildRelevanceSummary(baseCtx({ privacy_limited: true }));
+    expect(s).toContain('private');
+    expect(s).not.toContain('87-point');
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-SOCIAL-MEMORY`

**Layer:** AGTL (gateway assistant intelligence)

**Priority:** P1

---

## 📋 Summary

Vitana must not answer social/community questions from generic knowledge. This PR adds the **Social Memory Intelligence layer**: before answering anything about people, matches, messages, groups, posts, or events, the assistant retrieves the user's **live Maxina Community context** and reasons from it — with explainable recommendations ("because you follow her…", "3 people you follow are attending") and next-best-action guidance.

Builds directly on the mandatory Memory Orchestrator (#2830/#2831): the social pack is injected **inside** the `USER MEMORY CONTEXT` block, so the existing self-check rules (weave don't recite, current message wins, never re-offer dismissed) govern it automatically. No new parallel path.

All table names were verified against the **live production database** (the code-level `matches_daily` does not exist; the populated sources are `daily_matches`, `user_follows`, `chat_messages`, `profile_posts`, `global_community_events`, etc.).

---

## ✅ Changes

- [x] New module `services/gateway/src/services/social-memory/` (8 files, kebab-case per Phase 2B): types grounded in live schema, repository with **explicit privacy filters** (service-role client → blocked/muted authors, hidden posts, public-posts-only, own-conversations-only, tenant scope enforced in code), parallel context builder with per-section degradation, Person Intelligence builder (relationship flags, match score+reasons, shared interests/groups/events, latest public posts, last chat, recommended next action, speech-ready relevance summary — private profiles minimized to name-only, blocked people return not-found), person/network activity builder, explainable post+event rankers, DE+EN social intent classifier + person-name extraction (incl. umlaut word-boundary fix), prompt renderer with anti-hallucination hints
- [x] Gateway endpoints `routes/memory-social.ts` at `/api/v1/memory/social` (`requireAuth`+`requireTenant`, strictly self-scoped from JWT — body `userId` other than `current-user`/self → 403): `GET context/me | following | followers | matches | messages | group-chats | interesting-posts | interesting-events | person/:userId | activity/:personId`, `POST assistant-context` (spec response shape)
- [x] Assistant integration in `memory-orchestrator.ts`: per-turn social intent detection; social pack fetched in parallel and injected into the memory prompt block; **community surfaces only** (dev/admin never receive community social context, VTID-03183 spirit); telemetry gains `social_loaded` + `social_intent_kinds`
- [x] Meaningful-moment memory persistence only (person-focus queries → `memory_items` category `network_relationships` via existing `writeMemoryItemWithIdentity`; never for privacy-limited profiles)
- [x] `memory.social.context_built` OASIS event (counts only — no names/content, logs cannot leak private data)

---

## 🧪 Testing

- [x] New `test/services/social-memory.test.ts` (27 tests): all acceptance-criteria questions classify as social (EN+DE), person extraction ("Talk about Mariia Maksina latest activities" → `Mariia Maksina`), ranker reasons/ordering (followed-author dominance, high-quality-match boost, interest/goal/location reasons), prompt privacy instructions for private profiles, relevance-summary narrative
- [x] Memory-orchestrator suite still green (31) — non-social turns unchanged
- [x] Full gateway suite: 6,215 passed; only pre-existing `nav-manifest-sync` env failure
- [x] `tsc --noEmit` clean
- [ ] Staging verification post-merge: live turns "Wem folge ich?", "Welche Matches habe ich?", "Erzähl mir von Mariia Maksina", "Was hat sich seit gestern getan?" + telemetry `social_loaded=true`

---

## 📝 Phase 2B Naming Compliance Checklist

- [x] All new files kebab-case; no workflow changes; event topic `memory.social.context_built` snake/dot case; no Command Hub frontend files touched

---

## 🚨 Breaking Changes

None. Non-social turns are byte-identical (social fetch only fires on social intent, community role). Social sections degrade independently — a failing stream never blocks the reply.

---

## 👀 Reviewers

@exafyltd

---

## 📌 Additional Notes

- **Frontend follow-up (vitana-v1):** Social Memory Panel, Person Intelligence Card, Interesting Today card, and memory-permission settings are UI work in the frontend repo; every data element they need is already served by these endpoints (`assistantSystemHints`, `recommendedActions`, `personContext`, ranked lists with `reason[]`).
- **Block/mute ground truth:** the live tables `user_blocked_authors` / `user_muted_authors` / `user_hidden_posts` (frontend-owned, RLS) are honored on every read; the gateway code map previously assumed these didn't exist.
- Example answer the layer now supports: *"Mariia Maksina is relevant to you because you follow them, they are a 87-point match for you (you're both strong in sleep), you share interests around fitness, dance. Best next step: Send a first message — you matched but never talked."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDeWcwo8qwBnCdr2h48Fy9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDeWcwo8qwBnCdr2h48Fy9)_