### PR TITLE
Autopilot Phase 1 (connect-people + community-groups): implement 7 gaps, fix 5 broken handlers

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -11,6 +11,14 @@
 # when unset, dispatch calls no-op (fail-open, no errors).
 DEFAULT_TENANT_ID=
 
+# Attribution user_id for autopilot-created content that needs a created_by
+# (e.g. AP-0201/AP-0209 auto-created community groups). Optional: the call
+# site defaults to the all-zeros UUID when unset, which is harmless since
+# global_community_groups.created_by has no FK constraint — but set this to
+# a real service/bot app_users row for the "created by" attribution to
+# resolve to something meaningful in the UI.
+VITANA_BOT_USER_ID=
+
 # Autopilot on-demand regeneration (VTID-03301).
 # Cooldown/debounce window (ms) that suppresses a fresh community recommendation
 # batch when one was generated within the window — prevents back-to-back

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -3,6 +3,14 @@
 # the deploy workflow / Cloud Run env. This file documents OPTIONAL operator
 # knobs with sensible code-side defaults, so they are discoverable and bindable.
 
+# Autopilot Automations Engine (VTID-01250) — the tenant that
+# heartbeat/cron/event automations run against, and that the new
+# /groups/:id/view (AP-0106) and D48 opportunity dispatch (AP-0110) event
+# emitters use. Widely read across gateway routes (community.ts, automations.ts,
+# matchmaking.ts, etc.). Required for automation event dispatch to fire;
+# when unset, dispatch calls no-op (fail-open, no errors).
+DEFAULT_TENANT_ID=
+
 # Autopilot on-demand regeneration (VTID-03301).
 # Cooldown/debounce window (ms) that suppresses a fresh community recommendation
 # batch when one was generated within the window — prevents back-to-back

--- a/services/gateway/src/routes/community.ts
+++ b/services/gateway/src/routes/community.ts
@@ -9,7 +9,7 @@
  * Endpoints:
  * - POST /api/v1/community/groups              - Create a community group
  * - POST /api/v1/community/groups/:id/join     - Join a community group
- * - POST /api/v1/community/groups/:id/view     - Track group view (AP-0106 social proof)
+ * - POST /api/v1/community/global-groups/:id/view - Track group view (AP-0106 social proof)
  * - POST /api/v1/community/meetups             - Create a meetup
  * - POST /api/v1/community/recommendations/recompute - Recompute recommendations
  * - GET  /api/v1/community/recommendations     - Get recommendations
@@ -363,14 +363,17 @@ router.post('/groups/:id/join', async (req: Request, res: Response) => {
 });
 
 /**
- * POST /groups/:id/view -> POST /api/v1/community/groups/:id/view
+ * POST /global-groups/:id/view -> POST /api/v1/community/global-groups/:id/view
  *
  * Fire-and-forget view tracking for AP-0106 ("People You Know Are Here"
  * Social Proof). Called by the frontend when a user opens a group detail
  * page; dispatches user.group.viewed so the automation can check whether
- * any of the viewer's connections are already members.
+ * any of the viewer's connections are already members. Lives under
+ * global-groups (not groups) because global_community_groups is the real,
+ * live groups schema — see the /global-groups/:id/join comment below for
+ * why community_groups (VTID-01084) is never-deployed.
  */
-router.post('/groups/:id/view', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+router.post('/global-groups/:id/view', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
   // impact-allow-no-oasis: a page view is telemetry, not a state transition
   // (CLAUDE.md OASIS rule: "Never mark polling or heartbeats as OASIS
   // events"). The automation dispatch below IS the meaningful side effect;

--- a/services/gateway/src/routes/community.ts
+++ b/services/gateway/src/routes/community.ts
@@ -392,6 +392,11 @@ router.post('/groups/:id/view', requireAuth, async (req: AuthenticatedRequest, r
     }).catch(err => console.warn(`[${VTID}] dispatch user.group.viewed failed:`, err.message));
   }
 
+  // impact-allow-no-oasis: a page view is telemetry, not a state transition
+  // (CLAUDE.md OASIS rule: "Never mark polling or heartbeats as OASIS
+  // events"). The automation dispatch above IS the meaningful side effect;
+  // automation-executor already emits autopilot.automation.completed/failed
+  // per run, so a second OASIS event here would be a duplicate signal.
   return res.status(200).json({ ok: true });
 });
 

--- a/services/gateway/src/routes/community.ts
+++ b/services/gateway/src/routes/community.ts
@@ -9,6 +9,7 @@
  * Endpoints:
  * - POST /api/v1/community/groups              - Create a community group
  * - POST /api/v1/community/groups/:id/join     - Join a community group
+ * - POST /api/v1/community/groups/:id/view     - Track group view (AP-0106 social proof)
  * - POST /api/v1/community/meetups             - Create a meetup
  * - POST /api/v1/community/recommendations/recompute - Recompute recommendations
  * - GET  /api/v1/community/recommendations     - Get recommendations
@@ -359,6 +360,41 @@ router.post('/groups/:id/join', async (req: Request, res: Response) => {
       error: err.message
     });
   }
+});
+
+/**
+ * POST /groups/:id/view -> POST /api/v1/community/groups/:id/view
+ *
+ * Fire-and-forget view tracking for AP-0106 ("People You Know Are Here"
+ * Social Proof). Called by the frontend when a user opens a group detail
+ * page; dispatches user.group.viewed so the automation can check whether
+ * any of the viewer's connections are already members.
+ */
+router.post('/groups/:id/view', async (req: Request, res: Response) => {
+  const groupId = req.params.id;
+
+  const token = getBearerToken(req);
+  if (!token) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const uuidValidation = z.string().uuid('Invalid group ID').safeParse(groupId);
+  if (!uuidValidation.success) {
+    return res.status(400).json({ ok: false, error: 'Invalid group ID format' });
+  }
+
+  let userId = '';
+  try { userId = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).sub; } catch {}
+
+  const tenantId = process.env.DEFAULT_TENANT_ID;
+  if (tenantId && userId) {
+    dispatchEvent(tenantId, 'user.group.viewed', {
+      user_id: userId,
+      group_id: groupId,
+    }).catch(err => console.warn(`[${VTID}] dispatch user.group.viewed failed:`, err.message));
+  }
+
+  return res.status(200).json({ ok: true });
 });
 
 /**

--- a/services/gateway/src/routes/community.ts
+++ b/services/gateway/src/routes/community.ts
@@ -370,22 +370,20 @@ router.post('/groups/:id/join', async (req: Request, res: Response) => {
  * page; dispatches user.group.viewed so the automation can check whether
  * any of the viewer's connections are already members.
  */
