### PR TITLE
Command Hub: move Awareness / Journey Context / Tool Catalog from Voice → Conversation (DEV-COMHU-03400)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2756,10 +2756,13 @@ const NAVIGATION_CONFIG = [
         "section": "conversation",
         "basePath": "/command-hub/conversation/",
         "tabs": [
-            { "key": "config",     "label": "Config",           "path": "/command-hub/conversation/config/" },
-            { "key": "monitor",    "label": "Monitor",          "path": "/command-hub/conversation/monitor/" },
-            { "key": "tools",      "label": "Tool Health",      "path": "/command-hub/conversation/tools/" },
-            { "key": "simulator",  "label": "Simulator",        "path": "/command-hub/conversation/simulator/" }
+            { "key": "config",       "label": "Config",         "path": "/command-hub/conversation/config/" },
+            { "key": "monitor",      "label": "Monitor",        "path": "/command-hub/conversation/monitor/" },
+            { "key": "tools",        "label": "Tool Health",    "path": "/command-hub/conversation/tools/" },
+            { "key": "simulator",    "label": "Simulator",      "path": "/command-hub/conversation/simulator/" },
+            { "key": "awareness",      "label": "Awareness",       "path": "/command-hub/conversation/awareness/" },
+            { "key": "journey-context","label": "Journey Context", "path": "/command-hub/conversation/journey-context/" },
+            { "key": "tool-catalog",   "label": "Tool Catalog",    "path": "/command-hub/conversation/tool-catalog/" }
         ]
     },
     // VTID-02856: Unified Voice section — owns every voice-management surface.
