### PR TITLE
BOOTSTRAP-GREETING-CONTINUITY: spoken-facts ledger — greetings speak deltas, never repeat levels

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -624,6 +624,36 @@ export function createUpstreamLiveMessageHandler(
               const fullTranscript = session.outputTranscriptBuffer.trim();
               chatBridgeAssistantText = fullTranscript;
 
+              // Greeting-facts ledger: capture Vitana's FIRST spoken turn of
+              // the session so the NEXT session's opener gets it as a
+              // wording-variety negative example (rule 2: never greet with
+              // the same wording twice in a row). Fire-and-forget; must
+              // never block the voice path.
+              const isFirstAssistantTurn = !session.transcriptTurns.some(
+                (t) => t.role === 'assistant',
+              );
+              if (
+                isFirstAssistantTurn &&
+                session.identity?.tenant_id &&
+                session.identity?.user_id
+              ) {
+                const _gflTenant = session.identity.tenant_id;
+                const _gflUser = session.identity.user_id;
+                const _gflSb = getSupabase();
+                if (_gflSb) {
+                  import('../../../services/conversation/greeting-facts-ledger')
+                    .then(({ recordGreetingUtterance }) =>
+                      recordGreetingUtterance({
+                        supabase: _gflSb,
+                        tenantId: _gflTenant,
+                        userId: _gflUser,
+                        utterance: fullTranscript,
+                      }),
+                    )
+                    .catch(() => { /* continuity is best-effort */ });
+                }
+              }
+
               // Forwarding v2d: the FORCED FIRST UTTERANCE flag MUST flip even
               // for the greeting turn — that IS the forced utterance. Setting
               // it inside the `else` branch (greeting-turn = false) was the

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7752,6 +7752,21 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                 const { gatherOverviewPayload } = await import('../services/assistant-continuation/providers/new-day-overview-payload');
                 const { buildNewDayOverviewBlock } = await import('../services/assistant-continuation/providers/new-day-overview-prompt');
                 const { todayInTimezone, localHourInTimezone } = await import('../services/assistant-continuation/providers/new-day-return');
+                // Spoken-facts continuity (greeting-facts ledger): what did we
+                // ALREADY tell this user? Read in parallel with the payload
+                // gather; bounded + fail-open so it can never delay or silence
+                // the greeting.
+                const {
+                  readGreetingLedger,
+                  computeFactDeltas,
+                  extractSpokenFactsFromPayload,
+                  recordGreetingFacts,
+                  EMPTY_GREETING_LEDGER,
+                } = await import('../services/conversation/greeting-facts-ledger');
+                const _tenantNd = session.identity?.tenant_id ?? null;
+                const _ledgerPromiseNd = _tenantNd
+                  ? readGreetingLedger({ supabase: _supaNd, tenantId: _tenantNd, userId: _uidNd })
+                  : Promise.resolve({ ...EMPTY_GREETING_LEDGER });
                 // Last session's LOCAL date (YYYY-MM-DD) bounds the "since last
                 // session" calendar lookback. Derive it from the pre-fetched
                 // last-session timestamp; null falls back to a 24h window inside
@@ -7794,12 +7809,23 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                     _overview.messages_unread > 0 ||
                     _overview.reminders_today.count > 0);
                 if (_overview && _hasContent) {
+                  const _ledgerNd = await Promise.race([
+                    _ledgerPromiseNd,
+                    new Promise<typeof EMPTY_GREETING_LEDGER>((r) =>
+                      setTimeout(() => r({ ...EMPTY_GREETING_LEDGER }), 800),
+                    ),
+                  ]).catch(() => ({ ...EMPTY_GREETING_LEDGER }));
+                  const _spokenFactsNd = extractSpokenFactsFromPayload(_overview);
+                  const _deltasNd = computeFactDeltas(_spokenFactsNd, _ledgerNd);
                   const _block = buildNewDayOverviewBlock({
                     payload: _overview,
                     lang: greetLang,
                     firstName: _firstNameNd.trim(),
                     localHour: localHourInTimezone(_nowNd, _tzNd),
                     timezone: _tzNd,
+                    factDeltas: _deltasNd,
+                    previousUtterance: _ledgerNd.last_utterance,
+                    sessionsToday: _ledgerNd.sessions_today,
                   });
                   if (_block && _block.trim().length > 0) {
                     ws.send(
@@ -7818,6 +7844,16 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                       .update({ last_full_briefing_date: _todayNd })
                       .eq('user_id', _uidNd)
                       .then(() => {}, () => {});
+                    // Ledger write: these facts are now "told" — the next
+                    // opener speaks deltas, not the same levels again.
+                    if (_tenantNd && Object.keys(_spokenFactsNd).length > 0) {
+                      void recordGreetingFacts({
+                        supabase: _supaNd,
+                        tenantId: _tenantNd,
+                        userId: _uidNd,
+                        facts: _spokenFactsNd,
+                      });
+                    }
                     emitDiag(session, 'greeting_sent', {
                       lang,
                       prompt_len: _block.length,
@@ -7943,6 +7979,20 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                     const _nowR = new Date();
                     const { gatherOverviewPayload } = await import('../services/assistant-continuation/providers/new-day-overview-payload');
                     const { todayInTimezone } = await import('../services/assistant-continuation/providers/new-day-return');
+                    // Spoken-facts continuity — same ledger the daily briefing
+                    // uses, so a reopen never re-announces the counts the
+                    // briefing already spoke this morning.
+                    const {
+                      readGreetingLedger,
+                      computeFactDeltas,
+                      extractSpokenFactsFromPayload,
+                      recordGreetingFacts,
+                      EMPTY_GREETING_LEDGER,
+                    } = await import('../services/conversation/greeting-facts-ledger');
+                    const _tenantR = session.identity?.tenant_id ?? null;
+                    const _ledgerPromiseR = _tenantR
+                      ? readGreetingLedger({ supabase: _supaR, tenantId: _tenantR, userId: _uidR })
+                      : Promise.resolve({ ...EMPTY_GREETING_LEDGER });
                     const _lastSessIsoR = (session as any).lastSessionInfo?.time ?? null;
                     const _lastSessDateR =
                       typeof _lastSessIsoR === 'string' && _lastSessIsoR.length > 0
@@ -7966,6 +8016,14 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                     const _recentNbaKeysR = Array.isArray((session as any).recentNbaKeys)
                       ? ((session as any).recentNbaKeys as string[])
                       : [];
+                    const _ledgerR = await Promise.race([
+                      _ledgerPromiseR,
+                      new Promise<typeof EMPTY_GREETING_LEDGER>((r) =>
+                        setTimeout(() => r({ ...EMPTY_GREETING_LEDGER }), 800),
+                      ),
+                    ]).catch(() => ({ ...EMPTY_GREETING_LEDGER }));
+                    const _spokenFactsR = extractSpokenFactsFromPayload(_payloadR);
+                    const _deltasR = computeFactDeltas(_spokenFactsR, _ledgerR);
                     const { text: _dirR, nba: _nbaR } = buildResumeDirective({
                       register: _registerR,
                       payload: _payloadR,
@@ -7977,6 +8035,9 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                       // Screen awareness: deepen toward completing the action on
                       // the screen the user is already on, never redirect there.
                       currentScreen: (session as any).current_route ?? null,
+                      factDeltas: _deltasR,
+                      previousUtterance: _ledgerR.last_utterance,
+                      sessionsToday: _ledgerR.sessions_today,
                     });
                     // CONTINUE/quick_resume can speak with no payload (pure
                     // thread continuation); same_day needs at least the NBA or a
@@ -8002,6 +8063,17 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
                           .update({ recent_nbas: _updatedNbas })
                           .eq('user_id', _uidR)
                           .then(() => {}, () => {});
+                      }
+                      // Ledger write — the reopen surfaced these facts (as
+                      // deltas or soft references); refresh their spoken_at so
+                      // the next open still treats stable levels as known.
+                      if (_tenantR && Object.keys(_spokenFactsR).length > 0) {
+                        void recordGreetingFacts({
+                          supabase: _supaR,
+                          tenantId: _tenantR,
+                          userId: _uidR,
+                          facts: _spokenFactsR,
+                        });
                       }
                       emitDiag(session, 'greeting_sent', {
                         lang,

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
@@ -33,6 +33,11 @@
 
 import { VERTEX_WAKE_BRIEF_OVERRIDE_MARKER } from '../../../orb/live/instruction/wake-brief-marker';
 import type { OverviewPayload } from './new-day-overview-payload';
+import {
+  buildFactContinuityLines,
+  buildPreviousGreetingSection,
+  type FactDelta,
+} from '../../conversation/greeting-facts-ledger';
 
 export interface BuildOverviewBlockArgs {
   payload: OverviewPayload;
@@ -40,6 +45,12 @@ export interface BuildOverviewBlockArgs {
   firstName: string | null;
   localHour: number;
   timezone: string;
+  /** Spoken-facts continuity (greeting-facts ledger). Absent → legacy behavior. */
+  factDeltas?: Record<string, FactDelta>;
+  /** Vitana's previous first utterance — wording-variety negative example. */
+  previousUtterance?: string | null;
+  /** How many sessions the user already opened today (0/unknown → omit). */
+  sessionsToday?: number | null;
 }
 
 function timeOfDay(localHour: number): 'morning' | 'afternoon' | 'evening' {
@@ -94,7 +105,21 @@ export function buildNewDayOverviewBlock(args: BuildOverviewBlockArgs): string {
   const compact = compactPayloadForPrompt(args.payload);
   const payloadJson = JSON.stringify(compact, null, 2);
   const shapeExample = buildShapeExample(langCode);
-  const coverageChecklist = buildCoverageChecklist(args.payload);
+  const deltas = args.factDeltas ?? {};
+  const coverageChecklist = buildCoverageChecklist(args.payload, deltas);
+  const continuityLines = buildFactContinuityLines(deltas);
+  const continuitySection = continuityLines.length
+    ? `\n## ALREADY-SPOKEN FACTS — CONTINUITY RULES (rule 1: never repeat updates)\n\n` +
+      `You have greeted this user before. The ledger below says which numbers ` +
+      `they have ALREADY heard from you. An unchanged number is NOT news — ` +
+      `restating it makes you sound like a machine reading the same dashboard ` +
+      `every day. Speak deltas; let stable facts rest.\n\n${continuityLines.join('\n')}\n`
+    : '';
+  const previousGreetingSection = buildPreviousGreetingSection(args.previousUtterance ?? null);
+  const sessionsTodayLine =
+    typeof args.sessionsToday === 'number' && args.sessionsToday > 0
+      ? `Sessions the user already opened today: ${args.sessionsToday}`
+      : null;
 
   return `\n\n${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}
 
@@ -131,10 +156,17 @@ ${langCode}. Speak in the user's language. Do not switch mid-message.
 If the payload contains the user's own goal text, use their exact
 wording verbatim — the goal is their words, not yours.
 
+## SITUATION — LET THIS SHAPE THE OPENING, NOT A SCRIPT
+
+The situation decides how the greeting sounds. A quiet late evening is
+not a bright morning; a first session after days away is not a routine
+morning check-in. Read the situation, then compose for it.
+
 ${nameLine}
 Local time-of-day bucket: ${tod}
-Local timezone: ${args.timezone}
-
+Local hour: ${args.localHour}
+Local timezone: ${args.timezone}${sessionsTodayLine ? `\n${sessionsTodayLine}` : ''}
+${continuitySection}${previousGreetingSection}
 ## SHAPE EXAMPLE — IMITATE THE TEXTURE AND BREADTH, NEVER THE CONTENT
 
 The example below is in a TOTALLY DIFFERENT domain (Anna, meditation
@@ -159,6 +191,11 @@ the checklist, you have failed the contract — expand. Two-sentence
 greetings are forbidden.
 
 ## THE TEN COMPOSITION MOVES (NON-NEGOTIABLE)
+
+Quoted phrases inside these rules illustrate the INTENT of a move — they
+are NOT fixed wording. Compose every sentence freshly, in your own words,
+differently from any previous greeting. Copying an example phrase verbatim
+two days in a row is a contract failure.
 
 1. WARMTH BEFORE FACTS. Open with the time-of-day salutation in
    ${langCode} + the user's first name (if known) + ONE warmth
@@ -344,8 +381,15 @@ Subsequent turns follow the normal conversation flow.`;
 // inventory of things it must address before stopping.
 // ---------------------------------------------------------------------------
 
-function buildCoverageChecklist(p: OverviewPayload): string {
+function buildCoverageChecklist(
+  p: OverviewPayload,
+  deltas: Record<string, FactDelta> = {},
+): string {
   const items: string[] = [];
+  // Spoken-facts continuity: a number the user already heard (unchanged)
+  // must not be restated; a changed number is spoken as its change.
+  const status = (key: string) => deltas[key]?.status ?? 'new';
+  const changeOf = (key: string) => deltas[key]?.delta ?? null;
 
   if (p.journey) {
     const j = p.journey;
@@ -388,9 +432,19 @@ function buildCoverageChecklist(p: OverviewPayload): string {
     const nextClause = g.next_session_title
       ? `Their next session is "${g.next_session_title}".`
       : 'Offer the next session.';
+    // Momentum beat is LEDGER-CONDITIONAL: the running total is only news
+    // the first time (or when it moved). An unchanged count restated every
+    // morning is the robotic repeat the user reported.
+    const sessStatus = status('sessions_completed');
+    const momentumLine =
+      sessStatus === 'unchanged'
+        ? `    • MOMENTUM: the user ALREADY KNOWS they have completed ${g.sessions_completed} sessions (${topicsClause}) — you told them and nothing changed. Do NOT restate the count. Carry the momentum without numbers (the thread, not the tally).\n`
+        : sessStatus === 'changed' && (changeOf('sessions_completed') ?? 0) > 0
+          ? `    • MOMENTUM: the user completed ${changeOf('sessions_completed')} more session(s) since you last mentioned it (now ${g.sessions_completed} total, ${topicsClause}). Speak the ADVANCE — the progress since last time is the news, not the running total.\n`
+          : `    • MOMENTUM: the user has completed ${g.sessions_completed} guided sessions (${topicsClause}). You may state this once, concretely — compose the sentence yourself.\n`;
     items.push(
-      `- [ ] ADDRESS (guided journey — speak BOTH of these, do not drop them):\n` +
-        `    • MOMENTUM: the user has completed ${g.sessions_completed} guided sessions (${topicsClause}). Say this concretely as a NUMBER — e.g. "du hast schon ${g.sessions_completed} Sessions geschafft".\n` +
+      `- [ ] ADDRESS (guided journey):\n` +
+        momentumLine +
         `    • NEXT SESSION (named, never generic "next step"): ${nextClause} Name it and offer to do it together.${recallHint}\n` +
         `    (This learning beat is what makes the briefing feel like a continuing journey — it is NOT optional when the user is in the guided curriculum.)`,
     );
@@ -403,7 +457,11 @@ function buildCoverageChecklist(p: OverviewPayload): string {
     const trendHint = p.vitana_index.trend_7d !== null
       ? ` 7-day trend: ${p.vitana_index.trend_7d >= 0 ? '+' : ''}${p.vitana_index.trend_7d}.`
       : '';
-    items.push(`- [ ] ADDRESS: Vitana Index ${p.vitana_index.today} (${p.vitana_index.tier ?? 'tier unknown'}, ${p.vitana_index.balance_label ?? 'balance unknown'}).${pillarHint}${trendHint} (Rule 3 — pair number with meaning + pillar attribution.)`);
+    const idxHint =
+      status('vitana_index') === 'unchanged'
+        ? ' NOTE: the Index value is UNCHANGED since you last told the user — do not announce the number as news; interpret the stability ("dein Index hält sich stabil") or what drives it instead.'
+        : '';
+    items.push(`- [ ] ADDRESS: Vitana Index ${p.vitana_index.today} (${p.vitana_index.tier ?? 'tier unknown'}, ${p.vitana_index.balance_label ?? 'balance unknown'}).${pillarHint}${trendHint} (Rule 3 — pair number with meaning + pillar attribution.)${idxHint}`);
   } else {
     items.push(`- [ ] ADDRESS: Vitana Index is NOT SET UP — invite the user to set it up together (Rule 6, P2).`);
   }
@@ -435,11 +493,33 @@ function buildCoverageChecklist(p: OverviewPayload): string {
   }
 
   if (p.matches_unread > 0) {
-    items.push(`- [ ] ADDRESS: ${p.matches_unread} unread match notification(s) — offer to look together. (P2.)`);
+    const s = status('matches_unread');
+    if (s === 'unchanged') {
+      items.push(
+        `- [ ] OPTIONAL: the user already knows about their ${p.matches_unread} open match(es) (unchanged since last mentioned). Do NOT restate the count; mention matches only number-free if you connect them to something new.`,
+      );
+    } else if (s === 'changed' && (changeOf('matches_unread') ?? 0) > 0) {
+      items.push(
+        `- [ ] ADDRESS: ${changeOf('matches_unread')} NEW match(es) since you last mentioned it — speak the new ones, not the total. Offer to look together. (P2.)`,
+      );
+    } else {
+      items.push(`- [ ] ADDRESS: ${p.matches_unread} unread match notification(s) — offer to look together. (P2.)`);
+    }
   }
 
   if (p.messages_unread > 0) {
-    items.push(`- [ ] ADDRESS: ${p.messages_unread} unread message(s) — count only, NEVER quote content. (P2.)`);
+    const s = status('messages_unread');
+    if (s === 'unchanged') {
+      items.push(
+        `- [ ] OPTIONAL: the user already knows about their ${p.messages_unread} unread message(s) (unchanged since last mentioned). Do NOT restate the count. At most a soft, number-free nod ("deine Nachrichten warten noch") — or skip it entirely.`,
+      );
+    } else if (s === 'changed' && (changeOf('messages_unread') ?? 0) > 0) {
+      items.push(
+        `- [ ] ADDRESS: ${changeOf('messages_unread')} NEW message(s) arrived since you last mentioned the inbox — speak the new ones ("${changeOf('messages_unread')} neue seit …"), never the running total. Count only, NEVER quote content. (P2.)`,
+      );
+    } else {
+      items.push(`- [ ] ADDRESS: ${p.messages_unread} unread message(s) — count only, NEVER quote content. (P2.)`);
+    }
   }
 
   if (p.reminders_today.count > 0 && p.reminders_today.next) {

--- a/services/gateway/src/services/conversation/decide-opening.ts
+++ b/services/gateway/src/services/conversation/decide-opening.ts
@@ -31,6 +31,7 @@ import type { OverviewPayload } from '../assistant-continuation/providers/new-da
 import type { TemporalBucket } from '../guide/temporal-bucket';
 import { selectNextBestAction, type NextBestAction, type NbaKey } from './next-best-action';
 import { surfaceForRoute, screenCompletionFor } from './screen-surface';
+import { buildPreviousGreetingSection, type FactDelta } from './greeting-facts-ledger';
 
 export type OpeningRegister =
   | 'first_time'
@@ -85,6 +86,15 @@ export interface ResumeDirectiveInput {
    *  maps to an actionable surface, the next step DEEPENS toward completing the
    *  action there instead of redirecting the user away. */
   currentScreen?: string | null;
+  /** Spoken-facts continuity from the greeting-facts ledger. When present,
+   *  `new_since_last` carries ONLY genuinely-new deltas (never a level the
+   *  user already heard) and unchanged facts move to `already_mentioned`. */
+  factDeltas?: Record<string, FactDelta>;
+  /** Vitana's previous first utterance — handed to the model as a
+   *  wording-variety negative example (rule 2: never repeat the greeting). */
+  previousUtterance?: string | null;
+  /** How many sessions the user already opened today (context, rule 4). */
+  sessionsToday?: number | null;
 }
 
 export interface ResumeDirective {
@@ -127,12 +137,35 @@ export function buildResumeDirective(input: ResumeDirectiveInput): ResumeDirecti
   const rawRecall = payload?.guided_journey?.last_session_recall ?? null;
   const nextSessionTitle = payload?.guided_journey?.next_session_title ?? null;
   const recall = rawRecall && rawRecall !== nextSessionTitle ? rawRecall : null;
+
+  // "What's new" must be NEWS. Without the ledger, a level (10 unread all
+  // day) was re-announced on every reopen as "new since earlier" — the
+  // exact robotic repeat the user reported. With deltas: unchanged counts
+  // move to `already_mentioned` (present but forbidden to restate); changed
+  // counts are phrased as their CHANGE; only never-mentioned facts may
+  // appear as plain counts.
+  const deltas = input.factDeltas ?? null;
   const newBits: string[] = [];
-  if (payload) {
-    if (payload.matches_unread > 0) newBits.push(`${payload.matches_unread} new match(es)`);
-    if (payload.messages_unread > 0) newBits.push(`${payload.messages_unread} unread message(s)`);
-    if (payload.reminders_today && payload.reminders_today.count > 0) newBits.push(`${payload.reminders_today.count} reminder(s) due today`);
-  }
+  const alreadyMentioned: string[] = [];
+  const pushBit = (key: string, plainLabel: (n: number) => string, deltaLabel: (d: number) => string) => {
+    if (!payload) return;
+    const d = deltas?.[key];
+    const current =
+      key === 'reminders_today' ? payload.reminders_today?.count ?? 0 :
+      key === 'matches_unread' ? payload.matches_unread :
+      payload.messages_unread;
+    if (!current || current <= 0) return;
+    if (!d || d.status === 'new') {
+      newBits.push(plainLabel(current));
+    } else if (d.status === 'changed' && (d.delta ?? 0) > 0) {
+      newBits.push(deltaLabel(d.delta as number));
+    } else {
+      alreadyMentioned.push(plainLabel(current));
+    }
+  };
+  pushBit('matches_unread', (n) => `${n} new match(es)`, (d) => `${d} match(es) new since you last mentioned matches`);
+  pushBit('messages_unread', (n) => `${n} unread message(s)`, (d) => `${d} message(s) arrived since you last mentioned the inbox`);
+  pushBit('reminders_today', (n) => `${n} reminder(s) due today`, (d) => `${d} more reminder(s) came due since you last mentioned them`);
 
   // Register-specific framing rules the model must obey.
   const framing =
@@ -153,10 +186,24 @@ export function buildResumeDirective(input: ResumeDirectiveInput): ResumeDirecti
   if (completion) compact.complete_on_current_screen = true;
   if (recall) compact.where_we_left_off = recall;
   if (newBits.length) compact.new_since_last = newBits;
+  if (alreadyMentioned.length) compact.already_mentioned = alreadyMentioned;
+  if (typeof input.sessionsToday === 'number' && input.sessionsToday > 0) {
+    compact.sessions_today = input.sessionsToday;
+  }
   if (nba) {
+    // Ledger-aware suggestion detail: the model must never receive a stale
+    // level to recite. Unchanged count → number-free reference; changed
+    // count → lead with the delta (the news), total only as context.
+    const msgDelta = deltas?.messages_unread;
+    const nbaDetail =
+      nba.key === 'reply_messages' && msgDelta?.status === 'unchanged'
+        ? 'the unread messages the user already knows about'
+        : nba.key === 'reply_messages' && msgDelta?.status === 'changed' && (msgDelta.delta ?? 0) > 0
+          ? `${msgDelta.delta} new message(s) since last mentioned (${msgDelta.current} waiting in total)`
+          : nba.detail;
     compact.suggested_next_step = {
       kind: nba.key,
-      what: nba.detail,
+      what: nbaDetail,
       why: nba.rationale,
       // The REAL ORB tool that executes this when the user accepts. null = no
       // one-shot tool → guide the user through it, never promise to do it.
@@ -182,7 +229,7 @@ MUST end with the suggested next step as a concrete offer ("ich würde
 vorschlagen, wir …" / "I'd suggest we …"), phrased as doing it WITH the user.
 
 ${framing}
-
+${buildPreviousGreetingSection(input.previousUtterance ?? null)}
 ## LANGUAGE
 ${(lang || 'en').toLowerCase()}. Speak only in the user's language.
 ${nameLine}
@@ -197,6 +244,9 @@ ${nameLine}
   it naturally, never as a database row. When it is ABSENT, do NOT invent a "we
   were just on X" line; lead with what's new and the next step instead.
 - Only mention ${'`new_since_last`'} items that are present; if empty, skip — do not say "nothing new".
+- ${'`already_mentioned`'} items are things the user ALREADY heard from you and
+  that have NOT changed. NEVER restate their counts or announce them as news.
+  At most a soft, number-free reference when it genuinely serves the thread.
 - ALWAYS finish with ${'`suggested_next_step`'} as a guided offer. Never end on a bare "How can I help?".
 - EXECUTION — do not just describe, DO IT: ${'`suggested_next_step.execute_with_tool`'}
   names the real tool that performs this action. When the user accepts, CALL that

--- a/services/gateway/src/services/conversation/greeting-facts-ledger.ts
+++ b/services/gateway/src/services/conversation/greeting-facts-ledger.ts
@@ -1,0 +1,337 @@
+/**
+ * Conversation Flow — greeting-facts ledger (spoken-content continuity).
+ *
+ * THE gap behind "Vitana greets me with the same stats every session":
+ * every opener recomputes level stats (unread messages, sessions completed,
+ * Index) fresh from the DB, and NOTHING records that they were already
+ * spoken. The cadence machinery (`wake_cadence:*`) tracks style and timing;
+ * `recent_openers` tracks provider identity; this module tracks the FACTS
+ * a greeting actually told the user, so the next opener can speak deltas
+ * ("zwei neue seit heute Morgen") instead of restating levels ("du hast
+ * 10 ungelesene Nachrichten") — and so consecutive greetings never reuse
+ * the same wording (the previous first utterance is stored and handed to
+ * the model as a negative example).
+ *
+ * Storage: two signals in `user_assistant_state` — the exact pattern of
+ * `wake-cadence-signals.ts` and the next-action `dedupe-store.ts`:
+ *
+ *   `greeting_facts_v1`            { facts: { <key>: { value, spoken_at } } }
+ *   `greeting_last_utterance_v1`   { text, spoken_at }
+ *
+ * Read paths fail OPEN (empty ledger on any error) — a DB outage must
+ * never silence or degrade the greeting; it just loses continuity for
+ * one session. Write paths are fire-and-forget and never throw.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OverviewPayload } from '../assistant-continuation/providers/new-day-overview-payload';
+
+export const SIGNAL_GREETING_FACTS = 'greeting_facts_v1';
+export const SIGNAL_GREETING_LAST_UTTERANCE = 'greeting_last_utterance_v1';
+
+/** A fact's spoken value is considered "known to the user" this long. */
+export const FACT_FRESHNESS_MS = 48 * 3600 * 1000;
+
+/** Stored utterances are capped so the signal row stays small. */
+export const UTTERANCE_MAX_CHARS = 400;
+
+export interface SpokenFact {
+  value: number;
+  spoken_at: string;
+}
+
+export interface GreetingLedger {
+  facts: Record<string, SpokenFact>;
+  last_utterance: string | null;
+  last_utterance_at: string | null;
+  /** Sessions opened today (piggy-backed from `wake_cadence:sessions_today`
+   *  in the same query — situation context for rule 4). Null when unknown. */
+  sessions_today: number | null;
+}
+
+export const EMPTY_GREETING_LEDGER: GreetingLedger = {
+  facts: {},
+  last_utterance: null,
+  last_utterance_at: null,
+  sessions_today: null,
+};
+
+export type FactStatus = 'new' | 'changed' | 'unchanged';
+
+export interface FactDelta {
+  key: string;
+  current: number;
+  /** Last value spoken to the user (null when never spoken / stale). */
+  previous: number | null;
+  /** current - previous; null when previous is unknown. */
+  delta: number | null;
+  status: FactStatus;
+  spoken_at: string | null;
+}
+
+export interface LedgerIdentity {
+  supabase: SupabaseClient;
+  tenantId: string;
+  userId: string;
+  nowIso?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+/** Fail-open read of the greeting ledger. Never throws; empty on error. */
+export async function readGreetingLedger(inputs: LedgerIdentity): Promise<GreetingLedger> {
+  if (!inputs.tenantId || !inputs.userId) return { ...EMPTY_GREETING_LEDGER };
+  const nowIso = inputs.nowIso ?? new Date().toISOString();
+  try {
+    const { data, error } = await inputs.supabase
+      .from('user_assistant_state')
+      .select('signal_name, value')
+      .eq('tenant_id', inputs.tenantId)
+      .eq('user_id', inputs.userId)
+      .in('signal_name', [
+        SIGNAL_GREETING_FACTS,
+        SIGNAL_GREETING_LAST_UTTERANCE,
+        'wake_cadence:sessions_today',
+      ]);
+    if (error) return { ...EMPTY_GREETING_LEDGER };
+    const out: GreetingLedger = { ...EMPTY_GREETING_LEDGER, facts: {} };
+    for (const row of (data || []) as Array<{ signal_name: string; value: unknown }>) {
+      if (row.signal_name === SIGNAL_GREETING_FACTS) {
+        out.facts = parseFacts(row.value);
+      } else if (row.signal_name === SIGNAL_GREETING_LAST_UTTERANCE) {
+        const v = row.value as { text?: unknown; spoken_at?: unknown } | null;
+        if (v && typeof v === 'object' && typeof v.text === 'string' && v.text.trim()) {
+          out.last_utterance = v.text;
+          out.last_utterance_at = typeof v.spoken_at === 'string' ? v.spoken_at : null;
+        }
+      } else if (row.signal_name === 'wake_cadence:sessions_today') {
+        const v = row.value as { date?: unknown; count?: unknown } | null;
+        if (
+          v &&
+          typeof v === 'object' &&
+          v.date === nowIso.slice(0, 10) &&
+          typeof v.count === 'number' &&
+          Number.isFinite(v.count)
+        ) {
+          out.sessions_today = v.count;
+        }
+      }
+    }
+    return out;
+  } catch {
+    return { ...EMPTY_GREETING_LEDGER };
+  }
+}
+
+export function parseFacts(value: unknown): Record<string, SpokenFact> {
+  const out: Record<string, SpokenFact> = {};
+  if (!value || typeof value !== 'object') return out;
+  const facts = (value as { facts?: unknown }).facts;
+  if (!facts || typeof facts !== 'object') return out;
+  for (const [key, raw] of Object.entries(facts as Record<string, unknown>)) {
+    if (!raw || typeof raw !== 'object') continue;
+    const v = (raw as { value?: unknown }).value;
+    const at = (raw as { spoken_at?: unknown }).spoken_at;
+    if (typeof v === 'number' && Number.isFinite(v) && typeof at === 'string') {
+      out[key] = { value: v, spoken_at: at };
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Delta computation (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare the facts the opener is ABOUT to draw from against what was
+ * already spoken. A fact previously spoken within FACT_FRESHNESS_MS:
+ * same value → 'unchanged' (restating it is the robotic repeat — forbid),
+ * different value → 'changed' (speak the delta). Never spoken / stale →
+ * 'new' (the full number is allowed once).
+ */
+export function computeFactDeltas(
+  current: Record<string, number>,
+  ledger: GreetingLedger,
+  opts?: { nowIso?: string; freshnessMs?: number },
+): Record<string, FactDelta> {
+  const nowMs = Date.parse(opts?.nowIso ?? new Date().toISOString());
+  const freshnessMs = opts?.freshnessMs ?? FACT_FRESHNESS_MS;
+  const out: Record<string, FactDelta> = {};
+  for (const [key, value] of Object.entries(current)) {
+    if (!Number.isFinite(value)) continue;
+    const prior = ledger.facts[key];
+    const priorMs = prior ? Date.parse(prior.spoken_at) : NaN;
+    const fresh =
+      prior && Number.isFinite(priorMs) && Number.isFinite(nowMs) && nowMs - priorMs < freshnessMs;
+    if (!fresh) {
+      out[key] = { key, current: value, previous: null, delta: null, status: 'new', spoken_at: null };
+    } else if (prior!.value === value) {
+      out[key] = {
+        key,
+        current: value,
+        previous: prior!.value,
+        delta: 0,
+        status: 'unchanged',
+        spoken_at: prior!.spoken_at,
+      };
+    } else {
+      out[key] = {
+        key,
+        current: value,
+        previous: prior!.value,
+        delta: value - prior!.value,
+        status: 'changed',
+        spoken_at: prior!.spoken_at,
+      };
+    }
+  }
+  return out;
+}
+
+/**
+ * The numeric facts an opener can recite, extracted from the overview
+ * payload. Only levels prone to robotic repetition are tracked — the
+ * ledger is a repeat-guard, not a data store.
+ */
+export function extractSpokenFactsFromPayload(p: OverviewPayload | null): Record<string, number> {
+  if (!p) return {};
+  const out: Record<string, number> = {};
+  if (typeof p.messages_unread === 'number') out.messages_unread = p.messages_unread;
+  if (typeof p.matches_unread === 'number') out.matches_unread = p.matches_unread;
+  if (p.reminders_today && typeof p.reminders_today.count === 'number') {
+    out.reminders_today = p.reminders_today.count;
+  }
+  if (p.guided_journey && typeof p.guided_journey.sessions_completed === 'number') {
+    out.sessions_completed = p.guided_journey.sessions_completed;
+  }
+  if (p.vitana_index.state === 'ok' && typeof p.vitana_index.today === 'number') {
+    out.vitana_index = p.vitana_index.today;
+  }
+  if (typeof p.diary_last_7d === 'number') out.diary_last_7d = p.diary_last_7d;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Write (fire-and-forget)
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge the facts just handed to the opener into the ledger. Read-modify-
+ * write (same trade-off as recordWakeSessionStart — a lost race only costs
+ * one session of continuity). Never throws.
+ */
+export async function recordGreetingFacts(
+  inputs: LedgerIdentity & { facts: Record<string, number> },
+): Promise<{ ok: boolean; reason?: string }> {
+  if (!inputs.tenantId || !inputs.userId) return { ok: false, reason: 'missing_identity' };
+  const keys = Object.keys(inputs.facts);
+  if (keys.length === 0) return { ok: false, reason: 'no_facts' };
+  const nowIso = inputs.nowIso ?? new Date().toISOString();
+  try {
+    const { data: existing } = await inputs.supabase
+      .from('user_assistant_state')
+      .select('value')
+      .eq('tenant_id', inputs.tenantId)
+      .eq('user_id', inputs.userId)
+      .eq('signal_name', SIGNAL_GREETING_FACTS)
+      .maybeSingle();
+    const merged = existing ? parseFacts((existing as { value: unknown }).value) : {};
+    for (const key of keys) {
+      const value = inputs.facts[key];
+      if (Number.isFinite(value)) merged[key] = { value, spoken_at: nowIso };
+    }
+    const { error } = await inputs.supabase.from('user_assistant_state').upsert(
+      {
+        tenant_id: inputs.tenantId,
+        user_id: inputs.userId,
+        signal_name: SIGNAL_GREETING_FACTS,
+        value: { facts: merged },
+        last_seen_at: nowIso,
+      },
+      { onConflict: 'tenant_id,user_id,signal_name' },
+    );
+    if (error) return { ok: false, reason: error.message };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, reason: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
+ * Store Vitana's actual first spoken turn of a session (truncated), so the
+ * NEXT session can show it to the model as a negative example ("do not
+ * reuse this wording"). Never throws.
+ */
+export async function recordGreetingUtterance(
+  inputs: LedgerIdentity & { utterance: string },
+): Promise<{ ok: boolean; reason?: string }> {
+  if (!inputs.tenantId || !inputs.userId) return { ok: false, reason: 'missing_identity' };
+  const text = (inputs.utterance || '').trim().slice(0, UTTERANCE_MAX_CHARS);
+  if (!text) return { ok: false, reason: 'empty_utterance' };
+  const nowIso = inputs.nowIso ?? new Date().toISOString();
+  try {
+    const { error } = await inputs.supabase.from('user_assistant_state').upsert(
+      {
+        tenant_id: inputs.tenantId,
+        user_id: inputs.userId,
+        signal_name: SIGNAL_GREETING_LAST_UTTERANCE,
+        value: { text, spoken_at: nowIso },
+        last_seen_at: nowIso,
+      },
+      { onConflict: 'tenant_id,user_id,signal_name' },
+    );
+    if (error) return { ok: false, reason: error.message };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, reason: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt helpers (pure) — shared by the daily briefing and the resume
+// register so both compose against the same continuity rules.
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-fact composition guidance for the model. Data stays available (the
+ * payload still carries the numbers); this section tells the model which
+ * numbers the user has ALREADY heard, so it weaves instead of recites.
+ */
+export function buildFactContinuityLines(deltas: Record<string, FactDelta>): string[] {
+  const lines: string[] = [];
+  for (const d of Object.values(deltas)) {
+    if (d.status === 'unchanged') {
+      lines.push(
+        `- ${d.key} = ${d.current}: ALREADY TOLD to the user (unchanged since last mentioned). ` +
+          `Do NOT restate this number. At most a soft, number-free reference if it serves the conversation.`,
+      );
+    } else if (d.status === 'changed' && d.delta !== null) {
+      const dir = d.delta > 0 ? `+${d.delta}` : `${d.delta}`;
+      lines.push(
+        `- ${d.key} = ${d.current} (was ${d.previous} when last mentioned, ${dir} since): ` +
+          `speak the CHANGE, not the running total — the change is the news.`,
+      );
+    }
+    // status === 'new' → no line: the number is fresh and may be spoken once.
+  }
+  return lines;
+}
+
+/**
+ * The wording-variety negative example. Concrete previous utterances beat
+ * abstract "vary your wording" instructions — the model reliably avoids a
+ * shown example.
+ */
+export function buildPreviousGreetingSection(lastUtterance: string | null): string {
+  if (!lastUtterance || !lastUtterance.trim()) return '';
+  return (
+    `\n## YOUR PREVIOUS GREETING TO THIS USER (NEGATIVE EXAMPLE — NEVER IMITATE)\n\n` +
+    `"${lastUtterance.trim()}"\n\n` +
+    `Compose a DIFFERENT opening: different first words, different sentence ` +
+    `structure, a different opening move. Repeating the wording, rhythm, or ` +
+    `structure of the previous greeting is a contract failure.\n`
+  );
+}

--- a/services/gateway/src/services/memory-orchestrator.ts
+++ b/services/gateway/src/services/memory-orchestrator.ts
@@ -415,6 +415,11 @@ Style rules for memory (non-negotiable):
   Reference at most one or two memory details per reply, chosen because
   they make THIS answer better.
 - Never re-offer anything in the do_not_repeat list above.
+- GREETING RULE: never recite social or community COUNTS (followers,
+  matches, unread messages, sessions learned) in a greeting or session
+  opening. This context is background knowledge — use it when the user
+  asks or when it genuinely serves the current topic, never as an
+  opening status report.
 - These rules complement (and never override) any proactive-opener,
   Life Compass, or persona directives elsewhere in this prompt: those
   decide WHAT to lead with; this memory decides how personally you say it.

--- a/services/gateway/test/services/conversation/greeting-continuity.test.ts
+++ b/services/gateway/test/services/conversation/greeting-continuity.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Greeting continuity — spoken-facts ledger + wording-variety walls.
+ *
+ * The four operator rules under test:
+ *   1. never repeat updates from the previous session (unchanged levels
+ *      are forbidden; changed levels are spoken as their DELTA)
+ *   2. never reuse the previous greeting's wording (negative example)
+ *   3. no hardcoded speeches (the mandated "du hast schon X Sessions
+ *      geschafft" template is GONE from the briefing contract)
+ *   4. context-first (SITUATION block present; sessions_today surfaced)
+ */
+
+import {
+  computeFactDeltas,
+  extractSpokenFactsFromPayload,
+  parseFacts,
+  buildFactContinuityLines,
+  buildPreviousGreetingSection,
+  readGreetingLedger,
+  recordGreetingFacts,
+  recordGreetingUtterance,
+  EMPTY_GREETING_LEDGER,
+  SIGNAL_GREETING_FACTS,
+  SIGNAL_GREETING_LAST_UTTERANCE,
+  UTTERANCE_MAX_CHARS,
+  type GreetingLedger,
+} from '../../../src/services/conversation/greeting-facts-ledger';
+import { buildResumeDirective } from '../../../src/services/conversation/decide-opening';
+import { buildNewDayOverviewBlock } from '../../../src/services/assistant-continuation/providers/new-day-overview-prompt';
+import type { OverviewPayload } from '../../../src/services/assistant-continuation/providers/new-day-overview-payload';
+
+const NOW = '2026-07-03T08:00:00.000Z';
+const YESTERDAY = '2026-07-02T08:00:00.000Z';
+const LAST_WEEK = '2026-06-20T08:00:00.000Z';
+
+function ledgerWith(
+  facts: Record<string, { value: number; spoken_at: string }>,
+  lastUtterance: string | null = null,
+): GreetingLedger {
+  return {
+    facts,
+    last_utterance: lastUtterance,
+    last_utterance_at: lastUtterance ? YESTERDAY : null,
+    sessions_today: null,
+  };
+}
+
+function basePayload(overrides: Partial<OverviewPayload> = {}): OverviewPayload {
+  return {
+    journey: null,
+    vitana_index: { state: 'not_set_up' } as OverviewPayload['vitana_index'],
+    life_compass: { state: 'not_set' } as OverviewPayload['life_compass'],
+    calendar_today: { count: 0, next: null } as OverviewPayload['calendar_today'],
+    calendar_passed: { count: 0, most_recent: null } as OverviewPayload['calendar_passed'],
+    autopilot: { state: 'none_yet', today_checkpoint: null, this_week: [], pending_total: 0 } as OverviewPayload['autopilot'],
+    matches_unread: 0,
+    messages_unread: 0,
+    reminders_today: { count: 0, next: null },
+    guided_journey: null,
+    diary_last_7d: 1,
+    last_session_date_user_tz: null,
+    ...overrides,
+  } as OverviewPayload;
+}
+
+// ---------------------------------------------------------------------------
+// Delta computation (rule 1 core)
+// ---------------------------------------------------------------------------
+
+describe('computeFactDeltas', () => {
+  it('marks a never-spoken fact as new', () => {
+    const d = computeFactDeltas({ messages_unread: 10 }, ledgerWith({}), { nowIso: NOW });
+    expect(d.messages_unread.status).toBe('new');
+    expect(d.messages_unread.previous).toBeNull();
+  });
+
+  it('marks an identical fresh fact as unchanged', () => {
+    const d = computeFactDeltas(
+      { messages_unread: 10 },
+      ledgerWith({ messages_unread: { value: 10, spoken_at: YESTERDAY } }),
+      { nowIso: NOW },
+    );
+    expect(d.messages_unread.status).toBe('unchanged');
+    expect(d.messages_unread.delta).toBe(0);
+  });
+
+  it('marks a moved fact as changed with the exact delta', () => {
+    const d = computeFactDeltas(
+      { messages_unread: 12, sessions_completed: 13 },
+      ledgerWith({
+        messages_unread: { value: 10, spoken_at: YESTERDAY },
+        sessions_completed: { value: 11, spoken_at: YESTERDAY },
+      }),
+      { nowIso: NOW },
+    );
+    expect(d.messages_unread.status).toBe('changed');
+    expect(d.messages_unread.delta).toBe(2);
+    expect(d.sessions_completed.delta).toBe(2);
+  });
+
+  it('treats a stale spoken fact (>48h) as new again', () => {
+    const d = computeFactDeltas(
+      { messages_unread: 10 },
+      ledgerWith({ messages_unread: { value: 10, spoken_at: LAST_WEEK } }),
+      { nowIso: NOW },
+    );
+    expect(d.messages_unread.status).toBe('new');
+  });
+});
+
+describe('extractSpokenFactsFromPayload', () => {
+  it('extracts the repetition-prone levels', () => {
+    const facts = extractSpokenFactsFromPayload(
+      basePayload({
+        messages_unread: 10,
+        matches_unread: 3,
+        guided_journey: {
+          sessions_completed: 11,
+          topics_learned: 21,
+          topics_total: 30,
+          next_session_title: 'Zellgesundheit',
+          last_session_recall: null,
+        },
+        vitana_index: { state: 'ok', today: 72 } as unknown as OverviewPayload['vitana_index'],
+        reminders_today: { count: 2, next: null },
+      }),
+    );
+    expect(facts).toMatchObject({
+      messages_unread: 10,
+      matches_unread: 3,
+      sessions_completed: 11,
+      vitana_index: 72,
+      reminders_today: 2,
+    });
+  });
+
+  it('returns empty for a null payload', () => {
+    expect(extractSpokenFactsFromPayload(null)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resume directive (same-day reopens — where "10 Nachrichten" repeated)
+// ---------------------------------------------------------------------------
+
+describe('buildResumeDirective — spoken-facts continuity', () => {
+  const payload = basePayload({
+    messages_unread: 10,
+    guided_journey: {
+      sessions_completed: 11,
+      topics_learned: 21,
+      topics_total: 30,
+      next_session_title: 'Zellgesundheit',
+      last_session_recall: null,
+    },
+  });
+
+  it('unchanged counts move OUT of new_since_last into already_mentioned', () => {
+    const deltas = computeFactDeltas(extractSpokenFactsFromPayload(payload), ledgerWith({
+      messages_unread: { value: 10, spoken_at: YESTERDAY },
+      sessions_completed: { value: 11, spoken_at: YESTERDAY },
+    }), { nowIso: NOW });
+    const { text } = buildResumeDirective({
+      register: 'same_day',
+      payload,
+      firstName: 'Dragan',
+      lang: 'de',
+      timeAgo: 'about 3 hours ago',
+      factDeltas: deltas,
+    });
+    expect(text).not.toContain('"new_since_last"');
+    expect(text).toContain('"already_mentioned"');
+    expect(text).toContain('NEVER restate their counts');
+  });
+
+  it('a changed count is phrased as its delta, never the running total', () => {
+    const deltas = computeFactDeltas(extractSpokenFactsFromPayload(payload), ledgerWith({
+      messages_unread: { value: 8, spoken_at: YESTERDAY },
+    }), { nowIso: NOW });
+    const { text } = buildResumeDirective({
+      register: 'same_day',
+      payload,
+      firstName: 'Dragan',
+      lang: 'de',
+      timeAgo: 'about 3 hours ago',
+      factDeltas: deltas,
+    });
+    expect(text).toContain('2 message(s) arrived since you last mentioned the inbox');
+    // Neither the what's-new list nor the suggestion may hand the model the
+    // plain running total to recite.
+    expect(text).not.toContain('10 unread message(s)');
+  });
+
+  it('without a ledger (legacy call) the plain counts still flow', () => {
+    const { text } = buildResumeDirective({
+      register: 'same_day',
+      payload,
+      firstName: 'Dragan',
+      lang: 'de',
+      timeAgo: 'about 3 hours ago',
+    });
+    expect(text).toContain('10 unread message(s)');
+  });
+
+  it('the previous greeting is embedded as a negative example (rule 2)', () => {
+    const { text } = buildResumeDirective({
+      register: 'quick_resume',
+      payload,
+      firstName: 'Dragan',
+      lang: 'de',
+      timeAgo: 'a few minutes ago',
+      previousUtterance: 'Guten Morgen Dragan, du hast 10 ungelesene Nachrichten.',
+    });
+    expect(text).toContain('YOUR PREVIOUS GREETING TO THIS USER');
+    expect(text).toContain('Guten Morgen Dragan, du hast 10 ungelesene Nachrichten.');
+    expect(text).toContain('NEVER IMITATE');
+  });
+
+  it('the reply_messages suggestion drops the stale number when unchanged', () => {
+    const deltas = computeFactDeltas(extractSpokenFactsFromPayload(payload), ledgerWith({
+      messages_unread: { value: 10, spoken_at: YESTERDAY },
+    }), { nowIso: NOW });
+    const { text, nba } = buildResumeDirective({
+      register: 'same_day',
+      payload,
+      firstName: 'Dragan',
+      lang: 'de',
+      timeAgo: 'about 3 hours ago',
+      factDeltas: deltas,
+    });
+    if (nba?.key === 'reply_messages') {
+      expect(text).toContain('the unread messages the user already knows about');
+      expect(text).not.toContain('"what": "10 unread message(s)"');
+    }
+  });
+
+  it('sessions_today is surfaced as situation context (rule 4)', () => {
+    const { text } = buildResumeDirective({
+      register: 'same_day',
+      payload,
+      firstName: 'Dragan',
+      lang: 'de',
+      timeAgo: 'about 3 hours ago',
+      sessionsToday: 4,
+    });
+    expect(text).toContain('"sessions_today": 4');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Daily briefing block (once/day — where "11 Sessions" was mandated)
+// ---------------------------------------------------------------------------
+
+describe('buildNewDayOverviewBlock — de-templated, ledger-conditional coverage', () => {
+  const payload = basePayload({
+    messages_unread: 10,
+    guided_journey: {
+      sessions_completed: 11,
+      topics_learned: 21,
+      topics_total: 30,
+      next_session_title: 'Zellgesundheit',
+      last_session_recall: null,
+    },
+  });
+  const baseArgs = {
+    payload,
+    lang: 'de',
+    firstName: 'Dragan',
+    localHour: 8,
+    timezone: 'Europe/Berlin',
+  };
+
+  it('rule 3: the mandated "du hast schon X Sessions geschafft" template is gone', () => {
+    const block = buildNewDayOverviewBlock(baseArgs);
+    expect(block).not.toContain('du hast schon 11 Sessions geschafft');
+    expect(block).toContain('compose the sentence yourself');
+    expect(block).toContain('are NOT fixed wording');
+  });
+
+  it('rule 1: unchanged session count → coverage forbids restating it', () => {
+    const deltas = computeFactDeltas(extractSpokenFactsFromPayload(payload), ledgerWith({
+      sessions_completed: { value: 11, spoken_at: YESTERDAY },
+      messages_unread: { value: 10, spoken_at: YESTERDAY },
+    }), { nowIso: NOW });
+    const block = buildNewDayOverviewBlock({ ...baseArgs, factDeltas: deltas });
+    expect(block).toContain('Do NOT restate the count');
+    expect(block).toContain('ALREADY-SPOKEN FACTS');
+    // messages: soft nod at most, never the number as news
+    expect(block).toContain('already knows about their 10 unread message(s)');
+  });
+
+  it('rule 1: advanced session count → coverage demands the delta framing', () => {
+    const deltas = computeFactDeltas(extractSpokenFactsFromPayload(payload), ledgerWith({
+      sessions_completed: { value: 9, spoken_at: YESTERDAY },
+    }), { nowIso: NOW });
+    const block = buildNewDayOverviewBlock({ ...baseArgs, factDeltas: deltas });
+    expect(block).toContain('completed 2 more session(s)');
+    expect(block).toContain('the progress since last time is the news');
+  });
+
+  it('rule 2: the previous greeting appears as a negative example', () => {
+    const block = buildNewDayOverviewBlock({
+      ...baseArgs,
+      previousUtterance: 'Guten Morgen Dragan — schön, dass du wieder da bist.',
+    });
+    expect(block).toContain('YOUR PREVIOUS GREETING TO THIS USER');
+    expect(block).toContain('different first words');
+  });
+
+  it('rule 4: the SITUATION section frames the composition', () => {
+    const block = buildNewDayOverviewBlock({ ...baseArgs, sessionsToday: 2 });
+    expect(block).toContain('## SITUATION');
+    expect(block).toContain('Sessions the user already opened today: 2');
+    expect(block).toContain('Local hour: 8');
+  });
+
+  it('without a ledger the briefing still builds (legacy behavior)', () => {
+    const block = buildNewDayOverviewBlock(baseArgs);
+    expect(block).toContain('COVERAGE CHECKLIST');
+    expect(block).toContain('10 unread message(s)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ledger persistence (fake supabase — user_assistant_state contract)
+// ---------------------------------------------------------------------------
+
+type Row = { tenant_id: string; user_id: string; signal_name: string; value: unknown };
+
+function fakeSupabase(rows: Row[]) {
+  const state = [...rows];
+  const table = {
+    upserts: [] as unknown[],
+    from(name: string) {
+      if (name !== 'user_assistant_state') throw new Error(`unexpected table ${name}`);
+      const filters: Record<string, unknown> = {};
+      let inSignals: string[] | null = null;
+      const builder: any = {
+        select: () => builder,
+        eq: (col: string, val: unknown) => {
+          filters[col] = val;
+          return builder;
+        },
+        in: (_col: string, vals: string[]) => {
+          inSignals = vals;
+          return Promise.resolve({
+            data: state.filter(
+              (r) =>
+                r.tenant_id === filters.tenant_id &&
+                r.user_id === filters.user_id &&
+                (inSignals as string[]).includes(r.signal_name),
+            ),
+            error: null,
+          });
+        },
+        maybeSingle: () =>
+          Promise.resolve({
+            data:
+              state.find(
+                (r) =>
+                  r.tenant_id === filters.tenant_id &&
+                  r.user_id === filters.user_id &&
+                  r.signal_name === filters.signal_name,
+              ) ?? null,
+            error: null,
+          }),
+        upsert: (row: Row | Row[]) => {
+          for (const r of Array.isArray(row) ? row : [row]) {
+            table.upserts.push(r);
+            const idx = state.findIndex(
+              (s) =>
+                s.tenant_id === r.tenant_id &&
+                s.user_id === r.user_id &&
+                s.signal_name === r.signal_name,
+            );
+            if (idx >= 0) state[idx] = r;
+            else state.push(r);
+          }
+          return Promise.resolve({ error: null });
+        },
+      };
+      return builder;
+    },
+  };
+  return table;
+}
+
+describe('greeting ledger persistence', () => {
+  const ident = { tenantId: 't-1', userId: 'u-1' };
+
+  it('round-trips facts and the last utterance through user_assistant_state', async () => {
+    const sb = fakeSupabase([]);
+    await recordGreetingFacts({
+      supabase: sb as any,
+      ...ident,
+      facts: { messages_unread: 10, sessions_completed: 11 },
+      nowIso: NOW,
+    });
+    await recordGreetingUtterance({
+      supabase: sb as any,
+      ...ident,
+      utterance: 'Guten Morgen Dragan.',
+      nowIso: NOW,
+    });
+    const ledger = await readGreetingLedger({ supabase: sb as any, ...ident, nowIso: NOW });
+    expect(ledger.facts.messages_unread).toEqual({ value: 10, spoken_at: NOW });
+    expect(ledger.facts.sessions_completed).toEqual({ value: 11, spoken_at: NOW });
+    expect(ledger.last_utterance).toBe('Guten Morgen Dragan.');
+  });
+
+  it('merges new facts into the existing map without dropping others', async () => {
+    const sb = fakeSupabase([
+      {
+        ...{ tenant_id: 't-1', user_id: 'u-1' },
+        signal_name: SIGNAL_GREETING_FACTS,
+        value: { facts: { vitana_index: { value: 72, spoken_at: YESTERDAY } } },
+      },
+    ]);
+    await recordGreetingFacts({
+      supabase: sb as any,
+      ...ident,
+      facts: { messages_unread: 12 },
+      nowIso: NOW,
+    });
+    const ledger = await readGreetingLedger({ supabase: sb as any, ...ident, nowIso: NOW });
+    expect(ledger.facts.vitana_index.value).toBe(72);
+    expect(ledger.facts.messages_unread.value).toBe(12);
+  });
+
+  it('reads sessions_today from the cadence signal in the same query', async () => {
+    const sb = fakeSupabase([
+      {
+        tenant_id: 't-1',
+        user_id: 'u-1',
+        signal_name: 'wake_cadence:sessions_today',
+        value: { date: NOW.slice(0, 10), count: 3 },
+      },
+    ]);
+    const ledger = await readGreetingLedger({ supabase: sb as any, ...ident, nowIso: NOW });
+    expect(ledger.sessions_today).toBe(3);
+  });
+
+  it('ignores a stale sessions_today from another day', async () => {
+    const sb = fakeSupabase([
+      {
+        tenant_id: 't-1',
+        user_id: 'u-1',
+        signal_name: 'wake_cadence:sessions_today',
+        value: { date: '2026-07-01', count: 9 },
+      },
+    ]);
+    const ledger = await readGreetingLedger({ supabase: sb as any, ...ident, nowIso: NOW });
+    expect(ledger.sessions_today).toBeNull();
+  });
+
+  it('fails OPEN: missing identity or throwing client → empty ledger, ok:false', async () => {
+    const throwing = { from: () => { throw new Error('db down'); } };
+    const ledger = await readGreetingLedger({ supabase: throwing as any, ...ident });
+    expect(ledger).toEqual({ ...EMPTY_GREETING_LEDGER });
+    const wr = await recordGreetingFacts({
+      supabase: throwing as any,
+      ...ident,
+      facts: { messages_unread: 1 },
+    });
+    expect(wr.ok).toBe(false);
+    const noId = await recordGreetingUtterance({
+      supabase: throwing as any,
+      tenantId: '',
+      userId: 'u-1',
+      utterance: 'x',
+    });
+    expect(noId).toEqual({ ok: false, reason: 'missing_identity' });
+  });
+
+  it('truncates stored utterances to the cap', async () => {
+    const sb = fakeSupabase([]);
+    await recordGreetingUtterance({
+      supabase: sb as any,
+      ...ident,
+      utterance: 'A'.repeat(2000),
+      nowIso: NOW,
+    });
+    const ledger = await readGreetingLedger({ supabase: sb as any, ...ident, nowIso: NOW });
+    expect((ledger.last_utterance as string).length).toBe(UTTERANCE_MAX_CHARS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure prompt helpers
+// ---------------------------------------------------------------------------
+
+describe('prompt helpers', () => {
+  it('buildFactContinuityLines emits rules only for unchanged/changed facts', () => {
+    const lines = buildFactContinuityLines({
+      a: { key: 'a', current: 5, previous: 5, delta: 0, status: 'unchanged', spoken_at: YESTERDAY },
+      b: { key: 'b', current: 7, previous: 4, delta: 3, status: 'changed', spoken_at: YESTERDAY },
+      c: { key: 'c', current: 9, previous: null, delta: null, status: 'new', spoken_at: null },
+    });
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('Do NOT restate this number');
+    expect(lines[1]).toContain('speak the CHANGE');
+  });
+
+  it('buildPreviousGreetingSection is empty without an utterance', () => {
+    expect(buildPreviousGreetingSection(null)).toBe('');
+    expect(buildPreviousGreetingSection('  ')).toBe('');
+  });
+
+  it('parseFacts drops malformed entries', () => {
+    const facts = parseFacts({
+      facts: {
+        good: { value: 3, spoken_at: NOW },
+        bad_value: { value: 'x', spoken_at: NOW },
+        bad_at: { value: 3, spoken_at: 42 },
+        not_obj: 7,
+      },
+    });
+    expect(Object.keys(facts)).toEqual(['good']);
+  });
+
+  it('exports the signal names the wiring depends on', () => {
+    expect(SIGNAL_GREETING_FACTS).toBe('greeting_facts_v1');
+    expect(SIGNAL_GREETING_LAST_UTTERANCE).toBe('greeting_last_utterance_v1');
+  });
+});


### PR DESCRIPTION
# Why

Vitana greeted every session with the same stats ("du hast X ungelesene Nachrichten … Y Sessions gelernt"). Root cause, verified end-to-end: every opener recomputes **level** stats fresh from the DB, and **nothing records that they were already spoken**. The cadence machinery (`wake_cadence:*`) tracks style/timing; `recent_openers` tracks provider identity; `recent_nbas` tracks suggestion keys — no store tracked spoken **content**. Three paths recited the same levels:

- Daily briefing coverage contract **mandated** the recital (rule a2 "du hast schon X Sessions geschafft", rule j message count) — the same numbers day after day.
- Same-day resume (`decide-opening.ts`) put the **total** `messages_unread` into `new_since_last` on every reopen — a level presented as news.
- The `reply_messages` NBA detail carried the same total.

Operator rules implemented: **(1)** never repeat updates from the previous session **(2)** never reuse the previous greeting's wording **(3)** no hardcoded speeches **(4)** context-first composition.

# What

- **NEW `services/conversation/greeting-facts-ledger.ts`** — two signals in `user_assistant_state` (exact pattern of `wake-cadence-signals.ts` / next-action `dedupe-store.ts`, no migration needed):
  - `greeting_facts_v1` — which numbers were spoken, with values + timestamps (48h freshness). `computeFactDeltas` → `new` / `changed` / `unchanged`.
  - `greeting_last_utterance_v1` — Vitana's actual previous first spoken turn (truncated 400 chars), handed to the model as a wording-variety **negative example**.
  - Fail-open reads (DB outage never silences the greeting), fire-and-forget writes.
- **`decide-opening.ts`** — `new_since_last` carries only genuine deltas ("2 message(s) arrived since you last mentioned the inbox"); unchanged levels move to `already_mentioned` with a hard never-restate rule; the `reply_messages` suggestion detail is delta-aware; previous-greeting negative example; `sessions_today` situation context.
- **`new-day-overview-prompt.ts`** — coverage checklist is ledger-conditional (unchanged count → forbidden to restate; changed → speak the advance); the mandated `"du hast schon X Sessions geschafft"` template is **removed** (coverage keeps the topic, the model composes the words); SITUATION section; example phrases declared intent-only.
- **`orb-live.ts`** — both greeting paths (daily briefing + resume register) read the ledger (bounded 800 ms, fail-open) and record the surfaced facts after sending.
- **`upstream-message-handler.ts`** — captures the first assistant turn of each session into the ledger.
- **`memory-orchestrator.ts`** — greeting rule: social/community counts are background knowledge, never an opening status report.

Legacy behavior is fully preserved when the ledger is absent/empty (first contact, anonymous, DB down).

# Tests

`test/services/conversation/greeting-continuity.test.ts` (28) — delta math incl. 48h staleness, resume + briefing composition walls for all four rules, ledger persistence contract on a fake `user_assistant_state`, fail-open, truncation. Satisfies the conversation-flow-change-needs-test gate. Full gateway suite green — 6281 passed; the one failure is the pre-existing cross-repo `nav-manifest-sync` drift gate (compares against the local vitana-v1 checkout; untouched by this diff).

# How it should sound (staging verification script)

1. First session of the day → full briefing, numbers only where new/changed ("seit gestern zwei Sessions weiter", "drei neue Nachrichten").
2. Reopen 30 min later, nothing changed → thread continuation, **no counts**, different wording than the morning greeting.
3. Reopen after new messages arrived → "zwei neue seit heute Morgen", never the running total.
4. Next morning, nothing changed → no repeated stat recital; previous greeting's wording avoided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDeWcwo8qwBnCdr2h48Fy9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDeWcwo8qwBnCdr2h48Fy9)_