### PR TITLE
feat(memory): daily-learning — fix dead preferences, wire routine extractor, felt-learning surfaces (BOOTSTRAP-MEMORY-DAILY-LEARNING)

### DIFF
--- a/docs/autopilot-automations/09-memory-intelligence.md
+++ b/docs/autopilot-automations/09-memory-intelligence.md
@@ -105,3 +105,101 @@ When Autopilot suggests features or explains Vitana concepts, pulls context from
 **APIs used:**
 - `POST /api/v1/assistant/knowledge/search`
 - Knowledge Hub service (VTID-0538)
+
+---
+
+## AP-0906 — Routine Pattern Extraction
+
+| Field | Value |
+|-------|-------|
+| **Status** | `IMPLEMENTED` |
+| **Priority** | `P2` |
+| **Trigger** | Cron, daily 3:30am |
+| **Handler** | `runRoutinePatternExtraction` |
+
+**What it does:**
+Fans `extractPatternsForUser` (guide/pattern-extractor, VTID-01936 — previously caller-less) over users with calendar activity in the last 30 days, writing time-of-day / day-of-week / category-affinity routines to `user_routines`. The UserContextProfiler and guide awareness-context read that table, so routines flow into the ORB voice profile.
+
+---
+
+## AP-0907 — Daily Learning Digest
+
+| Field | Value |
+|-------|-------|
+| **Status** | `IMPLEMENTED` |
+| **Priority** | `P2` |
+| **Trigger** | Cron, daily 18:10 |
+| **Handler** | `runDailyLearningDigest` |
+
+**What it does:**
+The standalone half of the shared felt-learning detector (`conversation/new-facts-detector.ts`): notifies users who gained `memory_facts` in the last 24h but did not get the moment in a session (greeting-ledger `facts_learned` not spoken today, `learning_surfaced_v1` not stamped today). Localized via the gateway i18n catalog; silent when nothing new.
+
+---
+
+## AP-0908 — Behavior-Derived Preference Inference
+
+| Field | Value |
+|-------|-------|
+| **Status** | `IMPLEMENTED` |
+| **Priority** | `P2` |
+| **Trigger** | Cron, daily 4:40am |
+| **Handler** | `runBehaviorPreferenceInference` |
+
+**What it does:**
+Turns AP-0906's `user_routines` (confidence ≥ 0.6) into `user_preference_*` memory facts via `write_fact` — provenance `behavior_inferred`, confidence 0.55. Idempotent: identical values are skipped, so re-runs cause no supersession churn.
+
+---
+
+## AP-0909 — Relationship Graph Projection
+
+| Field | Value |
+|-------|-------|
+| **Status** | `IMPLEMENTED` |
+| **Priority** | `P2` |
+| **Trigger** | Cron, daily 3:50am |
+| **Handler** | `runRelationshipGraphProjection` |
+
+**What it does:**
+The graph as a DERIVED INDEX (the only creation path since Cognee's Phase 8 retirement): projects person-facts (`spouse_name`, `friend_name_*`, …) into `relationship_nodes` + person→node relation edges, and mutual follows into person↔person `connected` edges (the shape AP-0801 counts). Rebuildable from source data at any time; Loop 13 (nightly consolidator) is the single decay mechanism. **AP-0903 is retired** — its conflicting decay formula double-decayed the same rows.
+
+---
+
+## AP-0910 — Memory Embedding Backfill
+
+| Field | Value |
+|-------|-------|
+| **Status** | `IMPLEMENTED` |
+| **Priority** | `P2` |
+| **Trigger** | Cron, hourly at :25 |
+| **Handler** | `runMemoryEmbeddingBackfill` |
+
+**What it does:**
+Drains the fact-embedding backlog (96% of live facts were unembedded, blinding tier-2 semantic retrieval) in batches of 100 via `generateBatchEmbeddings`. New writes embed inline in the inline-fact-extractor; this catches history and misses. Cheap no-op once the backlog is empty.
+
+---
+
+## AP-0911 — User Model Synthesis
+
+| Field | Value |
+|-------|-------|
+| **Status** | `IMPLEMENTED` |
+| **Priority** | `P1` |
+| **Trigger** | Cron, daily 5:05am |
+| **Handler** | `runUserModelSynthesis` |
+
+**What it does:**
+One LLM pass per active user (≥3 facts) connecting facts + routines + active goal + Vitana Index into a compact grounded narrative ("who is this person"), stored in `user_assistant_state` (`user_profile_narrative_v1`) and injected by the UserContextProfiler into the TTL-cached ORB bootstrap — synthesized understanding at zero added latency. Skips users whose inputs hash is unchanged.
+
+---
+
+## AP-0912 — Health Correlation Insights
+
+| Field | Value |
+|-------|-------|
+| **Status** | `IMPLEMENTED` |
+| **Priority** | `P1` |
+| **Trigger** | Cron, daily 4:55am |
+| **Handler** | `runHealthCorrelationInsights` |
+
+**What it does:**
+Deterministic (no-LLM, no hallucinated health claims) correlation rules over `vitana_index_scores` and `diary_entries`: pillar trends (≥10-point move over ~2 weeks) and diary lapses (silent week after a ≥3-entry week) become `health_insight_*` memory facts (provenance `system_observed`, confidence 0.9). Auto-superseded as the picture changes; surfaced through the felt-learning detector and woven into AP-0911 narratives.

--- a/services/gateway/src/i18n/catalog.ts
+++ b/services/gateway/src/i18n/catalog.ts
@@ -23,6 +23,11 @@ export type GatewayI18nKey =
   | 'notif.weekly_digest.body'
   | 'notif.weekly_summary.title'
   | 'notif.weekly_summary.body'
+  // BOOTSTRAP-MEMORY-DAILY-LEARNING: felt-learning surfaces
+  | 'notif.daily_learning.title'
+  | 'notif.daily_learning.body'
+  | 'notif.memory_match.title'
+  | 'notif.memory_match.body'
   | 'notif.weekly_reflection.title'
   | 'notif.weekly_reflection.body'
   | 'notif.meetup_starting_soon.title'
@@ -127,6 +132,10 @@ const DE: LocaleCatalog = {
   'notif.weekly_digest.body': 'Sieh dir an, was diese Woche in deiner Community passiert ist.',
   'notif.weekly_summary.title': 'Deine wöchentliche Zusammenfassung',
   'notif.weekly_summary.body': 'Hier ist ein Überblick über deine Aktivität und deinen Fortschritt diese Woche.',
+  'notif.daily_learning.title': 'Ich habe heute etwas über dich gelernt',
+  'notif.daily_learning.body': 'Dein Erinnerungsgarten ist heute um {count} neue Erinnerungen gewachsen. Schau vorbei, was ich mir gemerkt habe.',
+  'notif.memory_match.title': 'Mir ist etwas an dir aufgefallen',
+  'notif.memory_match.body': 'Ich habe mir gemerkt, dass du {trait} erwähnt hast – genau deshalb könnte dieses Match gut zu dir passen.',
   'notif.weekly_reflection.title': 'Wöchentliche Reflexion',
   'notif.weekly_reflection.body': 'Nimm dir ein paar Minuten Zeit, um über deine Woche nachzudenken und Absichten zu setzen.',
   'notif.meetup_starting_soon.title': 'Meetup beginnt bald',
@@ -222,6 +231,10 @@ const EN: LocaleCatalog = {
   'notif.weekly_digest.body': 'See what happened in your community this week.',
   'notif.weekly_summary.title': 'Your Weekly Summary',
   'notif.weekly_summary.body': 'Here\'s a snapshot of your activity and progress this week.',
+  'notif.daily_learning.title': 'I learned something new about you today',
+  'notif.daily_learning.body': 'Your memory garden grew by {count} new memories today. Take a look at what I noticed.',
+  'notif.memory_match.title': 'I noticed something about you',
+  'notif.memory_match.body': 'I remembered you mentioned {trait} — that is exactly why this match could be a great fit for you.',
   'notif.weekly_reflection.title': 'Weekly Reflection',
   'notif.weekly_reflection.body': 'Take a few minutes to reflect on your week and set intentions.',
   'notif.meetup_starting_soon.title': 'Meetup Starting Soon',

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-payload.ts
@@ -39,6 +39,7 @@ import { fetchLifeCompass, fetchVitanaIndexForProfiler } from '../../user-contex
 // imported above), hence the alias.
 import { getJourneyState as getGuidedJourneyState } from '../../guided-journey/guided-journey-state';
 import { resolveCurriculumFacts } from './login-briefing';
+import { detectNewFacts } from '../../conversation/new-facts-detector';
 
 // ---------------------------------------------------------------------------
 // Type definitions
@@ -164,6 +165,13 @@ export interface OverviewPayload {
   // -- DIARY (voice-only, streak proxy) --
   diary_last_7d: number;
 
+  // -- MEMORY LEARNING (facts extracted since we last spoke — the felt-
+  //    learning beat; BOOTSTRAP-MEMORY-DAILY-LEARNING) --
+  facts_learned_since_last: {
+    count: number;
+    sample: Array<{ key: string; value: string }>;
+  } | null;
+
   // -- GUIDED JOURNEY (learning progress + "where we left off") --
   guided_journey: {
     /** Curriculum sessions the user has completed (current_session - 1). */
@@ -288,6 +296,7 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     remindersToday,
     diary7d,
     guidedJourney,
+    factsLearned,
   ] = await Promise.all([
     getJourneyState(args.supabase, args.userId).catch(() => null),
     fetchVitanaIndexForProfiler(args.supabase, args.userId).catch(() => null),
@@ -301,6 +310,12 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     fetchRemindersToday(args.supabase, args.userId, startUtc, endUtc),
     fetchDiaryLast7Days(args.supabase, args.userId, args.now),
     fetchGuidedJourney(args.supabase, args.userId, args.lang ?? 'en'),
+    detectNewFacts({
+      supabase: args.supabase,
+      userId: args.userId,
+      sinceIso: lookbackIso,
+      nowMs: args.now.getTime(),
+    }).catch(() => null),
   ]);
 
   const lifeCompass = projectLifeCompass(lcSnapshot);
@@ -315,6 +330,7 @@ export async function gatherOverviewPayload(args: AggregateArgs): Promise<Overvi
     messages_unread: msgsUnread,
     reminders_today: remindersToday,
     diary_last_7d: diary7d,
+    facts_learned_since_last: factsLearned && factsLearned.count > 0 ? factsLearned : null,
     guided_journey: guidedJourney,
     last_session_date_user_tz: args.lastSessionDateUserTz,
   };

--- a/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/new-day-overview-prompt.ts
@@ -530,6 +530,20 @@ function buildCoverageChecklist(
     items.push(`- [ ] ADDRESS: 0 diary entries in the last 7 days — invite a brief entry, gently (Rule 6, P2).`);
   }
 
+  // Felt learning (BOOTSTRAP-MEMORY-DAILY-LEARNING): the user should FEEL
+  // that Vitana learned something about them since last time. Guarded by the
+  // ledger like every other number — never restated once spoken.
+  if (p.facts_learned_since_last && p.facts_learned_since_last.count > 0) {
+    if (status('facts_learned') !== 'unchanged') {
+      const sample = p.facts_learned_since_last.sample
+        .map((f) => `${f.key.replace(/_/g, ' ')} = "${f.value}"`)
+        .join('; ');
+      items.push(
+        `- [ ] ADDRESS: since you last spoke you LEARNED ${p.facts_learned_since_last.count} new thing(s) about the user (${sample}). Weave exactly ONE naturally into the greeting ("ich habe mir gemerkt, dass …") — warm, specific, never a recited list and never the raw key names. This is the moment the user feels you grow with them. (P2.)`,
+      );
+    }
+  }
+
   if (items.length === 0) {
     return '- [ ] (No applicable items — speak a warm short greeting and ask the user what they want to focus on.)';
   }
@@ -601,6 +615,9 @@ function compactPayloadForPrompt(p: OverviewPayload): Record<string, unknown> {
     out.guided_journey = p.guided_journey;
   }
   out.diary_last_7d = p.diary_last_7d;
+  if (p.facts_learned_since_last && p.facts_learned_since_last.count > 0) {
+    out.facts_learned_since_last = p.facts_learned_since_last;
+  }
   if (p.last_session_date_user_tz) out.last_session_date_user_tz = p.last_session_date_user_tz;
   return out;
 }

--- a/services/gateway/src/services/automation-handlers/memory-intelligence.ts
+++ b/services/gateway/src/services/automation-handlers/memory-intelligence.ts
@@ -8,6 +8,14 @@
 
 import { AutomationContext } from '../../types/automations';
 import { registerHandler } from '../automation-executor';
+import { tt } from '../../i18n/catalog';
+import { getUserLocale, bulkGetUserLocales } from '../../i18n/server-locale';
+import {
+  detectNewFacts,
+  markLearningSurfaced,
+  readLearningSurfacedAt,
+} from '../conversation/new-facts-detector';
+import { SIGNAL_GREETING_FACTS, parseFacts } from '../conversation/greeting-facts-ledger';
 
 // ── AP-0901: Memory-Informed Matching ───────────────────────
 // On a positive match reaction, look up the user's most recent self-facts
@@ -38,10 +46,15 @@ async function runMemoryInformedMatching(ctx: AutomationContext) {
 
   if (!facts?.length) return { usersAffected: 0, actionsTaken: 0 };
 
+  // BOOTSTRAP-MEMORY-DAILY-LEARNING (3d): the copy leads with "I remembered
+  // you mentioned X" — the stored fact is announced as learning, not used as
+  // silent background justification. Localized via the gateway catalog
+  // (CLAUDE.md 13b) instead of the previous hardcoded English.
   const trait = facts[0].fact_value;
+  const lc = await getUserLocale(supabase, userId);
   ctx.notify(userId, 'orb_suggestion', {
-    title: 'A Match Worth a Second Look',
-    body: `Based on what you've shared with your ORB about ${trait}, this match might be a great fit.`,
+    title: tt('notif.memory_match.title', lc),
+    body: tt('notif.memory_match.body', lc, { trait }),
     data: { url: '/matches', match_id: matchId },
   });
 
@@ -224,6 +237,178 @@ async function runRoutinePatternExtraction(ctx: AutomationContext) {
   return { usersAffected, actionsTaken };
 }
 
+// ── AP-0907: Daily Learning Digest ──────────────────────────
+// The standalone half of the shared felt-learning detector (3a): for users
+// who gained memory_facts in the last 24h but did NOT get the moment in a
+// session today (greeting-ledger `facts_learned` spoken today, or already
+// notified today), send one "I learned something new about you" push with
+// a deep link into the Memory Garden. Silent when nothing new — no filler.
+const LEARNING_DIGEST_WINDOW_MS = 24 * 3600 * 1000;
+const LEARNING_DIGEST_MAX_USERS_PER_RUN = 500;
+
+async function runDailyLearningDigest(ctx: AutomationContext) {
+  const { supabase, tenantId } = ctx;
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const today = nowIso.slice(0, 10);
+  const sinceIso = new Date(nowMs - LEARNING_DIGEST_WINDOW_MS).toISOString();
+
+  // One query shrinks the fan-out to users who actually learned something.
+  const { data: factRows, error } = await supabase
+    .from('memory_facts')
+    .select('user_id')
+    .eq('tenant_id', tenantId)
+    .is('superseded_at', null)
+    .gt('extracted_at', sinceIso)
+    .limit(5000);
+  if (error) {
+    ctx.log(`memory_facts scan failed: ${error.message}`);
+    return { usersAffected: 0, actionsTaken: 0 };
+  }
+  const userIds = [...new Set((factRows || []).map((r: any) => r.user_id).filter(Boolean))].slice(
+    0,
+    LEARNING_DIGEST_MAX_USERS_PER_RUN,
+  ) as string[];
+  if (userIds.length === 0) return { usersAffected: 0, actionsTaken: 0 };
+
+  const locales = await bulkGetUserLocales(supabase, userIds);
+
+  let usersAffected = 0;
+  for (const userId of userIds) {
+    try {
+      // Guard 1: greeting already surfaced learning in a session today (3e wins).
+      const { data: ledgerRow } = await supabase
+        .from('user_assistant_state')
+        .select('value')
+        .eq('tenant_id', tenantId)
+        .eq('user_id', userId)
+        .eq('signal_name', SIGNAL_GREETING_FACTS)
+        .maybeSingle();
+      const spokenAt = ledgerRow
+        ? parseFacts((ledgerRow as { value: unknown }).value).facts_learned?.spoken_at
+        : undefined;
+      if (spokenAt && spokenAt.slice(0, 10) === today) continue;
+
+      // Guard 2: this digest already fired today.
+      const surfacedAt = await readLearningSurfacedAt(supabase, tenantId, userId);
+      if (surfacedAt && surfacedAt.slice(0, 10) === today) continue;
+
+      const result = await detectNewFacts({ supabase, userId, tenantId, sinceIso, nowMs });
+      if (result.count === 0) continue;
+
+      const lc = locales.get(userId);
+      ctx.notify(userId, 'orb_suggestion', {
+        title: tt('notif.daily_learning.title', lc),
+        body: tt('notif.daily_learning.body', lc, { count: result.count }),
+        data: { url: '/memory' },
+      });
+      await markLearningSurfaced(supabase, tenantId, userId, result.count, nowIso);
+      usersAffected++;
+    } catch (err: any) {
+      ctx.log(`learning digest failed for ${userId.slice(0, 8)}…: ${err?.message}`);
+    }
+  }
+
+  await ctx.emitEvent('autopilot.memory.learning_digest_sent', {
+    users_scanned: userIds.length,
+    users_notified: usersAffected,
+  });
+  return { usersAffected, actionsTaken: usersAffected };
+}
+
+// ── AP-0908: Behavior-Derived Preference Inference ──────────
+// Phase 2 of the felt-learning plan: turn observed behavior (the routines
+// AP-0906 extracts into user_routines) into user_preference_* memory_facts
+// via the write_fact RPC — provenance 'behavior_inferred', confidence 0.55
+// (below the 0.80 of explicit statements, above the 0.55 retrieval floor so
+// the fixed fetchPreferences() picks them up). The Memory Garden visibly
+// grows from behavior, not just conversation. Idempotent: identical values
+// are skipped so re-runs cause no supersession churn.
+const BEHAVIOR_PREF_MIN_ROUTINE_CONFIDENCE = 0.6;
+const BEHAVIOR_PREF_CONFIDENCE = 0.55;
+const BEHAVIOR_PREF_MAX_USERS_PER_RUN = 500;
+
+const ROUTINE_KIND_TO_PREF: Record<string, { factKey: string; metaField: string }> = {
+  time_of_day_preference: { factKey: 'user_preference_active_time', metaField: 'time_of_day' },
+  day_of_week_rhythm: { factKey: 'user_preference_active_day', metaField: 'day_of_week' },
+  category_affinity: { factKey: 'user_preference_activity_focus', metaField: 'tag' },
+};
+
+async function runBehaviorPreferenceInference(ctx: AutomationContext) {
+  const { supabase, tenantId } = ctx;
+
+  const { data: routines, error } = await supabase
+    .from('user_routines')
+    .select('user_id, routine_kind, confidence, metadata')
+    .gte('confidence', BEHAVIOR_PREF_MIN_ROUTINE_CONFIDENCE)
+    .order('confidence', { ascending: false })
+    .limit(3000);
+  if (error) {
+    ctx.log(`user_routines scan failed: ${error.message}`);
+    return { usersAffected: 0, actionsTaken: 0 };
+  }
+
+  // Highest-confidence routine per (user, kind) wins — rows are ordered desc.
+  const derived = new Map<string, Map<string, string>>(); // userId → factKey → value
+  for (const r of (routines || []) as Array<{ user_id: string; routine_kind: string; metadata: any }>) {
+    const mapping = ROUTINE_KIND_TO_PREF[r.routine_kind];
+    if (!mapping || !r.user_id) continue;
+    const value = String(r.metadata?.[mapping.metaField] ?? '').trim();
+    if (!value) continue;
+    if (!derived.has(r.user_id)) derived.set(r.user_id, new Map());
+    const userFacts = derived.get(r.user_id)!;
+    if (!userFacts.has(mapping.factKey)) userFacts.set(mapping.factKey, value);
+  }
+  const userIds = [...derived.keys()].slice(0, BEHAVIOR_PREF_MAX_USERS_PER_RUN);
+  if (userIds.length === 0) return { usersAffected: 0, actionsTaken: 0 };
+
+  // Skip identical current facts — no daily supersession churn.
+  const { data: existingRows } = await supabase
+    .from('memory_facts')
+    .select('user_id, fact_key, fact_value')
+    .eq('tenant_id', tenantId)
+    .in('user_id', userIds)
+    .like('fact_key', 'user_preference_%')
+    .is('superseded_at', null);
+  const existing = new Map<string, string>();
+  for (const row of (existingRows || []) as Array<{ user_id: string; fact_key: string; fact_value: string }>) {
+    existing.set(`${row.user_id}:${row.fact_key}`, row.fact_value);
+  }
+
+  let usersAffected = 0;
+  let actionsTaken = 0;
+  for (const userId of userIds) {
+    let wroteAny = false;
+    for (const [factKey, value] of derived.get(userId)!) {
+      if (existing.get(`${userId}:${factKey}`) === value) continue;
+      const { error: rpcErr } = await supabase.rpc('write_fact', {
+        p_tenant_id: tenantId,
+        p_user_id: userId,
+        p_fact_key: factKey,
+        p_fact_value: value,
+        p_entity: 'self',
+        p_fact_value_type: 'text',
+        p_provenance_source: 'behavior_inferred',
+        p_provenance_confidence: BEHAVIOR_PREF_CONFIDENCE,
+      });
+      if (rpcErr) {
+        ctx.log(`write_fact ${factKey} failed for ${userId.slice(0, 8)}…: ${rpcErr.message}`);
+        continue;
+      }
+      wroteAny = true;
+      actionsTaken++;
+    }
+    if (wroteAny) usersAffected++;
+  }
+
+  await ctx.emitEvent('autopilot.memory.behavior_preferences_written', {
+    users_scanned: userIds.length,
+    users_with_new_preferences: usersAffected,
+    facts_written: actionsTaken,
+  });
+  return { usersAffected, actionsTaken };
+}
+
 export function registerMemoryIntelligenceHandlers(): void {
   registerHandler('runMemoryInformedMatching', runMemoryInformedMatching);
   registerHandler('runFactExtractionAudit', runFactExtractionAudit);
@@ -231,4 +416,6 @@ export function registerMemoryIntelligenceHandlers(): void {
   registerHandler('runSemanticMemoryContextForAutopilot', runSemanticMemoryContextForAutopilot);
   registerHandler('runKnowledgeBaseContextForSuggestions', runKnowledgeBaseContextForSuggestions);
   registerHandler('runRoutinePatternExtraction', runRoutinePatternExtraction);
+  registerHandler('runDailyLearningDigest', runDailyLearningDigest);
+  registerHandler('runBehaviorPreferenceInference', runBehaviorPreferenceInference);
 }

--- a/services/gateway/src/services/automation-handlers/memory-intelligence.ts
+++ b/services/gateway/src/services/automation-handlers/memory-intelligence.ts
@@ -167,10 +167,68 @@ async function runKnowledgeBaseContextForSuggestions(ctx: AutomationContext) {
   return { usersAffected: 0, actionsTaken: 1 };
 }
 
+// ── AP-0906: Routine Pattern Extraction ─────────────────────
+// Wires the previously caller-less guide/pattern-extractor (VTID-01936):
+// for every user with calendar activity in the extractor's 30-day window,
+// derive time-of-day / day-of-week / category-affinity routines into
+// user_routines. The UserContextProfiler and guide awareness-context
+// already read that table, so extracted routines flow straight into the
+// ORB voice profile and the brain's routine-weaving.
+const ROUTINE_EXTRACT_LOOKBACK_DAYS = 30;
+const ROUTINE_EXTRACT_MAX_USERS_PER_RUN = 200;
+const ROUTINE_EXTRACT_EVENT_SCAN_LIMIT = 5000;
+
+async function runRoutinePatternExtraction(ctx: AutomationContext) {
+  const { supabase } = ctx;
+  const sinceIso = new Date(Date.now() - ROUTINE_EXTRACT_LOOKBACK_DAYS * 86_400_000).toISOString();
+
+  const { data: rows, error } = await supabase
+    .from('calendar_events')
+    .select('user_id')
+    .gte('start_time', sinceIso)
+    .not('user_id', 'is', null)
+    .limit(ROUTINE_EXTRACT_EVENT_SCAN_LIMIT);
+
+  if (error) {
+    ctx.log(`calendar_events scan failed: ${error.message}`);
+    return { usersAffected: 0, actionsTaken: 0 };
+  }
+
+  const userIds = [...new Set((rows || []).map((r: any) => r.user_id).filter(Boolean))].slice(
+    0,
+    ROUTINE_EXTRACT_MAX_USERS_PER_RUN,
+  );
+
+  const { extractPatternsForUser } = await import('../guide/pattern-extractor');
+
+  let usersAffected = 0;
+  let actionsTaken = 0;
+  for (const userId of userIds) {
+    try {
+      const result = await extractPatternsForUser(userId as string);
+      if (result.routines_written > 0) {
+        usersAffected++;
+        actionsTaken += result.routines_written;
+      }
+    } catch (err: any) {
+      ctx.log(`pattern extraction failed for ${String(userId).slice(0, 8)}…: ${err?.message}`);
+    }
+  }
+
+  await ctx.emitEvent('autopilot.memory.routines_extracted', {
+    users_scanned: userIds.length,
+    users_with_routines: usersAffected,
+    routines_written: actionsTaken,
+  });
+
+  return { usersAffected, actionsTaken };
+}
+
 export function registerMemoryIntelligenceHandlers(): void {
   registerHandler('runMemoryInformedMatching', runMemoryInformedMatching);
   registerHandler('runFactExtractionAudit', runFactExtractionAudit);
   registerHandler('runRelationshipGraphMaintenance', runRelationshipGraphMaintenance);
   registerHandler('runSemanticMemoryContextForAutopilot', runSemanticMemoryContextForAutopilot);
   registerHandler('runKnowledgeBaseContextForSuggestions', runKnowledgeBaseContextForSuggestions);
+  registerHandler('runRoutinePatternExtraction', runRoutinePatternExtraction);
 }

--- a/services/gateway/src/services/automation-handlers/memory-intelligence.ts
+++ b/services/gateway/src/services/automation-handlers/memory-intelligence.ts
@@ -90,37 +90,11 @@ async function runFactExtractionAudit(ctx: AutomationContext) {
   return { usersAffected: 0, actionsTaken: 1 };
 }
 
-// ── AP-0903: Relationship Graph Maintenance ─────────────────
-// Decays relationship_edges.strength for edges with no interaction in 90+
-// days (real last_interaction_at column), keeping match/social-proof
-// automations from over-weighting stale connections.
-const GRAPH_DECAY_STALE_DAYS = 90;
-const GRAPH_DECAY_AMOUNT = 10;
-const GRAPH_DECAY_MAX_EDGES_PER_RUN = 500;
-
-async function runRelationshipGraphMaintenance(ctx: AutomationContext) {
-  const { supabase, tenantId } = ctx;
-  let actionsTaken = 0;
-
-  const staleCutoff = new Date(Date.now() - GRAPH_DECAY_STALE_DAYS * 86_400_000).toISOString();
-
-  const { data: staleEdges } = await supabase
-    .from('relationship_edges')
-    .select('id, strength')
-    .eq('tenant_id', tenantId)
-    .lt('last_interaction_at', staleCutoff)
-    .gt('strength', 0)
-    .limit(GRAPH_DECAY_MAX_EDGES_PER_RUN);
-
-  for (const edge of staleEdges || []) {
-    const newStrength = Math.max(0, (edge.strength || 0) - GRAPH_DECAY_AMOUNT);
-    await supabase.from('relationship_edges').update({ strength: newStrength }).eq('id', edge.id);
-    actionsTaken++;
-  }
-
-  await ctx.emitEvent('autopilot.memory.graph_edges_decayed', { edges_decayed: actionsTaken });
-  return { usersAffected: 0, actionsTaken };
-}
+// ── AP-0903: RETIRED (BOOTSTRAP-MEMORY-DAILY-LEARNING) ──────
+// Its edge decay double-decayed the same relationship_edges rows the
+// nightly consolidator's Loop 13 already maintains, on a conflicting
+// formula (flat −10 @ 90d vs. Loop 13's 5%-toward-mid @ 30d). Loop 13
+// is the single decay mechanism now; AP-0909 below owns graph CREATION.
 
 // ── AP-0904: Semantic Memory Search for Autopilot Context ───
 // Fired before another automation executes (same 'automation.pre_execute'
@@ -409,13 +383,452 @@ async function runBehaviorPreferenceInference(ctx: AutomationContext) {
   return { usersAffected, actionsTaken };
 }
 
+// ── AP-0909: Relationship Graph Projection ──────────────────
+// The graph is a DERIVED INDEX over memory_facts + app social events —
+// never a second extraction write-path (that dual-write drift is why
+// Cognee was retired in Phase 8). Nightly, idempotent, fully rebuildable:
+//
+//   1. Person-facts (spouse_name, friend_name_*, child_name, …) →
+//      relationship_nodes (node_type 'person', owner-scoped in metadata)
+//      + a person→node edge carrying the relation as edge_type.
+//   2. Mutual follows → person↔person 'connected' edges — exactly the
+//      shape AP-0801's social-comfort gate already counts.
+//
+// Loop 13 (nightly consolidator) stays the ONLY strength-decay mechanism.
+// Column names follow the LIVE relationship_edges schema (source_type/
+// source_id/target_type/target_id/edge_type/last_interaction_at), which
+// diverged from the VTID-01087 migration file — verified 2026-07-06.
+const GRAPH_PROJECT_MAX_FACTS_PER_RUN = 1000;
+const GRAPH_PROJECT_MAX_FOLLOWS = 5000;
+const GRAPH_PROJECT_MAX_NAME_LEN = 60;
+
+const PERSON_FACT_RELATIONS: Array<{ pattern: RegExp; relation: string }> = [
+  { pattern: /^(spouse|husband|wife)_name/, relation: 'spouse' },
+  { pattern: /^(fiancee|fiance)_name/, relation: 'fiancee' },
+  { pattern: /^partner_name/, relation: 'partner' },
+  { pattern: /^(mother|father|parent)_name/, relation: 'parent' },
+  { pattern: /^(child|son|daughter)_name/, relation: 'child' },
+  { pattern: /^grandchild_name/, relation: 'grandchild' },
+  { pattern: /^(sister|brother|sibling)_name/, relation: 'sibling' },
+  { pattern: /^(user_)?friend_name/, relation: 'friend' },
+  { pattern: /^colleague_name/, relation: 'colleague' },
+];
+
+function relationForFactKey(factKey: string): string | null {
+  for (const { pattern, relation } of PERSON_FACT_RELATIONS) {
+    if (pattern.test(factKey)) return relation;
+  }
+  return null;
+}
+
+async function runRelationshipGraphProjection(ctx: AutomationContext) {
+  const { supabase, tenantId } = ctx;
+  const nowIso = new Date().toISOString();
+  let nodesCreated = 0;
+  let edgesCreated = 0;
+  const usersTouched = new Set<string>();
+
+  // ---- 1. Disclosed persons from memory_facts ----
+  const { data: facts, error: factsErr } = await supabase
+    .from('memory_facts')
+    .select('user_id, fact_key, fact_value, extracted_at')
+    .eq('tenant_id', tenantId)
+    .is('superseded_at', null)
+    .like('fact_key', '%name%')
+    .limit(GRAPH_PROJECT_MAX_FACTS_PER_RUN);
+  if (factsErr) {
+    ctx.log(`person-fact scan failed: ${factsErr.message}`);
+  }
+
+  for (const fact of (facts || []) as Array<{ user_id: string; fact_key: string; fact_value: string; extracted_at: string }>) {
+    try {
+      const relation = relationForFactKey(fact.fact_key || '');
+      const name = String(fact.fact_value || '').trim();
+      if (!relation || !fact.user_id || !name || name.length > GRAPH_PROJECT_MAX_NAME_LEN) continue;
+
+      // Node: one 'person' node per (owner, name) — owner-scoped so two
+      // users' "Maria" never merge.
+      const { data: existingNode } = await supabase
+        .from('relationship_nodes')
+        .select('id')
+        .eq('tenant_id', tenantId)
+        .eq('node_type', 'person')
+        .eq('title', name)
+        .eq('metadata->>owner_user_id', fact.user_id)
+        .maybeSingle();
+      let nodeId = (existingNode as { id?: string } | null)?.id ?? null;
+      if (!nodeId) {
+        const { data: inserted, error: insErr } = await supabase
+          .from('relationship_nodes')
+          .insert({
+            tenant_id: tenantId,
+            node_type: 'person',
+            title: name,
+            domain: 'community',
+            metadata: {
+              owner_user_id: fact.user_id,
+              relation,
+              fact_key: fact.fact_key,
+              origin: 'memory_facts_projection',
+            },
+          })
+          .select('id')
+          .single();
+        if (insErr || !inserted) {
+          ctx.log(`node insert failed for ${fact.fact_key}: ${insErr?.message}`);
+          continue;
+        }
+        nodeId = (inserted as { id: string }).id;
+        nodesCreated++;
+      }
+
+      // Edge: user →(relation)→ node. last_interaction_at tracks the fact's
+      // recency so Loop 13's decay stays honest.
+      const { data: existingEdge } = await supabase
+        .from('relationship_edges')
+        .select('id')
+        .eq('tenant_id', tenantId)
+        .eq('source_type', 'person')
+        .eq('source_id', fact.user_id)
+        .eq('target_type', 'node')
+        .eq('target_id', nodeId)
+        .eq('edge_type', relation)
+        .maybeSingle();
+      if (existingEdge) {
+        await supabase
+          .from('relationship_edges')
+          .update({ last_interaction_at: fact.extracted_at || nowIso, updated_at: nowIso })
+          .eq('id', (existingEdge as { id: string }).id);
+      } else {
+        const { error: edgeErr } = await supabase.from('relationship_edges').insert({
+          tenant_id: tenantId,
+          source_type: 'person',
+          source_id: fact.user_id,
+          target_type: 'node',
+          target_id: nodeId,
+          edge_type: relation,
+          strength: 10,
+          last_interaction_at: fact.extracted_at || nowIso,
+          metadata: { origin: 'memory_facts_projection', fact_key: fact.fact_key },
+        });
+        if (edgeErr) {
+          ctx.log(`edge insert failed for ${fact.fact_key}: ${edgeErr.message}`);
+          continue;
+        }
+        edgesCreated++;
+      }
+      usersTouched.add(fact.user_id);
+    } catch (err: any) {
+      ctx.log(`projection failed for fact ${fact.fact_key}: ${err?.message}`);
+    }
+  }
+
+  // ---- 2. Mutual follows → person↔person 'connected' edges ----
+  const { data: follows, error: followErr } = await supabase
+    .from('user_follows')
+    .select('follower_id, following_id')
+    .limit(GRAPH_PROJECT_MAX_FOLLOWS);
+  if (followErr) {
+    ctx.log(`user_follows scan failed: ${followErr.message}`);
+  } else {
+    const pairs = new Set(
+      ((follows || []) as Array<{ follower_id: string; following_id: string }>).map(
+        (f) => `${f.follower_id}>${f.following_id}`,
+      ),
+    );
+    for (const pair of pairs) {
+      const [a, b] = pair.split('>');
+      if (!a || !b || a === b || !pairs.has(`${b}>${a}`)) continue;
+      if (a > b) continue; // handle each mutual pair once; write both directions below
+      for (const [src, tgt] of [[a, b], [b, a]] as Array<[string, string]>) {
+        try {
+          const { data: existing } = await supabase
+            .from('relationship_edges')
+            .select('id')
+            .eq('tenant_id', tenantId)
+            .eq('source_type', 'person')
+            .eq('source_id', src)
+            .eq('target_type', 'person')
+            .eq('target_id', tgt)
+            .eq('edge_type', 'connected')
+            .maybeSingle();
+          if (existing) continue;
+          const { error: edgeErr } = await supabase.from('relationship_edges').insert({
+            tenant_id: tenantId,
+            source_type: 'person',
+            source_id: src,
+            target_type: 'person',
+            target_id: tgt,
+            edge_type: 'connected',
+            strength: 10,
+            last_interaction_at: nowIso,
+            metadata: { origin: 'mutual_follow_projection' },
+          });
+          if (edgeErr) {
+            ctx.log(`connected-edge insert failed: ${edgeErr.message}`);
+            continue;
+          }
+          edgesCreated++;
+          usersTouched.add(src);
+        } catch (err: any) {
+          ctx.log(`follow projection failed: ${err?.message}`);
+        }
+      }
+    }
+  }
+
+  await ctx.emitEvent('autopilot.memory.graph_projected', {
+    nodes_created: nodesCreated,
+    edges_created: edgesCreated,
+    users_touched: usersTouched.size,
+  });
+  return { usersAffected: usersTouched.size, actionsTaken: nodesCreated + edgesCreated };
+}
+
+// ── AP-0910: Memory Embedding Backfill ──────────────────────
+// Only ~4% of live memory_facts carried embeddings (the inline extractor's
+// REST write path never embedded), leaving tier-2 semantic fact retrieval
+// blind. New writes now embed inline (inline-fact-extractor); this backfill
+// drains the historical backlog and catches any write-path misses. Hourly,
+// bounded, no-ops cheaply once the backlog is empty.
+const EMBED_BACKFILL_BATCH = 100;
+
+async function runMemoryEmbeddingBackfill(ctx: AutomationContext) {
+  const { supabase, tenantId } = ctx;
+
+  const { data: rows, error } = await supabase
+    .from('memory_facts')
+    .select('id, fact_key, fact_value')
+    .eq('tenant_id', tenantId)
+    .is('superseded_at', null)
+    .is('embedding', null)
+    .limit(EMBED_BACKFILL_BATCH);
+  if (error) {
+    ctx.log(`backlog scan failed: ${error.message}`);
+    return { usersAffected: 0, actionsTaken: 0 };
+  }
+  if (!rows?.length) return { usersAffected: 0, actionsTaken: 0 };
+
+  const { generateBatchEmbeddings } = await import('../embedding-service');
+  const texts = (rows as Array<{ fact_key: string; fact_value: string }>).map(
+    (r) => `${r.fact_key}: ${r.fact_value}`,
+  );
+  const batch = await generateBatchEmbeddings(texts);
+  if (!batch.ok || !batch.embeddings) {
+    ctx.log(`batch embedding failed: ${batch.error}`);
+    return { usersAffected: 0, actionsTaken: 0 };
+  }
+
+  let embedded = 0;
+  const nowIso = new Date().toISOString();
+  for (let i = 0; i < rows.length; i++) {
+    const vec = batch.embeddings[i];
+    if (!Array.isArray(vec)) continue;
+    const { error: upErr } = await supabase
+      .from('memory_facts')
+      .update({
+        embedding: JSON.stringify(vec),
+        embedding_model: batch.model || 'text-embedding-3-small',
+        embedding_updated_at: nowIso,
+      })
+      .eq('id', (rows[i] as { id: string }).id);
+    if (upErr) {
+      ctx.log(`embedding store failed for ${(rows[i] as { id: string }).id}: ${upErr.message}`);
+      continue;
+    }
+    embedded++;
+  }
+
+  await ctx.emitEvent('autopilot.memory.embeddings_backfilled', {
+    scanned: rows.length,
+    embedded,
+  });
+  return { usersAffected: 0, actionsTaken: embedded };
+}
+
+// ── AP-0911: User Model Synthesis ───────────────────────────
+// Nightly narrative profile per active user (see user-model-synthesis.ts):
+// one LLM pass connects facts + routines + goal + Vitana Index into a
+// compact "who is this person" paragraph the ORB bootstrap injects at zero
+// latency cost. Skips users with <3 facts and unchanged inputs.
+const SYNTHESIS_MAX_USERS_PER_RUN = 100;
+
+async function runUserModelSynthesis(ctx: AutomationContext) {
+  const { supabase, tenantId } = ctx;
+
+  const { data: factRows, error } = await supabase
+    .from('memory_facts')
+    .select('user_id')
+    .eq('tenant_id', tenantId)
+    .is('superseded_at', null)
+    .limit(10000);
+  if (error) {
+    ctx.log(`fact scan failed: ${error.message}`);
+    return { usersAffected: 0, actionsTaken: 0 };
+  }
+  const counts = new Map<string, number>();
+  for (const r of (factRows || []) as Array<{ user_id: string }>) {
+    if (r.user_id) counts.set(r.user_id, (counts.get(r.user_id) || 0) + 1);
+  }
+  const userIds = [...counts.entries()]
+    .filter(([, n]) => n >= 3)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, SYNTHESIS_MAX_USERS_PER_RUN)
+    .map(([id]) => id);
+
+  const { synthesizeUserModel } = await import('../user-model-synthesis');
+  let written = 0;
+  for (const userId of userIds) {
+    try {
+      const result = await synthesizeUserModel(supabase, tenantId, userId);
+      if (result.written) written++;
+    } catch (err: any) {
+      ctx.log(`synthesis failed for ${userId.slice(0, 8)}…: ${err?.message}`);
+    }
+  }
+
+  await ctx.emitEvent('autopilot.memory.profiles_synthesized', {
+    users_scanned: userIds.length,
+    narratives_written: written,
+  });
+  return { usersAffected: written, actionsTaken: written };
+}
+
+// ── AP-0912: Health Correlation Insights ────────────────────
+// The "sees contextual influence" differentiator, made concrete with
+// DETERMINISTIC rules (no LLM → no hallucinated health claims). Each rule
+// writes a health_insight_* memory fact (provenance system_observed) via
+// write_fact — auto-superseded when the picture changes, and surfaced to
+// the user through the same felt-learning detector as every other fact.
+//   R1: a pillar moved ≥ INSIGHT_PILLAR_DELTA over ~7 days → trend insight.
+//   R2: diary went silent after a consistent streak → lapse insight.
+const INSIGHT_PILLAR_DELTA = 10;
+const INSIGHT_MAX_USERS_PER_RUN = 200;
+const PILLAR_COLUMNS = ['score_sleep', 'score_nutrition', 'score_exercise', 'score_hydration', 'score_mental'] as const;
+
+async function runHealthCorrelationInsights(ctx: AutomationContext) {
+  const { supabase, tenantId } = ctx;
+  const now = Date.now();
+  const since14d = new Date(now - 14 * 86_400_000).toISOString().slice(0, 10);
+
+  const { data: scoreRows, error } = await supabase
+    .from('vitana_index_scores')
+    .select('user_id, date, score_sleep, score_nutrition, score_exercise, score_hydration, score_mental')
+    .eq('tenant_id', tenantId)
+    .gte('date', since14d)
+    .order('date', { ascending: true })
+    .limit(10000);
+  if (error) {
+    ctx.log(`index scan failed: ${error.message}`);
+    return { usersAffected: 0, actionsTaken: 0 };
+  }
+
+  const byUser = new Map<string, Array<Record<string, any>>>();
+  for (const row of (scoreRows || []) as Array<Record<string, any>>) {
+    if (!row.user_id) continue;
+    if (!byUser.has(row.user_id)) byUser.set(row.user_id, []);
+    byUser.get(row.user_id)!.push(row);
+  }
+
+  const writeInsight = async (userId: string, key: string, value: string) => {
+    const { error: rpcErr } = await supabase.rpc('write_fact', {
+      p_tenant_id: tenantId,
+      p_user_id: userId,
+      p_fact_key: key,
+      p_fact_value: value,
+      p_entity: 'self',
+      p_fact_value_type: 'text',
+      p_provenance_source: 'system_observed',
+      p_provenance_confidence: 0.9,
+    });
+    if (rpcErr) {
+      ctx.log(`insight write ${key} failed for ${userId.slice(0, 8)}…: ${rpcErr.message}`);
+      return false;
+    }
+    return true;
+  };
+
+  let usersAffected = 0;
+  let actionsTaken = 0;
+  const userIds = [...byUser.keys()].slice(0, INSIGHT_MAX_USERS_PER_RUN);
+
+  for (const userId of userIds) {
+    const rows = byUser.get(userId)!;
+    if (rows.length < 4) continue; // too little signal for a defensible trend
+    let wroteAny = false;
+
+    // R1 — pillar trend: first vs last reading in the window.
+    const first = rows[0];
+    const last = rows[rows.length - 1];
+    for (const col of PILLAR_COLUMNS) {
+      const a = Number(first[col]);
+      const b = Number(last[col]);
+      if (!Number.isFinite(a) || !Number.isFinite(b)) continue;
+      const delta = b - a;
+      if (Math.abs(delta) < INSIGHT_PILLAR_DELTA) continue;
+      const pillar = col.replace('score_', '');
+      const direction = delta > 0 ? 'improved' : 'declined';
+      const ok = await writeInsight(
+        userId,
+        `health_insight_${pillar}_trend`,
+        `${pillar} pillar ${direction} by ${Math.abs(Math.round(delta))} points over the last two weeks`,
+      );
+      if (ok) {
+        wroteAny = true;
+        actionsTaken++;
+      }
+    }
+
+    if (wroteAny) usersAffected++;
+  }
+
+  // R2 — diary lapse: entries in the previous week but none in the last one.
+  const since7dIso = new Date(now - 7 * 86_400_000).toISOString();
+  const since14dIso = new Date(now - 14 * 86_400_000).toISOString();
+  const { data: diaryRows } = await supabase
+    .from('diary_entries')
+    .select('user_id, created_at')
+    .gte('created_at', since14dIso)
+    .limit(5000);
+  const diaryByUser = new Map<string, { recent: number; prior: number }>();
+  for (const row of (diaryRows || []) as Array<{ user_id: string; created_at: string }>) {
+    if (!row.user_id) continue;
+    const bucket = diaryByUser.get(row.user_id) || { recent: 0, prior: 0 };
+    if (row.created_at >= since7dIso) bucket.recent++;
+    else bucket.prior++;
+    diaryByUser.set(row.user_id, bucket);
+  }
+  for (const [userId, bucket] of diaryByUser) {
+    if (bucket.prior >= 3 && bucket.recent === 0) {
+      const ok = await writeInsight(
+        userId,
+        'health_insight_diary_lapse',
+        `stopped diary entries this week after ${bucket.prior} entries the week before`,
+      );
+      if (ok) {
+        actionsTaken++;
+        usersAffected++;
+      }
+    }
+  }
+
+  await ctx.emitEvent('autopilot.memory.health_insights_written', {
+    users_with_insights: usersAffected,
+    insights_written: actionsTaken,
+  });
+  return { usersAffected, actionsTaken };
+}
+
 export function registerMemoryIntelligenceHandlers(): void {
   registerHandler('runMemoryInformedMatching', runMemoryInformedMatching);
   registerHandler('runFactExtractionAudit', runFactExtractionAudit);
-  registerHandler('runRelationshipGraphMaintenance', runRelationshipGraphMaintenance);
+  registerHandler('runRelationshipGraphProjection', runRelationshipGraphProjection);
   registerHandler('runSemanticMemoryContextForAutopilot', runSemanticMemoryContextForAutopilot);
   registerHandler('runKnowledgeBaseContextForSuggestions', runKnowledgeBaseContextForSuggestions);
   registerHandler('runRoutinePatternExtraction', runRoutinePatternExtraction);
   registerHandler('runDailyLearningDigest', runDailyLearningDigest);
   registerHandler('runBehaviorPreferenceInference', runBehaviorPreferenceInference);
+  registerHandler('runMemoryEmbeddingBackfill', runMemoryEmbeddingBackfill);
+  registerHandler('runUserModelSynthesis', runUserModelSynthesis);
+  registerHandler('runHealthCorrelationInsights', runHealthCorrelationInsights);
 }

--- a/services/gateway/src/services/automation-registry.ts
+++ b/services/gateway/src/services/automation-registry.ts
@@ -758,11 +758,13 @@ const MEMORY_INTEL: AutomationDefinition[] = [
     handler: 'runFactExtractionAudit',
   },
   {
+    // Retired (BOOTSTRAP-MEMORY-DAILY-LEARNING): its decay double-decayed
+    // the rows Loop 13 (nightly consolidator) already maintains, on a
+    // conflicting formula. Loop 13 is the single decay mechanism.
     id: 'AP-0903', name: 'Relationship Graph Maintenance', domain: 'memory-intelligence',
-    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'cron',
-    triggerConfig: { cronExpression: '0 4 * * 0' }, // Sunday 4am
+    status: 'DEPRECATED', priority: 'P2', triggerType: 'cron',
+    triggerConfig: { cronExpression: '0 4 * * 0' },
     targetRoles: [...MEMBER_ROLES],
-    handler: 'runRelationshipGraphMaintenance',
   },
   {
     id: 'AP-0904', name: 'Semantic Memory Search for Autopilot Context', domain: 'memory-intelligence',
@@ -807,6 +809,48 @@ const MEMORY_INTEL: AutomationDefinition[] = [
     triggerConfig: { cronExpression: '40 4 * * *' }, // daily 4:40am
     targetRoles: [...MEMBER_ROLES],
     handler: 'runBehaviorPreferenceInference',
+  },
+  {
+    // The relationship graph as a DERIVED INDEX: nightly projection of
+    // person-facts + mutual follows into relationship_nodes/edges (the only
+    // creation path since Cognee's Phase 8 retirement). Loop 13 decays.
+    id: 'AP-0909', name: 'Relationship Graph Projection', domain: 'memory-intelligence',
+    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'cron',
+    triggerConfig: { cronExpression: '50 3 * * *' }, // daily 3:50am, after AP-0906
+    targetRoles: [...MEMBER_ROLES],
+    handler: 'runRelationshipGraphProjection',
+  },
+  {
+    // Drains the fact-embedding backlog (96% of live facts were unembedded,
+    // blinding tier-2 semantic retrieval). Hourly, 100/run, cheap no-op when
+    // the backlog is empty; new writes embed inline in the extractor.
+    id: 'AP-0910', name: 'Memory Embedding Backfill', domain: 'memory-intelligence',
+    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'cron',
+    triggerConfig: { cronExpression: '25 * * * *' }, // hourly at :25
+    targetRoles: [...MEMBER_ROLES],
+    handler: 'runMemoryEmbeddingBackfill',
+  },
+  {
+    // Nightly narrative profile synthesis — one LLM pass per active user
+    // connecting facts/routines/goal/Index into a compact "who is this
+    // person" paragraph for the ORB bootstrap. After all nightly writers
+    // (AP-0906 3:30, AP-0909 3:50, AP-0908 4:40) so it reads fresh inputs.
+    id: 'AP-0911', name: 'User Model Synthesis', domain: 'memory-intelligence',
+    status: 'IMPLEMENTED', priority: 'P1', triggerType: 'cron',
+    triggerConfig: { cronExpression: '5 5 * * *' }, // daily 5:05am
+    targetRoles: [...MEMBER_ROLES],
+    handler: 'runUserModelSynthesis',
+  },
+  {
+    // Deterministic health-correlation insights (pillar trends, diary
+    // lapses) written as health_insight_* memory facts — the "sees
+    // contextual influence" beat, grounded in real Index/diary data.
+    // Before synthesis (5:05) so narratives can weave fresh insights.
+    id: 'AP-0912', name: 'Health Correlation Insights', domain: 'memory-intelligence',
+    status: 'IMPLEMENTED', priority: 'P1', triggerType: 'cron',
+    triggerConfig: { cronExpression: '55 4 * * *' }, // daily 4:55am
+    targetRoles: [...MEMBER_ROLES],
+    handler: 'runHealthCorrelationInsights',
   },
 ];
 

--- a/services/gateway/src/services/automation-registry.ts
+++ b/services/gateway/src/services/automation-registry.ts
@@ -787,6 +787,27 @@ const MEMORY_INTEL: AutomationDefinition[] = [
     targetRoles: [...MEMBER_ROLES],
     handler: 'runRoutinePatternExtraction',
   },
+  {
+    // "I learned something new about you today" — the standalone half of the
+    // shared felt-learning detector; the greeting ledger (6th signal) wins
+    // for users who opened a session, this catches the rest. Evening slot so
+    // the day's conversations have been extracted.
+    id: 'AP-0907', name: 'Daily Learning Digest', domain: 'memory-intelligence',
+    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'cron',
+    triggerConfig: { cronExpression: '10 18 * * *' }, // daily 18:10
+    targetRoles: [...MEMBER_ROLES],
+    handler: 'runDailyLearningDigest',
+  },
+  {
+    // Turns AP-0906's user_routines into user_preference_* memory_facts
+    // (provenance behavior_inferred) so preferences grow from behavior, not
+    // just conversation. Runs after AP-0906's 3:30am extraction.
+    id: 'AP-0908', name: 'Behavior-Derived Preference Inference', domain: 'memory-intelligence',
+    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'cron',
+    triggerConfig: { cronExpression: '40 4 * * *' }, // daily 4:40am
+    targetRoles: [...MEMBER_ROLES],
+    handler: 'runBehaviorPreferenceInference',
+  },
 ];
 
 // =============================================================================

--- a/services/gateway/src/services/automation-registry.ts
+++ b/services/gateway/src/services/automation-registry.ts
@@ -778,6 +778,15 @@ const MEMORY_INTEL: AutomationDefinition[] = [
     targetRoles: ALL_ROLES,
     handler: 'runKnowledgeBaseContextForSuggestions',
   },
+  {
+    // Wires guide/pattern-extractor (VTID-01936) — previously fully built
+    // but caller-less. Nightly, before the profiler's morning reads.
+    id: 'AP-0906', name: 'Routine Pattern Extraction', domain: 'memory-intelligence',
+    status: 'IMPLEMENTED', priority: 'P2', triggerType: 'cron',
+    triggerConfig: { cronExpression: '30 3 * * *' }, // daily 3:30am
+    targetRoles: [...MEMBER_ROLES],
+    handler: 'runRoutinePatternExtraction',
+  },
 ];
 
 // =============================================================================

--- a/services/gateway/src/services/conversation/greeting-facts-ledger.ts
+++ b/services/gateway/src/services/conversation/greeting-facts-ledger.ts
@@ -95,7 +95,10 @@ export async function readGreetingLedger(inputs: LedgerIdentity): Promise<Greeti
         SIGNAL_GREETING_LAST_UTTERANCE,
         'wake_cadence:sessions_today',
       ]);
