### PR TITLE
Add Vitana recommendation-identity UI metadata to autopilot recommendations

### DIFF
--- a/services/gateway/src/i18n/catalog.ts
+++ b/services/gateway/src/i18n/catalog.ts
@@ -110,7 +110,11 @@ export type GatewayI18nKey =
   | 'priority.greeting.afternoon.named'
   | 'priority.greeting.afternoon'
   | 'priority.greeting.evening.named'
-  | 'priority.greeting.evening';
+  | 'priority.greeting.evening'
+  // Autopilot recommendation identity (recommendation-identity work) — the
+  // "Vitana empfiehlt" header shown on every AI-generated recommendation card
+  // so the source is never rendered as a bare "AI" label.
+  | 'recommendation.vitana_label';
 
 type LocaleCatalog = Record<GatewayI18nKey, string>;
 
@@ -206,6 +210,7 @@ const DE: LocaleCatalog = {
   'priority.greeting.afternoon': 'Guten Tag. Bereit, wenn du es bist.',
   'priority.greeting.evening.named': 'Guten Abend, {name}. Bereit, wenn du es bist.',
   'priority.greeting.evening': 'Guten Abend. Bereit, wenn du es bist.',
+  'recommendation.vitana_label': 'Vitana empfiehlt',
 };
 
 const EN: LocaleCatalog = {
@@ -300,6 +305,7 @@ const EN: LocaleCatalog = {
   'priority.greeting.afternoon': 'Good afternoon. Ready when you are.',
   'priority.greeting.evening.named': 'Good evening, {name}. Ready when you are.',
   'priority.greeting.evening': 'Good evening. Ready when you are.',
+  'recommendation.vitana_label': 'Vitana recommends',
 };
 
 // Draft locales — start as a copy of EN; replace with native strings as they

--- a/services/gateway/src/routes/autopilot-recommendations.ts
+++ b/services/gateway/src/routes/autopilot-recommendations.ts
@@ -28,6 +28,28 @@ import { notifyUserAsync } from '../services/notification-service';
 import { DEFAULT_WAVE_CONFIG, buildTemplateToWaveMap } from '../services/wave-defaults';
 import { derivePillarImpact } from '../services/recommendation-engine/pillar-impact';
 import { evaluateRecAlignment } from '../services/recommendation-engine/alignment-evaluator';
+import { tt, GATEWAY_DEFAULT_LOCALE, type GatewayLocale } from '../i18n/catalog';
+import { getUserLocale } from '../i18n/server-locale';
+
+/**
+ * Recommendation-identity work: resolve the requesting user's locale for the
+ * "Vitana empfiehlt" header (see annotateWithPillarImpact below). Best-effort —
+ * anonymous/Command-Hub callers (no userId) fall back to GATEWAY_DEFAULT_LOCALE,
+ * and any Supabase error also falls back rather than failing the request.
+ */
+async function resolveRecommendationLocale(userId: string | null | undefined): Promise<GatewayLocale> {
+  if (!userId) return GATEWAY_DEFAULT_LOCALE;
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const svcKey = process.env.SUPABASE_SERVICE_ROLE;
+  if (!supabaseUrl || !svcKey) return GATEWAY_DEFAULT_LOCALE;
+  try {
+    const { createClient } = await import('@supabase/supabase-js');
+    const supa = createClient(supabaseUrl, svcKey);
+    return await getUserLocale(supa, userId);
+  } catch {
+    return GATEWAY_DEFAULT_LOCALE;
+  }
+}
 
 /**
  * Phase 5 of the Ultimate Goal hardening (VTID-02935): when a recommendation
@@ -88,11 +110,29 @@ async function emitAlignmentEventForActivation(params: {
  * with derived pillar_impact ({primary_pillar, magnitude}). Read-time derivation
  * from contribution_vector JSONB — see services/.../pillar-impact.ts.
  * Mutates each row in place (cheap and unambiguous for response payload use).
+ *
+ * Also stamps the Vitana recommendation-identity UI metadata (see CLAUDE.md
+ * "recommendation-identity" work) so the frontend never renders a bare "AI"
+ * label: `recommended_by`/`visual_identity` are locale-independent identifiers
+ * the UI uses to pick the ORB avatar; `recommendation_label` is the localized
+ * "Vitana empfiehlt" copy, resolved via the gateway i18n catalog.
  */
-function annotateWithPillarImpact<T extends { contribution_vector?: unknown }>(rows: T[]): Array<T & { pillar_impact: ReturnType<typeof derivePillarImpact> }> {
+function annotateWithPillarImpact<T extends { contribution_vector?: unknown }>(
+  rows: T[],
+  locale: GatewayLocale = GATEWAY_DEFAULT_LOCALE,
+): Array<T & {
+  pillar_impact: ReturnType<typeof derivePillarImpact>;
+  recommended_by: 'vitana';
+  recommendation_label: string;
+  visual_identity: 'orb';
+}> {
+  const recommendation_label = tt('recommendation.vitana_label', locale);
   return rows.map((row) => ({
     ...row,
     pillar_impact: derivePillarImpact(row.contribution_vector as Record<string, unknown> | null | undefined),
+    recommended_by: 'vitana' as const,
+    recommendation_label,
+    visual_identity: 'orb' as const,
   }));
 }
 
@@ -160,7 +200,8 @@ async function buildCommunityRecsResponse(
       startDay <= 30 ? 'month'    : 'future';
   }
 
-  return annotateWithPillarImpact(recommendations).slice(0, limit);
+  const locale = await resolveRecommendationLocale(userId);
+  return annotateWithPillarImpact(recommendations, locale).slice(0, limit);
 }
 
 // =============================================================================
@@ -645,9 +686,10 @@ router.get('/', async (req: Request, res: Response) => {
           }));
       }
 