-router.post('/groups/:id/view', async (req: Request, res: Response) => {
+router.post('/groups/:id/view', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  // impact-allow-no-oasis: a page view is telemetry, not a state transition
+  // (CLAUDE.md OASIS rule: "Never mark polling or heartbeats as OASIS
+  // events"). The automation dispatch below IS the meaningful side effect;
+  // automation-executor already emits autopilot.automation.completed/failed
+  // per run, so a second OASIS event here would be a duplicate signal.
   const groupId = req.params.id;
-
-  const token = getBearerToken(req);
-  if (!token) {
-    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-  }
 
   const uuidValidation = z.string().uuid('Invalid group ID').safeParse(groupId);
   if (!uuidValidation.success) {
     return res.status(400).json({ ok: false, error: 'Invalid group ID format' });
   }
 
-  let userId = '';
-  try { userId = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).sub; } catch {}
-
+  const userId = req.identity?.user_id;
   const tenantId = process.env.DEFAULT_TENANT_ID;
   if (tenantId && userId) {
     dispatchEvent(tenantId, 'user.group.viewed', {

--- a/services/gateway/src/services/automation-executor.ts
+++ b/services/gateway/src/services/automation-executor.ts
@@ -193,6 +193,15 @@ export function registerHandler(
   console.log(`[AutomationExecutor] Registered handler: ${handlerName}`);
 }
 
+/**
+ * Look up a registered handler by name (used by tests and introspection).
+ */
+export function getHandler(
+  handlerName: string
+): ((ctx: AutomationContext) => Promise<{ usersAffected: number; actionsTaken: number }>) | undefined {
+  return handlers[handlerName];
+}
+
 // =============================================================================
 // Role-aware user query
 // =============================================================================

--- a/services/gateway/src/services/automation-handlers/community-groups.ts
+++ b/services/gateway/src/services/automation-handlers/community-groups.ts
@@ -8,6 +8,11 @@ import { AutomationContext } from '../../types/automations';
 import { registerHandler } from '../automation-executor';
 
 // ── AP-0202: Group Invite Follow-Up ─────────────────────────
+// Real schema: community_groups/community_memberships (VTID-01084) were
+// never deployed; global_community_groups is the live groups table.
+// community_group_invitations IS live, but its invitee column is
+// invited_user_id, not user_id. app_users' primary key is user_id, not id
+// (a mistake repeated across several handlers in this file before this fix).
 async function runGroupInviteFollowUp(ctx: AutomationContext) {
   const { supabase, tenantId } = ctx;
   let usersAffected = 0;
@@ -17,7 +22,7 @@ async function runGroupInviteFollowUp(ctx: AutomationContext) {
 
   const { data: pendingInvites } = await supabase
     .from('community_group_invitations')
-    .select('id, user_id, group_id, invited_by')
+    .select('id, invited_user_id, group_id, invited_by')
     .eq('tenant_id', tenantId)
     .eq('status', 'pending')
     .lte('created_at', fortyEightHoursAgo)
@@ -25,18 +30,18 @@ async function runGroupInviteFollowUp(ctx: AutomationContext) {
 
   for (const invite of pendingInvites || []) {
     const { data: group } = await supabase
-      .from('community_groups')
-      .select('name, topic_keys')
+      .from('global_community_groups')
+      .select('name')
       .eq('id', invite.group_id)
       .maybeSingle();
 
     const { data: inviter } = await supabase
       .from('app_users')
       .select('display_name')
-      .eq('id', invite.invited_by)
+      .eq('user_id', invite.invited_by)
       .maybeSingle();
 
-    ctx.notify(invite.user_id, 'group_invitation_received', {
+    ctx.notify(invite.invited_user_id, 'group_invitation_received', {
       title: 'Group Invitation Reminder',
       body: `${inviter?.display_name || 'Someone'} invited you to join "${group?.name || 'a group'}"`,
       data: { url: `/community/groups/${invite.group_id}`, group_id: invite.group_id },
@@ -50,21 +55,23 @@ async function runGroupInviteFollowUp(ctx: AutomationContext) {
 }
 
 // ── AP-0203: New Member Welcome ─────────────────────────────
+// Real schema: global_community_groups/global_community_group_members
+// (no tenant_id — the global community is shared across tenants).
 async function runNewMemberWelcome(ctx: AutomationContext) {
   const payload = ctx.run.metadata as any;
   const { user_id, group_id } = payload || {};
   if (!user_id || !group_id) return { usersAffected: 0, actionsTaken: 0 };
 
-  const { supabase, tenantId } = ctx;
+  const { supabase } = ctx;
 
   const { data: group } = await supabase
-    .from('community_groups')
+    .from('global_community_groups')
     .select('name, description, created_by')
     .eq('id', group_id)
     .maybeSingle();
 
   const { count: memberCount } = await supabase
-    .from('community_memberships')
+    .from('global_community_group_members')
     .select('id', { count: 'exact', head: true })
     .eq('group_id', group_id);
 
@@ -77,7 +84,7 @@ async function runNewMemberWelcome(ctx: AutomationContext) {
   // Notify group creator
   if (group?.created_by && group.created_by !== user_id) {
     const { data: newMember } = await supabase
-      .from('app_users').select('display_name').eq('id', user_id).maybeSingle();
+      .from('app_users').select('display_name').eq('user_id', user_id).maybeSingle();
 
     ctx.notify(group.created_by, 'someone_joined_your_group', {
       title: 'New Group Member!',
@@ -124,7 +131,7 @@ async function runWelcomeSquad(ctx: AutomationContext) {
   const { data: newMember } = await supabase
     .from('app_users')
     .select('display_name')
-    .eq('id', user_id)
+    .eq('user_id', user_id)
     .maybeSingle();
   const newMemberName = newMember?.display_name || 'A new member';
 
@@ -224,80 +231,66 @@ async function runWelcomeSquad(ctx: AutomationContext) {
 }
 
 // ── AP-0207: Meetup RSVP Encouragement ──────────────────────
+// Real schema: community_meetups/community_meetup_attendance were never
+// deployed. global_community_events/global_event_participants is the live
+// equivalent — but events there aren't linked to a group_id, so "notify
+// group members who haven't RSVP'd" has no live equivalent. Adapted to the
+// schema that actually exists: nudge the event's own creator to help
+// promote it when registrations are low as start time approaches.
 async function runMeetupRsvpEncouragement(ctx: AutomationContext) {
-  const { supabase, tenantId } = ctx;
+  const { supabase } = ctx;
   let usersAffected = 0;
   let actionsTaken = 0;
 
   const now = new Date();
   const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
 
-  // Find meetups starting in next 24h with < 3 RSVPs
-  const { data: meetups } = await supabase
-    .from('community_meetups')
-    .select('id, title, group_id, starts_at')
-    .eq('tenant_id', tenantId)
-    .gte('starts_at', now.toISOString())
-    .lte('starts_at', in24h.toISOString());
+  const { data: events } = await supabase
+    .from('global_community_events')
+    .select('id, title, created_by, start_time, participant_count, max_participants')
+    .gte('start_time', now.toISOString())
+    .lte('start_time', in24h.toISOString())
+    .not('created_by', 'is', null);
 
-  for (const meetup of meetups || []) {
-    const { count: rsvpCount } = await supabase
-      .from('community_meetup_attendance')
-      .select('id', { count: 'exact', head: true })
-      .eq('meetup_id', meetup.id)
-      .eq('status', 'rsvp');
+  for (const event of events || []) {
+    const participantCount = event.participant_count || 0;
+    if (participantCount >= 3) continue;
 
-    if ((rsvpCount || 0) >= 3) continue;
+    ctx.notify(event.created_by, 'meetup_recommended', {
+      title: 'Your event is tomorrow',
+      body: `"${event.title}" starts soon with ${participantCount} registered${event.max_participants ? ` (room for ${event.max_participants})` : ''}. Share it to fill more seats.`,
+      data: { url: `/community/events/${event.id}`, event_id: event.id },
+    });
 
-    // Get group members who haven't RSVP'd
-    const { data: rsvpUsers } = await supabase
-      .from('community_meetup_attendance')
-      .select('user_id')
-      .eq('meetup_id', meetup.id);
-
-    const rsvpSet = new Set((rsvpUsers || []).map((r: any) => r.user_id));
-
-    const { data: groupMembers } = await supabase
-      .from('community_memberships')
-      .select('user_id')
-      .eq('group_id', meetup.group_id)
-      .limit(20);
-
-    for (const member of groupMembers || []) {
-      if (rsvpSet.has(member.user_id)) continue;
-
-      ctx.notify(member.user_id, 'meetup_recommended', {
-        title: 'Meetup Tomorrow!',
-        body: `"${meetup.title}" is tomorrow — ${rsvpCount || 0} people are going. Join them?`,
-        data: { url: `/community/meetups/${meetup.id}`, meetup_id: meetup.id },
-      });
-
-      usersAffected++;
-      actionsTaken++;
-    }
+    usersAffected++;
+    actionsTaken++;
   }
 
   return { usersAffected, actionsTaken };
 }
 
 // ── AP-0208: Post-Meetup Connection Prompt ──────────────────
+// Real schema: global_community_events/global_event_participants (see
+// AP-0207 comment). global_event_participants has no distinct "attended"
+// status observed live (only 'attending'), so this fires on registered
+// participants once the event has ended.
 async function runPostMeetupConnect(ctx: AutomationContext) {
   const payload = ctx.run.metadata as any;
   const meetupId = payload?.meetup_id;
   if (!meetupId) return { usersAffected: 0, actionsTaken: 0 };
 
-  const { supabase, tenantId } = ctx;
+  const { supabase } = ctx;
   let usersAffected = 0;
   let actionsTaken = 0;
 
   const { data: attendees } = await supabase
-    .from('community_meetup_attendance')
+    .from('global_event_participants')
     .select('user_id')
-    .eq('meetup_id', meetupId)
-    .eq('status', 'attended');
+    .eq('event_id', meetupId)
+    .eq('status', 'attending');
 
   const { data: meetup } = await supabase
-    .from('community_meetups')
+    .from('global_community_events')
     .select('title')
     .eq('id', meetupId)
     .maybeSingle();
@@ -317,20 +310,20 @@ async function runPostMeetupConnect(ctx: AutomationContext) {
 
 // ── AP-0210: Community Digest for Group Creators ────────────
 async function runCommunityCreatorDigest(ctx: AutomationContext) {
-  const { supabase, tenantId } = ctx;
+  const { supabase } = ctx;
   let usersAffected = 0;
   let actionsTaken = 0;
 
   const { data: groups } = await supabase
-    .from('community_groups')
+    .from('global_community_groups')
     .select('id, name, created_by')
-    .eq('tenant_id', tenantId);
+    .not('created_by', 'is', null);
 
   for (const group of groups || []) {
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 
     const { count: newMembers } = await supabase
-      .from('community_memberships')
+      .from('global_community_group_members')
       .select('id', { count: 'exact', head: true })
       .eq('group_id', group.id)
       .gte('joined_at', sevenDaysAgo);
@@ -438,6 +431,394 @@ async function runReviveYourGroup(ctx: AutomationContext) {
   return { usersAffected, actionsTaken };
 }
 
+const VITANA_BOT_USER_ID = process.env.VITANA_BOT_USER_ID || '00000000-0000-0000-0000-000000000000';
+
+// ── AP-0201: Auto-Create Group from Interest Cluster ────────
+// Clusters on user_interests.interest (the live interest-signal table —
+// user_topic_profile, used by AP-0102, does not exist in the live DB).
+// Bounded: at most INTEREST_CLUSTER_MAX_NEW_GROUPS new groups per run, skips
+// any interest that already has a public group.
+const INTEREST_CLUSTER_MIN_USERS = 5;
+const INTEREST_CLUSTER_MIN_CONFIDENCE = 0.6;
+const INTEREST_CLUSTER_MAX_NEW_GROUPS = 2;
+const INTEREST_CLUSTER_MAX_MEMBERS_PER_GROUP = 20;
+
+async function runAutoCreateGroupFromInterestCluster(ctx: AutomationContext) {
+  const { supabase } = ctx;
+  let usersAffected = 0;
+  let actionsTaken = 0;
+
+  const { data: interestRows } = await supabase
+    .from('user_interests')
+    .select('user_id, interest, confidence_score')
+    .gte('confidence_score', INTEREST_CLUSTER_MIN_CONFIDENCE)
+    .limit(2000);
+
+  const usersByInterest = new Map<string, string[]>();
+  for (const row of interestRows || []) {
+    const key = (row.interest || '').trim().toLowerCase();
+    if (!key) continue;
+    const users = usersByInterest.get(key) || [];
+    if (!users.includes(row.user_id)) users.push(row.user_id);
+    usersByInterest.set(key, users);
+  }
+
+  let groupsCreated = 0;
+  for (const [interest, userIds] of usersByInterest) {
+    if (groupsCreated >= INTEREST_CLUSTER_MAX_NEW_GROUPS) break;
+    if (userIds.length < INTEREST_CLUSTER_MIN_USERS) continue;
+
+    const { data: existingGroup } = await supabase
+      .from('global_community_groups')
+      .select('id')
+      .ilike('category', interest)
+      .limit(1)
+      .maybeSingle();
+    if (existingGroup) continue;
+
+    const displayName = interest.replace(/(^|\s)\S/g, (c: string) => c.toUpperCase());
+    const { data: newGroup, error: createErr } = await supabase
+      .from('global_community_groups')
+      .insert({
+        name: `${displayName} Circle`,
+        description: `Auto-created for members who share an interest in ${displayName}.`,
+        category: interest,
+        is_public: true,
+        created_by: VITANA_BOT_USER_ID,
+      })
+      .select('id, name')
+      .single();
+    if (createErr || !newGroup) continue;
+
+    const memberIds = userIds.slice(0, INTEREST_CLUSTER_MAX_MEMBERS_PER_GROUP);
+    await supabase
+      .from('global_community_group_members')
+      .insert(memberIds.map((user_id) => ({ group_id: newGroup.id, user_id, role: 'member' })));
+
+    for (const user_id of memberIds) {
+      ctx.notify(user_id, 'group_recommended', {
+        title: `New group: ${newGroup.name}`,
+        body: `We created a group for people who share your interest in ${displayName}.`,
+        data: { url: `/community/groups/${newGroup.id}`, group_id: newGroup.id },
+      });
+      usersAffected++;
+      actionsTaken++;
+    }
+
+    groupsCreated++;
+    actionsTaken++;
+  }
+
+  await ctx.emitEvent('autopilot.community.groups_auto_created', { groups_created: groupsCreated });
+
+  return { usersAffected, actionsTaken };
+}
+
+// ── AP-0204: Auto-Suggest Meetup from Group Activity ────────
+// Registry originally specified an event trigger (community.chat.activity_
+// spike), but nothing in the gateway inserts group chat messages — the
+// frontend writes global_messages directly via Supabase, so there is no
+// gateway-side hook to dispatch that event from. Implemented as a heartbeat
+// scan of global_messages volume per group instead (see registry entry).
+const ACTIVITY_SPIKE_WINDOW_HOURS = 3;
+const ACTIVITY_SPIKE_MIN_MESSAGES = 15;
+const ACTIVITY_SPIKE_COOLDOWN_DAYS = 7;
+const ACTIVITY_SPIKE_MAX_SUGGESTIONS = 20;
+
+async function runAutoSuggestMeetupFromGroupActivity(ctx: AutomationContext) {
+  const { supabase } = ctx;
+  let usersAffected = 0;
+  let actionsTaken = 0;
+
+  const windowStart = new Date(Date.now() - ACTIVITY_SPIKE_WINDOW_HOURS * 60 * 60 * 1000).toISOString();
+  const cooldownCutoff = new Date(Date.now() - ACTIVITY_SPIKE_COOLDOWN_DAYS * 86_400_000).toISOString();
+
+  const { data: groups } = await supabase
+    .from('global_community_groups')
+    .select('id, name, created_by, chat_thread_id')
+    .not('chat_thread_id', 'is', null)
+    .not('created_by', 'is', null)
+    .limit(500);
+
+  let suggestionsSent = 0;
+  for (const group of groups || []) {
+    if (suggestionsSent >= ACTIVITY_SPIKE_MAX_SUGGESTIONS) break;
+
+    const { count: messageCount } = await supabase
+      .from('global_messages')
+      .select('id', { count: 'exact', head: true })
+      .eq('thread_id', group.chat_thread_id)
+      .gte('created_at', windowStart);
+
+    if ((messageCount || 0) < ACTIVITY_SPIKE_MIN_MESSAGES) continue;
+
+    const { data: recentSuggestion } = await supabase
+      .from('user_notifications')
+      .select('id')
+      .eq('user_id', group.created_by)
+      .contains('data', { automation_id: 'AP-0204', group_id: group.id })
+      .gte('created_at', cooldownCutoff)
+      .limit(1);
+    if (recentSuggestion && recentSuggestion.length > 0) continue;
+
+    ctx.notify(group.created_by, 'orb_proactive_message', {
+      title: `${group.name} is buzzing 🔥`,
+      body: `${messageCount} messages in the last ${ACTIVITY_SPIKE_WINDOW_HOURS}h — a great time to plan a meetup while everyone's engaged.`,
+      data: {
+        url: `/community/groups/${group.id}`,
+        group_id: group.id,
+        via: 'autopilot',
+        automation_id: 'AP-0204',
+      },
+    });
+
+    usersAffected++;
+    actionsTaken++;
+    suggestionsSent++;
+  }
+
+  return { usersAffected, actionsTaken };
+}
+
+// ── AP-0205: Group Health Monitor ───────────────────────────
+// Weekly ops/admin digest: dormant groups (no posts in DORMANT_DAYS, mirrors
+// AP-0211's threshold) and groups with zero members, so ops has visibility
+// before a group needs manual intervention.
+const HEALTH_MONITOR_MAX_GROUPS_LISTED = 10;
+
+async function runGroupHealthMonitor(ctx: AutomationContext) {
+  const { supabase } = ctx;
+  let usersAffected = 0;
+  let actionsTaken = 0;
+
+  const dormantCutoff = new Date(Date.now() - DORMANT_DAYS * 86_400_000).toISOString();
+
+  const { data: groups } = await supabase
+    .from('global_community_groups')
+    .select('id, name, member_count')
+    .eq('status', 'approved')
+    .limit(1000);
+
+  const emptyGroups: string[] = [];
+  const dormantGroups: string[] = [];
+
+  for (const group of groups || []) {
+    if ((group.member_count || 0) === 0) {
+      emptyGroups.push(group.name);
+      continue;
+    }
+
+    const { data: lastPost } = await supabase
+      .from('group_posts')
+      .select('created_at')
+      .eq('group_id', group.id)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (!lastPost || lastPost.created_at < dormantCutoff) {
+      dormantGroups.push(group.name);
+    }
+  }
+
+  if (emptyGroups.length === 0 && dormantGroups.length === 0) {
+    return { usersAffected: 0, actionsTaken: 0 };
+  }
+
+  const opsUsers = await ctx.queryTargetUsers();
+  for (const { user_id } of opsUsers) {
+    ctx.notify(user_id, 'admin_digest', {
+      title: 'Weekly Group Health Report',
+      body: `${dormantGroups.length} dormant, ${emptyGroups.length} empty of ${groups?.length || 0} total groups.`,
+      data: {
+        dormant_groups: dormantGroups.slice(0, HEALTH_MONITOR_MAX_GROUPS_LISTED).join(', '),
+        empty_groups: emptyGroups.slice(0, HEALTH_MONITOR_MAX_GROUPS_LISTED).join(', '),
+      },
+    });
+    usersAffected++;
+    actionsTaken++;
+  }
+
+  await ctx.emitEvent('autopilot.group_health.reported', {
+    total_groups: groups?.length || 0,
+    dormant_count: dormantGroups.length,
+    empty_count: emptyGroups.length,
+  });
+
+  return { usersAffected, actionsTaken };
+}
+
+// ── AP-0206: Cross-Group Introduction ───────────────────────
+// Finds pairs of users who co-belong to 2+ of the same groups but have no
+// relationship_edges connection yet, and suggests they connect. Bounded to
+// a sample of users per run to keep the O(n²) pairing cheap.
+const CROSS_GROUP_MAX_USERS_SCANNED = 200;
+const CROSS_GROUP_MIN_SHARED_GROUPS = 2;
+const CROSS_GROUP_MAX_INTROS = 20;
+
+async function runCrossGroupIntroduction(ctx: AutomationContext) {
+  const { supabase, tenantId } = ctx;
+  let usersAffected = 0;
+  let actionsTaken = 0;
+
+  const { data: memberships } = await supabase
+    .from('global_community_group_members')
+    .select('user_id, group_id')
+    .limit(5000);
+
+  const groupsByUser = new Map<string, Set<string>>();
+  for (const m of memberships || []) {
+    const set = groupsByUser.get(m.user_id) || new Set<string>();
+    set.add(m.group_id);
+    groupsByUser.set(m.user_id, set);
+  }
+
+  const userIds = [...groupsByUser.keys()].slice(0, CROSS_GROUP_MAX_USERS_SCANNED);
+  const introduced = new Set<string>(); // "userA|userB" pairs already handled this run
+
+  let introsSent = 0;
+  for (let i = 0; i < userIds.length && introsSent < CROSS_GROUP_MAX_INTROS; i++) {
+    for (let j = i + 1; j < userIds.length && introsSent < CROSS_GROUP_MAX_INTROS; j++) {
+      const userA = userIds[i];
+      const userB = userIds[j];
+      const pairKey = [userA, userB].sort().join('|');
+      if (introduced.has(pairKey)) continue;
+
+      const groupsA = groupsByUser.get(userA)!;
+      const groupsB = groupsByUser.get(userB)!;
+      let shared = 0;
+      for (const g of groupsA) if (groupsB.has(g)) shared++;
+      if (shared < CROSS_GROUP_MIN_SHARED_GROUPS) continue;
+
+      const { data: existingEdge } = await supabase
+        .from('relationship_edges')
+        .select('id')
+        .eq('tenant_id', tenantId)
+        .eq('source_type', 'person')
+        .eq('source_id', userA)
+        .eq('target_type', 'person')
+        .eq('target_id', userB)
+        .limit(1);
+      if (existingEdge && existingEdge.length > 0) continue;
+
+      introduced.add(pairKey);
+
+      ctx.notify(userA, 'person_match_suggested', {
+        title: 'You keep showing up together',
+        body: `You and someone else are both in ${shared} of the same groups — want to connect?`,
+        data: { peer_id: userB, url: `/chat/${userB}` },
+      });
+      ctx.notify(userB, 'person_match_suggested', {
+        title: 'You keep showing up together',
+        body: `You and someone else are both in ${shared} of the same groups — want to connect?`,
+        data: { peer_id: userA, url: `/chat/${userA}` },
+      });
+
+      usersAffected += 2;
+      actionsTaken += 2;
+      introsSent++;
+    }
+  }
+
+  return { usersAffected, actionsTaken };
+}
+
+// ── AP-0209: Group Creation from Match Cluster ──────────────
+// Finds fully-connected triangles in relationship_edges (three mutually
+// "connected" users with no group in common) and auto-creates a group for
+// them. Bounded to MATCH_CLUSTER_MAX_NEW_GROUPS per run.
+const MATCH_CLUSTER_MAX_NEW_GROUPS = 2;
+const MATCH_CLUSTER_MAX_EDGES_SCANNED = 3000;
+
+async function runGroupCreationFromMatchCluster(ctx: AutomationContext) {
+  const { supabase, tenantId } = ctx;
+  let usersAffected = 0;
+  let actionsTaken = 0;
+
+  const { data: edges } = await supabase
+    .from('relationship_edges')
+    .select('source_id, target_id')
+    .eq('tenant_id', tenantId)
+    .eq('source_type', 'person')
+    .eq('target_type', 'person')
+    .eq('edge_type', 'connected')
+    .limit(MATCH_CLUSTER_MAX_EDGES_SCANNED);
+
+  const connections = new Map<string, Set<string>>();
+  for (const e of edges || []) {
+    if (!connections.has(e.source_id)) connections.set(e.source_id, new Set());
+    connections.get(e.source_id)!.add(e.target_id);
+  }
+
+  const foundTriangles: [string, string, string][] = [];
+  for (const [a, aConns] of connections) {
+    for (const b of aConns) {
+      const bConns = connections.get(b);
+      if (!bConns) continue;
+      for (const c of bConns) {
+        if (c === a) continue;
+        if (aConns.has(c)) {
+          const triangle = [a, b, c].sort() as [string, string, string];
+          const key = triangle.join('|');
+          if (!foundTriangles.some((t) => t.join('|') === key)) {
+            foundTriangles.push(triangle);
+          }
+        }
+      }
+    }
+  }
+
+  let groupsCreated = 0;
+  for (const [userA, userB, userC] of foundTriangles) {
+    if (groupsCreated >= MATCH_CLUSTER_MAX_NEW_GROUPS) break;
+
+    // Skip if these three already share a group.
+    const { data: sharedMemberships } = await supabase
+      .from('global_community_group_members')
+      .select('group_id, user_id')
+      .in('user_id', [userA, userB, userC]);
+
+    const groupCounts = new Map<string, number>();
+    for (const m of sharedMemberships || []) {
+      groupCounts.set(m.group_id, (groupCounts.get(m.group_id) || 0) + 1);
+    }
+    if ([...groupCounts.values()].some((count) => count === 3)) continue;
+
+    const { data: newGroup, error: createErr } = await supabase
+      .from('global_community_groups')
+      .insert({
+        name: 'Your Match Circle',
+        description: 'Auto-created for a group of mutually connected matches.',
+        is_public: false,
+        created_by: VITANA_BOT_USER_ID,
+      })
+      .select('id, name')
+      .single();
+    if (createErr || !newGroup) continue;
+
+    await supabase.from('global_community_group_members').insert(
+      [userA, userB, userC].map((user_id) => ({ group_id: newGroup.id, user_id, role: 'member' }))
+    );
+
+    for (const user_id of [userA, userB, userC]) {
+      ctx.notify(user_id, 'group_recommended', {
+        title: 'A group just for your circle',
+        body: 'We created a private group for you and two mutual connections.',
+        data: { url: `/community/groups/${newGroup.id}`, group_id: newGroup.id },
+      });
+      usersAffected++;
+      actionsTaken++;
+    }
+
+    groupsCreated++;
+    actionsTaken++;
+  }
+
+  await ctx.emitEvent('autopilot.community.match_cluster_groups_created', { groups_created: groupsCreated });
+
+  return { usersAffected, actionsTaken };
+}
+
 export function registerCommunityGroupsHandlers(): void {
   registerHandler('runGroupInviteFollowUp', runGroupInviteFollowUp);
   registerHandler('runNewMemberWelcome', runNewMemberWelcome);
@@ -446,4 +827,9 @@ export function registerCommunityGroupsHandlers(): void {
   registerHandler('runMeetupRsvpEncouragement', runMeetupRsvpEncouragement);
   registerHandler('runPostMeetupConnect', runPostMeetupConnect);
   registerHandler('runCommunityCreatorDigest', runCommunityCreatorDigest);
+  registerHandler('runAutoCreateGroupFromInterestCluster', runAutoCreateGroupFromInterestCluster);
+  registerHandler('runAutoSuggestMeetupFromGroupActivity', runAutoSuggestMeetupFromGroupActivity);
+  registerHandler('runGroupHealthMonitor', runGroupHealthMonitor);
+  registerHandler('runCrossGroupIntroduction', runCrossGroupIntroduction);
+  registerHandler('runGroupCreationFromMatchCluster', runGroupCreationFromMatchCluster);
 }

--- a/services/gateway/src/services/automation-handlers/connect-people.ts
+++ b/services/gateway/src/services/automation-handlers/connect-people.ts
@@ -367,10 +367,12 @@ async function runPeopleYouKnowSocialProof(ctx: AutomationContext) {
   const knownMemberIds = (members || []).map((m: any) => m.user_id);
   if (knownMemberIds.length === 0) return { usersAffected: 0, actionsTaken: 0 };
 
+  // app_users' primary key is user_id, not id (a mistake repeated across
+  // several already-shipped automation handlers — see PR discussion).
   const { data: knownUsers } = await supabase
     .from('app_users')
     .select('display_name')
-    .in('id', knownMemberIds.slice(0, 3));
+    .in('user_id', knownMemberIds.slice(0, 3));
 
   const names = (knownUsers || []).map((u: any) => u.display_name).filter(Boolean);
   const body = names.length > 0

--- a/services/gateway/src/services/automation-handlers/connect-people.ts
+++ b/services/gateway/src/services/automation-handlers/connect-people.ts
@@ -338,19 +338,28 @@ async function runPeopleYouKnowSocialProof(ctx: AutomationContext) {
 
   const { supabase, tenantId } = ctx;
 
+  // relationship_edges' live schema is source_type/source_id/target_type/
+  // target_id/edge_type (NOT user_id/relationship_type — several other
+  // already-shipped handlers in this file/domain still use that stale
+  // column set and silently no-op; see PR discussion for the wider finding).
   const { data: connections } = await supabase
     .from('relationship_edges')
     .select('target_id')
     .eq('tenant_id', tenantId)
-    .eq('user_id', userId)
+    .eq('source_type', 'person')
+    .eq('source_id', userId)
     .eq('target_type', 'person')
-    .eq('relationship_type', 'connected');
+    .eq('edge_type', 'connected');
 
   const connectionIds = (connections || []).map((c: any) => c.target_id);
   if (connectionIds.length === 0) return { usersAffected: 0, actionsTaken: 0 };
 
+  // community_groups/community_group_members (VTID-01084) were never
+  // deployed — global_community_groups/global_community_group_members is
+  // the real, live groups schema (no tenant_id; the global community is
+  // shared across tenants).
   const { data: members } = await supabase
-    .from('community_group_members')
+    .from('global_community_group_members')
     .select('user_id')
     .eq('group_id', groupId)
     .in('user_id', connectionIds);
@@ -397,21 +406,25 @@ async function runOpportunitySocialLayer(ctx: AutomationContext) {
     .from('relationship_edges')
     .select('target_id')
     .eq('tenant_id', tenantId)
-    .eq('user_id', userId)
+    .eq('source_type', 'person')
+    .eq('source_id', userId)
     .eq('target_type', 'person')
-    .eq('relationship_type', 'connected');
+    .eq('edge_type', 'connected');
 
   const connectionIds = (connections || []).map((c: any) => c.target_id);
   if (connectionIds.length === 0) return { usersAffected: 0, actionsTaken: 0 };
 
-  // Find connections who engaged with a similar opportunity type recently
+  // Find connections who engaged with a similar opportunity type recently.
+  // status is 'active' | 'dismissed' | 'engaged' | 'expired' — 'engaged' is
+  // the ContextualOpportunityRecord value for acted-on (see
+  // types/opportunity-surfacing.ts).
   const { data: peerOpportunities, count } = await supabase
     .from('contextual_opportunities')
     .select('id, user_id', { count: 'exact' })
     .eq('tenant_id', tenantId)
     .eq('opportunity_type', opportunityType)
     .in('user_id', connectionIds)
-    .in('status', ['active', 'acted_on'])
+    .in('status', ['active', 'engaged'])
     .limit(10);
 
   if (!count || count === 0) return { usersAffected: 0, actionsTaken: 0 };

--- a/services/gateway/src/services/automation-handlers/connect-people.ts
+++ b/services/gateway/src/services/automation-handlers/connect-people.ts
@@ -329,6 +329,108 @@ async function runProactiveMatchBatch(ctx: AutomationContext) {
   return { usersAffected: 0, actionsTaken: 0 };
 }
 
+// ── AP-0106: "People You Know Are Here" Social Proof ────────
+async function runPeopleYouKnowSocialProof(ctx: AutomationContext) {
+  const payload = ctx.run.metadata as any;
+  const userId = payload?.user_id;
+  const groupId = payload?.group_id;
+  if (!userId || !groupId) return { usersAffected: 0, actionsTaken: 0 };
+
+  const { supabase, tenantId } = ctx;
+
+  const { data: connections } = await supabase
+    .from('relationship_edges')
+    .select('target_id')
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId)
+    .eq('target_type', 'person')
+    .eq('relationship_type', 'connected');
+
+  const connectionIds = (connections || []).map((c: any) => c.target_id);
+  if (connectionIds.length === 0) return { usersAffected: 0, actionsTaken: 0 };
+
+  const { data: members } = await supabase
+    .from('community_group_members')
+    .select('user_id')
+    .eq('group_id', groupId)
+    .in('user_id', connectionIds);
+
+  const knownMemberIds = (members || []).map((m: any) => m.user_id);
+  if (knownMemberIds.length === 0) return { usersAffected: 0, actionsTaken: 0 };
+
+  const { data: knownUsers } = await supabase
+    .from('app_users')
+    .select('display_name')
+    .in('id', knownMemberIds.slice(0, 3));
+
+  const names = (knownUsers || []).map((u: any) => u.display_name).filter(Boolean);
+  const body = names.length > 0
+    ? `${names.join(', ')}${knownMemberIds.length > names.length ? ' and others' : ''} you know ${knownMemberIds.length === 1 ? 'is' : 'are'} in this group.`
+    : `${knownMemberIds.length} ${knownMemberIds.length === 1 ? 'person' : 'people'} you know ${knownMemberIds.length === 1 ? 'is' : 'are'} in this group.`;
+
+  ctx.notify(userId, 'group_social_proof', {
+    title: 'People You Know Are Here',
+    body,
+    data: { url: `/community/groups/${groupId}`, group_id: groupId },
+  });
+
+  await ctx.emitEvent('autopilot.connect.social_proof_shown', {
+    user_id: userId,
+    group_id: groupId,
+    known_member_count: knownMemberIds.length,
+  });
+
+  return { usersAffected: 1, actionsTaken: 1 };
+}
+
+// ── AP-0110: Opportunity Surfacing with Social Layer ────────
+async function runOpportunitySocialLayer(ctx: AutomationContext) {
+  const payload = ctx.run.metadata as any;
+  const userId = payload?.user_id;
+  const opportunityId = payload?.opportunity_id;
+  const opportunityType = payload?.opportunity_type;
+  if (!userId || !opportunityId || !opportunityType) return { usersAffected: 0, actionsTaken: 0 };
+
+  const { supabase, tenantId } = ctx;
+
+  const { data: connections } = await supabase
+    .from('relationship_edges')
+    .select('target_id')
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId)
+    .eq('target_type', 'person')
+    .eq('relationship_type', 'connected');
+
+  const connectionIds = (connections || []).map((c: any) => c.target_id);
+  if (connectionIds.length === 0) return { usersAffected: 0, actionsTaken: 0 };
+
+  // Find connections who engaged with a similar opportunity type recently
+  const { data: peerOpportunities, count } = await supabase
+    .from('contextual_opportunities')
+    .select('id, user_id', { count: 'exact' })
+    .eq('tenant_id', tenantId)
+    .eq('opportunity_type', opportunityType)
+    .in('user_id', connectionIds)
+    .in('status', ['active', 'acted_on'])
+    .limit(10);
+
+  if (!count || count === 0) return { usersAffected: 0, actionsTaken: 0 };
+
+  ctx.notify(userId, 'opportunity_social_layer', {
+    title: 'Others Explored This Too',
+    body: `${count} ${count === 1 ? 'person' : 'people'} you know engaged with something similar recently.`,
+    data: { opportunity_id: opportunityId, peer_count: String(count) },
+  });
+
+  await ctx.emitEvent('autopilot.opportunity.social_layer_added', {
+    user_id: userId,
+    opportunity_id: opportunityId,
+    peer_count: count,
+  });
+
+  return { usersAffected: 1, actionsTaken: 1 };
+}
+
 // ── Register all handlers ───────────────────────────────────
 export function registerConnectPeopleHandlers(): void {
   registerHandler('runDailyMatchDelivery', runDailyMatchDelivery);
@@ -336,7 +438,9 @@ export function registerConnectPeopleHandlers(): void {
   registerHandler('runMutualAcceptIntroduction', runMutualAcceptIntroduction);
   registerHandler('runFirstConversationStarter', runFirstConversationStarter);
   registerHandler('runGroupRecommendationPush', runGroupRecommendationPush);
+  registerHandler('runPeopleYouKnowSocialProof', runPeopleYouKnowSocialProof);
   registerHandler('runSocialAlignmentSuggestions', runSocialAlignmentSuggestions);
   registerHandler('runMatchQualityLoop', runMatchQualityLoop);
   registerHandler('runProactiveMatchBatch', runProactiveMatchBatch);
+  registerHandler('runOpportunitySocialLayer', runOpportunitySocialLayer);
 }

--- a/services/gateway/src/services/automation-registry.ts
+++ b/services/gateway/src/services/automation-registry.ts
@@ -88,9 +88,10 @@ const CONNECT_PEOPLE: AutomationDefinition[] = [
   },
   {
     id: 'AP-0106', name: '"People You Know Are Here" Social Proof', domain: 'connect-people',
-    status: 'PLANNED', priority: 'P1', triggerType: 'event',
+    status: 'IMPLEMENTED', priority: 'P1', triggerType: 'event',
     triggerConfig: { eventTopic: 'user.group.viewed' },
     targetRoles: [...MEMBER_ROLES],
+    handler: 'runPeopleYouKnowSocialProof',
   },
   {
     id: 'AP-0107', name: 'Proactive Social Alignment Suggestions', domain: 'connect-people',
@@ -115,9 +116,10 @@ const CONNECT_PEOPLE: AutomationDefinition[] = [
   },
   {
     id: 'AP-0110', name: 'Opportunity Surfacing with Social Layer', domain: 'connect-people',
-    status: 'PLANNED', priority: 'P2', triggerType: 'event',
+    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'event',
     triggerConfig: { eventTopic: 'opportunity.detected' },
     targetRoles: [...MEMBER_ROLES],
+    handler: 'runOpportunitySocialLayer',
   },
 ];
 

--- a/services/gateway/src/services/automation-registry.ts
+++ b/services/gateway/src/services/automation-registry.ts
@@ -129,9 +129,10 @@ const CONNECT_PEOPLE: AutomationDefinition[] = [
 const COMMUNITY_GROUPS: AutomationDefinition[] = [
   {
     id: 'AP-0201', name: 'Auto-Create Group from Interest Cluster', domain: 'community-groups',
-    status: 'PLANNED', priority: 'P1', triggerType: 'heartbeat',
+    status: 'IMPLEMENTED', priority: 'P1', triggerType: 'heartbeat',
     triggerConfig: { intervalMinutes: 1440 },
     targetRoles: [...MEMBER_ROLES],
+    handler: 'runAutoCreateGroupFromInterestCluster',
   },
   {
     id: 'AP-0202', name: 'Group Invite Follow-Up', domain: 'community-groups',
@@ -149,21 +150,27 @@ const COMMUNITY_GROUPS: AutomationDefinition[] = [
   },
   {
     id: 'AP-0204', name: 'Auto-Suggest Meetup from Group Activity', domain: 'community-groups',
-    status: 'PLANNED', priority: 'P1', triggerType: 'event',
-    triggerConfig: { eventTopic: 'community.chat.activity_spike' },
+    // No gateway-side hook exists for the originally-specified
+    // community.chat.activity_spike event (group chat writes go straight
+    // from frontend to Supabase) — implemented as a heartbeat scan instead.
+    status: 'IMPLEMENTED', priority: 'P1', triggerType: 'heartbeat',
+    triggerConfig: { intervalMinutes: 180 },
     targetRoles: [...MEMBER_ROLES],
+    handler: 'runAutoSuggestMeetupFromGroupActivity',
   },
   {
     id: 'AP-0205', name: 'Group Health Monitor', domain: 'community-groups',
-    status: 'PLANNED', priority: 'P2', triggerType: 'cron',
+    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'cron',
     triggerConfig: { cronExpression: '0 10 * * 1' },
     targetRoles: [...OPS_ROLES],
+    handler: 'runGroupHealthMonitor',
   },
   {
     id: 'AP-0206', name: 'Cross-Group Introduction', domain: 'community-groups',
-    status: 'PLANNED', priority: 'P2', triggerType: 'heartbeat',
+    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'heartbeat',
     triggerConfig: { intervalMinutes: 10080 }, // weekly
     targetRoles: [...MEMBER_ROLES],
+    handler: 'runCrossGroupIntroduction',
   },
   {
     id: 'AP-0207', name: 'Meetup RSVP Encouragement', domain: 'community-groups',
@@ -181,9 +188,10 @@ const COMMUNITY_GROUPS: AutomationDefinition[] = [
   },
   {
     id: 'AP-0209', name: 'Group Creation from Match Cluster', domain: 'community-groups',
-    status: 'PLANNED', priority: 'P2', triggerType: 'heartbeat',
+    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'heartbeat',
     triggerConfig: { intervalMinutes: 1440 },
     targetRoles: [...MEMBER_ROLES],
+    handler: 'runGroupCreationFromMatchCluster',
   },
   {
     id: 'AP-0210', name: 'Community Digest for Group Creators', domain: 'community-groups',

--- a/services/gateway/src/services/d48-opportunity-surfacing-engine.ts
+++ b/services/gateway/src/services/d48-opportunity-surfacing-engine.ts
@@ -37,6 +37,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
 import { emitOasisEvent } from './oasis-event-service';
+import { dispatchEvent } from './automation-executor';
 import {
   OpportunitySurfacingInput,
   OpportunitySurfacingResponse,
@@ -1101,6 +1102,17 @@ export async function surfaceOpportunities(
     // Store opportunities
     await storeOpportunities(limitedOpportunities, input, supabase);
     rulesApplied.push('store_opportunities');
+
+    // Dispatch AP-0110 (Opportunity Surfacing with Social Layer) for the
+    // top-ranked opportunity only — avoids a notification per opportunity.
+    const topOpportunity = limitedOpportunities[0];
+    if (topOpportunity && input.tenant_id) {
+      dispatchEvent(input.tenant_id, 'opportunity.detected', {
+        user_id: input.user_id,
+        opportunity_id: topOpportunity.opportunity_id,
+        opportunity_type: topOpportunity.opportunity_type,
+      }).catch(err => console.warn(`${LOG_PREFIX} dispatch opportunity.detected failed:`, err.message));
+    }
 
     const duration = Date.now() - startTime;
 

--- a/services/gateway/test/services/automation-handlers-community-groups.test.ts
+++ b/services/gateway/test/services/automation-handlers-community-groups.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Autopilot Automations Phase 1 — community-groups domain.
+ *
+ * Two things pinned here:
+ *
+ * 1. Source-level wall: community_groups/community_memberships/
+ *    community_meetups/community_meetup_attendance (VTID-01084, never
+ *    deployed) and the app_users.id-instead-of-user_id mistake must not
+ *    reappear in this file. Both were confirmed live bugs in several
+ *    already-"IMPLEMENTED" handlers (AP-0202/0203/0207/0208/0210) — found
+ *    while building the 5 PLANNED gaps in this domain, fixed alongside them.
+ * 2. Behavior of the 5 newly-implemented automations (AP-0201, AP-0204,
+ *    AP-0205, AP-0206, AP-0209), each against the real live schema
+ *    (global_community_groups / global_community_group_members /
+ *    global_messages / relationship_edges with source_type/source_id/
+ *    target_type/target_id/edge_type).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  AUTOMATION_REGISTRY,
+  getAutomation,
+} from '../../src/services/automation-registry';
+import { getHandler } from '../../src/services/automation-executor';
+import { registerCommunityGroupsHandlers } from '../../src/services/automation-handlers/community-groups';
+import { AutomationContext } from '../../src/types/automations';
+
+registerCommunityGroupsHandlers();
+
+const SRC = path.join(__dirname, '..', '..', 'src', 'services', 'automation-handlers', 'community-groups.ts');
+
+describe('community-groups — source-level wall against never-deployed / wrong-column tables', () => {
+  const src = fs.readFileSync(SRC, 'utf8');
+
+  it('never references the never-deployed VTID-01084 tables', () => {
+    expect(src).not.toMatch(/from\(['"]community_groups['"]\)/);
+    expect(src).not.toMatch(/from\(['"]community_memberships['"]\)/);
+    expect(src).not.toMatch(/from\(['"]community_meetups['"]\)/);
+    expect(src).not.toMatch(/from\(['"]community_meetup_attendance['"]\)/);
+  });
+
+  it('never queries app_users by "id" (the real PK is user_id)', () => {
+    const appUsersBlocks = src.split("from('app_users')").slice(1);
+    for (const block of appUsersBlocks) {
+      const nextFewLines = block.slice(0, 150);
+      expect(nextFewLines).not.toMatch(/\.eq\(['"]id['"],/);
+      expect(nextFewLines).not.toMatch(/\.in\(['"]id['"],/);
+    }
+  });
+
+  it('uses the real live groups/events tables', () => {
+    expect(src).toContain("from('global_community_groups')");
+    expect(src).toContain("from('global_community_group_members')");
+    expect(src).toContain("from('global_community_events')");
+    expect(src).toContain("from('global_event_participants')");
+  });
+});
+
+describe('registry — the 5 PLANNED community-groups gaps are now implemented', () => {
+  const expected: Record<string, string> = {
+    'AP-0201': 'runAutoCreateGroupFromInterestCluster',
+    'AP-0204': 'runAutoSuggestMeetupFromGroupActivity',
+    'AP-0205': 'runGroupHealthMonitor',
+    'AP-0206': 'runCrossGroupIntroduction',
+    'AP-0209': 'runGroupCreationFromMatchCluster',
+  };
+
+  for (const [id, handlerName] of Object.entries(expected)) {
+    it(`${id} has status IMPLEMENTED with handler ${handlerName}`, () => {
+      const def = getAutomation(id);
+      expect(def?.status).toBe('IMPLEMENTED');
+      expect(def?.handler).toBe(handlerName);
+      expect(getHandler(handlerName)).toBeInstanceOf(Function);
+    });
+  }
+
+  it('no community-groups automation marked IMPLEMENTED/LIVE is missing a handler', () => {
+    const domain = AUTOMATION_REGISTRY.filter((d) => d.domain === 'community-groups');
+    for (const def of domain) {
+      if (def.status === 'IMPLEMENTED' || def.status === 'LIVE') {
+        expect(def.handler).toBeTruthy();
+      }
+    }
+  });
+});
+
+/**
+ * Sequenced thenable Supabase fake: each table maps to a queue of results,
+ * consumed in call order (FIFO), repeating the last entry once exhausted.
+ * insert()/select()/eq()/etc all return `this`; resolving yields the queued
+ * result. Enough to exercise multi-step handlers without a real client.
+ */
+function makeFakeSupabase(resultsByTable: Record<string, Array<{ data?: any; count?: number; error?: any }>>) {
+  const cursors: Record<string, number> = {};
+  return {
+    from(table: string) {
+      const queue = resultsByTable[table] || [{ data: [], error: null }];
+      const idx = Math.min(cursors[table] || 0, queue.length - 1);
+      cursors[table] = (cursors[table] || 0) + 1;
+      const result = queue[idx];
+      const chain: any = {
+        select: () => chain,
+        insert: () => chain,
+        eq: () => chain,
+        neq: () => chain,
+        in: () => chain,
+        not: () => chain,
+        ilike: () => chain,
+        gte: () => chain,
+        lte: () => chain,
+        contains: () => chain,
+        order: () => chain,
+        limit: () => chain,
+        maybeSingle: () => Promise.resolve(result),
+        single: () => Promise.resolve(result),
+        then: (resolve: any) => Promise.resolve(result).then(resolve),
+      };
+      return chain;
+    },
+  };
+}
+
+function makeCtx(
+  supabase: any,
+  metadata: Record<string, unknown> = {},
+  queryTargetUsers: Array<{ user_id: string; active_role: string }> = []
+): { ctx: AutomationContext; notify: jest.Mock } {
+  const notify = jest.fn();
+  const ctx: AutomationContext = {
+    tenantId: 't-1',
+    targetRoles: 'all',
+    supabase,
+    run: {
+      id: 'run-1',
+      tenant_id: 't-1',
+      automation_id: 'AP-TEST',
+      trigger_type: 'heartbeat',
+      target_roles: 'all',
+      status: 'running',
+      users_affected: 0,
+      actions_taken: 0,
+      metadata,
+      started_at: new Date().toISOString(),
+    },
+    log: jest.fn(),
+    notify,
+    emitEvent: jest.fn(async () => {}),
+    queryTargetUsers: jest.fn(async () => queryTargetUsers),
+  };
+  return { ctx, notify };
+}
+
+describe('runAutoCreateGroupFromInterestCluster (AP-0201)', () => {
+  it('creates a group and notifies members when a cluster meets the threshold', async () => {
+    const clusterUsers = ['u1', 'u2', 'u3', 'u4', 'u5'].map((user_id) => ({
+      user_id, interest: 'pickleball', confidence_score: 0.9,
+    }));
+    const supabase = makeFakeSupabase({
+      user_interests: [{ data: clusterUsers, error: null }],
+      global_community_groups: [
+        { data: null, error: null }, // existing-group check: none found
+        { data: { id: 'g-1', name: 'Pickleball Circle' }, error: null }, // insert().select().single()
+      ],
+      global_community_group_members: [{ data: null, error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+
+    const handler = getHandler('runAutoCreateGroupFromInterestCluster')!;
+    const result = await handler(ctx);
+
+    expect(notify).toHaveBeenCalledTimes(5);
+    expect(result.usersAffected).toBe(5);
+  });
+
+  it('is a no-op when no interest cluster meets the minimum user threshold', async () => {
+    const supabase = makeFakeSupabase({
+      user_interests: [{ data: [{ user_id: 'u1', interest: 'pickleball', confidence_score: 0.9 }], error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+
+    const handler = getHandler('runAutoCreateGroupFromInterestCluster')!;
+    const result = await handler(ctx);
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});
+
+describe('runAutoSuggestMeetupFromGroupActivity (AP-0204)', () => {
+  it('notifies the creator when message volume spikes and no recent suggestion exists', async () => {
+    const supabase = makeFakeSupabase({
+      global_community_groups: [{ data: [{ id: 'g-1', name: 'Runners', created_by: 'creator-1', chat_thread_id: 't-1' }], error: null }],
+      global_messages: [{ data: [], count: 20, error: null }],
+      user_notifications: [{ data: [], error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+
+    const handler = getHandler('runAutoSuggestMeetupFromGroupActivity')!;
+    const result = await handler(ctx);
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toBe('creator-1');
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 1 });
+  });
+
+  it('is a no-op when message volume is below the spike threshold', async () => {
+    const supabase = makeFakeSupabase({
+      global_community_groups: [{ data: [{ id: 'g-1', name: 'Runners', created_by: 'creator-1', chat_thread_id: 't-1' }], error: null }],
+      global_messages: [{ data: [], count: 2, error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+
+    const handler = getHandler('runAutoSuggestMeetupFromGroupActivity')!;
+    const result = await handler(ctx);
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});
+
+describe('runGroupHealthMonitor (AP-0205)', () => {
+  it('reports dormant and empty groups to ops/admin users', async () => {
+    const supabase = makeFakeSupabase({
+      global_community_groups: [{
+        data: [
+          { id: 'g-1', name: 'Active Group', member_count: 5 },
+          { id: 'g-2', name: 'Empty Group', member_count: 0 },
+        ],
+        error: null,
+      }],
+      group_posts: [{ data: null, error: null }], // no recent post -> dormant
+    });
+    const { ctx, notify } = makeCtx(supabase, {}, [{ user_id: 'admin-1', active_role: 'admin' }]);
+
+    const handler = getHandler('runGroupHealthMonitor')!;
+    const result = await handler(ctx);
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toBe('admin-1');
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 1 });
+  });
+
+  it('is a no-op when there are no dormant or empty groups', async () => {
+    const supabase = makeFakeSupabase({
+      global_community_groups: [{ data: [], error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase, {}, [{ user_id: 'admin-1', active_role: 'admin' }]);
+
+    const handler = getHandler('runGroupHealthMonitor')!;
+    const result = await handler(ctx);
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});
+
+describe('runCrossGroupIntroduction (AP-0206)', () => {
+  it('introduces two users who share 2+ groups and have no existing edge', async () => {
+    const supabase = makeFakeSupabase({
+      global_community_group_members: [{
+        data: [
+          { user_id: 'u1', group_id: 'g-1' },
+          { user_id: 'u1', group_id: 'g-2' },
+          { user_id: 'u2', group_id: 'g-1' },
+          { user_id: 'u2', group_id: 'g-2' },
+        ],
+        error: null,
+      }],
+      relationship_edges: [{ data: [], error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+
+    const handler = getHandler('runCrossGroupIntroduction')!;
+    const result = await handler(ctx);
+
+    expect(notify).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ usersAffected: 2, actionsTaken: 2 });
+  });
+
+  it('is a no-op when users share fewer than 2 groups', async () => {
+    const supabase = makeFakeSupabase({
+      global_community_group_members: [{
+        data: [
+          { user_id: 'u1', group_id: 'g-1' },
+          { user_id: 'u2', group_id: 'g-1' },
+        ],
+        error: null,
+      }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+
+    const handler = getHandler('runCrossGroupIntroduction')!;
+    const result = await handler(ctx);
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});
+
+describe('runGroupCreationFromMatchCluster (AP-0209)', () => {
+  it('creates a group for a mutually-connected triangle with no shared group yet', async () => {
+    const supabase = makeFakeSupabase({
+      relationship_edges: [{
+        data: [
+          { source_id: 'u1', target_id: 'u2' },
+          { source_id: 'u2', target_id: 'u1' },
+          { source_id: 'u1', target_id: 'u3' },
+          { source_id: 'u3', target_id: 'u1' },
+          { source_id: 'u2', target_id: 'u3' },
+          { source_id: 'u3', target_id: 'u2' },
+        ],
+        error: null,
+      }],
+      global_community_group_members: [{ data: [], error: null }, { data: null, error: null }],
+      global_community_groups: [{ data: { id: 'g-new', name: 'Your Match Circle' }, error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+
+    const handler = getHandler('runGroupCreationFromMatchCluster')!;
+    const result = await handler(ctx);
+
+    expect(notify).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({ usersAffected: 3, actionsTaken: 4 });
+  });
+
+  it('is a no-op when no fully-connected triangle exists', async () => {
+    const supabase = makeFakeSupabase({
+      relationship_edges: [{
+        data: [
+          { source_id: 'u1', target_id: 'u2' },
+          { source_id: 'u2', target_id: 'u3' },
+        ],
+        error: null,
+      }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+
+    const handler = getHandler('runGroupCreationFromMatchCluster')!;
+    const result = await handler(ctx);
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});

--- a/services/gateway/test/services/automation-handlers-connect-people.test.ts
+++ b/services/gateway/test/services/automation-handlers-connect-people.test.ts
@@ -99,7 +99,7 @@ describe('runPeopleYouKnowSocialProof (AP-0106)', () => {
   it('notifies the viewer when connections are members of the viewed group', async () => {
     const supabase = makeFakeSupabase({
       relationship_edges: { data: [{ target_id: 'friend-1' }], error: null },
-      community_group_members: { data: [{ user_id: 'friend-1' }], error: null },
+      global_community_group_members: { data: [{ user_id: 'friend-1' }], error: null },
       app_users: { data: [{ display_name: 'Alex' }], error: null },
     });
     const { ctx, notify } = makeCtx(supabase, { user_id: 'viewer-1', group_id: 'group-1' });

--- a/services/gateway/test/services/automation-handlers-connect-people.test.ts
+++ b/services/gateway/test/services/automation-handlers-connect-people.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Autopilot Automations Phase 1 — connect-people domain gap closure.
+ *
+ * AP-0106 ("People You Know Are Here" Social Proof) and AP-0110 (Opportunity
+ * Surfacing with Social Layer) were PLANNED-only entries with no handler.
+ * This pins: both are now IMPLEMENTED with a registered handler, and each
+ * handler's core behavior (notify when social overlap exists, no-op when it
+ * doesn't).
+ */
+
+import {
+  AUTOMATION_REGISTRY,
+  getAutomation,
+} from '../../src/services/automation-registry';
+import { registerHandler, getHandler } from '../../src/services/automation-executor';
+import { registerConnectPeopleHandlers } from '../../src/services/automation-handlers/connect-people';
+import { AutomationContext } from '../../src/types/automations';
+
+registerConnectPeopleHandlers();
+
+/**
+ * Minimal thenable Supabase query-builder fake. Every chain method returns
+ * `this`; resolving the chain (via await / .then) yields the configured
+ * result for that table. Enough to exercise the two handlers under test
+ * without a real Supabase client.
+ */
+function makeFakeSupabase(resultsByTable: Record<string, { data?: any; count?: number; error?: any }>) {
+  return {
+    from(table: string) {
+      const result = resultsByTable[table] || { data: [], error: null };
+      const chain: any = {
+        select: () => chain,
+        eq: () => chain,
+        neq: () => chain,
+        in: () => chain,
+        order: () => chain,
+        limit: () => chain,
+        maybeSingle: () => Promise.resolve(result),
+        single: () => Promise.resolve(result),
+        then: (resolve: any) => Promise.resolve(result).then(resolve),
+      };
+      return chain;
+    },
+  };
+}
+
+function makeCtx(supabase: any, metadata: Record<string, unknown>): { ctx: AutomationContext; notify: jest.Mock } {
+  const notify = jest.fn();
+  const ctx: AutomationContext = {
+    tenantId: 't-1',
+    targetRoles: 'all',
+    supabase,
+    run: {
+      id: 'run-1',
+      tenant_id: 't-1',
+      automation_id: 'AP-TEST',
+      trigger_type: 'event',
+      target_roles: 'all',
+      status: 'running',
+      users_affected: 0,
+      actions_taken: 0,
+      metadata,
+      started_at: new Date().toISOString(),
+    },
+    log: jest.fn(),
+    notify,
+    emitEvent: jest.fn(async () => {}),
+    queryTargetUsers: jest.fn(async () => []),
+  };
+  return { ctx, notify };
+}
+
+describe('registry — AP-0106 and AP-0110 are implemented', () => {
+  it('AP-0106 has status IMPLEMENTED and a registered handler', () => {
+    const def = getAutomation('AP-0106');
+    expect(def?.status).toBe('IMPLEMENTED');
+    expect(def?.handler).toBe('runPeopleYouKnowSocialProof');
+    expect(getHandler(def!.handler!)).toBeInstanceOf(Function);
+  });
+
+  it('AP-0110 has status IMPLEMENTED and a registered handler', () => {
+    const def = getAutomation('AP-0110');
+    expect(def?.status).toBe('IMPLEMENTED');
+    expect(def?.handler).toBe('runOpportunitySocialLayer');
+    expect(getHandler(def!.handler!)).toBeInstanceOf(Function);
+  });
+
+  it('no PLANNED automation in connect-people is missing a handler if IMPLEMENTED', () => {
+    const connectPeople = AUTOMATION_REGISTRY.filter(d => d.domain === 'connect-people');
+    for (const def of connectPeople) {
+      if (def.status === 'IMPLEMENTED' || def.status === 'LIVE') {
+        expect(def.handler).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe('runPeopleYouKnowSocialProof (AP-0106)', () => {
+  it('notifies the viewer when connections are members of the viewed group', async () => {
+    const supabase = makeFakeSupabase({
+      relationship_edges: { data: [{ target_id: 'friend-1' }], error: null },
+      community_group_members: { data: [{ user_id: 'friend-1' }], error: null },
+      app_users: { data: [{ display_name: 'Alex' }], error: null },
+    });
+    const { ctx, notify } = makeCtx(supabase, { user_id: 'viewer-1', group_id: 'group-1' });
+
+    const handler = getHandler('runPeopleYouKnowSocialProof')!;
+    const result = await handler(ctx);
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toBe('viewer-1');
+    expect(notify.mock.calls[0][2].body).toContain('Alex');
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 1 });
+  });
+
+  it('is a no-op when the viewer has no connections', async () => {
+    const supabase = makeFakeSupabase({
+      relationship_edges: { data: [], error: null },
+    });
+    const { ctx, notify } = makeCtx(supabase, { user_id: 'viewer-1', group_id: 'group-1' });
+
+    const handler = getHandler('runPeopleYouKnowSocialProof')!;
+    const result = await handler(ctx);
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+
+  it('is a no-op when required payload fields are missing', async () => {
+    const supabase = makeFakeSupabase({});
+    const { ctx, notify } = makeCtx(supabase, {});
+
+    const handler = getHandler('runPeopleYouKnowSocialProof')!;
+    const result = await handler(ctx);
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});
+
+describe('runOpportunitySocialLayer (AP-0110)', () => {
+  it('notifies the user when connections engaged with a similar opportunity', async () => {
+    const supabase = makeFakeSupabase({
+      relationship_edges: { data: [{ target_id: 'friend-1' }, { target_id: 'friend-2' }], error: null },
+      contextual_opportunities: {
+        data: [{ id: 'o-1', user_id: 'friend-1' }],
+        count: 1,
+        error: null,
+      },
+    });
+    const { ctx, notify } = makeCtx(supabase, {
+      user_id: 'viewer-1',
+      opportunity_id: 'opp-1',
+      opportunity_type: 'health_checkin',
+    });
+
+    const handler = getHandler('runOpportunitySocialLayer')!;
+    const result = await handler(ctx);
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toBe('viewer-1');
+    expect(notify.mock.calls[0][2].data.opportunity_id).toBe('opp-1');
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 1 });
+  });
+
+  it('is a no-op when no connections engaged with a similar opportunity', async () => {
+    const supabase = makeFakeSupabase({
+      relationship_edges: { data: [{ target_id: 'friend-1' }], error: null },
+      contextual_opportunities: { data: [], count: 0, error: null },
+    });
+    const { ctx, notify } = makeCtx(supabase, {
+      user_id: 'viewer-1',
+      opportunity_id: 'opp-1',
+      opportunity_type: 'health_checkin',
+    });
+
+    const handler = getHandler('runOpportunitySocialLayer')!;
+    const result = await handler(ctx);
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});

--- a/supabase/migrations/20260704200000_vtid_01142_contextual_opportunities_table.sql
+++ b/supabase/migrations/20260704200000_vtid_01142_contextual_opportunities_table.sql
@@ -1,0 +1,82 @@
+-- impact-allow-solo-migration: recovers schema that ALREADY-MERGED code
+-- (services/gateway/src/services/d48-opportunity-surfacing-engine.ts
+-- storeOpportunities/checkUserFatigue/dismissOpportunity/recordEngagement/
+-- getActiveOpportunities, and now automation-handlers/connect-people.ts
+-- runOpportunitySocialLayer) already calls against these exact table/column
+-- names. No app code change is needed or expected.
+/**
+ * D48 Context-Aware Opportunity & Experience Surfacing Engine — missing table
+ *
+ * VTID: VTID-01142
+ *
+ * `contextual_opportunities` is read/written throughout
+ * d48-opportunity-surfacing-engine.ts (surfaceOpportunities/storeOpportunities,
+ * checkUserFatigue, filterCandidates cooldown check, dismissOpportunity,
+ * recordEngagement, getActiveOpportunities) but was never defined in any
+ * migration — every insert/select has been silently no-op'ing (Supabase
+ * "relation does not exist" errors are caught and console.warn'd, never
+ * surfaced) since the engine shipped. Discovered while wiring AP-0110
+ * (Opportunity Surfacing with Social Layer), which reads this table to find
+ * connections who engaged with a similar opportunity.
+ *
+ * Schema mirrors `ContextualOpportunityRecord` in
+ * services/gateway/src/types/opportunity-surfacing.ts exactly.
+ */
+
+CREATE TABLE IF NOT EXISTS contextual_opportunities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  session_id text,
+  opportunity_type text NOT NULL,
+  title text NOT NULL,
+  description text NOT NULL,
+  confidence integer NOT NULL DEFAULT 0 CHECK (confidence >= 0 AND confidence <= 100),
+  why_now text NOT NULL DEFAULT '',
+  relevance_factors jsonb NOT NULL DEFAULT '[]',
+  suggested_action jsonb NOT NULL DEFAULT '{}',
+  dismissible boolean NOT NULL DEFAULT true,
+  priority_domain text NOT NULL,
+  external_id text,
+  external_type text,
+  window_id text,
+  guidance_id text,
+  alignment_signal_ids jsonb DEFAULT '[]',
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'dismissed', 'engaged', 'expired')),
+  dismissed_at timestamptz,
+  dismissed_reason text,
+  engaged_at timestamptz,
+  engagement_type text,
+  expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- checkUserFatigue: WHERE tenant_id, user_id, created_at >= today
+CREATE INDEX IF NOT EXISTS idx_contextual_opportunities_tenant_user_created
+  ON contextual_opportunities (tenant_id, user_id, created_at DESC);
+
+-- cooldown check (filterCandidates): WHERE tenant_id, user_id, status='dismissed', dismissed_at >= cutoff
+-- AP-0110 peer lookup: WHERE tenant_id, opportunity_type, user_id IN (...), status IN (...)
+CREATE INDEX IF NOT EXISTS idx_contextual_opportunities_tenant_user_status
+  ON contextual_opportunities (tenant_id, user_id, status);
+CREATE INDEX IF NOT EXISTS idx_contextual_opportunities_tenant_type_status
+  ON contextual_opportunities (tenant_id, opportunity_type, status);
+
+-- external_id lookup for cooldown Set membership
+CREATE INDEX IF NOT EXISTS idx_contextual_opportunities_external_id
+  ON contextual_opportunities (external_id) WHERE external_id IS NOT NULL;
+
+ALTER TABLE contextual_opportunities ENABLE ROW LEVEL SECURITY;
+
+-- surfaceOpportunities/dismissOpportunity/recordEngagement/getActiveOpportunities
+-- run against a user-scoped client (createUserClient(authToken)) when a JWT is
+-- present, so users need direct read/write on their own rows.
+CREATE POLICY "Users manage own contextual opportunities"
+  ON contextual_opportunities FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Service role full access on contextual_opportunities"
+  ON contextual_opportunities FOR ALL
+  USING (true) WITH CHECK (true);


### PR DESCRIPTION
## Summary

VTID-01250 (Autopilot Automations Engine). First two domains of Phase 1
(close 32 `PLANNED`-status gaps across 10 already-built domains).

### connect-people (2 automations implemented)
- **AP-0106** — `"People You Know Are Here" Social Proof`. Triggered on
  `user.group.viewed` (new endpoint `POST /api/v1/community/global-groups/:id/view`).
  Notifies a group viewer if any connections are already members.
- **AP-0110** — `Opportunity Surfacing with Social Layer`. Triggered on
  `opportunity.detected` (wired into D48's `surfaceOpportunities()`).
  Notifies a user if connections engaged with a similar opportunity.

### community-groups (5 automations implemented, 5 already-shipped handlers fixed)
Implemented: **AP-0201** (auto-create group from interest cluster),
**AP-0204** (auto-suggest meetup from group activity — heartbeat, not event;
see code comment for why), **AP-0205** (group health monitor),
**AP-0206** (cross-group introduction), **AP-0209** (group creation from
match cluster).

Fixed (found broken against the live DB while verifying this domain):
**AP-0202/0203/0207/0208/0210** were querying tables that were never
deployed (`community_groups`, `community_memberships`, `community_meetups`,
`community_meetup_attendance` — VTID-01084) or using the wrong `app_users`
primary key (`id` instead of the real `user_id`). Repointed at the real,
live schema: `global_community_groups`, `global_community_group_members`,
`global_community_events`, `global_event_participants`.

### Cross-cutting fixes
- `relationship_edges`'s live schema is `source_type/source_id/target_type/
  target_id/edge_type`, not `user_id/relationship_type/context` — fixed in
  the new AP-0106/0110/0206/0209 handlers (other already-shipped handlers
  using the stale schema are flagged as follow-up, not fixed here).
- `contextual_opportunities` (D48 Opportunity Surfacing) had no migration
  anywhere in the repo — every read/write has been silently no-op'ing since
  the engine shipped. Added + applied the missing table live.
- Documented `DEFAULT_TENANT_ID` and `VITANA_BOT_USER_ID` in `.env.example`
  (both read pervasively but had no discoverable binding).

## Test plan

- [x] `test/services/automation-handlers-connect-people.test.ts` (8 tests)
- [x] `test/services/automation-handlers-community-groups.test.ts` (19 tests,
      including a source-level wall against the never-deployed tables and
      the `app_users.id` mistake reappearing)
- [x] `npm run build` — clean TypeScript compile
- [x] All CI checks green
- [ ] Frontend wiring of the new `/global-groups/:id/view` call is a
      follow-up, not part of this PR — the endpoint and automation work
      end-to-end once called.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDeWcwo8qwBnCdr2h48Fy9)_