-    if (error) return { ...EMPTY_GREETING_LEDGER };
+    if (error) {
+      emitLedgerReadFailure(inputs, error.message);
+      return { ...EMPTY_GREETING_LEDGER };
+    }
     const out: GreetingLedger = { ...EMPTY_GREETING_LEDGER, facts: {} };
     for (const row of (data || []) as Array<{ signal_name: string; value: unknown }>) {
       if (row.signal_name === SIGNAL_GREETING_FACTS) {
@@ -120,9 +123,31 @@ export async function readGreetingLedger(inputs: LedgerIdentity): Promise<Greeti
       }
     }
     return out;
-  } catch {
+  } catch (e) {
+    emitLedgerReadFailure(inputs, e instanceof Error ? e.message : String(e));
     return { ...EMPTY_GREETING_LEDGER };
   }
+}
+
+/**
+ * The ledger stays fail-open (a DB outage must never silence a greeting),
+ * but the failure is no longer invisible: emit an OASIS event so the
+ * continuity loss shows up in ops instead of silently degrading greetings.
+ * Fire-and-forget; dynamic import avoids a service-layer cycle.
+ */
+function emitLedgerReadFailure(inputs: LedgerIdentity, reason: string): void {
+  import('../oasis-event-service')
+    .then(({ emitOasisEvent }) =>
+      emitOasisEvent({
+        vtid: 'BOOTSTRAP-MEMORY-DAILY-LEARNING',
+        type: 'memory.greeting_ledger.read_failed',
+        source: 'gateway',
+        status: 'warning',
+        message: `greeting-facts ledger read failed open: ${reason}`,
+        payload: { user_id: inputs.userId, tenant_id: inputs.tenantId, reason },
+      } as any),
+    )
+    .catch(() => {});
 }
 
 export function parseFacts(value: unknown): Record<string, SpokenFact> {
@@ -211,6 +236,12 @@ export function extractSpokenFactsFromPayload(p: OverviewPayload | null): Record
     out.vitana_index = p.vitana_index.today;
   }
   if (typeof p.diary_last_7d === 'number') out.diary_last_7d = p.diary_last_7d;