+      const roleLocale = await resolveRecommendationLocale(userId);
       return res.status(200).json({
         ok: true,
-        recommendations: annotateWithPillarImpact(recommendations),
+        recommendations: annotateWithPillarImpact(recommendations, roleLocale),
         count: recommendations.length,
         has_more: hasMore,
         ...(waves ? { waves } : {}),
@@ -682,9 +724,10 @@ router.get('/', async (req: Request, res: Response) => {
       recommendations.pop();
     }
 
+    const rpcLocale = await resolveRecommendationLocale(userId);
     return res.status(200).json({
       ok: true,
-      recommendations: annotateWithPillarImpact(recommendations),
+      recommendations: annotateWithPillarImpact(recommendations, rpcLocale),
       count: recommendations.length,
       has_more: hasMore,
       vtid: 'VTID-01180',


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-VITANA-RECOMMENDATION-IDENTITY` _(no pre-existing OASIS VTID for this task; frontend companion PR is exafyltd/vitana-v1#same-branch)_

**Layer:** APIL

**Priority:** P2

---

## 📋 Summary

Companion to the frontend recommendation-identity work: the Autopilot Recommendation API (`GET /api/v1/autopilot/recommendations`, `POST /generate`) returned bare recommendation rows with no indication they come from Vitana, so the frontend had nothing to key its ORB-branded UI off of. This adds three UI metadata fields to every recommendation row.

---

## ✅ Changes

- [x] `annotateWithPillarImpact()` in `services/gateway/src/routes/autopilot-recommendations.ts` now stamps every row with:
  - `recommended_by: 'vitana'`
  - `recommendation_label: <localized "Vitana empfiehlt">`
  - `visual_identity: 'orb'`
- [x] `recommendation_label` is resolved via the gateway i18n catalog (new `recommendation.vitana_label` key added to `GatewayI18nKey` + `DE`/`EN` catalogs in `services/gateway/src/i18n/catalog.ts`, per the CLAUDE.md §13b hard rule against hardcoding gateway-emitted user-visible strings) using the requesting user's locale, resolved best-effort via the existing `getUserLocale()` helper (new `resolveRecommendationLocale()`, falls back to `de` for anonymous/Command-Hub callers or on any Supabase error).
- [x] All three response sites that build recommendation lists (`buildCommunityRecsResponse`, `GET /` role-based path, `GET /` RPC fallback path) pass the resolved locale through.

---

## 🧪 Testing

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest test/routes/autopilot-recommendations-complete.test.ts test/services/autopilot-community-actions-coverage.test.ts test/services/autopilot-voice-tools.test.ts` — 19/19 passing, no regressions
- [ ] Verified in staging/dev environment — not run; this sandbox's network policy blocks the Supabase/gateway hosts needed to hit a live environment

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- N/A — no workflow files touched

### File Names
- [x] No new files added (existing files modified only); all follow kebab-case already

### Code Standards
- [x] No new VTID constants introduced (task predates an OASIS VTID; see reference above)
- N/A — no new event types/status values introduced

### Cloud Run Deployments
- N/A — no deploy/infra changes

### Documentation
- [x] VTID/BOOTSTRAP ID referenced in commit message

---

## 🚨 Breaking Changes

None — purely additive fields on existing response payloads.

---

## 📌 Additional Notes

Frontend companion PR (same branch name `claude/vitana-recommendation-identity-da8zbz`) is in `exafyltd/vitana-v1`, adding the `VitanaRecommendationHeader` component and wiring the ORB identity into the News screen cards and chat avatar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xptst7XwBcA412cqEX3BdZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xptst7XwBcA412cqEX3BdZ)_