@@ -2772,9 +2775,6 @@ const NAVIGATION_CONFIG = [
             { "key": "improve",         "label": "Improve",            "path": "/command-hub/voice/improve/" },
             { "key": "orb-live",        "label": "Orb LIVE",           "path": "/command-hub/voice/orb-live/" },
             { "key": "providers",       "label": "Providers & Voice",  "path": "/command-hub/voice/providers/" },
-            { "key": "awareness",       "label": "Awareness",          "path": "/command-hub/voice/awareness/" },
-            { "key": "journey-context", "label": "Journey Context",    "path": "/command-hub/voice/journey-context/" },
-            { "key": "tools",           "label": "Tool Catalog",       "path": "/command-hub/voice/tools/" },
             { "key": "self-healing",    "label": "Self-Healing",       "path": "/command-hub/voice/self-healing/" },
             { "key": "test-contracts",  "label": "Test Contracts",     "path": "/command-hub/voice/test-contracts/" },
             { "key": "livekit-test",    "label": "LiveKit Test Bench", "path": "/command-hub/voice/livekit-test/" },
@@ -7225,6 +7225,17 @@ function renderModuleContent(moduleKey, tab) {
         container.appendChild(renderConversationToolHealthView());
     } else if (moduleKey === 'conversation' && tab === 'simulator') {
         container.appendChild(renderConversationSimulatorView());
+    } else if (moduleKey === 'conversation' && tab === 'awareness') {
+        // Moved from Voice (DEV-COMHU): Awareness registry/test/watchdogs belongs
+        // to Conversation design + monitoring. Sub-tab strip Registry/Test/Watchdogs.
+        container.appendChild(renderVoiceAwarenessView());
+    } else if (moduleKey === 'conversation' && tab === 'journey-context') {
+        // Moved from Voice (DEV-COMHU): durable assistant state + match-journey panel.
+        container.appendChild(renderJourneyContextView());
+    } else if (moduleKey === 'conversation' && tab === 'tool-catalog') {
+        // Moved from Voice (DEV-COMHU): the ORB tool catalog. Keyed 'tool-catalog'
+        // so it does not collide with Conversation's existing 'tools' (Tool Health).
+        container.appendChild(renderVoiceToolsCatalogView());
 
     // ──── VTID-02856: Voice section · VTID-02865: Improve cockpit ────
     } else if (moduleKey === 'voice' && tab === 'improve') {
@@ -7240,14 +7251,6 @@ function renderModuleContent(moduleKey, tab) {
         // VTID-02857: Providers & Voice — V2V (Vertex/LiveKit) + STT + TTS
         // provider switches + TTS voice/language/speed.
         container.appendChild(renderVoiceProvidersView());
-    } else if (moduleKey === 'voice' && tab === 'awareness') {
-        // Sub-tab strip for Registry / Test / Watchdogs
-        container.appendChild(renderVoiceAwarenessView());
-    } else if (moduleKey === 'voice' && tab === 'journey-context') {
-        // VTID-02909 (B0c): durable assistant state + match-journey panel
-        container.appendChild(renderJourneyContextView());
-    } else if (moduleKey === 'voice' && tab === 'tools') {
-        container.appendChild(renderVoiceToolsCatalogView());
     } else if (moduleKey === 'voice' && tab === 'self-healing') {
         // Voice slice extracted from autonomy/self-healing
         container.appendChild(renderVoiceSelfHealingPanel());
@@ -10798,11 +10801,19 @@ const AUTONOMY_REDIRECTS = {
     '/command-hub/autonomy-pulse/':               { section: 'autonomy', tab: 'autonomy-pulse' },
     '/command-hub/autonomy-trace/':               { section: 'autonomy', tab: 'autonomy-trace' },
     '/command-hub/dev-autopilot/':                { section: 'autonomy', tab: 'autopilot-developer' },
-    // Assistant section moves (Round 2) — kept for legacy bookmarks; awareness-* now redirect onward to Voice (below).
-    '/command-hub/admin/awareness/':              { section: 'voice',     tab: 'awareness', subtab: 'registry' },
-    '/command-hub/testing-qa/vitana-awareness/':  { section: 'voice',     tab: 'awareness', subtab: 'test' },
-    '/command-hub/autonomy/awareness-registry/':  { section: 'voice',     tab: 'awareness', subtab: 'registry' },
-    '/command-hub/autonomy/awareness-test/':      { section: 'voice',     tab: 'awareness', subtab: 'test' },
+    // Assistant section moves (Round 2) — kept for legacy bookmarks. DEV-COMHU:
+    // Awareness moved from Voice into Conversation (design + monitoring), so these
+    // now resolve onward to the Conversation / Awareness tab.
+    '/command-hub/admin/awareness/':              { section: 'conversation', tab: 'awareness', subtab: 'registry' },
+    '/command-hub/testing-qa/vitana-awareness/':  { section: 'conversation', tab: 'awareness', subtab: 'test' },
+    '/command-hub/autonomy/awareness-registry/':  { section: 'conversation', tab: 'awareness', subtab: 'registry' },
+    '/command-hub/autonomy/awareness-test/':      { section: 'conversation', tab: 'awareness', subtab: 'test' },
+    // DEV-COMHU: Awareness / Journey Context / Tool Catalog moved from Voice into
+    // Conversation. Keep the old /voice/ deep-links working (silent redirect).
+    // Tool Catalog is keyed 'tool-catalog' in Conversation (Voice used 'tools').
+    '/command-hub/voice/awareness/':                  { section: 'conversation', tab: 'awareness', subtab: 'registry' },
+    '/command-hub/voice/journey-context/':            { section: 'conversation', tab: 'journey-context' },
+    '/command-hub/voice/tools/':                      { section: 'conversation', tab: 'tool-catalog' },
     // VTID-02856: Voice section consolidation. Old paths now resolve to the unified Voice tabs.
     '/command-hub/diagnostics/voice-lab/':            { section: 'voice', tab: 'orb-live' },
     '/command-hub/diagnostics/voice-lab/experiments/':{ section: 'assistant', tab: 'experiments' },
@@ -10810,18 +10821,20 @@ const AUTONOMY_REDIRECTS = {
     '/command-hub/diagnostics/voice-lab/sessions/':   { section: 'assistant', tab: 'sessions' },
     '/command-hub/diagnostics/voice-lab/metrics/':    { section: 'assistant', tab: 'metrics' },
     '/command-hub/assistant/orb-live/':                { section: 'voice', tab: 'orb-live' },
-    '/command-hub/assistant/voice-tools/':             { section: 'voice', tab: 'tools' },
-    '/command-hub/assistant/awareness-registry/':      { section: 'voice', tab: 'awareness', subtab: 'registry' },
-    '/command-hub/assistant/awareness-test/':          { section: 'voice', tab: 'awareness', subtab: 'test' },
+    '/command-hub/assistant/voice-tools/':             { section: 'conversation', tab: 'tool-catalog' },
+    '/command-hub/assistant/awareness-registry/':      { section: 'conversation', tab: 'awareness', subtab: 'registry' },
+    '/command-hub/assistant/awareness-test/':          { section: 'conversation', tab: 'awareness', subtab: 'test' },
     '/command-hub/testing-qa/livekit-test/':           { section: 'voice', tab: 'livekit-test' },
     '/command-hub/testing-qa/e2e/orb-monitor/':        { section: 'voice', tab: 'orb-ui-monitor' },
 };
 
 // VTID-02856: Apply optional `subtab` field from a redirect entry to the
-// matching tab state. Only the Voice / Awareness tab uses this today.
+// matching tab state. DEV-COMHU: Awareness moved Voice → Conversation, so the
+// Awareness sub-tab (Registry/Test/Watchdogs) now lives under the Conversation
+// section. renderVoiceAwarenessView still reads state.voiceAwareness.
 function applyRouteSubtab(route) {
     if (!route || !route.subtab) return;
-    if (route.section === 'voice' && route.tab === 'awareness') {
+    if (route.section === 'conversation' && route.tab === 'awareness') {
         if (!state.voiceAwareness) state.voiceAwareness = { activeSubTab: 'registry' };
         state.voiceAwareness.activeSubTab = route.subtab;
     }
@@ -44646,7 +44659,7 @@ function handleVoiceImproveAction(item, verb) {
     var vi = state.voiceImprove;
     if (verb === 'investigate' || verb === 'open_in_self_healing') {
         var target = '/command-hub/voice/orb-live/';
-        if (item.source === 'awareness_not_wired' || item.source.startsWith('watchdog_')) target = '/command-hub/voice/awareness/';
+        if (item.source === 'awareness_not_wired' || item.source.startsWith('watchdog_')) target = '/command-hub/conversation/awareness/';
         else if (item.source === 'healing_quarantine' || item.source === 'self_healing_escalation' || item.source === 'architecture_report' || item.source === 'failure_class_no_rule') target = '/command-hub/voice/self-healing/';
         else if (item.source === 'provider_drift') target = '/command-hub/voice/providers/';
         history.pushState(null, '', target);

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260531-DEV-COMHU-0504-audio-ready-r3"></script>
-  <script src="/command-hub/app.js?v=20260703-DEV-COMHU-03366-conversation"></script>
+  <script src="/command-hub/app.js?v=20260706-DEV-COMHU-03400-conv-tabs-move"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
   <!-- Phase 0 staging build (P0.5): PUBLISH→staging-source card + CLOCK revert -->

--- a/services/gateway/test/orb/context/b0c-journey-context-panel.test.ts
+++ b/services/gateway/test/orb/context/b0c-journey-context-panel.test.ts
@@ -88,11 +88,14 @@ describe('B0c — Journey Context Match Journey panel', () => {
       }
     });
 
-    it('is wired into the voice section tab handler', () => {
-      // The Voice → Journey Context tab must be wired so navigating to
-      // /command-hub/voice/journey-context/ actually renders this panel.
+    it('is wired into the conversation section tab handler', () => {
+      // DEV-COMHU-03400: Journey Context moved Voice → Conversation (design +
+      // monitoring). The Conversation → Journey Context tab must be wired so
+      // navigating to /command-hub/conversation/journey-context/ renders this
+      // panel; the old /voice/ deep-link is kept as a silent redirect.
       expect(src).toContain("'journey-context'");
-      expect(src).toContain('/command-hub/voice/journey-context/');
+      expect(src).toContain('/command-hub/conversation/journey-context/');
+      expect(src).toContain('/command-hub/voice/journey-context/'); // legacy redirect preserved
       expect(src).toContain('renderJourneyContextView');
     });
   });


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `DEV-COMHU-03400` (DEV / COMHU, spec_status=approved, in_progress)

## 📋 Summary

Move three Command Hub tabs from the **Voice** section into the **Conversation** section, so the supervisor finds all conversation design + monitoring surfaces in one place:

- **Awareness** (Registry / Test / Watchdogs)
- **Journey Context**
- **Tool Catalog**

These are conversation-design/monitoring surfaces, not voice-transport management — this is purely a nav reorganization. No behaviour, backend routes, or panel internals change.

## ✅ Changes (`services/gateway/src/frontend/command-hub/`)

- **`NAVIGATION_CONFIG`** — moved the 3 tab entries from the Voice section into Conversation. **Tool Catalog is re-keyed `tool-catalog`** in Conversation because the section already owns a `tools` key (**Tool Health**) — this avoids a key collision.
- **`renderModuleContent`** — the 3 tabs now dispatch under `moduleKey === 'conversation'` (`awareness → renderVoiceAwarenessView`, `journey-context → renderJourneyContextView`, `tool-catalog → renderVoiceToolsCatalogView`). Removed the old `voice` branches. (Render functions keep their existing names — only their mount point moved.)
- **`AUTONOMY_REDIRECTS`** — repointed the existing awareness / voice-tools aliases to Conversation, and **added silent redirects** for the old `/command-hub/voice/{awareness,journey-context,tools}/` deep-links so existing bookmarks keep working.
- **`applyRouteSubtab`** — the Awareness sub-tab (Registry/Test/Watchdogs) now resolves under `section: 'conversation'`.
- **Self-Heal inbox deep-link** (`awareness_not_wired` / `watchdog_*`) → `/command-hub/conversation/awareness/`.
- **`index.html`** — bumped the `app.js ?v=` cache-buster.
- **Backend `/api/v1/voice/*` data endpoints are unchanged** — this is nav placement only.

## 🧪 Testing

- [x] `node --check app.js` → syntax OK.
- [x] No inline `voice` dispatch left for the 3 tabs; Voice nav no longer lists them; Conversation nav lists all 3.
- [x] The moved routes are **not** in the generated `navigation-catalog.ts` (community-app manifest), so the `nav:sync` gate is unaffected.
- [x] Updated `b0c-journey-context-panel.test.ts` to assert the Conversation wiring (legacy `/voice/` redirect preserved) — **24 passed**.
- [ ] **Staging** — visual verification (Command Hub → Conversation shows the 3 new tabs; each renders; old `/voice/` deep-links redirect) after merge on `preview-gateway.vitanaland.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gRupZZzocMCtj6uNtWexo

---
_Generated by [Claude Code](https://claude.ai/code/session_012gRupZZzocMCtj6uNtWexo)_