+  // 6th signal (BOOTSTRAP-MEMORY-DAILY-LEARNING): facts Vitana learned since
+  // the last session. Only tracked when > 0 — a zero would pollute the ledger
+  // with a "new" fact that carries no news.
+  if (p.facts_learned_since_last && p.facts_learned_since_last.count > 0) {
+    out.facts_learned = p.facts_learned_since_last.count;
+  }
   return out;
 }
 

--- a/services/gateway/src/services/conversation/new-facts-detector.ts
+++ b/services/gateway/src/services/conversation/new-facts-detector.ts
@@ -1,0 +1,127 @@
+/**
+ * New-facts detector — the shared "what did Vitana learn about you?" query.
+ * (BOOTSTRAP-MEMORY-DAILY-LEARNING, Phase 3)
+ *
+ * ONE detector feeds BOTH felt-learning surfaces so the user is never told
+ * the same thing twice in a day:
+ *
+ *   1. The greeting path (6th greeting-ledger signal `facts_learned`) —
+ *      gatherOverviewPayload calls detectNewFacts with the last-session
+ *      cutoff; the ledger's existing delta machinery guards repeats.
+ *   2. The AP-0907 daily notification — fires only for users who did NOT
+ *      get the moment in a session today (checks the greeting ledger's
+ *      `facts_learned.spoken_at` and its own `learning_surfaced_v1` stamp).
+ *
+ * Counts current (non-superseded) memory_facts rows extracted after the
+ * cutoff. The cutoff is clamped to LOOKBACK_CAP_MS so a returning user
+ * isn't greeted with weeks of accumulated "news".
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const SIGNAL_LEARNING_SURFACED = 'learning_surfaced_v1';
+
+/** Never look further back than this, whatever the last-session cutoff says. */
+export const LOOKBACK_CAP_MS = 7 * 24 * 3600 * 1000;
+
+/** Fact keys that are learning plumbing, not felt learning — never surfaced. */
+const EXCLUDED_FACT_KEYS = new Set(['preferred_language']);
+
+const SAMPLE_LIMIT = 3;
+
+export interface NewFactsResult {
+  count: number;
+  sample: Array<{ key: string; value: string }>;
+}
+
+export interface DetectNewFactsArgs {
+  supabase: SupabaseClient;
+  userId: string;
+  tenantId?: string;
+  /** Cutoff (ISO). Clamped to now - LOOKBACK_CAP_MS. */
+  sinceIso: string;
+  nowMs?: number;
+}
+
+/** Best-effort: any failure → zero result (surfaces stay silent, never wrong). */
+export async function detectNewFacts(args: DetectNewFactsArgs): Promise<NewFactsResult> {
+  const empty: NewFactsResult = { count: 0, sample: [] };
+  if (!args.supabase || !args.userId || !args.sinceIso) return empty;
+  const nowMs = args.nowMs ?? Date.now();
+  const sinceMs = Date.parse(args.sinceIso);
+  const clampedSinceIso = new Date(
+    Math.max(Number.isFinite(sinceMs) ? sinceMs : 0, nowMs - LOOKBACK_CAP_MS),
+  ).toISOString();
+  try {
+    let query = args.supabase
+      .from('memory_facts')
+      .select('fact_key, fact_value')
+      .eq('user_id', args.userId)
+      .is('superseded_at', null)
+      .gt('extracted_at', clampedSinceIso)
+      .order('extracted_at', { ascending: false })
+      .limit(50);
+    if (args.tenantId) query = query.eq('tenant_id', args.tenantId);
+    const { data, error } = await query;
+    if (error || !Array.isArray(data)) return empty;
+    const rows = (data as Array<{ fact_key?: unknown; fact_value?: unknown }>).filter(
+      (r) => typeof r.fact_key === 'string' && !EXCLUDED_FACT_KEYS.has(r.fact_key),
+    );
+    return {
+      count: rows.length,
+      sample: rows.slice(0, SAMPLE_LIMIT).map((r) => ({
+        key: String(r.fact_key),
+        value: String(r.fact_value ?? '').slice(0, 80),
+      })),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** When was learning last surfaced to this user (via AP-0907)? Null = never/error. */
+export async function readLearningSurfacedAt(
+  supabase: SupabaseClient,
+  tenantId: string,
+  userId: string,
+): Promise<string | null> {
+  try {
+    const { data, error } = await supabase
+      .from('user_assistant_state')
+      .select('value')
+      .eq('tenant_id', tenantId)
+      .eq('user_id', userId)
+      .eq('signal_name', SIGNAL_LEARNING_SURFACED)
+      .maybeSingle();
+    if (error || !data) return null;
+    const at = (data as { value?: { surfaced_at?: unknown } }).value?.surfaced_at;
+    return typeof at === 'string' ? at : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Stamp that learning was surfaced (fire-and-forget, never throws). */
+export async function markLearningSurfaced(
+  supabase: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  count: number,
+  nowIso?: string,
+): Promise<void> {
+  const at = nowIso ?? new Date().toISOString();
+  try {
+    await supabase.from('user_assistant_state').upsert(
+      {
+        tenant_id: tenantId,
+        user_id: userId,
+        signal_name: SIGNAL_LEARNING_SURFACED,
+        value: { surfaced_at: at, count },
+        last_seen_at: at,
+      },
+      { onConflict: 'tenant_id,user_id,signal_name' },
+    );
+  } catch {
+    /* fire-and-forget */
+  }
+}

--- a/services/gateway/src/services/diary-health-extractor.ts
+++ b/services/gateway/src/services/diary-health-extractor.ts
@@ -327,5 +327,34 @@ export async function persistDiaryHealthFeatures(
       failed += 1;
     }
   }
+
+  // BOOTSTRAP-MEMORY-DAILY-LEARNING (diary de-silo): the diary previously
+  // fed ONLY the Vitana Index recompute — the assistant's memory never knew
+  // what the diary revealed. Mirror the day's notable signals into ONE
+  // rolling memory fact (auto-superseded daily by write_fact), so diary
+  // health data reaches retrieval, the Memory Garden, and the felt-learning
+  // detector. Fire-and-forget: never blocks the feature write path.
+  const notable = writes.filter((w) => w.feature_key !== 'journal_entry');
+  if (written > 0 && notable.length > 0) {
+    const summary = notable
+      .slice(0, 4)
+      .map((w) => `${w.feature_key.replace(/_/g, ' ')}: ${w.feature_value}${w.feature_unit ? ` ${w.feature_unit}` : ''}`)
+      .join(', ');
+    admin
+      .rpc('write_fact', {
+        p_tenant_id: tenantId,
+        p_user_id: userId,
+        p_fact_key: 'diary_recent_health_signals',
+        p_fact_value: `${summary} (diary ${date})`,
+        p_entity: 'self',
+        p_fact_value_type: 'text',
+        p_provenance_source: 'system_observed',
+        p_provenance_confidence: 0.6,
+      })
+      .then(({ error }: { error: { message: string } | null }) => {
+        if (error) console.warn(`[VTID-01977] diary→memory fact write failed: ${error.message}`);
+      });
+  }
+
   return { written, failed };
 }

--- a/services/gateway/src/services/feature-flags.ts
+++ b/services/gateway/src/services/feature-flags.ts
@@ -20,10 +20,18 @@ import { isStaging } from '../env';
 
 export type FeatureFlagSetting = 'off' | 'staging-only' | 'staging+prod';
 
+// Behavior-safe defaults (BOOTSTRAP-MEMORY-DAILY-LEARNING): shadow-mode flags
+// only LOG a naive-vs-ranked comparison and never change what ships, so they
+// default ON in staging to collect flip-evidence without an operator env
+// change. An explicit env value always wins.
+const DEFAULT_SETTINGS: Record<string, FeatureFlagSetting> = {
+  VOICE_RANKING_SHADOW: 'staging-only',
+};
+
 function readSetting(name: string): FeatureFlagSetting {
   const raw = process.env[`FEATURE_${name}_ENV`];
-  if (raw === 'staging-only' || raw === 'staging+prod') return raw;
-  return 'off';
+  if (raw === 'off' || raw === 'staging-only' || raw === 'staging+prod') return raw;
+  return DEFAULT_SETTINGS[name] ?? 'off';
 }
 
 /**

--- a/services/gateway/src/services/guide/pattern-extractor.ts
+++ b/services/gateway/src/services/guide/pattern-extractor.ts
@@ -11,9 +11,10 @@
  *   - Nightly (via existing scheduler.ts pattern — separate VTID to wire cron)
  *   - On-demand (e.g., after a major calendar update)
  *
- * STATUS: function is fully implemented + idempotent. Cron wiring is
- * deferred — for now the function is exposed and can be invoked manually
- * or by a future scheduled job.
+ * STATUS: fully implemented + idempotent. Wired to the nightly AP-0906
+ * automation (automation-registry.ts / automation-handlers/
+ * memory-intelligence.ts), which fans extractPatternsForUser out over
+ * users with recent calendar activity.
  */
 
 import { getSupabase } from '../../lib/supabase';
@@ -93,9 +94,12 @@ export async function extractPatternsForUser(userId: string): Promise<ExtractRes
 
   const sinceIso = new Date(Date.now() - LOOKBACK_DAYS * 86400000).toISOString();
 
+  // NOTE: no time_slot column here — the live calendar_events table does
+  // not have one, and PostgREST rejects the whole select when any column
+  // is missing (verified against production schema 2026-07-05).
   const { data: events, error } = await supabase
     .from('calendar_events')
-    .select('id, start_time, completion_status, status, event_type, wellness_tags, time_slot')
+    .select('id, start_time, completion_status, status, event_type, wellness_tags')
     .eq('user_id', userId)
     .gte('start_time', sinceIso);
 
@@ -111,7 +115,6 @@ export async function extractPatternsForUser(userId: string): Promise<ExtractRes
     status: string;
     event_type: string;
     wellness_tags: string[] | null;
-    time_slot: string | null;
   };
 
   const evList = (events as EvShape[]).filter((e) => e.start_time);

--- a/services/gateway/src/services/inline-fact-extractor.ts
+++ b/services/gateway/src/services/inline-fact-extractor.ts
@@ -57,6 +57,7 @@ Return ONLY a JSON array of facts. Each fact must have:
 - "fact_value": the value (e.g. "Dusan", "Amsterdam", "blue", "Maria", "engineer")
 - "entity": "self" if about the user, "disclosed" if about someone else
 - "fact_value_type": "text", "date", or "number"
+- "stated": true if the user EXPLICITLY said it in their own words; false if you inferred it from context
 
 Common fact keys:
 - user_name, user_residence, user_hometown, user_birthday, user_occupation, user_company
@@ -68,19 +69,24 @@ Common fact keys:
 - <person>_birthday, <person>_health_condition (dates/conditions of people the user discloses, e.g. spouse_birthday)
 - upcoming_event_* (a concrete planned event with its date, e.g. upcoming_event_wedding)
 
+Also capture meaningful OBSERVATIONS (stated:false) — things a caring companion would remember even though the user didn't declare them as facts:
+- user_observation_mood ("stressed about work"), user_observation_energy ("low, poor sleep")
+- user_observation_concern ("worried about mother's health"), user_observation_life_event ("moving apartments next month")
+Only when the conversation genuinely supports them — never guess.
+
 Rules:
-- Only extract facts the USER explicitly states (not assistant assumptions)
+- Mark facts the USER explicitly states with "stated": true; contextual inferences with "stated": false
 - If no facts are present, return an empty array: []
-- Do NOT invent facts. Only extract what is clearly stated.
-- Keep fact_value concise (1-5 words)
+- Do NOT invent facts. Only extract what the conversation clearly supports.
+- Keep fact_value concise (1-8 words)
 - For preferences, use "user_favorite_X" or "user_preference_X" as the key
 
 Example input:
-User: My name is Dusan and I live in Amsterdam. My favorite tea is Earl Grey.
+User: My name is Dusan and I live in Amsterdam. My favorite tea is Earl Grey. Ugh, barely slept, the deadline is killing me.
 Assistant: Nice to meet you Dusan! Amsterdam is a beautiful city.
 
 Example output:
-[{"fact_key":"user_name","fact_value":"Dusan","entity":"self","fact_value_type":"text"},{"fact_key":"user_residence","fact_value":"Amsterdam","entity":"self","fact_value_type":"text"},{"fact_key":"user_favorite_tea","fact_value":"Earl Grey","entity":"self","fact_value_type":"text"}]`;
+[{"fact_key":"user_name","fact_value":"Dusan","entity":"self","fact_value_type":"text","stated":true},{"fact_key":"user_residence","fact_value":"Amsterdam","entity":"self","fact_value_type":"text","stated":true},{"fact_key":"user_favorite_tea","fact_value":"Earl Grey","entity":"self","fact_value_type":"text","stated":true},{"fact_key":"user_observation_energy","fact_value":"poor sleep, work deadline stress","entity":"self","fact_value_type":"text","stated":false}]`;
 
 // =============================================================================
 // Types
@@ -91,7 +97,19 @@ interface ExtractedFact {
   fact_value: string;
   entity: string;
   fact_value_type: string;
+  /** True when the user explicitly said it; false for contextual inference. */
+  stated?: boolean;
 }
+
+// Base confidence by provenance (BOOTSTRAP-MEMORY-DAILY-LEARNING): the old
+// flat 0.80-for-everything made confidence meaningless — 333 of 339 facts in
+// prod were labeled assistant_inferred even when the user literally said them.
+const CONFIDENCE_STATED = 0.9;
+const CONFIDENCE_INFERRED = 0.7;
+// Re-mention bump: each time the same key+value is extracted again, confidence
+// grows (evidence-weighted memory) up to a cap.
+const CONFIDENCE_REMENTION_BUMP = 0.05;
+const CONFIDENCE_CAP = 0.98;
 
 // =============================================================================
 // Core: Extract facts using Gemini
@@ -203,13 +221,15 @@ function parseFactsResponse(raw: string): ExtractedFact[] {
     if (!Array.isArray(parsed)) return [];
 
     // Validate each fact
-    return parsed.filter((f: any) =>
-      f &&
-      typeof f.fact_key === 'string' && f.fact_key.length > 0 &&
-      typeof f.fact_value === 'string' && f.fact_value.length > 0 &&
-      typeof f.entity === 'string' &&
-      typeof f.fact_value_type === 'string'
-    );
+    return parsed
+      .filter((f: any) =>
+        f &&
+        typeof f.fact_key === 'string' && f.fact_key.length > 0 &&
+        typeof f.fact_value === 'string' && f.fact_value.length > 0 &&
+        typeof f.entity === 'string' &&
+        typeof f.fact_value_type === 'string'
+      )
+      .map((f: any) => ({ ...f, stated: f.stated === true }));
   } catch (err) {
     console.warn(`[VTID-01225-inline] Failed to parse extraction response: ${raw.substring(0, 100)}`);
     return [];
@@ -263,13 +283,50 @@ async function persistFact(
     console.warn(`[VTID-02000] canonical fact check failed (non-fatal):`, checkErr);
   }
 
+  // BOOTSTRAP-MEMORY-DAILY-LEARNING: real provenance + evidence-weighted
+  // confidence. Facts the user explicitly stated are user_stated @ 0.9;
+  // contextual inferences are assistant_inferred @ 0.7. A re-mention of the
+  // SAME key+value bumps the existing confidence instead of resetting it —
+  // repeated evidence makes memory more certain, and the conversational
+  // confirmation loop ("is that still right?") upgrades facts the same way.
+  const provenance = fact.stated ? 'user_stated' : 'assistant_inferred';
+  let confidence = fact.stated ? CONFIDENCE_STATED : CONFIDENCE_INFERRED;
+  try {
+    const existingResp = await fetch(
+      `${SUPABASE_URL}/rest/v1/memory_facts?` +
+        `tenant_id=eq.${encodeURIComponent(tenant_id)}&user_id=eq.${encodeURIComponent(user_id)}&` +
+        `fact_key=eq.${encodeURIComponent(effectiveFactKey)}&superseded_at=is.null&` +
+        `select=fact_value,provenance_confidence&limit=1`,
+      {
+        headers: {
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+        },
+      },
+    );
+    if (existingResp.ok) {
+      const rows = (await existingResp.json()) as Array<{ fact_value?: string; provenance_confidence?: number }>;
+      const existing = rows?.[0];
+      if (
+        existing &&
+        typeof existing.fact_value === 'string' &&
+        existing.fact_value.trim().toLowerCase() === fact.fact_value.trim().toLowerCase()
+      ) {
+        const prior = Number(existing.provenance_confidence) || 0;
+        confidence = Math.min(CONFIDENCE_CAP, Math.max(confidence, prior + CONFIDENCE_REMENTION_BUMP));
+      }
+    }
+  } catch {
+    // Evidence lookup is best-effort; base confidence stands.
+  }
+
   // VTID-01952: Identity Lock chokepoint. Inline LLM extraction is an
   // inference path — never allowed to write identity-class facts (name,
   // DOB, gender, email, etc.). DB trigger is defense-in-depth.
   const lockCheck = await assertWriteFact({
     fact_key: effectiveFactKey,
-    provenance_source: 'assistant_inferred',
-    provenance_confidence: 0.80,
+    provenance_source: provenance,
+    provenance_confidence: confidence,
     actor_id: 'inline-fact-extractor',
     source_engine: 'inline-fact-extractor',
     tenant_id,
@@ -298,14 +355,25 @@ async function persistFact(
         p_fact_value: fact.fact_value,
         p_entity: fact.entity,
         p_fact_value_type: fact.fact_value_type,
-        p_provenance_source: 'assistant_inferred',
-        p_provenance_confidence: 0.80,
+        p_provenance_source: provenance,
+        p_provenance_confidence: confidence,
       }),
     });
 
     if (response.ok) {
       const factId = await response.json();
       console.log(`[VTID-01225-inline] Persisted: ${fact.fact_key}="${fact.fact_value}" (id=${factId})`);
+      // BOOTSTRAP-MEMORY-DAILY-LEARNING: embed on write (fire-and-forget).
+      // This path wrote 96% of live facts without embeddings, which left
+      // tier-2 semantic fact retrieval permanently blind.
+      if (typeof factId === 'string' && factId) {
+        try {
+          const { generateFactEmbeddingAsync } = await import('./memory-facts-service');
+          generateFactEmbeddingAsync(factId, effectiveFactKey, fact.fact_value);
+        } catch {
+          /* embedding is best-effort; the backfill automation catches misses */
+        }
+      }
       return true;
     } else {
       const errorText = await response.text();

--- a/services/gateway/src/services/inline-fact-extractor.ts
+++ b/services/gateway/src/services/inline-fact-extractor.ts
@@ -61,9 +61,12 @@ Return ONLY a JSON array of facts. Each fact must have:
 Common fact keys:
 - user_name, user_residence, user_hometown, user_birthday, user_occupation, user_company
 - user_favorite_color, user_favorite_food, user_favorite_drink, user_favorite_*
-- user_allergy, user_medication, user_health_condition
-- user_preference_*, user_goal_*
+- user_allergy, user_medication, user_health_condition, user_dietary_restriction, user_doctor_name
+- user_preference_*, user_goal_*, user_hobby_*, user_language, user_pet_name
 - spouse_name, fiancee_name, partner_name, mother_name, father_name, child_name, friend_name_*
+- sibling_name, colleague_name, grandchild_name (people the user mentions by role)
+- <person>_birthday, <person>_health_condition (dates/conditions of people the user discloses, e.g. spouse_birthday)
+- upcoming_event_* (a concrete planned event with its date, e.g. upcoming_event_wedding)
 
 Rules:
 - Only extract facts the USER explicitly states (not assistant assumptions)

--- a/services/gateway/src/services/memory-orchestrator.ts
+++ b/services/gateway/src/services/memory-orchestrator.ts
@@ -12,8 +12,8 @@
  *   - memory-broker         → GOVERNANCE block (dismissed recommendations
  *                             + proactive pauses = the do-not-repeat list)
  *   - life_compass          → active goals
- *   - user_preferences /    → explicit + inferred preferences
- *     user_inferred_preferences
+ *   - memory_facts          → explicit + inferred preferences
+ *     (user_preference_* keys, via preference-facts.ts)
  *
  * and returns ONE prompt block wrapped in an unmistakable sentinel:
  *
@@ -51,6 +51,7 @@ import {
 import {
   computeRetrievalRouterDecision,
 } from './retrieval-router';
+import { fetchPreferenceFacts } from './preference-facts';
 import { ContextLens, createContextLens } from '../types/context-lens';
 import {
   ContextPack,
@@ -239,62 +240,22 @@ async function fetchActiveGoals(userId: string): Promise<ActiveGoal[]> {
 }
 
 /**
- * Explicit + high-confidence inferred preferences. Same tables and
- * thresholds as user-context-profiler.fetchPreferences (explicit wins,
- * inferred only above 0.55 confidence).
+ * Explicit + high-confidence inferred preferences, read from memory_facts
+ * under the user_preference_* fact-key prefix (see preference-facts.ts).
+ * The previous sources — user_preferences key/value columns and the
+ * user_inferred_preferences table — never matched the live schema and
+ * silently returned nothing. Verified against production 2026-07-05.
  */
-async function fetchPreferences(userId: string): Promise<PreferenceEntry[]> {
+async function fetchPreferences(tenantId: string, userId: string): Promise<PreferenceEntry[]> {
   const supabase = getSupabase();
   if (!supabase) return [];
-  const out: PreferenceEntry[] = [];
-  const [explicit, inferred] = await Promise.all([
-    supabase
-      .from('user_preferences')
-      .select('category, preference_key, preference_value')
-      .eq('user_id', userId)
-      .limit(15),
-    supabase
-      .from('user_inferred_preferences')
-      .select('category, preference_key, preference_value, confidence')
-      .eq('user_id', userId)
-      .order('confidence', { ascending: false })
-      .limit(10),
-  ]);
-  if (!explicit.error && explicit.data) {
-    for (const row of explicit.data as any[]) {
-      out.push({
-        category: row.category ?? 'preference',
-        key: row.preference_key ?? '',
-        value: stringifyPreferenceValue(row.preference_value),
-        source: 'explicit',
-      });
-    }
-  }
-  const seen = new Set(out.map((p) => `${p.category}:${p.key}`));
-  if (!inferred.error && inferred.data) {
-    for (const row of inferred.data as any[]) {
-      if ((row.confidence ?? 0) < 0.55) continue;
-      const dedupeKey = `${row.category ?? 'preference'}:${row.preference_key ?? ''}`;
-      if (seen.has(dedupeKey)) continue; // explicit always wins
-      out.push({
-        category: row.category ?? 'preference',
-        key: row.preference_key ?? '',
-        value: stringifyPreferenceValue(row.preference_value),
-        source: 'inferred',
-      });
-    }
-  }
-  return out;
-}
-
-function stringifyPreferenceValue(v: unknown): string {
-  if (v == null) return '';
-  if (typeof v === 'string') return v;
-  try {
-    return JSON.stringify(v);
-  } catch {
-    return String(v);
-  }
+  const facts = await fetchPreferenceFacts(supabase, userId, { tenantId, limit: 15 });
+  return facts.map((f) => ({
+    category: 'preference',
+    key: f.key,
+    value: f.value,
+    source: f.source,
+  }));
 }
 
 /**
@@ -579,7 +540,7 @@ export async function buildAssistantMemoryContext(
   const [packRes, goalsRes, prefsRes, dnrRes, socialRes] = await Promise.allSettled([
     buildContextPack(contextPackInput),
     communityRole ? fetchActiveGoals(input.user_id) : Promise.resolve([]),
-    fetchPreferences(input.user_id),
+    fetchPreferences(input.tenant_id, input.user_id),
     fetchDoNotRepeat(input.tenant_id, input.user_id),
     fetchSocial,
   ]);

--- a/services/gateway/src/services/memory-orchestrator.ts
+++ b/services/gateway/src/services/memory-orchestrator.ts
@@ -366,7 +366,15 @@ Before you answer, silently decide:
      or precision — never as proof that you remember.
   4. Is any memory conflicting or outdated? The user's CURRENT message
      always wins over stored memory; treat the stored version as stale
-     and do not argue from it.
+     and do not argue from it. When the user contradicts something you
+     remembered, briefly ACKNOWLEDGE the update in passing ("noted —
+     mornings now instead of evenings") so they feel the memory adapting,
+     then move on. Never defend the old version.
+  5. CONFIRMATION LOOP: if an [inferred] memory item is directly relevant
+     to this turn, you may weave ONE light confirmation into your answer
+     ("you mentioned once you prefer evening runs — is that still right?").
+     At most one confirmation per conversation, only when it fits
+     naturally, and never for [explicit] items the user already stated.
 
 Style rules for memory (non-negotiable):
 - Weave memory into your voice so the conversation feels deeply personal
@@ -390,6 +398,27 @@ Style rules for memory (non-negotiable):
 /**
  * Compose the full sentinel-wrapped memory block.
  */
+/**
+ * Cold-start curiosity (BOOTSTRAP-MEMORY-DAILY-LEARNING): with almost no
+ * stored facts there is nothing to be intelligent about — the median live
+ * user has ONE fact. Until the corpus exists, the assistant earns it: one
+ * natural get-to-know-you question per conversation, never an interview.
+ */
+export const COLD_START_FACTS_THRESHOLD = 5;
+
+function buildColdStartSection(): string {
+  return `<get_to_know_the_user>
+You still know very little about this user. Once per conversation, where it
+fits naturally, weave in ONE curious, caring question about their life —
+sleep and daily rhythm, the people who matter to them, what they are working
+toward, or what a good day looks like for them. Pick whichever is closest to
+the current topic. Never ask more than one, never make it feel like a form,
+and skip it entirely if the user is in the middle of something urgent.
+</get_to_know_the_user>
+
+`;
+}
+
 export function formatMemoryContextForPrompt(input: {
   context_pack: ContextPack;
   goals: ActiveGoal[];
@@ -399,13 +428,15 @@ export function formatMemoryContextForPrompt(input: {
   social_block?: string;
   skip_goal_section?: boolean;
   user_timezone?: string;
+  /** Cold start: almost no stored facts — inject the get-to-know directive. */
+  cold_start?: boolean;
 }): string {
   const packBlock = formatContextPackForLLM(input.context_pack, {
     userTimezone: input.user_timezone,
   });
 
   return `${MEMORY_CONTEXT_SENTINEL}
-${packBlock}${buildGoalsSection(input.goals, input.skip_goal_section === true)}${buildPreferencesSection(input.preferences)}${input.social_block || ''}${buildDoNotRepeatSection(input.do_not_repeat)}${buildSelfCheckSection()}
+${packBlock}${buildGoalsSection(input.goals, input.skip_goal_section === true)}${buildPreferencesSection(input.preferences)}${input.social_block || ''}${buildDoNotRepeatSection(input.do_not_repeat)}${input.cold_start ? buildColdStartSection() : ''}${buildSelfCheckSection()}
 ${MEMORY_CONTEXT_END_SENTINEL}
 `;
 }
@@ -596,6 +627,9 @@ export async function buildAssistantMemoryContext(
     do_not_repeat: doNotRepeat,
     skip_goal_section: input.skip_goal_section || !communityRole,
     user_timezone: input.user_timezone,
+    // Cold start only on community surfaces — dev/admin consoles must never
+    // get get-to-know-you prompts.
+    cold_start: communityRole && factsLoaded < COLD_START_FACTS_THRESHOLD,
   });
 
   const telemetry: MemoryTurnTelemetry = {

--- a/services/gateway/src/services/preference-facts.ts
+++ b/services/gateway/src/services/preference-facts.ts
@@ -1,0 +1,80 @@
+/**
+ * Preference facts — the single live source for user preferences.
+ * (BOOTSTRAP-MEMORY-DAILY-LEARNING, 2026-07-05)
+ *
+ * The legacy pair of sources never matched the live schema: the real
+ * `user_preferences` table is a wide app-settings row (autopilot/STT/TTS/AI
+ * columns) with no category/preference_key/preference_value columns, and
+ * `user_inferred_preferences` does not exist in production at all. Both
+ * queries errored inside PostgREST and were silently swallowed, so no
+ * preferences ever reached the assistant context.
+ *
+ * Preferences now come from `memory_facts` under the `user_preference_*`
+ * fact-key prefix — rows the inline fact extractor already writes today via
+ * the write_fact() RPC (auto-supersession, provenance tracking). This also
+ * gives behavior-derived preferences a single destination: write a
+ * `user_preference_*` fact and every consumer picks it up.
+ *
+ * Source mapping:
+ *   provenance_source = 'user_stated'  → 'explicit' (always kept)
+ *   anything else (assistant_inferred,
+ *   behavior_inferred, …)              → 'inferred' (kept only at/above
+ *                                         the 0.55 confidence floor)
+ */
+
+type SupabaseLike = { from: (table: string) => any };
+
+export interface PreferenceFact {
+  /** fact_key with the user_preference_ prefix stripped, e.g. 'exercise'. */
+  key: string;
+  value: string;
+  source: 'explicit' | 'inferred';
+  confidence: number;
+}
+
+export const PREFERENCE_FACT_KEY_PREFIX = 'user_preference_';
+export const INFERRED_PREFERENCE_MIN_CONFIDENCE = 0.55;
+
+export async function fetchPreferenceFacts(
+  client: SupabaseLike,
+  userId: string,
+  opts: { tenantId?: string; limit?: number } = {},
+): Promise<PreferenceFact[]> {
+  if (!client || !userId) return [];
+  const limit = opts.limit ?? 15;
+  try {
+    let query = client
+      .from('memory_facts')
+      .select('fact_key, fact_value, provenance_source, provenance_confidence, extracted_at')
+      .eq('user_id', userId)
+      .like('fact_key', `${PREFERENCE_FACT_KEY_PREFIX}%`)
+      .is('superseded_at', null)
+      .order('extracted_at', { ascending: false })
+      .limit(Math.min(limit * 3, 60));
+    if (opts.tenantId) query = query.eq('tenant_id', opts.tenantId);
+    const { data, error } = await query;
+    if (error || !Array.isArray(data)) return [];
+
+    const out: PreferenceFact[] = [];
+    const seen = new Set<string>();
+    for (const row of data as any[]) {
+      const rawKey = typeof row.fact_key === 'string' ? row.fact_key : '';
+      const key = rawKey.startsWith(PREFERENCE_FACT_KEY_PREFIX)
+        ? rawKey.slice(PREFERENCE_FACT_KEY_PREFIX.length)
+        : '';
+      if (!key || seen.has(key)) continue;
+      // Newest row per key is authoritative (write_fact supersedes older
+      // rows anyway) — never resurrect an older value for a skipped key.
+      seen.add(key);
+      const source: PreferenceFact['source'] =
+        row.provenance_source === 'user_stated' ? 'explicit' : 'inferred';
+      const confidence = Number(row.provenance_confidence ?? 0) || 0;
+      if (source === 'inferred' && confidence < INFERRED_PREFERENCE_MIN_CONFIDENCE) continue;
+      out.push({ key, value: String(row.fact_value ?? ''), source, confidence });
+      if (out.length >= limit) break;
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -1001,19 +1001,30 @@ export async function getUserContextSummary(
     ? Promise.resolve({ ok: true, facts: [] as any[] })
     : getCurrentFacts({ tenant_id: opts.tenantId, user_id: userId });
 
+  // BOOTSTRAP-MEMORY-DAILY-LEARNING: the nightly synthesized "who is this
+  // person" narrative (AP-0911). Reads a single user_assistant_state row —
+  // cheap, and the section self-skips when no narrative exists yet.
+  const fetchNarrativeIfWanted =
+    (cfg && !cfg.isEnabled('profile.narrative.enabled')) || !opts.tenantId
+      ? Promise.resolve(null)
+      : import('./user-model-synthesis')
+          .then((m) => m.readUserProfileNarrative(client, opts.tenantId!, userId))
+          .catch(() => null);
+
   // VTID-03037: account/tenure fetch. Always in the batch — no awareness-
   // registry gate yet; the section itself self-skips when created_at is
   // missing. The query is cheap (single-row lookup on a PK) and adds no
   // measurable latency because it parallelizes with the existing five.
   const fetchAccountPromise = fetchAppUsersAccount(client, userId);
 
-  const [activities, routines, prefs, vitana, factsResult, account] = await Promise.all([
+  const [activities, routines, prefs, vitana, factsResult, account, narrative] = await Promise.all([
     fetchActivitiesIfWanted,
     fetchRoutinesIfWanted,
     fetchPrefsIfWanted,
     fetchVitanaIfWanted,
     fetchFactsIfWanted,
     fetchAccountPromise,
+    fetchNarrativeIfWanted,
   ]);
 
   const sections = [
@@ -1022,6 +1033,11 @@ export async function getUserContextSummary(
     // path's USER AWARENESS positioning (tenure line at top of awareness
     // block) so both pipelines agree on the high-signal placement.
     buildAccountSection(account, now),
+    // Synthesized narrative FIRST after account — it's the connected picture;
+    // the sections below are its raw evidence.
+    narrative
+      ? `[PROFILE SYNTHESIS — nightly, connect-the-dots summary]\n${narrative.narrative}`
+      : '',
     (!cfg || cfg.isEnabled('activity.summary.enabled')) ? buildActivitySummarySection(activities) : '',
     (!cfg || cfg.isEnabled('routines.enabled'))         ? buildRoutinesSection(routines, activities) : '',
     (!cfg || cfg.isEnabled('preferences.explicit.enabled') || cfg.isEnabled('preferences.inferred.enabled'))

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -25,6 +25,7 @@
  */
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { getCurrentFacts } from './memory-facts-service';
+import { fetchPreferenceFacts } from './preference-facts';
 import { getAwarenessConfig } from './awareness-registry';
 import { getJourneyEngagementBonus } from './guided-journey/journey-index-award';
 
@@ -219,41 +220,22 @@ async function fetchAppUsersAccount(
   }
 }
 
-async function fetchPreferences(client: SupabaseClient, userId: string): Promise<PreferenceRow[]> {
-  const out: PreferenceRow[] = [];
-  const explicit = await client
-    .from('user_preferences')
-    .select('category, preference_key, preference_value')
-    .eq('user_id', userId)
-    .limit(20);
-  if (!explicit.error && explicit.data) {
-    for (const row of explicit.data as any[]) {
-      out.push({
-        category: row.category ?? 'preference',
-        preference_key: row.preference_key ?? row.key ?? '',
-        preference_value: row.preference_value ?? row.value ?? null,
-        source: 'explicit',
-      });
-    }
-  }
-  const inferred = await client
-    .from('user_inferred_preferences')
-    .select('category, preference_key, preference_value, confidence')
-    .eq('user_id', userId)
-    .order('confidence', { ascending: false })
-    .limit(15);
-  if (!inferred.error && inferred.data) {
-    for (const row of inferred.data as any[]) {
-      if ((row.confidence ?? 0) < 0.55) continue;
-      out.push({
-        category: row.category ?? 'preference',
-        preference_key: row.preference_key ?? row.key ?? '',
-        preference_value: row.preference_value ?? row.value ?? null,
-        source: 'inferred',
-      });
-    }
-  }
-  return out;
+// Preferences come from memory_facts (user_preference_* keys, see
+// preference-facts.ts). The old user_preferences key/value columns and the
+// user_inferred_preferences table never existed in the live schema — both
+// queries errored and this section was silently empty. Fixed 2026-07-05.
+async function fetchPreferences(
+  client: SupabaseClient,
+  userId: string,
+  tenantId?: string,
+): Promise<PreferenceRow[]> {
+  const facts = await fetchPreferenceFacts(client, userId, { tenantId, limit: 20 });
+  return facts.map((f) => ({
+    category: 'preference',
+    preference_key: f.key,
+    preference_value: f.value,
+    source: f.source,
+  }));
 }
 
 // =============================================================================
@@ -1009,7 +991,7 @@ export async function getUserContextSummary(
 
   const fetchPrefsIfWanted = (cfg && !cfg.isEnabled('preferences.explicit.enabled') && !cfg.isEnabled('preferences.inferred.enabled'))
     ? Promise.resolve([] as PreferenceRow[])
-    : fetchPreferences(client, userId);
+    : fetchPreferences(client, userId, opts.tenantId);
 
   const fetchVitanaIfWanted = (cfg && !cfg.isEnabled('health.enabled'))
     ? Promise.resolve(null)

--- a/services/gateway/src/services/user-model-synthesis.ts
+++ b/services/gateway/src/services/user-model-synthesis.ts
@@ -1,0 +1,254 @@
+/**
+ * User-model synthesis — the nightly "who is this person?" narrative.
+ * (BOOTSTRAP-MEMORY-DAILY-LEARNING)
+ *
+ * The user's picture lives in five stores (memory_facts, user_routines,
+ * vitana_index_scores, life_compass, diary) that are separately queried and
+ * concatenated at answer time. Nobody sounds insightful reading five lists.
+ * This service has an LLM synthesize each active user into ONE compact
+ * narrative profile ("Dragan, planning a September wedding to Sarah; sleep
+ * is his weak pillar and dips after evening sessions; responds best to
+ * concrete morning plans…") and stores it in user_assistant_state under
+ * `user_profile_narrative_v1`.
+ *
+ * The UserContextProfiler injects the narrative into the (TTL-cached) ORB
+ * bootstrap instruction, so voice sessions open with synthesized
+ * understanding at zero added latency. Regenerated nightly by AP-0911 only
+ * when the underlying inputs changed (inputs hash).
+ *
+ * Grounding contract: the prompt forbids invention — the narrative may only
+ * restate and CONNECT what the inputs already say. The synthesis is written
+ * in English (system-instruction language); the model answers the user in
+ * their own language per the session's language directive.
+ */
+
+import { VertexAI } from '@google-cloud/vertexai';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const SIGNAL_PROFILE_NARRATIVE = 'user_profile_narrative_v1';
+/** Below this many live facts a narrative adds nothing — skip. */
+export const MIN_FACTS_FOR_NARRATIVE = 3;
+const MAX_FACTS_IN_PROMPT = 30;
+const MAX_ROUTINES_IN_PROMPT = 5;
+const NARRATIVE_MODEL = 'gemini-2.0-flash';
+
+const VERTEX_PROJECT =
+  process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
+const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
+
+let vertexAI: VertexAI | null = null;
+try {
+  vertexAI = new VertexAI({ project: VERTEX_PROJECT, location: VERTEX_LOCATION });
+} catch (err: any) {
+  console.warn(`[user-model-synthesis] Vertex init failed: ${err?.message}`);
+}
+
+const SYNTHESIS_SYSTEM_PROMPT = `You write a compact profile of a wellness-community member for their AI companion's private context. INPUTS are structured records the system has verified. Your job is to SYNTHESIZE, not to list:
+
+- Connect related records into one picture (a goal + a routine + a weak health pillar that plausibly relate — say how).
+- 4 to 8 sentences of plain English prose. No headings, no bullets, no markdown.
+- STRICT GROUNDING: only restate or connect what the inputs say. NEVER invent details, diagnoses, or causes the inputs don't support. Use hedged language ("seems to", "may be related") for connections.
+- Prioritize: health-relevant patterns first, then people who matter to them, then preferences/routines, then open threads (upcoming events, concerns).
+- Write about "the user" in third person. This text is never shown to the user directly.`;
+
+export interface SynthesisInputs {
+  facts: Array<{ fact_key: string; fact_value: string; provenance_source: string }>;
+  routines: Array<{ title: string; summary: string }>;
+  goal: string | null;
+  index: { total: number | null; weakest_pillar: string | null } | null;
+}
+
+export interface SynthesisResult {
+  ok: boolean;
+  written: boolean;
+  reason?: string;
+}
+
+/** Stable, cheap change-detector over the synthesis inputs. */
+export function computeInputsHash(inputs: SynthesisInputs): string {
+  const s = JSON.stringify([
+    inputs.facts.map((f) => `${f.fact_key}=${f.fact_value}`).sort(),
+    inputs.routines.map((r) => r.title).sort(),
+    inputs.goal,
+    inputs.index?.total ?? null,
+    inputs.index?.weakest_pillar ?? null,
+  ]);
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return String(h >>> 0);
+}
+
+export async function gatherSynthesisInputs(
+  supabase: SupabaseClient,
+  tenantId: string,
+  userId: string,
+): Promise<SynthesisInputs> {
+  const [factsRes, routinesRes, goalRes, indexRes] = await Promise.all([
+    supabase
+      .from('memory_facts')
+      .select('fact_key, fact_value, provenance_source')
+      .eq('tenant_id', tenantId)
+      .eq('user_id', userId)
+      .is('superseded_at', null)
+      .order('provenance_confidence', { ascending: false })
+      .order('extracted_at', { ascending: false })
+      .limit(MAX_FACTS_IN_PROMPT),
+    supabase
+      .from('user_routines')
+      .select('title, summary')
+      .eq('user_id', userId)
+      .order('confidence', { ascending: false })
+      .limit(MAX_ROUTINES_IN_PROMPT),
+    supabase
+      .from('life_compass')
+      .select('primary_goal')
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(1),
+    supabase
+      .from('vitana_index_scores')
+      .select('score_total, score_nutrition, score_hydration, score_exercise, score_sleep, score_mental')
+      .eq('user_id', userId)
+      .order('date', { ascending: false })
+      .limit(1),
+  ]);
+
+  let index: SynthesisInputs['index'] = null;
+  const idx = (indexRes.data || [])[0] as Record<string, number> | undefined;
+  if (idx && typeof idx.score_total === 'number') {
+    const pillars: Array<[string, number]> = [
+      ['nutrition', idx.score_nutrition],
+      ['hydration', idx.score_hydration],
+      ['exercise', idx.score_exercise],
+      ['sleep', idx.score_sleep],
+      ['mental', idx.score_mental],
+    ].filter(([, v]) => typeof v === 'number') as Array<[string, number]>;
+    pillars.sort((a, b) => a[1] - b[1]);
+    index = { total: idx.score_total, weakest_pillar: pillars[0]?.[0] ?? null };
+  }
+
+  return {
+    facts: (factsRes.data || []) as SynthesisInputs['facts'],
+    routines: (routinesRes.data || []) as SynthesisInputs['routines'],
+    goal: ((goalRes.data || [])[0] as { primary_goal?: string } | undefined)?.primary_goal ?? null,
+    index,
+  };
+}
+
+async function callSynthesisModel(inputs: SynthesisInputs): Promise<string | null> {
+  if (!vertexAI) return null;
+  const lines: string[] = [];
+  lines.push('FACTS (verified memory records):');
+  for (const f of inputs.facts) {
+    lines.push(`- ${f.fact_key} = ${f.fact_value} [${f.provenance_source}]`);
+  }
+  if (inputs.routines.length) {
+    lines.push('ROUTINES (observed behavior patterns):');
+    for (const r of inputs.routines) lines.push(`- ${r.title}: ${r.summary}`);
+  }
+  if (inputs.goal) lines.push(`ACTIVE GOAL: ${inputs.goal}`);
+  if (inputs.index) {
+    lines.push(
+      `VITANA INDEX: total ${inputs.index.total}${inputs.index.weakest_pillar ? `, weakest pillar: ${inputs.index.weakest_pillar}` : ''}`,
+    );
+  }
+
+  try {
+    const model = vertexAI.getGenerativeModel({
+      model: NARRATIVE_MODEL,
+      generationConfig: { temperature: 0.3, maxOutputTokens: 400, topP: 0.9 },
+      systemInstruction: { role: 'system', parts: [{ text: SYNTHESIS_SYSTEM_PROMPT }] },
+    });
+    const response = await model.generateContent({
+      contents: [{ role: 'user', parts: [{ text: lines.join('\n') }] }],
+    });
+    const text = response.response?.candidates?.[0]?.content?.parts?.[0]?.text;
+    const narrative = typeof text === 'string' ? text.trim() : '';
+    return narrative.length >= 40 ? narrative : null;
+  } catch (err: any) {
+    console.warn(`[user-model-synthesis] model call failed: ${err?.message}`);
+    return null;
+  }
+}
+
+/**
+ * Synthesize + store one user's narrative. Skips (written:false) when the
+ * user has too few facts or when the inputs hash is unchanged since the
+ * last run — re-synthesis without new information is pure cost.
+ */
+export async function synthesizeUserModel(
+  supabase: SupabaseClient,
+  tenantId: string,
+  userId: string,
+): Promise<SynthesisResult> {
+  const inputs = await gatherSynthesisInputs(supabase, tenantId, userId);
+  if (inputs.facts.length < MIN_FACTS_FOR_NARRATIVE) {
+    return { ok: true, written: false, reason: 'too_few_facts' };
+  }
+  const hash = computeInputsHash(inputs);
+
+  const { data: existing } = await supabase
+    .from('user_assistant_state')
+    .select('value')
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId)
+    .eq('signal_name', SIGNAL_PROFILE_NARRATIVE)
+    .maybeSingle();
+  const prior = (existing as { value?: { inputs_hash?: string } } | null)?.value;
+  if (prior?.inputs_hash === hash) {
+    return { ok: true, written: false, reason: 'inputs_unchanged' };
+  }
+
+  const narrative = await callSynthesisModel(inputs);
+  if (!narrative) return { ok: false, written: false, reason: 'model_failed' };
+
+  const nowIso = new Date().toISOString();
+  const { error } = await supabase.from('user_assistant_state').upsert(
+    {
+      tenant_id: tenantId,
+      user_id: userId,
+      signal_name: SIGNAL_PROFILE_NARRATIVE,
+      value: {
+        narrative,
+        generated_at: nowIso,
+        inputs_hash: hash,
+        facts_count: inputs.facts.length,
+      },
+      last_seen_at: nowIso,
+    },
+    { onConflict: 'tenant_id,user_id,signal_name' },
+  );
+  if (error) return { ok: false, written: false, reason: error.message };
+  return { ok: true, written: true };
+}
+
+/** Read the stored narrative (null when absent/stale-schema/error). */
+export async function readUserProfileNarrative(
+  supabase: SupabaseClient,
+  tenantId: string,
+  userId: string,
+): Promise<{ narrative: string; generated_at: string } | null> {
+  try {
+    const { data, error } = await supabase
+      .from('user_assistant_state')
+      .select('value')
+      .eq('tenant_id', tenantId)
+      .eq('user_id', userId)
+      .eq('signal_name', SIGNAL_PROFILE_NARRATIVE)
+      .maybeSingle();
+    if (error || !data) return null;
+    const v = (data as { value?: { narrative?: unknown; generated_at?: unknown } }).value;
+    if (v && typeof v.narrative === 'string' && v.narrative.trim()) {
+      return {
+        narrative: v.narrative,
+        generated_at: typeof v.generated_at === 'string' ? v.generated_at : '',
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/services/gateway/test/inline-fact-extractor.test.ts
+++ b/services/gateway/test/inline-fact-extractor.test.ts
@@ -136,8 +136,60 @@ describe('VTID-01225: Inline Fact Extractor', () => {
       expect(firstWrite.body).toHaveProperty('p_fact_value');
       expect(firstWrite.body).toHaveProperty('p_entity');
       expect(firstWrite.body).toHaveProperty('p_fact_value_type');
+      // Facts without stated:true are contextual inferences → 0.7 base
+      // confidence (BOOTSTRAP-MEMORY-DAILY-LEARNING evidence-weighted model).
       expect(firstWrite.body).toHaveProperty('p_provenance_source', 'assistant_inferred');
-      expect(firstWrite.body).toHaveProperty('p_provenance_confidence', 0.80);
+      expect(firstWrite.body).toHaveProperty('p_provenance_confidence', 0.7);
+    });
+
+    it('writes stated facts as user_stated with higher base confidence', async () => {
+      vertexResponseText = JSON.stringify([
+        { fact_key: 'user_favorite_tea', fact_value: 'Earl Grey', entity: 'self', fact_value_type: 'text', stated: true },
+      ]);
+      await extractAndPersistFacts({
+        conversationText: 'User: My favorite tea is Earl Grey, definitely.\nAssistant: Noted!',
+        tenant_id: 'tenant-123',
+        user_id: 'user-456',
+        session_id: 'session-789',
+      });
+      const writeFactCalls = fetchCalls.filter(c => c.url.includes('write_fact'));
+      expect(writeFactCalls.length).toBe(1);
+      expect(writeFactCalls[0].body).toHaveProperty('p_provenance_source', 'user_stated');
+      expect(writeFactCalls[0].body).toHaveProperty('p_provenance_confidence', 0.9);
+    });
+
+    it('bumps confidence when the same key+value is re-mentioned (evidence-weighted)', async () => {
+      vertexResponseText = JSON.stringify([
+        { fact_key: 'user_favorite_tea', fact_value: 'Earl Grey', entity: 'self', fact_value_type: 'text', stated: true },
+      ]);
+      // The pre-write evidence lookup finds an existing identical fact @ 0.9.
+      mockFetch.mockImplementation(async (url: string, options?: RequestInit) => {
+        const method = options?.method || 'GET';
+        const body = options?.body ? JSON.parse(options.body as string) : undefined;
+        fetchCalls.push({ url, method, body });
+        if (url.includes('/rest/v1/memory_facts?')) {
+          return { ok: true, json: async () => ([{ fact_value: 'Earl Grey', provenance_confidence: 0.9 }]) };
+        }
+        if (url.includes('generateContent')) {
+          return {
+            ok: true,
+            json: async () => ({ candidates: [{ content: { parts: [{ text: vertexResponseText }] } }] }),
+          };
+        }
+        if (url.includes('/rest/v1/rpc/write_fact')) {
+          return { ok: true, json: async () => 'fact-uuid-123' };
+        }
+        return { ok: true, json: async () => ({}), text: async () => '' };
+      });
+      await extractAndPersistFacts({
+        conversationText: 'User: Like I said, Earl Grey is my favorite tea.\nAssistant: I remember!',
+        tenant_id: 'tenant-123',
+        user_id: 'user-456',
+        session_id: 'session-789',
+      });
+      const writeFactCalls = fetchCalls.filter(c => c.url.includes('rpc/write_fact'));
+      expect(writeFactCalls.length).toBe(1);
+      expect(writeFactCalls[0].body.p_provenance_confidence).toBeCloseTo(0.95);
     });
 
     it('should pass correct authorization headers to write_fact', async () => {
@@ -259,9 +311,11 @@ describe('VTID-01225: Inline Fact Extractor', () => {
         expect(typeof body.p_provenance_source).toBe('string');
         expect(typeof body.p_provenance_confidence).toBe('number');
 
-        // Verify provenance values
-        expect(body.p_provenance_source).toBe('assistant_inferred');
-        expect(body.p_provenance_confidence).toBe(0.80);
+        // Provenance is stated-aware: user_stated (0.9 base) for explicit
+        // statements, assistant_inferred (0.7 base) for contextual inference.
+        expect(['user_stated', 'assistant_inferred']).toContain(body.p_provenance_source);
+        expect(body.p_provenance_confidence).toBeGreaterThanOrEqual(0.7);
+        expect(body.p_provenance_confidence).toBeLessThanOrEqual(0.98);
       }
     });
 

--- a/services/gateway/test/services/assistant-continuation/providers/new-day-overview-plan-phase.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/new-day-overview-plan-phase.test.ts
@@ -57,6 +57,7 @@ function makePayload(journey: OverviewPayload['journey']): OverviewPayload {
     messages_unread: 0,
     reminders_today: { count: 0, next: null },
     diary_last_7d: 0,
+    facts_learned_since_last: null,
     guided_journey: null,
     last_session_date_user_tz: '2026-05-31',
   };

--- a/services/gateway/test/services/automation-handlers-phase2.test.ts
+++ b/services/gateway/test/services/automation-handlers-phase2.test.ts
@@ -19,6 +19,14 @@ import { registerBusinessOpportunityHandlers } from '../../src/services/automati
 import { registerHealthActionInitiativeHandlers } from '../../src/services/automation-handlers/health-action-initiative';
 import { AutomationContext } from '../../src/types/automations';
 
+// AP-0906 fans out to the guide pattern-extractor — mock it so the handler
+// test controls per-user results without a live supabase in the extractor.
+jest.mock('../../src/services/guide/pattern-extractor', () => ({
+  extractPatternsForUser: jest.fn(),
+}));
+import { extractPatternsForUser } from '../../src/services/guide/pattern-extractor';
+const mockedExtract = extractPatternsForUser as jest.MockedFunction<typeof extractPatternsForUser>;
+
 registerPersonalizationEnginesHandlers();
 registerMemoryIntelligenceHandlers();
 registerEventMeetupInitiativeHandlers();
@@ -98,6 +106,7 @@ describe('registry wiring — Phase 2 (5 new domains)', () => {
     'AP-0903': 'runRelationshipGraphMaintenance',
     'AP-0904': 'runSemanticMemoryContextForAutopilot',
     'AP-0905': 'runKnowledgeBaseContextForSuggestions',
+    'AP-0906': 'runRoutinePatternExtraction',
     'AP-1401': 'runSmartEventCreation',
     'AP-1402': 'runCalendarAvailabilityCheck',
     'AP-1403': 'runAutoInvitationSender',
@@ -210,6 +219,56 @@ describe('runRelationshipGraphMaintenance (AP-0903)', () => {
     const handler = getHandler('runRelationshipGraphMaintenance')!;
     const result = await handler(ctx);
     expect(result).toEqual({ usersAffected: 0, actionsTaken: 2 });
+  });
+});
+
+describe('runRoutinePatternExtraction (AP-0906)', () => {
+  beforeEach(() => mockedExtract.mockReset());
+
+  it('extracts routines once per distinct user with recent calendar activity', async () => {
+    const supabase = makeFakeSupabase({
+      calendar_events: [{ data: [{ user_id: 'u1' }, { user_id: 'u1' }, { user_id: 'u2' }], error: null }],
+    });
+    mockedExtract.mockImplementation(async (userId: string) => ({
+      user_id: userId,
+      routines_written: userId === 'u1' ? 2 : 0,
+      routines: [],
+      events_examined: 5,
+    }));
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runRoutinePatternExtraction')!;
+    const result = await handler(ctx);
+    expect(mockedExtract).toHaveBeenCalledTimes(2);
+    expect(mockedExtract).toHaveBeenCalledWith('u1');
+    expect(mockedExtract).toHaveBeenCalledWith('u2');
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 2 });
+    expect(ctx.emitEvent).toHaveBeenCalledWith('autopilot.memory.routines_extracted', {
+      users_scanned: 2,
+      users_with_routines: 1,
+      routines_written: 2,
+    });
+  });
+
+  it('is a no-op when nobody has recent calendar activity', async () => {
+    const supabase = makeFakeSupabase({ calendar_events: [{ data: [], error: null }] });
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runRoutinePatternExtraction')!;
+    const result = await handler(ctx);
+    expect(mockedExtract).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+
+  it('keeps going when extraction fails for one user', async () => {
+    const supabase = makeFakeSupabase({
+      calendar_events: [{ data: [{ user_id: 'u1' }, { user_id: 'u2' }], error: null }],
+    });
+    mockedExtract
+      .mockRejectedValueOnce(new Error('supabase down'))
+      .mockResolvedValueOnce({ user_id: 'u2', routines_written: 1, routines: [], events_examined: 4 });
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runRoutinePatternExtraction')!;
+    const result = await handler(ctx);
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 1 });
   });
 });
 

--- a/services/gateway/test/services/automation-handlers-phase2.test.ts
+++ b/services/gateway/test/services/automation-handlers-phase2.test.ts
@@ -27,6 +27,19 @@ jest.mock('../../src/services/guide/pattern-extractor', () => ({
 import { extractPatternsForUser } from '../../src/services/guide/pattern-extractor';
 const mockedExtract = extractPatternsForUser as jest.MockedFunction<typeof extractPatternsForUser>;
 
+// AP-0910 batches embeddings; AP-0911 delegates to the synthesis service —
+// mock both so handler tests stay hermetic (no Vertex/OpenAI calls).
+jest.mock('../../src/services/embedding-service', () => ({
+  generateBatchEmbeddings: jest.fn(),
+}));
+jest.mock('../../src/services/user-model-synthesis', () => ({
+  synthesizeUserModel: jest.fn(),
+}));
+import { generateBatchEmbeddings } from '../../src/services/embedding-service';
+import { synthesizeUserModel } from '../../src/services/user-model-synthesis';
+const mockedBatchEmbed = generateBatchEmbeddings as jest.MockedFunction<typeof generateBatchEmbeddings>;
+const mockedSynthesize = synthesizeUserModel as jest.MockedFunction<typeof synthesizeUserModel>;
+
 registerPersonalizationEnginesHandlers();
 registerMemoryIntelligenceHandlers();
 registerEventMeetupInitiativeHandlers();
@@ -103,12 +116,15 @@ describe('registry wiring — Phase 2 (5 new domains)', () => {
     'AP-0805': 'runOverloadDetectionThrottle',
     'AP-0901': 'runMemoryInformedMatching',
     'AP-0902': 'runFactExtractionAudit',
-    'AP-0903': 'runRelationshipGraphMaintenance',
     'AP-0904': 'runSemanticMemoryContextForAutopilot',
     'AP-0905': 'runKnowledgeBaseContextForSuggestions',
     'AP-0906': 'runRoutinePatternExtraction',
     'AP-0907': 'runDailyLearningDigest',
     'AP-0908': 'runBehaviorPreferenceInference',
+    'AP-0909': 'runRelationshipGraphProjection',
+    'AP-0910': 'runMemoryEmbeddingBackfill',
+    'AP-0911': 'runUserModelSynthesis',
+    'AP-0912': 'runHealthCorrelationInsights',
     'AP-1401': 'runSmartEventCreation',
     'AP-1402': 'runCalendarAvailabilityCheck',
     'AP-1403': 'runAutoInvitationSender',
@@ -212,15 +228,84 @@ describe('runMemoryInformedMatching (AP-0901)', () => {
   });
 });
 
-describe('runRelationshipGraphMaintenance (AP-0903)', () => {
-  it('decays strength on stale edges', async () => {
+describe('AP-0903 retirement', () => {
+  it('is DEPRECATED in the registry and its decay handler is gone (Loop 13 owns decay)', () => {
+    const def = getAutomation('AP-0903');
+    expect(def?.status).toBe('DEPRECATED');
+    expect(def?.handler).toBeUndefined();
+    expect(getHandler('runRelationshipGraphMaintenance')).toBeUndefined();
+  });
+});
+
+describe('runRelationshipGraphProjection (AP-0909)', () => {
+  it('projects a person-fact into a node + relation edge', async () => {
     const supabase = makeFakeSupabase({
-      relationship_edges: [{ data: [{ id: 'e1', strength: 50 }, { id: 'e2', strength: 5 }], error: null }],
+      memory_facts: [
+        { data: [{ user_id: 'u1', fact_key: 'spouse_name', fact_value: 'Maria', extracted_at: '2026-07-01T00:00:00Z' }], error: null },
+      ],
+      relationship_nodes: [
+        { data: null, error: null }, // node lookup miss
+        { data: { id: 'node-1' }, error: null }, // insert returns id
+      ],
+      relationship_edges: [
+        { data: null, error: null }, // edge lookup miss
+        { data: null, error: null }, // insert ok
+      ],
+      user_follows: [{ data: [], error: null }],
     });
     const { ctx } = makeCtx(supabase);
-    const handler = getHandler('runRelationshipGraphMaintenance')!;
+    const handler = getHandler('runRelationshipGraphProjection')!;
     const result = await handler(ctx);
-    expect(result).toEqual({ usersAffected: 0, actionsTaken: 2 });
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 2 }); // 1 node + 1 edge
+    expect(ctx.emitEvent).toHaveBeenCalledWith('autopilot.memory.graph_projected', {
+      nodes_created: 1,
+      edges_created: 1,
+      users_touched: 1,
+    });
+  });
+
+  it('projects mutual follows into connected edges (both directions), one-way follows ignored', async () => {
+    const supabase = makeFakeSupabase({
+      memory_facts: [{ data: [], error: null }],
+      user_follows: [
+        {
+          data: [
+            { follower_id: 'a', following_id: 'b' },
+            { follower_id: 'b', following_id: 'a' }, // mutual
+            { follower_id: 'a', following_id: 'c' }, // one-way
+          ],
+          error: null,
+        },
+      ],
+      relationship_edges: [
+        { data: null, error: null }, // a→b lookup miss
+        { data: null, error: null }, // a→b insert
+        { data: null, error: null }, // b→a lookup miss
+        { data: null, error: null }, // b→a insert
+      ],
+    });
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runRelationshipGraphProjection')!;
+    const result = await handler(ctx);
+    expect(result.actionsTaken).toBe(2); // exactly the two directions of one mutual pair
+  });
+
+  it('is idempotent — existing nodes and edges are not recreated', async () => {
+    const supabase = makeFakeSupabase({
+      memory_facts: [
+        { data: [{ user_id: 'u1', fact_key: 'friend_name', fact_value: 'Jovana', extracted_at: '2026-07-01T00:00:00Z' }], error: null },
+      ],
+      relationship_nodes: [{ data: { id: 'node-1' }, error: null }], // node exists
+      relationship_edges: [
+        { data: { id: 'edge-1' }, error: null }, // edge exists
+        { data: null, error: null }, // last_interaction_at update
+      ],
+      user_follows: [{ data: [], error: null }],
+    });
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runRelationshipGraphProjection')!;
+    const result = await handler(ctx);
+    expect(result.actionsTaken).toBe(0);
   });
 });
 
@@ -375,6 +460,110 @@ describe('runBehaviorPreferenceInference (AP-0908)', () => {
     const result = await handler(ctx);
     expect(supabase.rpc).not.toHaveBeenCalled();
     expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});
+
+describe('runMemoryEmbeddingBackfill (AP-0910)', () => {
+  it('embeds the unembedded backlog in one batch', async () => {
+    const supabase = makeFakeSupabase({
+      memory_facts: [
+        { data: [{ id: 'f1', fact_key: 'user_favorite_tea', fact_value: 'Earl Grey' }], error: null },
+        { data: null, error: null }, // update
+      ],
+    });
+    mockedBatchEmbed.mockResolvedValue({ ok: true, embeddings: [[0.1, 0.2]], model: 'test-model' });
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runMemoryEmbeddingBackfill')!;
+    const result = await handler(ctx);
+    expect(mockedBatchEmbed).toHaveBeenCalledWith(['user_favorite_tea: Earl Grey']);
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 1 });
+  });
+
+  it('is a no-op when the backlog is empty', async () => {
+    const supabase = makeFakeSupabase({ memory_facts: [{ data: [], error: null }] });
+    mockedBatchEmbed.mockClear();
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runMemoryEmbeddingBackfill')!;
+    const result = await handler(ctx);
+    expect(mockedBatchEmbed).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});
+
+describe('runUserModelSynthesis (AP-0911)', () => {
+  it('synthesizes only users with at least 3 live facts', async () => {
+    const supabase = makeFakeSupabase({
+      memory_facts: [
+        {
+          data: [
+            { user_id: 'u1' }, { user_id: 'u1' }, { user_id: 'u1' }, // 3 facts → eligible
+            { user_id: 'u2' }, // 1 fact → skipped
+          ],
+          error: null,
+        },
+      ],
+    });
+    mockedSynthesize.mockReset();
+    mockedSynthesize.mockResolvedValue({ ok: true, written: true });
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runUserModelSynthesis')!;
+    const result = await handler(ctx);
+    expect(mockedSynthesize).toHaveBeenCalledTimes(1);
+    expect(mockedSynthesize).toHaveBeenCalledWith(supabase, 't-1', 'u1');
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 1 });
+  });
+});
+
+describe('runHealthCorrelationInsights (AP-0912)', () => {
+  it('writes a pillar-trend insight when a pillar moves >= 10 points', async () => {
+    const supabase: any = makeFakeSupabase({
+      vitana_index_scores: [
+        {
+          data: [
+            { user_id: 'u1', date: '2026-06-24', score_sleep: 120, score_nutrition: 100, score_exercise: 100, score_hydration: 100, score_mental: 100 },
+            { user_id: 'u1', date: '2026-06-28', score_sleep: 115, score_nutrition: 100, score_exercise: 100, score_hydration: 100, score_mental: 100 },
+            { user_id: 'u1', date: '2026-07-02', score_sleep: 110, score_nutrition: 100, score_exercise: 100, score_hydration: 100, score_mental: 100 },
+            { user_id: 'u1', date: '2026-07-06', score_sleep: 100, score_nutrition: 100, score_exercise: 100, score_hydration: 100, score_mental: 100 },
+          ],
+          error: null,
+        },
+      ],
+      diary_entries: [{ data: [], error: null }],
+    });
+    supabase.rpc = jest.fn(async () => ({ data: 'fact-id', error: null }));
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runHealthCorrelationInsights')!;
+    const result = await handler(ctx);
+    expect(supabase.rpc).toHaveBeenCalledWith('write_fact', expect.objectContaining({
+      p_fact_key: 'health_insight_sleep_trend',
+      p_provenance_source: 'system_observed',
+    }));
+    expect(result.usersAffected).toBe(1);
+  });
+
+  it('writes a diary-lapse insight when a streak stops', async () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 86_400_000).toISOString();
+    const supabase: any = makeFakeSupabase({
+      vitana_index_scores: [{ data: [], error: null }],
+      diary_entries: [
+        {
+          data: [
+            { user_id: 'u1', created_at: eightDaysAgo },
+            { user_id: 'u1', created_at: eightDaysAgo },
+            { user_id: 'u1', created_at: eightDaysAgo },
+          ],
+          error: null,
+        },
+      ],
+    });
+    supabase.rpc = jest.fn(async () => ({ data: 'fact-id', error: null }));
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runHealthCorrelationInsights')!;
+    const result = await handler(ctx);
+    expect(supabase.rpc).toHaveBeenCalledWith('write_fact', expect.objectContaining({
+      p_fact_key: 'health_insight_diary_lapse',
+    }));
+    expect(result.actionsTaken).toBe(1);
   });
 });
 

--- a/services/gateway/test/services/automation-handlers-phase2.test.ts
+++ b/services/gateway/test/services/automation-handlers-phase2.test.ts
@@ -107,6 +107,8 @@ describe('registry wiring — Phase 2 (5 new domains)', () => {
     'AP-0904': 'runSemanticMemoryContextForAutopilot',
     'AP-0905': 'runKnowledgeBaseContextForSuggestions',
     'AP-0906': 'runRoutinePatternExtraction',
+    'AP-0907': 'runDailyLearningDigest',
+    'AP-0908': 'runBehaviorPreferenceInference',
     'AP-1401': 'runSmartEventCreation',
     'AP-1402': 'runCalendarAvailabilityCheck',
     'AP-1403': 'runAutoInvitationSender',
@@ -269,6 +271,110 @@ describe('runRoutinePatternExtraction (AP-0906)', () => {
     const handler = getHandler('runRoutinePatternExtraction')!;
     const result = await handler(ctx);
     expect(result).toEqual({ usersAffected: 1, actionsTaken: 1 });
+  });
+});
+
+describe('runDailyLearningDigest (AP-0907)', () => {
+  it('notifies a user who gained facts and was not surfaced today', async () => {
+    const supabase = makeFakeSupabase({
+      // 1st: tenant-wide scan → u1; 2nd: detectNewFacts for u1
+      memory_facts: [
+        { data: [{ user_id: 'u1' }], error: null },
+        { data: [{ fact_key: 'user_favorite_tea', fact_value: 'Earl Grey' }], error: null },
+      ],
+      // 1st: greeting-ledger row (none); 2nd: learning_surfaced (none); 3rd: upsert stamp
+      user_assistant_state: [
+        { data: null, error: null },
+        { data: null, error: null },
+        { data: null, error: null },
+      ],
+      app_users: [{ data: [], error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+    const handler = getHandler('runDailyLearningDigest')!;
+    const result = await handler(ctx);
+    expect(notify).toHaveBeenCalledTimes(1);
+    const payload = notify.mock.calls[0][2];
+    expect(payload.data.url).toBe('/memory');
+    expect(payload.title.length).toBeGreaterThan(0);
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 1 });
+  });
+
+  it('stays silent when the greeting already surfaced learning today', async () => {
+    const today = new Date().toISOString();
+    const supabase = makeFakeSupabase({
+      memory_facts: [{ data: [{ user_id: 'u1' }], error: null }],
+      user_assistant_state: [
+        // greeting ledger says facts_learned was spoken today (3e won)
+        { data: { value: { facts: { facts_learned: { value: 2, spoken_at: today } } } }, error: null },
+      ],
+      app_users: [{ data: [], error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+    const handler = getHandler('runDailyLearningDigest')!;
+    const result = await handler(ctx);
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+
+  it('is a no-op when nobody learned anything', async () => {
+    const supabase = makeFakeSupabase({ memory_facts: [{ data: [], error: null }] });
+    const { ctx, notify } = makeCtx(supabase);
+    const handler = getHandler('runDailyLearningDigest')!;
+    const result = await handler(ctx);
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
+});
+
+describe('runBehaviorPreferenceInference (AP-0908)', () => {
+  it('writes user_preference_* facts from high-confidence routines via write_fact', async () => {
+    const supabase: any = makeFakeSupabase({
+      user_routines: [
+        {
+          data: [
+            { user_id: 'u1', routine_kind: 'time_of_day_preference', confidence: 0.8, metadata: { time_of_day: 'evening' } },
+            { user_id: 'u1', routine_kind: 'category_affinity', confidence: 0.7, metadata: { tag: 'yoga' } },
+          ],
+          error: null,
+        },
+      ],
+      memory_facts: [{ data: [], error: null }],
+    });
+    supabase.rpc = jest.fn(async () => ({ data: 'fact-uuid', error: null }));
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runBehaviorPreferenceInference')!;
+    const result = await handler(ctx);
+    expect(supabase.rpc).toHaveBeenCalledTimes(2);
+    expect(supabase.rpc).toHaveBeenCalledWith('write_fact', expect.objectContaining({
+      p_fact_key: 'user_preference_active_time',
+      p_fact_value: 'evening',
+      p_provenance_source: 'behavior_inferred',
+      p_provenance_confidence: 0.55,
+    }));
+    expect(result).toEqual({ usersAffected: 1, actionsTaken: 2 });
+  });
+
+  it('skips identical existing facts (no supersession churn)', async () => {
+    const supabase: any = makeFakeSupabase({
+      user_routines: [
+        {
+          data: [
+            { user_id: 'u1', routine_kind: 'time_of_day_preference', confidence: 0.8, metadata: { time_of_day: 'evening' } },
+          ],
+          error: null,
+        },
+      ],
+      memory_facts: [
+        { data: [{ user_id: 'u1', fact_key: 'user_preference_active_time', fact_value: 'evening' }], error: null },
+      ],
+    });
+    supabase.rpc = jest.fn(async () => ({ data: 'fact-uuid', error: null }));
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runBehaviorPreferenceInference')!;
+    const result = await handler(ctx);
+    expect(supabase.rpc).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
   });
 });
 

--- a/services/gateway/test/services/conversation/compute-greeting-decision.golden.test.ts
+++ b/services/gateway/test/services/conversation/compute-greeting-decision.golden.test.ts
@@ -75,6 +75,7 @@ function richPayload(over: Partial<OverviewPayload> = {}): OverviewPayload {
     messages_unread: 0,
     reminders_today: { count: 0, next: null },
     diary_last_7d: 3,
+    facts_learned_since_last: null,
     guided_journey: null,
     last_session_date_user_tz: null,
     ...over,

--- a/services/gateway/test/services/conversation/conversation-flow.test.ts
+++ b/services/gateway/test/services/conversation/conversation-flow.test.ts
@@ -33,6 +33,7 @@ function emptyPayload(over: Partial<OverviewPayload> = {}): OverviewPayload {
     messages_unread: 0,
     reminders_today: { count: 0, next: null },
     diary_last_7d: 3,
+    facts_learned_since_last: null,
     guided_journey: null,
     last_session_date_user_tz: null,
     ...over,
@@ -136,6 +137,7 @@ describe('rankNextBestActions — value × timeliness, always grounded', () => {
       messages_unread: 26,
       matches_unread: 15,
       diary_last_7d: 0,
+      facts_learned_since_last: null,
       guided_journey: { sessions_completed: 8, topics_learned: 18, topics_total: 90, next_session_title: 'Vitana Index', last_session_recall: 'Vitana Index' },
     });
     // Open 1: top action (messages).

--- a/services/gateway/test/services/conversation/decide-conversation-flow.test.ts
+++ b/services/gateway/test/services/conversation/decide-conversation-flow.test.ts
@@ -40,6 +40,7 @@ function richPayload(over: Partial<OverviewPayload> = {}): OverviewPayload {
     messages_unread: 0,
     reminders_today: { count: 0, next: null },
     diary_last_7d: 3,
+    facts_learned_since_last: null,
     guided_journey: null,
     last_session_date_user_tz: null,
     ...over,

--- a/services/gateway/test/services/conversation/greeting-continuity.test.ts
+++ b/services/gateway/test/services/conversation/greeting-continuity.test.ts
@@ -58,6 +58,7 @@ function basePayload(overrides: Partial<OverviewPayload> = {}): OverviewPayload 
     reminders_today: { count: 0, next: null },
     guided_journey: null,
     diary_last_7d: 1,
+    facts_learned_since_last: null,
     last_session_date_user_tz: null,
     ...overrides,
   } as OverviewPayload;

--- a/services/gateway/test/services/conversation/new-facts-detector.test.ts
+++ b/services/gateway/test/services/conversation/new-facts-detector.test.ts
@@ -1,0 +1,143 @@
+/**
+ * new-facts-detector — unit tests (BOOTSTRAP-MEMORY-DAILY-LEARNING)
+ *
+ * Contract:
+ *   - counts non-superseded memory_facts newer than the cutoff
+ *   - clamps the cutoff to LOOKBACK_CAP_MS (returning users aren't flooded)
+ *   - excludes plumbing keys (preferred_language) from count and sample
+ *   - sample capped at 3, values truncated
+ *   - degrades to zero on error
+ *   - surfaced-stamp read/write round-trips through user_assistant_state
+ */
+
+import {
+  detectNewFacts,
+  markLearningSurfaced,
+  readLearningSurfacedAt,
+  LOOKBACK_CAP_MS,
+  SIGNAL_LEARNING_SURFACED,
+} from '../../../src/services/conversation/new-facts-detector';
+
+interface Recorded {
+  method: string;
+  args: any[];
+}
+
+function makeClient(rows: any[] | null, error: any = null) {
+  const calls: Recorded[] = [];
+  const upserts: any[] = [];
+  const chain: any = {};
+  for (const m of ['select', 'eq', 'is', 'gt', 'order', 'limit', 'in', 'like']) {
+    chain[m] = (...args: any[]) => {
+      calls.push({ method: m, args });
+      return chain;
+    };
+  }
+  chain.maybeSingle = () => Promise.resolve({ data: rows?.[0] ?? null, error });
+  chain.then = (res: any, rej: any) => Promise.resolve({ data: rows, error }).then(res, rej);
+  const client: any = {
+    from: jest.fn(() => chain),
+  };
+  chain.upsert = (row: any) => {
+    upserts.push(row);
+    return Promise.resolve({ data: null, error: null });
+  };
+  return { client, calls, upserts };
+}
+
+describe('detectNewFacts', () => {
+  const NOW = Date.parse('2026-07-06T12:00:00Z');
+
+  it('counts fresh facts and returns a capped sample', async () => {
+    const rows = [
+      { fact_key: 'user_favorite_tea', fact_value: 'Earl Grey' },
+      { fact_key: 'user_preference_exercise', fact_value: 'morning runs' },
+      { fact_key: 'spouse_name', fact_value: 'Maria' },
+      { fact_key: 'user_hobby_dance', fact_value: 'salsa' },
+    ];
+    const { client } = makeClient(rows);
+    const result = await detectNewFacts({
+      supabase: client,
+      userId: 'u1',
+      sinceIso: '2026-07-06T00:00:00Z',
+      nowMs: NOW,
+    });
+    expect(result.count).toBe(4);
+    expect(result.sample).toHaveLength(3);
+    expect(result.sample[0]).toEqual({ key: 'user_favorite_tea', value: 'Earl Grey' });
+  });
+
+  it('excludes plumbing keys like preferred_language', async () => {
+    const { client } = makeClient([
+      { fact_key: 'preferred_language', fact_value: 'de' },
+      { fact_key: 'user_name', fact_value: 'Dragan' },
+    ]);
+    const result = await detectNewFacts({
+      supabase: client,
+      userId: 'u1',
+      sinceIso: '2026-07-06T00:00:00Z',
+      nowMs: NOW,
+    });
+    expect(result.count).toBe(1);
+    expect(result.sample.map((s) => s.key)).toEqual(['user_name']);
+  });
+
+  it('clamps the cutoff to the 7-day lookback cap', async () => {
+    const { client, calls } = makeClient([]);
+    await detectNewFacts({
+      supabase: client,
+      userId: 'u1',
+      sinceIso: '2020-01-01T00:00:00Z', // ancient last session
+      nowMs: NOW,
+    });
+    const gtCall = calls.find((c) => c.method === 'gt');
+    expect(gtCall).toBeDefined();
+    expect(gtCall!.args[0]).toBe('extracted_at');
+    expect(Date.parse(gtCall!.args[1])).toBe(NOW - LOOKBACK_CAP_MS);
+  });
+
+  it('filters superseded rows and tenant-scopes when given', async () => {
+    const { client, calls } = makeClient([]);
+    await detectNewFacts({
+      supabase: client,
+      userId: 'u1',
+      tenantId: 't1',
+      sinceIso: '2026-07-06T00:00:00Z',
+      nowMs: NOW,
+    });
+    expect(calls).toContainEqual({ method: 'is', args: ['superseded_at', null] });
+    expect(calls).toContainEqual({ method: 'eq', args: ['tenant_id', 't1'] });
+  });
+
+  it('returns zero on query error and on missing inputs', async () => {
+    const { client } = makeClient(null, { message: 'boom' });
+    expect(
+      await detectNewFacts({ supabase: client, userId: 'u1', sinceIso: '2026-07-06T00:00:00Z' }),
+    ).toEqual({ count: 0, sample: [] });
+    expect(await detectNewFacts({ supabase: client, userId: '', sinceIso: 'x' })).toEqual({
+      count: 0,
+      sample: [],
+    });
+  });
+});
+
+describe('learning-surfaced stamp', () => {
+  it('markLearningSurfaced upserts the signal row', async () => {
+    const { client, upserts } = makeClient([]);
+    await markLearningSurfaced(client, 't1', 'u1', 3, '2026-07-06T18:10:00Z');
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toMatchObject({
+      tenant_id: 't1',
+      user_id: 'u1',
+      signal_name: SIGNAL_LEARNING_SURFACED,
+      value: { surfaced_at: '2026-07-06T18:10:00Z', count: 3 },
+    });
+  });
+
+  it('readLearningSurfacedAt returns the stamp or null', async () => {
+    const { client } = makeClient([{ value: { surfaced_at: '2026-07-06T18:10:00Z', count: 3 } }]);
+    expect(await readLearningSurfacedAt(client, 't1', 'u1')).toBe('2026-07-06T18:10:00Z');
+    const { client: emptyClient } = makeClient([]);
+    expect(await readLearningSurfacedAt(emptyClient, 't1', 'u1')).toBeNull();
+  });
+});

--- a/services/gateway/test/services/memory-orchestrator.test.ts
+++ b/services/gateway/test/services/memory-orchestrator.test.ts
@@ -131,7 +131,7 @@ function makeSupabaseStub(rowsByTable: Record<string, any[]>) {
       const result = { data: rowsByTable[table] ?? [], error: null };
       const chain: any = {};
       const passthrough = () => chain;
-      for (const m of ['select', 'eq', 'order', 'limit', 'gte', 'in']) chain[m] = passthrough;
+      for (const m of ['select', 'eq', 'order', 'limit', 'gte', 'in', 'like', 'is']) chain[m] = passthrough;
       chain.then = (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject);
       return chain;
     },
@@ -158,12 +158,13 @@ beforeEach(() => {
   mockedGetSupabase.mockReturnValue(
     makeSupabaseStub({
       life_compass: [{ primary_goal: 'Improve sleep quality', category: 'sleep', is_system_seeded: false }],
-      user_preferences: [
-        { category: 'lifestyle', preference_key: 'wake_time', preference_value: '06:30' },
-      ],
-      user_inferred_preferences: [
-        { category: 'nutrition', preference_key: 'diet', preference_value: 'vegetarian', confidence: 0.8 },
-        { category: 'nutrition', preference_key: 'low_conf', preference_value: 'ignored', confidence: 0.3 },
+      // Preferences live in memory_facts under user_preference_* keys
+      // (the legacy user_preferences/user_inferred_preferences sources
+      // never matched the live schema — see preference-facts.ts).
+      memory_facts: [
+        { fact_key: 'user_preference_wake_time', fact_value: '06:30', provenance_source: 'user_stated', provenance_confidence: 0.8 },
+        { fact_key: 'user_preference_diet', fact_value: 'vegetarian', provenance_source: 'assistant_inferred', provenance_confidence: 0.8 },
+        { fact_key: 'user_preference_low_conf', fact_value: 'ignored', provenance_source: 'behavior_inferred', provenance_confidence: 0.3 },
       ],
     }),
   );

--- a/services/gateway/test/services/memory-social-conversation-flow.test.ts
+++ b/services/gateway/test/services/memory-social-conversation-flow.test.ts
@@ -150,8 +150,7 @@ function makeFakeSupabase(overrides: Record<string, (select: string) => any[]> =
     user_muted_authors: () => [],
     user_hidden_posts: () => [],
     life_compass: () => [{ primary_goal: 'Improve sleep quality', category: 'sleep' }],
-    user_preferences: () => [],
-    user_inferred_preferences: () => [],
+    memory_facts: () => [],
     ...overrides,
   };
 
@@ -163,7 +162,7 @@ function makeFakeSupabase(overrides: Record<string, (select: string) => any[]> =
         selectCols = cols;
         return chain;
       };
-      for (const m of ['eq', 'in', 'or', 'gte', 'lt', 'is', 'neq', 'order', 'limit']) {
+      for (const m of ['eq', 'in', 'or', 'gte', 'lt', 'is', 'neq', 'order', 'limit', 'like']) {
         chain[m] = () => chain;
       }
       const resolve = () => {

--- a/services/gateway/test/services/preference-facts.test.ts
+++ b/services/gateway/test/services/preference-facts.test.ts
@@ -1,0 +1,114 @@
+/**
+ * preference-facts — unit tests (BOOTSTRAP-MEMORY-DAILY-LEARNING)
+ *
+ * Contract under test:
+ *   - reads memory_facts filtered to the user_preference_* prefix with
+ *     superseded rows excluded (and tenant scoping when provided)
+ *   - provenance_source 'user_stated' → explicit (always kept);
+ *     everything else → inferred, dropped below the 0.55 floor
+ *   - newest row per key wins; a skipped (low-confidence) key is not
+ *     resurrected from an older row
+ *   - degrades to [] on query error / throwing client
+ */
+
+import {
+  fetchPreferenceFacts,
+  PREFERENCE_FACT_KEY_PREFIX,
+  INFERRED_PREFERENCE_MIN_CONFIDENCE,
+} from '../../src/services/preference-facts';
+
+interface RecordedCall {
+  method: string;
+  args: any[];
+}
+
+function makeClient(rows: any[], error: any = null) {
+  const calls: RecordedCall[] = [];
+  const chain: any = {};
+  for (const m of ['select', 'eq', 'like', 'is', 'order', 'limit', 'gte', 'in']) {
+    chain[m] = (...args: any[]) => {
+      calls.push({ method: m, args });
+      return chain;
+    };
+  }
+  chain.then = (resolve: any, reject: any) =>
+    Promise.resolve({ data: rows, error }).then(resolve, reject);
+  const client = { from: jest.fn(() => chain) };
+  return { client, calls };
+}
+
+const fact = (key: string, value: string, source: string, confidence: number) => ({
+  fact_key: `${PREFERENCE_FACT_KEY_PREFIX}${key}`,
+  fact_value: value,
+  provenance_source: source,
+  provenance_confidence: confidence,
+});
+
+describe('fetchPreferenceFacts', () => {
+  it('maps user_stated to explicit and other provenance to inferred', async () => {
+    const { client } = makeClient([
+      fact('exercise', 'morning runs', 'user_stated', 0.8),
+      fact('music', 'jazz', 'assistant_inferred', 0.7),
+      fact('sessions', 'evening', 'behavior_inferred', 0.6),
+    ]);
+    const result = await fetchPreferenceFacts(client, 'u1');
+    expect(result).toEqual([
+      { key: 'exercise', value: 'morning runs', source: 'explicit', confidence: 0.8 },
+      { key: 'music', value: 'jazz', source: 'inferred', confidence: 0.7 },
+      { key: 'sessions', value: 'evening', source: 'inferred', confidence: 0.6 },
+    ]);
+  });
+
+  it(`drops inferred facts below the ${INFERRED_PREFERENCE_MIN_CONFIDENCE} confidence floor but keeps low-confidence explicit ones`, async () => {
+    const { client } = makeClient([
+      fact('diet', 'vegetarian', 'assistant_inferred', 0.3),
+      fact('drink', 'green tea', 'user_stated', 0.2),
+    ]);
+    const result = await fetchPreferenceFacts(client, 'u1');
+    expect(result.map((r) => r.key)).toEqual(['drink']);
+  });
+
+  it('keeps only the newest row per key and never resurrects a skipped key', async () => {
+    // Rows arrive newest-first (order extracted_at desc).
+    const { client } = makeClient([
+      fact('music', 'techno', 'assistant_inferred', 0.4), // newest, below floor → key skipped
+      fact('music', 'jazz', 'user_stated', 0.9), // older — must NOT come back
+      fact('drink', 'coffee', 'user_stated', 0.8),
+      fact('drink', 'tea', 'user_stated', 0.8), // older duplicate — dropped
+    ]);
+    const result = await fetchPreferenceFacts(client, 'u1');
+    expect(result).toEqual([{ key: 'drink', value: 'coffee', source: 'explicit', confidence: 0.8 }]);
+  });
+
+  it('respects the limit', async () => {
+    const rows = Array.from({ length: 10 }, (_, i) => fact(`k${i}`, `v${i}`, 'user_stated', 0.8));
+    const { client } = makeClient(rows);
+    const result = await fetchPreferenceFacts(client, 'u1', { limit: 3 });
+    expect(result).toHaveLength(3);
+  });
+
+  it('filters on the user_preference_ prefix, excludes superseded rows, and tenant-scopes when given', async () => {
+    const { client, calls } = makeClient([]);
+    await fetchPreferenceFacts(client, 'u1', { tenantId: 't1' });
+    expect(client.from).toHaveBeenCalledWith('memory_facts');
+    expect(calls).toContainEqual({ method: 'like', args: ['fact_key', `${PREFERENCE_FACT_KEY_PREFIX}%`] });
+    expect(calls).toContainEqual({ method: 'is', args: ['superseded_at', null] });
+    expect(calls).toContainEqual({ method: 'eq', args: ['user_id', 'u1'] });
+    expect(calls).toContainEqual({ method: 'eq', args: ['tenant_id', 't1'] });
+  });
+
+  it('returns [] on query error and on a throwing client', async () => {
+    const { client: errClient } = makeClient(null as any, { message: 'boom' });
+    expect(await fetchPreferenceFacts(errClient, 'u1')).toEqual([]);
+
+    const throwing = { from: () => { throw new Error('no like method'); } };
+    expect(await fetchPreferenceFacts(throwing as any, 'u1')).toEqual([]);
+  });
+
+  it('returns [] without querying when client or userId is missing', async () => {
+    expect(await fetchPreferenceFacts(null as any, 'u1')).toEqual([]);
+    const { client } = makeClient([]);
+    expect(await fetchPreferenceFacts(client, '')).toEqual([]);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-MEMORY-DAILY-LEARNING` _(bootstrap-tagged per commit convention — references VTID-01936, VTID-01192, VTID-01087, VTID-01250)_

**Layer:** APIL

**Priority:** P1

---

## 📋 Summary

Three staged commits that take Vitana's memory from "silently recalls a handful of static facts" to a learning, adapting, health-aware user model: fixes the dead plumbing, builds the felt-learning surfaces, then upgrades capture quality, retrieval, synthesis, and health-context reasoning end to end.

---

## ✅ Changes

### Commit 1 (a3634d9) — plumbing fixes
- [x] `fetchPreferences()` dead-schema fix in both consumers → shared `preference-facts.ts` reading `memory_facts` (`user_preference_*` prefix)
- [x] AP-0906 Routine Pattern Extraction — first caller for the VTID-01936 pattern-extractor; also removed its select of the nonexistent `calendar_events.time_slot` column

### Commit 2 (e8f1d48) — felt daily learning
- [x] Shared new-facts detector + greeting-ledger 6th signal (`facts_learned`) + new-day prompt beat
- [x] AP-0907 Daily Learning Digest ("Ich habe heute etwas über dich gelernt", catalog-localized)
- [x] AP-0908 Behavior-Derived Preferences (`behavior_inferred` @ 0.55 via `write_fact`)
- [x] AP-0901 copy reframe to learned-framing + i18n; greeting-ledger OASIS event on read failure; Cognee-era entity-key coverage ported into the extractor prompt

### Commit 3 (f70cea0) — super-intelligence build-out (full plan 1–7)
- [x] **Capture (1):** per-fact `stated` flag → real provenance (`user_stated` @ 0.9 / `assistant_inferred` @ 0.7 — was flat 0.80 for everything); re-mention confidence bumps (+0.05, cap 0.98); observation facts (mood/energy/concern/life-event)
- [x] **Embeddings (2):** embed-on-write in the extractor (96% of live facts had no embedding — tier-2 semantic retrieval was blind); AP-0910 hourly backfill; `VOICE_RANKING_SHADOW` defaults to staging-only (behavior-safe comparison logging)
- [x] **AP-0911 User Model Synthesis (3):** nightly grounded LLM narrative per active user, stored in `user_assistant_state`, injected via the UserContextProfiler into the TTL-cached ORB bootstrap — synthesized understanding at zero latency cost
- [x] **Health context (4):** AP-0912 deterministic correlation insights (pillar trends, diary lapses) as `health_insight_*` facts; diary-health-extractor now mirrors daily diary signals into a rolling memory fact (diary silo de-siloed)
- [x] **Prompt layer (5+6):** confirmation loop (verify one `[inferred]` memory naturally, max once/conversation), contradiction acknowledgment, cold-start get-to-know-you directive (community users with <5 facts)
- [x] **AP-0909 Relationship Graph Projection (7):** graph as a derived, rebuildable index — person-facts → nodes + relation edges, mutual follows → `connected` edges, written against the **live** polymorphic edge schema (the VTID-01087 migration file diverged from production). **AP-0903 retired** — Loop 13 is the single decay mechanism.

---

## 🧪 Testing

- [x] Live Supabase schema verified by direct inspection before each subsystem (memory_facts provenance distribution, relationship_edges live shape vs. migration, user_follows, vitana_index_scores)
- [x] **Full gateway suite: 6,571 tests passing.** New suites: `preference-facts`, `new-facts-detector`, extractor provenance/evidence cases, AP-0906–0912 handler + registry wiring
- [x] Only local failure is the pre-existing `nav-manifest-sync` drift gate (VTID-02783) — compares `navigation-catalog.ts` (untouched) against the vitana-v1 nav manifest (untouched); skips in CI
- [ ] Staging verification — pending merge (staging-first flow)

---

## 📝 Phase 2B Naming Compliance Checklist

- [x] New files kebab-case (`preference-facts.ts`, `new-facts-detector.ts`, `user-model-synthesis.ts`)
- [x] Event types snake_case (`autopilot.memory.graph_projected`, `…embeddings_backfilled`, `…profiles_synthesized`, `…health_insights_written`)
- [x] No workflow or deploy changes
- [x] Bootstrap tag in all commit messages; `docs/autopilot-automations/09-memory-intelligence.md` updated for AP-0906–0912 and the AP-0903 retirement

---

## 🔗 Links

- Frontend half: exafyltd/vitana-v1#846

---

## 🚨 Breaking Changes

None. AP-0903's registry entry remains (status `DEPRECATED`); all other consumers keep their shapes. `OverviewPayload` gained one nullable field (fixtures updated).

---

## 📌 Additional Notes

- **CLAUDE.md §14 is stale** (still documents the Cognee flow as live, and its relationship-graph column sketch doesn't match production). Deliberately not rewritten here — flagged for a human-signed-off doc pass.
- New provenance value `behavior_inferred` and `system_observed` insights flow through existing confidence-aware readers unchanged.
- Ops follow-ups after merge: watch `[memory.retrieval.shadow]` logs on staging to decide the `BOOTSTRAP_CONTEXT_RANKED_RETRIEVAL` flip; AP-0910 drains the ~500-fact embedding backlog in ~5 hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nXnLyojrW5m8L9SegctxH