### PR TITLE
feat(voice): complete the Voice Tools Catalog — build all planned ORB tools (VTID-02754…02782)

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -1131,5 +1131,34 @@ Retention: 2 years. Upsert on the unique key keeps the rollup job idempotent.
 
 ---
 
+## VTID-02779 — Voice Clock (alarms / timers / pomodoro)
+
+### voice_clock_items
+
+```
+voice_clock_items (
+  id UUID PK, tenant_id UUID, user_id UUID NOT NULL,
+  kind TEXT NOT NULL CHECK (alarm|timer|pomodoro),
+  label TEXT,
+  fires_at TIMESTAMPTZ,               -- absolute UTC instant the item rings
+  recurrence TEXT,                    -- daily|weekdays|NULL (alarms only)
+  duration_seconds INT,               -- timers/pomodoros only
+  status TEXT NOT NULL DEFAULT 'active' CHECK (active|fired|cancelled|completed),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Written by the ORB voice tools `set_alarm` / `start_timer` / `start_pomodoro`
+(services/gateway/src/services/orb-tools/reminders-clock-tools.ts).
+RLS-on with an owner policy (`auth.uid() = user_id`) + service-role bypass.
+Indexes: `(user_id, status)` for list/delete; partial index on `fires_at`
+WHERE `status='active'` for the future tick job.
+
+**Follow-up needed:** FIRING (push/chime delivery when `fires_at` passes) is
+not yet implemented — a cron/tick job analogous to `/reminders-tick` must be
+added to claim due rows and transition `active → fired`.
+
+---
+
 **Remember:** This file is the SINGLE SOURCE OF TRUTH for table names.
 When in doubt, CHECK HERE FIRST!

--- a/scripts/orb-tools-lift-scanner.mjs
+++ b/scripts/orb-tools-lift-scanner.mjs
@@ -88,6 +88,56 @@ function extractRegistry(src) {
   for (const m of body.matchAll(/^\s*([a-z_][a-z0-9_]*)\s*:/gm)) {
     keys.add(m[1]);
   }
+  // BOOTSTRAP-VOICE-CATALOG-COMPLETE: ES6 shorthand properties
+  // (`dev_list_vtids,` instead of `dev_list_vtids: dev_list_vtids,`, used by
+  // developer-tools.ts) have no colon and were invisible to the pattern above.
+  for (const m of body.matchAll(/^\s*([a-z_][a-z0-9_]*)\s*,/gm)) {
+    keys.add(m[1]);
+  }
+  // BOOTSTRAP-VOICE-CATALOG-COMPLETE: per-domain modules are merged in via
+  // `...FOO_TOOL_HANDLERS,` spreads (services/orb-tools/*.ts), not literal
+  // keys — resolve each spread identifier back to its import and pull its
+  // own handler-object keys the same way (same logic as the sibling fix in
+  // scripts/voice-tools-manifest-reconcile.mjs and
+  // voice-pipeline-spec/tools/extract-ts.ts — kept in sync deliberately).
+  for (const sm of body.matchAll(/^\s*\.\.\.([A-Z][A-Z0-9_]*)\s*,/gm)) {
+    const spreadName = sm[1];
+    const importMatch = src.match(
+      new RegExp(`import\\s*\\{[^}]*\\b${spreadName}\\b[^}]*\\}\\s*from\\s*'([^']+)'`),
+    );
+    if (!importMatch) continue;
+    const modPath = resolve(
+      ROOT,
+      'services/gateway/src/services',
+      importMatch[1].replace(/^\.\//, '') + '.ts',
+    );
+    let modSrc;
+    try {
+      modSrc = readFileSync(modPath, 'utf8');
+    } catch {
+      continue;
+    }
+    const declIdx = modSrc.indexOf(`export const ${spreadName}`);
+    if (declIdx < 0) continue;
+    const modOpen = modSrc.indexOf('{', declIdx);
+    if (modOpen < 0) continue;
+    let modDepth = 0;
+    let modClose = -1;
+    for (let i = modOpen; i < modSrc.length; i++) {
+      if (modSrc[i] === '{') modDepth++;
+      else if (modSrc[i] === '}') {
+        modDepth--;
+        if (modDepth === 0) {
+          modClose = i;
+          break;
+        }
+      }
+    }
+    if (modClose < 0) continue;
+    const modBody = modSrc.slice(modOpen + 1, modClose);
+    for (const mm of modBody.matchAll(/^\s*([a-z_][a-z0-9_]*)\s*:/gm)) keys.add(mm[1]);
+    for (const mm of modBody.matchAll(/^\s*([a-z_][a-z0-9_]*)\s*,/gm)) keys.add(mm[1]);
+  }
   return keys;
 }
 

--- a/scripts/orb-tools-lift-scanner.mjs
+++ b/scripts/orb-tools-lift-scanner.mjs
@@ -264,13 +264,24 @@ const SHARED_ONLY_INTENTIONAL = new Set([
 ]);
 const intentionalInline = [];
 
+// BOOTSTRAP-VOICE-CATALOG-COMPLETE: orb-live.ts's default case has a
+// generic dispatch fallback — `if (ORB_TOOL_NAMES.includes(toolName))
+// { … dispatchOrbToolForVertex … }` — so EVERY tool in ORB_TOOL_REGISTRY
+// is Vertex-reachable even without its own `case` arm. This is the
+// intended pattern going forward: new tools land in the shared registry
+// and need no per-tool Vertex wiring at all. Without this check, every
+// tool added the new way is indistinguishable from a stale "forgot to
+// wire it" gap and fails ORB_TOOLS_PARITY_GATE=1 on every future PR.
+const HAS_GENERIC_VERTEX_FALLBACK = /ORB_TOOL_NAMES\.includes\(\s*toolName\s*\)/.test(vertexSrc);
+
 // Tracked separately so the report shows "shared-only OK" for the
-// dedicated-handler set without contributing to the warning exit code.
+// dedicated-handler set (and, when present, the generic-fallback set)
+// without contributing to the warning exit code.
 const sharedOnlyOk = [];
 for (const name of registry) {
   const v = vertexCases.get(name);
   if (!v) {
-    if (SHARED_ONLY_INTENTIONAL.has(name)) sharedOnlyOk.push(name);
+    if (SHARED_ONLY_INTENTIONAL.has(name) || HAS_GENERIC_VERTEX_FALLBACK) sharedOnlyOk.push(name);
     else sharedOnly.push(name);
     continue;
   }
@@ -338,13 +349,17 @@ if (sharedOnly.length > 0) {
 }
 
 if (sharedOnlyOk.length > 0) {
-  out += `### ℹ️ shared-only OK — ${sharedOnlyOk.length} tool(s) routed via dedicated Vertex handler\n\n`;
-  out += 'These are in `ORB_TOOL_REGISTRY` but DON\'T appear as a `case` arm in ';
-  out += 'the switch because Vertex routes them via a dedicated handler ';
-  out += '(handleNavigate / handleNavigateToScreen / handleGetCurrentScreen) ';
-  out += 'before the switch. Each handler delegates to the shared dispatcher ';
-  out += 'internally — full parity, just not via a case arm. ';
-  out += 'Allowlist: `SHARED_ONLY_INTENTIONAL` in `scripts/orb-tools-lift-scanner.mjs`.\n\n';
+  out += `### ℹ️ shared-only OK — ${sharedOnlyOk.length} tool(s) covered without a Vertex \`case\` arm\n\n`;
+  out += 'These are in `ORB_TOOL_REGISTRY` but DON\'T appear as a `case` arm in the switch. Two ways that\'s fine:\n\n';
+  out += '1. Routed via a dedicated Vertex handler (handleNavigate / handleNavigateToScreen / ';
+  out += 'handleGetCurrentScreen) before the switch — allowlisted in `SHARED_ONLY_INTENTIONAL`.\n';
+  if (HAS_GENERIC_VERTEX_FALLBACK) {
+    out += '2. Covered by the generic dispatch fallback in the switch\'s `default` case — ';
+    out += '`if (ORB_TOOL_NAMES.includes(toolName)) { …dispatchOrbToolForVertex… }` — detected in ';
+    out += 'orb-live.ts, so every registry tool is Vertex-reachable without per-tool wiring. ';
+    out += 'This is the intended pattern for new tools going forward.\n';
+  }
+  out += '\n';
   for (const n of sharedOnlyOk) {
     out += `- \`${n}\`\n`;
   }

--- a/scripts/voice-tools-manifest-reconcile.mjs
+++ b/scripts/voice-tools-manifest-reconcile.mjs
@@ -72,7 +72,16 @@ function readSource(path) {
 function extractSharedRegistry(src) {
   // Matches the `ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = { … };` block
   // and pulls every key. Same logic as orb-tools-lift-scanner.
-  const idx = src.indexOf('ORB_TOOL_REGISTRY');
+  //
+  // BOOTSTRAP-VOICE-CATALOG-COMPLETE fix: must anchor on the DECLARATION
+  // (`export const ORB_TOOL_REGISTRY`), not the bare identifier — the
+  // `offer_action` handler references `ORB_TOOL_REGISTRY[tool]` earlier in
+  // the file (validating the offered tool exists), and a naive
+  // `indexOf('ORB_TOOL_REGISTRY')` would latch onto that reference instead
+  // of the real object literal, making every registry-only tool (reachable
+  // on Vertex only through the generic dispatcher fallback in orb-live.ts,
+  // with no dedicated `case` arm) look LiveKit-only.
+  const idx = src.indexOf('export const ORB_TOOL_REGISTRY');
   if (idx < 0) return new Set();
   const open = src.indexOf('{', idx);
   if (open < 0) return new Set();
@@ -96,6 +105,53 @@ function extractSharedRegistry(src) {
   let m;
   while ((m = pat.exec(body)) !== null) {
     keys.add(m[1]);
+  }
+  // BOOTSTRAP-VOICE-CATALOG-COMPLETE: per-domain modules are merged in via
+  // `...FOO_TOOL_HANDLERS,` spreads (services/orb-tools/*.ts), not literal
+  // `key: value` pairs — the regex above can't see through a spread. Resolve
+  // each spread identifier back to its import statement, read that module,
+  // and pull its own `FOO_TOOL_HANDLERS: Record<...> = { … }` keys the same
+  // way. Keeps working for any future domain module with zero script changes.
+  const spreadPat = /^[ \t]*\.\.\.([A-Z][A-Z0-9_]*)\s*,/gm;
+  let sm;
+  const spreadNames = new Set();
+  while ((sm = spreadPat.exec(body)) !== null) {
+    spreadNames.add(sm[1]);
+  }
+  for (const spreadName of spreadNames) {
+    const importRe = new RegExp(`import\\s*\\{[^}]*\\b${spreadName}\\b[^}]*\\}\\s*from\\s*'([^']+)'`);
+    const importMatch = src.match(importRe);
+    if (!importMatch) continue;
+    const modPath = resolve(ROOT, 'services/gateway/src/services', importMatch[1].replace(/^\.\//, '') + '.ts');
+    let modSrc;
+    try {
+      modSrc = readFileSync(modPath, 'utf8');
+    } catch {
+      continue;
+    }
+    const declIdx = modSrc.indexOf(`export const ${spreadName}`);
+    if (declIdx < 0) continue;
+    const modOpen = modSrc.indexOf('{', declIdx);
+    if (modOpen < 0) continue;
+    let modDepth = 0;
+    let modClose = -1;
+    for (let i = modOpen; i < modSrc.length; i++) {
+      if (modSrc[i] === '{') modDepth++;
+      else if (modSrc[i] === '}') {
+        modDepth--;
+        if (modDepth === 0) {
+          modClose = i;
+          break;
+        }
+      }
+    }
+    if (modClose < 0) continue;
+    const modBody = modSrc.slice(modOpen + 1, modClose);
+    let mm;
+    const modPat = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*[(a-zA-Z_]/gm;
+    while ((mm = modPat.exec(modBody)) !== null) {
+      keys.add(mm[1]);
+    }
   }
   return keys;
 }
@@ -167,6 +223,41 @@ function extractLivekitTools(src) {
   return tools;
 }
 
+// BOOTSTRAP-VOICE-CATALOG-COMPLETE: admin_* tools are a THIRD Vertex-wiring
+// path — dispatched via `ADMIN_TOOL_NAMES.includes(toolName)` in orb-live.ts's
+// default case, backed by `ADMIN_TOOL_HANDLERS` in admin-voice-tools.ts (not
+// the shared ORB_TOOL_REGISTRY, not a `case` arm). Without this they read as
+// "planned" even though they're fully implemented and reachable.
+const ADMIN_TOOLS = resolve(ROOT, 'services/gateway/src/services/admin-voice-tools.ts');
+
+function extractAdminTools(src) {
+  const idx = src.indexOf('export const ADMIN_TOOL_HANDLERS');
+  if (idx < 0) return new Set();
+  const open = src.indexOf('{', idx);
+  if (open < 0) return new Set();
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close < 0) return new Set();
+  const body = src.slice(open + 1, close);
+  const keys = new Set();
+  const pat = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*[a-zA-Z_]/gm;
+  let m;
+  while ((m = pat.exec(body)) !== null) {
+    keys.add(m[1]);
+  }
+  return keys;
+}
+
 // ---------------------------------------------------------------------------
 // Reconciliation
 // ---------------------------------------------------------------------------
@@ -175,17 +266,19 @@ function main() {
   const sharedSrc = readSource(SHARED);
   const vertexSrc = readSource(VERTEX);
   const livekitSrc = readSource(LIVEKIT);
+  const adminSrc = readSource(ADMIN_TOOLS);
 
   const shared = extractSharedRegistry(sharedSrc);
   const vertexCases = extractVertexTools(vertexSrc);
   const livekit = extractLivekitTools(livekitSrc);
+  const admin = extractAdminTools(adminSrc);
 
   // A tool is "wired on Vertex" if either:
   //   - It's a case arm in orb-live.ts (Vertex pipeline serves it inline
   //     OR delegates it to the shared dispatcher).
   //   - It's in ORB_TOOL_REGISTRY (the shared dispatcher serves it; both
   //     pipelines route through it via dispatchOrbToolForVertex).
-  const vertex = new Set([...vertexCases, ...shared]);
+  const vertex = new Set([...vertexCases, ...shared, ...admin]);
 
   // A tool is "wired on LiveKit" if it's in all_tool_names() (the agent
   // registers it with the LLM). LiveKit's HTTP tool path also goes through

--- a/scripts/voice-tools-manifest-reconcile.mjs
+++ b/scripts/voice-tools-manifest-reconcile.mjs
@@ -101,7 +101,7 @@ function extractSharedRegistry(src) {
   const body = src.slice(open + 1, close);
   const keys = new Set();
   // `  search_events: tool_search_events,` or `  navigate_to_screen: (args, id) => …`
-  const pat = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*[(a-zA-Z_]/gm;
+  const pat = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)\s*(?::\s*[(a-zA-Z_]|,)/gm;
   let m;
   while ((m = pat.exec(body)) !== null) {
     keys.add(m[1]);
@@ -148,7 +148,7 @@ function extractSharedRegistry(src) {
     if (modClose < 0) continue;
     const modBody = modSrc.slice(modOpen + 1, modClose);
     let mm;
-    const modPat = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*[(a-zA-Z_]/gm;
+    const modPat = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)\s*(?::\s*[(a-zA-Z_]|,)/gm;
     while ((mm = modPat.exec(modBody)) !== null) {
       keys.add(mm[1]);
     }

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -1899,6 +1899,932 @@ async def get_current_screen(context: RunContext) -> str:
     return summarize(body)
 
 
+
+# ============================================================================
+# BOOTSTRAP-VOICE-CATALOG-COMPLETE — every tool built out from the Voice Tools
+# Catalog's `status: planned` backlog + P0 community-feature gaps. Handlers
+# live server-side in services/gateway/src/services/orb-tools/*.ts, dispatched
+# through the shared ORB_TOOL_REGISTRY via POST /api/v1/orb/tool — these
+# wrappers are thin: marshal args, call _dispatch[_with_directive], summarize.
+# ============================================================================
+
+@function_tool
+async def get_highest_vitana_index(context: RunContext) -> str:
+    """Get the community member with the highest Vitana Index right now."""
+    body = await _dispatch(context, "get_highest_vitana_index")
+    return summarize(body)
+
+
+@function_tool
+async def get_top_in_pillar(context: RunContext, pillar: str) -> str:
+    """Get the community member with the top score in ONE Vitana Index pillar."""
+    body = await _dispatch(context, "get_top_in_pillar", {
+            "pillar": pillar,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_first_member(context: RunContext) -> str:
+    """Get the very first (earliest-registered / OG) community member."""
+    body = await _dispatch(context, "get_first_member")
+    return summarize(body)
+
+
+@function_tool
+async def get_newest_member(context: RunContext) -> str:
+    """Get the most recently joined community member."""
+    body = await _dispatch(context, "get_newest_member")
+    return summarize(body)
+
+
+@function_tool
+async def get_most_followed(context: RunContext) -> str:
+    """Get the community member with the most followers."""
+    body = await _dispatch(context, "get_most_followed")
+    return summarize(body)
+
+
+@function_tool
+async def ask_who_is(context: RunContext, query: str) -> str:
+    """Answer ANY free-form 'who is...?' superlative question about the"""
+    body = await _dispatch(context, "ask_who_is", {
+            "query": query,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_diary_entries(context: RunContext, date_from: str | None = None, date_to: str | None = None, limit: float | None = None) -> str:
+    """List the user's Daily Diary entries, newest first, optionally within a date window."""
+    body = await _dispatch(context, "list_diary_entries", {
+            "date_from": date_from,
+            "date_to": date_to,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_diary_streak(context: RunContext) -> str:
+    """Get the user's diary streak: current consecutive days with an entry plus their longest streak ever."""
+    body = await _dispatch(context, "get_diary_streak")
+    return summarize(body)
+
+
+@function_tool
+async def get_memory_timeline(context: RunContext, date_from: str | None = None, date_to: str | None = None, limit: float | None = None) -> str:
+    """Chronological timeline of what Vitana remembers: memory items, extracted facts, and diary entries, newest first."""
+    body = await _dispatch(context, "get_memory_timeline", {
+            "date_from": date_from,
+            "date_to": date_to,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def recall_memory_about(context: RunContext, topic: str, category: str | None = None) -> str:
+    """Search stored memories and facts about ONE specific topic, person, or thing."""
+    body = await _dispatch(context, "recall_memory_about", {
+            "topic": topic,
+            "category": category,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_memory_garden_summary(context: RunContext) -> str:
+    """Overview of the user's Memory Garden: how many memories are stored per category."""
+    body = await _dispatch(context, "get_memory_garden_summary")
+    return summarize(body)
+
+
+@function_tool
+async def forget_memory(context: RunContext, memory_id: str, confirm: bool | None = None) -> str:
+    """Permanently delete ONE stored memory, only after the user explicitly confirms."""
+    body = await _dispatch(context, "forget_memory", {
+            "memory_id": memory_id,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def reschedule_event(context: RunContext, new_start: str, event_id: str | None = None, title_query: str | None = None, new_end: str | None = None, timezone: str | None = None) -> str:
+    """Move an existing calendar event to a new start time (duration is kept unless new_end is given)."""
+    body = await _dispatch(context, "reschedule_event", {
+            "new_start": new_start,
+            "event_id": event_id,
+            "title_query": title_query,
+            "new_end": new_end,
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def cancel_event(context: RunContext, event_id: str | None = None, title_query: str | None = None, confirm: bool | None = None, timezone: str | None = None) -> str:
+    """Cancel (soft-delete) a calendar event — the event stays in history with status 'cancelled'."""
+    body = await _dispatch(context, "cancel_event", {
+            "event_id": event_id,
+            "title_query": title_query,
+            "confirm": confirm,
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def complete_event(context: RunContext, event_id: str | None = None, title_query: str | None = None, outcome: str | None = None, notes: str | None = None, timezone: str | None = None) -> str:
+    """Mark a calendar event as completed, skipped, or partially done."""
+    body = await _dispatch(context, "complete_event", {
+            "event_id": event_id,
+            "title_query": title_query,
+            "outcome": outcome,
+            "notes": notes,
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def find_free_slot(context: RunContext, duration_minutes: float, search_from: str | None = None, search_to: str | None = None, timezone: str | None = None) -> str:
+    """Find the next free slot of a given length in the user's calendar, within waking hours (8 AM-10 PM user-local)."""
+    body = await _dispatch(context, "find_free_slot", {
+            "duration_minutes": duration_minutes,
+            "search_from": search_from,
+            "search_to": search_to,
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_event_details(context: RunContext, event_id: str | None = None, title_query: str | None = None, timezone: str | None = None) -> str:
+    """Read the full details of ONE calendar event: exact time, end, location, type, status, notes."""
+    body = await _dispatch(context, "get_event_details", {
+            "event_id": event_id,
+            "title_query": title_query,
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def check_calendar_conflicts(context: RunContext, start_time: str, end_time: str | None = None, timezone: str | None = None) -> str:
+    """Check whether a proposed time window overlaps existing confirmed calendar events."""
+    body = await _dispatch(context, "check_calendar_conflicts", {
+            "start_time": start_time,
+            "end_time": end_time,
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def snooze_reminder(context: RunContext, reminder_id: str | None = None, text_query: str | None = None, minutes: float | None = None) -> str:
+    """Push an existing reminder out by N minutes (default 10, max 1440)."""
+    body = await _dispatch(context, "snooze_reminder", {
+            "reminder_id": reminder_id,
+            "text_query": text_query,
+            "minutes": minutes,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def update_reminder(context: RunContext, reminder_id: str | None = None, text_query: str | None = None, new_text: str | None = None, new_time: str | None = None) -> str:
+    """Edit an existing reminder's text and/or time."""
+    body = await _dispatch(context, "update_reminder", {
+            "reminder_id": reminder_id,
+            "text_query": text_query,
+            "new_text": new_text,
+            "new_time": new_time,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def acknowledge_reminder(context: RunContext, reminder_id: str | None = None, text_query: str | None = None) -> str:
+    """Mark a fired reminder as heard/acknowledged so it stops being re-delivered."""
+    body = await _dispatch(context, "acknowledge_reminder", {
+            "reminder_id": reminder_id,
+            "text_query": text_query,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def complete_reminder(context: RunContext, reminder_id: str | None = None, text_query: str | None = None) -> str:
+    """Mark a reminder as DONE (the user did the thing). Sets status=completed."""
+    body = await _dispatch(context, "complete_reminder", {
+            "reminder_id": reminder_id,
+            "text_query": text_query,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_missed_reminders(context: RunContext) -> str:
+    """List reminders that fired but were never acknowledged (the user missed them)."""
+    body = await _dispatch(context, "list_missed_reminders")
+    return summarize(body)
+
+
+@function_tool
+async def set_alarm(context: RunContext, time: str, label: str | None = None, recurrence: str | None = None, timezone: str | None = None) -> str:
+    """Set a wake-up/clock alarm at a specific time of day (optionally recurring)."""
+    body = await _dispatch(context, "set_alarm", {
+            "time": time,
+            "label": label,
+            "recurrence": recurrence,
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_alarms(context: RunContext, timezone: str | None = None) -> str:
+    """List the user's active alarms with times and labels."""
+    body = await _dispatch(context, "list_alarms", {
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def delete_alarm(context: RunContext, alarm_id: str | None = None, label: str | None = None, time: str | None = None, timezone: str | None = None, confirm: bool | None = None) -> str:
+    """Cancel an alarm. Two-step confirm flow: first call WITHOUT confirm to find"""
+    body = await _dispatch(context, "delete_alarm", {
+            "alarm_id": alarm_id,
+            "label": label,
+            "time": time,
+            "timezone": timezone,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def start_timer(context: RunContext, duration_minutes: float, label: str | None = None) -> str:
+    """Start a countdown timer (1-1440 minutes)."""
+    body = await _dispatch(context, "start_timer", {
+            "duration_minutes": duration_minutes,
+            "label": label,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def start_pomodoro(context: RunContext, duration_minutes: float | None = None, label: str | None = None) -> str:
+    """Start a pomodoro focus block (5-90 minutes; 25 if omitted)."""
+    body = await _dispatch(context, "start_pomodoro", {
+            "duration_minutes": duration_minutes,
+            "label": label,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_active_timers(context: RunContext) -> str:
+    """List running timers and pomodoros with the remaining time on each."""
+    body = await _dispatch(context, "list_active_timers")
+    return summarize(body)
+
+
+@function_tool
+async def get_world_time(context: RunContext, location: str) -> str:
+    """Get the current local time in a city or IANA timezone (no internet needed)."""
+    body = await _dispatch(context, "get_world_time", {
+            "location": location,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_my_groups(context: RunContext) -> str:
+    """List the community groups the user belongs to, with member counts."""
+    body = await _dispatch(context, "list_my_groups")
+    return summarize(body)
+
+
+@function_tool
+async def create_group(context: RunContext, name: str, description: str | None = None, privacy: str | None = None, confirm: bool | None = None) -> str:
+    """Create a new community group. Requires a name; privacy is public or"""
+    body = await _dispatch_with_directive(context, "create_group", {
+            "name": name,
+            "description": description,
+            "privacy": privacy,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def join_group(context: RunContext, query: str | None = None, group_id: str | None = None) -> str:
+    """Join a community group by name or group_id. Resolves fuzzy names and"""
+    body = await _dispatch_with_directive(context, "join_group", {
+            "query": query,
+            "group_id": group_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def invite_to_group(context: RunContext, group: str | None = None, group_id: str | None = None, member_name: str | None = None, member_user_id: str | None = None, message: str | None = None) -> str:
+    """Invite another community member to a group. Resolves the member by"""
+    body = await _dispatch(context, "invite_to_group", {
+            "group": group,
+            "group_id": group_id,
+            "member_name": member_name,
+            "member_user_id": member_user_id,
+            "message": message,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def accept_invitation(context: RunContext, invitation_id: str | None = None, group: str | None = None) -> str:
+    """Accept a pending group invitation (joins the group). With no"""
+    body = await _dispatch_with_directive(context, "accept_invitation", {
+            "invitation_id": invitation_id,
+            "group": group,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def decline_invitation(context: RunContext, invitation_id: str | None = None, group: str | None = None, confirm: bool | None = None) -> str:
+    """Decline a pending group invitation. ALWAYS call once WITHOUT confirm"""
+    body = await _dispatch(context, "decline_invitation", {
+            "invitation_id": invitation_id,
+            "group": group,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def rsvp_event(context: RunContext, query: str | None = None, event_id: str | None = None) -> str:
+    """RSVP / sign the user up for a community event or meetup, by event_id"""
+    body = await _dispatch(context, "rsvp_event", {
+            "query": query,
+            "event_id": event_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def cancel_rsvp(context: RunContext, query: str | None = None, event_id: str | None = None, confirm: bool | None = None) -> str:
+    """Cancel the user's RSVP for an upcoming event. ALWAYS call once"""
+    body = await _dispatch(context, "cancel_rsvp", {
+            "query": query,
+            "event_id": event_id,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_upcoming_meetups(context: RunContext) -> str:
+    """List upcoming community meetups/events the user could attend, soonest"""
+    body = await _dispatch(context, "list_upcoming_meetups")
+    return summarize(body)
+
+
+@function_tool
+async def join_live_room(context: RunContext, query: str | None = None, room_id: str | None = None) -> str:
+    """Join/open a community live room by name or room_id. Returns a"""
+    body = await _dispatch_with_directive(context, "join_live_room", {
+            "query": query,
+            "room_id": room_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def start_conversation(context: RunContext, member: str | None = None, member_user_id: str | None = None, message: str | None = None) -> str:
+    """Start (or reuse) a direct-message conversation with a named community member,"""
+    body = await _dispatch(context, "start_conversation", {
+            "member": member,
+            "member_user_id": member_user_id,
+            "message": message,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_conversations(context: RunContext, limit: float | None = None) -> str:
+    """List the user's recent direct-message conversations, newest first, with"""
+    body = await _dispatch(context, "list_conversations", {
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def mark_conversation_read(context: RunContext, member: str | None = None, member_user_id: str | None = None, all: bool | None = None) -> str:
+    """Mark direct messages as read. With member set, marks that conversation;"""
+    body = await _dispatch(context, "mark_conversation_read", {
+            "member": member,
+            "member_user_id": member_user_id,
+            "all": all,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def mute_conversation(context: RunContext, member: str | None = None) -> str:
+    """Mute a chat conversation. NOTE: chat muting is not supported in Vitana yet —"""
+    body = await _dispatch(context, "mute_conversation", {
+            "member": member,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def archive_conversation(context: RunContext, member: str | None = None) -> str:
+    """Archive a chat conversation. NOTE: chat archiving does not exist in Vitana —"""
+    body = await _dispatch(context, "archive_conversation", {
+            "member": member,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def update_account_visibility(context: RunContext, visibility: str, confirm: bool | None = None) -> str:
+    """Set the visibility of the user's WHOLE profile: public, followers_only, or private."""
+    body = await _dispatch(context, "update_account_visibility", {
+            "visibility": visibility,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def update_privacy_field(context: RunContext, field: str, visibility: str) -> str:
+    """Set the visibility of ONE profile field: public, followers_only, or private."""
+    body = await _dispatch(context, "update_privacy_field", {
+            "field": field,
+            "visibility": visibility,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def block_user(context: RunContext, member: str | None = None, member_user_id: str | None = None, confirm: bool | None = None) -> str:
+    """Block a community member so their posts and messages are hidden from the user."""
+    body = await _dispatch(context, "block_user", {
+            "member": member,
+            "member_user_id": member_user_id,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def unblock_user(context: RunContext, member: str | None = None, member_user_id: str | None = None) -> str:
+    """Unblock a previously blocked member so their posts and messages show again."""
+    body = await _dispatch(context, "unblock_user", {
+            "member": member,
+            "member_user_id": member_user_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def submit_bug_report(context: RunContext, summary: str, screen: str | None = None) -> str:
+    """File a bug ticket (kind=bug) in the feedback pipeline. No persona swap —"""
+    body = await _dispatch(context, "submit_bug_report", {
+            "summary": summary,
+            "screen": screen,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def submit_support_ticket(context: RunContext, summary: str) -> str:
+    """File a support ticket (kind=support_question) for a question the team"""
+    body = await _dispatch(context, "submit_support_ticket", {
+            "summary": summary,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def submit_marketplace_dispute(context: RunContext, summary: str, order_reference: str | None = None) -> str:
+    """File a marketplace dispute ticket (kind=marketplace_claim): refunds, wrong"""
+    body = await _dispatch(context, "submit_marketplace_dispute", {
+            "summary": summary,
+            "order_reference": order_reference,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def submit_account_issue(context: RunContext, summary: str) -> str:
+    """File an account ticket (kind=account_issue): login problems, password or"""
+    body = await _dispatch(context, "submit_account_issue", {
+            "summary": summary,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_my_tickets(context: RunContext) -> str:
+    """List the user's OPEN feedback tickets (bugs, support, disputes, account)"""
+    body = await _dispatch(context, "list_my_tickets")
+    return summarize(body)
+
+
+@function_tool
+async def set_language(context: RunContext, language: str) -> str:
+    """Set the user's app + voice language. Persists the same setting the app's"""
+    body = await _dispatch(context, "set_language", {
+            "language": language,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def set_theme(context: RunContext, theme: str | None = None) -> str:
+    """Handle a request to change the visual theme (light / dark / system)."""
+    body = await _dispatch(context, "set_theme", {
+            "theme": theme,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def set_voice_preferences(context: RunContext, pace: str | None = None, voice: str | None = None, tone: str | None = None) -> str:
+    """Tune the app's spoken-voice settings: pace (slow / normal / fast), voice"""
+    body = await _dispatch(context, "set_voice_preferences", {
+            "pace": pace,
+            "voice": voice,
+            "tone": tone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_connected_apps(context: RunContext) -> str:
+    """List the user's connected integrations: Google, YouTube, social accounts,"""
+    body = await _dispatch(context, "list_connected_apps")
+    return summarize(body)
+
+
+@function_tool
+async def disconnect_app(context: RunContext, provider: str, confirm: bool | None = None) -> str:
+    """Disconnect one connected integration (Google, YouTube, Instagram, an AI"""
+    body = await _dispatch(context, "disconnect_app", {
+            "provider": provider,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def global_search(context: RunContext, query: str, limit: float | None = None) -> str:
+    """Unified community search across people, posts, events, groups, products,"""
+    body = await _dispatch(context, "global_search", {
+            "query": query,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def browse_news_feed(context: RunContext, limit: float | None = None, scope: str | None = None) -> str:
+    """Read the community news feed aloud: recent posts with author and a"""
+    body = await _dispatch(context, "browse_news_feed", {
+            "limit": limit,
+            "scope": scope,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def snooze_recommendation(context: RunContext, recommendation: str, hours: float | None = None) -> str:
+    """Snooze an Autopilot recommendation so it resurfaces later (default 24h,"""
+    body = await _dispatch(context, "snooze_recommendation", {
+            "recommendation": recommendation,
+            "hours": hours,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dismiss_recommendation(context: RunContext, recommendation: str, reason: str | None = None, confirm: bool | None = None) -> str:
+    """Dismiss an Autopilot recommendation for good (it will not come back)."""
+    body = await _dispatch(context, "dismiss_recommendation", {
+            "recommendation": recommendation,
+            "reason": reason,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def explain_recommendation(context: RunContext, recommendation: str) -> str:
+    """Explain WHY a specific Autopilot recommendation was suggested: its"""
+    body = await _dispatch(context, "explain_recommendation", {
+            "recommendation": recommendation,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def update_intent(context: RunContext, intent: str, new_title: str | None = None, new_text: str | None = None, new_category: str | None = None) -> str:
+    """Edit one of the user's OWN intent posts (title, description text, or"""
+    body = await _dispatch(context, "update_intent", {
+            "intent": intent,
+            "new_title": new_title,
+            "new_text": new_text,
+            "new_category": new_category,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def delete_intent(context: RunContext, intent: str, confirm: bool | None = None) -> str:
+    """Take down one of the user's OWN intent posts from the board (closes it;"""
+    body = await _dispatch(context, "delete_intent", {
+            "intent": intent,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def browse_intent_board(context: RunContext, query: str | None = None, limit: float | None = None) -> str:
+    """Browse the open community intent board (Open Asks): what other members"""
+    body = await _dispatch(context, "browse_intent_board", {
+            "query": query,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dispute_match(context: RunContext, match_id: str | None = None, reason: str | None = None, reason_category: str | None = None, confirm: bool | None = None) -> str:
+    """Open a dispute on a match the user is part of (no-show, misrepresented,"""
+    body = await _dispatch(context, "dispute_match", {
+            "match_id": match_id,
+            "reason": reason,
+            "reason_category": reason_category,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def find_perfect_match(context: RunContext, ask: str | None = None, kind_hint: str | None = None, confirmed: bool | None = None) -> str:
+    """Flagship people-match: find the PERFECT person for the user — workout"""
+    body = await _dispatch_with_directive(context, "find_perfect_match", {
+            "ask": ask,
+            "kind_hint": kind_hint,
+            "confirmed": confirmed,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_emotional_state(context: RunContext) -> str:
+    """Read the user's current emotional and cognitive signals (D28): mood,"""
+    body = await _dispatch(context, "get_emotional_state")
+    return summarize(body)
+
+
+@function_tool
+async def get_situational_awareness(context: RunContext, timezone: str | None = None) -> str:
+    """Summarize the user's current situation (D32): time-of-day window,"""
+    body = await _dispatch(context, "get_situational_awareness", {
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_availability(context: RunContext, timezone: str | None = None) -> str:
+    """Check how available and ready the user is right now (D33): availability"""
+    body = await _dispatch(context, "get_availability", {
+            "timezone": timezone,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_environmental_context(context: RunContext) -> str:
+    """Read the user's environment and mobility context (D34): where they"""
+    body = await _dispatch(context, "get_environmental_context")
+    return summarize(body)
+
+
+@function_tool
+async def get_life_stage_context(context: RunContext) -> str:
+    """Read the user's life-stage context (D40): life phase and stability,"""
+    body = await _dispatch(context, "get_life_stage_context")
+    return summarize(body)
+
+
+@function_tool
+async def follow_member(context: RunContext, name: str) -> str:
+    """FOLLOW a community member by their spoken name."""
+    body = await _dispatch(context, "follow_member", {
+            "name": name,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def unfollow_member(context: RunContext, name: str, confirmed: bool | None = None) -> str:
+    """UNFOLLOW a community member by name. Two-step confirm:"""
+    body = await _dispatch(context, "unfollow_member", {
+            "name": name,
+            "confirmed": confirmed,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_notifications(context: RunContext, limit: float | None = None) -> str:
+    """READ the user's recent notifications, unread first. Speakable."""
+    body = await _dispatch(context, "get_notifications", {
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def mark_notifications_read(context: RunContext, reference: str | None = None) -> str:
+    """MARK notifications as read — all unread ones, or only those whose title"""
+    body = await _dispatch(context, "mark_notifications_read", {
+            "reference": reference,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_wallet_balance(context: RunContext) -> str:
+    """READ-ONLY wallet snapshot: balance per currency, active subscription,"""
+    body = await _dispatch(context, "get_wallet_balance")
+    return summarize(body)
+
+
+@function_tool
+async def update_profile(context: RunContext, display_name: str | None = None, bio: str | None = None, city: str | None = None, country: str | None = None, location: str | None = None, confirmed: bool | None = None) -> str:
+    """UPDATE simple own-profile fields: display_name, bio, city, country, location."""
+    body = await _dispatch(context, "update_profile", {
+            "display_name": display_name,
+            "bio": bio,
+            "city": city,
+            "country": country,
+            "location": location,
+            "confirmed": confirmed,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def play_podcast(context: RunContext, query: str | None = None) -> str:
+    """PLAY an internal Vitana Media Hub podcast by title or topic. Returns an"""
+    body = await _dispatch_with_directive(context, "play_podcast", {
+            "query": query,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def like_post(context: RunContext, author_name: str, post_reference: str | None = None) -> str:
+    """LIKE a community feed post — resolves 'the last post from <name>' to that"""
+    body = await _dispatch(context, "like_post", {
+            "author_name": author_name,
+            "post_reference": post_reference,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def comment_on_post(context: RunContext, author_name: str, text: str, post_reference: str | None = None, confirmed: bool | None = None) -> str:
+    """COMMENT on a community feed post (public text). Two-step confirm:"""
+    body = await _dispatch(context, "comment_on_post", {
+            "author_name": author_name,
+            "text": text,
+            "post_reference": post_reference,
+            "confirmed": confirmed,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_vtids(context: RunContext, status: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. List recent VTID tasks from the ledger (id, title, status)."""
+    body = await _dispatch(context, "dev_list_vtids", {
+            "status": status,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_vtid_status(context: RunContext, vtid: str) -> str:
+    """DEVELOPER ONLY. Get one VTID task by id — status, spec status, terminal state, claim."""
+    body = await _dispatch(context, "dev_get_vtid_status", {
+            "vtid": vtid,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_pending_approvals(context: RunContext, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. List PRs/actions waiting in the approvals queue (same queue as the Command Hub approvals view)."""
+    body = await _dispatch(context, "dev_list_pending_approvals", {
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_count_approvals(context: RunContext) -> str:
+    """DEVELOPER ONLY. Count how many items are pending approval."""
+    body = await _dispatch(context, "dev_count_approvals")
+    return summarize(body)
+
+
+@function_tool
+async def dev_approve_pr(context: RunContext, vtid: str | None = None, approval_id: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Approve a queued approval — merges its PR via the governed pipeline."""
+    body = await _dispatch(context, "dev_approve_pr", {
+            "vtid": vtid,
+            "approval_id": approval_id,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_reject_pr(context: RunContext, reason: str, vtid: str | None = None, approval_id: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Reject a queued approval and record why."""
+    body = await _dispatch(context, "dev_reject_pr", {
+            "reason": reason,
+            "vtid": vtid,
+            "approval_id": approval_id,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_voice_sessions(context: RunContext, status: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. List recent ORB voice sessions from the Voice Lab (who, when, duration, turns)."""
+    body = await _dispatch(context, "dev_list_voice_sessions", {
+            "status": status,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_routines(context: RunContext) -> str:
+    """DEVELOPER ONLY. List the daily Claude routines with last-run status."""
+    body = await _dispatch(context, "dev_list_routines")
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_routine_detail(context: RunContext, name: str, runs_limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Detail one routine plus its last runs."""
+    body = await _dispatch(context, "dev_get_routine_detail", {
+            "name": name,
+            "runs_limit": runs_limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_active_healing(context: RunContext) -> str:
+    """DEVELOPER ONLY. Show self-healing work currently in flight: active healing VTIDs and pending diagnoses."""
+    body = await _dispatch(context, "dev_list_active_healing")
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_autonomy_pulse(context: RunContext) -> str:
+    """DEVELOPER ONLY. One-shot autonomy status: pending findings, pending heals, executions"""
+    body = await _dispatch(context, "dev_get_autonomy_pulse")
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_agents(context: RunContext, tier: str | None = None) -> str:
+    """DEVELOPER ONLY. List registered agents with heartbeat-derived health (healthy/degraded/down)."""
+    body = await _dispatch(context, "dev_list_agents", {
+            "tier": tier,
+        })
+    return summarize(body)
+
+
 # ---------------------------------------------------------------------------
 # Catalogue export — used by tests + libcst smoke
 # ---------------------------------------------------------------------------
@@ -1970,6 +2896,63 @@ def all_tool_names() -> list[str]:
         "find_perfect_product", "find_perfect_practitioner",
         # Navigation (3)
         "navigate", "navigate_to_screen", "get_current_screen",
+        # BOOTSTRAP-VOICE-CATALOG-COMPLETE — every tool built out from the
+        # Voice Tools Catalog's `status: planned` backlog + P0 community-
+        # feature gaps. Implementations live in services/gateway/src/
+        # services/orb-tools/*.ts, reached through the shared dispatcher via
+        # POST /api/v1/orb/tool exactly like the tools above.
+        # Superlatives (6)
+        "get_highest_vitana_index", "get_top_in_pillar", "get_first_member",
+        "get_newest_member", "get_most_followed", "ask_who_is",
+        # Diary + Memory (6)
+        "list_diary_entries", "get_diary_streak", "get_memory_timeline",
+        "recall_memory_about", "get_memory_garden_summary", "forget_memory",
+        # Calendar management (6)
+        "reschedule_event", "cancel_event", "complete_event", "find_free_slot",
+        "get_event_details", "check_calendar_conflicts",
+        # Reminders lifecycle (5)
+        "snooze_reminder", "update_reminder", "acknowledge_reminder",
+        "complete_reminder", "list_missed_reminders",
+        # Clock (7)
+        "set_alarm", "list_alarms", "delete_alarm", "start_timer",
+        "start_pomodoro", "list_active_timers", "get_world_time",
+        # Community groups (6)
+        "list_my_groups", "create_group", "join_group", "invite_to_group",
+        "accept_invitation", "decline_invitation",
+        # Events / RSVP (4)
+        "rsvp_event", "cancel_rsvp", "list_upcoming_meetups", "join_live_room",
+        # Chat management (5)
+        "start_conversation", "list_conversations", "mark_conversation_read",
+        "mute_conversation", "archive_conversation",
+        # Privacy (4)
+        "update_account_visibility", "update_privacy_field", "block_user",
+        "unblock_user",
+        # Feedback (5)
+        "submit_bug_report", "submit_support_ticket", "submit_marketplace_dispute",
+        "submit_account_issue", "list_my_tickets",
+        # Settings (5)
+        "set_language", "set_theme", "set_voice_preferences",
+        "list_connected_apps", "disconnect_app",
+        # Search / News (2)
+        "global_search", "browse_news_feed",
+        # Autopilot recommendation management (3)
+        "snooze_recommendation", "dismiss_recommendation", "explain_recommendation",
+        # Intent management (4)
+        "update_intent", "delete_intent", "browse_intent_board", "dispute_match",
+        # Match (1)
+        "find_perfect_match",
+        # Awareness (5)
+        "get_emotional_state", "get_situational_awareness", "get_availability",
+        "get_environmental_context", "get_life_stage_context",
+        # Developer — role-gated server-side (developer/admin/exafy_admin) (12)
+        "dev_list_vtids", "dev_get_vtid_status", "dev_list_pending_approvals",
+        "dev_count_approvals", "dev_approve_pr", "dev_reject_pr",
+        "dev_list_voice_sessions", "dev_list_routines", "dev_get_routine_detail",
+        "dev_list_active_healing", "dev_get_autonomy_pulse", "dev_list_agents",
+        # P0 community-feature gaps (9)
+        "follow_member", "unfollow_member", "get_notifications",
+        "mark_notifications_read", "get_wallet_balance", "update_profile",
+        "play_podcast", "like_post", "comment_on_post",
     ]
 
 

--- a/services/gateway/src/orb/live/tools/live-tool-catalog.ts
+++ b/services/gateway/src/orb/live/tools/live-tool-catalog.ts
@@ -20,6 +20,15 @@
  */
 
 import { ADMIN_TOOL_SCHEMAS } from '../../../services/admin-voice-tools';
+// BOOTSTRAP-VOICE-CATALOG-COMPLETE — Vertex declarations for every tool built
+// out from the Voice Tools Catalog's `status: planned` backlog + the P0
+// community-feature gaps. Handlers live in services/orb-tools/*, spread into
+// the shared ORB_TOOL_REGISTRY in orb-tools-shared.ts; these are just the
+// function_declarations Vertex needs to see the tools exist.
+import {
+  NEW_DOMAIN_TOOL_DECLARATIONS,
+  DEVELOPER_DOMAIN_TOOL_DECLARATIONS,
+} from '../../../services/orb-tools-shared';
 
 
 /**
@@ -2424,11 +2433,26 @@ export function buildLiveApiTools(
             required: [],
           },
         },
+        // BOOTSTRAP-VOICE-CATALOG-COMPLETE — every tool built out from the
+        // Voice Tools Catalog's `status: planned` backlog + P0 community-
+        // feature gaps (Superlatives, Diary, Memory, Calendar management,
+        // Reminders lifecycle, Clock, Groups, Events/RSVP, Chat management,
+        // Privacy, Feedback, Settings, Search/News, Autopilot management,
+        // Intent management, Awareness, follow/notifications/wallet-read/
+        // profile/media/likes). Community-role tools — always declared for
+        // authenticated sessions, same as everything else in this array.
+        ...NEW_DOMAIN_TOOL_DECLARATIONS,
         // BOOTSTRAP-ADMIN-DD: admin voice tools — only injected when active_role
         // is admin / exafy_admin / developer. Community sessions never see them
         // and the orb dispatcher rejects them server-side regardless.
         ...(activeRole && ['admin', 'exafy_admin', 'developer'].includes(activeRole)
           ? ADMIN_TOOL_SCHEMAS
+          : []),
+        // BOOTSTRAP-VOICE-CATALOG-COMPLETE — Developer voice tools (VTID-02782).
+        // Same role gate as ADMIN_TOOL_SCHEMAS; handlers re-check role
+        // server-side regardless (developer-tools.ts developerGate()).
+        ...(activeRole && ['admin', 'exafy_admin', 'developer'].includes(activeRole)
+          ? DEVELOPER_DOMAIN_TOOL_DECLARATIONS
           : []),
       ],
     },

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -637,8 +637,14 @@ async function fetchUserRolePreference(
  * (gateway's historical source). role_preference wins when set — it reflects
  * the user's current UI selection. Fall back to active_role when unset or
  * when the preference RPC is unavailable (older deployments).
+ *
+ * Exported (BOOTSTRAP-VOICE-CATALOG-COMPLETE) so routes/orb-tool.ts — the
+ * LiveKit HTTP tool dispatcher — can resolve the same app-level role Vertex
+ * does. Without this, role-gated tools (e.g. developer-tools.ts's dev_*
+ * suite) would see only the raw JWT `role` claim ("authenticated"), never
+ * "developer"/"admin"/"exafy_admin", and deny every legitimate LiveKit call.
  */
-async function resolveEffectiveRole(
+export async function resolveEffectiveRole(
   userId: string,
   tenantId: string
 ): Promise<string | null> {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5756,6 +5756,38 @@ async function executeLiveApiToolInner(
             args,
           );
         }
+        // BOOTSTRAP-VOICE-CATALOG-COMPLETE — generic fallback for every tool
+        // built out from the Voice Tools Catalog's `status: planned` backlog.
+        // These have no bespoke Vertex case arm (unlike the older tools
+        // above) — they're declarative handlers registered only in the
+        // shared ORB_TOOL_REGISTRY, so route through the same dispatcher
+        // the explicit case arms above use. Handlers re-check role
+        // server-side (e.g. developer-tools.ts's developerGate()).
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+        if (SUPABASE_URL && SUPABASE_SERVICE_ROLE) {
+          const { createClient } = await import('@supabase/supabase-js');
+          const { ORB_TOOL_NAMES, dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+          if (ORB_TOOL_NAMES.includes(toolName)) {
+            const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+            return await dispatchOrbToolForVertex(
+              toolName,
+              args ?? {},
+              {
+                user_id: lens.user_id,
+                tenant_id: lens.tenant_id ?? null,
+                role: session.active_role || session.identity?.role || null,
+                vitana_id: session.identity?.vitana_id ?? null,
+                session_id: session.sessionId,
+                thread_id: session.thread_id || session.sessionId,
+                turn_number: session.turn_count,
+                session_started_iso: session.createdAt.toISOString(),
+                lang: session.lang ?? null,
+              },
+              supabase,
+            );
+          }
+        }
         return {
           success: false,
           result: '',

--- a/services/gateway/src/routes/orb-tool.ts
+++ b/services/gateway/src/routes/orb-tool.ts
@@ -23,6 +23,7 @@ import {
   type OrbToolArgs,
   type OrbToolIdentity,
 } from '../services/orb-tools-shared';
+import { resolveEffectiveRole } from './orb-live';
 
 const router = Router();
 const VTID = 'VTID-LIVEKIT-TOOLS';
@@ -46,10 +47,20 @@ router.post('/orb/tool', requireAuth, async (req: AuthenticatedRequest, res: Res
   if (!userId) {
     return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: VTID });
   }
+  // BOOTSTRAP-VOICE-CATALOG-COMPLETE: req.identity.role is the raw Supabase
+  // JWT `role` claim (the DB role, e.g. "authenticated") — NEVER the app-level
+  // role (community/developer/admin/exafy_admin). Role-gated tools (e.g.
+  // developer-tools.ts's dev_* suite) must see the SAME resolved role Vertex
+  // sessions do, or they deny every legitimate developer/admin LiveKit call.
+  // Falls back to the raw JWT role if resolution fails or tenant is unknown.
+  const tenantId = req.identity?.tenant_id ?? null;
+  const effectiveRole = tenantId
+    ? await resolveEffectiveRole(userId, tenantId).catch(() => null)
+    : null;
   const identity: OrbToolIdentity = {
     user_id: userId,
-    tenant_id: req.identity?.tenant_id ?? null,
-    role: req.identity?.role ?? null,
+    tenant_id: tenantId,
+    role: effectiveRole ?? req.identity?.role ?? null,
     vitana_id: req.identity?.vitana_id ?? null,
   };
   const sb = adminClient() || getSupabase();

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -31,6 +31,22 @@ import { shouldBlockTool } from './intelligence/role-policy-enforcer';
 import { tool_record_journey_answer } from './journey-foundation/record-journey-answer-tool';
 import { fetchVitanaIndexForProfiler } from './user-context-profiler';
 import { resolvePillarKey } from '../lib/vitana-pillars';
+// BOOTSTRAP-VOICE-CATALOG-COMPLETE — domain modules for every tool that was
+// `status: planned` in the Voice Tools Catalog (tool-manifest.json), plus the
+// P0 coverage gaps found in the community-feature audit. Each module owns its
+// own handlers + Vertex declarations; this file only spreads them into the
+// single dispatchable registry / declaration list both pipelines read.
+import { SUPERLATIVES_TOOL_HANDLERS, SUPERLATIVES_TOOL_DECLARATIONS } from './orb-tools/superlatives-tools';
+import { DIARY_MEMORY_TOOL_HANDLERS, DIARY_MEMORY_TOOL_DECLARATIONS } from './orb-tools/diary-memory-tools';
+import { CALENDAR_MGMT_TOOL_HANDLERS, CALENDAR_MGMT_TOOL_DECLARATIONS } from './orb-tools/calendar-management-tools';
+import { REMINDERS_CLOCK_TOOL_HANDLERS, REMINDERS_CLOCK_TOOL_DECLARATIONS } from './orb-tools/reminders-clock-tools';
+import { GROUPS_EVENTS_TOOL_HANDLERS, GROUPS_EVENTS_TOOL_DECLARATIONS } from './orb-tools/groups-events-tools';
+import { CHAT_PRIVACY_TOOL_HANDLERS, CHAT_PRIVACY_TOOL_DECLARATIONS } from './orb-tools/chat-privacy-tools';
+import { FEEDBACK_SETTINGS_TOOL_HANDLERS, FEEDBACK_SETTINGS_TOOL_DECLARATIONS } from './orb-tools/feedback-settings-tools';
+import { DISCOVERY_TOOL_HANDLERS, DISCOVERY_TOOL_DECLARATIONS } from './orb-tools/discovery-tools';
+import { AWARENESS_TOOL_HANDLERS, AWARENESS_TOOL_DECLARATIONS } from './orb-tools/awareness-tools';
+import { DEVELOPER_TOOL_HANDLERS, DEVELOPER_TOOL_DECLARATIONS } from './orb-tools/developer-tools';
+import { P0_GAP_TOOL_HANDLERS, P0_GAP_TOOL_DECLARATIONS } from './orb-tools/p0-gap-tools';
 import {
   lookupScreen,
   lookupByAlias,
@@ -5090,7 +5106,44 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   // NAV_CONTINUATION_BIND — offer_action: Vitana records the exact action she is
   // proposing so a later "Ja" executes it deterministically (invariant #10).
   offer_action: tool_offer_action,
+  // BOOTSTRAP-VOICE-CATALOG-COMPLETE — every tool that was `status: planned`
+  // in the Voice Tools Catalog, now built out per-domain (see imports above).
+  ...SUPERLATIVES_TOOL_HANDLERS,
+  ...DIARY_MEMORY_TOOL_HANDLERS,
+  ...CALENDAR_MGMT_TOOL_HANDLERS,
+  ...REMINDERS_CLOCK_TOOL_HANDLERS,
+  ...GROUPS_EVENTS_TOOL_HANDLERS,
+  ...CHAT_PRIVACY_TOOL_HANDLERS,
+  ...FEEDBACK_SETTINGS_TOOL_HANDLERS,
+  ...DISCOVERY_TOOL_HANDLERS,
+  ...AWARENESS_TOOL_HANDLERS,
+  ...DEVELOPER_TOOL_HANDLERS,
+  ...P0_GAP_TOOL_HANDLERS,
 };
+
+// BOOTSTRAP-VOICE-CATALOG-COMPLETE — combined Vertex/Gemini function
+// declarations for every newly-built domain module. live-tool-catalog.ts
+// spreads this into buildLiveApiTools() so Vertex sessions see the tools;
+// LiveKit's tools.py declares its own @function_tool wrappers per name but
+// dispatches through the same ORB_TOOL_REGISTRY above.
+export const NEW_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  ...SUPERLATIVES_TOOL_DECLARATIONS,
+  ...DIARY_MEMORY_TOOL_DECLARATIONS,
+  ...CALENDAR_MGMT_TOOL_DECLARATIONS,
+  ...REMINDERS_CLOCK_TOOL_DECLARATIONS,
+  ...GROUPS_EVENTS_TOOL_DECLARATIONS,
+  ...CHAT_PRIVACY_TOOL_DECLARATIONS,
+  ...FEEDBACK_SETTINGS_TOOL_DECLARATIONS,
+  ...DISCOVERY_TOOL_DECLARATIONS,
+  ...AWARENESS_TOOL_DECLARATIONS,
+  ...P0_GAP_TOOL_DECLARATIONS,
+];
+
+// Developer tools are role-gated the same way ADMIN_TOOL_SCHEMAS is —
+// declared only for developer/admin/exafy_admin sessions. Kept separate so
+// live-tool-catalog.ts can apply the same activeRole check it already uses
+// for ADMIN_TOOL_SCHEMAS.
+export const DEVELOPER_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = DEVELOPER_TOOL_DECLARATIONS;
 
 export const ORB_TOOL_NAMES = Object.keys(ORB_TOOL_REGISTRY);
 

--- a/services/gateway/src/services/orb-tools/awareness-tools.ts
+++ b/services/gateway/src/services/orb-tools/awareness-tools.ts
@@ -1,0 +1,929 @@
+/**
+ * Awareness-signal voice tools (VTID-02778).
+ *
+ * Per-user awareness snapshots for the ORB assistant, one tool per Awareness
+ * dimension: D28 emotional/cognitive signals, D32 situational awareness,
+ * D33 availability/readiness, D34 environment/mobility and D40 life-stage
+ * context. Each handler is backed by the REAL dimension engine or its
+ * canonical tables — D28 reads `emotional_cognitive_signals` (falling back to
+ * recent `memory_diary_entries` moods), D32/D33 call the deterministic
+ * in-process engines enriched with live `calendar_events` + `reminders`
+ * density, D34 calls the D34 engine seeded with the user's stored
+ * `memory_facts.user_residence`, and D40 reads `life_stage_assessments` +
+ * `life_stage_goals` + the active `life_compass` row + membership tenure.
+ * Every spoken snapshot states what it is based on; nothing is invented.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import {
+  computeSituationalAwareness,
+  toOrbSituationContext,
+} from '../d32-situational-awareness-engine';
+import {
+  computeAvailabilityReadiness,
+  getCurrentAvailability,
+} from '../d33-availability-readiness-engine';
+import { computeContext } from '../d34-environmental-mobility-engine';
+import type { TimeContextSignals, AvailabilityReadinessBundle } from '../../types/availability-readiness';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** ok:false when there is no authenticated user — all five tools read personal state. */
+function authGate(tool: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id || !id.tenant_id) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+/** "a few minutes ago" / "3 hours ago" / "2 days ago" from an ISO timestamp. */
+function relativePastPhrase(iso: string | null | undefined): string {
+  if (!iso) return 'recently';
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return 'recently';
+  const mins = (Date.now() - t) / 60000;
+  if (mins < 10) return 'a few minutes ago';
+  if (mins < 90) return `${Math.round(mins)} minutes ago`;
+  if (mins < 36 * 60) return `${Math.round(mins / 60)} hours ago`;
+  return `${Math.round(mins / (60 * 24))} days ago`;
+}
+
+/** "in 25 minutes" / "in about 3 hours" from a minutes-from-now count. */
+function inMinutesPhrase(mins: number): string {
+  if (mins <= 1) return 'right about now';
+  if (mins < 90) return `in ${Math.round(mins)} minutes`;
+  return `in about ${Math.round(mins / 60)} hours`;
+}
+
+function isValidTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the user's timezone: explicit tool arg first, then the timezone the
+ * user last set a reminder in (`reminders.user_tz` — a real, user-provided
+ * signal), else undefined (engines fall back to UTC).
+ */
+async function resolveUserTimezone(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<string | undefined> {
+  const explicit = typeof args.timezone === 'string' ? args.timezone.trim() : '';
+  if (explicit && isValidTimezone(explicit)) return explicit;
+  try {
+    const { data } = await sb
+      .from('reminders')
+      .select('user_tz')
+      .eq('user_id', id.user_id)
+      .eq('tenant_id', id.tenant_id)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    const tz = data?.[0]?.user_tz;
+    if (typeof tz === 'string' && tz && tz !== 'UTC' && isValidTimezone(tz)) return tz;
+  } catch {
+    /* timezone is best-effort */
+  }
+  return undefined;
+}
+
+/** Hour/day-of-week signals in the user's local timezone (UTC when unknown). */
+function timeContextFor(tz: string | undefined, now: Date = new Date()): TimeContextSignals {
+  let hour = now.getUTCHours();
+  let dow = now.getUTCDay();
+  if (tz) {
+    try {
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: tz,
+        hour: 'numeric',
+        hourCycle: 'h23',
+        weekday: 'short',
+      }).formatToParts(now);
+      const h = Number(parts.find((p) => p.type === 'hour')?.value);
+      if (Number.isFinite(h)) hour = h;
+      const wd = parts.find((p) => p.type === 'weekday')?.value ?? '';
+      const idx = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].indexOf(wd);
+      if (idx >= 0) dow = idx;
+    } catch {
+      /* keep UTC */
+    }
+  }
+  return { current_hour: hour, day_of_week: dow, is_weekend: dow === 0 || dow === 6 };
+}
+
+interface CalendarEventLite {
+  id: string;
+  title: string | null;
+  start_time: string;
+  end_time: string | null;
+  event_type: string | null;
+}
+
+interface CalendarWindow {
+  in_progress: CalendarEventLite | null;
+  next_event: CalendarEventLite | null;
+  minutes_to_next: number | null;
+  upcoming_count: number;
+  horizon_hours: number;
+  fetched: boolean;
+}
+
+const CALENDAR_HORIZON_HOURS = 12;
+const DEFAULT_EVENT_DURATION_MS = 60 * 60 * 1000;
+
+/**
+ * One pass over the user's `calendar_events` (the canonical calendar table):
+ * events from 2h back to +12h, classified into in-progress / next / density.
+ */
+async function fetchCalendarWindow(
+  sb: SupabaseClient,
+  userId: string,
+  now: Date = new Date(),
+): Promise<CalendarWindow> {
+  const empty: CalendarWindow = {
+    in_progress: null,
+    next_event: null,
+    minutes_to_next: null,
+    upcoming_count: 0,
+    horizon_hours: CALENDAR_HORIZON_HOURS,
+    fetched: false,
+  };
+  try {
+    const fromIso = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString();
+    const toIso = new Date(now.getTime() + CALENDAR_HORIZON_HOURS * 60 * 60 * 1000).toISOString();
+    const { data, error } = await sb
+      .from('calendar_events')
+      .select('id, title, start_time, end_time, event_type')
+      .eq('user_id', userId)
+      .eq('status', 'scheduled')
+      .gte('start_time', fromIso)
+      .lte('start_time', toIso)
+      .order('start_time', { ascending: true })
+      .limit(20);
+    if (error || !Array.isArray(data)) return empty;
+
+    const rows = data as CalendarEventLite[];
+    const nowMs = now.getTime();
+    let inProgress: CalendarEventLite | null = null;
+    const upcoming: CalendarEventLite[] = [];
+    for (const ev of rows) {
+      const startMs = Date.parse(ev.start_time);
+      if (!Number.isFinite(startMs)) continue;
+      if (startMs > nowMs) {
+        upcoming.push(ev);
+        continue;
+      }
+      const endMs = ev.end_time ? Date.parse(ev.end_time) : startMs + DEFAULT_EVENT_DURATION_MS;
+      if (Number.isFinite(endMs) && endMs >= nowMs && !inProgress) inProgress = ev;
+    }
+    const next = upcoming[0] ?? null;
+    return {
+      in_progress: inProgress,
+      next_event: next,
+      minutes_to_next: next ? Math.max(0, Math.round((Date.parse(next.start_time) - nowMs) / 60000)) : null,
+      upcoming_count: upcoming.length,
+      horizon_hours: CALENDAR_HORIZON_HOURS,
+      fetched: true,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_emotional_state — D28 emotional/cognitive signals
+// ---------------------------------------------------------------------------
+
+interface D28StateEntry {
+  state?: string;
+  score?: number;
+  confidence?: number;
+}
+
+interface D28SignalRow {
+  emotional_states: unknown;
+  cognitive_states: unknown;
+  engagement_level: string | null;
+  engagement_confidence: number | null;
+  urgency_detected: boolean | null;
+  hesitation_detected: boolean | null;
+  created_at: string | null;
+  decay_at: string | null;
+}
+
+/** Strongest non-neutral states first (score-sorted); neutral only when alone. */
+function topStates(raw: unknown, max = 2): D28StateEntry[] {
+  if (!Array.isArray(raw)) return [];
+  const items = raw
+    .filter((s): s is D28StateEntry => !!s && typeof s === 'object' && typeof (s as D28StateEntry).state === 'string')
+    .sort((a, b) => (Number(b.score) || 0) - (Number(a.score) || 0));
+  const meaningful = items.filter((s) => s.state !== 'neutral' && (Number(s.score) || 0) >= 30);
+  return (meaningful.length > 0 ? meaningful : items).slice(0, max);
+}
+
+function speakStates(entries: D28StateEntry[]): string {
+  return entries.map((s) => String(s.state).replace(/_/g, ' ')).join(' and ');
+}
+
+export async function tool_get_emotional_state(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_emotional_state', id);
+  if (gate) return gate;
+  try {
+    const nowMs = Date.now();
+
+    // 1) Real source: latest non-decayed D28 signal bundle for this user.
+    const { data: signalRows, error: signalErr } = await sb
+      .from('emotional_cognitive_signals')
+      .select(
+        'emotional_states, cognitive_states, engagement_level, engagement_confidence, ' +
+          'urgency_detected, hesitation_detected, created_at, decay_at',
+      )
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id)
+      .eq('decayed', false)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (signalErr) {
+      return { ok: false, error: `get_emotional_state failed: ${signalErr.message}` };
+    }
+
+    const row = (signalRows as unknown as D28SignalRow[] | null)?.[0];
+    const createdMs = row ? Date.parse(String(row.created_at)) : NaN;
+    const decayMs = row?.decay_at ? Date.parse(String(row.decay_at)) : NaN;
+    const fresh =
+      !!row &&
+      Number.isFinite(createdMs) &&
+      nowMs - createdMs <= 24 * 60 * 60 * 1000 &&
+      (!row.decay_at || (Number.isFinite(decayMs) && decayMs > nowMs));
+
+    if (fresh && row) {
+      const emo = topStates(row.emotional_states);
+      const cog = topStates(row.cognitive_states);
+      const parts: string[] = [];
+      parts.push(`Based on your conversation signals from ${relativePastPhrase(String(row.created_at))}:`);
+      if (emo.length > 0) parts.push(`emotionally you come across as ${speakStates(emo)},`);
+      if (cog.length > 0) parts.push(`cognitively ${speakStates(cog)},`);
+      parts.push(`with ${String(row.engagement_level ?? 'medium')} engagement.`);
+      if (row.urgency_detected) parts.push('Your recent messages carried some urgency.');
+      if (row.hesitation_detected) parts.push('There was a bit of hesitation too.');
+      parts.push('These are light behavioral observations, not a clinical assessment.');
+      return {
+        ok: true,
+        result: {
+          source: 'conversation_signals',
+          emotional_states: emo.map((s) => ({ state: s.state, score: s.score ?? null })),
+          cognitive_states: cog.map((s) => ({ state: s.state, score: s.score ?? null })),
+          engagement_level: row.engagement_level ?? null,
+          urgency_detected: !!row.urgency_detected,
+          hesitation_detected: !!row.hesitation_detected,
+          computed_at: row.created_at ?? null,
+        },
+        text: parts.join(' '),
+      };
+    }
+
+    // 2) Best-effort fallback: recent diary moods/energy (real user data).
+    const sinceDate = new Date(nowMs - 14 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const { data: diaryRows } = await sb
+      .from('memory_diary_entries')
+      .select('mood, energy_level, entry_date')
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id)
+      .gte('entry_date', sinceDate)
+      .order('entry_date', { ascending: false })
+      .limit(5);
+    const withMood = (diaryRows ?? []).filter(
+      (d) => (typeof d.mood === 'string' && d.mood.trim() !== '') || typeof d.energy_level === 'number',
+    );
+    if (withMood.length > 0) {
+      const latest = withMood[0];
+      const energies = withMood
+        .map((d) => Number(d.energy_level))
+        .filter((n) => Number.isFinite(n));
+      const avgEnergy = energies.length > 0 ? Math.round((energies.reduce((a, b) => a + b, 0) / energies.length) * 10) / 10 : null;
+      const bits: string[] = ['I have no live conversation signals right now, so this comes from your recent diary:'];
+      if (latest.mood) bits.push(`your last logged mood was "${latest.mood}" (${latest.entry_date}).`);
+      if (avgEnergy !== null) {
+        bits.push(`Average energy across your last ${energies.length} ${energies.length === 1 ? 'entry' : 'entries'}: ${avgEnergy} out of 10.`);
+      }
+      return {
+        ok: true,
+        result: {
+          source: 'diary',
+          latest_mood: latest.mood ?? null,
+          latest_entry_date: latest.entry_date ?? null,
+          average_energy: avgEnergy,
+          entries_considered: withMood.length,
+        },
+        text: bits.join(' '),
+      };
+    }
+
+    // 3) Honest empty state (ok:true — an empty state is not a failure).
+    return {
+      ok: true,
+      result: { source: 'none', available: false },
+      text:
+        'I have no recent emotional or cognitive signals for you — no analyzed conversation turns and no recent diary moods or energy logs. Nothing is wrong; there is just no data yet.',
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_emotional_state failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_situational_awareness — D32 situational summary
+// ---------------------------------------------------------------------------
+
+export async function tool_get_situational_awareness(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_situational_awareness', id);
+  if (gate) return gate;
+  try {
+    const timezone = await resolveUserTimezone(args, id, sb);
+    const cal = await fetchCalendarWindow(sb, id.user_id);
+
+    const computed = await computeSituationalAwareness({
+      user_id: id.user_id,
+      tenant_id: id.tenant_id as string,
+      session_id: id.session_id ?? undefined,
+      timezone,
+      calendar_hints: cal.fetched
+        ? {
+            next_event_in_minutes: cal.minutes_to_next ?? undefined,
+            is_free_now: !cal.in_progress,
+          }
+        : undefined,
+    });
+    if (!computed.ok || !computed.bundle) {
+      return { ok: false, error: computed.error || 'get_situational_awareness failed' };
+    }
+
+    const ctx = toOrbSituationContext(computed.bundle);
+    const parts: string[] = [];
+    parts.push(
+      `Right now it's ${String(ctx.time_window).replace(/_/g, ' ')} for you${ctx.is_late_night ? ' (late night)' : ''}.`,
+    );
+    parts.push(
+      `Availability looks ${String(ctx.availability).replace(/_/g, ' ')}, energy ${String(ctx.energy).replace(/_/g, ' ')}, so a ${ctx.suggested_depth} interaction depth fits best.`,
+    );
+    if (cal.in_progress) {
+      parts.push(`You appear to be in "${cal.in_progress.title ?? 'a calendar event'}" at the moment.`);
+    } else if (cal.next_event && cal.minutes_to_next !== null) {
+      parts.push(`Next on your calendar: "${cal.next_event.title ?? 'an event'}" ${inMinutesPhrase(cal.minutes_to_next)}.`);
+    }
+    if (ctx.active_constraints.length > 0) {
+      parts.push(`Active constraints: ${ctx.active_constraints.map((c) => String(c).replace(/_/g, ' ')).join(', ')}.`);
+    }
+    parts.push(
+      `This is inferred from the time of day${cal.fetched ? ' and your calendar' : ''}${timezone ? ` (timezone ${timezone})` : ''} — ${ctx.confidence}% confidence.`,
+    );
+
+    return {
+      ok: true,
+      result: {
+        time_window: ctx.time_window,
+        is_late_night: ctx.is_late_night,
+        availability: ctx.availability,
+        energy: ctx.energy,
+        suggested_depth: ctx.suggested_depth,
+        active_constraints: ctx.active_constraints,
+        next_event_title: cal.next_event?.title ?? null,
+        next_event_in_minutes: cal.minutes_to_next,
+        in_event_now: !!cal.in_progress,
+        confidence: ctx.confidence,
+        timezone: timezone ?? null,
+      },
+      text: parts.join(' '),
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_situational_awareness failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_availability — D33 availability / readiness
+// ---------------------------------------------------------------------------
+
+const TIME_WINDOW_PHRASES: Record<string, string> = {
+  immediate: 'only a couple of minutes',
+  short: 'a short window of a few minutes',
+  extended: 'a longer stretch of time',
+  defer: 'a moment better saved for later',
+};
+
+export async function tool_get_availability(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_availability', id);
+  if (gate) return gate;
+  try {
+    const now = new Date();
+    const timezone = await resolveUserTimezone(args, id, sb);
+    const cal = await fetchCalendarWindow(sb, id.user_id, now);
+
+    // Reminders due soon (real "active timers"): pending, next 4 hours.
+    let remindersDue: Array<{ action_text: string | null; next_fire_at: string }> = [];
+    try {
+      const { data } = await sb
+        .from('reminders')
+        .select('action_text, next_fire_at')
+        .eq('user_id', id.user_id)
+        .eq('tenant_id', id.tenant_id)
+        .eq('status', 'pending')
+        .lte('next_fire_at', new Date(now.getTime() + 4 * 60 * 60 * 1000).toISOString())
+        .order('next_fire_at', { ascending: true })
+        .limit(5);
+      remindersDue = Array.isArray(data) ? data : [];
+    } catch {
+      /* reminders are additive context */
+    }
+
+    // Prefer the live in-session D33 bundle when one is cached for this session.
+    let bundle: AvailabilityReadinessBundle | null = null;
+    let basis = 'your calendar and the time of day';
+    if (id.session_id) {
+      const cached = await getCurrentAvailability(id.session_id);
+      if (cached.ok && cached.bundle) {
+        bundle = cached.bundle;
+        basis = 'this session and your calendar';
+      }
+    }
+    if (!bundle) {
+      const computed = await computeAvailabilityReadiness({
+        session_id: id.session_id ?? undefined,
+        time_context: timeContextFor(timezone, now),
+        calendar: cal.fetched
+          ? {
+              has_upcoming_event: !!cal.next_event,
+              minutes_to_next_event: cal.minutes_to_next ?? undefined,
+              is_in_meeting: !!cal.in_progress,
+              calendar_availability: cal.in_progress ? 'busy' : 'free',
+            }
+          : undefined,
+      });
+      if (!computed.ok || !computed.bundle) {
+        return { ok: false, error: computed.message || computed.error || 'get_availability failed' };
+      }
+      bundle = computed.bundle;
+    }
+
+    const parts: string[] = [];
+    parts.push(
+      `Your availability looks ${bundle.availability.level}, with ${TIME_WINDOW_PHRASES[bundle.time_window.window] ?? bundle.time_window.window} available` +
+        `${typeof bundle.time_window.estimated_minutes === 'number' ? ` (about ${Math.round(bundle.time_window.estimated_minutes)} minutes)` : ''}.`,
+    );
+    parts.push(`Readiness for engagement is around ${Math.round(bundle.readiness.score * 100)}%.`);
+    if (cal.in_progress) {
+      parts.push(`You seem to be in "${cal.in_progress.title ?? 'a calendar event'}" right now.`);
+    } else if (cal.next_event && cal.minutes_to_next !== null) {
+      parts.push(`Next commitment: "${cal.next_event.title ?? 'an event'}" ${inMinutesPhrase(cal.minutes_to_next)}.`);
+    }
+    if (cal.fetched) {
+      parts.push(
+        cal.upcoming_count > 0
+          ? `You have ${cal.upcoming_count} calendar ${cal.upcoming_count === 1 ? 'item' : 'items'} in the next ${cal.horizon_hours} hours.`
+          : `Your calendar is clear for the next ${cal.horizon_hours} hours.`,
+      );
+    }
+    if (remindersDue.length > 0) {
+      const first = remindersDue[0];
+      const mins = Math.max(0, Math.round((Date.parse(first.next_fire_at) - now.getTime()) / 60000));
+      parts.push(
+        `${remindersDue.length} reminder${remindersDue.length === 1 ? '' : 's'} due within 4 hours — the next one${first.action_text ? ` ("${first.action_text}")` : ''} ${inMinutesPhrase(mins)}.`,
+      );
+    }
+    parts.push(`Based on ${basis}.`);
+
+    return {
+      ok: true,
+      result: {
+        availability_level: bundle.availability.level,
+        time_window: bundle.time_window.window,
+        estimated_minutes: bundle.time_window.estimated_minutes ?? null,
+        readiness_score: bundle.readiness.score,
+        availability_tag: bundle.availability_tag,
+        in_event_now: !!cal.in_progress,
+        next_event_title: cal.next_event?.title ?? null,
+        next_event_in_minutes: cal.minutes_to_next,
+        upcoming_events_count: cal.upcoming_count,
+        reminders_due_count: remindersDue.length,
+        was_user_override: bundle.was_user_override,
+      },
+      text: parts.join(' '),
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_availability failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_environmental_context — D34 environment / mobility
+// ---------------------------------------------------------------------------
+
+export async function tool_get_environmental_context(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_environmental_context', id);
+  if (gate) return gate;
+  try {
+    // Real stored location: the user's residence fact from the Memory Garden
+    // (memory_facts.user_residence, written by the Cognee extractor).
+    let residence: string | null = null;
+    try {
+      const { data } = await sb
+        .from('memory_facts')
+        .select('fact_value')
+        .eq('tenant_id', id.tenant_id)
+        .eq('user_id', id.user_id)
+        .eq('fact_key', 'user_residence')
+        .eq('entity', 'self')
+        .is('superseded_by', null)
+        .order('extracted_at', { ascending: false })
+        .limit(1);
+      const v = data?.[0]?.fact_value;
+      residence = typeof v === 'string' && v.trim() !== '' ? v.trim() : null;
+    } catch {
+      /* residence fact is best-effort seed data */
+    }
+
+    const computed = await computeContext(
+      {
+        user_id: id.user_id,
+        session_id: id.session_id ?? undefined,
+        explicit_location: residence ? { city: residence } : undefined,
+        force_refresh: false,
+      },
+      id.user_jwt ?? undefined,
+    );
+    if (!computed.ok || !computed.bundle) {
+      return { ok: false, error: computed.message || computed.error || 'get_environmental_context failed' };
+    }
+    const b = computed.bundle;
+    const loc = b.location_context;
+    const mob = b.mobility_profile;
+    const env = b.environmental_constraints;
+
+    const parts: string[] = [];
+    if (loc.city || loc.country) {
+      const place = [loc.city, loc.region, loc.country].filter(Boolean).join(', ');
+      const sourceNote =
+        loc.source === 'explicit'
+          ? 'the location you shared with me'
+          : loc.source === 'preferences'
+            ? 'your saved location preferences'
+            : loc.source === 'visit_history'
+              ? 'your recent visit history'
+              : 'an inferred hint';
+      parts.push(
+        `You're ${loc.travel_state === 'traveling' ? 'traveling — currently around' : 'based in'} ${place} (from ${sourceNote}).`,
+      );
+    } else {
+      parts.push("I don't have a location for you — nothing stored or shared yet.");
+    }
+    if (mob.mode_preference && mob.mode_preference !== 'unknown') {
+      parts.push(`You usually get around by ${String(mob.mode_preference).replace(/_/g, ' ')}.`);
+    }
+    if (env.is_late_night) parts.push("It's late night in your area.");
+    else if (env.is_early_morning) parts.push("It's early morning in your area.");
+    if (env.indoor_outdoor_preference !== 'either') {
+      parts.push(`${env.indoor_outdoor_preference === 'indoor' ? 'Indoor' : 'Outdoor'} activities suit the current conditions best.`);
+    }
+    if (b.environment_tags.length > 0) {
+      parts.push(`Environment notes: ${b.environment_tags.map((t) => String(t).replace(/_/g, ' ')).join(', ')}.`);
+    }
+    if (b.fallback_applied) {
+      parts.push('Most of this is a neutral default — I have little real location or mobility data for you yet.');
+    } else {
+      parts.push(`Overall confidence: ${b.overall_confidence}%.`);
+    }
+
+    return {
+      ok: true,
+      result: {
+        city: loc.city ?? null,
+        region: loc.region ?? null,
+        country: loc.country ?? null,
+        location_source: loc.source,
+        travel_state: loc.travel_state,
+        urban_density: loc.urban_density,
+        mode_preference: mob.mode_preference,
+        environment_tags: b.environment_tags,
+        is_late_night: env.is_late_night,
+        is_early_morning: env.is_early_morning,
+        overall_confidence: b.overall_confidence,
+        fallback_applied: b.fallback_applied,
+      },
+      text: parts.join(' '),
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_environmental_context failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_life_stage_context — D40 life-stage context
+// ---------------------------------------------------------------------------
+
+const DECADE_WORDS: Record<number, string> = {
+  10: 'teens',
+  20: 'twenties',
+  30: 'thirties',
+  40: 'forties',
+  50: 'fifties',
+  60: 'sixties',
+  70: 'seventies',
+  80: 'eighties',
+  90: 'nineties',
+};
+
+/** "in your fifties" from a birthday string; null when unparseable. */
+function ageBandPhrase(birthdayRaw: string, now: Date = new Date()): string | null {
+  const t = Date.parse(birthdayRaw);
+  if (!Number.isFinite(t)) return null;
+  const age = Math.floor((now.getTime() - t) / (365.25 * 24 * 60 * 60 * 1000));
+  if (age < 10 || age > 110) return null;
+  const decade = Math.floor(age / 10) * 10;
+  const word = DECADE_WORDS[decade];
+  return word ? `in your ${word}` : null;
+}
+
+/** "8 months" / "2 years" tenure phrase from a created_at ISO. */
+function tenurePhrase(iso: string): string | null {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return null;
+  const days = (Date.now() - t) / (24 * 60 * 60 * 1000);
+  if (days < 0) return null;
+  if (days < 14) return `${Math.max(1, Math.round(days))} days`;
+  if (days < 60) return `${Math.round(days / 7)} weeks`;
+  if (days < 700) return `${Math.round(days / 30)} months`;
+  return `${Math.round(days / 365)} years`;
+}
+
+interface LifeStageAssessmentRow {
+  phase: string;
+  phase_confidence: number;
+  stability_level: string;
+  transition_flag: boolean;
+  transition_type: string | null;
+}
+
+interface LifeCompassRow {
+  primary_goal: string | null;
+  category: string | null;
+}
+
+export async function tool_get_life_stage_context(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_life_stage_context', id);
+  if (gate) return gate;
+  try {
+    // 1) Latest valid D40 assessment.
+    let assessment: LifeStageAssessmentRow | null = null;
+    try {
+      const { data } = await sb
+        .from('life_stage_assessments')
+        .select('phase, phase_confidence, stability_level, transition_flag, transition_type')
+        .eq('tenant_id', id.tenant_id)
+        .eq('user_id', id.user_id)
+        .eq('valid', true)
+        .order('created_at', { ascending: false })
+        .limit(1);
+      assessment = (data as LifeStageAssessmentRow[] | null)?.[0] ?? null;
+    } catch {
+      /* assessment is one of several sources */
+    }
+
+    // 2) Active D40 goals (top priority first).
+    let goals: Array<{ category: string; description: string }> = [];
+    try {
+      const { data } = await sb
+        .from('life_stage_goals')
+        .select('category, description, priority')
+        .eq('tenant_id', id.tenant_id)
+        .eq('user_id', id.user_id)
+        .eq('status', 'active')
+        .order('priority', { ascending: false })
+        .limit(3);
+      goals = Array.isArray(data) ? data : [];
+    } catch {
+      /* goals optional */
+    }
+
+    // 3) Active Life Compass (primary long-term goal + category).
+    let compass: LifeCompassRow | null = null;
+    try {
+      const { data } = await sb
+        .from('life_compass')
+        .select('primary_goal, category')
+        .eq('user_id', id.user_id)
+        .eq('is_active', true)
+        .order('created_at', { ascending: false })
+        .limit(1);
+      compass = (data as LifeCompassRow[] | null)?.[0] ?? null;
+    } catch {
+      /* compass optional */
+    }
+
+    // 4) Community tenure from app_users.created_at.
+    let tenure: string | null = null;
+    try {
+      const { data } = await sb
+        .from('app_users')
+        .select('created_at')
+        .eq('user_id', id.user_id)
+        .limit(1);
+      if (data?.[0]?.created_at) tenure = tenurePhrase(String(data[0].created_at));
+    } catch {
+      /* tenure optional */
+    }
+
+    // 5) Age band from the user's stated birthday (memory_facts.user_birthday).
+    let ageBand: string | null = null;
+    try {
+      const { data } = await sb
+        .from('memory_facts')
+        .select('fact_value')
+        .eq('tenant_id', id.tenant_id)
+        .eq('user_id', id.user_id)
+        .eq('fact_key', 'user_birthday')
+        .eq('entity', 'self')
+        .is('superseded_by', null)
+        .order('extracted_at', { ascending: false })
+        .limit(1);
+      const v = data?.[0]?.fact_value;
+      if (typeof v === 'string' && v.trim() !== '') ageBand = ageBandPhrase(v.trim());
+    } catch {
+      /* age band optional */
+    }
+
+    const parts: string[] = [];
+    if (assessment) {
+      parts.push(
+        `You're in a${assessment.phase === 'exploratory' || assessment.phase === 'optimizing' ? 'n' : ''} ${assessment.phase} life phase (${assessment.phase_confidence}% confidence), with ${assessment.stability_level} stability.`,
+      );
+      if (assessment.transition_flag) {
+        parts.push(`A life transition is in play${assessment.transition_type ? ` (${String(assessment.transition_type).replace(/_/g, ' ')})` : ''}.`);
+      }
+    }
+    if (compass?.primary_goal) {
+      parts.push(`Your Life Compass points at ${compass.category ? `${compass.category}: ` : ''}"${compass.primary_goal}".`);
+    }
+    if (goals.length > 0 && !compass?.primary_goal) {
+      const g = goals[0];
+      parts.push(`Your top active goal is ${String(g.category).replace(/_/g, ' ')}: "${g.description}".`);
+    }
+    if (ageBand) parts.push(`You're ${ageBand} (based on the birthday you shared).`);
+    if (tenure) parts.push(`You've been part of the community for ${tenure}.`);
+
+    if (parts.length === 0) {
+      return {
+        ok: true,
+        result: { available: false },
+        text:
+          "I don't have life-stage context for you yet — no life-stage assessment, no Life Compass goal, and no birthday on record. We can set up your Life Compass whenever you like.",
+      };
+    }
+    parts.push('This is based on what you\'ve shared and your activity — you know your life best.');
+
+    return {
+      ok: true,
+      result: {
+        phase: assessment?.phase ?? null,
+        phase_confidence: assessment?.phase_confidence ?? null,
+        stability_level: assessment?.stability_level ?? null,
+        in_transition: assessment?.transition_flag ?? false,
+        life_compass_category: compass?.category ?? null,
+        life_compass_goal: compass?.primary_goal ?? null,
+        top_goal_category: goals[0]?.category ?? null,
+        age_band: ageBand,
+        member_tenure: tenure,
+      },
+      text: parts.join(' '),
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_life_stage_context failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const AWARENESS_TOOL_HANDLERS: Record<string, Handler> = {
+  get_emotional_state: tool_get_emotional_state,
+  get_situational_awareness: tool_get_situational_awareness,
+  get_availability: tool_get_availability,
+  get_environmental_context: tool_get_environmental_context,
+  get_life_stage_context: tool_get_life_stage_context,
+};
+
+export const AWARENESS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'get_emotional_state',
+    description: [
+      "Read the user's current emotional and cognitive signals (D28): mood,",
+      'focus, engagement, urgency, hesitation — from analyzed conversation',
+      'signals, or recent diary moods/energy when no live signals exist.',
+      'CALL WHEN the user asks: "how am I doing?", "how do I seem to you?",',
+      '"wie wirke ich gerade?", "wie geht es mir laut meinen Daten?".',
+      'Speak the returned text as-is — it already names the data source.',
+      'Never diagnose; these are light behavioral observations only.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_situational_awareness',
+    description: [
+      "Summarize the user's current situation (D32): time-of-day window,",
+      'availability, energy, suggested conversation depth and any active',
+      'constraints, enriched with their next calendar commitment.',
+      'CALL WHEN the user asks: "what\'s my situation right now?", "is this',
+      'a good moment?", "wie sieht meine Lage gerade aus?", "passt es gerade?".',
+      'Optionally pass timezone (IANA name like Europe/Berlin) if known.',
+      'Speak the returned text; it states what the summary is based on.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        timezone: {
+          type: 'string',
+          description: "The user's IANA timezone (e.g. Europe/Berlin), only if known.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_availability',
+    description: [
+      'Check how available and ready the user is right now (D33): availability',
+      'level, time window, readiness score, calendar density for the next',
+      'hours, whether they are in an event, and reminders due soon.',
+      'CALL WHEN the user asks: "do I have time right now?", "is now a good',
+      'time?", "habe ich gerade Zeit?", "ist jetzt ein guter Zeitpunkt?",',
+      'or BEFORE proposing a long activity or deep session.',
+      'Optionally pass timezone (IANA name) if known. Speak the returned text.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        timezone: {
+          type: 'string',
+          description: "The user's IANA timezone (e.g. Europe/Berlin), only if known.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_environmental_context',
+    description: [
+      "Read the user's environment and mobility context (D34): where they",
+      'are based or traveling, how they get around, late-night/early-morning',
+      'flags and indoor/outdoor suitability — from stored location facts,',
+      'preferences and visit history. Never invents a location.',
+      'CALL WHEN the user asks: "what do you know about where I am?",',
+      '"was weißt du über meine Umgebung?", or before suggesting nearby or',
+      'outdoor activities. Speak the returned text; it names its sources.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_life_stage_context',
+    description: [
+      "Read the user's life-stage context (D40): life phase and stability,",
+      'any transition, Life Compass goal and category, age band (from their',
+      'stated birthday) and community tenure.',
+      'CALL WHEN the user asks: "where am I in life?", "what stage am I in?",',
+      '"wo stehe ich gerade im Leben?", "in welcher Lebensphase bin ich?",',
+      'or when tailoring long-term advice to their life situation.',
+      'Speak the returned text; it is non-prescriptive — the user knows',
+      'their life best. If nothing is on record, offer to set up Life Compass.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+];

--- a/services/gateway/src/services/orb-tools/calendar-management-tools.ts
+++ b/services/gateway/src/services/orb-tools/calendar-management-tools.ts
@@ -1,0 +1,767 @@
+/**
+ * Calendar management voice tools (VTID-02761).
+ *
+ * Read/write management of the user's Intelligent Calendar (`calendar_events`)
+ * beyond the existing search/create tools: reschedule, soft-cancel, mark
+ * complete, find a free slot, read one event in detail, and check a proposed
+ * window for conflicts. Write paths reuse the canonical calendar-service
+ * functions (rescheduleEvent / softDeleteEvent / markEventCompleted /
+ * checkConflicts) so business rules (original_start_time preservation,
+ * reschedule_count, status transitions) live in exactly one place.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import {
+  rescheduleEvent,
+  softDeleteEvent,
+  markEventCompleted,
+  checkConflicts,
+} from '../calendar-service';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const EVENT_FIELDS =
+  'id, title, description, location, start_time, end_time, event_type, status, ' +
+  'completion_status, completed_at, completion_notes, reschedule_count, ' +
+  'original_start_time, priority_score, wellness_tags, source_type, role_context';
+
+interface CalendarEventRow {
+  id: string;
+  title: string;
+  description: string | null;
+  location: string | null;
+  start_time: string;
+  end_time: string | null;
+  event_type: string;
+  status: string;
+  completion_status: string | null;
+  completed_at: string | null;
+  completion_notes: string | null;
+  reschedule_count: number;
+  original_start_time: string | null;
+  priority_score: number;
+  wellness_tags: string[] | null;
+  source_type: string;
+  role_context: string;
+}
+
+const DEFAULT_DURATION_MS = 60 * 60 * 1000;
+const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+const WAKE_START_HOUR = 8; // 08:00 user-local
+const WAKE_END_HOUR = 22; // 22:00 user-local
+
+function strArg(args: OrbToolArgs, key: string): string {
+  const v = args[key];
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+/** timezone arg, falling back to args.user_timezone, then UTC. */
+function resolveTimezone(args: OrbToolArgs): string {
+  const tz = strArg(args, 'timezone') || strArg(args, 'user_timezone') || 'UTC';
+  try {
+    // Throws RangeError for unknown IANA names.
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return tz;
+  } catch {
+    return 'UTC';
+  }
+}
+
+function parseIso(value: string): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Speakable "Tue, Jul 7, 9:00 AM" in the user's timezone. */
+function fmtWhen(iso: string | null | undefined, tz: string): string {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleString('en-US', {
+      timeZone: tz,
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  } catch {
+    return String(iso);
+  }
+}
+
+/** Minutes to ADD to a UTC instant to get wall-clock time in tz. */
+function tzOffsetMinutes(tz: string, at: Date): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts: Record<string, string> = {};
+  for (const p of dtf.formatToParts(at)) parts[p.type] = p.value;
+  const asUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour) === 24 ? 0 : Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+  );
+  return Math.round((asUtc - at.getTime()) / 60000);
+}
+
+/** UTC instant of wall-clock (y, mo(1-12), d, h:mi) in tz. */
+function utcFromLocal(tz: string, y: number, mo: number, d: number, h: number, mi: number): number {
+  const guess = Date.UTC(y, mo - 1, d, h, mi, 0, 0);
+  const offset = tzOffsetMinutes(tz, new Date(guess));
+  return guess - offset * 60000;
+}
+
+/** Local calendar date (in tz) of a UTC instant. */
+function localDateParts(tz: string, at: Date): { y: number; mo: number; d: number } {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts: Record<string, string> = {};
+  for (const p of dtf.formatToParts(at)) parts[p.type] = p.value;
+  return { y: Number(parts.year), mo: Number(parts.month), d: Number(parts.day) };
+}
+
+type ResolveOutcome =
+  | { kind: 'found'; event: CalendarEventRow }
+  | { kind: 'ambiguous'; matches: CalendarEventRow[] }
+  | { kind: 'none' }
+  | { kind: 'error'; message: string };
+
+/**
+ * Resolve one calendar event by explicit `event_id` or fuzzy `title_query`
+ * (ilike on title, scoped to the user, cancelled excluded on title search).
+ * Prefers upcoming events; multiple plausible matches → disambiguation list.
+ */
+async function resolveEvent(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<ResolveOutcome> {
+  const eventId = strArg(args, 'event_id');
+  const titleQuery = strArg(args, 'title_query') || strArg(args, 'title');
+
+  if (eventId) {
+    const { data, error } = await sb
+      .from('calendar_events')
+      .select(EVENT_FIELDS)
+      .eq('user_id', id.user_id)
+      .eq('id', eventId)
+      .limit(1);
+    if (error) return { kind: 'error', message: error.message };
+    const row = (data as unknown as CalendarEventRow[] | null)?.[0];
+    return row ? { kind: 'found', event: row } : { kind: 'none' };
+  }
+
+  if (!titleQuery) {
+    return { kind: 'error', message: 'Provide event_id or title_query to identify the event.' };
+  }
+
+  const { data, error } = await sb
+    .from('calendar_events')
+    .select(EVENT_FIELDS)
+    .eq('user_id', id.user_id)
+    .neq('status', 'cancelled')
+    .ilike('title', `%${titleQuery}%`)
+    .order('start_time', { ascending: false })
+    .limit(20);
+  if (error) return { kind: 'error', message: error.message };
+
+  const matches = ((data as unknown as CalendarEventRow[] | null) ?? [])
+    .slice()
+    .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime());
+  if (matches.length === 0) return { kind: 'none' };
+  if (matches.length === 1) return { kind: 'found', event: matches[0] };
+
+  const nowMs = Date.now();
+  const upcoming = matches.filter(
+    (e) => new Date(e.end_time ?? e.start_time).getTime() >= nowMs,
+  );
+  if (upcoming.length === 1) return { kind: 'found', event: upcoming[0] };
+  return { kind: 'ambiguous', matches: upcoming.length > 1 ? upcoming : matches };
+}
+
+function disambiguationResult(matches: CalendarEventRow[], tz: string): OrbToolResult {
+  const listed = matches.slice(0, 5);
+  const lines = listed
+    .map((e, i) => `${i + 1}) "${e.title}" on ${fmtWhen(e.start_time, tz)}`)
+    .join('; ');
+  return {
+    ok: true,
+    result: {
+      needs_disambiguation: true,
+      matches: listed.map((e) => ({ id: e.id, title: e.title, start_time: e.start_time })),
+    },
+    text:
+      `I found ${matches.length} matching events: ${lines}. ` +
+      `Ask the user which one they mean, then call the tool again with that event_id.`,
+  };
+}
+
+function requireUser(toolName: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id?.user_id) {
+    return { ok: false, error: `${toolName} requires an authenticated user.` };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// reschedule_event
+// ---------------------------------------------------------------------------
+
+export async function tool_reschedule_event(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = requireUser('reschedule_event', id);
+  if (gate) return gate;
+  try {
+    const tz = resolveTimezone(args);
+    const newStart = parseIso(strArg(args, 'new_start'));
+    if (!newStart) {
+      return { ok: false, error: 'reschedule_event requires new_start as an ISO 8601 timestamp.' };
+    }
+
+    const resolved = await resolveEvent(args, id, sb);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return { ok: true, result: { found: false }, text: 'I could not find that event on the calendar.' };
+    }
+    if (resolved.kind === 'ambiguous') return disambiguationResult(resolved.matches, tz);
+
+    const event = resolved.event;
+    const explicitEnd = parseIso(strArg(args, 'new_end'));
+    let newEnd: Date;
+    if (explicitEnd) {
+      newEnd = explicitEnd;
+    } else {
+      // Keep the event's current duration; fall back to 60 minutes.
+      const oldStart = new Date(event.start_time).getTime();
+      const oldEnd = event.end_time ? new Date(event.end_time).getTime() : NaN;
+      const durationMs =
+        Number.isFinite(oldEnd) && oldEnd > oldStart ? oldEnd - oldStart : DEFAULT_DURATION_MS;
+      newEnd = new Date(newStart.getTime() + durationMs);
+    }
+    if (newEnd.getTime() <= newStart.getTime()) {
+      return { ok: false, error: 'new_end must be after new_start.' };
+    }
+
+    const updated = await rescheduleEvent(
+      event.id,
+      id.user_id,
+      newStart.toISOString(),
+      newEnd.toISOString(),
+    );
+    if (!updated) {
+      return { ok: false, error: 'Failed to reschedule the event. Please try again.' };
+    }
+    return {
+      ok: true,
+      result: {
+        event_id: event.id,
+        title: event.title,
+        old_start: event.start_time,
+        new_start: newStart.toISOString(),
+        new_end: newEnd.toISOString(),
+      },
+      text: `Done — I moved "${event.title}" from ${fmtWhen(event.start_time, tz)} to ${fmtWhen(newStart.toISOString(), tz)}.`,
+    };
+  } catch (err) {
+    return { ok: false, error: `reschedule_event failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// cancel_event
+// ---------------------------------------------------------------------------
+
+export async function tool_cancel_event(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = requireUser('cancel_event', id);
+  if (gate) return gate;
+  try {
+    const tz = resolveTimezone(args);
+    const resolved = await resolveEvent(args, id, sb);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return { ok: true, result: { found: false }, text: 'I could not find that event on the calendar.' };
+    }
+    if (resolved.kind === 'ambiguous') return disambiguationResult(resolved.matches, tz);
+
+    const event = resolved.event;
+    if (event.status === 'cancelled') {
+      return {
+        ok: true,
+        result: { event_id: event.id, already_cancelled: true },
+        text: `"${event.title}" is already cancelled.`,
+      };
+    }
+
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: {
+          needs_confirmation: true,
+          event_id: event.id,
+          title: event.title,
+          start_time: event.start_time,
+        },
+        text:
+          `Found "${event.title}" on ${fmtWhen(event.start_time, tz)}. ` +
+          `Ask the user to confirm the cancellation, then call cancel_event again with confirm=true and event_id=${event.id}.`,
+      };
+    }
+
+    const cancelled = await softDeleteEvent(event.id, id.user_id);
+    if (!cancelled) {
+      return { ok: false, error: 'Failed to cancel the event. Please try again.' };
+    }
+    return {
+      ok: true,
+      result: { event_id: event.id, title: event.title, status: 'cancelled' },
+      text: `Cancelled — "${event.title}" on ${fmtWhen(event.start_time, tz)} is off the calendar.`,
+    };
+  } catch (err) {
+    return { ok: false, error: `cancel_event failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// complete_event
+// ---------------------------------------------------------------------------
+
+const VALID_OUTCOMES = ['completed', 'skipped', 'partial'] as const;
+
+export async function tool_complete_event(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = requireUser('complete_event', id);
+  if (gate) return gate;
+  try {
+    const tz = resolveTimezone(args);
+    const outcome = (strArg(args, 'outcome') || 'completed') as (typeof VALID_OUTCOMES)[number];
+    if (!VALID_OUTCOMES.includes(outcome)) {
+      return {
+        ok: false,
+        error: `Invalid outcome "${outcome}". Use one of: ${VALID_OUTCOMES.join(', ')}.`,
+      };
+    }
+
+    const resolved = await resolveEvent(args, id, sb);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return { ok: true, result: { found: false }, text: 'I could not find that event on the calendar.' };
+    }
+    if (resolved.kind === 'ambiguous') return disambiguationResult(resolved.matches, tz);
+
+    const event = resolved.event;
+    const notes = strArg(args, 'notes') || null;
+    const updated = await markEventCompleted(event.id, id.user_id, outcome, notes);
+    if (!updated) {
+      return { ok: false, error: 'Failed to update the event. Please try again.' };
+    }
+
+    const spokenOutcome =
+      outcome === 'completed'
+        ? 'marked as completed'
+        : outcome === 'skipped'
+          ? 'marked as skipped'
+          : 'marked as partially done';
+    return {
+      ok: true,
+      result: { event_id: event.id, title: event.title, completion_status: outcome },
+      text: `Nice — "${event.title}" (${fmtWhen(event.start_time, tz)}) is ${spokenOutcome}.`,
+    };
+  } catch (err) {
+    return { ok: false, error: `complete_event failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// find_free_slot
+// ---------------------------------------------------------------------------
+
+export async function tool_find_free_slot(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = requireUser('find_free_slot', id);
+  if (gate) return gate;
+  try {
+    const duration = Math.round(Number(args.duration_minutes));
+    if (!Number.isFinite(duration) || duration < 5 || duration > 720) {
+      return {
+        ok: false,
+        error: 'find_free_slot requires duration_minutes between 5 and 720.',
+      };
+    }
+    const durationMs = duration * 60000;
+    const tz = resolveTimezone(args);
+
+    const now = new Date();
+    const from = parseIso(strArg(args, 'search_from')) ?? now;
+    const defaultTo = new Date(from.getTime() + 7 * 86400000);
+    let to = parseIso(strArg(args, 'search_to')) ?? defaultTo;
+    const maxTo = new Date(from.getTime() + 30 * 86400000);
+    if (to.getTime() > maxTo.getTime()) to = maxTo;
+    if (to.getTime() <= from.getTime()) {
+      return { ok: false, error: 'search_to must be after search_from.' };
+    }
+
+    // Busy intervals: non-cancelled events overlapping the window.
+    const { data, error } = await sb
+      .from('calendar_events')
+      .select('id, title, start_time, end_time, status')
+      .eq('user_id', id.user_id)
+      .neq('status', 'cancelled')
+      .lt('start_time', to.toISOString())
+      .gt('end_time', from.toISOString())
+      .order('start_time', { ascending: true })
+      .limit(500);
+    if (error) return { ok: false, error: `find_free_slot failed: ${error.message}` };
+
+    const busy = ((data as Array<{ start_time: string; end_time: string | null }> | null) ?? [])
+      .filter((e) => e.end_time)
+      .map((e) => ({
+        start: new Date(e.start_time).getTime(),
+        end: new Date(e.end_time as string).getTime(),
+      }))
+      .sort((a, b) => a.start - b.start);
+    // Merge overlapping busy intervals.
+    const merged: Array<{ start: number; end: number }> = [];
+    for (const b of busy) {
+      const last = merged[merged.length - 1];
+      if (last && b.start <= last.end) last.end = Math.max(last.end, b.end);
+      else merged.push({ ...b });
+    }
+
+    const roundUp15 = (ms: number) => Math.ceil(ms / FIFTEEN_MIN_MS) * FIFTEEN_MIN_MS;
+    const earliestMs = Math.max(from.getTime(), now.getTime());
+
+    let slotStartMs: number | null = null;
+    const totalDays = Math.ceil((to.getTime() - from.getTime()) / 86400000) + 1;
+    for (let day = 0; day < totalDays && slotStartMs === null; day++) {
+      const probe = new Date(from.getTime() + day * 86400000);
+      const { y, mo, d } = localDateParts(tz, probe);
+      const windowStart = utcFromLocal(tz, y, mo, d, WAKE_START_HOUR, 0);
+      const windowEnd = utcFromLocal(tz, y, mo, d, WAKE_END_HOUR, 0);
+      const effEnd = Math.min(windowEnd, to.getTime());
+      let cursor = roundUp15(Math.max(windowStart, earliestMs));
+
+      for (const b of merged) {
+        if (b.end <= cursor) continue;
+        if (b.start >= effEnd) break;
+        if (b.start - cursor >= durationMs) break; // gap before this busy block fits
+        cursor = roundUp15(Math.max(cursor, b.end));
+      }
+      if (cursor + durationMs <= effEnd) slotStartMs = cursor;
+    }
+
+    if (slotStartMs === null) {
+      return {
+        ok: true,
+        result: { slot_found: false, duration_minutes: duration },
+        text:
+          `I couldn't find a free ${duration}-minute slot between ` +
+          `${fmtWhen(from.toISOString(), tz)} and ${fmtWhen(to.toISOString(), tz)} ` +
+          `within waking hours (8 AM to 10 PM). Want me to look further out?`,
+      };
+    }
+
+    const slotStartIso = new Date(slotStartMs).toISOString();
+    const slotEndIso = new Date(slotStartMs + durationMs).toISOString();
+    return {
+      ok: true,
+      result: {
+        slot_found: true,
+        slot_start: slotStartIso,
+        slot_end: slotEndIso,
+        duration_minutes: duration,
+        timezone: tz,
+      },
+      text: `You're free for ${duration} minutes on ${fmtWhen(slotStartIso, tz)} (until ${fmtWhen(slotEndIso, tz)}).`,
+    };
+  } catch (err) {
+    return { ok: false, error: `find_free_slot failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_event_details
+// ---------------------------------------------------------------------------
+
+export async function tool_get_event_details(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = requireUser('get_event_details', id);
+  if (gate) return gate;
+  try {
+    const tz = resolveTimezone(args);
+    const resolved = await resolveEvent(args, id, sb);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { found: false },
+        text: 'I could not find a matching event on the calendar.',
+      };
+    }
+    if (resolved.kind === 'ambiguous') return disambiguationResult(resolved.matches, tz);
+
+    const e = resolved.event;
+    const bits: string[] = [`"${e.title}" is on ${fmtWhen(e.start_time, tz)}`];
+    if (e.end_time) bits.push(`until ${fmtWhen(e.end_time, tz)}`);
+    if (e.location) bits.push(`at ${e.location}`);
+    bits.push(`(${e.event_type}, status ${e.status}`);
+    let tail = ')';
+    if (e.completion_status) tail = `, ${e.completion_status})`;
+    const desc = e.description ? ` Notes: ${String(e.description).slice(0, 200)}` : '';
+    return {
+      ok: true,
+      result: { found: true, event: e },
+      text: `${bits.join(' ')}${tail}.${desc}`,
+    };
+  } catch (err) {
+    return { ok: false, error: `get_event_details failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// check_calendar_conflicts
+// ---------------------------------------------------------------------------
+
+export async function tool_check_calendar_conflicts(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = requireUser('check_calendar_conflicts', id);
+  if (gate) return gate;
+  try {
+    const tz = resolveTimezone(args);
+    const start = parseIso(strArg(args, 'start_time') || strArg(args, 'proposed_start'));
+    if (!start) {
+      return {
+        ok: false,
+        error: 'check_calendar_conflicts requires start_time as an ISO 8601 timestamp.',
+      };
+    }
+    const end =
+      parseIso(strArg(args, 'end_time') || strArg(args, 'proposed_end')) ??
+      new Date(start.getTime() + DEFAULT_DURATION_MS);
+    if (end.getTime() <= start.getTime()) {
+      return { ok: false, error: 'end_time must be after start_time.' };
+    }
+
+    const conflicts = await checkConflicts(
+      id.user_id,
+      id.role ?? 'community',
+      start.toISOString(),
+      end.toISOString(),
+    );
+
+    if (conflicts.length === 0) {
+      return {
+        ok: true,
+        result: { has_conflicts: false, conflicts: [] },
+        text: `That window (${fmtWhen(start.toISOString(), tz)} to ${fmtWhen(end.toISOString(), tz)}) is free — no conflicts.`,
+      };
+    }
+
+    const lines = conflicts
+      .slice(0, 5)
+      .map((c) => `"${c.title}" at ${fmtWhen(c.start_time, tz)}`)
+      .join('; ');
+    return {
+      ok: true,
+      result: {
+        has_conflicts: true,
+        conflicts: conflicts.map((c) => ({
+          id: c.id,
+          title: c.title,
+          start_time: c.start_time,
+          end_time: c.end_time,
+        })),
+      },
+      text: `That overlaps with ${conflicts.length} event${conflicts.length === 1 ? '' : 's'}: ${lines}. Want a different time?`,
+    };
+  } catch (err) {
+    return { ok: false, error: `check_calendar_conflicts failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const CALENDAR_MGMT_TOOL_HANDLERS: Record<string, Handler> = {
+  reschedule_event: tool_reschedule_event,
+  cancel_event: tool_cancel_event,
+  complete_event: tool_complete_event,
+  find_free_slot: tool_find_free_slot,
+  get_event_details: tool_get_event_details,
+  check_calendar_conflicts: tool_check_calendar_conflicts,
+};
+
+export const CALENDAR_MGMT_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'reschedule_event',
+    description: [
+      'Move an existing calendar event to a new start time (duration is kept unless new_end is given).',
+      'WHEN TO CALL: "move my yoga to 6 pm", "reschedule my doctor appointment to Friday",',
+      '"Verschieb mein Meeting auf morgen 10 Uhr", "Kannst du das Training auf Freitag legen?".',
+      'Identify the event by event_id (preferred) or title_query (fuzzy title match).',
+      'If multiple events match, the result lists candidates — ask the user which one, then call again with event_id.',
+      'After success, confirm the new day and time back to the user.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        event_id: { type: 'string', description: 'Exact calendar event id (UUID), if known.' },
+        title_query: {
+          type: 'string',
+          description: 'Fuzzy title to find the event, e.g. "yoga" or "dentist". Use when event_id is unknown.',
+        },
+        new_start: { type: 'string', description: 'New start time, ISO 8601 (e.g. "2026-07-10T18:00:00Z").' },
+        new_end: {
+          type: 'string',
+          description: 'Optional new end time, ISO 8601. Omit to keep the original duration.',
+        },
+        timezone: { type: 'string', description: 'IANA timezone for spoken times, e.g. "Europe/Berlin".' },
+      },
+      required: ['new_start'],
+    },
+  },
+  {
+    name: 'cancel_event',
+    description: [
+      'Cancel (soft-delete) a calendar event — the event stays in history with status "cancelled".',
+      'WHEN TO CALL: "cancel my yoga class", "delete the dentist appointment",',
+      '"Sag das Meeting morgen ab", "Lösch den Termin am Freitag".',
+      'Destructive: first call WITHOUT confirm to fetch the event, ask the user to confirm,',
+      'then call again with confirm=true and the event_id. Speak the cancelled title back.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        event_id: { type: 'string', description: 'Exact calendar event id (UUID), if known.' },
+        title_query: { type: 'string', description: 'Fuzzy title to find the event when event_id is unknown.' },
+        confirm: {
+          type: 'boolean',
+          description: 'Set true ONLY after the user has verbally confirmed the cancellation.',
+        },
+        timezone: { type: 'string', description: 'IANA timezone for spoken times.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'complete_event',
+    description: [
+      'Mark a calendar event as completed, skipped, or partially done.',
+      'WHEN TO CALL: "I finished my workout", "mark the meditation as done", "I skipped my run today",',
+      '"Ich habe das Training gemacht", "Hab die Meditation ausgelassen".',
+      'outcome must be one of: completed, skipped, partial (default completed).',
+      'After success, acknowledge briefly — completed health events feed the Vitana Index.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        event_id: { type: 'string', description: 'Exact calendar event id (UUID), if known.' },
+        title_query: { type: 'string', description: 'Fuzzy title to find the event when event_id is unknown.' },
+        outcome: { type: 'string', description: 'One of: completed, skipped, partial. Defaults to completed.' },
+        notes: { type: 'string', description: 'Optional short completion note from the user.' },
+        timezone: { type: 'string', description: 'IANA timezone for spoken times.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'find_free_slot',
+    description: [
+      'Find the next free slot of a given length in the user\'s calendar, within waking hours (8 AM-10 PM user-local).',
+      'WHEN TO CALL: "when am I free for an hour?", "find me 30 minutes tomorrow",',
+      '"Wann habe ich morgen Zeit?", "Finde mir eine freie Stunde diese Woche".',
+      'duration_minutes is required (5-720). search_from/search_to are ISO 8601; default is the next 7 days.',
+      'Pass the user\'s IANA timezone so waking hours and spoken times are local.',
+      'Speak the found day + time back, or say nothing was free and offer to look further out.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        duration_minutes: { type: 'number', description: 'Required slot length in minutes (5 to 720).' },
+        search_from: { type: 'string', description: 'Optional ISO 8601 start of the search window. Defaults to now.' },
+        search_to: {
+          type: 'string',
+          description: 'Optional ISO 8601 end of the search window. Defaults to 7 days after search_from (max 30).',
+        },
+        timezone: { type: 'string', description: 'IANA timezone, e.g. "Europe/Berlin". Defaults to UTC.' },
+      },
+      required: ['duration_minutes'],
+    },
+  },
+  {
+    name: 'get_event_details',
+    description: [
+      'Read the full details of ONE calendar event: exact time, end, location, type, status, notes.',
+      'WHEN TO CALL: "when exactly is my dentist appointment?", "where is the meetup?",',
+      '"Wann genau ist mein Zahnarzttermin?", "Wo findet das Treffen statt?".',
+      'Identify by event_id or title_query (fuzzy). If several match, the result lists candidates — ask which one.',
+      'Speak the concrete details (day, time, place); never a raw data dump.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        event_id: { type: 'string', description: 'Exact calendar event id (UUID), if known.' },
+        title_query: { type: 'string', description: 'Fuzzy title to find the event when event_id is unknown.' },
+        timezone: { type: 'string', description: 'IANA timezone for spoken times.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'check_calendar_conflicts',
+    description: [
+      'Check whether a proposed time window overlaps existing confirmed calendar events.',
+      'WHEN TO CALL: before creating or rescheduling an event, or when the user asks',
+      '"does 3 pm work on Friday?", "Passt Dienstag 10 Uhr?", "Habe ich da schon etwas?".',
+      'start_time is required (ISO 8601); end_time defaults to one hour after start_time.',
+      'If there are conflicts, name the overlapping events and suggest checking another time.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        start_time: { type: 'string', description: 'Proposed start, ISO 8601 (e.g. "2026-07-10T15:00:00Z").' },
+        end_time: { type: 'string', description: 'Proposed end, ISO 8601. Defaults to 1 hour after start_time.' },
+        timezone: { type: 'string', description: 'IANA timezone for spoken times.' },
+      },
+      required: ['start_time'],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/chat-privacy-tools.ts
+++ b/services/gateway/src/services/orb-tools/chat-privacy-tools.ts
@@ -1,0 +1,967 @@
+/**
+ * Chat management (VTID-02771) + Privacy (VTID-02776) voice tools.
+ *
+ * Chat tools operate on the canonical peer-to-peer DM store: `chat_messages`
+ * (tenant_id, sender_id, receiver_id, content, read_at, created_at, group_id
+ * — see supabase/migrations/20260225200000_chat_messages.sql and
+ * 20260525000000_VTID_03089_chat_groups.sql). There is NO conversations
+ * table for DMs — a "conversation" is the set of messages between two users,
+ * and the only per-participant state is `read_at` on received rows. Muting /
+ * archiving a chat thread has no backing column anywhere in the schema, so
+ * those two tools return an honest "not supported yet" answer instead of
+ * inventing columns.
+ *
+ * Privacy tools operate on `profiles.account_visibility` (per-field jsonb
+ * tier map, private | connections | public — vitana-v1 migration
+ * 20260421000000_add_account_profile_fields.sql, server mirror in
+ * src/lib/account-visibility.ts) and on `user_blocked_authors`
+ * (vitana-v1 migration 20260622130000_vtid_03319_phase2_feed_safety.sql;
+ * already read by the gateway's social-memory exclusion filters).
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { FIELD_DEFAULTS, HARDCODED_KEYS, type FieldVisibility } from '../../lib/account-visibility';
+import { runRecentConversations } from '../social-memory/social-read-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+interface ResolvedMember {
+  user_id: string;
+  display_name: string | null;
+  vitana_id: string | null;
+}
+
+function memberDisplay(m: ResolvedMember): string {
+  return m.display_name || m.vitana_id || 'that member';
+}
+
+/** First non-empty string among the given arg keys. */
+function argString(args: OrbToolArgs, ...keys: string[]): string {
+  for (const k of keys) {
+    const v = args[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return '';
+}
+
+/**
+ * Tenant backfill — voice sessions sometimes carry a null tenant_id even when
+ * app_users has one (same recovery tool_send_chat_message does; the
+ * chat_messages table is tenant-scoped so we cannot query without it).
+ */
+async function resolveTenantId(
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<string | null> {
+  if (id.tenant_id) return id.tenant_id;
+  const { data } = await sb
+    .from('app_users')
+    .select('tenant_id')
+    .eq('user_id', id.user_id)
+    .maybeSingle();
+  return (data as { tenant_id?: string } | null)?.tenant_id ?? null;
+}
+
+/**
+ * Resolve a spoken name / Vitana ID / UUID to a single confident member.
+ * Uses the same canonical RPC as tool_resolve_recipient
+ * (resolve_recipient_candidates) with the same 0.85 confidence / ambiguity
+ * thresholds, so "who the user means" is identical across surfaces.
+ */
+async function resolveMember(
+  raw: string,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<{ ok: true; member: ResolvedMember } | { ok: false; error: string }> {
+  const token = raw.trim();
+  if (!token) {
+    return { ok: false, error: 'Who do you mean? Please say their name or Vitana ID.' };
+  }
+
+  if (UUID_RE.test(token)) {
+    const { data, error } = await sb
+      .from('app_users')
+      .select('user_id, display_name, vitana_id')
+      .eq('user_id', token)
+      .maybeSingle();
+    if (error) {
+      return { ok: false, error: 'I had a problem looking that member up — want me to try again?' };
+    }
+    if (!data) {
+      return { ok: false, error: "I couldn't find that member — they may have left the community." };
+    }
+    return { ok: true, member: data as ResolvedMember };
+  }
+
+  const { data, error } = await sb.rpc('resolve_recipient_candidates', {
+    p_actor: id.user_id,
+    p_token: token,
+    p_limit: 5,
+    p_global: true,
+  });
+  if (error) {
+    return { ok: false, error: `I had a problem looking up ${token} — want me to try again?` };
+  }
+  const candidates = (data || []) as Array<{
+    user_id: string;
+    vitana_id: string | null;
+    display_name: string | null;
+    score: number;
+  }>;
+  if (candidates.length === 0) {
+    return { ok: false, error: `I couldn't find anyone named "${token}" in the community.` };
+  }
+  const topScore = Number(candidates[0].score);
+  const secondScore = candidates[1] ? Number(candidates[1].score) : 0;
+  const ambiguous =
+    topScore < 0.85 || secondScore / Math.max(topScore, 0.0001) > 0.85;
+  if (ambiguous) {
+    const names = candidates
+      .slice(0, 3)
+      .map((c) => c.display_name || c.vitana_id || c.user_id)
+      .join(', ');
+    return {
+      ok: false,
+      error: `I found several possible matches for "${token}": ${names}. Which one did you mean?`,
+    };
+  }
+  const top = candidates[0];
+  return {
+    ok: true,
+    member: {
+      user_id: top.user_id,
+      display_name: top.display_name ?? null,
+      vitana_id: top.vitana_id ?? null,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Chat tools (VTID-02771)
+// ---------------------------------------------------------------------------
+
+/**
+ * start_conversation — start (or reuse) a DM with a named member and
+ * optionally send a first message.
+ *
+ * With a message: delegates to the hardened tool_send_chat_message path
+ * (label re-resolution, receiver verification, quota, push notify) via a
+ * runtime import of orb-tools-shared — dynamic so the parent's value-import
+ * of this module doesn't create a load-time require cycle.
+ * Without a message: resolves the member and reports whether a conversation
+ * already exists, handing the model the recipient_user_id for the send turn.
+ */
+export const tool_start_conversation: Handler = async (args, id, sb) => {
+  if (!id.user_id) {
+    return { ok: false, error: 'start_conversation requires an authenticated user.' };
+  }
+  try {
+    const memberArg = argString(
+      args,
+      'member',
+      'member_name',
+      'name',
+      'spoken_name',
+      'recipient_label',
+    );
+    const memberIdArg = argString(args, 'member_user_id', 'recipient_user_id');
+    const message = argString(args, 'message', 'first_message', 'body');
+
+    if (message) {
+      // Reuse the full hardened send path (resolution, validation, quota,
+      // notification). It accepts either a UUID or a spoken label.
+      const shared = await import('../orb-tools-shared');
+      return shared.tool_send_chat_message(
+        {
+          recipient_user_id: memberIdArg || undefined,
+          recipient_label: memberArg || undefined,
+          body: message,
+        },
+        id,
+        sb,
+      );
+    }
+
+    const resolved = await resolveMember(memberIdArg || memberArg, id, sb);
+    if (!resolved.ok) return resolved;
+    const member = resolved.member;
+    if (member.user_id === id.user_id) {
+      return { ok: false, error: "You can't start a conversation with yourself." };
+    }
+
+    const tenantId = await resolveTenantId(id, sb);
+    if (!tenantId) {
+      return {
+        ok: false,
+        error: "I can't open a conversation right now — I'm missing some account context. Try once more in a moment.",
+      };
+    }
+
+    const { data: lastRows, error: lastErr } = await sb
+      .from('chat_messages')
+      .select('id, content, created_at')
+      .eq('tenant_id', tenantId)
+      .or(
+        `and(sender_id.eq.${id.user_id},receiver_id.eq.${member.user_id}),and(sender_id.eq.${member.user_id},receiver_id.eq.${id.user_id})`,
+      )
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (lastErr) {
+      return { ok: false, error: 'I had a problem checking your chats — want me to try again?' };
+    }
+    const existing = (lastRows || [])[0] as { created_at?: string } | undefined;
+    const name = memberDisplay(member);
+    const text = existing
+      ? `You already have a conversation with ${name} (last message ${new Date(existing.created_at ?? '').toDateString()}). What would you like to say? I'll send it with send_chat_message.`
+      : `${name} is in the community and ready to chat — no conversation yet. What should the first message say? I'll send it with send_chat_message.`;
+    return {
+      ok: true,
+      result: {
+        recipient_user_id: member.user_id,
+        recipient_vitana_id: member.vitana_id,
+        recipient_display_name: member.display_name,
+        existing_conversation: Boolean(existing),
+      },
+      text,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'start_conversation error';
+    return { ok: false, error: `I hit a snag starting that conversation (${msg}).` };
+  }
+};
+
+/**
+ * list_conversations — recent DM conversations with last-message snippets.
+ * Thin wrapper over the canonical runRecentConversations (blocked-user
+ * exclusion, fail-closed privacy, speakable output) with tenant backfill.
+ */
+export const tool_list_conversations: Handler = async (args, id, sb) => {
+  if (!id.user_id) {
+    return { ok: false, error: 'list_conversations requires an authenticated user.' };
+  }
+  try {
+    const tenantId = await resolveTenantId(id, sb);
+    if (!tenantId) {
+      return {
+        ok: false,
+        error: "I can't read your conversations right now — I'm missing some account context. Try once more in a moment.",
+      };
+    }
+    return await runRecentConversations(
+      { limit: args.limit },
+      { user_id: id.user_id, tenant_id: tenantId },
+    );
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'list_conversations error';
+    return { ok: false, error: `I couldn't read your conversations just now (${msg}).` };
+  }
+};
+
+/**
+ * mark_conversation_read — set read_at on unread DMs. Per-participant read
+ * state lives on the chat_messages rows themselves (read_at, receiver-only —
+ * same mutation as the frontend's POST /api/v1/chat/read and /read-all).
+ * With a member: marks that thread. Without (or all=true): marks everything.
+ */
+export const tool_mark_conversation_read: Handler = async (args, id, sb) => {
+  if (!id.user_id) {
+    return { ok: false, error: 'mark_conversation_read requires an authenticated user.' };
+  }
+  try {
+    const tenantId = await resolveTenantId(id, sb);
+    if (!tenantId) {
+      return {
+        ok: false,
+        error: "I can't update your messages right now — I'm missing some account context. Try once more in a moment.",
+      };
+    }
+    const memberArg = argString(args, 'member', 'member_name', 'name', 'peer');
+    const memberIdArg = argString(args, 'member_user_id', 'peer_id');
+    const markAll = args.all === true || (!memberArg && !memberIdArg);
+
+    if (markAll) {
+      const { error, count } = await sb
+        .from('chat_messages')
+        .update({ read_at: new Date().toISOString() }, { count: 'exact' })
+        .eq('tenant_id', tenantId)
+        .eq('receiver_id', id.user_id)
+        .is('read_at', null);
+      if (error) {
+        return { ok: false, error: "I couldn't mark your messages read just now — want me to try again?" };
+      }
+      const n = count ?? 0;
+      return {
+        ok: true,
+        result: { scope: 'all', updated: n },
+        text: n > 0 ? `Done — marked ${n} unread message(s) as read.` : 'You had no unread messages — nothing to mark.',
+      };
+    }
+
+    const resolved = await resolveMember(memberIdArg || memberArg, id, sb);
+    if (!resolved.ok) return resolved;
+    const member = resolved.member;
+    const { error, count } = await sb
+      .from('chat_messages')
+      .update({ read_at: new Date().toISOString() }, { count: 'exact' })
+      .eq('tenant_id', tenantId)
+      .eq('sender_id', member.user_id)
+      .eq('receiver_id', id.user_id)
+      .is('read_at', null);
+    if (error) {
+      return { ok: false, error: "I couldn't mark that conversation read just now — want me to try again?" };
+    }
+    const n = count ?? 0;
+    const name = memberDisplay(member);
+    return {
+      ok: true,
+      result: { scope: 'peer', peer_user_id: member.user_id, updated: n },
+      text:
+        n > 0
+          ? `Done — marked ${n} message(s) from ${name} as read.`
+          : `Nothing was unread from ${name} — the conversation is already up to date.`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'mark_conversation_read error';
+    return { ok: false, error: `I hit a snag updating that (${msg}).` };
+  }
+};
+
+/**
+ * mute_conversation — graceful "not supported". Verified against the schema:
+ * chat_messages / chat_groups / chat_group_members carry no per-participant
+ * mute flag (migrations 20260225200000, 20260525000000). user_muted_authors
+ * exists but is a FEED-safety control (hides an author's posts), not a chat
+ * mute — repurposing it would silently hide their community posts too.
+ */
+export const tool_mute_conversation: Handler = async (args, _id, _sb) => {
+  const who = argString(args, 'member', 'member_name', 'name');
+  return {
+    ok: true,
+    result: { supported: false },
+    text:
+      `Muting individual chat conversations isn't supported in Vitana yet — chats have no mute setting. ` +
+      `If ${who || 'someone'} is bothering you, I can block them entirely (block_user) so their posts and messages stop reaching you. Offer that; do not pretend the chat was muted.`,
+  };
+};
+
+/**
+ * archive_conversation — graceful "not supported". No archived flag exists
+ * anywhere in the chat schema, and the messaging read tools explicitly forbid
+ * offering "archived" messages (see social-read-tools MESSAGES_RULES).
+ */
+export const tool_archive_conversation: Handler = async (_args, _id, _sb) => {
+  return {
+    ok: true,
+    result: { supported: false },
+    text:
+      'Archiving chat conversations isn\'t supported in Vitana yet — there is no "archived" state for chats. ' +
+      'Say so plainly. The user can mark a conversation read (mark_conversation_read) or block a member (block_user) instead. Never claim messages were archived.',
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Privacy tools (VTID-02776)
+// ---------------------------------------------------------------------------
+
+/** Spoken tier → canonical account_visibility tier. */
+function normalizeVisibility(raw: string): FieldVisibility | null {
+  const v = raw.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  if (v === 'public' || v === 'everyone') return 'public';
+  if (v === 'followers_only' || v === 'followers' || v === 'connections' || v === 'connections_only') {
+    return 'connections';
+  }
+  if (v === 'private' || v === 'only_me' || v === 'nobody' || v === 'hidden') return 'private';
+  return null;
+}
+
+const TIER_SPOKEN: Record<FieldVisibility, string> = {
+  public: 'visible to everyone',
+  connections: 'visible to your connections only',
+  private: 'private (only you)',
+};
+
+/**
+ * Read-merge-write helper for profiles.account_visibility (jsonb tier map,
+ * keyed by user_id — same column the Privacy & Visibility settings screen
+ * writes; server mirror of FIELD_DEFAULTS lives in lib/account-visibility.ts).
+ */
+async function writeVisibilityMap(
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+  mutate: (current: Record<string, FieldVisibility>) => Record<string, FieldVisibility>,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const { data, error } = await sb
+    .from('profiles')
+    .select('account_visibility')
+    .eq('user_id', id.user_id)
+    .maybeSingle();
+  if (error) {
+    return { ok: false, error: "I couldn't read your privacy settings just now — want me to try again?" };
+  }
+  if (!data) {
+    return { ok: false, error: "I couldn't find your profile — try again in a moment." };
+  }
+  const current = ((data as { account_visibility?: Record<string, FieldVisibility> })
+    .account_visibility ?? {}) as Record<string, FieldVisibility>;
+  const next = mutate({ ...current });
+  const { error: updErr } = await sb
+    .from('profiles')
+    .update({ account_visibility: next })
+    .eq('user_id', id.user_id);
+  if (updErr) {
+    return { ok: false, error: "I couldn't save your privacy settings just now — want me to try again?" };
+  }
+  return { ok: true };
+}
+
+/**
+ * update_account_visibility — set the WHOLE profile to one tier by writing
+ * every user-toggleable FIELD_DEFAULTS key into account_visibility (there is
+ * no single global visibility column; the per-field jsonb map is the real
+ * mechanism). followers_only maps to the schema's 'connections' tier.
+ * Confirm-gated: changing all fields at once is a big switch.
+ */
+export const tool_update_account_visibility: Handler = async (args, id, sb) => {
+  if (!id.user_id) {
+    return { ok: false, error: 'update_account_visibility requires an authenticated user.' };
+  }
+  try {
+    const tier = normalizeVisibility(argString(args, 'visibility', 'level'));
+    if (!tier) {
+      return {
+        ok: false,
+        error: 'Which visibility do you want: public, followers only, or private?',
+      };
+    }
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { requires_confirmation: true, visibility: tier },
+        text:
+          `This will make EVERY profile field ${TIER_SPOKEN[tier]} — name, age, location, contact details, preferences. ` +
+          `Confirm with the user, then call update_account_visibility again with confirm=true.`,
+      };
+    }
+    const written = await writeVisibilityMap(id, sb, (map) => {
+      for (const key of Object.keys(FIELD_DEFAULTS)) {
+        if (!HARDCODED_KEYS.has(key)) map[key] = tier;
+      }
+      return map;
+    });
+    if (!written.ok) return written;
+    return {
+      ok: true,
+      result: { visibility: tier },
+      text: `Done — your profile is now ${TIER_SPOKEN[tier]}. Partner-search posts stay private regardless (safety rule).`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'update_account_visibility error';
+    return { ok: false, error: `I hit a snag changing that (${msg}).` };
+  }
+};
+
+/**
+ * Spoken field name → canonical account_visibility key (EN + DE aliases).
+ * Keys must exist in FIELD_DEFAULTS — never invent a visibility key.
+ */
+const PRIVACY_FIELD_ALIASES: Record<string, string> = {
+  age: 'derivedAgeBand',
+  age_band: 'derivedAgeBand',
+  alter: 'derivedAgeBand',
+  birthday: 'dateOfBirth',
+  birthdate: 'dateOfBirth',
+  date_of_birth: 'dateOfBirth',
+  geburtstag: 'dateOfBirth',
+  geburtsdatum: 'dateOfBirth',
+  location: 'city',
+  city: 'city',
+  stadt: 'city',
+  ort: 'city',
+  country: 'country',
+  land: 'country',
+  address: 'address',
+  adresse: 'address',
+  email: 'email',
+  e_mail: 'email',
+  phone: 'phone',
+  phone_number: 'phone',
+  telefon: 'phone',
+  gender: 'gender',
+  geschlecht: 'gender',
+  marital_status: 'maritalStatus',
+  familienstand: 'maritalStatus',
+  first_name: 'firstName',
+  vorname: 'firstName',
+  last_name: 'lastName',
+  nachname: 'lastName',
+  dance: 'dancePreferences',
+  dance_preferences: 'dancePreferences',
+  tanz: 'dancePreferences',
+  partner: 'partnerPreferences',
+  partner_preferences: 'partnerPreferences',
+  services: 'serviceOfferings',
+  service_offerings: 'serviceOfferings',
+  posts: 'myPosts',
+  my_posts: 'myPosts',
+};
+
+const HEALTH_FIELD_TOKENS = new Set(['health', 'health_data', 'gesundheit', 'gesundheitsdaten']);
+
+/**
+ * update_privacy_field — set one field's visibility tier in
+ * profiles.account_visibility. Only real FIELD_DEFAULTS keys are writable;
+ * health data has no profile-visibility key because it never appears on the
+ * profile at all.
+ */
+export const tool_update_privacy_field: Handler = async (args, id, sb) => {
+  if (!id.user_id) {
+    return { ok: false, error: 'update_privacy_field requires an authenticated user.' };
+  }
+  try {
+    const rawField = argString(args, 'field', 'field_name');
+    if (!rawField) {
+      return { ok: false, error: 'Which field do you want to change — for example age, location, email, or phone?' };
+    }
+    const norm = rawField.trim().toLowerCase().replace(/[\s-]+/g, '_');
+    if (HEALTH_FIELD_TOKENS.has(norm)) {
+      return {
+        ok: true,
+        result: { field: 'health', changed: false },
+        text: 'Health data never appears on the profile — it is always private and has no visibility setting to change. Reassure the user.',
+      };
+    }
+    // Exact canonical key (e.g. "dateOfBirth") or spoken alias.
+    const key =
+      rawField in FIELD_DEFAULTS ? rawField : PRIVACY_FIELD_ALIASES[norm] ?? null;
+    if (!key || !(key in FIELD_DEFAULTS)) {
+      return {
+        ok: false,
+        error:
+          `"${rawField}" isn't a profile privacy field. You can change: age, birthday, location, country, address, email, phone, gender, name, dance preferences, partner preferences, service offerings, or posts.`,
+      };
+    }
+    if (HARDCODED_KEYS.has(key)) {
+      return {
+        ok: false,
+        error: 'That field is always private for safety and cannot be changed.',
+      };
+    }
+    const tier = normalizeVisibility(argString(args, 'visibility', 'level'));
+    if (!tier) {
+      return { ok: false, error: 'Which visibility: public, followers only, or private?' };
+    }
+    const written = await writeVisibilityMap(id, sb, (map) => {
+      map[key] = tier;
+      return map;
+    });
+    if (!written.ok) return written;
+    return {
+      ok: true,
+      result: { field: key, visibility: tier },
+      text: `Done — your ${rawField} is now ${TIER_SPOKEN[tier]}.`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'update_privacy_field error';
+    return { ok: false, error: `I hit a snag changing that (${msg}).` };
+  }
+};
+
+/**
+ * block_user — confirm-gated block via user_blocked_authors (the personal
+ * safety table the feed and the messaging read tools already exclude on).
+ */
+export const tool_block_user: Handler = async (args, id, sb) => {
+  if (!id.user_id) {
+    return { ok: false, error: 'block_user requires an authenticated user.' };
+  }
+  try {
+    const memberArg = argString(args, 'member', 'member_name', 'name', 'spoken_name');
+    const memberIdArg = argString(args, 'member_user_id', 'user_id_to_block');
+    const resolved = await resolveMember(memberIdArg || memberArg, id, sb);
+    if (!resolved.ok) return resolved;
+    const member = resolved.member;
+    if (member.user_id === id.user_id) {
+      return { ok: false, error: "You can't block yourself." };
+    }
+    const name = memberDisplay(member);
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: {
+          requires_confirmation: true,
+          member_user_id: member.user_id,
+          member_vitana_id: member.vitana_id,
+          member_display_name: member.display_name,
+        },
+        text:
+          `Found ${name}${member.vitana_id ? ` (${member.vitana_id})` : ''}. Blocking hides their posts and messages from you. ` +
+          `Confirm with the user, then call block_user again with confirm=true and member_user_id=${member.user_id}.`,
+      };
+    }
+    const { error } = await sb
+      .from('user_blocked_authors')
+      .upsert(
+        { user_id: id.user_id, author_id: member.user_id },
+        { onConflict: 'user_id,author_id' },
+      );
+    if (error) {
+      return { ok: false, error: `I couldn't block ${name} just now — want me to try again?` };
+    }
+    return {
+      ok: true,
+      result: { blocked_user_id: member.user_id, blocked_display_name: member.display_name },
+      text: `Done — ${name} is blocked. Their posts and messages won't be shown to you anymore. You can undo this anytime by asking me to unblock them.`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'block_user error';
+    return { ok: false, error: `I hit a snag blocking that member (${msg}).` };
+  }
+};
+
+/**
+ * unblock_user — remove a row from user_blocked_authors. Matches the spoken
+ * name against the user's OWN blocked list (not the whole community), so an
+ * ambiguous community name can't unblock the wrong person.
+ */
+export const tool_unblock_user: Handler = async (args, id, sb) => {
+  if (!id.user_id) {
+    return { ok: false, error: 'unblock_user requires an authenticated user.' };
+  }
+  try {
+    const memberArg = argString(args, 'member', 'member_name', 'name', 'spoken_name');
+    const memberIdArg = argString(args, 'member_user_id');
+    if (!memberArg && !memberIdArg) {
+      return { ok: false, error: 'Who would you like to unblock?' };
+    }
+
+    const { data: blockedRows, error: blockedErr } = await sb
+      .from('user_blocked_authors')
+      .select('author_id')
+      .eq('user_id', id.user_id)
+      .limit(500);
+    if (blockedErr) {
+      return { ok: false, error: "I couldn't read your blocked list just now — want me to try again?" };
+    }
+    const blockedIds = ((blockedRows || []) as Array<{ author_id: string }>).map(
+      (r) => r.author_id,
+    );
+    if (blockedIds.length === 0) {
+      return {
+        ok: true,
+        result: { unblocked: false, blocked_count: 0 },
+        text: "You haven't blocked anyone — there is nobody to unblock.",
+      };
+    }
+
+    const { data: peopleRows, error: peopleErr } = await sb
+      .from('app_users')
+      .select('user_id, display_name, vitana_id')
+      .in('user_id', blockedIds);
+    if (peopleErr) {
+      return { ok: false, error: "I couldn't read your blocked list just now — want me to try again?" };
+    }
+    const people = (peopleRows || []) as ResolvedMember[];
+
+    let matches: ResolvedMember[];
+    if (memberIdArg && UUID_RE.test(memberIdArg)) {
+      matches = blockedIds.includes(memberIdArg)
+        ? [people.find((p) => p.user_id === memberIdArg) ?? { user_id: memberIdArg, display_name: null, vitana_id: null }]
+        : [];
+    } else {
+      const tokens = memberArg.toLowerCase().split(/\s+/).filter((t) => t.length >= 2);
+      matches = people.filter((p) => {
+        const dn = (p.display_name ?? '').toLowerCase();
+        const vid = (p.vitana_id ?? '').toLowerCase();
+        return tokens.length > 0 && tokens.every((t) => dn.includes(t) || vid.includes(t));
+      });
+    }
+
+    const blockedNames = people
+      .slice(0, 6)
+      .map((p) => memberDisplay(p))
+      .join(', ');
+    if (matches.length === 0) {
+      return {
+        ok: true,
+        result: { unblocked: false, blocked_count: blockedIds.length },
+        text: `${memberArg || 'That member'} isn't on your blocked list. Currently blocked: ${blockedNames}.`,
+      };
+    }
+    if (matches.length > 1) {
+      const names = matches.slice(0, 3).map((p) => memberDisplay(p)).join(', ');
+      return {
+        ok: false,
+        error: `Several blocked members match "${memberArg}": ${names}. Which one did you mean?`,
+      };
+    }
+
+    const target = matches[0];
+    const { error: delErr } = await sb
+      .from('user_blocked_authors')
+      .delete()
+      .eq('user_id', id.user_id)
+      .eq('author_id', target.user_id);
+    if (delErr) {
+      return { ok: false, error: `I couldn't unblock ${memberDisplay(target)} just now — want me to try again?` };
+    }
+    return {
+      ok: true,
+      result: { unblocked: true, unblocked_user_id: target.user_id },
+      text: `Done — ${memberDisplay(target)} is unblocked. You'll see their posts and messages again.`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'unblock_user error';
+    return { ok: false, error: `I hit a snag unblocking that member (${msg}).` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const CHAT_PRIVACY_TOOL_HANDLERS: Record<string, Handler> = {
+  start_conversation: tool_start_conversation,
+  list_conversations: tool_list_conversations,
+  mark_conversation_read: tool_mark_conversation_read,
+  mute_conversation: tool_mute_conversation,
+  archive_conversation: tool_archive_conversation,
+  update_account_visibility: tool_update_account_visibility,
+  update_privacy_field: tool_update_privacy_field,
+  block_user: tool_block_user,
+  unblock_user: tool_unblock_user,
+};
+
+export const CHAT_PRIVACY_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'start_conversation',
+    description: [
+      'Start (or reuse) a direct-message conversation with a named community member,',
+      'optionally sending the first message in the same call.',
+      'WHEN: "start a chat with Maria", "message Alex for the first time",',
+      '"schreib Maria an", "starte eine Unterhaltung mit Alex".',
+      'Pass member (spoken name or Vitana ID) or member_user_id (UUID from resolve_recipient).',
+      'With message set, it sends immediately via the canonical send path.',
+      'Without message, it resolves the member, says whether a conversation already',
+      'exists, and returns recipient_user_id — read back the name, ask what to say,',
+      'then send with send_chat_message or call this again with message set.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        member: {
+          type: 'string',
+          description: 'Spoken name or Vitana ID of the member to chat with.',
+        },
+        member_user_id: {
+          type: 'string',
+          description: 'UUID of the member if already resolved (preferred over member).',
+        },
+        message: {
+          type: 'string',
+          description: 'Optional first message to send immediately. Only pass after the user confirmed the wording.',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'list_conversations',
+    description: [
+      'List the user\'s recent direct-message conversations, newest first, with',
+      'who wrote last and a short snippet.',
+      'WHEN: "show my conversations", "who have I been chatting with?",',
+      '"zeig meine Chats", "mit wem habe ich geschrieben?".',
+      'These are internal Maxina messages — no Google account involved.',
+      'Speak the names and snippets naturally; to continue one, use send_chat_message.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'How many conversations to return, 1-15. Uses a sensible default when omitted.',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'mark_conversation_read',
+    description: [
+      'Mark direct messages as read. With member set, marks that conversation;',
+      'without it (or with all=true), marks ALL unread messages.',
+      'WHEN: "mark my chat with Maria as read", "mark everything read",',
+      '"markiere den Chat mit Maria als gelesen", "alles als gelesen markieren".',
+      'Afterwards, confirm how many messages were marked.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        member: {
+          type: 'string',
+          description: 'Spoken name or Vitana ID of the conversation partner. Omit to mark everything.',
+        },
+        member_user_id: {
+          type: 'string',
+          description: 'UUID of the conversation partner if already resolved.',
+        },
+        all: {
+          type: 'boolean',
+          description: 'Set true to mark every unread message as read.',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'mute_conversation',
+    description: [
+      'Mute a chat conversation. NOTE: chat muting is not supported in Vitana yet —',
+      'this tool answers honestly and suggests block_user as the stronger alternative.',
+      'WHEN: "mute this chat", "mute Maria", "schalte den Chat stumm".',
+      'Relay the returned text plainly; never claim the chat was muted.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        member: {
+          type: 'string',
+          description: 'Spoken name of the conversation partner (used to word the answer).',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'archive_conversation',
+    description: [
+      'Archive a chat conversation. NOTE: chat archiving does not exist in Vitana —',
+      'this tool answers honestly. Never invent or offer "archived messages".',
+      'WHEN: "archive this chat", "archiviere den Chat mit Maria".',
+      'Relay the returned text plainly; suggest mark_conversation_read or block_user instead.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        member: {
+          type: 'string',
+          description: 'Spoken name of the conversation partner (used to word the answer).',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'update_account_visibility',
+    description: [
+      'Set the visibility of the user\'s WHOLE profile: public, followers_only, or private.',
+      'Writes every per-field visibility setting at once (partner-search posts stay private).',
+      'WHEN: "make my profile private", "set my account to public",',
+      '"mach mein Profil privat", "stell mein Konto auf öffentlich".',
+      'Two-step: first call returns a confirmation request — read it back, get an',
+      'explicit yes, then call again with confirm=true. Then confirm the change out loud.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        visibility: {
+          type: 'string',
+          description: 'One of: public, followers_only, private.',
+        },
+        confirm: {
+          type: 'boolean',
+          description: 'Pass true only after the user explicitly confirmed the change.',
+        },
+      },
+      required: ['visibility'],
+    },
+  },
+  {
+    name: 'update_privacy_field',
+    description: [
+      'Set the visibility of ONE profile field: public, followers_only, or private.',
+      'Fields: age, birthday, location (city), country, address, email, phone, gender,',
+      'first/last name, marital status, dance/partner preferences, service offerings, posts.',
+      'WHEN: "hide my age", "make my location visible to followers only",',
+      '"verstecke mein Alter", "zeig meine Stadt nur meinen Kontakten".',
+      'Health data is always private and has no setting. Confirm the change out loud after.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        field: {
+          type: 'string',
+          description: 'The field to change, e.g. "age", "location", "email", "phone", "birthday".',
+        },
+        visibility: {
+          type: 'string',
+          description: 'One of: public, followers_only, private.',
+        },
+      },
+      required: ['field', 'visibility'],
+    },
+  },
+  {
+    name: 'block_user',
+    description: [
+      'Block a community member so their posts and messages are hidden from the user.',
+      'WHEN: "block Maria", "I don\'t want to see Alex anymore",',
+      '"blockiere Maria", "ich will nichts mehr von Alex sehen".',
+      'Two-step: the first call resolves the member and returns a confirmation request —',
+      'read the name back, get an explicit yes, then call again with confirm=true and',
+      'the returned member_user_id. Afterwards, confirm the block and mention it can be undone.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        member: {
+          type: 'string',
+          description: 'Spoken name or Vitana ID of the member to block.',
+        },
+        member_user_id: {
+          type: 'string',
+          description: 'UUID of the member (from the confirmation step or resolve_recipient).',
+        },
+        confirm: {
+          type: 'boolean',
+          description: 'Pass true only after the user explicitly confirmed the block.',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'unblock_user',
+    description: [
+      'Unblock a previously blocked member so their posts and messages show again.',
+      'Matches the name against the user\'s own blocked list only.',
+      'WHEN: "unblock Maria", "entblockiere Maria", "hebe die Blockierung von Alex auf".',
+      'If the name is not on the blocked list, the tool says who currently is —',
+      'relay that plainly. Afterwards, confirm the unblock out loud.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        member: {
+          type: 'string',
+          description: 'Spoken name or Vitana ID of the member to unblock.',
+        },
+        member_user_id: {
+          type: 'string',
+          description: 'UUID of the member if known.',
+        },
+      },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/developer-tools.ts
+++ b/services/gateway/src/services/orb-tools/developer-tools.ts
@@ -1,0 +1,1034 @@
+/**
+ * Developer voice tools (VTID-02782).
+ *
+ * Voice access to the Command Hub's developer surfaces so a developer/admin
+ * can ask the ORB about platform state instead of clicking through tabs:
+ * VTID ledger (vtid_ledger), approvals queue (routes/approvals.ts), voice
+ * sessions (Voice Lab / oasis_events), daily routines (routines +
+ * routine_runs), self-healing (vtid_ledger + self_healing_log), autonomy
+ * pulse (aggregatePulse from routes/autonomy-pulse.ts) and the agent
+ * registry (agents_registry). Every handler re-checks the caller's role
+ * server-side — only developer / admin / exafy_admin may execute, mirroring
+ * the admin_role_required gate in services/admin-voice-tools.ts.
+ *
+ * Approve/reject reuse the EXACT logic behind the Command Hub buttons by
+ * calling the gateway's own /api/v1/approvals routes (the same
+ * gateway-self-call pattern routes/approvals.ts and routes/execute.ts use
+ * for autonomous-pr-merge) — no new approval state machine is invented.
+ */
+import { createHash } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// Role gate — mirror of admin-voice-tools.ts (PRIVILEGED_ROLES / deny()),
+// same error-code shape so pipelines treat it like admin_role_required.
+// ---------------------------------------------------------------------------
+
+const DEVELOPER_ROLES = new Set(['developer', 'admin', 'exafy_admin']);
+
+/** Returns a deny result when the identity may not use developer tools, else null. */
+export function developerGate(id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: 'developer tools require an authenticated user.' };
+  }
+  const role = String(id.role ?? '').toLowerCase();
+  if (!DEVELOPER_ROLES.has(role)) {
+    return { ok: false, error: 'developer_role_required' };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function clampLimit(raw: unknown, def: number, max: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return def;
+  return Math.max(1, Math.min(max, Math.round(n)));
+}
+
+/** Compact relative age for speech ("12 min ago", "3 h ago", "2 days ago"). */
+function relAge(iso: string | null | undefined): string {
+  if (!iso) return 'unknown time';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms)) return 'unknown time';
+  const min = Math.round(ms / 60_000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min} min ago`;
+  const h = Math.round(min / 60);
+  if (h < 48) return `${h} h ago`;
+  return `${Math.round(h / 24)} days ago`;
+}
+
+/**
+ * Normalize spoken VTID references. Accepts "VTID-01234", "vtid 1234",
+ * "1234" and returns candidate ledger keys (VTIDs are 4 or 5 digits, some
+ * zero-padded, e.g. VTID-0542 and VTID-01200 both exist).
+ */
+export function normalizeVtidCandidates(raw: unknown): string[] {
+  const s = String(raw ?? '').trim().toUpperCase();
+  const m = s.match(/(\d{3,5})/);
+  if (!m) return [];
+  const digits = m[1].replace(/^0+(?=\d{4})/, ''); // trim leading zeros beyond 4 digits
+  const out = new Set<string>();
+  out.add(`VTID-${m[1]}`); // exactly as spoken
+  out.add(`VTID-${digits.padStart(4, '0')}`);
+  out.add(`VTID-${digits.padStart(5, '0')}`);
+  return [...out];
+}
+
+/**
+ * Deterministic approval id — MUST match generateApprovalId() in
+ * routes/approvals.ts (appr_<vtid>_<sha256(vtid) first 6 hex>).
+ */
+export function approvalIdForVtid(vtid: string): string {
+  const hash = createHash('sha256').update(vtid).digest('hex').slice(0, 6);
+  return `appr_${vtid}_${hash}`;
+}
+
+/** Same gateway-self-call base the approvals route itself uses. */
+function gatewayBaseUrl(): string {
+  return process.env.GATEWAY_URL || `http://localhost:${process.env.PORT || 8080}`;
+}
+
+async function approvalsApi(
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<{ ok: boolean; status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`${gatewayBaseUrl()}/api/v1/approvals${path}`, {
+    method: init?.method || 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await res.json()) as Record<string, unknown>;
+  } catch {
+    /* non-JSON body — keep {} */
+  }
+  return { ok: res.ok, status: res.status, body };
+}
+
+// ---------------------------------------------------------------------------
+// dev_list_vtids — recent rows from vtid_ledger
+// ---------------------------------------------------------------------------
+
+interface VtidRow {
+  vtid: string;
+  title: string | null;
+  description: string | null;
+  status: string | null;
+  spec_status: string | null;
+  is_terminal: boolean | null;
+  terminal_outcome?: string | null;
+  claimed_by?: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export const dev_list_vtids: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 5, 20);
+  const status = String(args.status ?? '').trim().toLowerCase();
+  try {
+    let q = sb
+      .from('vtid_ledger')
+      .select('vtid, title, description, status, spec_status, is_terminal, created_at, updated_at')
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (status) q = q.eq('status', status);
+    const { data, error } = await q;
+    if (error) return { ok: false, error: error.message };
+    const rows = (data ?? []) as VtidRow[];
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { vtids: [] },
+        text: status
+          ? `No VTIDs with status "${status}" in the ledger.`
+          : 'No VTIDs found in the ledger.',
+      };
+    }
+    const lines = rows.map((r) => {
+      const title = r.title || r.description || '(untitled)';
+      return `${r.vtid} — ${title} (${r.status ?? 'unknown'}${r.spec_status ? `, spec ${r.spec_status}` : ''})`;
+    });
+    return {
+      ok: true,
+      result: { vtids: rows },
+      text: `${rows.length} recent VTIDs${status ? ` with status ${status}` : ''}: ${lines.join('. ')}`,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_list_vtids failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// dev_get_vtid_status — one VTID by (fuzzy) id
+// ---------------------------------------------------------------------------
+
+export const dev_get_vtid_status: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const candidates = normalizeVtidCandidates(args.vtid);
+  if (candidates.length === 0) {
+    return { ok: false, error: 'dev_get_vtid_status requires a VTID like "VTID-01234" or "1234".' };
+  }
+  try {
+    const { data, error } = await sb
+      .from('vtid_ledger')
+      .select(
+        'vtid, title, description, status, spec_status, is_terminal, terminal_outcome, claimed_by, created_at, updated_at',
+      )
+      .in('vtid', candidates)
+      .limit(1);
+    if (error) return { ok: false, error: error.message };
+    const row = ((data ?? []) as VtidRow[])[0];
+    if (!row) {
+      return {
+        ok: true,
+        result: { found: false, candidates },
+        text: `I could not find ${candidates[0]} in the VTID ledger.`,
+      };
+    }
+    const title = row.title || row.description || '(untitled)';
+    const parts = [
+      `${row.vtid}: ${title}.`,
+      `Status ${row.status ?? 'unknown'}, spec ${row.spec_status ?? 'unknown'}.`,
+      row.is_terminal
+        ? `Terminal with outcome ${row.terminal_outcome ?? 'unknown'}.`
+        : 'Not terminal yet.',
+      row.claimed_by ? `Claimed by ${row.claimed_by}.` : '',
+      `Created ${relAge(row.created_at)}, updated ${relAge(row.updated_at)}.`,
+    ].filter(Boolean);
+    return { ok: true, result: { found: true, vtid: row }, text: parts.join(' ') };
+  } catch (err) {
+    return { ok: false, error: `dev_get_vtid_status failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// dev_list_pending_approvals / dev_count_approvals — approvals queue
+// (same derived queue the Command Hub approvals view renders)
+// ---------------------------------------------------------------------------
+
+interface ApprovalItem {
+  approval_id: string;
+  vtid: string;
+  title: string;
+  pr_number: number | null;
+  head_branch: string | null;
+  checks_status: string;
+  governance_status: string;
+}
+
+export const dev_list_pending_approvals: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 5, 20);
+  try {
+    const { ok, status, body } = await approvalsApi(`/pending?limit=${limit}`);
+    if (!ok || body.ok !== true) {
+      return { ok: false, error: `approvals queue unavailable (${status}): ${String(body.error ?? 'unknown')}` };
+    }
+    const items = (Array.isArray(body.items) ? body.items : []) as ApprovalItem[];
+    if (items.length === 0) {
+      return { ok: true, result: { items: [] }, text: 'The approvals queue is empty — nothing is waiting for approval.' };
+    }
+    const lines = items.map((it) => {
+      const pr = it.pr_number ? `PR #${it.pr_number}` : it.head_branch ? `branch ${it.head_branch}` : 'no PR yet';
+      return `${it.vtid} "${it.title}" — ${pr}, checks ${it.checks_status}, governance ${it.governance_status}`;
+    });
+    return {
+      ok: true,
+      result: { items },
+      text: `${items.length} item${items.length === 1 ? '' : 's'} waiting for approval: ${lines.join('. ')}. Say the VTID to approve or reject one.`,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_list_pending_approvals failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+export const dev_count_approvals: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  try {
+    const { ok, status, body } = await approvalsApi('/count');
+    if (!ok || body.ok !== true) {
+      return { ok: false, error: `approvals count unavailable (${status}): ${String(body.error ?? 'unknown')}` };
+    }
+    const n = Number(body.pending_count ?? 0);
+    return {
+      ok: true,
+      result: { pending_count: n },
+      text: n === 0
+        ? 'There are no pending approvals right now.'
+        : `There ${n === 1 ? 'is 1 item' : `are ${n} items`} waiting for approval.`,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_count_approvals failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// dev_approve_pr / dev_reject_pr — confirm-gated mutations that call the
+// exact routes the Command Hub approve/reject buttons call.
+// ---------------------------------------------------------------------------
+
+async function resolveApprovalTarget(
+  args: OrbToolArgs,
+  sb: SupabaseClient,
+): Promise<{ approval_id: string; vtid: string } | { error: string }> {
+  const givenId = String(args.approval_id ?? '').trim();
+  if (givenId) {
+    const m = givenId.match(/appr_(VTID-\d{4,5})_/);
+    return { approval_id: givenId, vtid: m ? m[1] : givenId };
+  }
+  const candidates = normalizeVtidCandidates(args.vtid);
+  if (candidates.length === 0) {
+    return { error: 'Provide an approval_id or a VTID like "VTID-01234".' };
+  }
+  // Resolve the exact ledger VTID string first — the approval id is a hash
+  // of the exact vtid text, so "1234" must become the real ledger key.
+  const { data, error } = await sb
+    .from('vtid_ledger')
+    .select('vtid')
+    .in('vtid', candidates)
+    .limit(1);
+  if (error) return { error: error.message };
+  const row = ((data ?? []) as Array<{ vtid: string }>)[0];
+  if (!row) return { error: `VTID ${candidates[0]} not found in the ledger.` };
+  return { approval_id: approvalIdForVtid(row.vtid), vtid: row.vtid };
+}
+
+export const dev_approve_pr: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  try {
+    const target = await resolveApprovalTarget(args, sb);
+    if ('error' in target) return { ok: false, error: target.error };
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { requires_confirmation: true, approval_id: target.approval_id, vtid: target.vtid },
+        text: `Approving ${target.vtid} will merge its PR into main and trigger the staging deploy. Ask the developer to confirm, then call dev_approve_pr again with confirm=true.`,
+      };
+    }
+    const { ok, status, body } = await approvalsApi(`/${encodeURIComponent(target.approval_id)}/approve`, {
+      method: 'POST',
+      body: {},
+    });
+    if (!ok || body.ok !== true) {
+      return {
+        ok: true,
+        result: { approved: false, status, detail: body },
+        text: `Approval of ${target.vtid} did not go through: ${String(body.error ?? `gateway returned ${status}`)}.`,
+      };
+    }
+    const merged = Boolean((body.result as Record<string, unknown> | undefined)?.merged);
+    return {
+      ok: true,
+      result: { approved: true, merged, detail: body.result ?? null },
+      text: merged
+        ? `${target.vtid} approved and its PR is merged. The push pipeline will deploy it to staging.`
+        : `${target.vtid} approved. The merge is queued — checks may still be running.`,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_approve_pr failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+export const dev_reject_pr: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const reason = String(args.reason ?? '').trim();
+  if (!reason) {
+    return { ok: false, error: 'dev_reject_pr requires a reason. Ask the developer why they are rejecting it.' };
+  }
+  try {
+    const target = await resolveApprovalTarget(args, sb);
+    if ('error' in target) return { ok: false, error: target.error };
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { requires_confirmation: true, approval_id: target.approval_id, vtid: target.vtid, reason },
+        text: `Ready to reject ${target.vtid} with reason "${reason}". Ask the developer to confirm, then call dev_reject_pr again with confirm=true.`,
+      };
+    }
+    const { ok, status, body } = await approvalsApi(`/${encodeURIComponent(target.approval_id)}/reject`, {
+      method: 'POST',
+      body: { reason },
+    });
+    if (!ok || body.ok !== true) {
+      return {
+        ok: true,
+        result: { rejected: false, status, detail: body },
+        text: `Rejection of ${target.vtid} did not go through: ${String(body.error ?? `gateway returned ${status}`)}.`,
+      };
+    }
+    return {
+      ok: true,
+      result: { rejected: true, vtid: target.vtid, reason },
+      text: `${target.vtid} rejected. Reason recorded: ${reason}.`,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_reject_pr failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// dev_list_voice_sessions — recent ORB voice sessions (Voice Lab source:
+// oasis_events session start/stop topics, same as routes/voice-lab.ts)
+// ---------------------------------------------------------------------------
+
+const VOICE_SESSION_START_TOPICS = ['voice.live.session.started', 'vtid.live.session.start'];
+const VOICE_SESSION_END_TOPICS = ['voice.live.session.ended', 'vtid.live.session.stop'];
+const VOICE_LAB_VTIDS = ['VTID-01218A', 'VTID-01155', 'VTID-VOICE-HEALING', 'VTID-LIVEKIT-AGENT'];
+
+interface VoiceEventRow {
+  created_at: string;
+  vitana_id?: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export const dev_list_voice_sessions: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 5, 10);
+  const statusFilter = String(args.status ?? 'all').toLowerCase();
+  try {
+    const [startsRes, endsRes] = await Promise.all([
+      sb
+        .from('oasis_events')
+        .select('created_at, vitana_id, metadata')
+        .in('topic', VOICE_SESSION_START_TOPICS)
+        .in('vtid', VOICE_LAB_VTIDS)
+        .order('created_at', { ascending: false })
+        .limit(40),
+      sb
+        .from('oasis_events')
+        .select('created_at, vitana_id, metadata')
+        .in('topic', VOICE_SESSION_END_TOPICS)
+        .in('vtid', VOICE_LAB_VTIDS)
+        .order('created_at', { ascending: false })
+        .limit(100),
+    ]);
+    if (startsRes.error) return { ok: false, error: startsRes.error.message };
+    const starts = (startsRes.data ?? []) as VoiceEventRow[];
+    const ends = ((endsRes.data ?? []) as VoiceEventRow[]).reduce((map, ev) => {
+      const sid = String(ev.metadata?.session_id ?? '');
+      if (sid && !map.has(sid)) map.set(sid, ev);
+      return map;
+    }, new Map<string, VoiceEventRow>());
+
+    const sessions: Array<Record<string, unknown>> = [];
+    for (const start of starts) {
+      const sid = String(start.metadata?.session_id ?? '');
+      if (!sid) continue;
+      const end = ends.get(sid);
+      const active = !end;
+      if (statusFilter === 'active' && !active) continue;
+      if (statusFilter === 'ended' && active) continue;
+      const durationMs = Number(end?.metadata?.duration_ms ?? 0)
+        || (end ? new Date(end.created_at).getTime() - new Date(start.created_at).getTime() : 0);
+      sessions.push({
+        session_id: sid,
+        status: active ? 'active' : 'ended',
+        started_at: start.created_at,
+        duration_ms: durationMs || null,
+        turn_count: Number(end?.metadata?.turn_count ?? end?.metadata?.turn_number ?? 0),
+        lang: start.metadata?.lang ?? null,
+        user_email: start.metadata?.email ?? null,
+        user_role: start.metadata?.active_role ?? null,
+      });
+      if (sessions.length >= limit) break;
+    }
+    if (sessions.length === 0) {
+      return {
+        ok: true,
+        result: { sessions: [] },
+        text: statusFilter === 'active'
+          ? 'No ORB voice sessions are active right now.'
+          : 'No recent ORB voice sessions found.',
+      };
+    }
+    const lines = sessions.map((s) => {
+      const who = String(s.user_email ?? 'unknown user') + (s.user_role ? ` (${String(s.user_role)})` : '');
+      const dur = s.duration_ms ? `, ${Math.max(1, Math.round(Number(s.duration_ms) / 60_000))} min` : '';
+      const turns = Number(s.turn_count) > 0 ? `, ${Number(s.turn_count)} turns` : '';
+      return `${who} — ${String(s.status)}, started ${relAge(String(s.started_at))}${dur}${turns}`;
+    });
+    return {
+      ok: true,
+      result: { sessions },
+      text: `${sessions.length} recent voice session${sessions.length === 1 ? '' : 's'}: ${lines.join('. ')}`,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_list_voice_sessions failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// dev_list_routines / dev_get_routine_detail — Claude daily routines
+// (routines + routine_runs tables, same as routes/routines.ts)
+// ---------------------------------------------------------------------------
+
+interface RoutineRow {
+  name: string;
+  display_name: string | null;
+  description?: string | null;
+  cron_schedule: string | null;
+  enabled: boolean;
+  last_run_at: string | null;
+  last_run_status: string | null;
+  last_run_summary: string | null;
+  consecutive_failures: number | null;
+}
+
+interface RoutineRunRow {
+  id: string;
+  started_at: string;
+  finished_at: string | null;
+  status: string;
+  trigger: string | null;
+  summary: string | null;
+  error: string | null;
+  duration_ms: number | null;
+}
+
+export const dev_list_routines: Handler = async (_args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  try {
+    const { data, error } = await sb
+      .from('routines')
+      .select('name, display_name, cron_schedule, enabled, last_run_at, last_run_status, last_run_summary, consecutive_failures')
+      .order('name', { ascending: true });
+    if (error) return { ok: false, error: error.message };
+    const rows = (data ?? []) as RoutineRow[];
+    if (rows.length === 0) {
+      return { ok: true, result: { routines: [] }, text: 'No daily routines are registered yet.' };
+    }
+    const failing = rows.filter((r) => r.last_run_status === 'failure' || (r.consecutive_failures ?? 0) > 0);
+    const spoken = [...failing, ...rows.filter((r) => !failing.includes(r))].slice(0, 5);
+    const lines = spoken.map((r) => {
+      const name = r.display_name || r.name;
+      const last = r.last_run_status
+        ? `last run ${r.last_run_status} ${relAge(r.last_run_at)}`
+        : 'never run';
+      const fails = (r.consecutive_failures ?? 0) > 0 ? `, ${r.consecutive_failures} consecutive failures` : '';
+      return `${name} — ${r.enabled ? 'enabled' : 'disabled'}, ${last}${fails}`;
+    });
+    const summary =
+      `${rows.length} routines (${rows.filter((r) => r.enabled).length} enabled, ` +
+      `${failing.length} failing).`;
+    return { ok: true, result: { routines: rows }, text: `${summary} ${lines.join('. ')}` };
+  } catch (err) {
+    return { ok: false, error: `dev_list_routines failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+export const dev_get_routine_detail: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const rawName = String(args.name ?? '').trim();
+  if (!rawName) return { ok: false, error: 'dev_get_routine_detail requires a routine name.' };
+  const runsLimit = clampLimit(args.runs_limit, 5, 10);
+  try {
+    // Exact match first, then a fuzzy fallback so spoken names resolve.
+    let routine: RoutineRow | undefined;
+    const exact = await sb.from('routines').select('*').eq('name', rawName).limit(1);
+    if (exact.error) return { ok: false, error: exact.error.message };
+    routine = ((exact.data ?? []) as RoutineRow[])[0];
+    if (!routine) {
+      const needle = rawName.replace(/[,()%]/g, '').replace(/\s+/g, '%');
+      const fuzzy = await sb
+        .from('routines')
+        .select('*')
+        .or(`name.ilike.%${needle}%,display_name.ilike.%${needle}%`)
+        .limit(1);
+      if (fuzzy.error) return { ok: false, error: fuzzy.error.message };
+      routine = ((fuzzy.data ?? []) as RoutineRow[])[0];
+    }
+    if (!routine) {
+      return { ok: true, result: { found: false }, text: `I could not find a routine matching "${rawName}".` };
+    }
+    const runsRes = await sb
+      .from('routine_runs')
+      .select('id, started_at, finished_at, status, trigger, summary, error, duration_ms')
+      .eq('routine_name', routine.name)
+      .order('started_at', { ascending: false })
+      .limit(runsLimit);
+    if (runsRes.error) return { ok: false, error: runsRes.error.message };
+    const runs = (runsRes.data ?? []) as RoutineRunRow[];
+    const name = routine.display_name || routine.name;
+    const head =
+      `${name}: ${routine.enabled ? 'enabled' : 'disabled'}, schedule ${routine.cron_schedule ?? 'unknown'}. ` +
+      (routine.last_run_status
+        ? `Last run ${routine.last_run_status} ${relAge(routine.last_run_at)}${routine.last_run_summary ? ` — ${routine.last_run_summary}` : ''}.`
+        : 'Never run.');
+    const runLines = runs.map((r) => {
+      const dur = r.duration_ms ? `, ${Math.max(1, Math.round(r.duration_ms / 60_000))} min` : '';
+      const note = r.status === 'failure' && r.error ? ` (${r.error})` : r.summary ? ` — ${r.summary}` : '';
+      return `${r.status} ${relAge(r.started_at)}${dur}${note}`;
+    });
+    return {
+      ok: true,
+      result: { found: true, routine, runs },
+      text: runs.length > 0 ? `${head} Last ${runs.length} runs: ${runLines.join('. ')}` : head,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_get_routine_detail failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// dev_list_active_healing — self-healing runs in flight
+// (mirrors GET /api/v1/self-healing/active: vtid_ledger rows tagged
+// metadata->>source=self-healing, plus pending self_healing_log diagnoses)
+// ---------------------------------------------------------------------------
+
+const HEALING_ACTIVE_STATUSES = ['allocated', 'pending', 'scheduled', 'in_progress', 'paused'];
+
+interface HealLogRow {
+  id: string;
+  vtid: string | null;
+  endpoint: string | null;
+  failure_class: string | null;
+  created_at: string;
+}
+
+export const dev_list_active_healing: Handler = async (_args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  try {
+    const [tasksRes, pendingRes] = await Promise.all([
+      sb
+        .from('vtid_ledger')
+        .select('vtid, title, status, spec_status, created_at')
+        .filter('metadata->>source', 'eq', 'self-healing')
+        .in('status', HEALING_ACTIVE_STATUSES)
+        .order('created_at', { ascending: false })
+        .limit(20),
+      sb
+        .from('self_healing_log')
+        .select('id, vtid, endpoint, failure_class, created_at')
+        .eq('outcome', 'pending')
+        .order('created_at', { ascending: false })
+        .limit(20),
+    ]);
+    if (tasksRes.error) return { ok: false, error: tasksRes.error.message };
+    const tasks = (tasksRes.data ?? []) as VtidRow[];
+    const pending = (pendingRes.data ?? []) as HealLogRow[];
+    if (tasks.length === 0 && pending.length === 0) {
+      return {
+        ok: true,
+        result: { active_tasks: [], pending_diagnoses: [] },
+        text: 'Self-healing is quiet — no healing tasks in flight and no pending diagnoses.',
+      };
+    }
+    const taskLines = tasks.slice(0, 5).map(
+      (t) => `${t.vtid} — ${t.title || '(untitled)'} (${t.status}, ${relAge(t.created_at)})`,
+    );
+    const pendingLines = pending.slice(0, 3).map(
+      (p) => `${p.failure_class ?? 'failure'} on ${p.endpoint ?? 'unknown endpoint'} (${relAge(p.created_at)})`,
+    );
+    const parts: string[] = [];
+    parts.push(`${tasks.length} healing task${tasks.length === 1 ? '' : 's'} in flight` +
+      (taskLines.length ? `: ${taskLines.join('. ')}` : '.'));
+    parts.push(`${pending.length} pending diagnos${pending.length === 1 ? 'is' : 'es'}` +
+      (pendingLines.length ? `: ${pendingLines.join('. ')}` : '.'));
+    return {
+      ok: true,
+      result: { active_tasks: tasks, pending_diagnoses: pending },
+      text: parts.join(' '),
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_list_active_healing failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// dev_get_autonomy_pulse — unified autonomy metrics. Fetches the exact four
+// row sets routes/autonomy-pulse.ts fetches and reuses its exported pure
+// aggregatePulse() so the voice answer matches the Command Hub Pulse view.
+// ---------------------------------------------------------------------------
+
+const EXECUTION_INFLIGHT_STATUSES = ['cooling', 'running', 'ci', 'merging', 'deploying', 'verifying'];
+
+export const dev_get_autonomy_pulse: Handler = async (_args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  try {
+    const [findingsRes, healsRes, execsRes, contractsRes, terminalizedRes] = await Promise.all([
+      sb
+        .from('autopilot_recommendations')
+        .select('id, title, summary, risk_class, impact_score, effort_score, auto_exec_eligible, domain, first_seen_at, seen_count, spec_snapshot')
+        .eq('source_type', 'dev_autopilot')
+        .eq('status', 'new')
+        .order('impact_score', { ascending: false, nullsFirst: false })
+        .limit(50),
+      sb
+        .from('self_healing_log')
+        .select('id, vtid, endpoint, failure_class, created_at, diagnosis, attempt_number')
+        .eq('outcome', 'pending')
+        .order('created_at', { ascending: false })
+        .limit(50),
+      sb
+        .from('dev_autopilot_executions')
+        .select('id, finding_id, status, pr_url, pr_number, branch, execute_after, auto_fix_depth, self_healing_vtid, created_at, updated_at')
+        .in('status', EXECUTION_INFLIGHT_STATUSES)
+        .order('created_at', { ascending: false })
+        .limit(50),
+      sb
+        .from('test_contracts')
+        .select('id, capability, service, environment, target_endpoint, target_file, owner, status, last_status, last_run_at, last_failure_signature')
+        .in('status', ['fail', 'quarantined'])
+        .order('last_run_at', { ascending: false, nullsFirst: false })
+        .limit(50),
+      // Recently terminalized VTIDs (last 24h) — autonomy throughput signal.
+      sb
+        .from('vtid_ledger')
+        .select('vtid, title, terminal_outcome, updated_at')
+        .eq('is_terminal', true)
+        .gte('updated_at', new Date(Date.now() - 24 * 3600_000).toISOString())
+        .order('updated_at', { ascending: false })
+        .limit(20),
+    ]);
+    const findings = findingsRes.data ?? [];
+    const heals = healsRes.data ?? [];
+    const executions = execsRes.data ?? [];
+    const contracts = contractsRes.data ?? [];
+    const terminalized = (terminalizedRes.data ?? []) as Array<{
+      vtid: string; title: string | null; terminal_outcome: string | null; updated_at: string;
+    }>;
+
+    // Reuse the Command Hub Pulse normalizer/sorter when importable.
+    let topTitles: string[] = [];
+    let severityCounts = { critical: 0, warning: 0, info: 0 };
+    try {
+      const pulseModule = await import('../../routes/autonomy-pulse');
+      type Aggregate = typeof pulseModule.aggregatePulse;
+      const items = pulseModule.aggregatePulse(
+        findings as unknown as Parameters<Aggregate>[0],
+        heals as unknown as Parameters<Aggregate>[1],
+        executions as unknown as Parameters<Aggregate>[2],
+        contracts as unknown as Parameters<Aggregate>[3],
+      );
+      severityCounts = {
+        critical: items.filter((i) => i.severity === 'critical').length,
+        warning: items.filter((i) => i.severity === 'warning').length,
+        info: items.filter((i) => i.severity === 'info').length,
+      };
+      topTitles = items.slice(0, 3).map((i) => `${i.title} (${i.severity})`);
+    } catch {
+      /* aggregation unavailable — raw counts below still speak */
+    }
+
+    const total = findings.length + heals.length + executions.length + contracts.length;
+    const succeeded = terminalized.filter((t) => t.terminal_outcome === 'success').length;
+    const text =
+      `Autonomy pulse: ${total} open item${total === 1 ? '' : 's'} — ` +
+      `${findings.length} pending findings, ${heals.length} pending heals, ` +
+      `${executions.length} executions in flight, ${contracts.length} failing contracts` +
+      (severityCounts.critical + severityCounts.warning + severityCounts.info > 0
+        ? ` (${severityCounts.critical} critical, ${severityCounts.warning} warning)`
+        : '') +
+      `. ${terminalized.length} VTIDs terminalized in the last 24 hours (${succeeded} succeeded).` +
+      (topTitles.length ? ` Top attention items: ${topTitles.join('. ')}.` : '');
+    return {
+      ok: true,
+      result: {
+        counts: {
+          findings: findings.length,
+          heals: heals.length,
+          executions: executions.length,
+          contracts: contracts.length,
+          total,
+          ...severityCounts,
+        },
+        terminalized_24h: terminalized.length,
+        terminalized_success_24h: succeeded,
+        top_items: topTitles,
+      },
+      text,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_get_autonomy_pulse failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// dev_list_agents — agents_registry with the same heartbeat decay logic
+// routes/agents-registry.ts applies at read time
+// ---------------------------------------------------------------------------
+
+interface AgentRow {
+  agent_id: string;
+  display_name: string | null;
+  tier: 'service' | 'embedded' | 'scheduled' | string;
+  status: string | null;
+  last_heartbeat_at: string | null;
+  llm_provider: string | null;
+}
+
+/** Read-time status decay — mirrors deriveStatus() in routes/agents-registry.ts. */
+export function deriveAgentStatus(row: AgentRow): string {
+  const base = row.status ?? 'unknown';
+  if (!row.last_heartbeat_at) return base;
+  const age = Date.now() - new Date(row.last_heartbeat_at).getTime();
+  if (row.tier === 'embedded') return base;
+  if (row.tier === 'scheduled') {
+    if (age > 24 * 3600_000) return 'down';
+    if (age > 6 * 3600_000) return 'degraded';
+    return base;
+  }
+  if (base === 'healthy') {
+    if (age > 5 * 60_000) return 'down';
+    if (age > 2 * 60_000) return 'degraded';
+  }
+  return base;
+}
+
+export const dev_list_agents: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const tier = String(args.tier ?? '').trim().toLowerCase();
+  try {
+    let q = sb
+      .from('agents_registry')
+      .select('agent_id, display_name, tier, status, last_heartbeat_at, llm_provider')
+      .order('tier', { ascending: true })
+      .order('agent_id', { ascending: true });
+    if (tier) q = q.eq('tier', tier);
+    const { data, error } = await q;
+    if (error) return { ok: false, error: error.message };
+    const rows = ((data ?? []) as AgentRow[]).map((r) => ({ ...r, derived_status: deriveAgentStatus(r) }));
+    if (rows.length === 0) {
+      return { ok: true, result: { agents: [] }, text: 'The agent registry is empty.' };
+    }
+    const counts = {
+      total: rows.length,
+      healthy: rows.filter((r) => r.derived_status === 'healthy').length,
+      degraded: rows.filter((r) => r.derived_status === 'degraded').length,
+      down: rows.filter((r) => r.derived_status === 'down').length,
+      unknown: rows.filter((r) => !['healthy', 'degraded', 'down'].includes(r.derived_status)).length,
+    };
+    const problems = rows.filter((r) => r.derived_status === 'down' || r.derived_status === 'degraded');
+    const spoken = [...problems, ...rows.filter((r) => !problems.includes(r))].slice(0, 5);
+    const lines = spoken.map((r) => {
+      const hb = r.last_heartbeat_at ? `, heartbeat ${relAge(r.last_heartbeat_at)}` : '';
+      return `${r.display_name || r.agent_id} (${r.tier}) — ${r.derived_status}${hb}`;
+    });
+    const head = `${counts.total} agents: ${counts.healthy} healthy, ${counts.degraded} degraded, ${counts.down} down.`;
+    return { ok: true, result: { counts, agents: rows }, text: `${head} ${lines.join('. ')}` };
+  } catch (err) {
+    return { ok: false, error: `dev_list_agents failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const DEVELOPER_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_list_vtids,
+  dev_get_vtid_status,
+  dev_list_pending_approvals,
+  dev_count_approvals,
+  dev_approve_pr,
+  dev_reject_pr,
+  dev_list_voice_sessions,
+  dev_list_routines,
+  dev_get_routine_detail,
+  dev_list_active_healing,
+  dev_get_autonomy_pulse,
+  dev_list_agents,
+};
+
+export const DEVELOPER_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'dev_list_vtids',
+    description: [
+      'DEVELOPER ONLY. List recent VTID tasks from the ledger (id, title, status).',
+      'Call when the developer asks: "what are the latest VTIDs", "show open tasks",',
+      '"welche VTIDs laufen gerade", "zeig mir die letzten Tasks".',
+      'Optionally filter by status (scheduled, in_progress, completed, pending, blocked, cancelled).',
+      'Speak each VTID id with its title and status.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', description: 'Optional status filter: scheduled, in_progress, completed, pending, blocked, cancelled.' },
+        limit: { type: 'integer', description: 'Max rows, 1-20. Use 5 unless the developer asks for more.' },
+      },
+    },
+  },
+  {
+    name: 'dev_get_vtid_status',
+    description: [
+      'DEVELOPER ONLY. Get one VTID task by id — status, spec status, terminal state, claim.',
+      'Call when the developer asks: "what is the status of VTID 1234", "is 2782 done",',
+      '"wie steht es um VTID 1234", "ist die Task fertig".',
+      'Accepts loose ids: "VTID-01234", "vtid 1234" or just "1234".',
+      'Speak the title, status, spec status and whether it is terminal.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID reference, e.g. "VTID-01234" or "1234".' },
+      },
+      required: ['vtid'],
+    },
+  },
+  {
+    name: 'dev_list_pending_approvals',
+    description: [
+      'DEVELOPER ONLY. List PRs/actions waiting in the approvals queue (same queue as the Command Hub approvals view).',
+      'Call when the developer asks: "what is waiting for approval", "any PRs to approve",',
+      '"was wartet auf Freigabe", "gibt es offene Approvals".',
+      'Speak VTID, title, PR number and checks status for each item; then offer to approve or reject.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        limit: { type: 'integer', description: 'Max items, 1-20. Use 5 unless asked for more.' },
+      },
+    },
+  },
+  {
+    name: 'dev_count_approvals',
+    description: [
+      'DEVELOPER ONLY. Count how many items are pending approval.',
+      'Call when the developer asks: "how many approvals are pending",',
+      '"wie viele Freigaben stehen an". Speak just the number.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_approve_pr',
+    description: [
+      'DEVELOPER ONLY. Approve a queued approval — merges its PR via the governed pipeline.',
+      'Call when the developer says: "approve VTID 1234", "merge that PR", "gib 1234 frei".',
+      'TWO-STEP: first call WITHOUT confirm to get the confirmation text, read it to the',
+      'developer, and only after an explicit yes call again with confirm=true.',
+      'Identify the item by vtid (preferred, from dev_list_pending_approvals) or approval_id.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID of the queued item, e.g. "VTID-01234".' },
+        approval_id: { type: 'string', description: 'Exact approval id (appr_VTID-XXXXX_hash) if known.' },
+        confirm: { type: 'boolean', description: 'Set true ONLY after the developer explicitly confirmed.' },
+      },
+    },
+  },
+  {
+    name: 'dev_reject_pr',
+    description: [
+      'DEVELOPER ONLY. Reject a queued approval and record why.',
+      'Call when the developer says: "reject VTID 1234 because ...", "lehne 1234 ab, weil ...".',
+      'A reason is REQUIRED — ask for one if the developer did not give it.',
+      'TWO-STEP: first call WITHOUT confirm, read the confirmation back, then call',
+      'again with confirm=true after an explicit yes.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID of the queued item.' },
+        approval_id: { type: 'string', description: 'Exact approval id if known.' },
+        reason: { type: 'string', description: 'Why it is being rejected. Required.' },
+        confirm: { type: 'boolean', description: 'Set true ONLY after the developer explicitly confirmed.' },
+      },
+      required: ['reason'],
+    },
+  },
+  {
+    name: 'dev_list_voice_sessions',
+    description: [
+      'DEVELOPER ONLY. List recent ORB voice sessions from the Voice Lab (who, when, duration, turns).',
+      'Call when the developer asks: "who used voice recently", "any active voice sessions",',
+      '"welche Voice-Sessions liefen zuletzt", "läuft gerade eine Session".',
+      'Optionally filter to active or ended sessions. Speak user, status and start time.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', description: 'Filter: active, ended, or all (all when omitted).' },
+        limit: { type: 'integer', description: 'Max sessions, 1-10. Use 5 unless asked for more.' },
+      },
+    },
+  },
+  {
+    name: 'dev_list_routines',
+    description: [
+      'DEVELOPER ONLY. List the daily Claude routines with last-run status.',
+      'Call when the developer asks: "how are the routines doing", "did the nightly routines run",',
+      '"wie laufen die Routinen", "sind die Routinen durchgelaufen".',
+      'Speak failing routines first, then the rest, with last run result and age.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_get_routine_detail',
+    description: [
+      'DEVELOPER ONLY. Detail one routine plus its last runs.',
+      'Call when the developer asks: "what happened in the morning-report routine",',
+      '"warum ist die Routine fehlgeschlagen", "zeig mir die letzten Läufe von X".',
+      'Accepts the routine name or a close spoken match. Speak schedule, last status and recent runs.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Routine name or display name (fuzzy match allowed).' },
+        runs_limit: { type: 'integer', description: 'How many recent runs to include, 1-10. Use 5.' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'dev_list_active_healing',
+    description: [
+      'DEVELOPER ONLY. Show self-healing work currently in flight: active healing VTIDs and pending diagnoses.',
+      'Call when the developer asks: "is self-healing doing anything", "any heals running",',
+      '"läuft gerade ein Self-Healing", "gibt es offene Heilungen".',
+      'Speak counts plus the endpoints/VTIDs involved.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_get_autonomy_pulse',
+    description: [
+      'DEVELOPER ONLY. One-shot autonomy status: pending findings, pending heals, executions',
+      'in flight, failing test contracts, and VTIDs terminalized in the last 24 hours.',
+      'Call when the developer asks: "give me the autonomy pulse", "how is the autopilot doing",',
+      '"wie steht die Autonomie", "was macht der Autopilot gerade".',
+      'Speak the counts and the top attention items.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_list_agents',
+    description: [
+      'DEVELOPER ONLY. List registered agents with heartbeat-derived health (healthy/degraded/down).',
+      'Call when the developer asks: "are all agents up", "which agents are down",',
+      '"sind alle Agenten gesund", "welche Agents laufen".',
+      'Optionally filter by tier (service, embedded, scheduled). Speak problem agents first.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        tier: { type: 'string', description: 'Optional tier filter: service, embedded, scheduled.' },
+      },
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/diary-memory-tools.ts
+++ b/services/gateway/src/services/orb-tools/diary-memory-tools.ts
@@ -1,0 +1,758 @@
+/**
+ * Diary + Memory voice tools (VTID-02757).
+ *
+ * Read/manage tools over the user's Daily Diary (`diary_entries`) and the
+ * Memory Garden (`memory_items` + `memory_facts`, garden category tables
+ * from VTID-01086/01225): list diary entries in a date window, compute the
+ * diary streak the same way the `user_diary_streak` view does (consecutive
+ * UTC calendar days), build a chronological memory timeline, topic recall,
+ * per-garden-category counts for "what do you remember about me?", and a
+ * confirm-gated forget_memory. memory_items has NO soft-delete column
+ * (VTID-01104), so forget_memory hard-deletes the row and records the
+ * deletion in the VTID-01099 `memory_deletions` governance ledger.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** ok:false gate when the tool needs an authenticated user (and tenant). */
+function authGate(tool: string, id: OrbToolIdentity, needTenant = false): OrbToolResult | null {
+  if (!id.user_id || (needTenant && !id.tenant_id)) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+/** Parse an optional YYYY-MM-DD arg; undefined when absent, null when malformed. */
+function parseDateArg(raw: unknown): string | undefined | null {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  const s = String(raw).trim();
+  return DATE_RE.test(s) ? s : null;
+}
+
+function clampLimit(raw: unknown, def: number, max: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return def;
+  return Math.min(Math.floor(n), max);
+}
+
+/** "Jun 12" / "Jun 12, 2025" — English; the LLM translates when speaking DE. */
+function dayPhrase(iso: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return iso;
+  const opts: Intl.DateTimeFormatOptions =
+    d.getUTCFullYear() === new Date().getUTCFullYear()
+      ? { month: 'short', day: 'numeric', timeZone: 'UTC' }
+      : { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' };
+  return d.toLocaleDateString('en-US', opts);
+}
+
+function snippet(text: string, max = 120): string {
+  const clean = text.replace(/\s+/g, ' ').trim();
+  return clean.length <= max ? clean : `${clean.slice(0, max - 1).trimEnd()}…`;
+}
+
+/** Escape LIKE wildcards so user topics can't act as patterns. */
+function escapeLike(s: string): string {
+  return s.replace(/[\\%_]/g, (m) => `\\${m}`);
+}
+
+/** UTC calendar day string of an ISO timestamp (matches user_diary_streak view). */
+function utcDay(iso: string): string {
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
+function addDays(day: string, delta: number): string {
+  const d = new Date(`${day}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + delta);
+  return d.toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// list_diary_entries — diary_entries(id, user_id, text, source, tags, created_at)
+// ---------------------------------------------------------------------------
+
+interface DiaryRow {
+  id: string;
+  text: string;
+  source: string | null;
+  tags: string[] | null;
+  created_at: string;
+}
+
+export async function tool_list_diary_entries(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('list_diary_entries', id);
+  if (gate) return gate;
+
+  const dateFrom = parseDateArg(args.date_from);
+  const dateTo = parseDateArg(args.date_to);
+  if (dateFrom === null || dateTo === null) {
+    return { ok: false, error: 'list_diary_entries dates must be YYYY-MM-DD.' };
+  }
+  const limit = clampLimit(args.limit, 10, 30);
+
+  try {
+    let q = sb
+      .from('diary_entries')
+      .select('id, text, source, tags, created_at')
+      .eq('user_id', id.user_id);
+    if (dateFrom) q = q.gte('created_at', `${dateFrom}T00:00:00.000Z`);
+    if (dateTo) q = q.lte('created_at', `${dateTo}T23:59:59.999Z`);
+
+    const { data, error } = await q.order('created_at', { ascending: false }).limit(limit);
+    if (error) return { ok: false, error: `Could not load diary entries: ${error.message}` };
+
+    const rows = (data || []) as DiaryRow[];
+    if (rows.length === 0) {
+      const windowTxt = dateFrom || dateTo
+        ? ` between ${dateFrom ?? 'the beginning'} and ${dateTo ?? 'today'}`
+        : '';
+      return {
+        ok: true,
+        result: { entries: [], count: 0 },
+        text: `The user has no diary entries${windowTxt}. Offer to log one now.`,
+      };
+    }
+
+    const lines = rows.map((r) => `${dayPhrase(r.created_at)}: ${snippet(r.text)}`);
+    return {
+      ok: true,
+      result: {
+        count: rows.length,
+        entries: rows.map((r) => ({
+          id: r.id,
+          text: r.text,
+          source: r.source,
+          created_at: r.created_at,
+        })),
+      },
+      text:
+        `Found ${rows.length} diary ${rows.length === 1 ? 'entry' : 'entries'} (newest first): ` +
+        lines.join(' | ') +
+        ' — summarize naturally in the user\'s language; do not read IDs.',
+    };
+  } catch (err) {
+    return { ok: false, error: `list_diary_entries failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_diary_streak — consecutive UTC-day streak from diary_entries.created_at
+// (same day-rule as the user_diary_streak view: streak may end today OR
+// yesterday; a 2+ day gap breaks it).
+// ---------------------------------------------------------------------------
+
+export async function tool_get_diary_streak(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_diary_streak', id);
+  if (gate) return gate;
+
+  try {
+    const { data, error } = await sb
+      .from('diary_entries')
+      .select('created_at')
+      .eq('user_id', id.user_id)
+      .order('created_at', { ascending: false })
+      .limit(1000);
+    if (error) return { ok: false, error: `Could not load diary entries: ${error.message}` };
+
+    const rows = (data || []) as Array<{ created_at: string }>;
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { current_streak_days: 0, longest_streak_days: 0, last_entry_day: null },
+        text: 'The user has no diary entries yet, so there is no streak. Encourage them to start today.',
+      };
+    }
+
+    const daySet = new Set(rows.map((r) => utcDay(r.created_at)));
+    const days = Array.from(daySet).sort(); // ascending YYYY-MM-DD
+
+    // Current streak: consecutive days ending today (or yesterday).
+    const today = new Date().toISOString().slice(0, 10);
+    let cursor = daySet.has(today) ? today : addDays(today, -1);
+    let current = 0;
+    while (daySet.has(cursor)) {
+      current += 1;
+      cursor = addDays(cursor, -1);
+    }
+
+    // Longest streak across the fetched window.
+    let longest = 1;
+    let run = 1;
+    for (let i = 1; i < days.length; i += 1) {
+      run = days[i] === addDays(days[i - 1], 1) ? run + 1 : 1;
+      if (run > longest) longest = run;
+    }
+    if (current > longest) longest = current;
+
+    const lastDay = days[days.length - 1];
+    const text =
+      current > 0
+        ? `The user's current diary streak is ${current} consecutive ${current === 1 ? 'day' : 'days'}` +
+          `${daySet.has(today) ? ' including today' : ' (no entry yet today — an entry today keeps it alive)'}. ` +
+          `Longest streak so far: ${longest} days. Celebrate briefly.`
+        : `The user's diary streak is currently broken — the last entry was on ${dayPhrase(`${lastDay}T00:00:00Z`)}. ` +
+          `Their longest streak so far is ${longest} days. Encourage a fresh start today.`;
+
+    return {
+      ok: true,
+      result: {
+        current_streak_days: current,
+        longest_streak_days: longest,
+        last_entry_day: lastDay,
+        has_entry_today: daySet.has(today),
+      },
+      text,
+    };
+  } catch (err) {
+    return { ok: false, error: `get_diary_streak failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_memory_timeline — memory_items + active memory_facts + diary_entries
+// merged chronologically (newest first).
+// ---------------------------------------------------------------------------
+
+interface TimelineEvent {
+  when: string;
+  kind: 'memory' | 'fact' | 'diary';
+  category: string | null;
+  text: string;
+  id: string | null;
+}
+
+export async function tool_get_memory_timeline(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_memory_timeline', id, true);
+  if (gate) return gate;
+
+  const dateFrom = parseDateArg(args.date_from);
+  const dateTo = parseDateArg(args.date_to);
+  if (dateFrom === null || dateTo === null) {
+    return { ok: false, error: 'get_memory_timeline dates must be YYYY-MM-DD.' };
+  }
+  const limit = clampLimit(args.limit, 15, 40);
+  const fromIso = dateFrom ? `${dateFrom}T00:00:00.000Z` : undefined;
+  const toIso = dateTo ? `${dateTo}T23:59:59.999Z` : undefined;
+
+  try {
+    let itemsQ = sb
+      .from('memory_items')
+      .select('id, category_key, source, content, occurred_at')
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id);
+    if (fromIso) itemsQ = itemsQ.gte('occurred_at', fromIso);
+    if (toIso) itemsQ = itemsQ.lte('occurred_at', toIso);
+
+    let factsQ = sb
+      .from('memory_facts')
+      .select('id, fact_key, fact_value, extracted_at')
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id)
+      .is('superseded_by', null);
+    if (fromIso) factsQ = factsQ.gte('extracted_at', fromIso);
+    if (toIso) factsQ = factsQ.lte('extracted_at', toIso);
+
+    let diaryQ = sb
+      .from('diary_entries')
+      .select('id, text, created_at')
+      .eq('user_id', id.user_id);
+    if (fromIso) diaryQ = diaryQ.gte('created_at', fromIso);
+    if (toIso) diaryQ = diaryQ.lte('created_at', toIso);
+
+    const [items, facts, diary] = await Promise.all([
+      itemsQ.order('occurred_at', { ascending: false }).limit(limit),
+      factsQ.order('extracted_at', { ascending: false }).limit(Math.min(limit, 15)),
+      diaryQ.order('created_at', { ascending: false }).limit(Math.min(limit, 15)),
+    ]);
+    if (items.error) {
+      return { ok: false, error: `Could not load memory timeline: ${items.error.message}` };
+    }
+
+    const events: TimelineEvent[] = [];
+    for (const r of (items.data || []) as Array<{
+      id: string; category_key: string; source: string; content: string; occurred_at: string;
+    }>) {
+      events.push({ when: r.occurred_at, kind: 'memory', category: r.category_key, text: snippet(r.content), id: r.id });
+    }
+    // facts/diary are best-effort enrichments — a failed sub-query degrades, not fails.
+    for (const r of (facts.data || []) as Array<{
+      id: string; fact_key: string; fact_value: string; extracted_at: string;
+    }>) {
+      events.push({ when: r.extracted_at, kind: 'fact', category: r.fact_key, text: snippet(`${r.fact_key.replace(/_/g, ' ')}: ${r.fact_value}`, 100), id: r.id });
+    }
+    for (const r of (diary.data || []) as Array<{ id: string; text: string; created_at: string }>) {
+      events.push({ when: r.created_at, kind: 'diary', category: 'diary', text: snippet(r.text), id: r.id });
+    }
+
+    events.sort((a, b) => (a.when < b.when ? 1 : -1));
+    const top = events.slice(0, limit);
+
+    if (top.length === 0) {
+      const windowTxt = dateFrom || dateTo
+        ? ` between ${dateFrom ?? 'the beginning'} and ${dateTo ?? 'today'}`
+        : '';
+      return {
+        ok: true,
+        result: { events: [], count: 0 },
+        text: `No memories, facts, or diary entries found${windowTxt}.`,
+      };
+    }
+
+    const spoken = top
+      .slice(0, 8)
+      .map((e) => `${dayPhrase(e.when)} (${e.kind}): ${e.text}`)
+      .join(' | ');
+    return {
+      ok: true,
+      result: { count: top.length, events: top },
+      text:
+        `Memory timeline, newest first (${top.length} entr${top.length === 1 ? 'y' : 'ies'}): ${spoken}` +
+        (top.length > 8 ? ` … and ${top.length - 8} more.` : '') +
+        ' Retell it as a short narrative in the user\'s language.',
+    };
+  } catch (err) {
+    return { ok: false, error: `get_memory_timeline failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// recall_memory_about — topic ilike search over memory_items (+ active
+// memory_facts), optional garden/source category filter via
+// memory_category_mapping.
+// ---------------------------------------------------------------------------
+
+/** Expand a spoken category (garden key OR source key) into source category keys. */
+async function expandCategory(sb: SupabaseClient, category: string): Promise<string[]> {
+  const cats = new Set<string>([category]);
+  try {
+    const { data } = await sb
+      .from('memory_category_mapping')
+      .select('source_category, garden_category');
+    for (const m of (data || []) as Array<{ source_category: string; garden_category: string }>) {
+      if (m.garden_category === category) cats.add(m.source_category);
+    }
+  } catch {
+    // best-effort — fall back to the raw category key
+  }
+  return Array.from(cats);
+}
+
+export async function tool_recall_memory_about(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('recall_memory_about', id, true);
+  if (gate) return gate;
+
+  const topic = String(args.topic ?? '').trim();
+  if (!topic) return { ok: false, error: 'recall_memory_about requires a non-empty topic.' };
+  const category = typeof args.category === 'string' ? args.category.trim().toLowerCase() : '';
+  const pattern = `%${escapeLike(topic)}%`;
+
+  try {
+    let itemsQ = sb
+      .from('memory_items')
+      .select('id, category_key, content, occurred_at')
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id)
+      .ilike('content', pattern);
+    if (category) {
+      itemsQ = itemsQ.in('category_key', await expandCategory(sb, category));
+    }
+
+    const factsValueQ = sb
+      .from('memory_facts')
+      .select('id, fact_key, fact_value, extracted_at')
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id)
+      .is('superseded_by', null)
+      .ilike('fact_value', pattern)
+      .limit(5);
+    const factsKeyQ = sb
+      .from('memory_facts')
+      .select('id, fact_key, fact_value, extracted_at')
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id)
+      .is('superseded_by', null)
+      .ilike('fact_key', pattern)
+      .limit(5);
+
+    const [items, factsByValue, factsByKey] = await Promise.all([
+      itemsQ.order('occurred_at', { ascending: false }).limit(10),
+      factsValueQ,
+      factsKeyQ,
+    ]);
+    if (items.error) {
+      return { ok: false, error: `Could not search memory: ${items.error.message}` };
+    }
+
+    type FactRow = { id: string; fact_key: string; fact_value: string; extracted_at: string };
+    const factMap = new Map<string, FactRow>();
+    for (const f of [
+      ...((factsByValue.data || []) as FactRow[]),
+      ...((factsByKey.data || []) as FactRow[]),
+    ]) {
+      factMap.set(f.id, f);
+    }
+    const facts = Array.from(factMap.values()).slice(0, 5);
+    const rows = (items.data || []) as Array<{
+      id: string; category_key: string; content: string; occurred_at: string;
+    }>;
+
+    if (rows.length === 0 && facts.length === 0) {
+      return {
+        ok: true,
+        result: { items: [], facts: [], count: 0 },
+        text:
+          `No stored memories found about "${topic}"${category ? ` in category ${category}` : ''}. ` +
+          'Say so honestly and offer to remember it now — do not invent memories.',
+      };
+    }
+
+    const parts: string[] = [];
+    if (facts.length > 0) {
+      parts.push(
+        'Known facts: ' +
+          facts.map((f) => `${f.fact_key.replace(/_/g, ' ')} = ${f.fact_value}`).join('; '),
+      );
+    }
+    if (rows.length > 0) {
+      parts.push(
+        'Memories: ' +
+          rows
+            .slice(0, 6)
+            .map((r) => `${dayPhrase(r.occurred_at)} [${r.category_key}]: ${snippet(r.content, 100)}`)
+            .join(' | '),
+      );
+    }
+
+    return {
+      ok: true,
+      result: {
+        count: rows.length + facts.length,
+        items: rows,
+        facts,
+      },
+      text:
+        `What I remember about "${topic}": ${parts.join('. ')}. ` +
+        'Answer conversationally in the user\'s language using only this content.',
+    };
+  } catch (err) {
+    return { ok: false, error: `recall_memory_about failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_memory_garden_summary — counts per garden category (VTID-01086 config
+// + mapping), computed with per-category exact count queries.
+// ---------------------------------------------------------------------------
+
+export async function tool_get_memory_garden_summary(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_memory_garden_summary', id, true);
+  if (gate) return gate;
+
+  try {
+    // Garden config (labels + order) and source→garden mapping. Both are
+    // small lookup tables; failure falls back to raw category_key grouping.
+    const [cfgRes, mapRes] = await Promise.all([
+      sb
+        .from('memory_garden_config')
+        .select('category_key, label, display_order')
+        .order('display_order', { ascending: true }),
+      sb.from('memory_category_mapping').select('source_category, garden_category'),
+    ]);
+
+    const gardenLabels = new Map<string, string>();
+    for (const c of (cfgRes.data || []) as Array<{ category_key: string; label: string }>) {
+      gardenLabels.set(c.category_key, c.label);
+    }
+    const sourceToGarden = new Map<string, string>();
+    for (const m of (mapRes.data || []) as Array<{ source_category: string; garden_category: string }>) {
+      sourceToGarden.set(m.source_category, m.garden_category);
+    }
+
+    // One page of the user's category keys — grouped in JS. memory_items has
+    // no GROUP BY via PostgREST, and the garden RPC is auth.uid()-scoped
+    // (unavailable to the service-role client).
+    const { data, error } = await sb
+      .from('memory_items')
+      .select('category_key')
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id)
+      .limit(1000);
+    if (error) return { ok: false, error: `Could not load memory summary: ${error.message}` };
+
+    const rows = (data || []) as Array<{ category_key: string }>;
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { total: 0, categories: [] },
+        text:
+          'The Memory Garden is empty — nothing stored about the user yet. ' +
+          'Explain that memories grow as they talk to Vitana, and offer to save something now.',
+      };
+    }
+
+    const counts = new Map<string, number>();
+    for (const r of rows) {
+      const garden = sourceToGarden.get(r.category_key) ?? r.category_key;
+      counts.set(garden, (counts.get(garden) ?? 0) + 1);
+    }
+
+    const categories = Array.from(counts.entries())
+      .map(([key, count]) => ({
+        category_key: key,
+        label: gardenLabels.get(key) ?? key.replace(/_/g, ' '),
+        count,
+      }))
+      .sort((a, b) => b.count - a.count);
+
+    const spoken = categories
+      .slice(0, 8)
+      .map((c) => `${c.label}: ${c.count}`)
+      .join(', ');
+
+    return {
+      ok: true,
+      result: { total: rows.length, categories },
+      text:
+        `The Memory Garden holds ${rows.length} memories about the user across ` +
+        `${categories.length} categor${categories.length === 1 ? 'y' : 'ies'} — ${spoken}. ` +
+        'Summarize warmly in the user\'s language; mention the biggest areas first.',
+    };
+  } catch (err) {
+    return { ok: false, error: `get_memory_garden_summary failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// forget_memory — confirm-gated delete of ONE memory_items row.
+// memory_items has no soft-delete column (VTID-01104), so after confirmation
+// we hard-delete the row and record it in the memory_deletions ledger
+// (VTID-01099) for the governance audit trail.
+// ---------------------------------------------------------------------------
+
+export async function tool_forget_memory(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('forget_memory', id, true);
+  if (gate) return gate;
+
+  const memoryId = String(args.memory_id ?? '').trim();
+  if (!memoryId) {
+    return { ok: false, error: 'forget_memory requires memory_id (use recall_memory_about to find it).' };
+  }
+
+  try {
+    const { data, error } = await sb
+      .from('memory_items')
+      .select('id, category_key, content, occurred_at')
+      .eq('id', memoryId)
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    if (error) return { ok: false, error: `Could not look up that memory: ${error.message}` };
+    if (!data) {
+      return {
+        ok: false,
+        error: 'That memory was not found (it may already be deleted or belongs to another account).',
+      };
+    }
+
+    const item = data as { id: string; category_key: string; content: string; occurred_at: string };
+    const described = `"${snippet(item.content, 140)}" (${item.category_key}, ${dayPhrase(item.occurred_at)})`;
+
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { requires_confirmation: true, memory_id: item.id, content: item.content },
+        text:
+          `Confirmation needed before deleting. The memory is: ${described}. ` +
+          'Read it back and ask the user to confirm; only when they clearly say yes, ' +
+          'call forget_memory again with confirm=true. Deletion is permanent.',
+      };
+    }
+
+    const del = await sb
+      .from('memory_items')
+      .delete()
+      .eq('id', memoryId)
+      .eq('tenant_id', id.tenant_id)
+      .eq('user_id', id.user_id);
+    if (del.error) {
+      return { ok: false, error: `Could not delete the memory: ${del.error.message}` };
+    }
+
+    // Governance ledger (VTID-01099) — best-effort; the delete already happened.
+    try {
+      await sb.from('memory_deletions').insert({
+        tenant_id: id.tenant_id,
+        user_id: id.user_id,
+        entity_type: 'memory_item',
+        entity_id: memoryId,
+        cascade: { type: 'memory_item', note: 'deleted via ORB forget_memory voice tool' },
+      });
+    } catch (ledgerErr) {
+      console.warn(
+        `[forget_memory] memory_deletions ledger insert failed (non-fatal): ${(ledgerErr as Error).message}`,
+      );
+    }
+
+    return {
+      ok: true,
+      result: { deleted: true, memory_id: memoryId },
+      text: `Done — the memory ${described} has been permanently forgotten. Confirm briefly to the user.`,
+    };
+  } catch (err) {
+    return { ok: false, error: `forget_memory failed: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const DIARY_MEMORY_TOOL_HANDLERS: Record<string, Handler> = {
+  list_diary_entries: tool_list_diary_entries,
+  get_diary_streak: tool_get_diary_streak,
+  get_memory_timeline: tool_get_memory_timeline,
+  recall_memory_about: tool_recall_memory_about,
+  get_memory_garden_summary: tool_get_memory_garden_summary,
+  forget_memory: tool_forget_memory,
+};
+
+export const DIARY_MEMORY_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'list_diary_entries',
+    description: [
+      "List the user's Daily Diary entries, newest first, optionally within a date window.",
+      'CALL THIS WHEN the user says:',
+      '  - "What did I write in my diary?" / "Was steht in meinem Tagebuch?"',
+      '  - "Show my diary entries from last week" / "Zeig meine Tagebucheinträge"',
+      '  - "What did I log yesterday?" / "Was habe ich gestern eingetragen?"',
+      'Then summarize the entries naturally — do not read them verbatim or mention IDs.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        date_from: { type: 'string', description: 'Optional start date, YYYY-MM-DD (inclusive).' },
+        date_to: { type: 'string', description: 'Optional end date, YYYY-MM-DD (inclusive).' },
+        limit: { type: 'number', description: 'Max entries to return, 1-30. Omit for 10.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_diary_streak',
+    description: [
+      "Get the user's diary streak: current consecutive days with an entry plus their longest streak ever.",
+      'CALL THIS WHEN the user asks:',
+      '  - "What\'s my diary streak?" / "Wie lang ist meine Tagebuch-Serie?"',
+      '  - "How many days in a row have I journaled?" / "Wie viele Tage am Stück?"',
+      'Then celebrate an active streak, or encourage a restart if it broke.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_memory_timeline',
+    description: [
+      "Chronological timeline of what Vitana remembers: memory items, extracted facts, and diary entries, newest first.",
+      'CALL THIS WHEN the user asks:',
+      '  - "What happened last month?" / "Was ist letzten Monat passiert?"',
+      '  - "Show my memory timeline" / "Zeig meine Erinnerungs-Zeitleiste"',
+      '  - "What did we talk about in June?" / "Worüber haben wir im Juni gesprochen?"',
+      'Then retell the timeline as a short narrative in the user\'s language.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        date_from: { type: 'string', description: 'Optional start date, YYYY-MM-DD (inclusive).' },
+        date_to: { type: 'string', description: 'Optional end date, YYYY-MM-DD (inclusive).' },
+        limit: { type: 'number', description: 'Max timeline entries, 1-40. Omit for 15.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'recall_memory_about',
+    description: [
+      'Search stored memories and facts about ONE specific topic, person, or thing.',
+      'CALL THIS WHEN the user asks:',
+      '  - "What do you know about my sister?" / "Was weißt du über meine Schwester?"',
+      '  - "Do you remember my trip to Rome?" / "Erinnerst du dich an meine Rom-Reise?"',
+      '  - "What did I tell you about my project?" / "Was habe ich dir über mein Projekt erzählt?"',
+      'Answer ONLY from the returned content — never invent memories. If empty, say so and offer to remember it now.',
+      'Optional category filter: personal_identity, health_wellness, lifestyle_routines, network_relationships,',
+      'learning_knowledge, business_projects, finance_assets, location_environment, digital_footprint,',
+      'values_aspirations, autopilot_context, future_plans, uncategorized.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        topic: { type: 'string', description: 'The topic, person, or thing to recall (a word or short phrase).' },
+        category: { type: 'string', description: 'Optional Memory Garden category key to narrow the search.' },
+      },
+      required: ['topic'],
+    },
+  },
+  {
+    name: 'get_memory_garden_summary',
+    description: [
+      "Overview of the user's Memory Garden: how many memories are stored per category.",
+      'CALL THIS WHEN the user asks:',
+      '  - "What do you remember about me?" / "Was weißt du alles über mich?"',
+      '  - "How full is my Memory Garden?" / "Wie sieht mein Memory Garden aus?"',
+      '  - "What kind of things have you saved?" / "Was hast du über mich gespeichert?"',
+      'Then summarize warmly: total memories and the biggest categories first.',
+      'For details on a specific topic, use recall_memory_about instead.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'forget_memory',
+    description: [
+      'Permanently delete ONE stored memory, only after the user explicitly confirms.',
+      'CALL THIS WHEN the user says:',
+      '  - "Forget that" / "Vergiss das" / "Lösch diese Erinnerung"',
+      '  - "Delete what you saved about X" / "Lösch, was du über X gespeichert hast"',
+      'Flow: find the memory_id via recall_memory_about, call WITHOUT confirm first —',
+      'the tool returns the memory text; read it back and ask the user to confirm.',
+      'Only when they clearly say yes, call again with confirm=true. Deletion is permanent.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        memory_id: { type: 'string', description: 'The id of the memory item to delete (from recall_memory_about results).' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user explicitly confirmed the deletion.' },
+      },
+      required: ['memory_id'],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/discovery-tools.ts
+++ b/services/gateway/src/services/orb-tools/discovery-tools.ts
@@ -1,0 +1,1410 @@
+/**
+ * Discovery voice tools (VTID-02773, VTID-02775, VTID-02777, VTID-02780).
+ *
+ * Search/news, Autopilot recommendation management, intent management, and
+ * match tools for the ORB assistant (community role). Every handler REUSES
+ * verified existing backings rather than inventing new ones:
+ *
+ *   - global_search        → profiles + profile_posts + global_community_events
+ *                            + community_groups + products_catalog +
+ *                            services_catalog (all verified in migrations /
+ *                            social-memory-repository / orb-tools-shared).
+ *   - browse_news_feed     → social-memory repository (fetchCandidatePosts —
+ *                            the same privacy-filtered "interesting posts"
+ *                            source the social-memory service uses).
+ *   - snooze/dismiss/explain_recommendation
+ *                          → autopilot_recommendations + the SAME
+ *                            snooze_autopilot_recommendation /
+ *                            reject_autopilot_recommendation RPCs the Command
+ *                            Hub routes call (routes/autopilot-recommendations.ts).
+ *   - update/delete_intent → user_intents, mirroring PATCH /api/v1/intents/:id
+ *                            and POST /api/v1/intents/:id/close (routes/intents.ts).
+ *                            "Delete" maps to status='closed' — the platform's
+ *                            only removal path (no hard-delete exists).
+ *   - browse_intent_board  → user_intents open-board query, mirroring
+ *                            GET /api/v1/intent-board (partner_seek excluded,
+ *                            never the user's own posts).
+ *   - dispute_match        → intent_disputes via raiseDispute()
+ *                            (services/intent-dispute-service.ts, VTID-01976).
+ *   - find_perfect_match   → runFindMatch() (services/intent-find-match.ts,
+ *                            BOOTSTRAP-FIND-MATCH-VOICE) fused with the Life
+ *                            Compass goal + weakest Vitana Index pillar, the
+ *                            same fusion inputs find_perfect_product /
+ *                            find_perfect_practitioner use (VTID-02830).
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import {
+  fetchExclusions,
+  fetchFollowEdges,
+  fetchCandidatePosts,
+  fetchPeople,
+  type RawPost,
+} from '../social-memory/social-memory-repository';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const UUID_RX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function authGate(tool: string, id: OrbToolIdentity, needTenant = false): OrbToolResult | null {
+  if (!id.user_id || (needTenant && !id.tenant_id)) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+function clampInt(raw: unknown, min: number, max: number, fallback: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(Math.round(n), min), max);
+}
+
+/** Strip characters that would break a PostgREST .or() filter string. */
+function orSafe(term: string): string {
+  return term.replace(/[,()*]/g, ' ').trim();
+}
+
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const ms = Date.now() - Date.parse(iso);
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  const mins = Math.floor(ms / 60000);
+  if (mins < 60) return `${Math.max(1, mins)} min ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return days === 1 ? 'yesterday' : `${days} days ago`;
+}
+
+function whenLabel(iso: string | null | undefined): string {
+  if (!iso) return 'date TBD';
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return 'date TBD';
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+function snippet(text: string | null | undefined, max = 90): string {
+  const t = (text || '').replace(/\s+/g, ' ').trim();
+  return t.length > max ? `${t.slice(0, max)}…` : t;
+}
+
+/**
+ * Life-Compass goal + weakest Vitana Index pillar — the same fusion inputs
+ * find_perfect_product / find_perfect_practitioner use. Uses the corrected
+ * life_compass schema (primary_goal / category / is_active, per VTID-03022).
+ * Best-effort: both lookups fail soft.
+ */
+async function getCompassAndWeakestPillar(
+  sb: SupabaseClient,
+  userId: string,
+): Promise<{ compass_goal: string | null; compass_category: string | null; weakest_pillar: string | null }> {
+  let goal: string | null = null;
+  let category: string | null = null;
+  let weakest: string | null = null;
+  try {
+    const { data } = await sb
+      .from('life_compass')
+      .select('primary_goal, category')
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const row = data as { primary_goal: string | null; category: string | null } | null;
+    goal = (row?.primary_goal || '').trim() || null;
+    category = (row?.category || '').trim() || null;
+  } catch {
+    /* best-effort */
+  }
+  try {
+    const { data } = await sb
+      .from('vitana_index_scores')
+      .select('pillars')
+      .eq('user_id', userId)
+      .order('computed_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const pillars = (data as { pillars: Record<string, number> | null } | null)?.pillars;
+    if (pillars && typeof pillars === 'object') {
+      const pairs = Object.entries(pillars).filter(([, v]) => typeof v === 'number');
+      pairs.sort((a, b) => a[1] - b[1]);
+      weakest = pairs[0]?.[0] ?? null;
+    }
+  } catch {
+    /* best-effort */
+  }
+  return { compass_goal: goal, compass_category: category, weakest_pillar: weakest };
+}
+
+// ---------------------------------------------------------------------------
+// global_search — unified search across people / posts / events / groups /
+// products / services (VTID-02773)
+// ---------------------------------------------------------------------------
+
+interface SearchGroups {
+  people: Array<{ user_id: string; display_name: string | null; handle: string | null; vitana_id: string | null; city: string | null }>;
+  posts: Array<{ id: string; author: string; snippet: string; created_at: string }>;
+  events: Array<{ id: string; title: string; start_time: string; location: string | null }>;
+  groups: Array<{ id: string; name: string; topic_key: string | null; description: string | null }>;
+  products: Array<{ id: string; name: string; product_type: string | null }>;
+  services: Array<{ id: string; name: string; service_type: string | null; provider_name: string | null }>;
+}
+
+export async function tool_global_search(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('global_search', id);
+  if (gate) return gate;
+  const query = String(args.query ?? '').trim();
+  if (query.length < 2) {
+    return { ok: false, error: 'global_search requires a query of at least 2 characters.' };
+  }
+  const perCategory = clampInt(args.limit, 1, 5, 3);
+  const safe = orSafe(query);
+
+  const found: SearchGroups = { people: [], posts: [], events: [], groups: [], products: [], services: [] };
+
+  // Privacy filters for the people/posts lanes. FAIL CLOSED: if exclusions
+  // cannot be loaded we skip those two lanes rather than risk surfacing
+  // blocked/muted authors (social-memory contract).
+  let excl: { blocked: Set<string>; muted: Set<string>; hidden_posts: Set<string> } | null = null;
+  try {
+    excl = await fetchExclusions(id.user_id);
+  } catch {
+    excl = null;
+  }
+
+  const tasks: Promise<void>[] = [];
+
+  // People — public-safe profile columns only (social-memory PROFILE_COLS subset).
+  if (excl) {
+    const blocked = excl.blocked;
+    tasks.push(
+      (async () => {
+        try {
+          const { data } = await sb
+            .from('profiles')
+            .select('user_id, display_name, handle, vitana_id, city')
+            .or(`display_name.ilike.*${safe}*,handle.ilike.*${safe}*`)
+            .limit(perCategory + 5);
+          for (const row of (data as SearchGroups['people'] | null) ?? []) {
+            if (row.user_id === id.user_id || blocked.has(row.user_id)) continue;
+            if (found.people.length < perCategory) found.people.push(row);
+          }
+        } catch {
+          /* lane is best-effort */
+        }
+      })(),
+    );
+
+    // Posts — public + moderation-approved only (mirrors fetchCandidatePosts filters).
+    const exclusions = excl;
+    tasks.push(
+      (async () => {
+        try {
+          const { data } = await sb
+            .from('profile_posts')
+            .select('id, user_id, content, created_at')
+            .eq('is_public', true)
+            .neq('moderation_status', 'rejected')
+            .ilike('content', `%${query}%`)
+            .order('created_at', { ascending: false })
+            .limit(perCategory + 5);
+          const rows = ((data as Array<{ id: string; user_id: string; content: string | null; created_at: string }> | null) ?? []).filter(
+            (p) =>
+              !exclusions.blocked.has(p.user_id) &&
+              !exclusions.muted.has(p.user_id) &&
+              !exclusions.hidden_posts.has(p.id),
+          );
+          const authors = await fetchPeople(rows.map((r) => r.user_id));
+          for (const p of rows.slice(0, perCategory)) {
+            const person = authors.get(p.user_id);
+            found.posts.push({
+              id: p.id,
+              author: person?.display_name || person?.handle || 'a member',
+              snippet: snippet(p.content),
+              created_at: p.created_at,
+            });
+          }
+        } catch {
+          /* lane is best-effort */
+        }
+      })(),
+    );
+  }
+
+  // Events — upcoming only (same table tool_search_events uses).
+  tasks.push(
+    (async () => {
+      try {
+        const { data } = await sb
+          .from('global_community_events')
+          .select('id, title, start_time, location')
+          .gte('start_time', new Date().toISOString())
+          .or(`title.ilike.*${safe}*,description.ilike.*${safe}*`)
+          .order('start_time', { ascending: true })
+          .limit(perCategory);
+        found.events = (data as SearchGroups['events'] | null) ?? [];
+      } catch {
+        /* lane is best-effort */
+      }
+    })(),
+  );
+
+  // Groups — tenant-scoped public groups (mirrors tool_search_community).
+  if (id.tenant_id) {
+    tasks.push(
+      (async () => {
+        try {
+          const { data } = await sb
+            .from('community_groups')
+            .select('id, name, topic_key, description')
+            .eq('tenant_id', id.tenant_id)
+            .eq('is_public', true)
+            .or(`name.ilike.*${safe}*,description.ilike.*${safe}*,topic_key.ilike.*${safe}*`)
+            .limit(perCategory);
+          found.groups = (data as SearchGroups['groups'] | null) ?? [];
+        } catch {
+          /* lane is best-effort */
+        }
+      })(),
+    );
+
+    // Products / services catalogs (tenant-scoped tables, VTID-01092).
+    tasks.push(
+      (async () => {
+        try {
+          const { data } = await sb
+            .from('products_catalog')
+            .select('id, name, product_type')
+            .eq('tenant_id', id.tenant_id)
+            .ilike('name', `%${query}%`)
+            .limit(perCategory);
+          found.products = (data as SearchGroups['products'] | null) ?? [];
+        } catch {
+          /* catalog may not be deployed in this env */
+        }
+      })(),
+    );
+    tasks.push(
+      (async () => {
+        try {
+          const { data } = await sb
+            .from('services_catalog')
+            .select('id, name, service_type, provider_name')
+            .eq('tenant_id', id.tenant_id)
+            .ilike('name', `%${query}%`)
+            .limit(perCategory);
+          found.services = (data as SearchGroups['services'] | null) ?? [];
+        } catch {
+          /* catalog may not be deployed in this env */
+        }
+      })(),
+    );
+  }
+
+  await Promise.allSettled(tasks);
+
+  const lines: string[] = [];
+  if (found.people.length > 0) {
+    lines.push(
+      `People: ${found.people
+        .map((p) => `${p.display_name || p.handle || 'a member'}${p.city ? ` (${p.city})` : ''}`)
+        .join('; ')}.`,
+    );
+  }
+  if (found.posts.length > 0) {
+    lines.push(`Posts: ${found.posts.map((p) => `${p.author}: "${p.snippet}"`).join('; ')}.`);
+  }
+  if (found.events.length > 0) {
+    lines.push(
+      `Events: ${found.events
+        .map((e) => `${e.title} (${whenLabel(e.start_time)}${e.location ? `, ${e.location}` : ''})`)
+        .join('; ')}.`,
+    );
+  }
+  if (found.groups.length > 0) {
+    lines.push(`Groups: ${found.groups.map((g) => `${g.name} — ${snippet(g.description, 60)}`).join('; ')}.`);
+  }
+  if (found.products.length > 0) {
+    lines.push(`Products: ${found.products.map((p) => p.name).join(', ')}.`);
+  }
+  if (found.services.length > 0) {
+    lines.push(
+      `Services: ${found.services.map((s) => `${s.name}${s.provider_name ? ` by ${s.provider_name}` : ''}`).join('; ')}.`,
+    );
+  }
+
+  if (lines.length === 0) {
+    return {
+      ok: true,
+      result: { query, ...found },
+      text: `Nothing in the community matched "${query}" — no people, posts, events, groups, or catalog items. Suggest rephrasing or trying a broader term.`,
+    };
+  }
+
+  return {
+    ok: true,
+    result: { query, ...found },
+    text:
+      `Search results for "${query}" — present the most relevant category first, top hits only:\n` +
+      lines.join('\n'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// browse_news_feed — read the community feed aloud (VTID-02773)
+// ---------------------------------------------------------------------------
+
+export async function tool_browse_news_feed(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('browse_news_feed', id);
+  if (gate) return gate;
+  const scope = args.scope === 'following' ? 'following' : 'all';
+  const limit = clampInt(args.limit, 1, 10, 5);
+
+  // FAIL CLOSED on privacy filters — never surface content from blocked/muted
+  // authors (same contract as the social read tools).
+  let excl: { blocked: Set<string>; muted: Set<string>; hidden_posts: Set<string> };
+  try {
+    excl = await fetchExclusions(id.user_id);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    return {
+      ok: false,
+      error: `browse_news_feed: privacy filters unavailable (${msg}). Tell the user honestly you cannot read the feed right now — do not guess.`,
+    };
+  }
+
+  try {
+    const edges = await fetchFollowEdges(id.user_id, excl.blocked, 100);
+    const followedIds = edges.following.map((e) => e.person.user_id);
+
+    if (scope === 'following' && followedIds.length === 0) {
+      return {
+        ok: true,
+        result: { scope, total: 0, posts: [] },
+        text:
+          'The user does not follow anyone yet, so the "following" feed is empty. Say so plainly and offer to show the whole community feed or find interesting members to follow.',
+      };
+    }
+
+    let posts: RawPost[] = await fetchCandidatePosts(id.user_id, followedIds, excl, 40);
+    if (scope === 'following') {
+      const followedSet = new Set(followedIds);
+      posts = posts.filter((p) => followedSet.has(p.user_id));
+    }
+    posts.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+    const top = posts.slice(0, limit);
+
+    if (top.length === 0) {
+      return {
+        ok: true,
+        result: { scope, total: 0, posts: [] },
+        text:
+          scope === 'following'
+            ? 'No recent posts from the people the user follows (last 14 days). Say so plainly and offer the full community feed instead.'
+            : 'The community feed has no recent posts (last 14 days). Say so plainly — and suggest the user posts something to get things going.',
+      };
+    }
+
+    const people = await fetchPeople(top.map((p) => p.user_id));
+    const lines = top.map((p) => {
+      const person = people.get(p.user_id);
+      const name = person?.display_name || person?.handle || 'A member';
+      const likes = p.likes_count > 0 ? `, ${p.likes_count} like${p.likes_count === 1 ? '' : 's'}` : '';
+      return `${name}: "${snippet(p.content)}" (${timeAgo(p.created_at)}${likes})`;
+    });
+
+    return {
+      ok: true,
+      result: {
+        scope,
+        total: top.length,
+        posts: top.map((p) => ({
+          id: p.id,
+          author: people.get(p.user_id)?.display_name || people.get(p.user_id)?.handle || null,
+          content: snippet(p.content, 200),
+          likes_count: p.likes_count,
+          comments_count: p.comments_count,
+          created_at: p.created_at,
+        })),
+      },
+      text:
+        `Top ${top.length} post${top.length === 1 ? '' : 's'} from the community feed (${scope === 'following' ? 'people the user follows' : 'everyone'}), newest first: ` +
+        `${lines.join('; ')}. Speak each as author plus a one-line summary — do not read long posts verbatim.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'browse_news_feed failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Autopilot recommendation management (VTID-02775)
+// ---------------------------------------------------------------------------
+
+interface RecRow {
+  id: string;
+  title: string | null;
+  summary: string | null;
+  domain: string | null;
+  risk_level: string | null;
+  impact_score: number | null;
+  effort_score: number | null;
+  status: string | null;
+  snoozed_until: string | null;
+  user_id: string | null;
+  source_type?: string | null;
+  source_ref?: string | null;
+  contribution_vector?: Record<string, number> | null;
+  economic_axis?: string | null;
+  created_at?: string | null;
+}
+
+type RecResolution =
+  | { ok: true; rec: RecRow }
+  | { ok: false; res: OrbToolResult };
+
+/**
+ * Resolve a spoken recommendation reference (UUID or title/summary fragment)
+ * to ONE autopilot_recommendations row the user is allowed to act on
+ * (their own row or a system-wide row — same ownership rule as
+ * tool_activate_recommendation).
+ */
+async function resolveRecommendation(
+  sb: SupabaseClient,
+  id: OrbToolIdentity,
+  ref: string,
+  statuses: string[] | null,
+  toolName: string,
+): Promise<RecResolution> {
+  if (UUID_RX.test(ref)) {
+    const { data, error } = await sb
+      .from('autopilot_recommendations')
+      .select('*')
+      .eq('id', ref)
+      .maybeSingle();
+    if (error) return { ok: false, res: { ok: false, error: `${toolName}: ${error.message}` } };
+    const rec = data as RecRow | null;
+    if (!rec) {
+      return {
+        ok: false,
+        res: {
+          ok: true,
+          result: { found: false },
+          text: 'I could not find that recommendation — it may have been removed. Offer to list the current recommendations instead.',
+        },
+      };
+    }
+    if (rec.user_id && rec.user_id !== id.user_id) {
+      return { ok: false, res: { ok: false, error: 'recommendation_belongs_to_another_user' } };
+    }
+    return { ok: true, rec };
+  }
+
+  let q = sb
+    .from('autopilot_recommendations')
+    .select('*')
+    .or(`user_id.eq.${id.user_id},user_id.is.null`)
+    .order('created_at', { ascending: false })
+    .limit(5);
+  if (statuses && statuses.length > 0) q = q.in('status', statuses);
+  if (ref) {
+    const safe = orSafe(ref);
+    q = q.or(`title.ilike.*${safe}*,summary.ilike.*${safe}*`);
+  }
+  const { data, error } = await q;
+  if (error) return { ok: false, res: { ok: false, error: `${toolName}: ${error.message}` } };
+  const rows = (data as RecRow[] | null) ?? [];
+  if (rows.length === 0) {
+    return {
+      ok: false,
+      res: {
+        ok: true,
+        result: { found: false, query: ref },
+        text: ref
+          ? `No open recommendation matched "${ref}". Offer to read the current recommendation list so the user can pick one.`
+          : 'There are no open recommendations right now. Say so plainly.',
+      },
+    };
+  }
+  if (rows.length > 1 && ref) {
+    const titles = rows.slice(0, 3).map((r) => `"${r.title ?? 'untitled'}"`);
+    return {
+      ok: false,
+      res: {
+        ok: true,
+        result: {
+          ambiguous: true,
+          candidates: rows.slice(0, 3).map((r) => ({ id: r.id, title: r.title })),
+        },
+        text: `Several recommendations match: ${titles.join(', ')}. Ask the user which one they mean, then call ${toolName} again with its id.`,
+      },
+    };
+  }
+  if (rows.length > 1) {
+    const titles = rows.slice(0, 3).map((r) => `"${r.title ?? 'untitled'}"`);
+    return {
+      ok: false,
+      res: {
+        ok: true,
+        result: {
+          ambiguous: true,
+          candidates: rows.slice(0, 3).map((r) => ({ id: r.id, title: r.title })),
+        },
+        text: `There are several open recommendations: ${titles.join(', ')}. Ask which one the user means, then call ${toolName} again with its id.`,
+      },
+    };
+  }
+  return { ok: true, rec: rows[0] };
+}
+
+export async function tool_snooze_recommendation(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('snooze_recommendation', id);
+  if (gate) return gate;
+  const ref = String(args.recommendation ?? args.id ?? '').trim();
+  // Same 1–168h clamp as POST /recommendations/:id/snooze.
+  const hours = clampInt(args.hours, 1, 168, 24);
+
+  try {
+    const resolved = await resolveRecommendation(sb, id, ref, ['new', 'snoozed'], 'snooze_recommendation');
+    if (!resolved.ok) return resolved.res;
+    const rec = resolved.rec;
+
+    // Same RPC the Command Hub snooze button calls (VTID-01180).
+    const { data, error } = await sb.rpc('snooze_autopilot_recommendation', {
+      p_recommendation_id: rec.id,
+      p_hours: hours,
+    });
+    if (error) return { ok: false, error: `snooze_recommendation: ${error.message}` };
+    const resp = data as { ok?: boolean; error?: string; snoozed_until?: string } | null;
+    if (!resp?.ok) {
+      return { ok: false, error: resp?.error || 'snooze_failed' };
+    }
+    const until = resp.snoozed_until ? whenLabel(resp.snoozed_until) : `${hours} hours from now`;
+    const title = rec.title ?? 'that recommendation';
+    return {
+      ok: true,
+      result: { id: rec.id, title: rec.title, hours, snoozed_until: resp.snoozed_until ?? null },
+      text: `Done — "${title}" is snoozed for ${hours} hours. It will come back around ${until}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'snooze_recommendation failed' };
+  }
+}
+
+export async function tool_dismiss_recommendation(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('dismiss_recommendation', id);
+  if (gate) return gate;
+  const ref = String(args.recommendation ?? args.id ?? '').trim();
+  const reason = String(args.reason ?? '').trim();
+  const confirmed = args.confirm === true;
+
+  try {
+    const resolved = await resolveRecommendation(sb, id, ref, ['new', 'snoozed'], 'dismiss_recommendation');
+    if (!resolved.ok) return resolved.res;
+    const rec = resolved.rec;
+    const title = rec.title ?? 'that recommendation';
+
+    // Destructive — confirm first, per the shared confirm-flow contract.
+    if (!confirmed) {
+      return {
+        ok: true,
+        result: { stage: 'awaiting_confirmation', recommendation_id: rec.id, title: rec.title },
+        text: `Confirm with the user first: dismiss "${title}" for good (it will not come back)? On a clear yes, call dismiss_recommendation again with recommendation="${rec.id}" and confirm=true.`,
+      };
+    }
+
+    // Same RPC the Command Hub dismiss button calls (VTID-01180).
+    const { data, error } = await sb.rpc('reject_autopilot_recommendation', {
+      p_recommendation_id: rec.id,
+      p_reason: reason || null,
+    });
+    if (error) return { ok: false, error: `dismiss_recommendation: ${error.message}` };
+    const resp = data as { ok?: boolean; error?: string } | null;
+    if (!resp?.ok) {
+      return { ok: false, error: resp?.error || 'dismiss_failed' };
+    }
+    return {
+      ok: true,
+      result: { id: rec.id, title: rec.title, status: 'rejected' },
+      text: `Done — "${title}" is dismissed and will not be suggested again.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'dismiss_recommendation failed' };
+  }
+}
+
+const PILLAR_KEYS = ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'];
+
+export async function tool_explain_recommendation(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('explain_recommendation', id);
+  if (gate) return gate;
+  const ref = String(args.recommendation ?? args.id ?? '').trim();
+
+  try {
+    // No status filter — the user may ask "why did you suggest that?" about
+    // an already-activated or snoozed recommendation too.
+    const resolved = await resolveRecommendation(sb, id, ref, null, 'explain_recommendation');
+    if (!resolved.ok) return resolved.res;
+    const rec = resolved.rec;
+
+    const bits: string[] = [];
+    if (rec.summary) bits.push(rec.summary);
+
+    // Pillar contributions (contribution_vector JSONB, populated by trigger
+    // from source_ref — 20260423150000_vitana_index_contribution_vector.sql).
+    const cv = rec.contribution_vector;
+    if (cv && typeof cv === 'object') {
+      const pairs = Object.entries(cv)
+        .filter(([k, v]) => PILLAR_KEYS.includes(k) && typeof v === 'number' && v > 0)
+        .sort((a, b) => b[1] - a[1]);
+      if (pairs.length > 0) {
+        bits.push(`It mainly strengthens your ${pairs.slice(0, 2).map(([k]) => k).join(' and ')} pillar${pairs.length > 1 ? 's' : ''}.`);
+      }
+    }
+
+    if (typeof rec.impact_score === 'number' && typeof rec.effort_score === 'number') {
+      const impact = rec.impact_score >= 8 ? 'high' : rec.impact_score >= 5 ? 'solid' : 'modest';
+      const effort = rec.effort_score <= 3 ? 'low' : rec.effort_score <= 6 ? 'moderate' : 'higher';
+      bits.push(`Expected impact is ${impact} (${rec.impact_score}/10) for ${effort} effort (${rec.effort_score}/10).`);
+    }
+    if (rec.economic_axis && rec.economic_axis !== 'none') {
+      bits.push(`It also advances the "${rec.economic_axis.replace(/_/g, ' ')}" axis of your longevity economy.`);
+    }
+    if (rec.source_type) {
+      bits.push(`Source: ${rec.source_type.replace(/_/g, ' ')}${rec.domain ? `, domain ${rec.domain}` : ''}.`);
+    } else if (rec.domain) {
+      bits.push(`Domain: ${rec.domain}.`);
+    }
+
+    const title = rec.title ?? 'This recommendation';
+    return {
+      ok: true,
+      result: {
+        id: rec.id,
+        title: rec.title,
+        summary: rec.summary,
+        domain: rec.domain,
+        risk_level: rec.risk_level,
+        impact_score: rec.impact_score,
+        effort_score: rec.effort_score,
+        contribution_vector: cv ?? null,
+        source_type: rec.source_type ?? null,
+        economic_axis: rec.economic_axis ?? null,
+        status: rec.status,
+      },
+      text: `Why "${title}": ${bits.join(' ')} Offer to activate, snooze, or dismiss it.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'explain_recommendation failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Intent management (VTID-02777)
+// ---------------------------------------------------------------------------
+
+interface IntentRow {
+  intent_id: string;
+  intent_kind: string | null;
+  category: string | null;
+  title: string | null;
+  scope: string | null;
+  status: string | null;
+  created_at: string | null;
+}
+
+const ACTIVE_INTENT_STATUSES = ['open', 'matched', 'engaged'];
+
+type IntentResolution =
+  | { ok: true; intent: IntentRow }
+  | { ok: false; res: OrbToolResult };
+
+/** Resolve a spoken intent reference (UUID or title fragment) to ONE of the user's own active intents. */
+async function resolveMyIntent(
+  sb: SupabaseClient,
+  id: OrbToolIdentity,
+  ref: string,
+  toolName: string,
+): Promise<IntentResolution> {
+  const COLS = 'intent_id, intent_kind, category, title, scope, status, created_at';
+  if (UUID_RX.test(ref)) {
+    const { data, error } = await sb
+      .from('user_intents')
+      .select(COLS)
+      .eq('intent_id', ref)
+      .eq('requester_user_id', id.user_id)
+      .maybeSingle();
+    if (error) return { ok: false, res: { ok: false, error: `${toolName}: ${error.message}` } };
+    const intent = data as IntentRow | null;
+    if (!intent) {
+      return {
+        ok: false,
+        res: {
+          ok: true,
+          result: { found: false },
+          text: 'I could not find that post among the user\'s own posts. Offer to list their posts so they can pick one.',
+        },
+      };
+    }
+    return { ok: true, intent };
+  }
+
+  let q = sb
+    .from('user_intents')
+    .select(COLS)
+    .eq('requester_user_id', id.user_id)
+    .in('status', ACTIVE_INTENT_STATUSES)
+    .order('created_at', { ascending: false })
+    .limit(5);
+  if (ref) {
+    const safe = orSafe(ref);
+    q = q.or(`title.ilike.*${safe}*,scope.ilike.*${safe}*,category.ilike.*${safe}*`);
+  }
+  const { data, error } = await q;
+  if (error) return { ok: false, res: { ok: false, error: `${toolName}: ${error.message}` } };
+  const rows = (data as IntentRow[] | null) ?? [];
+  if (rows.length === 0) {
+    return {
+      ok: false,
+      res: {
+        ok: true,
+        result: { found: false, query: ref },
+        text: ref
+          ? `None of the user's open posts matched "${ref}". Offer to list their posts so they can pick one.`
+          : 'The user has no open posts right now. Say so plainly and offer to create one.',
+      },
+    };
+  }
+  if (rows.length > 1) {
+    const titles = rows.slice(0, 3).map((r) => `"${r.title ?? 'untitled'}"`);
+    return {
+      ok: false,
+      res: {
+        ok: true,
+        result: {
+          ambiguous: true,
+          candidates: rows.slice(0, 3).map((r) => ({ intent_id: r.intent_id, title: r.title })),
+        },
+        text: `Several of the user's posts match: ${titles.join(', ')}. Ask which one they mean, then call ${toolName} again with its intent id.`,
+      },
+    };
+  }
+  return { ok: true, intent: rows[0] };
+}
+
+export async function tool_update_intent(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('update_intent', id);
+  if (gate) return gate;
+  const ref = String(args.intent ?? args.intent_id ?? '').trim();
+
+  // Same allowed-field subset as PATCH /api/v1/intents/:id (owner only).
+  const patch: Record<string, unknown> = {};
+  const newTitle = String(args.new_title ?? '').trim();
+  const newText = String(args.new_text ?? args.new_scope ?? '').trim();
+  const newCategory = String(args.new_category ?? '').trim();
+  if (newTitle) patch.title = newTitle;
+  if (newText) patch.scope = newText;
+  if (newCategory) patch.category = newCategory;
+  if (Object.keys(patch).length === 0) {
+    return {
+      ok: false,
+      error: 'update_intent needs at least one change: new_title, new_text, or new_category. Ask the user what they want to change.',
+    };
+  }
+
+  try {
+    const resolved = await resolveMyIntent(sb, id, ref, 'update_intent');
+    if (!resolved.ok) return resolved.res;
+    const intent = resolved.intent;
+
+    const { data, error } = await sb
+      .from('user_intents')
+      .update(patch)
+      .eq('intent_id', intent.intent_id)
+      .eq('requester_user_id', id.user_id)
+      .select('intent_id, title, scope, category')
+      .maybeSingle();
+    if (error) return { ok: false, error: `update_intent: ${error.message}` };
+    if (!data) return { ok: false, error: 'not_found_or_not_owner' };
+    const updated = data as { intent_id: string; title: string | null; scope: string | null; category: string | null };
+
+    const changed: string[] = [];
+    if (patch.title) changed.push(`title is now "${updated.title}"`);
+    if (patch.scope) changed.push(`description is now "${snippet(updated.scope, 120)}"`);
+    if (patch.category) changed.push(`category is now ${updated.category}`);
+    return {
+      ok: true,
+      result: { intent_id: updated.intent_id, updated: patch },
+      text: `Done — the post is updated: ${changed.join(', ')}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'update_intent failed' };
+  }
+}
+
+export async function tool_delete_intent(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('delete_intent', id);
+  if (gate) return gate;
+  const ref = String(args.intent ?? args.intent_id ?? '').trim();
+  const confirmed = args.confirm === true;
+
+  try {
+    const resolved = await resolveMyIntent(sb, id, ref, 'delete_intent');
+    if (!resolved.ok) return resolved.res;
+    const intent = resolved.intent;
+    const title = intent.title ?? 'that post';
+
+    if (!confirmed) {
+      return {
+        ok: true,
+        result: { stage: 'awaiting_confirmation', intent_id: intent.intent_id, title: intent.title },
+        text: `Confirm with the user first: take down the post "${title}"? It will disappear from the board and matching stops. On a clear yes, call delete_intent again with intent="${intent.intent_id}" and confirm=true.`,
+      };
+    }
+
+    // The platform's removal path is status='closed' (POST /intents/:id/close);
+    // there is no hard-delete for user_intents.
+    const { data, error } = await sb
+      .from('user_intents')
+      .update({ status: 'closed' })
+      .eq('intent_id', intent.intent_id)
+      .eq('requester_user_id', id.user_id)
+      .select('intent_id')
+      .maybeSingle();
+    if (error) return { ok: false, error: `delete_intent: ${error.message}` };
+    if (!data) return { ok: false, error: 'not_found_or_not_owner' };
+
+    return {
+      ok: true,
+      result: { intent_id: intent.intent_id, title: intent.title, status: 'closed' },
+      text: `Done — "${title}" is taken down from the board. The user can always post it again later.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'delete_intent failed' };
+  }
+}
+
+const KIND_LABELS: Record<string, string> = {
+  activity_seek: 'activity partner wanted',
+  social_seek: 'looking to connect',
+  commercial_buy: 'looking to buy',
+  commercial_sell: 'offering',
+  mutual_aid: 'help exchange',
+};
+
+export async function tool_browse_intent_board(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('browse_intent_board', id, true);
+  if (gate) return gate;
+  const query = String(args.query ?? '').trim();
+  const limit = clampInt(args.limit, 1, 10, 5);
+
+  try {
+    // Mirrors GET /api/v1/intent-board: tenant-scoped, open only, never the
+    // user's own posts, partner_seek excluded on the default surface.
+    let q = sb
+      .from('user_intents')
+      .select('intent_id, intent_kind, category, title, scope, created_at')
+      .eq('tenant_id', id.tenant_id)
+      .eq('status', 'open')
+      .neq('requester_user_id', id.user_id)
+      .neq('intent_kind', 'partner_seek')
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (query) {
+      const safe = orSafe(query);
+      q = q.or(`title.ilike.*${safe}*,scope.ilike.*${safe}*,category.ilike.*${safe}*`);
+    }
+    const { data, error } = await q;
+    if (error) return { ok: false, error: `browse_intent_board: ${error.message}` };
+    const rows = (data as IntentRow[] | null) ?? [];
+
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { query: query || null, intents: [] },
+        text: query
+          ? `No open asks on the board matched "${query}". Offer to browse the whole board or post the user's own ask.`
+          : 'The intent board has no open asks right now. Warmly suggest the user posts the first one — you can set it up by voice.',
+      };
+    }
+
+    const lines = rows.map((r) => {
+      const kind = KIND_LABELS[r.intent_kind ?? ''] ?? (r.intent_kind ?? 'ask');
+      return `"${r.title ?? 'untitled'}" (${kind}${r.created_at ? `, ${timeAgo(r.created_at)}` : ''})`;
+    });
+    return {
+      ok: true,
+      result: { query: query || null, intents: rows },
+      text:
+        `${rows.length} open ask${rows.length === 1 ? '' : 's'} on the community board${query ? ` matching "${query}"` : ''}: ` +
+        `${lines.join('; ')}. Present the top ones and offer to respond to one or post the user's own.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'browse_intent_board failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// dispute_match — open a dispute on a match (VTID-02780, reuses VTID-01976)
+// ---------------------------------------------------------------------------
+
+const DISPUTE_CATEGORIES = ['no_show', 'misrepresented', 'safety', 'payment', 'other'] as const;
+type DisputeCategory = (typeof DISPUTE_CATEGORIES)[number];
+
+function normalizeDisputeCategory(raw: unknown): DisputeCategory {
+  const v = String(raw ?? '').trim().toLowerCase().replace(/[\s-]+/g, '_');
+  return (DISPUTE_CATEGORIES as readonly string[]).includes(v) ? (v as DisputeCategory) : 'other';
+}
+
+export async function tool_dispute_match(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('dispute_match', id);
+  if (gate) return gate;
+  let matchId = String(args.match_id ?? '').trim();
+  const reason = String(args.reason ?? '').trim();
+  const category = normalizeDisputeCategory(args.reason_category);
+  const confirmed = args.confirm === true;
+
+  try {
+    // No match named → look across the user's own intents' matches; only
+    // auto-pick when it is unambiguous (exactly one recent match).
+    if (!matchId) {
+      const { data: myIntents, error: intErr } = await sb
+        .from('user_intents')
+        .select('intent_id')
+        .eq('requester_user_id', id.user_id)
+        .order('created_at', { ascending: false })
+        .limit(50);
+      if (intErr) return { ok: false, error: `dispute_match: ${intErr.message}` };
+      const intentIds = ((myIntents as Array<{ intent_id: string }> | null) ?? []).map((r) => r.intent_id);
+      if (intentIds.length === 0) {
+        return {
+          ok: true,
+          result: { found: false },
+          text: 'The user has no posts, so there is no match to dispute. Ask what happened — maybe this is general feedback instead.',
+        };
+      }
+      const list = intentIds.join(',');
+      const { data: matches, error: mErr } = await sb
+        .from('intent_matches')
+        .select('match_id, intent_a_id, intent_b_id, state, created_at')
+        .or(`intent_a_id.in.(${list}),intent_b_id.in.(${list})`)
+        .order('created_at', { ascending: false })
+        .limit(5);
+      if (mErr) return { ok: false, error: `dispute_match: ${mErr.message}` };
+      const rows = (matches as Array<{ match_id: string; state: string | null; created_at: string | null }> | null) ?? [];
+      if (rows.length === 0) {
+        return {
+          ok: true,
+          result: { found: false },
+          text: 'The user has no matches yet, so there is nothing to dispute. Ask what happened — maybe this is general feedback instead.',
+        };
+      }
+      if (rows.length > 1) {
+        const opts = rows.slice(0, 3).map((r) => `${r.match_id} (${r.state ?? 'unknown'}, ${timeAgo(r.created_at)})`);
+        return {
+          ok: true,
+          result: { ambiguous: true, candidates: rows.slice(0, 3) },
+          text: `The user has several matches: ${opts.join('; ')}. Ask which match this is about (or open My Matches with view_intent_matches), then call dispute_match again with match_id.`,
+        };
+      }
+      matchId = rows[0].match_id;
+    }
+
+    if (!reason) {
+      return {
+        ok: true,
+        result: { stage: 'needs_reason', match_id: matchId },
+        text: 'Ask the user in one warm sentence what went wrong with this match (no-show, misrepresented, safety, payment, or something else), then call dispute_match again with match_id, reason, and reason_category.',
+      };
+    }
+
+    if (!confirmed) {
+      return {
+        ok: true,
+        result: { stage: 'awaiting_confirmation', match_id: matchId, reason, reason_category: category },
+        text: `Read this back and confirm before filing: open a dispute on this match because "${reason}" (category: ${category.replace(/_/g, ' ')}). The other member and our team will review it. On a clear yes, call dispute_match again with confirm=true.`,
+      };
+    }
+
+    // Canonical dispute path (VTID-01976): verifies the raiser is a party on
+    // the match, denormalises vitana_ids, emits OASIS audit + admin notify.
+    const { raiseDispute } = await import('../intent-dispute-service');
+    const dispute = await raiseDispute({
+      match_id: matchId,
+      raised_by: id.user_id,
+      reason_category: category,
+      reason_detail: reason,
+      vitana_id_hint: id.vitana_id ?? null,
+    });
+
+    return {
+      ok: true,
+      result: { dispute_id: dispute.dispute_id, match_id: matchId, status: dispute.status },
+      text: 'The dispute is filed — our team will review it and follow up. Reassure the user their report is logged and they can add details any time from the match page.',
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'dispute_match failed';
+    if (msg === 'match_not_found') {
+      return {
+        ok: true,
+        result: { found: false },
+        text: 'I could not find that match. Offer to open My Matches (view_intent_matches) so the user can point at the right one.',
+      };
+    }
+    if (msg === 'not_a_party') {
+      return { ok: false, error: 'dispute_match: the user is not a participant of that match.' };
+    }
+    return { ok: false, error: msg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// find_perfect_match — flagship people-match search (VTID-02780)
+// ---------------------------------------------------------------------------
+
+/** Weakest pillar → a sensible default people-ask when the user is vague. */
+const PILLAR_DEFAULT_ASK: Record<string, string> = {
+  exercise: 'a workout partner to train with regularly',
+  sleep: 'an accountability partner for a better evening and sleep routine',
+  nutrition: 'a healthy-cooking and nutrition buddy',
+  hydration: 'an accountability buddy for daily healthy habits',
+  mental: 'a mindfulness or meditation partner',
+};
+
+export async function tool_find_perfect_match(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('find_perfect_match', id);
+  if (gate) return gate;
+  let ask = String(args.ask ?? args.utterance ?? args.query ?? '').trim();
+
+  try {
+    // Fusion inputs — same pair find_perfect_product/practitioner use.
+    const ctx = await getCompassAndWeakestPillar(sb, id.user_id);
+
+    let derivedFromPillar = false;
+    if (!ask) {
+      if (ctx.weakest_pillar && PILLAR_DEFAULT_ASK[ctx.weakest_pillar]) {
+        ask = PILLAR_DEFAULT_ASK[ctx.weakest_pillar];
+        derivedFromPillar = true;
+      } else {
+        return {
+          ok: true,
+          result: { stage: 'needs_ask' },
+          text: 'Ask the user in one warm sentence what kind of person they are looking for — a workout partner, an accountability buddy, a mentor, someone to learn with — then call find_perfect_match again with their answer as ask.',
+        };
+      }
+    }
+
+    // REUSE the find_match engine (BOOTSTRAP-FIND-MATCH-VOICE): classify +
+    // extract + search the live intent catalog, recommend existing people,
+    // and post the request (with confirm flow) so the user is discoverable.
+    const { runFindMatch } = await import('../intent-find-match');
+    const r = await runFindMatch(
+      { utterance: ask, kind_hint: args.kind_hint, confirmed: args.confirmed },
+      {
+        user_id: id.user_id,
+        tenant_id: id.tenant_id ?? null,
+        vitana_id: id.vitana_id ?? null,
+        session_id: id.session_id ?? null,
+      },
+    );
+    if (!r.ok) return { ok: false, error: r.error ?? 'find_perfect_match failed' };
+
+    const personalBits: string[] = [];
+    if (ctx.compass_goal) personalBits.push(`the user's Life Compass goal "${ctx.compass_goal}"`);
+    if (ctx.weakest_pillar) personalBits.push(`their ${ctx.weakest_pillar} pillar (currently their weakest)`);
+    const prefix =
+      personalBits.length > 0
+        ? `PERSONALIZATION — this people-search is aligned with ${personalBits.join(' and ')}${derivedFromPillar ? `; the ask "${ask}" was suggested from that pillar` : ''}. Mention this in one natural sentence. `
+        : '';
+
+    return {
+      ok: true,
+      result: {
+        ...r.data,
+        stage: r.stage,
+        ask,
+        ask_derived_from_pillar: derivedFromPillar,
+        compass_goal: ctx.compass_goal,
+        compass_category: ctx.compass_category,
+        weakest_pillar: ctx.weakest_pillar,
+      },
+      text: prefix + r.text,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'find_perfect_match failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const DISCOVERY_TOOL_HANDLERS: Record<string, Handler> = {
+  global_search: tool_global_search,
+  browse_news_feed: tool_browse_news_feed,
+  snooze_recommendation: tool_snooze_recommendation,
+  dismiss_recommendation: tool_dismiss_recommendation,
+  explain_recommendation: tool_explain_recommendation,
+  update_intent: tool_update_intent,
+  delete_intent: tool_delete_intent,
+  browse_intent_board: tool_browse_intent_board,
+  dispute_match: tool_dispute_match,
+  find_perfect_match: tool_find_perfect_match,
+};
+
+export const DISCOVERY_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'global_search',
+    description: [
+      'Unified community search across people, posts, events, groups, products,',
+      'and services in one call. Returns the top hits per category.',
+      'CALL WHEN the user asks a broad "find/search" question: "search for yoga",',
+      '"find anything about fasting", "such nach Tennis", "gibt es was zu Schlaf?".',
+      'For a specific person prefer find_community_member; for events only,',
+      'search_events. After the tool runs, present the most relevant category',
+      'first — top two or three hits, never the raw list.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'What the user is looking for, verbatim.' },
+        limit: { type: 'number', description: 'Max hits per category, 1-5. Omit for 3.' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'browse_news_feed',
+    description: [
+      'Read the community news feed aloud: recent posts with author and a',
+      'one-line summary. scope "following" limits to people the user follows;',
+      '"all" is the whole community (default).',
+      'CALL WHEN the user asks: "what\'s new in the community?", "read me the',
+      'feed", "was gibt es Neues?", "zeig mir die Neuigkeiten von Leuten denen',
+      'ich folge". After the tool runs, speak each post as author plus a short',
+      'summary — never read long posts word for word.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'How many posts to read, 1-10. Omit for 5.' },
+        scope: {
+          type: 'string',
+          enum: ['following', 'all'],
+          description: '"following" = only people the user follows; "all" = whole community (default).',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'snooze_recommendation',
+    description: [
+      'Snooze an Autopilot recommendation so it resurfaces later (default 24h,',
+      'max one week). Accepts the recommendation id or a spoken title fragment.',
+      'CALL WHEN the user says: "remind me about that later", "snooze the sleep',
+      'recommendation", "später erinnern", "leg das auf Wiedervorlage".',
+      'After the tool runs, confirm the title and when it will come back.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        recommendation: { type: 'string', description: 'Recommendation id (UUID) or a title fragment the user said.' },
+        hours: { type: 'number', description: 'Hours to snooze, 1-168. Omit for 24.' },
+      },
+      required: ['recommendation'],
+    },
+  },
+  {
+    name: 'dismiss_recommendation',
+    description: [
+      'Dismiss an Autopilot recommendation for good (it will not come back).',
+      'TWO-STEP: first call returns a confirmation question — read it back;',
+      'only after a clear yes call again with confirm=true.',
+      'CALL WHEN the user says: "not interested", "dismiss that suggestion",',
+      '"das interessiert mich nicht", "weg damit".',
+      'If the user just wants it later, use snooze_recommendation instead.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        recommendation: { type: 'string', description: 'Recommendation id (UUID) or a title fragment the user said.' },
+        reason: { type: 'string', description: 'OPTIONAL — why the user dismisses it, in their words.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user verbally confirmed the dismissal.' },
+      },
+      required: ['recommendation'],
+    },
+  },
+  {
+    name: 'explain_recommendation',
+    description: [
+      'Explain WHY a specific Autopilot recommendation was suggested: its',
+      'rationale, which Vitana pillars it strengthens, impact vs effort, and',
+      'where it came from. Accepts an id or a spoken title fragment.',
+      'CALL WHEN the user asks: "why are you suggesting this?", "what\'s that',
+      'recommendation about?", "warum schlägst du mir das vor?", "was bringt',
+      'mir das?". After the tool runs, narrate the reason in 2-3 sentences and',
+      'offer to activate, snooze, or dismiss it.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        recommendation: { type: 'string', description: 'Recommendation id (UUID) or a title fragment the user said.' },
+      },
+      required: ['recommendation'],
+    },
+  },
+  {
+    name: 'update_intent',
+    description: [
+      'Edit one of the user\'s OWN intent posts (title, description text, or',
+      'category). Accepts the intent id or a spoken title fragment.',
+      'CALL WHEN the user says: "change my tennis post to say weekends only",',
+      '"update the title of my ask", "ändere meinen Beitrag", "mach aus meinem',
+      'Post ...". Pass ONLY the fields that change. After the tool runs,',
+      'confirm what was updated in one sentence.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        intent: { type: 'string', description: 'Intent id (UUID) or a title fragment identifying the user\'s post.' },
+        new_title: { type: 'string', description: 'OPTIONAL — the new title.' },
+        new_text: { type: 'string', description: 'OPTIONAL — the new description / scope text.' },
+        new_category: { type: 'string', description: 'OPTIONAL — the new dotted category, e.g. sport.tennis.' },
+      },
+      required: ['intent'],
+    },
+  },
+  {
+    name: 'delete_intent',
+    description: [
+      'Take down one of the user\'s OWN intent posts from the board (closes it;',
+      'matching stops). TWO-STEP: first call returns a confirmation question —',
+      'read it back; only after a clear yes call again with confirm=true.',
+      'CALL WHEN the user says: "delete my post", "remove my tennis ask",',
+      '"lösch meinen Beitrag", "nimm das vom Brett".',
+      'If the ask was fulfilled, prefer mark_intent_fulfilled instead.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        intent: { type: 'string', description: 'Intent id (UUID) or a title fragment identifying the user\'s post.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user verbally confirmed the removal.' },
+      },
+      required: ['intent'],
+    },
+  },
+  {
+    name: 'browse_intent_board',
+    description: [
+      'Browse the open community intent board (Open Asks): what other members',
+      'are looking for, buying, selling, or offering right now. Optional query',
+      'filters by topic. Never shows the user\'s own posts.',
+      'CALL WHEN the user asks: "what are people looking for?", "browse the',
+      'asks board", "was suchen andere gerade?", "zeig mir das Schwarze Brett".',
+      'After the tool runs, present the top asks (title + kind) and offer to',
+      'respond to one or post the user\'s own ask.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'OPTIONAL — topic filter, e.g. "tennis" or "babysitting".' },
+        limit: { type: 'number', description: 'Max asks to return, 1-10. Omit for 5.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'dispute_match',
+    description: [
+      'Open a dispute on a match the user is part of (no-show, misrepresented,',
+      'safety, payment, other). MULTI-STEP: the tool first collects the reason,',
+      'then returns a confirmation question — only after a clear yes call again',
+      'with confirm=true. CALL WHEN the user says: "the seller never showed up",',
+      '"I want to report this match", "der Kontakt war fake", "ich möchte das',
+      'Match melden". Stay neutral and factual — never promise an outcome.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        match_id: { type: 'string', description: 'The match id if known. Omit to auto-detect from the user\'s recent matches.' },
+        reason: { type: 'string', description: 'What happened, in the user\'s words.' },
+        reason_category: {
+          type: 'string',
+          enum: ['no_show', 'misrepresented', 'safety', 'payment', 'other'],
+          description: 'Best-fitting category for what happened.',
+        },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user verbally confirmed filing the dispute.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'find_perfect_match',
+    description: [
+      'Flagship people-match: find the PERFECT person for the user — workout',
+      'partner, accountability buddy, mentor, learning partner — personalized',
+      'with their Life Compass goal and weakest Vitana pillar. Searches the',
+      'live community asks and, per the confirm flow, also posts the request',
+      'so the user becomes discoverable.',
+      'CALL WHEN the user says: "find me a workout partner", "who would be my',
+      'perfect accountability buddy?", "find den perfekten Trainingspartner',
+      'für mich", "such mir einen Mentor".',
+      'Follow the returned text exactly — it tells you whether matches were',
+      'found or a read-back confirmation is needed (then call again with',
+      'confirmed=true).',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        ask: { type: 'string', description: 'What kind of person the user wants, verbatim. May be omitted — then the weakest pillar suggests one.' },
+        kind_hint: { type: 'string', description: 'OPTIONAL intent kind hint, e.g. activity_seek or social_seek.' },
+        confirmed: { type: 'boolean', description: 'Pass true ONLY after the user confirmed posting the request (second call).' },
+      },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/feedback-settings-tools.ts
+++ b/services/gateway/src/services/orb-tools/feedback-settings-tools.ts
@@ -1,0 +1,1004 @@
+/**
+ * Feedback-ticket + Settings voice tools (VTID-02768, VTID-02772).
+ *
+ * Feedback (VTID-02768): typed shortcuts over the unified feedback pipeline
+ * (VTID-02047). Each submit_* tool files a `feedback_tickets` row of a fixed
+ * `kind` and confirms — it does NOT persona-swap the live call (that is
+ * report_to_specialist's job). Specialist resolution reuses the same
+ * persona-registry lookup the pipeline uses (`pickPersonaForKind[ForTenant]`,
+ * which reads the `agent_personas_registry` view — status='active' only), so
+ * the VTID-03044 Devon-only canary is honoured automatically: bug reports
+ * triage to devon; support / marketplace / account tickets file as unrouted
+ * ('new') until Sage / Atlas / Mira are re-enabled. When a specialist
+ * resolves, the ticket is created through the shared
+ * `executeReportToSpecialist` core (same insert + handoff event + OASIS
+ * emit); the two-gate consent RPC is intentionally bypassed via
+ * specialist_hint because calling a typed submit tool IS the explicit filing
+ * intent.
+ *
+ * Settings (VTID-02772): writes the SAME storage the app reads —
+ * `user_preferences.stt_language` (frontend Language picker) +
+ * `app_users.locale` (gateway i18n canonical) for language;
+ * `user_preferences.tts_*` for voice prefs; `social_connections` (connector
+ * dispatcher's token store) + `user_connections` (category='ai_assistant')
+ * for connected apps. Theme is device-local (next-themes localStorage in
+ * vitana-v1) — no server column exists, so set_theme answers gracefully.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { executeReportToSpecialist } from '../report-to-specialist-core';
+import {
+  pickPersonaForKind,
+  pickPersonaForKindForTenant,
+} from '../persona-registry';
+import { emitOasisEvent } from '../oasis-event-service';
+import {
+  disconnectSocialAccount,
+  getUserConnections,
+  SUPPORTED_PROVIDERS,
+  type SocialProvider,
+} from '../social-connect-service';
+import { invalidateUserLocale } from '../../i18n/server-locale';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const TICKET_SOURCE = 'orb-voice-typed-tool';
+const DEFAULT_SCREEN_PATH = '/orb/voice';
+
+// ---------------------------------------------------------------------------
+// Feedback tickets (VTID-02768)
+// ---------------------------------------------------------------------------
+
+type TypedTicketKind =
+  | 'bug'
+  | 'support_question'
+  | 'marketplace_claim'
+  | 'account_issue';
+
+const KIND_LABEL: Record<TypedTicketKind, string> = {
+  bug: 'bug report',
+  support_question: 'support question',
+  marketplace_claim: 'marketplace dispute',
+  account_issue: 'account issue',
+};
+
+function wordCount(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+function askForSpecifics(toolName: string, words: number, minWords: number): OrbToolResult {
+  return {
+    ok: true,
+    result: { decision: 'needs_details', word_count: words, min_words: minWords },
+    text:
+      `ASK_FOR_SPECIFICS: The summary is too short (${words} words, need at least ${minWords}). ` +
+      `Do NOT call ${toolName} again yet. Ask the user ONE follow-up question in their language ` +
+      `for concrete details (what exactly happened, which screen or feature, what they expected). ` +
+      `Then call ${toolName} again with a fuller summary in the user's own words. ` +
+      `Do not mention this internal check out loud.`,
+  };
+}
+
+function ticketFiledInstruction(
+  ticketNumber: string,
+  kind: TypedTicketKind,
+  specialist: string | null,
+): string {
+  const routing = specialist
+    ? 'It is already with our tech-support colleague.'
+    : 'Our team will pick it up and follow up.';
+  return (
+    `Ticket ${ticketNumber} filed (${KIND_LABEL[kind]}). ${routing} ` +
+    `Tell the user warmly in their language that the report is filed — mention the ticket number ONCE ` +
+    `so they can refer to it later. NEVER speak internal specialist names (Devon, Sage, Atlas, Mira). ` +
+    `Do not switch persona. Then STOP.`
+  );
+}
+
+/**
+ * Shared filing path for the four typed submit_* tools.
+ *
+ * 1. Resolve the owning specialist from the persona registry (active
+ *    personas only — VTID-03044 canary means only devon resolves today).
+ * 2. Specialist found → reuse `executeReportToSpecialist` with that hint
+ *    (identical ticket insert + feedback_handoff_events + OASIS emit as
+ *    report_to_specialist; the hint deterministically skips the two-gate
+ *    consent RPC, which is correct here — the typed tool call IS consent).
+ * 3. No enabled specialist → insert the ticket unrouted (status 'new',
+ *    resolver_agent null), mirroring the core's unrouted branch, and emit
+ *    the same `feedback.ticket.created` OASIS event.
+ */
+async function createTypedTicket(
+  toolName: string,
+  kind: TypedTicketKind,
+  minWords: number,
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+  extraFields: Record<string, unknown> = {},
+): Promise<OrbToolResult> {
+  if (!id.user_id) {
+    return { ok: false, error: `${toolName} requires an authenticated user.` };
+  }
+  const summary = String(args.summary ?? '').trim();
+  if (!summary) {
+    return { ok: false, error: 'summary is required' };
+  }
+  const words = wordCount(summary);
+  if (words < minWords) {
+    return askForSpecifics(toolName, words, minWords);
+  }
+
+  const screenPath = String(args.screen ?? '').trim() || DEFAULT_SCREEN_PATH;
+
+  // Same registry resolution the pipeline uses. Only status='active'
+  // personas resolve (VTID-03044: devon only), so this cannot route to a
+  // disabled specialist.
+  let specialist: string | null = null;
+  try {
+    specialist = id.tenant_id
+      ? await pickPersonaForKindForTenant(kind, id.tenant_id)
+      : await pickPersonaForKind(kind);
+  } catch {
+    specialist = null;
+  }
+
+  try {
+    if (specialist) {
+      const result = await executeReportToSpecialist(
+        { kind, summary, specialist_hint: specialist },
+        {
+          user_id: id.user_id,
+          tenant_id: id.tenant_id ?? null,
+          vitana_id: id.vitana_id ?? null,
+          lang: id.lang ?? null,
+        },
+        sb,
+        { gate_input: summary, source: TICKET_SOURCE, screen_path: screenPath },
+      );
+      switch (result.decision) {
+        case 'failed':
+          return { ok: false, error: result.error };
+        case 'vague':
+          return {
+            ok: true,
+            result: { decision: 'needs_details', word_count: result.word_count },
+            text: result.llm_instruction,
+          };
+        case 'stay_inline':
+          // Defensive — cannot happen with a specialist_hint set, but keep
+          // the LLM instruction honest if the core ever changes.
+          return {
+            ok: true,
+            result: { decision: 'stay_inline', rpc_gate: result.rpc_gate },
+            text: result.llm_instruction,
+          };
+        case 'created':
+          return {
+            ok: true,
+            result: {
+              decision: 'created',
+              ticket_id: result.ticket.id,
+              ticket_number: result.ticket.ticket_number,
+              kind,
+              specialist: result.persona,
+            },
+            text: ticketFiledInstruction(
+              result.ticket.ticket_number ?? '(pending)',
+              kind,
+              result.persona,
+            ),
+          };
+      }
+    }
+
+    // Unrouted path — mirrors executeReportToSpecialist's insert shape when
+    // no specialist is enabled (VTID-03044: support/marketplace/account).
+    const { data: created, error: insertError } = await sb
+      .from('feedback_tickets')
+      .insert({
+        user_id: id.user_id,
+        vitana_id: id.vitana_id ?? null,
+        kind,
+        status: 'new',
+        raw_transcript: summary,
+        intake_messages: [
+          { agent: 'vitana', role: 'user', content: summary, ts: new Date().toISOString() },
+        ],
+        structured_fields: {
+          specialist_hint: null,
+          voice_origin: true,
+          source: TICKET_SOURCE,
+          ...extraFields,
+        },
+        screen_path: screenPath,
+        resolver_agent: null,
+        triaged_at: null,
+      })
+      .select('id, ticket_number')
+      .single();
+
+    if (insertError || !created) {
+      return {
+        ok: false,
+        error: `feedback_tickets insert failed: ${insertError?.message ?? 'no row returned'}`,
+      };
+    }
+    const ticket = created as { id: string; ticket_number: string | null };
+
+    try {
+      await emitOasisEvent({
+        vtid: 'VTID-02768',
+        type: 'feedback.ticket.created' as never,
+        source: TICKET_SOURCE,
+        status: 'info',
+        message: `Voice tool ${toolName} created ticket ${ticket.ticket_number ?? '(pending)'} (${kind}) → unrouted`,
+        payload: {
+          ticket_id: ticket.id,
+          ticket_number: ticket.ticket_number,
+          kind,
+          specialist: null,
+          voice_origin: true,
+          source: TICKET_SOURCE,
+        },
+        actor_id: id.user_id,
+        actor_role: 'user',
+        surface: 'orb',
+        vitana_id: id.vitana_id ?? undefined,
+      });
+    } catch {
+      /* non-blocking — the ticket is the source of truth */
+    }
+
+    return {
+      ok: true,
+      result: {
+        decision: 'created',
+        ticket_id: ticket.id,
+        ticket_number: ticket.ticket_number,
+        kind,
+        specialist: null,
+      },
+      text: ticketFiledInstruction(ticket.ticket_number ?? '(pending)', kind, null),
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : `${toolName} failed` };
+  }
+}
+
+export async function tool_submit_bug_report(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const screen = String(args.screen ?? '').trim();
+  return createTypedTicket(
+    'submit_bug_report', 'bug', 15, args, id, sb,
+    screen ? { screen } : {},
+  );
+}
+
+export async function tool_submit_support_ticket(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  return createTypedTicket('submit_support_ticket', 'support_question', 12, args, id, sb);
+}
+
+export async function tool_submit_marketplace_dispute(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const orderReference = String(args.order_reference ?? '').trim();
+  return createTypedTicket(
+    'submit_marketplace_dispute', 'marketplace_claim', 12, args, id, sb,
+    orderReference ? { order_reference: orderReference } : {},
+  );
+}
+
+export async function tool_submit_account_issue(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  return createTypedTicket('submit_account_issue', 'account_issue', 12, args, id, sb);
+}
+
+// Open = anything before a terminal status. Matches the "active tickets"
+// partial index on feedback_tickets (priority, status).
+const CLOSED_STATUSES = ['resolved', 'user_confirmed', 'rejected', 'wont_fix', 'duplicate'];
+
+const SPEAKABLE_STATUS: Record<string, string> = {
+  new: 'received',
+  interviewing: 'in intake',
+  triaged: 'with the team',
+  spec_pending: 'being scoped',
+  spec_ready: 'scoped and queued',
+  answer_pending: 'being answered',
+  answer_ready: 'answer ready for you',
+  approved: 'approved for work',
+  in_progress: 'in progress',
+  needs_more_info: 'waiting on more info from you',
+  reopened: 'reopened',
+};
+
+export async function tool_list_my_tickets(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) {
+    return { ok: false, error: 'list_my_tickets requires an authenticated user.' };
+  }
+  try {
+    const { data, error } = await sb
+      .from('feedback_tickets')
+      .select('id, ticket_number, kind, status, created_at')
+      .eq('user_id', id.user_id)
+      .not('status', 'in', `(${CLOSED_STATUSES.join(',')})`)
+      .order('created_at', { ascending: false })
+      .limit(8);
+    if (error) {
+      return { ok: false, error: `Could not load tickets: ${error.message}` };
+    }
+    const rows = (data ?? []) as Array<{
+      id: string;
+      ticket_number: string | null;
+      kind: string;
+      status: string;
+      created_at: string;
+    }>;
+
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { tickets: [], total: 0 },
+        text:
+          'The user has NO open tickets right now. Say so plainly in their language — ' +
+          'everything they reported is either resolved or they have not filed anything yet.',
+      };
+    }
+
+    const lines = rows.map((t) => {
+      const kindLabel = KIND_LABEL[t.kind as TypedTicketKind] ?? t.kind.replace(/_/g, ' ');
+      const statusLabel = SPEAKABLE_STATUS[t.status] ?? t.status.replace(/_/g, ' ');
+      const filed = String(t.created_at ?? '').slice(0, 10);
+      return `${t.ticket_number ?? '(pending)'} — ${kindLabel}, ${statusLabel}, filed ${filed}`;
+    });
+    return {
+      ok: true,
+      result: { tickets: rows, total: rows.length },
+      text:
+        `The user has ${rows.length} open ticket(s): ${lines.join('; ')}. ` +
+        `Read them back naturally in the user's language — ticket number, what it is, and its status. ` +
+        `Do not mention internal specialist names.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'list_my_tickets failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Settings (VTID-02772)
+// ---------------------------------------------------------------------------
+
+const SUPPORTED_LANGUAGES: Record<string, { full: string; name: string }> = {
+  de: { full: 'de-DE', name: 'German (Deutsch)' },
+  en: { full: 'en-US', name: 'English' },
+  es: { full: 'es-ES', name: 'Spanish (Español)' },
+  sr: { full: 'sr-RS', name: 'Serbian (Srpski)' },
+};
+
+export async function tool_set_language(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) {
+    return { ok: false, error: 'set_language requires an authenticated user.' };
+  }
+  const raw = String(args.language ?? '').trim().toLowerCase();
+  const short = raw.split('-')[0];
+  const lang = SUPPORTED_LANGUAGES[short];
+  if (!lang) {
+    return {
+      ok: false,
+      error: `Unsupported language "${raw}". Supported: de (German), en (English), es (Spanish), sr (Serbian).`,
+    };
+  }
+  try {
+    // Primary store: user_preferences.stt_language — the column the frontend
+    // Language picker writes and the gateway i18n resolver reads as its live
+    // fallback. UNIQUE(user_id) → upsert.
+    const { error: prefError } = await sb.from('user_preferences').upsert(
+      {
+        user_id: id.user_id,
+        stt_language: lang.full,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id' },
+    );
+    if (prefError) {
+      return { ok: false, error: `Could not save language: ${prefError.message}` };
+    }
+
+    // Canonical i18n column (app_users.locale) — best-effort update; the row
+    // may not exist for pre-provisioned users and stt_language already wins
+    // for runtime resolution.
+    let appUsersUpdated = true;
+    try {
+      const { error: appUserError } = await sb
+        .from('app_users')
+        .update({ locale: short, updated_at: new Date().toISOString() })
+        .eq('user_id', id.user_id);
+      if (appUserError) appUsersUpdated = false;
+    } catch {
+      appUsersUpdated = false;
+    }
+
+    // Bust the gateway's 5-minute per-user locale cache so notifications and
+    // server-emitted strings switch immediately.
+    try {
+      invalidateUserLocale(id.user_id);
+    } catch {
+      /* cache invalidation is best-effort */
+    }
+
+    return {
+      ok: true,
+      result: {
+        language: short,
+        stt_language: lang.full,
+        app_users_locale_updated: appUsersUpdated,
+      },
+      text:
+        `Language saved: ${lang.name}. From this moment on, respond ONLY in ${lang.name}. ` +
+        `Tell the user (in ${lang.name}) that their language is now set — the app screens follow on the next reload.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'set_language failed' };
+  }
+}
+
+export async function tool_set_theme(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) {
+    return { ok: false, error: 'set_theme requires an authenticated user.' };
+  }
+  const theme = String(args.theme ?? '').trim().toLowerCase();
+  if (theme && !['light', 'dark', 'system'].includes(theme)) {
+    return { ok: false, error: `Unknown theme "${theme}". Options: light, dark, system.` };
+  }
+  // No server-side theme column exists: the app stores light/dark/system on
+  // the device (next-themes → localStorage), so a voice tool cannot persist
+  // it. Answer gracefully and point at the real switch.
+  return {
+    ok: true,
+    result: { persisted: false, requested_theme: theme || null },
+    text:
+      `The visual theme (light / dark / system) is a device setting stored in the app itself — ` +
+      `it cannot be changed from here. Tell the user in their language to open ` +
+      `Settings → Preferences and pick ${theme ? `"${theme}"` : 'light, dark, or system'} under Theme — it applies instantly on that device.`,
+  };
+}
+
+const PACE_TO_SPEED: Record<string, number> = { slow: 0.8, normal: 1.0, fast: 1.2 };
+
+export async function tool_set_voice_preferences(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) {
+    return { ok: false, error: 'set_voice_preferences requires an authenticated user.' };
+  }
+  const pace = String(args.pace ?? '').trim().toLowerCase();
+  const voice = String(args.voice ?? '').trim();
+  const tone = String(args.tone ?? '').trim();
+
+  if (!pace && !voice && !tone) {
+    return {
+      ok: false,
+      error: 'Nothing to change — provide at least one of: pace (slow/normal/fast), voice, tone.',
+    };
+  }
+  if (pace && PACE_TO_SPEED[pace] === undefined) {
+    return { ok: false, error: `Unknown pace "${pace}". Options: slow, normal, fast.` };
+  }
+
+  try {
+    const update: Record<string, unknown> = {
+      user_id: id.user_id,
+      updated_at: new Date().toISOString(),
+    };
+    const changes: string[] = [];
+    if (pace) {
+      update.tts_speed = PACE_TO_SPEED[pace];
+      changes.push(`pace ${pace} (${PACE_TO_SPEED[pace]}x)`);
+    }
+    if (voice) {
+      update.tts_voice = voice;
+      changes.push(`voice "${voice}"`);
+    }
+    if (tone) {
+      update.tts_character = tone;
+      changes.push(`tone "${tone}"`);
+    }
+
+    const { error } = await sb
+      .from('user_preferences')
+      .upsert(update, { onConflict: 'user_id' });
+    if (error) {
+      return { ok: false, error: `Could not save voice preferences: ${error.message}` };
+    }
+
+    return {
+      ok: true,
+      result: {
+        saved: true,
+        tts_speed: (update.tts_speed as number) ?? null,
+        tts_voice: voice || null,
+        tts_character: tone || null,
+      },
+      text:
+        `Voice preferences saved: ${changes.join(', ')}. Tell the user in their language that ` +
+        `their spoken-voice settings are updated — the app's speech output uses them from the next reply on.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'set_voice_preferences failed' };
+  }
+}
+
+const PROVIDER_DISPLAY: Record<string, string> = {
+  google: 'Google',
+  youtube: 'YouTube',
+  instagram: 'Instagram',
+  facebook: 'Facebook',
+  tiktok: 'TikTok',
+  linkedin: 'LinkedIn',
+  twitter: 'X (Twitter)',
+  spotify: 'Spotify',
+  openai: 'OpenAI (ChatGPT)',
+  anthropic: 'Anthropic (Claude)',
+  gemini: 'Google Gemini',
+  deepseek: 'DeepSeek',
+  mistral: 'Mistral',
+};
+
+function displayProvider(key: string): string {
+  return PROVIDER_DISPLAY[key] ?? key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+// Spoken names → connection keys (users say "Claude", not "anthropic").
+const PROVIDER_ALIASES: Record<string, string> = {
+  x: 'twitter',
+  chatgpt: 'openai',
+  claude: 'anthropic',
+  gmail: 'google',
+  'youtube music': 'youtube',
+};
+
+async function loadAiConnections(
+  sb: SupabaseClient,
+  userId: string,
+): Promise<Array<{ connector_id: string; connected_at: string | null }>> {
+  const { data, error } = await sb
+    .from('user_connections')
+    .select('connector_id, connected_at')
+    .eq('user_id', userId)
+    .eq('category', 'ai_assistant')
+    .eq('is_active', true);
+  if (error) return [];
+  return (data ?? []) as Array<{ connector_id: string; connected_at: string | null }>;
+}
+
+export async function tool_list_connected_apps(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) {
+    return { ok: false, error: 'list_connected_apps requires an authenticated user.' };
+  }
+  try {
+    const [social, ai] = await Promise.all([
+      getUserConnections(sb, id.user_id),
+      loadAiConnections(sb, id.user_id),
+    ]);
+
+    const entries: Array<{ provider: string; category: string; connected_at: string | null }> = [
+      ...social.map((c) => ({
+        provider: c.provider as string,
+        category: 'app',
+        connected_at: c.connected_at ?? null,
+      })),
+      ...ai.map((c) => ({
+        provider: c.connector_id,
+        category: 'ai_assistant',
+        connected_at: c.connected_at,
+      })),
+    ];
+
+    if (entries.length === 0) {
+      return {
+        ok: true,
+        result: { connections: [], total: 0 },
+        text:
+          'The user has NO connected apps yet. Say so plainly in their language, and mention they ' +
+          'can link Google, YouTube, or an AI assistant under Settings → Connected Apps.',
+      };
+    }
+
+    const spoken = entries.map((e) => {
+      const since = e.connected_at ? `, connected ${String(e.connected_at).slice(0, 10)}` : '';
+      return `${displayProvider(e.provider)}${e.category === 'ai_assistant' ? ' (AI assistant)' : ''}${since}`;
+    });
+    return {
+      ok: true,
+      result: { connections: entries, total: entries.length },
+      text:
+        `The user has ${entries.length} connected app(s): ${spoken.join('; ')}. ` +
+        `List them naturally in the user's language. They can manage them under Settings → Connected Apps.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'list_connected_apps failed' };
+  }
+}
+
+export async function tool_disconnect_app(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) {
+    return { ok: false, error: 'disconnect_app requires an authenticated user.' };
+  }
+  const rawProvider = String(args.provider ?? '').trim().toLowerCase();
+  if (!rawProvider) {
+    return { ok: false, error: 'provider is required (e.g. google, youtube, instagram, openai).' };
+  }
+  const provider = PROVIDER_ALIASES[rawProvider] ?? rawProvider;
+  const display = displayProvider(provider);
+
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, provider },
+      text:
+        `Disconnecting ${display} removes its access — features that rely on it stop working until it is ` +
+        `reconnected. Ask the user in their language to confirm they really want to disconnect ${display}. ` +
+        `Only after an explicit yes, call disconnect_app again with confirm=true. If they hesitate, do nothing.`,
+    };
+  }
+
+  try {
+    // 1) Social / OAuth connector (the token store the connector dispatcher
+    //    reads for read_email / play_music etc.) — reuse the exact service
+    //    function the settings route (POST /social/disconnect/:provider) uses.
+    if ((SUPPORTED_PROVIDERS as string[]).includes(provider)) {
+      const { data: socialRow } = await sb
+        .from('social_connections')
+        .select('id')
+        .eq('user_id', id.user_id)
+        .eq('provider', provider)
+        .eq('is_active', true)
+        .maybeSingle();
+      if (socialRow) {
+        const result = await disconnectSocialAccount(sb, id.user_id, provider as SocialProvider);
+        if (!result.ok) {
+          return { ok: false, error: `Could not disconnect ${display}: ${result.error ?? 'unknown error'}` };
+        }
+        return {
+          ok: true,
+          result: { disconnected: true, provider, category: 'app' },
+          text:
+            `${display} is disconnected. Confirm to the user in their language, and mention they can ` +
+            `reconnect anytime under Settings → Connected Apps.`,
+        };
+      }
+    }
+
+    // 2) AI assistant connection — same soft-disconnect + credential purge
+    //    the settings route (DELETE /api/v1/ai-assistants/:provider) performs.
+    const { data: aiRow } = await sb
+      .from('user_connections')
+      .select('id')
+      .eq('user_id', id.user_id)
+      .eq('connector_id', provider)
+      .eq('category', 'ai_assistant')
+      .eq('is_active', true)
+      .maybeSingle();
+    if (aiRow) {
+      const { error: updErr } = await sb
+        .from('user_connections')
+        .update({ is_active: false, disconnected_at: new Date().toISOString() })
+        .eq('id', (aiRow as { id: string }).id);
+      if (updErr) {
+        return { ok: false, error: `Could not disconnect ${display}: ${updErr.message}` };
+      }
+      // Purge the stored API key (overwrite with zero bytes, keep the row
+      // for audit) — mirrors the ai-assistants disconnect route.
+      try {
+        await sb
+          .from('ai_assistant_credentials')
+          .update({
+            encrypted_key: `\\x${'00'.repeat(32)}`,
+            encryption_iv: `\\x${'00'.repeat(12)}`,
+            encryption_tag: `\\x${'00'.repeat(16)}`,
+            last_verify_status: 'purged',
+          })
+          .eq('connection_id', (aiRow as { id: string }).id);
+      } catch {
+        /* row stays disconnected even if the purge write fails */
+      }
+      return {
+        ok: true,
+        result: { disconnected: true, provider, category: 'ai_assistant' },
+        text:
+          `${display} is disconnected and its stored key was removed. Confirm to the user in their ` +
+          `language; they can reconnect it under Settings → Connected Apps.`,
+      };
+    }
+
+    return {
+      ok: true,
+      result: { disconnected: false, provider, reason: 'not_connected' },
+      text:
+        `${display} is not connected — there is nothing to disconnect. Tell the user plainly in their ` +
+        `language; offer to list their connected apps if helpful.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'disconnect_app failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const FEEDBACK_SETTINGS_TOOL_HANDLERS: Record<string, Handler> = {
+  submit_bug_report: tool_submit_bug_report,
+  submit_support_ticket: tool_submit_support_ticket,
+  submit_marketplace_dispute: tool_submit_marketplace_dispute,
+  submit_account_issue: tool_submit_account_issue,
+  list_my_tickets: tool_list_my_tickets,
+  set_language: tool_set_language,
+  set_theme: tool_set_theme,
+  set_voice_preferences: tool_set_voice_preferences,
+  list_connected_apps: tool_list_connected_apps,
+  disconnect_app: tool_disconnect_app,
+};
+
+export const FEEDBACK_SETTINGS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'submit_bug_report',
+    description: [
+      'File a bug ticket (kind=bug) in the feedback pipeline. No persona swap —',
+      'just files and confirms. Call when the user describes something BROKEN and',
+      'wants it reported: "melde diesen Fehler", "die App stürzt ab, bitte melden",',
+      '"report this bug", "the button does nothing, file it".',
+      'The summary must be a concrete description of at least 15 words in the',
+      'user\'s own words — which screen, what happened, what was expected.',
+      'AFTER: speak the ticket number once and say the team will follow up.',
+      'For live handoff to a specialist use report_to_specialist instead.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        summary: {
+          type: 'string',
+          description: 'Concrete bug description, at least 15 words, in the user\'s own words (what broke, where, what was expected).',
+        },
+        screen: {
+          type: 'string',
+          description: 'Optional: the screen or feature where the bug happened (e.g. /events, profile page).',
+        },
+      },
+      required: ['summary'],
+    },
+  },
+  {
+    name: 'submit_support_ticket',
+    description: [
+      'File a support ticket (kind=support_question) for a question the team',
+      'should answer offline. Call when the user explicitly wants their question',
+      'logged for support: "erstell ein Support-Ticket", "leite meine Frage an den',
+      'Support weiter", "open a support ticket", "log this question for support".',
+      'Do NOT call for how-to questions you can answer yourself — answer inline.',
+      'Summary: at least 12 words describing the question and context.',
+      'AFTER: speak the ticket number once and say support will follow up.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        summary: {
+          type: 'string',
+          description: 'The user\'s question with context, at least 12 words.',
+        },
+      },
+      required: ['summary'],
+    },
+  },
+  {
+    name: 'submit_marketplace_dispute',
+    description: [
+      'File a marketplace dispute ticket (kind=marketplace_claim): refunds, wrong',
+      'or damaged items, orders that never arrived, seller issues, overcharges.',
+      'Triggers: "ich will mein Geld zurück", "die Bestellung ist nie angekommen",',
+      '"I want a refund", "the seller sent the wrong item, file a claim".',
+      'Summary: at least 12 words — what was ordered, what went wrong, what the',
+      'user wants (refund / replacement). Include the order number if they have it.',
+      'AFTER: speak the ticket number once and say the team will review the claim.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        summary: {
+          type: 'string',
+          description: 'Dispute description, at least 12 words: item, problem, desired outcome.',
+        },
+        order_reference: {
+          type: 'string',
+          description: 'Optional: order number or reference the user mentions.',
+        },
+      },
+      required: ['summary'],
+    },
+  },
+  {
+    name: 'submit_account_issue',
+    description: [
+      'File an account ticket (kind=account_issue): login problems, password or',
+      'email trouble, role/permission issues, profile data corrections, lockouts.',
+      'Triggers: "ich komme nicht in mein Konto", "meine E-Mail stimmt nicht,',
+      'bitte melden", "I\'m locked out", "report my login problem".',
+      'NEVER ask for or record passwords. Summary: at least 12 words describing',
+      'the account problem and what the user already tried.',
+      'AFTER: speak the ticket number once and say the team will follow up.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        summary: {
+          type: 'string',
+          description: 'Account problem description, at least 12 words. Never include passwords.',
+        },
+      },
+      required: ['summary'],
+    },
+  },
+  {
+    name: 'list_my_tickets',
+    description: [
+      'List the user\'s OPEN feedback tickets (bugs, support, disputes, account)',
+      'with number and status. Call when the user asks about their reports:',
+      '"was ist mit meinen Tickets?", "wie steht es um meine Fehlermeldung?",',
+      '"what happened to my bug report?", "show my open tickets".',
+      'AFTER: read back ticket number, what it is, and its status in the user\'s',
+      'language. Never mention internal specialist names.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'set_language',
+    description: [
+      'Set the user\'s app + voice language. Persists the same setting the app\'s',
+      'Language picker writes, so screens and notifications follow. Call when the',
+      'user asks to switch language: "stell auf Deutsch um", "sprich Englisch mit',
+      'mir", "switch the app to English", "cambia a español".',
+      'AFTER: respond ONLY in the new language from that moment on and confirm',
+      'the change; the app screens follow on the next reload.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        language: {
+          type: 'string',
+          enum: ['de', 'en', 'es', 'sr'],
+          description: 'Target language code: de (German), en (English), es (Spanish), sr (Serbian).',
+        },
+      },
+      required: ['language'],
+    },
+  },
+  {
+    name: 'set_theme',
+    description: [
+      'Handle a request to change the visual theme (light / dark / system).',
+      'Triggers: "mach den Dunkelmodus an", "stell auf hell", "switch to dark',
+      'mode", "use the system theme".',
+      'NOTE: the theme is stored on the device, not on the server — this tool',
+      'explains where to flip it (Settings → Preferences → Theme). Relay that',
+      'guidance in the user\'s language; do not promise the theme changed.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        theme: {
+          type: 'string',
+          enum: ['light', 'dark', 'system'],
+          description: 'The theme the user asked for.',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'set_voice_preferences',
+    description: [
+      'Tune the app\'s spoken-voice settings: pace (slow / normal / fast), voice',
+      'name, and tone/character. Persists to the same voice settings the app\'s',
+      'Voice & AI screen uses. Triggers: "sprich langsamer", "sprich schneller",',
+      '"klinge ruhiger", "speak slower please", "use a calmer tone".',
+      'Provide only the fields the user asked to change.',
+      'AFTER: confirm briefly what changed, in the user\'s language.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        pace: {
+          type: 'string',
+          enum: ['slow', 'normal', 'fast'],
+          description: 'Speaking speed the user asked for.',
+        },
+        voice: {
+          type: 'string',
+          description: 'Optional: a specific voice name the user asked for.',
+        },
+        tone: {
+          type: 'string',
+          description: 'Optional: tone/character, e.g. friendly, calm, energetic, professional.',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'list_connected_apps',
+    description: [
+      'List the user\'s connected integrations: Google, YouTube, social accounts,',
+      'and AI assistants (OpenAI, Anthropic, Gemini). Call when the user asks:',
+      '"welche Apps sind verbunden?", "ist mein Google-Konto verknüpft?",',
+      '"what apps are connected?", "is Spotify linked?".',
+      'AFTER: name each connected app naturally in the user\'s language; if none,',
+      'say so and mention Settings → Connected Apps.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'disconnect_app',
+    description: [
+      'Disconnect one connected integration (Google, YouTube, Instagram, an AI',
+      'assistant, ...). Triggers: "trenne mein Google-Konto", "entferne YouTube",',
+      '"disconnect my Google account", "unlink ChatGPT".',
+      'TWO-STEP: first call WITHOUT confirm — the tool returns a confirmation',
+      'question to relay. Only after the user explicitly says yes, call again',
+      'with confirm=true. Never disconnect without that explicit yes.',
+      'AFTER (confirmed): confirm it is disconnected and reconnectable in',
+      'Settings → Connected Apps.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        provider: {
+          type: 'string',
+          description: 'Which integration to disconnect, e.g. google, youtube, instagram, facebook, tiktok, linkedin, twitter, openai, anthropic, gemini.',
+        },
+        confirm: {
+          type: 'boolean',
+          description: 'Pass true ONLY after the user explicitly confirmed the disconnect out loud.',
+        },
+      },
+      required: ['provider'],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/groups-events-tools.ts
+++ b/services/gateway/src/services/orb-tools/groups-events-tools.ts
@@ -1,0 +1,1321 @@
+/**
+ * Community Groups (VTID-02764) + Events/RSVP (VTID-02774) voice tools.
+ *
+ * Groups tools operate on the REAL, populated groups schema —
+ * global_community_groups / global_community_group_members (see the
+ * "never-deployed VTID-01084 community_groups" note in
+ * routes/community.ts for why NOT community_groups/community_memberships)
+ * — plus community_group_invitations for the invite/accept/decline flow
+ * (its DB trigger sends the recipient a notification on insert).
+ * Events tools operate on global_community_events +
+ * global_event_participants (status='attending', UNIQUE(event_id,user_id),
+ * participant_count kept in sync — the exact contract the frontend's
+ * useEventParticipation hook uses), and live_rooms (tenant-scoped) for
+ * join_live_room, which returns the same navigate orb_directive shape
+ * search_community / search_events use so the UI opens the room screen.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+const VTID_GROUPS = 'VTID-02764';
+const VTID_EVENTS = 'VTID-02774';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** ok:false when there is no authenticated user — these tools touch user data. */
+function authGate(tool: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+/** "Tue, Jul 8, 6:00 PM" — English; the LLM translates when speaking DE. */
+function fmtWhen(iso: string | null | undefined): string {
+  if (!iso) return 'time to be announced';
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return 'time to be announced';
+  return d.toLocaleString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function memberCountPhrase(n: number | null | undefined): string {
+  const c = Number(n) || 0;
+  return `${c} member${c === 1 ? '' : 's'}`;
+}
+
+function navDirective(
+  screen_id: string,
+  route: string,
+  title: string,
+  reason: string,
+  vtid: string,
+): Record<string, unknown> {
+  return { type: 'orb_directive', directive: 'navigate', screen_id, route, title, reason, vtid };
+}
+
+/** tenant backfill from app_users when the voice session carries a null tenant. */
+async function resolveTenantId(id: OrbToolIdentity, sb: SupabaseClient): Promise<string | null> {
+  if (id.tenant_id) return id.tenant_id;
+  try {
+    const { data } = await sb
+      .from('app_users')
+      .select('tenant_id')
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    return (data as { tenant_id?: string | null } | null)?.tenant_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface GroupRow {
+  id: string;
+  name: string;
+  description: string | null;
+  member_count: number | null;
+  is_public: boolean | null;
+}
+
+type GroupResolution =
+  | { kind: 'one'; group: GroupRow }
+  | { kind: 'many'; groups: GroupRow[] }
+  | { kind: 'none'; query: string }
+  | { kind: 'error'; message: string };
+
+const GROUP_COLS = 'id, name, description, member_count, is_public';
+
+/** Resolve a group by UUID or fuzzy name against the live global groups schema. */
+async function resolveGroup(sb: SupabaseClient, rawId: unknown, rawQuery: unknown): Promise<GroupResolution> {
+  const groupId = String(rawId ?? '').trim();
+  const query = String(rawQuery ?? '').trim();
+
+  if (UUID_RE.test(groupId)) {
+    const { data, error } = await sb
+      .from('global_community_groups')
+      .select(GROUP_COLS)
+      .eq('id', groupId)
+      .eq('status', 'approved')
+      .maybeSingle();
+    if (error) return { kind: 'error', message: error.message };
+    if (!data) return { kind: 'none', query: groupId };
+    return { kind: 'one', group: data as GroupRow };
+  }
+
+  if (!query) return { kind: 'none', query: '' };
+
+  const { data, error } = await sb
+    .from('global_community_groups')
+    .select(GROUP_COLS)
+    .eq('status', 'approved')
+    .ilike('name', `%${query}%`)
+    .order('member_count', { ascending: false })
+    .limit(5);
+  if (error) return { kind: 'error', message: error.message };
+  const groups = (data as GroupRow[]) ?? [];
+  if (groups.length === 0) return { kind: 'none', query };
+  if (groups.length === 1) return { kind: 'one', group: groups[0] };
+  const exact = groups.find((g) => g.name.toLowerCase() === query.toLowerCase());
+  if (exact) return { kind: 'one', group: exact };
+  return { kind: 'many', groups };
+}
+
+/** Idempotent membership insert (unique-violation raced join = success). */
+async function ensureMembership(
+  sb: SupabaseClient,
+  groupId: string,
+  userId: string,
+  role: string,
+): Promise<{ already: boolean; error?: string }> {
+  const { data: existing } = await sb
+    .from('global_community_group_members')
+    .select('id')
+    .eq('group_id', groupId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (existing) return { already: true };
+  const { error } = await sb
+    .from('global_community_group_members')
+    .insert({ group_id: groupId, user_id: userId, role });
+  if (error) {
+    if ((error as { code?: string }).code === '23505') return { already: true };
+    return { already: false, error: error.message };
+  }
+  return { already: false };
+}
+
+/**
+ * Resolve a spoken member name to a user_id via the platform's canonical
+ * resolver RPC (same as tool_resolve_recipient / tool_send_chat_message).
+ */
+async function resolveMember(
+  sb: SupabaseClient,
+  actorUserId: string,
+  spoken: string,
+): Promise<
+  | { kind: 'one'; user_id: string; display_name: string }
+  | { kind: 'ambiguous'; names: string[] }
+  | { kind: 'none' }
+  | { kind: 'error'; message: string }
+> {
+  const { data, error } = await sb.rpc('resolve_recipient_candidates', {
+    p_actor: actorUserId,
+    p_token: spoken,
+    p_limit: 3,
+    p_global: true,
+  });
+  if (error) return { kind: 'error', message: error.message };
+  const candidates = (data || []) as Array<{
+    user_id: string;
+    vitana_id: string | null;
+    display_name: string | null;
+    score: number;
+  }>;
+  if (candidates.length === 0) return { kind: 'none' };
+  const top = candidates[0];
+  const topScore = Number(top.score) || 0;
+  const second = candidates[1] ? Number(candidates[1].score) || 0 : 0;
+  const ambiguous = topScore < 0.85 || (candidates.length > 1 && second / Math.max(topScore, 0.0001) > 0.85);
+  if (ambiguous) {
+    return {
+      kind: 'ambiguous',
+      names: candidates.slice(0, 3).map((c) => c.display_name || c.vitana_id || c.user_id),
+    };
+  }
+  return { kind: 'one', user_id: top.user_id, display_name: top.display_name || top.vitana_id || 'that member' };
+}
+
+// ---------------------------------------------------------------------------
+// list_my_groups (VTID-02764)
+// ---------------------------------------------------------------------------
+
+export async function tool_list_my_groups(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('list_my_groups', id);
+  if (gate) return gate;
+  try {
+    const { data: memberships, error: mErr } = await sb
+      .from('global_community_group_members')
+      .select('group_id, role, joined_at')
+      .eq('user_id', id.user_id)
+      .order('joined_at', { ascending: false })
+      .limit(25);
+    if (mErr) return { ok: false, error: mErr.message };
+
+    const rows = (memberships as Array<{ group_id: string; role: string; joined_at: string }>) ?? [];
+    const roleByGroup = new Map(rows.map((r) => [r.group_id, r.role]));
+
+    const found = new Map<string, GroupRow & { role: string }>();
+    if (rows.length > 0) {
+      const { data: groups, error: gErr } = await sb
+        .from('global_community_groups')
+        .select(GROUP_COLS)
+        .in('id', rows.map((r) => r.group_id));
+      if (gErr) return { ok: false, error: gErr.message };
+      for (const g of (groups as GroupRow[]) ?? []) {
+        found.set(g.id, { ...g, role: roleByGroup.get(g.id) ?? 'member' });
+      }
+    }
+
+    // Groups the user created count as theirs even without a membership row
+    // (mirrors the frontend's useUserGroups merge).
+    const { data: created } = await sb
+      .from('global_community_groups')
+      .select(GROUP_COLS)
+      .eq('created_by', id.user_id)
+      .eq('status', 'approved');
+    for (const g of (created as GroupRow[]) ?? []) {
+      if (!found.has(g.id)) found.set(g.id, { ...g, role: 'admin' });
+    }
+
+    const myGroups = Array.from(found.values());
+    if (myGroups.length === 0) {
+      return {
+        ok: true,
+        result: { groups: [] },
+        text: "You're not in any community groups yet. Want me to look for groups that match your interests?",
+      };
+    }
+    const spoken = myGroups
+      .slice(0, 8)
+      .map((g) => `${g.name} (${memberCountPhrase(g.member_count)}${g.role === 'admin' ? ', you're an admin' : ''})`)
+      .join('; ');
+    return {
+      ok: true,
+      result: {
+        groups: myGroups.map((g) => ({
+          group_id: g.id,
+          name: g.name,
+          member_count: g.member_count ?? 0,
+          role: g.role,
+          is_public: g.is_public ?? true,
+        })),
+      },
+      text: `You're in ${myGroups.length} group${myGroups.length === 1 ? '' : 's'}: ${spoken}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'list_my_groups failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// create_group (VTID-02764)
+// ---------------------------------------------------------------------------
+
+export async function tool_create_group(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('create_group', id);
+  if (gate) return gate;
+  const name = String(args.name ?? '').trim();
+  const description = String(args.description ?? '').trim();
+  const privacyRaw = String(args.privacy ?? 'public').trim().toLowerCase();
+  const isPublic = privacyRaw !== 'private';
+  if (!name) {
+    return { ok: false, error: 'create_group requires a group name. Ask the user what to call the group.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { needs_confirmation: true, name, privacy: isPublic ? 'public' : 'private', description: description || null },
+      text: `Confirm with the user: create a ${isPublic ? 'public' : 'private'} group called "${name}"${description ? ` (${description.slice(0, 80)})` : ''}? When they say yes, call create_group again with confirm:true.`,
+    };
+  }
+  try {
+    const { data: group, error } = await sb
+      .from('global_community_groups')
+      .insert({
+        name,
+        description: description || null,
+        is_public: isPublic,
+        created_by: id.user_id,
+        status: 'approved',
+        member_count: 0,
+      })
+      .select('id, name')
+      .single();
+    if (error || !group) {
+      return { ok: false, error: error?.message ?? 'group insert failed' };
+    }
+    const g = group as { id: string; name: string };
+    // Creator becomes admin member (DB trigger fallback, same as the UI).
+    await ensureMembership(sb, g.id, id.user_id, 'admin');
+
+    const route = `/comm/groups/${encodeURIComponent(g.id)}`;
+    return {
+      ok: true,
+      result: {
+        group_id: g.id,
+        name: g.name,
+        privacy: isPublic ? 'public' : 'private',
+        decision: 'auto_nav',
+        directive: navDirective('COMM.GROUP_DETAIL', route, g.name, 'create_group created', VTID_GROUPS),
+        redirect: { route },
+      },
+      text: `Done — I created the ${isPublic ? 'public' : 'private'} group "${g.name}" and made you its admin. Opening it now.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'create_group failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// join_group (VTID-02764)
+// ---------------------------------------------------------------------------
+
+export async function tool_join_group(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('join_group', id);
+  if (gate) return gate;
+  const queryLabel = String(args.query ?? args.name ?? '').trim();
+  try {
+    const resolved = await resolveGroup(sb, args.group_id, queryLabel);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { joined: false },
+        text: queryLabel
+          ? `I couldn't find a group matching "${queryLabel}". Want me to search the community groups for you?`
+          : 'Which group would you like to join? Tell me its name.',
+      };
+    }
+    if (resolved.kind === 'many') {
+      const names = resolved.groups.map((g) => `${g.name} (${memberCountPhrase(g.member_count)})`).join(', ');
+      return {
+        ok: true,
+        result: {
+          joined: false,
+          candidates: resolved.groups.map((g) => ({ group_id: g.id, name: g.name })),
+        },
+        text: `I found ${resolved.groups.length} groups matching that: ${names}. Which one do you mean?`,
+      };
+    }
+
+    const group = resolved.group;
+    if (group.is_public === false) {
+      // Private groups need an invitation — self-join is not allowed.
+      return {
+        ok: true,
+        result: { joined: false, group_id: group.id, name: group.name, private: true },
+        text: `"${group.name}" is a private group — you need an invitation from one of its members to join.`,
+      };
+    }
+
+    const membership = await ensureMembership(sb, group.id, id.user_id, 'member');
+    if (membership.error) return { ok: false, error: membership.error };
+    if (membership.already) {
+      return {
+        ok: true,
+        result: { joined: false, already_member: true, group_id: group.id, name: group.name },
+        text: `You're already a member of "${group.name}".`,
+      };
+    }
+
+    // Best-effort: fire the same automation event the gateway join route
+    // dispatches so the Welcome Squad (AP-0212/AP-0203) can react.
+    try {
+      const tenantId = id.tenant_id || process.env.DEFAULT_TENANT_ID;
+      if (tenantId) {
+        const { dispatchEvent } = await import('../automation-executor');
+        dispatchEvent(tenantId, 'community.member.joined', {
+          group_id: group.id,
+          user_id: id.user_id,
+        }).catch(() => {});
+      }
+    } catch {
+      /* automation dispatch must never break the voice flow */
+    }
+
+    const route = `/comm/groups/${encodeURIComponent(group.id)}`;
+    return {
+      ok: true,
+      result: {
+        joined: true,
+        group_id: group.id,
+        name: group.name,
+        decision: 'auto_nav',
+        directive: navDirective('COMM.GROUP_DETAIL', route, group.name, 'join_group joined', VTID_GROUPS),
+        redirect: { route },
+      },
+      text: `Welcome to "${group.name}"! You're now a member — opening the group for you.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'join_group failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// invite_to_group (VTID-02764)
+// ---------------------------------------------------------------------------
+
+export async function tool_invite_to_group(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('invite_to_group', id);
+  if (gate) return gate;
+  const memberName = String(args.member_name ?? args.member ?? '').trim();
+  const memberUserIdArg = String(args.member_user_id ?? '').trim();
+  const message = String(args.message ?? '').trim();
+  if (!memberName && !UUID_RE.test(memberUserIdArg)) {
+    return { ok: false, error: 'invite_to_group requires the name of the member to invite.' };
+  }
+  try {
+    const tenantId = await resolveTenantId(id, sb);
+    if (!tenantId) {
+      return { ok: false, error: 'invite_to_group requires an authenticated user.' };
+    }
+
+    const resolved = await resolveGroup(sb, args.group_id, String(args.group ?? args.query ?? '').trim());
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { invited: false },
+        text: 'I couldn\'t find that group. Which group did you want to invite them to?',
+      };
+    }
+    if (resolved.kind === 'many') {
+      const names = resolved.groups.map((g) => g.name).join(', ');
+      return {
+        ok: true,
+        result: { invited: false, candidates: resolved.groups.map((g) => ({ group_id: g.id, name: g.name })) },
+        text: `I found several groups: ${names}. Which one should I send the invitation for?`,
+      };
+    }
+    const group = resolved.group;
+
+    // Resolve the member (canonical resolver RPC, same as messaging tools).
+    let inviteeId = memberUserIdArg;
+    let inviteeName = memberName || 'that member';
+    if (!UUID_RE.test(inviteeId)) {
+      const member = await resolveMember(sb, id.user_id, memberName);
+      if (member.kind === 'error') return { ok: false, error: member.message };
+      if (member.kind === 'none') {
+        return {
+          ok: true,
+          result: { invited: false },
+          text: `I couldn't find anyone named "${memberName}" in the community — they may not have a Vitana account yet.`,
+        };
+      }
+      if (member.kind === 'ambiguous') {
+        return {
+          ok: true,
+          result: { invited: false, candidates: member.names },
+          text: `I found a few possible matches: ${member.names.join(', ')}. Which one did you mean?`,
+        };
+      }
+      inviteeId = member.user_id;
+      inviteeName = member.display_name;
+    }
+    if (inviteeId === id.user_id) {
+      return { ok: false, error: 'You cannot invite yourself to a group.' };
+    }
+
+    // Already a member? Say so instead of inviting.
+    const { data: existingMember } = await sb
+      .from('global_community_group_members')
+      .select('id')
+      .eq('group_id', group.id)
+      .eq('user_id', inviteeId)
+      .maybeSingle();
+    if (existingMember) {
+      return {
+        ok: true,
+        result: { invited: false, already_member: true, group_id: group.id },
+        text: `${inviteeName} is already a member of "${group.name}".`,
+      };
+    }
+
+    const { error: insErr } = await sb.from('community_group_invitations').insert({
+      tenant_id: tenantId,
+      group_id: group.id,
+      invited_by: id.user_id,
+      invited_user_id: inviteeId,
+      status: 'pending',
+      message: message || null,
+    });
+    if (insErr) {
+      if ((insErr as { code?: string }).code === '23505') {
+        return {
+          ok: true,
+          result: { invited: false, already_pending: true, group_id: group.id },
+          text: `${inviteeName} already has a pending invitation to "${group.name}".`,
+        };
+      }
+      return { ok: false, error: insErr.message };
+    }
+    return {
+      ok: true,
+      result: { invited: true, group_id: group.id, invited_user_id: inviteeId },
+      text: `Invitation sent — ${inviteeName} will get a notification to join "${group.name}".`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'invite_to_group failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// accept_invitation / decline_invitation (VTID-02764)
+// ---------------------------------------------------------------------------
+
+interface InvitationRow {
+  id: string;
+  group_id: string;
+  invited_by: string;
+  message: string | null;
+  created_at: string;
+}
+
+async function fetchPendingInvitations(
+  sb: SupabaseClient,
+  userId: string,
+): Promise<{ invitations: InvitationRow[]; groupNames: Map<string, string> } | { error: string }> {
+  const { data, error } = await sb
+    .from('community_group_invitations')
+    .select('id, group_id, invited_by, message, created_at')
+    .eq('invited_user_id', userId)
+    .eq('status', 'pending')
+    .order('created_at', { ascending: false })
+    .limit(10);
+  if (error) return { error: error.message };
+  const invitations = (data as InvitationRow[]) ?? [];
+  const groupNames = new Map<string, string>();
+  if (invitations.length > 0) {
+    const { data: groups } = await sb
+      .from('global_community_groups')
+      .select('id, name')
+      .in('id', invitations.map((i) => i.group_id));
+    for (const g of (groups as Array<{ id: string; name: string }>) ?? []) {
+      groupNames.set(g.id, g.name);
+    }
+  }
+  return { invitations, groupNames };
+}
+
+async function respondToInvitation(
+  action: 'accept' | 'decline',
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const tool = action === 'accept' ? 'accept_invitation' : 'decline_invitation';
+  const gate = authGate(tool, id);
+  if (gate) return gate;
+  try {
+    const pending = await fetchPendingInvitations(sb, id.user_id);
+    if ('error' in pending) return { ok: false, error: pending.error };
+    const { invitations, groupNames } = pending;
+    const nameOf = (inv: InvitationRow) => groupNames.get(inv.group_id) ?? 'a group';
+
+    if (invitations.length === 0) {
+      return {
+        ok: true,
+        result: { invitations: [] },
+        text: "You don't have any pending group invitations right now.",
+      };
+    }
+
+    const invitationId = String(args.invitation_id ?? '').trim();
+    let target: InvitationRow | undefined;
+    if (UUID_RE.test(invitationId)) {
+      target = invitations.find((i) => i.id === invitationId);
+      if (!target) {
+        return {
+          ok: true,
+          result: { invitations: invitations.map((i) => ({ invitation_id: i.id, group_name: nameOf(i) })) },
+          text: 'That invitation is no longer pending. ' +
+            `Your pending invitations: ${invitations.map(nameOf).join(', ')}.`,
+        };
+      }
+    } else if (invitations.length === 1) {
+      target = invitations[0];
+    } else {
+      // Try matching a spoken group name before asking.
+      const q = String(args.group ?? args.query ?? '').trim().toLowerCase();
+      if (q) {
+        const matches = invitations.filter((i) => nameOf(i).toLowerCase().includes(q));
+        if (matches.length === 1) target = matches[0];
+      }
+      if (!target) {
+        return {
+          ok: true,
+          result: {
+            invitations: invitations.map((i) => ({ invitation_id: i.id, group_id: i.group_id, group_name: nameOf(i) })),
+          },
+          text: `You have ${invitations.length} pending invitations: ${invitations.map(nameOf).join(', ')}. Which one should I ${action}?`,
+        };
+      }
+    }
+
+    const groupName = nameOf(target);
+
+    if (action === 'decline' && args.confirm !== true) {
+      return {
+        ok: true,
+        result: { needs_confirmation: true, invitation_id: target.id, group_name: groupName },
+        text: `Confirm with the user: decline the invitation to "${groupName}"? When they say yes, call decline_invitation again with this invitation_id and confirm:true.`,
+      };
+    }
+
+    const { error: updErr } = await sb
+      .from('community_group_invitations')
+      .update({ status: action === 'accept' ? 'accepted' : 'declined', responded_at: new Date().toISOString() })
+      .eq('id', target.id)
+      .eq('invited_user_id', id.user_id);
+    if (updErr) return { ok: false, error: updErr.message };
+
+    if (action === 'decline') {
+      return {
+        ok: true,
+        result: { declined: true, invitation_id: target.id, group_id: target.group_id },
+        text: `Okay — I've declined the invitation to "${groupName}".`,
+      };
+    }
+
+    const membership = await ensureMembership(sb, target.group_id, id.user_id, 'member');
+    if (membership.error) return { ok: false, error: membership.error };
+    const route = `/comm/groups/${encodeURIComponent(target.group_id)}`;
+    return {
+      ok: true,
+      result: {
+        accepted: true,
+        invitation_id: target.id,
+        group_id: target.group_id,
+        decision: 'auto_nav',
+        directive: navDirective('COMM.GROUP_DETAIL', route, groupName, 'accept_invitation joined', VTID_GROUPS),
+        redirect: { route },
+      },
+      text: `You've accepted the invitation — welcome to "${groupName}"! Opening the group now.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : `${tool} failed` };
+  }
+}
+
+export async function tool_accept_invitation(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  return respondToInvitation('accept', args, id, sb);
+}
+
+export async function tool_decline_invitation(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  return respondToInvitation('decline', args, id, sb);
+}
+
+// ---------------------------------------------------------------------------
+// rsvp_event (VTID-02774)
+// ---------------------------------------------------------------------------
+
+interface EventRow {
+  id: string;
+  title: string;
+  start_time: string;
+  location: string | null;
+  participant_count: number | null;
+  max_participants: number | null;
+}
+
+const EVENT_COLS = 'id, title, start_time, location, participant_count, max_participants';
+
+type EventResolution =
+  | { kind: 'one'; event: EventRow }
+  | { kind: 'many'; events: EventRow[] }
+  | { kind: 'none'; query: string }
+  | { kind: 'error'; message: string };
+
+async function resolveUpcomingEvent(sb: SupabaseClient, rawId: unknown, rawQuery: unknown): Promise<EventResolution> {
+  const eventId = String(rawId ?? '').trim();
+  const query = String(rawQuery ?? '').trim();
+
+  if (UUID_RE.test(eventId)) {
+    const { data, error } = await sb
+      .from('global_community_events')
+      .select(EVENT_COLS)
+      .eq('id', eventId)
+      .maybeSingle();
+    if (error) return { kind: 'error', message: error.message };
+    if (!data) return { kind: 'none', query: eventId };
+    return { kind: 'one', event: data as EventRow };
+  }
+
+  if (!query) return { kind: 'none', query: '' };
+
+  const { data, error } = await sb
+    .from('global_community_events')
+    .select(EVENT_COLS)
+    .gte('start_time', new Date().toISOString())
+    .ilike('title', `%${query}%`)
+    .order('start_time', { ascending: true })
+    .limit(5);
+  if (error) return { kind: 'error', message: error.message };
+  const events = (data as EventRow[]) ?? [];
+  if (events.length === 0) return { kind: 'none', query };
+  if (events.length === 1) return { kind: 'one', event: events[0] };
+  const exact = events.find((e) => e.title.toLowerCase() === query.toLowerCase());
+  if (exact) return { kind: 'one', event: exact };
+  return { kind: 'many', events };
+}
+
+function speakEventLine(e: EventRow): string {
+  return `"${e.title}" on ${fmtWhen(e.start_time)}${e.location ? ` at ${e.location}` : ''}`;
+}
+
+export async function tool_rsvp_event(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('rsvp_event', id);
+  if (gate) return gate;
+  const queryLabel = String(args.query ?? args.title ?? '').trim();
+  try {
+    const resolved = await resolveUpcomingEvent(sb, args.event_id, queryLabel);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { rsvped: false },
+        text: queryLabel
+          ? `I couldn't find an upcoming event matching "${queryLabel}". Want me to list the upcoming meetups?`
+          : 'Which event would you like to sign up for? Tell me its name.',
+      };
+    }
+    if (resolved.kind === 'many') {
+      const lines = resolved.events.map(speakEventLine).join('; ');
+      return {
+        ok: true,
+        result: {
+          rsvped: false,
+          candidates: resolved.events.map((e) => ({ event_id: e.id, title: e.title, start_time: e.start_time })),
+        },
+        text: `I found ${resolved.events.length} matching events: ${lines}. Which one do you mean?`,
+      };
+    }
+    const event = resolved.event;
+
+    const { data: existing } = await sb
+      .from('global_event_participants')
+      .select('id, status')
+      .eq('event_id', event.id)
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    if (existing && (existing as { status?: string }).status === 'attending') {
+      return {
+        ok: true,
+        result: { rsvped: false, already_attending: true, event_id: event.id, title: event.title },
+        text: `You're already signed up for ${speakEventLine(event)}.`,
+      };
+    }
+
+    const count = Number(event.participant_count) || 0;
+    if (event.max_participants != null && count >= event.max_participants) {
+      return {
+        ok: true,
+        result: { rsvped: false, full: true, event_id: event.id, title: event.title },
+        text: `Unfortunately "${event.title}" is already full (${event.max_participants} participants).`,
+      };
+    }
+
+    // Same write contract as the frontend's useEventParticipation hook:
+    // upsert on (event_id, user_id) with status 'attending'.
+    const { error: upErr } = await sb
+      .from('global_event_participants')
+      .upsert({ event_id: event.id, user_id: id.user_id, status: 'attending' }, { onConflict: 'event_id,user_id' });
+    if (upErr) return { ok: false, error: upErr.message };
+
+    // Sync participant_count on the event row (best-effort, like the UI).
+    if (!existing) {
+      try {
+        await sb
+          .from('global_community_events')
+          .update({ participant_count: count + 1 })
+          .eq('id', event.id);
+      } catch {
+        /* count sync is cosmetic — never fail the RSVP for it */
+      }
+    }
+
+    return {
+      ok: true,
+      result: { rsvped: true, event_id: event.id, title: event.title, start_time: event.start_time },
+      text: `You're in! I've signed you up for ${speakEventLine(event)}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'rsvp_event failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// cancel_rsvp (VTID-02774)
+// ---------------------------------------------------------------------------
+
+export async function tool_cancel_rsvp(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('cancel_rsvp', id);
+  if (gate) return gate;
+  const queryLabel = String(args.query ?? args.title ?? '').trim().toLowerCase();
+  const eventIdArg = String(args.event_id ?? '').trim();
+  try {
+    // Start from the user's own attending rows — cancellation only ever
+    // targets the caller's RSVPs.
+    const { data: parts, error: pErr } = await sb
+      .from('global_event_participants')
+      .select('event_id')
+      .eq('user_id', id.user_id)
+      .eq('status', 'attending');
+    if (pErr) return { ok: false, error: pErr.message };
+    const eventIds = ((parts as Array<{ event_id: string }>) ?? []).map((p) => p.event_id);
+    if (eventIds.length === 0) {
+      return { ok: true, result: { cancelled: false }, text: "You don't have any event RSVPs to cancel." };
+    }
+
+    const { data: events, error: eErr } = await sb
+      .from('global_community_events')
+      .select(EVENT_COLS)
+      .in('id', eventIds)
+      .gte('start_time', new Date().toISOString())
+      .order('start_time', { ascending: true });
+    if (eErr) return { ok: false, error: eErr.message };
+    let mine = (events as EventRow[]) ?? [];
+    if (UUID_RE.test(eventIdArg)) {
+      mine = mine.filter((e) => e.id === eventIdArg);
+    } else if (queryLabel) {
+      mine = mine.filter((e) => e.title.toLowerCase().includes(queryLabel));
+    }
+
+    if (mine.length === 0) {
+      return {
+        ok: true,
+        result: { cancelled: false },
+        text: "I couldn't find an upcoming RSVP of yours matching that. You may not be signed up for it.",
+      };
+    }
+    if (mine.length > 1) {
+      const lines = mine.slice(0, 5).map(speakEventLine).join('; ');
+      return {
+        ok: true,
+        result: {
+          cancelled: false,
+          candidates: mine.slice(0, 5).map((e) => ({ event_id: e.id, title: e.title, start_time: e.start_time })),
+        },
+        text: `You're signed up for ${mine.length} upcoming events: ${lines}. Which RSVP should I cancel?`,
+      };
+    }
+
+    const event = mine[0];
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { needs_confirmation: true, event_id: event.id, title: event.title },
+        text: `Confirm with the user: cancel their RSVP for ${speakEventLine(event)}? When they say yes, call cancel_rsvp again with this event_id and confirm:true.`,
+      };
+    }
+
+    const { error: delErr } = await sb
+      .from('global_event_participants')
+      .delete()
+      .eq('event_id', event.id)
+      .eq('user_id', id.user_id);
+    if (delErr) return { ok: false, error: delErr.message };
+
+    try {
+      const count = Number(event.participant_count) || 0;
+      await sb
+        .from('global_community_events')
+        .update({ participant_count: Math.max(0, count - 1) })
+        .eq('id', event.id);
+    } catch {
+      /* count sync is cosmetic */
+    }
+
+    return {
+      ok: true,
+      result: { cancelled: true, event_id: event.id, title: event.title },
+      text: `Done — I've cancelled your RSVP for "${event.title}".`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'cancel_rsvp failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// list_upcoming_meetups (VTID-02774)
+// ---------------------------------------------------------------------------
+
+export async function tool_list_upcoming_meetups(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('list_upcoming_meetups', id);
+  if (gate) return gate;
+  try {
+    const { data, error } = await sb
+      .from('global_community_events')
+      .select(EVENT_COLS)
+      .gte('start_time', new Date().toISOString())
+      .order('start_time', { ascending: true })
+      .limit(8);
+    if (error) return { ok: false, error: error.message };
+    const events = (data as EventRow[]) ?? [];
+    if (events.length === 0) {
+      return {
+        ok: true,
+        result: { events: [] },
+        text: 'There are no upcoming meetups scheduled right now. Check back soon — new events are added regularly!',
+      };
+    }
+
+    // Optional proximity: the user's home city (same source search_events uses).
+    let homeCity = '';
+    try {
+      const { data: locRow } = await sb
+        .from('location_preferences')
+        .select('home_city')
+        .eq('user_id', id.user_id)
+        .maybeSingle();
+      homeCity = ((locRow as { home_city?: string | null } | null)?.home_city ?? '').trim();
+    } catch {
+      /* best-effort — proceed without proximity */
+    }
+
+    // Mark which ones the user is already attending.
+    const attending = new Set<string>();
+    try {
+      const { data: parts } = await sb
+        .from('global_event_participants')
+        .select('event_id')
+        .eq('user_id', id.user_id)
+        .eq('status', 'attending')
+        .in('event_id', events.map((e) => e.id));
+      for (const p of (parts as Array<{ event_id: string }>) ?? []) attending.add(p.event_id);
+    } catch {
+      /* attendance markers are best-effort */
+    }
+
+    const isNear = (e: EventRow) =>
+      !!homeCity && !!e.location && e.location.toLowerCase().includes(homeCity.toLowerCase());
+    const ordered = homeCity ? [...events.filter(isNear), ...events.filter((e) => !isNear(e))] : events;
+
+    const lines = ordered
+      .slice(0, 5)
+      .map(
+        (e) =>
+          `${speakEventLine(e)}${isNear(e) ? ' (near you)' : ''}${attending.has(e.id) ? " (you're signed up)" : ''}`,
+      )
+      .join('; ');
+    return {
+      ok: true,
+      result: {
+        events: ordered.map((e) => ({
+          event_id: e.id,
+          title: e.title,
+          start_time: e.start_time,
+          location: e.location,
+          near_user: isNear(e),
+          attending: attending.has(e.id),
+        })),
+        home_city: homeCity || null,
+      },
+      text: `Upcoming meetups: ${lines}. Want me to sign you up for one?`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'list_upcoming_meetups failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// join_live_room (VTID-02774)
+// ---------------------------------------------------------------------------
+
+interface LiveRoomRow {
+  id: string;
+  title: string;
+  starts_at: string;
+  status: string;
+}
+
+export async function tool_join_live_room(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('join_live_room', id);
+  if (gate) return gate;
+  if (!id.tenant_id) {
+    // live_rooms is tenant-scoped — same guard tool_search_events applies.
+    return {
+      ok: true,
+      result: { rooms: [] },
+      text: 'Live rooms are unavailable for this session (no tenant context).',
+    };
+  }
+  const roomIdArg = String(args.room_id ?? '').trim();
+  const query = String(args.query ?? args.title ?? '').trim();
+  try {
+    let rooms: LiveRoomRow[] = [];
+    if (UUID_RE.test(roomIdArg)) {
+      const { data, error } = await sb
+        .from('live_rooms')
+        .select('id, title, starts_at, status')
+        .eq('tenant_id', id.tenant_id)
+        .eq('id', roomIdArg)
+        .in('status', ['scheduled', 'live'])
+        .maybeSingle();
+      if (error) return { ok: false, error: error.message };
+      if (data) rooms = [data as LiveRoomRow];
+    } else {
+      let q = sb
+        .from('live_rooms')
+        .select('id, title, starts_at, status')
+        .eq('tenant_id', id.tenant_id)
+        .in('status', ['scheduled', 'live'])
+        .order('starts_at', { ascending: true })
+        .limit(5);
+      if (query) q = q.ilike('title', `%${query}%`);
+      const { data, error } = await q;
+      if (error) return { ok: false, error: error.message };
+      rooms = (data as LiveRoomRow[]) ?? [];
+    }
+
+    if (rooms.length === 0) {
+      return {
+        ok: true,
+        result: { rooms: [] },
+        text: query
+          ? `I couldn't find a live room matching "${query}" that's live or scheduled right now.`
+          : 'There are no live rooms running or scheduled right now.',
+      };
+    }
+
+    const speakRoom = (r: LiveRoomRow) =>
+      `"${r.title}" (${r.status === 'live' ? 'LIVE now' : `starts ${fmtWhen(r.starts_at)}`})`;
+
+    // Dominant pick: single hit, exact title match, or — with no query — the
+    // one room that is live right now. Otherwise list and let the LLM ask.
+    let top: LiveRoomRow | undefined;
+    if (rooms.length === 1) {
+      top = rooms[0];
+    } else if (query) {
+      top = rooms.find((r) => r.title.toLowerCase() === query.toLowerCase());
+    } else {
+      const liveNow = rooms.filter((r) => r.status === 'live');
+      if (liveNow.length === 1) top = liveNow[0];
+    }
+
+    if (!top) {
+      return {
+        ok: true,
+        result: {
+          rooms: rooms.map((r) => ({ room_id: r.id, title: r.title, status: r.status, starts_at: r.starts_at })),
+          decision: 'list_only',
+        },
+        text: `I found ${rooms.length} rooms: ${rooms.map(speakRoom).join('; ')}. Which one should I open?`,
+      };
+    }
+
+    const route = `/comm/live-rooms/${encodeURIComponent(top.id)}/view`;
+    return {
+      ok: true,
+      result: {
+        room_id: top.id,
+        title: top.title,
+        status: top.status,
+        decision: 'auto_nav',
+        directive: navDirective('COMM.LIVE_ROOM_VIEWER', route, top.title, 'join_live_room resolved', VTID_EVENTS),
+        redirect: { route },
+      },
+      text:
+        top.status === 'live'
+          ? `Taking you into "${top.title}" — it's live right now.`
+          : `Opening "${top.title}" — it starts ${fmtWhen(top.starts_at)}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'join_live_room failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const GROUPS_EVENTS_TOOL_HANDLERS: Record<string, Handler> = {
+  list_my_groups: tool_list_my_groups,
+  create_group: tool_create_group,
+  join_group: tool_join_group,
+  invite_to_group: tool_invite_to_group,
+  accept_invitation: tool_accept_invitation,
+  decline_invitation: tool_decline_invitation,
+  rsvp_event: tool_rsvp_event,
+  cancel_rsvp: tool_cancel_rsvp,
+  list_upcoming_meetups: tool_list_upcoming_meetups,
+  join_live_room: tool_join_live_room,
+};
+
+export const GROUPS_EVENTS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'list_my_groups',
+    description: [
+      "List the community groups the user belongs to, with member counts.",
+      'CALL WHEN the user asks: "what groups am I in?", "show my groups",',
+      '"in welchen Gruppen bin ich?", "zeig mir meine Gruppen".',
+      'After the tool runs, read the group names and member counts aloud.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'create_group',
+    description: [
+      'Create a new community group. Requires a name; privacy is public or',
+      'private (default public). ALWAYS call once WITHOUT confirm first —',
+      'the tool returns a confirmation question; after the user says yes,',
+      'call again with confirm:true.',
+      'CALL WHEN the user says: "create a group called ...", "start a new',
+      'group", "erstelle eine Gruppe ...", "gründe eine neue Gruppe".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'The group name.' },
+        description: { type: 'string', description: 'Optional short group description.' },
+        privacy: { type: 'string', description: "Either 'public' or 'private'. Public if omitted." },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the creation.' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'join_group',
+    description: [
+      'Join a community group by name or group_id. Resolves fuzzy names and',
+      'lists candidates when several match. Private groups cannot be self-joined.',
+      'CALL WHEN the user says: "join the sleep group", "I want to join ...",',
+      '"tritt der Gruppe ... bei", "ich möchte der Gruppe beitreten".',
+      'After joining, tell the user they are in and the app is opening the group.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Spoken group name (fuzzy matched).' },
+        group_id: { type: 'string', description: 'Exact group UUID when already known from a previous tool result.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'invite_to_group',
+    description: [
+      'Invite another community member to a group. Resolves the member by',
+      'spoken name and the group by name; the member gets a notification.',
+      'CALL WHEN the user says: "invite Anna to my walking group",',
+      '"lade Anna in die Gruppe ... ein".',
+      'If the tool lists several member or group candidates, ask which one.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        group: { type: 'string', description: 'Spoken group name (fuzzy matched).' },
+        group_id: { type: 'string', description: 'Exact group UUID when known.' },
+        member_name: { type: 'string', description: 'Spoken name of the member to invite.' },
+        member_user_id: { type: 'string', description: 'Exact user UUID when known from a previous tool result.' },
+        message: { type: 'string', description: 'Optional personal message to include.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'accept_invitation',
+    description: [
+      'Accept a pending group invitation (joins the group). With no',
+      'invitation_id it lists the pending invitations, or acts when only one.',
+      'CALL WHEN the user says: "accept the invitation", "yes, join that group",',
+      '"nimm die Einladung an", "Einladung annehmen".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        invitation_id: { type: 'string', description: 'The invitation UUID from a previous tool result, if known.' },
+        group: { type: 'string', description: 'Spoken group name to pick among several pending invitations.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'decline_invitation',
+    description: [
+      'Decline a pending group invitation. ALWAYS call once WITHOUT confirm',
+      'first — the tool returns a confirmation question; after the user says',
+      'yes, call again with the invitation_id and confirm:true.',
+      'CALL WHEN the user says: "decline the invitation", "no thanks, decline',
+      'it", "lehne die Einladung ab", "Einladung ablehnen".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        invitation_id: { type: 'string', description: 'The invitation UUID from a previous tool result, if known.' },
+        group: { type: 'string', description: 'Spoken group name to pick among several pending invitations.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed declining.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'rsvp_event',
+    description: [
+      'RSVP / sign the user up for a community event or meetup, by event_id',
+      'or fuzzy title. Checks capacity and existing signup first.',
+      'CALL WHEN the user says: "sign me up for ...", "RSVP to the yoga',
+      'meetup", "melde mich für ... an", "ich will beim Event ... dabei sein".',
+      'If several events match, read the candidates and ask which one.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Spoken event title (fuzzy matched against upcoming events).' },
+        event_id: { type: 'string', description: 'Exact event UUID when known from a previous tool result.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'cancel_rsvp',
+    description: [
+      "Cancel the user's RSVP for an upcoming event. ALWAYS call once",
+      'WITHOUT confirm first — the tool returns a confirmation question;',
+      'after the user says yes, call again with the event_id and confirm:true.',
+      'CALL WHEN the user says: "cancel my RSVP", "I can\'t make it to ...",',
+      '"melde mich vom Event ... ab", "storniere meine Anmeldung".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Spoken event title (matched against the user\'s RSVPs).' },
+        event_id: { type: 'string', description: 'Exact event UUID when known.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the cancellation.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'list_upcoming_meetups',
+    description: [
+      'List upcoming community meetups/events the user could attend, soonest',
+      'first; events in the user\'s home city are flagged "near you" and',
+      'events they already RSVP\'d are marked.',
+      'CALL WHEN the user asks: "what meetups are coming up?", "any events',
+      'this week?", "welche Meetups stehen an?", "gibt es bald Events?".',
+      'Read the titles with dates aloud, then offer to sign them up.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'join_live_room',
+    description: [
+      'Join/open a community live room by name or room_id. Returns a',
+      'navigation directive that opens the room screen — the app navigates',
+      'automatically; do not describe the navigation mechanics.',
+      'CALL WHEN the user says: "join the live room", "take me into the ...',
+      'room", "bring mich in den Live-Raum", "öffne den Live-Raum ...".',
+      'If several rooms match, read the candidates and ask which one.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Spoken room title (fuzzy matched against live and scheduled rooms).' },
+        room_id: { type: 'string', description: 'Exact live room UUID when known.' },
+      },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/groups-events-tools.ts
+++ b/services/gateway/src/services/orb-tools/groups-events-tools.ts
@@ -252,7 +252,7 @@ export async function tool_list_my_groups(
     }
     const spoken = myGroups
       .slice(0, 8)
-      .map((g) => `${g.name} (${memberCountPhrase(g.member_count)}${g.role === 'admin' ? ', you're an admin' : ''})`)
+      .map((g) => `${g.name} (${memberCountPhrase(g.member_count)}${g.role === 'admin' ? ", you're an admin" : ''})`)
       .join('; ');
     return {
       ok: true,

--- a/services/gateway/src/services/orb-tools/groups-events-tools.ts
+++ b/services/gateway/src/services/orb-tools/groups-events-tools.ts
@@ -466,6 +466,25 @@ export async function tool_invite_to_group(
     }
     const group = resolved.group;
 
+    // Security: the caller must actually belong to the group before they can
+    // invite others into it. Without this check a non-member who can name or
+    // guess a private group's name could insert an invitation as themselves,
+    // and accept_invitation would then join the invitee — letting outsiders
+    // grow membership of groups they were never part of.
+    const { data: callerMembership, error: callerMembershipErr } = await sb
+      .from('global_community_group_members')
+      .select('id')
+      .eq('group_id', group.id)
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    if (callerMembershipErr) return { ok: false, error: callerMembershipErr.message };
+    if (!callerMembership) {
+      return {
+        ok: false,
+        error: `You must be a member of "${group.name}" to invite others.`,
+      };
+    }
+
     // Resolve the member (canonical resolver RPC, same as messaging tools).
     let inviteeId = memberUserIdArg;
     let inviteeName = memberName || 'that member';

--- a/services/gateway/src/services/orb-tools/p0-gap-tools.ts
+++ b/services/gateway/src/services/orb-tools/p0-gap-tools.ts
@@ -1,0 +1,822 @@
+/**
+ * P0 coverage-gap voice tools (BOOTSTRAP-VOICE-P0-GAPS).
+ *
+ * The community voice-gap analysis found whole daily-use surfaces with no
+ * voice path at all: follow/unfollow a member, read/clear notifications, a
+ * read-only wallet snapshot, simple own-profile edits, playing an internal
+ * Vitana podcast, and liking/commenting on community feed posts. This module
+ * closes those gaps with thin handlers over the REAL backings the app already
+ * uses: user_follows, user_notifications, wallet balance-service +
+ * user_subscriptions, profiles, media_uploads(+podcast_metadata), and
+ * profile_posts(+profile_post_likes/profile_post_comments). Public-text
+ * mutations (unfollow, profile edit, comment) are confirm-gated with a
+ * verbatim read-back, mirroring the create_community_post contract.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function strArg(args: OrbToolArgs, ...keys: string[]): string {
+  for (const key of keys) {
+    const v = args[key];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return '';
+}
+
+/** Accept both `confirmed` (create_community_post style) and `confirm`. */
+function isConfirmed(args: OrbToolArgs): boolean {
+  return args.confirmed === true || args.confirm === true;
+}
+
+function errText(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+/** Compact "3 days ago" / "2 hours ago" / "just now" for voice. */
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  const min = Math.floor(ms / 60_000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min} minute${min === 1 ? '' : 's'} ago`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h} hour${h === 1 ? '' : 's'} ago`;
+  const d = Math.floor(h / 24);
+  return `${d} day${d === 1 ? '' : 's'} ago`;
+}
+
+function snippet(content: string, max = 80): string {
+  const clean = content.replace(/\s+/g, ' ').trim();
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+interface ResolvedPerson {
+  user_id: string;
+  display_name: string | null;
+}
+
+/**
+ * Resolve a community member by spoken name via the privacy-filtered
+ * social-memory repository resolver (same source list_followers reads).
+ */
+async function resolveMember(name: string): Promise<ResolvedPerson | null> {
+  const { resolvePersonByName } = await import('../social-memory/social-memory-repository');
+  const person = await resolvePersonByName(name);
+  if (!person) return null;
+  return { user_id: person.user_id, display_name: person.display_name ?? null };
+}
+
+// ---------------------------------------------------------------------------
+// follow_member / unfollow_member — user_follows(follower_id, following_id)
+// ---------------------------------------------------------------------------
+
+export async function tool_follow_member(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'follow_member requires an authenticated user.' };
+  const name = strArg(args, 'name', 'member_name', 'query');
+  if (!name) return { ok: false, error: 'follow_member requires the member `name` to follow.' };
+  try {
+    const person = await resolveMember(name);
+    if (!person) {
+      return {
+        ok: true,
+        result: { followed: false, reason: 'member_not_found' },
+        text: `I couldn't find a community member matching "${name}". Ask the user to repeat or spell the name.`,
+      };
+    }
+    const who = person.display_name || name;
+    if (person.user_id === id.user_id) {
+      return { ok: true, result: { followed: false, reason: 'self' }, text: 'That is your own profile — you cannot follow yourself.' };
+    }
+    const { data: existing } = await sb
+      .from('user_follows')
+      .select('id')
+      .eq('follower_id', id.user_id)
+      .eq('following_id', person.user_id)
+      .maybeSingle();
+    if (existing) {
+      return { ok: true, result: { followed: true, already: true, user_id: person.user_id }, text: `You already follow ${who}.` };
+    }
+    const { error } = await sb
+      .from('user_follows')
+      .insert({ follower_id: id.user_id, following_id: person.user_id });
+    if (error) return { ok: false, error: `Could not follow ${who}: ${error.message}` };
+    return {
+      ok: true,
+      result: { followed: true, user_id: person.user_id, display_name: who },
+      text: `Done — you are now following ${who}.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'follow_member failed') };
+  }
+}
+
+export async function tool_unfollow_member(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'unfollow_member requires an authenticated user.' };
+  const name = strArg(args, 'name', 'member_name', 'query');
+  if (!name) return { ok: false, error: 'unfollow_member requires the member `name` to unfollow.' };
+  try {
+    const person = await resolveMember(name);
+    if (!person) {
+      return {
+        ok: true,
+        result: { unfollowed: false, reason: 'member_not_found' },
+        text: `I couldn't find a community member matching "${name}".`,
+      };
+    }
+    const who = person.display_name || name;
+    const { data: existing } = await sb
+      .from('user_follows')
+      .select('id')
+      .eq('follower_id', id.user_id)
+      .eq('following_id', person.user_id)
+      .maybeSingle();
+    if (!existing) {
+      return { ok: true, result: { unfollowed: false, reason: 'not_following' }, text: `You are not following ${who}, so there is nothing to unfollow.` };
+    }
+    if (!isConfirmed(args)) {
+      return {
+        ok: true,
+        result: { stage: 'awaiting_confirmation', display_name: who, user_id: person.user_id },
+        text: `CONFIRM REQUIRED: Ask the user "Should I unfollow ${who}?" and call unfollow_member again with confirmed=true only after they say yes.`,
+      };
+    }
+    const { error } = await sb
+      .from('user_follows')
+      .delete()
+      .eq('follower_id', id.user_id)
+      .eq('following_id', person.user_id);
+    if (error) return { ok: false, error: `Could not unfollow ${who}: ${error.message}` };
+    return {
+      ok: true,
+      result: { unfollowed: true, user_id: person.user_id, display_name: who },
+      text: `Done — you no longer follow ${who}.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'unfollow_member failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_notifications / mark_notifications_read — user_notifications
+// ---------------------------------------------------------------------------
+
+interface NotificationRow {
+  id: string;
+  type: string;
+  title: string;
+  body: string | null;
+  read_at: string | null;
+  created_at: string;
+}
+
+export async function tool_get_notifications(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id || !id.tenant_id) {
+    return { ok: false, error: 'get_notifications requires an authenticated user.' };
+  }
+  const limitRaw = Number(args.limit);
+  const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 20) : 10;
+  try {
+    const { data, error } = await sb
+      .from('user_notifications')
+      .select('id, type, title, body, read_at, created_at')
+      .eq('user_id', id.user_id)
+      .eq('tenant_id', id.tenant_id)
+      .order('created_at', { ascending: false })
+      .limit(20);
+    if (error) return { ok: false, error: `Could not read notifications: ${error.message}` };
+    const rows = (data ?? []) as NotificationRow[];
+    if (rows.length === 0) {
+      return { ok: true, result: { notifications: [], unread_count: 0 }, text: 'You have no notifications right now — all clear.' };
+    }
+    // Unread first, then newest first, capped for voice.
+    const sorted = [...rows].sort((a, b) => {
+      const ua = a.read_at ? 1 : 0;
+      const ub = b.read_at ? 1 : 0;
+      if (ua !== ub) return ua - ub;
+      return b.created_at.localeCompare(a.created_at);
+    });
+    const unread = rows.filter((r) => !r.read_at).length;
+    const spoken = sorted.slice(0, limit);
+    const lines = spoken.map((n) => {
+      const when = timeAgo(n.created_at);
+      const state = n.read_at ? '' : ' (unread)';
+      const body = n.body ? ` — ${snippet(n.body, 60)}` : '';
+      return `${n.title}${body}${when ? `, ${when}` : ''}${state}`;
+    });
+    const head =
+      unread > 0
+        ? `You have ${unread} unread notification${unread === 1 ? '' : 's'}.`
+        : 'No unread notifications — here are your latest.';
+    return {
+      ok: true,
+      result: {
+        unread_count: unread,
+        notifications: spoken.map((n) => ({
+          id: n.id,
+          type: n.type,
+          title: n.title,
+          read: !!n.read_at,
+          created_at: n.created_at,
+        })),
+      },
+      text: `${head}\n${lines.join('\n')}`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'get_notifications failed') };
+  }
+}
+
+export async function tool_mark_notifications_read(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id || !id.tenant_id) {
+    return { ok: false, error: 'mark_notifications_read requires an authenticated user.' };
+  }
+  const reference = strArg(args, 'reference', 'title');
+  const now = new Date().toISOString();
+  try {
+    let query = sb
+      .from('user_notifications')
+      .update({ read_at: now })
+      .eq('user_id', id.user_id)
+      .eq('tenant_id', id.tenant_id)
+      .is('read_at', null);
+    if (reference) {
+      // Scope to notifications whose title mentions the spoken reference.
+      const safe = reference.replace(/[%_,]/g, ' ').trim();
+      query = query.ilike('title', `%${safe}%`);
+    }
+    const { data, error } = await query.select('id');
+    if (error) return { ok: false, error: `Could not mark notifications read: ${error.message}` };
+    const count = (data ?? []).length;
+    if (count === 0) {
+      return {
+        ok: true,
+        result: { marked: 0 },
+        text: reference
+          ? `I found no unread notification matching "${reference}".`
+          : 'There were no unread notifications to mark.',
+      };
+    }
+    return {
+      ok: true,
+      result: { marked: count },
+      text: reference
+        ? `Done — marked ${count} notification${count === 1 ? '' : 's'} matching "${reference}" as read.`
+        : `Done — marked all ${count} unread notification${count === 1 ? '' : 's'} as read.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'mark_notifications_read failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_wallet_balance — READ-ONLY snapshot (wallet_accounts + wallet_ledger_entries
+// via wallet/balance-service, user_subscriptions for the active plan)
+// ---------------------------------------------------------------------------
+
+export async function tool_get_wallet_balance(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'get_wallet_balance requires an authenticated user.' };
+  try {
+    const { getAccountsForUser, getTransactionsForUser } = await import('../wallet/balance-service');
+    const [accounts, page] = await Promise.all([
+      getAccountsForUser(id.user_id),
+      getTransactionsForUser({ user_id: id.user_id, limit: 3 }),
+    ]);
+
+    // Active subscription (best effort — never block the balance on it).
+    interface SubscriptionRow {
+      plan_key: string;
+      status: string;
+      current_period_end: string | null;
+    }
+    let subscription: SubscriptionRow | null = null;
+    try {
+      let subQuery = sb
+        .from('user_subscriptions')
+        .select('plan_key, status, current_period_end')
+        .eq('user_id', id.user_id);
+      if (id.tenant_id) subQuery = subQuery.eq('tenant_id', id.tenant_id);
+      const { data: subRow } = await subQuery.maybeSingle();
+      subscription = (subRow as SubscriptionRow | null) ?? null;
+    } catch {
+      /* subscription read is optional */
+    }
+
+    const fmtMinor = (minor: number, currency: string) => `${(minor / 100).toFixed(2)} ${currency}`;
+
+    const balanceLine =
+      accounts.length > 0
+        ? `Your wallet balance is ${accounts.map((a) => fmtMinor(a.balance_minor, a.currency)).join(' and ')}.`
+        : 'Your wallet has no accounts yet — the balance is zero.';
+
+    const subLine =
+      subscription && subscription.status !== 'free' && subscription.status !== 'canceled'
+        ? ` Your ${subscription.plan_key} subscription is ${subscription.status}${
+            subscription.current_period_end
+              ? ` until ${new Date(subscription.current_period_end).toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}`
+              : ''
+          }.`
+        : '';
+
+    const txLine =
+      page.entries.length > 0
+        ? ` Latest transactions: ${page.entries
+            .map((e) => `${e.description || e.entry_type} ${e.direction === 'credit' ? '+' : '-'}${fmtMinor(e.amount_minor, e.currency)}`)
+            .join('; ')}.`
+        : '';
+
+    return {
+      ok: true,
+      result: {
+        accounts: accounts.map((a) => ({ currency: a.currency, balance_minor: a.balance_minor, status: a.status })),
+        subscription,
+        recent_transactions: page.entries.map((e) => ({
+          entry_type: e.entry_type,
+          direction: e.direction,
+          amount_minor: e.amount_minor,
+          currency: e.currency,
+          description: e.description,
+          created_at: e.created_at,
+        })),
+      },
+      text: `${balanceLine}${subLine}${txLine} This is read-only — payments and top-ups happen in the Wallet screen.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'get_wallet_balance failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// update_profile — simple own-profile fields on `profiles` (confirm-gated).
+// NEVER touches role or visibility (privacy tools own visibility).
+// ---------------------------------------------------------------------------
+
+const PROFILE_EDITABLE_FIELDS = ['display_name', 'bio', 'city', 'country', 'location'] as const;
+
+export async function tool_update_profile(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'update_profile requires an authenticated user.' };
+  const updates: Record<string, string> = {};
+  for (const field of PROFILE_EDITABLE_FIELDS) {
+    const v = args[field];
+    if (typeof v === 'string' && v.trim()) {
+      updates[field] = v.replace(/\s+/g, ' ').trim().slice(0, field === 'bio' ? 1000 : 120);
+    }
+  }
+  if (Object.keys(updates).length === 0) {
+    return {
+      ok: false,
+      error:
+        'update_profile requires at least one field to change: display_name, bio, city, country or location. Role and visibility cannot be changed here.',
+    };
+  }
+  try {
+    if (!isConfirmed(args)) {
+      const readback = Object.entries(updates)
+        .map(([k, v]) => `${k.replace('_', ' ')} to "${v}"`)
+        .join(', ');
+      return {
+        ok: true,
+        result: { stage: 'awaiting_confirmation', changes: updates },
+        text: `CONFIRM REQUIRED: Read the change back verbatim — setting ${readback} — then call update_profile again with confirmed=true after the user agrees.`,
+      };
+    }
+    const { error } = await sb.from('profiles').update(updates).eq('user_id', id.user_id);
+    if (error) return { ok: false, error: `Could not update your profile: ${error.message}` };
+    const spoken = Object.entries(updates)
+      .map(([k, v]) => `${k.replace('_', ' ')} is now "${v}"`)
+      .join(', ');
+    return {
+      ok: true,
+      result: { updated: true, changes: updates },
+      text: `Done — your ${spoken}.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'update_profile failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// play_podcast — internal Vitana Media Hub podcasts
+// (media_uploads media_type='podcast' + podcast_metadata; open_url directive
+// like play_music's vitana_hub path)
+// ---------------------------------------------------------------------------
+
+interface PodcastRow {
+  id: string;
+  title: string;
+  description: string | null;
+  file_url: string;
+  thumbnail_url: string | null;
+  duration: number | null;
+  podcast_metadata:
+    | { host_name?: string | null; series_name?: string | null }
+    | Array<{ host_name?: string | null; series_name?: string | null }>
+    | null;
+}
+
+export async function tool_play_podcast(
+  args: OrbToolArgs,
+  _id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const query = strArg(args, 'query', 'title', 'topic');
+  try {
+    let q = sb
+      .from('media_uploads')
+      .select('id, title, description, file_url, thumbnail_url, duration, podcast_metadata(host_name, series_name)')
+      .eq('status', 'approved')
+      .eq('is_public', true)
+      .eq('media_type', 'podcast');
+    if (query) {
+      const pattern = `%${query.replace(/[\\%_,]/g, ' ').trim()}%`;
+      q = q.or(`title.ilike.${pattern},description.ilike.${pattern}`);
+    }
+    const { data, error } = await q.order('plays_count', { ascending: false }).limit(5);
+    if (error) return { ok: false, error: `Podcast search failed: ${error.message}` };
+    const rows = (data ?? []) as unknown as PodcastRow[];
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { played: false, reason: 'no_match' },
+        text: query
+          ? `I couldn't find a Vitana podcast matching "${query}". Want me to open the Media Hub so you can browse?`
+          : 'There are no podcasts in the Vitana Media Hub yet. Want me to open the Media Hub?',
+      };
+    }
+    const hit = rows[0];
+    const meta = Array.isArray(hit.podcast_metadata) ? hit.podcast_metadata[0] : hit.podcast_metadata;
+    const host = meta?.host_name || '';
+    const series = meta?.series_name || '';
+    const directive = {
+      type: 'orb_directive',
+      directive: 'open_url',
+      url: hit.file_url,
+      title: hit.title,
+      channel: host || series,
+      source: 'vitana_hub',
+      query,
+      vtid: 'BOOTSTRAP-VOICE-P0-GAPS',
+    };
+    const byLine = host ? ` hosted by ${host}` : series ? ` from the series ${series}` : '';
+    return {
+      ok: true,
+      result: {
+        played: true,
+        podcast_id: hit.id,
+        title: hit.title,
+        url: hit.file_url,
+        directive, // Vertex emits via SSE/WS; LiveKit publishes over the data channel.
+      },
+      text: `Now playing the podcast "${hit.title}"${byLine} from the Vitana Media Hub.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'play_podcast failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// like_post / comment_on_post — profile_posts + profile_post_likes /
+// profile_post_comments (the community feed tables the app uses; the post
+// author is notified by DB triggers on the like/comment tables)
+// ---------------------------------------------------------------------------
+
+interface PostRow {
+  id: string;
+  user_id: string;
+  content: string;
+  created_at: string;
+}
+
+type PostOutcome =
+  | { kind: 'found'; post: PostRow; author: ResolvedPerson }
+  | { kind: 'no_author' }
+  | { kind: 'no_post'; author: ResolvedPerson }
+  | { kind: 'error'; message: string };
+
+/** Resolve "the last post from <name>" → most recent matching public post. */
+async function resolveAuthorPost(
+  sb: SupabaseClient,
+  authorName: string,
+  postReference: string,
+): Promise<PostOutcome> {
+  const author = await resolveMember(authorName);
+  if (!author) return { kind: 'no_author' };
+  const { data, error } = await sb
+    .from('profile_posts')
+    .select('id, user_id, content, created_at')
+    .eq('user_id', author.user_id)
+    .eq('is_public', true)
+    .order('created_at', { ascending: false })
+    .limit(5);
+  if (error) return { kind: 'error', message: error.message };
+  const posts = (data ?? []) as PostRow[];
+  if (posts.length === 0) return { kind: 'no_post', author };
+  if (postReference) {
+    const ref = postReference.toLowerCase();
+    const match = posts.find((p) => p.content.toLowerCase().includes(ref));
+    if (match) return { kind: 'found', post: match, author };
+  }
+  return { kind: 'found', post: posts[0], author };
+}
+
+export async function tool_like_post(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'like_post requires an authenticated user.' };
+  const authorName = strArg(args, 'author_name', 'author', 'name');
+  if (!authorName) return { ok: false, error: 'like_post requires `author_name` — whose post should be liked?' };
+  const postReference = strArg(args, 'post_reference', 'reference');
+  try {
+    const outcome = await resolveAuthorPost(sb, authorName, postReference);
+    if (outcome.kind === 'no_author') {
+      return { ok: true, result: { liked: false, reason: 'member_not_found' }, text: `I couldn't find a community member matching "${authorName}".` };
+    }
+    if (outcome.kind === 'error') return { ok: false, error: `Could not read posts: ${outcome.message}` };
+    const authorDisplay = outcome.author.display_name || authorName;
+    if (outcome.kind === 'no_post') {
+      return { ok: true, result: { liked: false, reason: 'no_posts' }, text: `${authorDisplay} has no public posts to like right now.` };
+    }
+    const { post } = outcome;
+    const { data: existing } = await sb
+      .from('profile_post_likes')
+      .select('id')
+      .eq('post_id', post.id)
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    if (existing) {
+      return {
+        ok: true,
+        result: { liked: true, already: true, post_id: post.id },
+        text: `You already liked ${authorDisplay}'s post "${snippet(post.content)}".`,
+      };
+    }
+    const { error } = await sb.from('profile_post_likes').insert({ post_id: post.id, user_id: id.user_id });
+    if (error) return { ok: false, error: `Could not like the post: ${error.message}` };
+    return {
+      ok: true,
+      result: { liked: true, post_id: post.id, author: authorDisplay },
+      text: `Done — you liked ${authorDisplay}'s post "${snippet(post.content)}".`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'like_post failed') };
+  }
+}
+
+export async function tool_comment_on_post(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'comment_on_post requires an authenticated user.' };
+  const authorName = strArg(args, 'author_name', 'author', 'name');
+  if (!authorName) return { ok: false, error: 'comment_on_post requires `author_name` — whose post should be commented on?' };
+  const rawText = strArg(args, 'text', 'comment', 'content');
+  if (!rawText) return { ok: false, error: 'comment_on_post requires the comment `text`.' };
+  const comment = rawText.replace(/\s+/g, ' ').trim().slice(0, 1000);
+  const postReference = strArg(args, 'post_reference', 'reference');
+  try {
+    const outcome = await resolveAuthorPost(sb, authorName, postReference);
+    if (outcome.kind === 'no_author') {
+      return { ok: true, result: { commented: false, reason: 'member_not_found' }, text: `I couldn't find a community member matching "${authorName}".` };
+    }
+    if (outcome.kind === 'error') return { ok: false, error: `Could not read posts: ${outcome.message}` };
+    const authorDisplay = outcome.author.display_name || authorName;
+    if (outcome.kind === 'no_post') {
+      return { ok: true, result: { commented: false, reason: 'no_posts' }, text: `${authorDisplay} has no public posts to comment on right now.` };
+    }
+    const { post } = outcome;
+    if (!isConfirmed(args)) {
+      return {
+        ok: true,
+        result: {
+          stage: 'awaiting_confirmation',
+          comment_preview: comment,
+          post_id: post.id,
+          post_snippet: snippet(post.content),
+        },
+        text: `CONFIRM REQUIRED: Read the comment back verbatim — "${comment}" — on ${authorDisplay}'s post "${snippet(post.content)}", then call comment_on_post again with confirmed=true after the user says post/yes.`,
+      };
+    }
+    const { error } = await sb
+      .from('profile_post_comments')
+      .insert({ post_id: post.id, user_id: id.user_id, content: comment });
+    if (error) return { ok: false, error: `Could not post the comment: ${error.message}` };
+    return {
+      ok: true,
+      result: { commented: true, post_id: post.id, author: authorDisplay, comment },
+      text: `Done — your comment is live on ${authorDisplay}'s post.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'comment_on_post failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const P0_GAP_TOOL_HANDLERS: Record<string, Handler> = {
+  follow_member: tool_follow_member,
+  unfollow_member: tool_unfollow_member,
+  get_notifications: tool_get_notifications,
+  mark_notifications_read: tool_mark_notifications_read,
+  get_wallet_balance: tool_get_wallet_balance,
+  update_profile: tool_update_profile,
+  play_podcast: tool_play_podcast,
+  like_post: tool_like_post,
+  comment_on_post: tool_comment_on_post,
+};
+
+export const P0_GAP_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'follow_member',
+    description: [
+      'FOLLOW a community member by their spoken name.',
+      'CALL THIS for: "Follow Anna" / "Folge Anna" / "Ich möchte Peter folgen" /',
+      '"Follow that member".',
+      'Resolves the name to a member; if no match, ask the user to repeat the name.',
+      'After success, confirm in one short sentence.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Spoken name (or handle) of the member to follow.' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'unfollow_member',
+    description: [
+      'UNFOLLOW a community member by name. Two-step confirm:',
+      'first call returns a confirmation question — ask it, then call again with',
+      'confirmed=true after the user says yes.',
+      'CALL THIS for: "Unfollow Anna" / "Entfolge Anna" / "Ich will Peter nicht mehr folgen".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Spoken name of the member to unfollow.' },
+        confirmed: { type: 'boolean', description: 'true only after the user verbally confirmed.' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'get_notifications',
+    description: [
+      "READ the user's recent notifications, unread first. Speakable.",
+      'CALL THIS for: "Any notifications?" / "Habe ich Benachrichtigungen?" /',
+      '"Was gibt es Neues für mich?" / "Read my notifications".',
+      'Speak the unread count and the top titles — never deflect to the bell icon.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'How many to read out, 1-20. Uses 10 when omitted.' },
+      },
+    },
+  },
+  {
+    name: 'mark_notifications_read',
+    description: [
+      'MARK notifications as read — all unread ones, or only those whose title',
+      'matches a spoken reference.',
+      'CALL THIS for: "Mark all as read" / "Alle als gelesen markieren" /',
+      '"Clear my notifications" / "Mark the match notification as read".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        reference: {
+          type: 'string',
+          description: 'Optional words from one notification title to mark only that one. Omit to mark all.',
+        },
+      },
+    },
+  },
+  {
+    name: 'get_wallet_balance',
+    description: [
+      'READ-ONLY wallet snapshot: balance per currency, active subscription,',
+      'last 3 transactions. NEVER moves money — payments happen in the Wallet screen.',
+      'CALL THIS for: "What is my wallet balance?" / "Wie viel Guthaben habe ich?" /',
+      '"Was ist auf meinem Wallet?" / "My last transactions".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'update_profile',
+    description: [
+      "UPDATE simple own-profile fields: display_name, bio, city, country, location.",
+      'Two-step confirm: first call returns a verbatim read-back — speak it, then',
+      'call again with confirmed=true after the user agrees.',
+      'CALL THIS for: "Change my bio to …" / "Ändere meinen Namen zu …" /',
+      '"Setze meine Stadt auf Berlin".',
+      'NEVER use this for role or profile visibility — privacy settings own those.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        display_name: { type: 'string', description: 'New display name.' },
+        bio: { type: 'string', description: 'New bio text.' },
+        city: { type: 'string', description: 'New city.' },
+        country: { type: 'string', description: 'New country.' },
+        location: { type: 'string', description: 'New free-text location, e.g. "Berlin, Germany".' },
+        confirmed: { type: 'boolean', description: 'true only after the user confirmed the read-back.' },
+      },
+    },
+  },
+  {
+    name: 'play_podcast',
+    description: [
+      'PLAY an internal Vitana Media Hub podcast by title or topic. Returns an',
+      'open_url directive the app uses to start playback.',
+      'CALL THIS for: "Play the longevity podcast" / "Spiel den Vitana Podcast" /',
+      '"Play a podcast about sleep".',
+      'For music use play_music instead. After success, say what is now playing.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Podcast title or topic. Omit to play the most popular one.' },
+      },
+    },
+  },
+  {
+    name: 'like_post',
+    description: [
+      "LIKE a community feed post — resolves \"the last post from <name>\" to that",
+      "member's most recent public post.",
+      'CALL THIS for: "Like Anna\'s post" / "Like den letzten Beitrag von Anna" /',
+      '"Gefällt mir für Peters Post".',
+      'After success, confirm which post was liked in one sentence.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        author_name: { type: 'string', description: "Spoken name of the post's author." },
+        post_reference: {
+          type: 'string',
+          description: 'Optional words from the post content to pick a specific post instead of the latest.',
+        },
+      },
+      required: ['author_name'],
+    },
+  },
+  {
+    name: 'comment_on_post',
+    description: [
+      "COMMENT on a community feed post (public text). Two-step confirm:",
+      'first call returns the comment for verbatim read-back — speak it, then call',
+      'again with confirmed=true after the user says post/yes.',
+      'CALL THIS for: "Comment on Anna\'s post: great work" /',
+      '"Kommentiere Peters Beitrag mit …".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        author_name: { type: 'string', description: "Spoken name of the post's author." },
+        text: { type: 'string', description: 'The comment text to post.' },
+        post_reference: {
+          type: 'string',
+          description: 'Optional words from the post content to pick a specific post instead of the latest.',
+        },
+        confirmed: { type: 'boolean', description: 'true only after the user confirmed the read-back.' },
+      },
+      required: ['author_name', 'text'],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/reminders-clock-tools.ts
+++ b/services/gateway/src/services/orb-tools/reminders-clock-tools.ts
@@ -1,0 +1,1130 @@
+/**
+ * Reminders lifecycle + Clock voice tools (VTID-02763, VTID-02779).
+ *
+ * Extends the VTID-02601 reminders feature (set_reminder / find_reminders /
+ * delete_reminder) with the full lifecycle the REST routes already support —
+ * snooze, edit, acknowledge, complete, missed-list — reusing the same
+ * `reminders` table + status machine (pending|dispatching|fired|completed|
+ * failed|cancelled, acked_at, snooze_count). Adds a voice clock (alarms,
+ * countdown timers, pomodoro blocks) backed by the new `voice_clock_items`
+ * table (migration 20260706100000_vtid_02779_voice_clock.sql), plus a
+ * network-free world-clock lookup via Intl time zones. NOTE: alarm/timer
+ * FIRING (push/chime when fires_at passes) needs a cron tick follow-up —
+ * this module ships the data layer + read/write tools.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { findReminders, formatTimeForVoice, type ReminderRow } from '../reminders-service';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// Shared helpers — reminders
+// ---------------------------------------------------------------------------
+
+/** Statuses a reminder can be acted on from (matches VTID-02601 routes). */
+const ACTIVE_REMINDER_STATUSES = ['pending', 'dispatching', 'fired'];
+
+const MIN_LEAD_MS = 60_000; // same 60s floor as reminders-service / PATCH route
+
+function strArg(args: OrbToolArgs, key: string): string {
+  const v = args[key];
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+function langOf(id: OrbToolIdentity): string {
+  return (id.lang || 'en').slice(0, 5);
+}
+
+type ReminderResolution =
+  | { kind: 'found'; row: ReminderRow }
+  | { kind: 'none'; message: string }
+  | { kind: 'ambiguous'; rows: ReminderRow[] };
+
+/**
+ * Resolve a single reminder by explicit reminder_id or free-text query.
+ * Text search reuses findReminders (ilike on action_text + spoken_message).
+ */
+async function resolveReminder(
+  sb: SupabaseClient,
+  userId: string,
+  args: OrbToolArgs,
+): Promise<ReminderResolution> {
+  const reminderId = strArg(args, 'reminder_id');
+  const textQuery = strArg(args, 'text_query');
+
+  if (reminderId) {
+    const { data, error } = await sb
+      .from('reminders')
+      .select('*')
+      .eq('id', reminderId)
+      .eq('user_id', userId)
+      .in('status', ACTIVE_REMINDER_STATUSES)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return { kind: 'none', message: 'No active reminder found with that id.' };
+    return { kind: 'found', row: data as ReminderRow };
+  }
+
+  const rows = await findReminders(sb, userId, {
+    query: textQuery,
+    include_fired: true,
+    limit: 5,
+  });
+  if (rows.length === 0) {
+    return { kind: 'none', message: `No active reminder matches "${textQuery}".` };
+  }
+  if (rows.length > 1) return { kind: 'ambiguous', rows };
+  return { kind: 'found', row: rows[0] };
+}
+
+function ambiguousRemindersText(rows: ReminderRow[], lang: string): string {
+  const list = rows
+    .map(
+      (r, i) =>
+        `${i + 1}. "${r.action_text}" at ${formatTimeForVoice(
+          new Date(r.next_fire_at),
+          r.user_tz,
+          lang,
+        )} (id ${r.id})`,
+    )
+    .join('; ');
+  return `I found ${rows.length} matching reminders: ${list}. Ask the user which one they mean, then call the tool again with that reminder_id.`;
+}
+
+// ---------------------------------------------------------------------------
+// Reminders lifecycle handlers (VTID-02763)
+// ---------------------------------------------------------------------------
+
+export async function tool_snooze_reminder(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'snooze_reminder requires an authenticated user.' };
+  if (!strArg(args, 'reminder_id') && !strArg(args, 'text_query')) {
+    return { ok: false, error: 'snooze_reminder needs reminder_id or text_query.' };
+  }
+  try {
+    const rawMinutes = Number(args.minutes);
+    const minutes = Math.max(1, Math.min(Number.isFinite(rawMinutes) ? Math.round(rawMinutes) : 10, 24 * 60));
+
+    const resolved = await resolveReminder(sb, id.user_id, args);
+    if (resolved.kind === 'none') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'ambiguous') {
+      return { ok: true, result: { ambiguous: true, count: resolved.rows.length }, text: ambiguousRemindersText(resolved.rows, langOf(id)) };
+    }
+    const row = resolved.row;
+
+    const newTimeIso = new Date(Date.now() + minutes * 60_000).toISOString();
+    const { data, error } = await sb
+      .from('reminders')
+      .update({
+        next_fire_at: newTimeIso,
+        status: 'pending',
+        fired_at: null,
+        acked_at: null,
+        delivery_via: null,
+        snooze_count: (row.snooze_count || 0) + 1,
+      })
+      .eq('id', row.id)
+      .eq('user_id', id.user_id)
+      .select('*')
+      .single();
+    if (error) throw new Error(error.message);
+
+    const human = formatTimeForVoice(new Date(newTimeIso), row.user_tz, langOf(id));
+    return {
+      ok: true,
+      result: { reminder_id: row.id, action_text: row.action_text, next_fire_at: newTimeIso, snoozed_minutes: minutes },
+      text: `Snoozed "${row.action_text}" by ${minutes} minutes — it will fire again at ${human}. (Snoozed ${(data as ReminderRow).snooze_count} time(s) so far.)`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `snooze_reminder failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+export async function tool_update_reminder(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'update_reminder requires an authenticated user.' };
+  if (!strArg(args, 'reminder_id') && !strArg(args, 'text_query')) {
+    return { ok: false, error: 'update_reminder needs reminder_id or text_query.' };
+  }
+  const newText = strArg(args, 'new_text');
+  const newTime = strArg(args, 'new_time');
+  if (!newText && !newTime) {
+    return { ok: false, error: 'update_reminder needs new_text and/or new_time.' };
+  }
+  try {
+    const resolved = await resolveReminder(sb, id.user_id, args);
+    if (resolved.kind === 'none') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'ambiguous') {
+      return { ok: true, result: { ambiguous: true, count: resolved.rows.length }, text: ambiguousRemindersText(resolved.rows, langOf(id)) };
+    }
+    const row = resolved.row;
+
+    const updates: Record<string, unknown> = {};
+    const changes: string[] = [];
+    let fireAtForVoice = new Date(row.next_fire_at);
+
+    if (newText) {
+      if (newText.length > 200) return { ok: false, error: 'new_text too long (max 200 chars).' };
+      updates.action_text = newText;
+      updates.spoken_message = newText;
+      updates.tts_audio_b64 = null; // pre-rendered audio is stale — re-render at fire time
+      changes.push(`text changed to "${newText}"`);
+    }
+    if (newTime) {
+      const t = new Date(newTime);
+      if (isNaN(t.getTime())) return { ok: false, error: `new_time is not a valid timestamp: ${newTime}` };
+      if (t.getTime() < Date.now() + MIN_LEAD_MS) {
+        return { ok: false, error: 'new_time must be at least 60 seconds in the future.' };
+      }
+      updates.next_fire_at = t.toISOString();
+      updates.status = 'pending';
+      updates.fired_at = null;
+      updates.acked_at = null;
+      updates.delivery_via = null;
+      fireAtForVoice = t;
+      changes.push(`time changed to ${formatTimeForVoice(t, row.user_tz, langOf(id))}`);
+    }
+
+    const { data, error } = await sb
+      .from('reminders')
+      .update(updates)
+      .eq('id', row.id)
+      .eq('user_id', id.user_id)
+      .select('*')
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return { ok: false, error: 'Reminder not found or already cancelled.' };
+
+    const updated = data as ReminderRow;
+    return {
+      ok: true,
+      result: { reminder_id: updated.id, action_text: updated.action_text, next_fire_at: updated.next_fire_at },
+      text: `Updated the reminder "${row.action_text}": ${changes.join(' and ')}. It will fire at ${formatTimeForVoice(fireAtForVoice, row.user_tz, langOf(id))}.`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `update_reminder failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+export async function tool_acknowledge_reminder(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'acknowledge_reminder requires an authenticated user.' };
+  if (!strArg(args, 'reminder_id') && !strArg(args, 'text_query')) {
+    return { ok: false, error: 'acknowledge_reminder needs reminder_id or text_query.' };
+  }
+  try {
+    const resolved = await resolveReminder(sb, id.user_id, args);
+    if (resolved.kind === 'none') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'ambiguous') {
+      return { ok: true, result: { ambiguous: true, count: resolved.rows.length }, text: ambiguousRemindersText(resolved.rows, langOf(id)) };
+    }
+    const row = resolved.row;
+
+    const { data, error } = await sb
+      .from('reminders')
+      .update({ acked_at: new Date().toISOString(), delivery_via: 'manual' })
+      .eq('id', row.id)
+      .eq('user_id', id.user_id)
+      .select('id, acked_at, delivery_via, action_text, status')
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return { ok: false, error: 'Reminder not found or already cancelled.' };
+
+    return {
+      ok: true,
+      result: { reminder_id: row.id, action_text: row.action_text, acked_at: (data as any).acked_at },
+      text: `Acknowledged the reminder "${row.action_text}" — it won't be re-delivered.`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `acknowledge_reminder failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+export async function tool_complete_reminder(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'complete_reminder requires an authenticated user.' };
+  if (!strArg(args, 'reminder_id') && !strArg(args, 'text_query')) {
+    return { ok: false, error: 'complete_reminder needs reminder_id or text_query.' };
+  }
+  try {
+    const resolved = await resolveReminder(sb, id.user_id, args);
+    if (resolved.kind === 'none') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'ambiguous') {
+      return { ok: true, result: { ambiguous: true, count: resolved.rows.length }, text: ambiguousRemindersText(resolved.rows, langOf(id)) };
+    }
+    const row = resolved.row;
+
+    const { data, error } = await sb
+      .from('reminders')
+      .update({ status: 'completed', acked_at: new Date().toISOString(), delivery_via: 'manual' })
+      .eq('id', row.id)
+      .eq('user_id', id.user_id)
+      .select('*')
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return { ok: false, error: 'Reminder not found or already cancelled.' };
+
+    return {
+      ok: true,
+      result: { reminder_id: row.id, action_text: row.action_text, status: 'completed' },
+      text: `Done — marked the reminder "${row.action_text}" as completed.`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `complete_reminder failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+export async function tool_list_missed_reminders(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'list_missed_reminders requires an authenticated user.' };
+  try {
+    const { data, error } = await sb
+      .from('reminders')
+      .select('*')
+      .eq('user_id', id.user_id)
+      .eq('status', 'fired')
+      .is('acked_at', null)
+      .order('fired_at', { ascending: false })
+      .limit(20);
+    if (error) throw new Error(error.message);
+
+    const rows = (data || []) as ReminderRow[];
+    if (rows.length === 0) {
+      return { ok: true, result: { count: 0, reminders: [] }, text: 'You have no missed reminders — everything fired was acknowledged.' };
+    }
+
+    const lang = langOf(id);
+    const list = rows
+      .map(
+        (r, i) =>
+          `${i + 1}. "${r.action_text}" (fired ${formatTimeForVoice(
+            new Date(r.fired_at || r.next_fire_at),
+            r.user_tz,
+            lang,
+          )})`,
+      )
+      .join('; ');
+    return {
+      ok: true,
+      result: {
+        count: rows.length,
+        reminders: rows.map((r) => ({ reminder_id: r.id, action_text: r.action_text, fired_at: r.fired_at })),
+      },
+      text: `You have ${rows.length} missed reminder(s): ${list}. The user can snooze, complete, or acknowledge each one.`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `list_missed_reminders failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers — clock (VTID-02779)
+// ---------------------------------------------------------------------------
+
+const CLOCK_TABLE = 'voice_clock_items';
+
+export interface VoiceClockItemRow {
+  id: string;
+  tenant_id: string | null;
+  user_id: string;
+  kind: 'alarm' | 'timer' | 'pomodoro';
+  label: string | null;
+  fires_at: string | null;
+  recurrence: string | null;
+  duration_seconds: number | null;
+  status: 'active' | 'fired' | 'cancelled' | 'completed';
+  created_at: string;
+}
+
+function isValidTimeZone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Offset (ms) to add to a UTC instant to get the wall clock in `tz`. */
+function tzOffsetMs(tz: string, at: Date): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts: Record<string, string> = {};
+  for (const p of dtf.formatToParts(at)) parts[p.type] = p.value;
+  const asUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour) % 24, // Intl emits "24" for midnight in some locales
+    Number(parts.minute),
+    Number(parts.second),
+  );
+  return asUtc - at.getTime();
+}
+
+/**
+ * Compute the next absolute fire instant for an alarm.
+ * `time` is "HH:MM" (interpreted in `tz`, next occurrence, skipping to Mon-Fri
+ * when recurrence='weekdays') or an absolute ISO timestamp (used as-is).
+ */
+export function computeNextAlarmFire(
+  time: string,
+  tz: string,
+  recurrence: string | null,
+): { fires_at?: Date; error?: string } {
+  const hhmm = /^([01]?\d|2[0-3]):([0-5]\d)$/.exec(time);
+  if (hhmm) {
+    const hour = Number(hhmm[1]);
+    const minute = Number(hhmm[2]);
+    const now = new Date();
+    const offset = tzOffsetMs(tz, now);
+    const wallNow = now.getTime() + offset;
+    const w = new Date(wallNow);
+    let candidateWall = Date.UTC(w.getUTCFullYear(), w.getUTCMonth(), w.getUTCDate(), hour, minute, 0);
+    if (candidateWall <= wallNow) candidateWall += 86_400_000;
+    if (recurrence === 'weekdays') {
+      while ([0, 6].includes(new Date(candidateWall).getUTCDay())) candidateWall += 86_400_000;
+    }
+    // Recompute the offset at the candidate instant so DST transitions land right.
+    const offsetAtFire = tzOffsetMs(tz, new Date(candidateWall - offset));
+    return { fires_at: new Date(candidateWall - offsetAtFire) };
+  }
+
+  const parsed = new Date(time);
+  if (isNaN(parsed.getTime())) {
+    return { error: `"${time}" is not a valid time. Use "HH:MM" (24h) or an ISO timestamp.` };
+  }
+  if (parsed.getTime() <= Date.now()) {
+    return { error: 'That time is in the past — give a future time.' };
+  }
+  return { fires_at: parsed };
+}
+
+function fmtInTz(d: Date, tz: string, opts: Intl.DateTimeFormatOptions, locale = 'en'): string {
+  try {
+    return new Intl.DateTimeFormat(locale, { timeZone: tz, ...opts }).format(d);
+  } catch {
+    return d.toISOString();
+  }
+}
+
+function fmtAlarmTime(d: Date, tz: string, locale: string): string {
+  return fmtInTz(d, tz, { weekday: 'long', hour: 'numeric', minute: '2-digit' }, locale);
+}
+
+function resolveTzArg(args: OrbToolArgs): { tz: string; error?: string } {
+  const raw = strArg(args, 'timezone');
+  if (!raw) return { tz: 'UTC' }; // documented assumption: UTC when the model omits timezone
+  if (!isValidTimeZone(raw)) {
+    return { tz: 'UTC', error: `"${raw}" is not a valid IANA timezone (e.g. Europe/Berlin).` };
+  }
+  return { tz: raw };
+}
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return 'finished';
+  const totalSec = Math.round(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  const parts: string[] = [];
+  if (h) parts.push(`${h} hour${h === 1 ? '' : 's'}`);
+  if (m) parts.push(`${m} minute${m === 1 ? '' : 's'}`);
+  if (!h && (s || parts.length === 0)) parts.push(`${s} second${s === 1 ? '' : 's'}`);
+  return `${parts.join(' ')} remaining`;
+}
+
+// ---------------------------------------------------------------------------
+// Clock handlers (VTID-02779)
+// ---------------------------------------------------------------------------
+
+export async function tool_set_alarm(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'set_alarm requires an authenticated user.' };
+  try {
+    const time = strArg(args, 'time');
+    if (!time) return { ok: false, error: 'set_alarm needs a time ("HH:MM" or ISO timestamp).' };
+
+    const recurrenceRaw = strArg(args, 'recurrence');
+    if (recurrenceRaw && !['daily', 'weekdays'].includes(recurrenceRaw)) {
+      return { ok: false, error: `Unsupported recurrence "${recurrenceRaw}" — use "daily", "weekdays", or omit for one-shot.` };
+    }
+    const recurrence = recurrenceRaw || null;
+
+    const { tz, error: tzError } = resolveTzArg(args);
+    if (tzError) return { ok: false, error: tzError };
+
+    const next = computeNextAlarmFire(time, tz, recurrence);
+    if (!next.fires_at) return { ok: false, error: next.error || 'Could not compute the alarm time.' };
+
+    const label = strArg(args, 'label') || null;
+    const { data, error } = await sb
+      .from(CLOCK_TABLE)
+      .insert({
+        tenant_id: id.tenant_id ?? null,
+        user_id: id.user_id,
+        kind: 'alarm',
+        label,
+        fires_at: next.fires_at.toISOString(),
+        recurrence,
+        status: 'active',
+      })
+      .select('*')
+      .single();
+    if (error) throw new Error(error.message);
+
+    const row = data as VoiceClockItemRow;
+    const when = fmtAlarmTime(next.fires_at, tz, langOf(id));
+    const repeat = recurrence === 'daily' ? ', repeating daily' : recurrence === 'weekdays' ? ', repeating on weekdays' : '';
+    return {
+      ok: true,
+      result: { alarm_id: row.id, fires_at: row.fires_at, recurrence, label, timezone: tz },
+      text: `Alarm set for ${when}${label ? ` — "${label}"` : ''}${repeat} (timezone ${tz}).`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `set_alarm failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+export async function tool_list_alarms(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'list_alarms requires an authenticated user.' };
+  try {
+    const { tz } = resolveTzArg(args); // invalid tz just falls back to UTC for display
+    const { data, error } = await sb
+      .from(CLOCK_TABLE)
+      .select('*')
+      .eq('user_id', id.user_id)
+      .eq('kind', 'alarm')
+      .eq('status', 'active')
+      .order('fires_at', { ascending: true })
+      .limit(20);
+    if (error) throw new Error(error.message);
+
+    const rows = (data || []) as VoiceClockItemRow[];
+    if (rows.length === 0) {
+      return { ok: true, result: { count: 0, alarms: [] }, text: 'You have no active alarms.' };
+    }
+    const lang = langOf(id);
+    const list = rows
+      .map((r, i) => {
+        const when = r.fires_at ? fmtAlarmTime(new Date(r.fires_at), tz, lang) : 'unscheduled';
+        const repeat = r.recurrence === 'daily' ? ', daily' : r.recurrence === 'weekdays' ? ', weekdays' : '';
+        return `${i + 1}. ${when}${r.label ? ` — "${r.label}"` : ''}${repeat}`;
+      })
+      .join('; ');
+    return {
+      ok: true,
+      result: {
+        count: rows.length,
+        alarms: rows.map((r) => ({ alarm_id: r.id, label: r.label, fires_at: r.fires_at, recurrence: r.recurrence })),
+      },
+      text: `You have ${rows.length} active alarm(s): ${list}.`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `list_alarms failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+export async function tool_delete_alarm(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'delete_alarm requires an authenticated user.' };
+  try {
+    const alarmId = strArg(args, 'alarm_id');
+    const label = strArg(args, 'label');
+    const time = strArg(args, 'time');
+    if (!alarmId && !label && !time) {
+      return { ok: false, error: 'delete_alarm needs alarm_id, or a label/time to match.' };
+    }
+
+    const { data, error } = await sb
+      .from(CLOCK_TABLE)
+      .select('*')
+      .eq('user_id', id.user_id)
+      .eq('kind', 'alarm')
+      .eq('status', 'active')
+      .order('fires_at', { ascending: true })
+      .limit(20);
+    if (error) throw new Error(error.message);
+    const all = (data || []) as VoiceClockItemRow[];
+
+    const { tz } = resolveTzArg(args);
+    const lang = langOf(id);
+    let matches = all;
+    if (alarmId) matches = matches.filter((r) => r.id === alarmId);
+    if (label) matches = matches.filter((r) => (r.label || '').toLowerCase().includes(label.toLowerCase()));
+    if (time) {
+      matches = matches.filter(
+        (r) => r.fires_at && fmtInTz(new Date(r.fires_at), tz, { hour: '2-digit', minute: '2-digit', hour12: false }) === time.padStart(5, '0'),
+      );
+    }
+
+    if (matches.length === 0) return { ok: false, error: 'No active alarm matches that — call list_alarms to see what exists.' };
+    if (matches.length > 1) {
+      const list = matches
+        .map((r, i) => `${i + 1}. ${r.fires_at ? fmtAlarmTime(new Date(r.fires_at), tz, lang) : 'unscheduled'}${r.label ? ` — "${r.label}"` : ''} (id ${r.id})`)
+        .join('; ');
+      return {
+        ok: true,
+        result: { ambiguous: true, count: matches.length },
+        text: `I found ${matches.length} matching alarms: ${list}. Ask the user which one to delete, then call delete_alarm again with that alarm_id.`,
+      };
+    }
+
+    const target = matches[0];
+    const when = target.fires_at ? fmtAlarmTime(new Date(target.fires_at), tz, lang) : 'unscheduled';
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { needs_confirmation: true, alarm_id: target.id },
+        text: `Found the alarm at ${when}${target.label ? ` — "${target.label}"` : ''}. Ask the user to confirm the deletion, then call delete_alarm again with alarm_id="${target.id}" and confirm=true.`,
+      };
+    }
+
+    const { data: cancelled, error: cancelError } = await sb
+      .from(CLOCK_TABLE)
+      .update({ status: 'cancelled' })
+      .eq('id', target.id)
+      .eq('user_id', id.user_id)
+      .eq('status', 'active')
+      .select('id')
+      .maybeSingle();
+    if (cancelError) throw new Error(cancelError.message);
+    if (!cancelled) return { ok: false, error: 'Alarm was already cancelled or no longer exists.' };
+
+    return {
+      ok: true,
+      result: { alarm_id: target.id, status: 'cancelled' },
+      text: `Deleted the alarm at ${when}${target.label ? ` — "${target.label}"` : ''}.`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `delete_alarm failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+export async function tool_start_timer(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'start_timer requires an authenticated user.' };
+  try {
+    const minutes = Number(args.duration_minutes);
+    if (!Number.isFinite(minutes) || minutes < 1 || minutes > 1440) {
+      return { ok: false, error: 'start_timer needs duration_minutes between 1 and 1440.' };
+    }
+    const label = strArg(args, 'label') || null;
+    const firesAt = new Date(Date.now() + minutes * 60_000);
+
+    const { data, error } = await sb
+      .from(CLOCK_TABLE)
+      .insert({
+        tenant_id: id.tenant_id ?? null,
+        user_id: id.user_id,
+        kind: 'timer',
+        label,
+        fires_at: firesAt.toISOString(),
+        duration_seconds: Math.round(minutes * 60),
+        status: 'active',
+      })
+      .select('*')
+      .single();
+    if (error) throw new Error(error.message);
+
+    const row = data as VoiceClockItemRow;
+    const mins = Math.round(minutes);
+    return {
+      ok: true,
+      result: { timer_id: row.id, fires_at: row.fires_at, duration_seconds: row.duration_seconds, label },
+      text: `Timer started: ${mins} minute${mins === 1 ? '' : 's'}${label ? ` for "${label}"` : ''}.`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `start_timer failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+export async function tool_start_pomodoro(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'start_pomodoro requires an authenticated user.' };
+  try {
+    const raw = args.duration_minutes;
+    const minutes = raw === undefined || raw === null || raw === '' ? 25 : Number(raw);
+    if (!Number.isFinite(minutes) || minutes < 5 || minutes > 90) {
+      return { ok: false, error: 'start_pomodoro needs duration_minutes between 5 and 90 (default 25).' };
+    }
+    const label = strArg(args, 'label') || null;
+    const firesAt = new Date(Date.now() + minutes * 60_000);
+
+    const { data, error } = await sb
+      .from(CLOCK_TABLE)
+      .insert({
+        tenant_id: id.tenant_id ?? null,
+        user_id: id.user_id,
+        kind: 'pomodoro',
+        label,
+        fires_at: firesAt.toISOString(),
+        duration_seconds: Math.round(minutes * 60),
+        status: 'active',
+      })
+      .select('*')
+      .single();
+    if (error) throw new Error(error.message);
+
+    const row = data as VoiceClockItemRow;
+    const mins = Math.round(minutes);
+    return {
+      ok: true,
+      result: { pomodoro_id: row.id, fires_at: row.fires_at, duration_seconds: row.duration_seconds, label },
+      text: `Pomodoro started: ${mins} minutes of focused work${label ? ` on "${label}"` : ''}. Encourage the user to stay on task until it ends.`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `start_pomodoro failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+export async function tool_list_active_timers(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  if (!id.user_id) return { ok: false, error: 'list_active_timers requires an authenticated user.' };
+  try {
+    const { data, error } = await sb
+      .from(CLOCK_TABLE)
+      .select('*')
+      .eq('user_id', id.user_id)
+      .in('kind', ['timer', 'pomodoro'])
+      .eq('status', 'active')
+      .order('fires_at', { ascending: true })
+      .limit(20);
+    if (error) throw new Error(error.message);
+
+    const rows = (data || []) as VoiceClockItemRow[];
+    if (rows.length === 0) {
+      return { ok: true, result: { count: 0, timers: [] }, text: 'You have no running timers or pomodoros.' };
+    }
+    const now = Date.now();
+    const list = rows
+      .map((r, i) => {
+        const kindName = r.kind === 'pomodoro' ? 'Pomodoro' : 'Timer';
+        const remaining = r.fires_at ? formatRemaining(new Date(r.fires_at).getTime() - now) : 'no end time';
+        return `${i + 1}. ${kindName}${r.label ? ` "${r.label}"` : ''} — ${remaining}`;
+      })
+      .join('; ');
+    return {
+      ok: true,
+      result: {
+        count: rows.length,
+        timers: rows.map((r) => ({
+          timer_id: r.id,
+          kind: r.kind,
+          label: r.label,
+          fires_at: r.fires_at,
+          remaining_seconds: r.fires_at ? Math.max(0, Math.round((new Date(r.fires_at).getTime() - now) / 1000)) : null,
+        })),
+      },
+      text: `You have ${rows.length} running: ${list}.`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `list_active_timers failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// World clock (no network — Intl only)
+// ---------------------------------------------------------------------------
+
+/** Common city name → IANA zone. Lookups are diacritic-insensitive lowercase. */
+export const CITY_TIMEZONES: Record<string, string> = {
+  berlin: 'Europe/Berlin',
+  munich: 'Europe/Berlin',
+  muenchen: 'Europe/Berlin',
+  hamburg: 'Europe/Berlin',
+  frankfurt: 'Europe/Berlin',
+  cologne: 'Europe/Berlin',
+  koln: 'Europe/Berlin',
+  vienna: 'Europe/Vienna',
+  wien: 'Europe/Vienna',
+  zurich: 'Europe/Zurich',
+  geneva: 'Europe/Zurich',
+  belgrade: 'Europe/Belgrade',
+  beograd: 'Europe/Belgrade',
+  'novi sad': 'Europe/Belgrade',
+  zagreb: 'Europe/Zagreb',
+  sarajevo: 'Europe/Sarajevo',
+  ljubljana: 'Europe/Ljubljana',
+  london: 'Europe/London',
+  dublin: 'Europe/Dublin',
+  paris: 'Europe/Paris',
+  madrid: 'Europe/Madrid',
+  barcelona: 'Europe/Madrid',
+  lisbon: 'Europe/Lisbon',
+  rome: 'Europe/Rome',
+  milan: 'Europe/Rome',
+  amsterdam: 'Europe/Amsterdam',
+  brussels: 'Europe/Brussels',
+  copenhagen: 'Europe/Copenhagen',
+  stockholm: 'Europe/Stockholm',
+  oslo: 'Europe/Oslo',
+  helsinki: 'Europe/Helsinki',
+  warsaw: 'Europe/Warsaw',
+  prague: 'Europe/Prague',
+  budapest: 'Europe/Budapest',
+  athens: 'Europe/Athens',
+  istanbul: 'Europe/Istanbul',
+  moscow: 'Europe/Moscow',
+  kyiv: 'Europe/Kyiv',
+  'tel aviv': 'Asia/Jerusalem',
+  cairo: 'Africa/Cairo',
+  johannesburg: 'Africa/Johannesburg',
+  dubai: 'Asia/Dubai',
+  mumbai: 'Asia/Kolkata',
+  delhi: 'Asia/Kolkata',
+  bangkok: 'Asia/Bangkok',
+  singapore: 'Asia/Singapore',
+  'hong kong': 'Asia/Hong_Kong',
+  shanghai: 'Asia/Shanghai',
+  beijing: 'Asia/Shanghai',
+  tokyo: 'Asia/Tokyo',
+  seoul: 'Asia/Seoul',
+  sydney: 'Australia/Sydney',
+  melbourne: 'Australia/Melbourne',
+  auckland: 'Pacific/Auckland',
+  'new york': 'America/New_York',
+  'washington': 'America/New_York',
+  miami: 'America/New_York',
+  boston: 'America/New_York',
+  toronto: 'America/Toronto',
+  chicago: 'America/Chicago',
+  'mexico city': 'America/Mexico_City',
+  denver: 'America/Denver',
+  'los angeles': 'America/Los_Angeles',
+  la: 'America/Los_Angeles',
+  'san francisco': 'America/Los_Angeles',
+  seattle: 'America/Los_Angeles',
+  vancouver: 'America/Vancouver',
+  'sao paulo': 'America/Sao_Paulo',
+  'buenos aires': 'America/Argentina/Buenos_Aires',
+};
+
+function normalizeCity(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export async function tool_get_world_time(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  try {
+    const location = strArg(args, 'location');
+    if (!location) {
+      return { ok: false, error: 'get_world_time needs a location — a city name (e.g. Berlin) or IANA timezone (e.g. Europe/Berlin).' };
+    }
+
+    const normalized = normalizeCity(location);
+    let tz = CITY_TIMEZONES[normalized];
+    let displayName = location;
+    if (!tz) {
+      // Not a known city — accept a valid IANA zone string directly.
+      if (isValidTimeZone(location)) {
+        tz = location;
+      } else {
+        return {
+          ok: false,
+          error: `I don't recognize "${location}". Try a major city (e.g. Berlin, Belgrade, London, New York, Tokyo) or a valid IANA timezone like "Europe/Berlin".`,
+        };
+      }
+      displayName = location.includes('/') ? location.split('/').pop()!.replace(/_/g, ' ') : location;
+    }
+
+    const now = new Date();
+    const lang = langOf(id);
+    const timeStr = fmtInTz(now, tz, { hour: 'numeric', minute: '2-digit' }, lang);
+    const dateStr = fmtInTz(now, tz, { weekday: 'long', month: 'long', day: 'numeric' }, lang);
+    return {
+      ok: true,
+      result: { timezone: tz, local_time: timeStr, local_date: dateStr, iso: now.toISOString() },
+      text: `It's currently ${timeStr} on ${dateStr} in ${displayName} (${tz}).`,
+    };
+  } catch (err: any) {
+    return { ok: false, error: `get_world_time failed: ${err?.message || 'unknown error'}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports for the parent integrator
+// ---------------------------------------------------------------------------
+
+export const REMINDERS_CLOCK_TOOL_HANDLERS: Record<string, Handler> = {
+  snooze_reminder: tool_snooze_reminder,
+  update_reminder: tool_update_reminder,
+  acknowledge_reminder: tool_acknowledge_reminder,
+  complete_reminder: tool_complete_reminder,
+  list_missed_reminders: tool_list_missed_reminders,
+  set_alarm: tool_set_alarm,
+  list_alarms: tool_list_alarms,
+  delete_alarm: tool_delete_alarm,
+  start_timer: tool_start_timer,
+  start_pomodoro: tool_start_pomodoro,
+  list_active_timers: tool_list_active_timers,
+  get_world_time: tool_get_world_time,
+};
+
+export const REMINDERS_CLOCK_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'snooze_reminder',
+    description: [
+      'Push an existing reminder out by N minutes (default 10, max 1440).',
+      "CALL WHEN the user says 'snooze it', 'remind me again in 15 minutes',",
+      "'verschieb die Erinnerung', 'erinnere mich später nochmal'.",
+      'Pass reminder_id when known (e.g. a reminder just fired), otherwise',
+      'text_query with words from the reminder. If the tool reports multiple',
+      'matches, ask the user which one and call again with that reminder_id.',
+      'After success, speak the confirmation with the new time from `text`.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        reminder_id: { type: 'string', description: 'UUID of the reminder, if known.' },
+        text_query: { type: 'string', description: "Free-text to find the reminder (e.g. 'magnesium')." },
+        minutes: { type: 'number', description: 'How many minutes to push it out. 1-1440; 10 if omitted.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'update_reminder',
+    description: [
+      "Edit an existing reminder's text and/or time.",
+      "CALL WHEN the user says 'change my reminder to 9pm', 'make it say X',",
+      "'ändere meine Erinnerung', 'verschiebe die Erinnerung auf 21 Uhr'.",
+      'Identify via reminder_id or text_query. new_time is an absolute UTC ISO',
+      'timestamp YOU compute from their words + timezone (min 60s in future).',
+      'If multiple reminders match, ask which one, then call again with the id.',
+      'After success, confirm the change using `text`.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        reminder_id: { type: 'string', description: 'UUID of the reminder, if known.' },
+        text_query: { type: 'string', description: 'Free-text to find the reminder.' },
+        new_text: { type: 'string', description: 'New reminder text (max 200 chars). Also becomes the spoken message.' },
+        new_time: { type: 'string', description: 'New absolute UTC ISO 8601 timestamp. Min 60s in the future.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'acknowledge_reminder',
+    description: [
+      'Mark a fired reminder as heard/acknowledged so it stops being re-delivered.',
+      "CALL WHEN the user says 'got it', 'okay, I heard the reminder', 'dismiss it',",
+      "'alles klar, habs gehört' after a reminder fired — but the task is NOT done yet.",
+      'Use complete_reminder instead when the user actually DID the thing.',
+      'Identify via reminder_id (preferred, e.g. from the fire event) or text_query.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        reminder_id: { type: 'string', description: 'UUID of the reminder, if known.' },
+        text_query: { type: 'string', description: 'Free-text to find the reminder.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'complete_reminder',
+    description: [
+      'Mark a reminder as DONE (the user did the thing). Sets status=completed.',
+      "CALL WHEN the user says 'done', 'I took my magnesium, check it off',",
+      "'erledigt', 'hab ich gemacht' about a reminder.",
+      'Identify via reminder_id or text_query. If multiple match, ask which one.',
+      'After success, give a short positive confirmation from `text`.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        reminder_id: { type: 'string', description: 'UUID of the reminder, if known.' },
+        text_query: { type: 'string', description: 'Free-text to find the reminder.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'list_missed_reminders',
+    description: [
+      "List reminders that fired but were never acknowledged (the user missed them).",
+      "CALL WHEN the user asks 'did I miss anything?', 'what reminders did I miss?',",
+      "'habe ich Erinnerungen verpasst?', or at the start of a session catch-up.",
+      'Speak each missed reminder with its text and when it fired, then offer to',
+      'snooze, complete, or acknowledge them.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'set_alarm',
+    description: [
+      'Set a wake-up/clock alarm at a specific time of day (optionally recurring).',
+      "CALL WHEN the user says 'wake me at 7', 'set an alarm for 6:30 on weekdays',",
+      "'stell einen Wecker auf 7 Uhr', 'weck mich um halb sieben'.",
+      "time is 'HH:MM' (24h, interpreted in the given timezone — next occurrence)",
+      'or an absolute ISO timestamp. ALWAYS pass the user timezone from context;',
+      'UTC is assumed when omitted. recurrence: daily, weekdays, or omit for once.',
+      'Prefer alarms for time-of-day wake-ups; use set_reminder for task reminders.',
+      'After success, confirm with the day + time from `text`.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        time: { type: 'string', description: "'HH:MM' 24h wall-clock time, or absolute ISO 8601 timestamp." },
+        label: { type: 'string', description: "Optional label, e.g. 'Gym'." },
+        recurrence: { type: 'string', enum: ['daily', 'weekdays'], description: 'Omit for a one-time alarm.' },
+        timezone: { type: 'string', description: "User's IANA timezone, e.g. Europe/Berlin. UTC assumed if omitted." },
+      },
+      required: ['time'],
+    },
+  },
+  {
+    name: 'list_alarms',
+    description: [
+      'List the user\'s active alarms with times and labels.',
+      "CALL WHEN the user asks 'what alarms do I have?', 'when is my alarm?',",
+      "'welche Wecker habe ich?', or before deleting/changing an alarm.",
+      'Pass timezone so times are spoken in local wall-clock time.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        timezone: { type: 'string', description: "User's IANA timezone for display. UTC assumed if omitted." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'delete_alarm',
+    description: [
+      'Cancel an alarm. Two-step confirm flow: first call WITHOUT confirm to find',
+      'the alarm (by alarm_id, label, or HH:MM time) — the tool answers with the',
+      'match and asks you to confirm with the user. After the user explicitly says',
+      'yes, call again with that alarm_id and confirm=true.',
+      "CALL WHEN the user says 'delete my alarm', 'cancel the 7am alarm',",
+      "'lösch den Wecker', 'Wecker ausschalten'.",
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        alarm_id: { type: 'string', description: 'UUID from list_alarms / a previous delete_alarm match.' },
+        label: { type: 'string', description: 'Match by label substring instead of id.' },
+        time: { type: 'string', description: "Match by 'HH:MM' local time instead of id (pass timezone too)." },
+        timezone: { type: 'string', description: "User's IANA timezone for the time match. UTC assumed if omitted." },
+        confirm: { type: 'boolean', description: 'true ONLY after the user explicitly confirmed the deletion.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'start_timer',
+    description: [
+      'Start a countdown timer (1-1440 minutes).',
+      "CALL WHEN the user says 'set a timer for 10 minutes', 'timer for the pasta',",
+      "'stell einen Timer auf 10 Minuten', 'Countdown 20 Minuten'.",
+      'For focused work blocks prefer start_pomodoro. After success, confirm the',
+      'duration and label from `text`.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        duration_minutes: { type: 'number', description: 'Countdown length in minutes, 1-1440.' },
+        label: { type: 'string', description: "Optional label, e.g. 'Pasta'." },
+      },
+      required: ['duration_minutes'],
+    },
+  },
+  {
+    name: 'start_pomodoro',
+    description: [
+      'Start a pomodoro focus block (5-90 minutes; 25 if omitted).',
+      "CALL WHEN the user says 'start a pomodoro', 'let's do a focus session',",
+      "'starte eine Pomodoro-Einheit', '45 Minuten Fokuszeit'.",
+      'After success, confirm the length and encourage focused work.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        duration_minutes: { type: 'number', description: 'Work block length in minutes, 5-90. 25 if omitted.' },
+        label: { type: 'string', description: "Optional focus topic, e.g. 'Deep work on the report'." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'list_active_timers',
+    description: [
+      'List running timers and pomodoros with the remaining time on each.',
+      "CALL WHEN the user asks 'how much time is left?', 'is my timer still running?',",
+      "'wie lange läuft mein Timer noch?', 'wie viel Zeit habe ich noch?'.",
+      'Speak each entry with its label and remaining time from `text`.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_world_time',
+    description: [
+      'Get the current local time in a city or IANA timezone (no internet needed).',
+      "CALL WHEN the user asks 'what time is it in Tokyo?', 'wie spät ist es in",
+      "Belgrad?', 'what's the time in New York right now?'.",
+      'location accepts a major city name (Berlin, Belgrade, London, New York,',
+      "Tokyo, ...) or any IANA zone like 'Europe/Berlin'. Speak the `text` answer.",
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        location: { type: 'string', description: "City name or IANA timezone, e.g. 'Berlin' or 'Europe/Berlin'." },
+      },
+      required: ['location'],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/superlatives-tools.ts
+++ b/services/gateway/src/services/orb-tools/superlatives-tools.ts
@@ -1,0 +1,449 @@
+/**
+ * Superlatives voice tools (VTID-02754).
+ *
+ * Community "who is...?" superlative lookups for the ORB assistant: highest
+ * Vitana Index, top scorer per pillar, first/newest member, most followed,
+ * plus an NL router (ask_who_is) for free-form superlative questions. All
+ * handlers REUSE the VTID-02754 service layer in
+ * services/voice-tools/superlatives.ts (privacy-filtered via
+ * global_community_profiles.is_visible) and, for unroutable questions,
+ * fall back to the same ranking pipeline the live find_community_member
+ * tool uses (services/voice-tools/community-member-ranker.ts). No ranking
+ * logic is re-implemented here — this module only adapts service results
+ * into speakable OrbToolResult text.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import {
+  getHighestVitanaIndex,
+  getTopInPillar,
+  getMemberByRegistration,
+  getMostFollowed,
+  askWhoIs,
+  type Pillar,
+  type SuperlativeResult,
+  type SuperlativeError,
+} from '../voice-tools/superlatives';
+import { findCommunityMember } from '../voice-tools/community-member-ranker';
+import { resolvePillarKey } from '../../lib/vitana-pillars';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+const VALID_PILLARS: readonly Pillar[] = ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'];
+
+/**
+ * Voice-friendly pillar resolution: canonical keys via resolvePillarKey,
+ * plus common English/German spoken synonyms the LLM may pass through.
+ */
+const PILLAR_SYNONYMS: Record<string, Pillar> = {
+  ernaehrung: 'nutrition',
+  'ernährung': 'nutrition',
+  essen: 'nutrition',
+  food: 'nutrition',
+  diet: 'nutrition',
+  wasser: 'hydration',
+  water: 'hydration',
+  trinken: 'hydration',
+  bewegung: 'exercise',
+  sport: 'exercise',
+  fitness: 'exercise',
+  workout: 'exercise',
+  schlaf: 'sleep',
+  rest: 'sleep',
+  geist: 'mental',
+  mind: 'mental',
+  mindfulness: 'mental',
+  achtsamkeit: 'mental',
+};
+
+function resolvePillar(raw: unknown): Pillar | undefined {
+  const canonical = resolvePillarKey(raw);
+  if (canonical && (VALID_PILLARS as readonly string[]).includes(canonical)) {
+    return canonical as Pillar;
+  }
+  if (typeof raw !== 'string') return undefined;
+  return PILLAR_SYNONYMS[raw.trim().toLowerCase()];
+}
+
+/** ok:false when there is no authenticated user — community data is member-only. */
+function authGate(tool: string, id: OrbToolIdentity, needTenant = false): OrbToolResult | null {
+  if (!id.user_id || (needTenant && !id.tenant_id)) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+/** "3 days ago" / "2 months ago" style phrase from an ISO date. */
+function relativeJoinedPhrase(iso: string | null): string {
+  if (!iso) return 'recently';
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return 'recently';
+  const days = (Date.now() - t) / (1000 * 60 * 60 * 24);
+  if (days < 1) return 'today';
+  if (days < 2) return 'yesterday';
+  if (days < 7) return `${Math.round(days)} days ago`;
+  if (days < 60) return `${Math.round(days / 7)} weeks ago`;
+  if (days < 730) return `${Math.round(days / 30)} months ago`;
+  return `${Math.round(days / 365)} years ago`;
+}
+
+/** "January 2026" style phrase from an ISO date (LLM translates when speaking DE). */
+function monthYearPhrase(iso: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return null;
+  return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+function displayNameOf(res: SuperlativeResult): string {
+  return res.profile?.display_name || 'A community member';
+}
+
+/**
+ * Empty community states ("nobody has a score yet") stay ok:true with an
+ * honest spoken line — Gemini Live treats ok:false as a hard failure and
+ * apologises, which is wrong for a merely-empty leaderboard.
+ */
+const EMPTY_ERRORS = new Set(['no_eligible_candidates', 'no_followers_data']);
+
+function isEmptyState(err: SuperlativeError): boolean {
+  return EMPTY_ERRORS.has(err.error) || err.error.startsWith('no_followers_data');
+}
+
+/** Turn a routed SuperlativeResult into one compact speakable sentence. */
+function speakSuperlative(res: SuperlativeResult): string {
+  const name = displayNameOf(res);
+  if (res.metric === 'vitana_index_total') {
+    return `${name} has the highest Vitana Index in the community right now — ${res.metric_value} points.`;
+  }
+  if (res.metric.startsWith('pillar_')) {
+    const pillar = res.metric.slice('pillar_'.length);
+    return `${name} leads the community on the ${pillar} pillar with a score of ${res.metric_value} points.`;
+  }
+  if (res.metric === 'first_member_registered') {
+    const since = monthYearPhrase(res.profile?.member_since ?? null);
+    return `${name} was the very first member of the community${since ? ` — a member since ${since}` : ''}.`;
+  }
+  if (res.metric === 'newest_member_registered') {
+    return `${name} is our newest community member — they joined ${relativeJoinedPhrase(res.profile?.member_since ?? null)}.`;
+  }
+  if (res.metric === 'follower_count') {
+    const n = Number(res.metric_value) || 0;
+    return `${name} is the most followed member of the community with ${n} follower${n === 1 ? '' : 's'}.`;
+  }
+  return `${name} tops the community on ${res.metric.replace(/_/g, ' ')} (${res.metric_value}).`;
+}
+
+function superlativePayload(res: SuperlativeResult): Record<string, unknown> {
+  return {
+    metric: res.metric,
+    metric_value: res.metric_value,
+    metric_unit: res.metric_unit ?? null,
+    display_name: displayNameOf(res),
+    vitana_id: res.profile?.vitana_id ?? null,
+    member_since: res.profile?.member_since ?? null,
+    total_eligible: res.total_eligible,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// get_highest_vitana_index
+// ---------------------------------------------------------------------------
+
+export async function tool_get_highest_vitana_index(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_highest_vitana_index', id);
+  if (gate) return gate;
+  try {
+    const res = await getHighestVitanaIndex(sb, 1);
+    if (!res.ok) {
+      if (isEmptyState(res)) {
+        return {
+          ok: true,
+          result: { available: false },
+          text: 'No community member has a visible Vitana Index score yet — the leaderboard is still empty.',
+        };
+      }
+      return { ok: false, error: res.error };
+    }
+    return { ok: true, result: superlativePayload(res), text: speakSuperlative(res) };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_highest_vitana_index failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_top_in_pillar
+// ---------------------------------------------------------------------------
+
+export async function tool_get_top_in_pillar(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_top_in_pillar', id);
+  if (gate) return gate;
+  const pillar = resolvePillar(args.pillar);
+  if (!pillar) {
+    return {
+      ok: false,
+      error: `get_top_in_pillar requires a pillar: ${VALID_PILLARS.join(', ')}.`,
+    };
+  }
+  try {
+    const res = await getTopInPillar(sb, pillar, 1);
+    if (!res.ok) {
+      if (isEmptyState(res)) {
+        return {
+          ok: true,
+          result: { available: false, pillar },
+          text: `No community member has a visible ${pillar} score yet.`,
+        };
+      }
+      return { ok: false, error: res.error };
+    }
+    return { ok: true, result: { ...superlativePayload(res), pillar }, text: speakSuperlative(res) };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_top_in_pillar failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_first_member / get_newest_member
+// ---------------------------------------------------------------------------
+
+async function memberByRegistration(
+  tool: 'get_first_member' | 'get_newest_member',
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate(tool, id);
+  if (gate) return gate;
+  try {
+    const res = await getMemberByRegistration(sb, tool === 'get_first_member' ? 'first' : 'newest', 1);
+    if (!res.ok) {
+      if (isEmptyState(res)) {
+        return {
+          ok: true,
+          result: { available: false },
+          text: 'There are no visible community members yet.',
+        };
+      }
+      return { ok: false, error: res.error };
+    }
+    return { ok: true, result: superlativePayload(res), text: speakSuperlative(res) };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : `${tool} failed` };
+  }
+}
+
+export async function tool_get_first_member(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  return memberByRegistration('get_first_member', id, sb);
+}
+
+export async function tool_get_newest_member(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  return memberByRegistration('get_newest_member', id, sb);
+}
+
+// ---------------------------------------------------------------------------
+// get_most_followed
+// ---------------------------------------------------------------------------
+
+export async function tool_get_most_followed(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_most_followed', id);
+  if (gate) return gate;
+  try {
+    const res = await getMostFollowed(sb, 1);
+    if (!res.ok) {
+      if (isEmptyState(res)) {
+        return {
+          ok: true,
+          result: { available: false },
+          text: 'No one in the community has any followers yet.',
+        };
+      }
+      return { ok: false, error: res.error };
+    }
+    return { ok: true, result: superlativePayload(res), text: speakSuperlative(res) };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_most_followed failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ask_who_is — NL router for free-form "who is...?" superlative questions
+// ---------------------------------------------------------------------------
+
+export async function tool_ask_who_is(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('ask_who_is', id, true);
+  if (gate) return gate;
+  const query = String(args.query ?? args.question ?? '').trim();
+  if (query.length < 2) {
+    return { ok: false, error: 'ask_who_is requires a non-empty query.' };
+  }
+
+  // 1) Route through the superlatives NL router first.
+  let clarifyText: string | null = null;
+  try {
+    const routed = await askWhoIs(sb, { question: query });
+    if (routed.ok === true) {
+      return {
+        ok: true,
+        result: { ...superlativePayload(routed), routed_to: routed.metric },
+        text: speakSuperlative(routed),
+      };
+    }
+    if (routed.ok === 'clarify') clarifyText = routed.question;
+    // ok === false (e.g. empty leaderboard for the routed metric) also falls
+    // through to the general member ranker below.
+  } catch {
+    /* router failure → try the ranker fallback */
+  }
+
+  // 2) Fall back to the same ranking pipeline find_community_member uses.
+  try {
+    const outcome = await findCommunityMember(sb, {
+      viewer_user_id: id.user_id,
+      viewer_tenant_id: id.tenant_id as string,
+      query,
+    });
+    return {
+      ok: true,
+      result: {
+        routed_to: 'find_community_member',
+        vitana_id: outcome.result.vitana_id,
+        display_name: outcome.result.display_name,
+        match_recipe: outcome.result.match_recipe,
+      },
+      text: outcome.result.voice_summary,
+    };
+  } catch (err: unknown) {
+    if (clarifyText) {
+      return { ok: true, result: { routed_to: 'clarify' }, text: clarifyText };
+    }
+    return { ok: false, error: err instanceof Error ? err.message : 'ask_who_is failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const SUPERLATIVES_TOOL_HANDLERS: Record<string, Handler> = {
+  get_highest_vitana_index: tool_get_highest_vitana_index,
+  get_top_in_pillar: tool_get_top_in_pillar,
+  get_first_member: tool_get_first_member,
+  get_newest_member: tool_get_newest_member,
+  get_most_followed: tool_get_most_followed,
+  ask_who_is: tool_ask_who_is,
+};
+
+export const SUPERLATIVES_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'get_highest_vitana_index',
+    description: [
+      'Get the community member with the highest Vitana Index right now.',
+      'Returns their name and score; private profiles are never revealed.',
+      'CALL WHEN the user asks: "who has the highest Vitana Index?",',
+      '"who is the healthiest member?", "wer hat den höchsten Vitana Index?",',
+      '"wer ist am gesündesten?".',
+      'After the tool runs, read the returned text aloud (one sentence).',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_top_in_pillar',
+    description: [
+      'Get the community member with the top score in ONE Vitana Index pillar.',
+      'pillar must be one of: nutrition, hydration, exercise, sleep, mental.',
+      'CALL WHEN the user asks: "who has the best sleep?", "who is the',
+      'fittest?", "wer schläft am besten?", "wer ist am fittesten?",',
+      '"wer trinkt am meisten Wasser?".',
+      'After the tool runs, read the returned text aloud (one sentence).',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        pillar: {
+          type: 'string',
+          description: 'One of: nutrition, hydration, exercise, sleep, mental.',
+        },
+      },
+      required: ['pillar'],
+    },
+  },
+  {
+    name: 'get_first_member',
+    description: [
+      'Get the very first (earliest-registered / OG) community member.',
+      'CALL WHEN the user asks: "who was the first member?", "who is the',
+      'longest-standing / OG member?", "wer war das erste Mitglied?",',
+      '"wer ist am längsten dabei?".',
+      'After the tool runs, read the returned text aloud (one sentence).',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_newest_member',
+    description: [
+      'Get the most recently joined community member.',
+      'CALL WHEN the user asks: "who is the newest member?", "who just',
+      'joined?", "wer ist das neueste Mitglied?", "wer ist gerade beigetreten?".',
+      'After the tool runs, read the returned text aloud (one sentence).',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_most_followed',
+    description: [
+      'Get the community member with the most followers.',
+      'CALL WHEN the user asks: "who has the most followers?", "who is the',
+      'most popular member?", "wer hat die meisten Follower?", "wer ist am',
+      'beliebtesten?".',
+      'After the tool runs, read the returned text aloud (one sentence).',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'ask_who_is',
+    description: [
+      'Answer ANY free-form "who is...?" superlative question about the',
+      'community that the specific superlative tools above do not cover.',
+      'Routes to the matching leaderboard (index, pillar, tenure, followers)',
+      'or falls back to the general community-member ranking.',
+      'CALL WHEN the user asks e.g.: "who is the most inspiring?", "who is',
+      'the best runner?", "wer ist der/die inspirierendste?", "wer ist am',
+      'aktivsten?". Pass the user\'s question verbatim as query.',
+      'After the tool runs, read the returned text aloud, then stop.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'The user\'s "who is...?" question, verbatim.',
+        },
+      },
+      required: ['query'],
+    },
+  },
+];

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-06T14:35:55.748Z",
+  "generated_at": "2026-07-06T14:48:07.618Z",
   "source": "reconciled",
   "total": 169,
   "tools": [
@@ -1958,7 +1958,8 @@
       "added_in_pr": 1926,
       "description": "Recent VTIDs from the ledger; filter by status.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -1975,7 +1976,8 @@
       "added_in_pr": 1926,
       "description": "Lookup a single VTID by id.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -1992,7 +1994,8 @@
       "added_in_pr": 1926,
       "description": "PRs / actions waiting on approval.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -2009,7 +2012,8 @@
       "added_in_pr": 1926,
       "description": "Pending approval count — for 'how many PRs are waiting?'.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -2026,7 +2030,8 @@
       "added_in_pr": 1926,
       "description": "Approve a queued PR / action by id (EXEC-DEPLOY hard gate applies).",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -2043,7 +2048,8 @@
       "added_in_pr": 1926,
       "description": "Reject a queued PR / action with reason.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -2060,7 +2066,8 @@
       "added_in_pr": 1926,
       "description": "Recent ORB voice sessions for Voice Lab.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -2077,7 +2084,8 @@
       "added_in_pr": 1926,
       "description": "Daily routines + last run status.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -2094,7 +2102,8 @@
       "added_in_pr": 1926,
       "description": "Routine detail + last N runs.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -2111,7 +2120,8 @@
       "added_in_pr": 1926,
       "description": "Self-healing runs in flight.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -2128,7 +2138,8 @@
       "added_in_pr": 1926,
       "description": "Autonomy loop metrics (in-flight VTIDs, terminalized, healing runs).",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {
@@ -2145,7 +2156,8 @@
       "added_in_pr": 1926,
       "description": "21-agent registry with heartbeat status.",
       "wired_in": [
-        "livekit"
+        "livekit",
+        "vertex"
       ]
     },
     {

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-05-07T23:43:18.327Z",
+  "generated_at": "2026-07-06T14:35:55.748Z",
   "source": "reconciled",
-  "total": 147,
+  "total": 169,
   "tools": [
     {
       "name": "search_knowledge",
@@ -720,11 +720,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02754",
       "added_in_pr": 1857,
       "description": "Top scorer in the community.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_top_in_pillar",
@@ -733,11 +736,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02754",
       "added_in_pr": 1857,
       "description": "Top scorer in a single pillar.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_first_member",
@@ -746,11 +752,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02754",
       "added_in_pr": 1857,
       "description": "First/OG community member.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_newest_member",
@@ -759,11 +768,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02754",
       "added_in_pr": 1857,
       "description": "Most recent community signup.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_most_followed",
@@ -772,11 +784,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02754",
       "added_in_pr": 1857,
       "description": "Member with the most followers.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "ask_who_is",
@@ -785,11 +800,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02754",
       "added_in_pr": 1857,
       "description": "NL router for free-form 'who is...?' questions.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "list_diary_entries",
@@ -798,11 +816,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02757",
       "added_in_pr": 1858,
       "description": "List the user's diary entries in a date window.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_diary_streak",
@@ -811,11 +832,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02757",
       "added_in_pr": 1858,
       "description": "Current + longest diary streak.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_memory_timeline",
@@ -824,11 +848,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02757",
       "added_in_pr": 1858,
       "description": "Chronological timeline of facts/diary/events.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "recall_memory_about",
@@ -837,11 +864,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02757",
       "added_in_pr": 1858,
       "description": "Topic search across memory items with category filter.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_memory_garden_summary",
@@ -850,11 +880,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02757",
       "added_in_pr": 1858,
       "description": "Counts per memory category — for 'what do you remember about me?'.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "forget_memory",
@@ -863,11 +896,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02757",
       "added_in_pr": 1858,
       "description": "Soft-delete a single memory item by id (after confirm).",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "reschedule_event",
@@ -876,11 +912,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02761",
       "added_in_pr": 1860,
       "description": "Move a calendar event to a new time.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "cancel_event",
@@ -889,11 +928,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02761",
       "added_in_pr": 1860,
       "description": "Soft-cancel a calendar event.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "complete_event",
@@ -902,11 +944,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02761",
       "added_in_pr": 1860,
       "description": "Mark an event completed/skipped/partial.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "find_free_slot",
@@ -915,11 +960,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02761",
       "added_in_pr": 1860,
       "description": "Find next available slot for a duration.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_event_details",
@@ -928,11 +976,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02761",
       "added_in_pr": 1860,
       "description": "Read full details of a single event.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "check_calendar_conflicts",
@@ -941,11 +992,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02761",
       "added_in_pr": 1860,
       "description": "Find events overlapping a proposed window.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "snooze_reminder",
@@ -954,11 +1008,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02763",
       "added_in_pr": 1861,
       "description": "Push a reminder out by N minutes.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "update_reminder",
@@ -967,11 +1024,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02763",
       "added_in_pr": 1861,
       "description": "Edit a reminder's text/time.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "acknowledge_reminder",
@@ -980,11 +1040,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02763",
       "added_in_pr": 1861,
       "description": "Mark a reminder as delivered.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "complete_reminder",
@@ -993,11 +1056,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02763",
       "added_in_pr": 1861,
       "description": "Mark a reminder as DONE.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "list_missed_reminders",
@@ -1006,11 +1072,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02763",
       "added_in_pr": 1861,
       "description": "List reminders that fired but weren't acked.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "list_my_groups",
@@ -1019,11 +1088,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02764",
       "added_in_pr": 1862,
       "description": "List the user's group memberships.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "create_group",
@@ -1032,11 +1104,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02764",
       "added_in_pr": 1862,
       "description": "Create a new community group.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "join_group",
@@ -1045,11 +1120,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02764",
       "added_in_pr": 1862,
       "description": "Join an existing group by id.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "invite_to_group",
@@ -1058,11 +1136,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02764",
       "added_in_pr": 1862,
       "description": "Invite a member to a group.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "accept_invitation",
@@ -1071,11 +1152,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02764",
       "added_in_pr": 1862,
       "description": "Accept a pending group invitation.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "decline_invitation",
@@ -1084,11 +1168,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02764",
       "added_in_pr": 1862,
       "description": "Decline a pending group invitation.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "submit_bug_report",
@@ -1097,11 +1184,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02768",
       "added_in_pr": 1865,
       "description": "Hand off to Devon (bug-report specialist).",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "submit_support_ticket",
@@ -1110,11 +1200,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02768",
       "added_in_pr": 1865,
       "description": "Hand off to Sage (support specialist).",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "submit_marketplace_dispute",
@@ -1123,11 +1216,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02768",
       "added_in_pr": 1865,
       "description": "Hand off to Atlas (marketplace dispute).",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "submit_account_issue",
@@ -1136,11 +1232,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02768",
       "added_in_pr": 1865,
       "description": "Hand off to Mira (account specialist).",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "list_my_tickets",
@@ -1149,11 +1248,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02768",
       "added_in_pr": 1865,
       "description": "List the user's open tickets.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "start_conversation",
@@ -1162,11 +1264,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02771",
       "added_in_pr": 1866,
       "description": "Start a new DM conversation.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "list_conversations",
@@ -1175,11 +1280,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02771",
       "added_in_pr": 1866,
       "description": "List recent conversations.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "mark_conversation_read",
@@ -1188,11 +1296,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02771",
       "added_in_pr": 1866,
       "description": "Mark a conversation read.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "mute_conversation",
@@ -1201,11 +1312,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02771",
       "added_in_pr": 1866,
       "description": "Mute a conversation.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "archive_conversation",
@@ -1214,11 +1328,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02771",
       "added_in_pr": 1866,
       "description": "Archive a conversation.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "set_language",
@@ -1227,11 +1344,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02772",
       "added_in_pr": 1869,
       "description": "Set the UI / voice language.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "set_theme",
@@ -1240,11 +1360,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02772",
       "added_in_pr": 1869,
       "description": "Set the visual theme.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "set_voice_preferences",
@@ -1253,11 +1376,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02772",
       "added_in_pr": 1869,
       "description": "Tune voice tone / pace / persona.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "list_connected_apps",
@@ -1266,11 +1392,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02772",
       "added_in_pr": 1869,
       "description": "List connected integrations.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "disconnect_app",
@@ -1279,11 +1408,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02772",
       "added_in_pr": 1869,
       "description": "Disconnect an integration.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "global_search",
@@ -1292,11 +1424,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02773",
       "added_in_pr": 1871,
       "description": "Unified search across people / posts / products / events.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "browse_news_feed",
@@ -1305,11 +1440,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02773",
       "added_in_pr": 1871,
       "description": "Browse the community news feed.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "rsvp_event",
@@ -1318,11 +1456,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02774",
       "added_in_pr": 1873,
       "description": "RSVP to an event.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "cancel_rsvp",
@@ -1331,11 +1472,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02774",
       "added_in_pr": 1873,
       "description": "Cancel an RSVP.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "list_upcoming_meetups",
@@ -1344,11 +1488,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02774",
       "added_in_pr": 1873,
       "description": "List upcoming meetups near the user.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "join_live_room",
@@ -1357,11 +1504,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02774",
       "added_in_pr": 1873,
       "description": "Join a live room.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "snooze_recommendation",
@@ -1370,11 +1520,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02775",
       "added_in_pr": 1874,
       "description": "Push an Autopilot recommendation later.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "dismiss_recommendation",
@@ -1383,11 +1536,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02775",
       "added_in_pr": 1874,
       "description": "Dismiss an Autopilot recommendation.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "explain_recommendation",
@@ -1396,11 +1552,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02775",
       "added_in_pr": 1874,
       "description": "Get a natural-language reason for a recommendation.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "update_account_visibility",
@@ -1409,11 +1568,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02776",
       "added_in_pr": 1875,
       "description": "Toggle account visibility (public / followers-only / private).",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "update_privacy_field",
@@ -1422,11 +1584,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02776",
       "added_in_pr": 1875,
       "description": "Set per-field visibility (e.g. age, location).",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "block_user",
@@ -1435,11 +1600,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02776",
       "added_in_pr": 1875,
       "description": "Block another community member.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "unblock_user",
@@ -1448,11 +1616,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02776",
       "added_in_pr": 1875,
       "description": "Unblock a previously-blocked member.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "update_intent",
@@ -1461,11 +1632,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02777",
       "added_in_pr": 1877,
       "description": "Edit an existing intent post.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "delete_intent",
@@ -1474,11 +1648,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02777",
       "added_in_pr": 1877,
       "description": "Delete an intent post.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "browse_intent_board",
@@ -1487,11 +1664,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02777",
       "added_in_pr": 1877,
       "description": "Browse the cross-tenant intent board.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "dispute_match",
@@ -1500,11 +1680,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02777",
       "added_in_pr": 1877,
       "description": "Open a dispute on a match.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_emotional_state",
@@ -1513,11 +1696,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02778",
       "added_in_pr": 1879,
       "description": "D28 emotional / cognitive signals.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_situational_awareness",
@@ -1526,11 +1712,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02778",
       "added_in_pr": 1879,
       "description": "D32 situational awareness signals.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_availability",
@@ -1539,11 +1728,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02778",
       "added_in_pr": 1879,
       "description": "D33 availability / readiness signals.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_environmental_context",
@@ -1552,11 +1744,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02778",
       "added_in_pr": 1879,
       "description": "D34 environmental / mobility signals.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_social_context",
@@ -1565,11 +1760,13 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02778",
       "added_in_pr": 1879,
       "description": "D35 social context signals.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "get_life_stage_context",
@@ -1578,11 +1775,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02778",
       "added_in_pr": 1879,
       "description": "D40 life stage signals.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "set_alarm",
@@ -1591,11 +1791,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02779",
       "added_in_pr": 1881,
       "description": "Set a wake-up alarm at HH:MM.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "list_alarms",
@@ -1604,11 +1807,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02779",
       "added_in_pr": 1881,
       "description": "List active alarms.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "delete_alarm",
@@ -1617,11 +1823,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02779",
       "added_in_pr": 1881,
       "description": "Cancel an alarm.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "start_timer",
@@ -1630,11 +1839,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02779",
       "added_in_pr": 1881,
       "description": "Start a countdown timer (60s-24h).",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "start_pomodoro",
@@ -1643,11 +1855,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02779",
       "added_in_pr": 1881,
       "description": "Start a pomodoro work block (5-90min).",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "list_active_timers",
@@ -1656,11 +1871,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02779",
       "added_in_pr": 1881,
       "description": "List active timers and pomodoros.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "get_world_time",
@@ -1669,11 +1887,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02779",
       "added_in_pr": 1881,
       "description": "Current local time in a city or IANA timezone.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "find_perfect_product",
@@ -1687,6 +1908,7 @@
       "added_in_pr": 1883,
       "description": "Flagship deep search — fuses pillar deficits, Life Compass goal, and multi-criteria filters into top-3 product picks with rationale.",
       "wired_in": [
+        "livekit",
         "vertex"
       ]
     },
@@ -1702,6 +1924,7 @@
       "added_in_pr": 1883,
       "description": "Flagship practitioner / coach / doctor search with multi-criteria filtering.",
       "wired_in": [
+        "livekit",
         "vertex"
       ]
     },
@@ -1712,24 +1935,14 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02780",
       "added_in_pr": 1883,
       "description": "Flagship people-match search (workout partner, accountability buddy, mentor).",
-      "wired_in": []
-    },
-    {
-      "name": "ask_who_is",
-      "surface": "Superlatives",
-      "category": "superlatives",
-      "role": [
-        "community"
-      ],
-      "status": "planned",
-      "vtid": "VTID-02780",
-      "added_in_pr": 1883,
-      "description": "Free-form 'who is...' superlative questions about the community.",
-      "wired_in": []
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ]
     },
     {
       "name": "dev_list_vtids",
@@ -1740,11 +1953,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Recent VTIDs from the ledger; filter by status.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_get_vtid_status",
@@ -1755,11 +1970,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Lookup a single VTID by id.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_list_pending_approvals",
@@ -1770,11 +1987,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "PRs / actions waiting on approval.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_count_approvals",
@@ -1785,11 +2004,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Pending approval count — for 'how many PRs are waiting?'.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_approve_pr",
@@ -1800,11 +2021,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Approve a queued PR / action by id (EXEC-DEPLOY hard gate applies).",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_reject_pr",
@@ -1815,11 +2038,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Reject a queued PR / action with reason.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_list_voice_sessions",
@@ -1830,11 +2055,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Recent ORB voice sessions for Voice Lab.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_list_routines",
@@ -1845,11 +2072,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Daily routines + last run status.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_get_routine_detail",
@@ -1860,11 +2089,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Routine detail + last N runs.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_list_active_healing",
@@ -1875,11 +2106,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Self-healing runs in flight.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_get_autonomy_pulse",
@@ -1890,11 +2123,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "Autonomy loop metrics (in-flight VTIDs, terminalized, healing runs).",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "dev_list_agents",
@@ -1905,11 +2140,13 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "vtid": "VTID-02782",
       "added_in_pr": 1926,
       "description": "21-agent registry with heartbeat status.",
-      "wired_in": []
+      "wired_in": [
+        "livekit"
+      ]
     },
     {
       "name": "admin_briefing",
@@ -1920,9 +2157,11 @@
         "exafy_admin",
         "developer"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Top open admin_insights for the tenant.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "admin_kpi_snapshot",
@@ -1933,9 +2172,11 @@
         "exafy_admin",
         "developer"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Current KPI family snapshot for the tenant.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "admin_insight_detail",
@@ -1946,9 +2187,11 @@
         "exafy_admin",
         "developer"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Full body of one admin insight.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "admin_approve",
@@ -1959,9 +2202,11 @@
         "exafy_admin",
         "developer"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Mark an insight approved.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "admin_reject",
@@ -1972,9 +2217,11 @@
         "exafy_admin",
         "developer"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Mark an insight rejected.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "admin_snooze",
@@ -1985,9 +2232,11 @@
         "exafy_admin",
         "developer"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Snooze an insight for N hours/days.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "admin_history",
@@ -1998,9 +2247,11 @@
         "exafy_admin",
         "developer"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "KPI family time-series for the last N days.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "admin_health_check",
@@ -2011,9 +2262,11 @@
         "exafy_admin",
         "developer"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Tenant-health-index probe.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "admin_pause_autopilot",
@@ -2024,9 +2277,11 @@
         "exafy_admin",
         "developer"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Emergency pause request for tenant autopilot.",
-      "wired_in": []
+      "wired_in": [
+        "vertex"
+      ]
     },
     {
       "name": "find_community_member",
@@ -2070,6 +2325,312 @@
       "description": "Navigate to a target screen (alias for navigate_to_screen).",
       "wired_in": [
         "livekit",
+        "vertex"
+      ]
+    },
+    {
+      "name": "follow_member",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "FOLLOW a community member by their spoken name.",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "BOOTSTRAP-VOICE-P0-GAPS"
+    },
+    {
+      "name": "unfollow_member",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "UNFOLLOW a community member by name. Two-step confirm:",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "BOOTSTRAP-VOICE-P0-GAPS"
+    },
+    {
+      "name": "get_notifications",
+      "surface": "Notifications",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "READ the user's recent notifications, unread first. Speakable.",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "BOOTSTRAP-VOICE-P0-GAPS"
+    },
+    {
+      "name": "mark_notifications_read",
+      "surface": "Notifications",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "MARK notifications as read — all unread ones, or only those whose title",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "BOOTSTRAP-VOICE-P0-GAPS"
+    },
+    {
+      "name": "get_wallet_balance",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "READ-ONLY wallet snapshot: balance per currency, active subscription,",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "BOOTSTRAP-VOICE-P0-GAPS"
+    },
+    {
+      "name": "update_profile",
+      "surface": "Profile",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "UPDATE simple own-profile fields: display_name, bio, city, country, location.",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "BOOTSTRAP-VOICE-P0-GAPS"
+    },
+    {
+      "name": "play_podcast",
+      "surface": "Media",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "PLAY an internal Vitana Media Hub podcast by title or topic. Returns an",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "BOOTSTRAP-VOICE-P0-GAPS"
+    },
+    {
+      "name": "like_post",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "LIKE a community feed post — resolves 'the last post from <name>' to that",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "BOOTSTRAP-VOICE-P0-GAPS"
+    },
+    {
+      "name": "comment_on_post",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "COMMENT on a community feed post (public text). Two-step confirm:",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "BOOTSTRAP-VOICE-P0-GAPS"
+    },
+    {
+      "name": "create_community_post",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Compose and publish a post to the user's community feed on their behalf.",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "get_life_compass",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Return the user's active Life Compass — the one-sentence long-term direction they set in Settings.",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "vtid": "VTID-03010"
+    },
+    {
+      "name": "list_followers",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Read who follows the user: count, names, mutual-follow count.",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "list_following",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Read who the user follows: count and names.",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "narrate_guided_session",
+      "surface": "Onboarding",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Speak the authored script of the user's next Guided Journey onboarding session.",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "recent_conversations",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Read the user's most recent direct-message conversations, newest first.",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "teacher_event",
+      "surface": "Onboarding",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Teacher Mode lifecycle: record a capability-awareness event (introduced/tried/completed/dismissed).",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "end_teaching_session",
+      "surface": "Onboarding",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Teacher Mode termination: close the orb overlay gracefully when the user wants to end.",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "view_messages",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Read the user's own internal community message inbox (unread or all recent).",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "find_match",
+      "surface": "Intents",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Find a match by searching the community catalog, then recommend existing matches or post the request.",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "get_autopilot_recommendations",
+      "surface": "Autopilot",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Read out what is prepared in the user's Autopilot — the same list shown in the Autopilot popup.",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "activate_autopilot_recommendations",
+      "surface": "Autopilot",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Activate one or more Autopilot recommendations on the user's behalf.",
+      "wired_in": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "offer_action",
+      "surface": "Internal",
+      "category": "internal",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Internal continuation-binding: records the exact action Vitana just proposed so a later \"yes\" executes it deterministically instead of re-interpreting the bare acceptance.",
+      "wired_in": [
         "vertex"
       ]
     }

--- a/services/gateway/test/orb-tools/awareness-tools.test.ts
+++ b/services/gateway/test/orb-tools/awareness-tools.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Awareness-signal voice tools (VTID-02778) — unit tests.
+ *
+ * The three deterministic dimension engines (D32/D33/D34) are mocked — their
+ * logic is owned and tested by their own modules; here we assert the handlers
+ * feed them real inputs (calendar hints, time context, residence seed) and
+ * turn their bundles into speakable text. Table-backed reads (D28 signals,
+ * diary fallback, D40 assessment/compass/tenure/birthday, calendar_events,
+ * reminders) run against a chainable mocked SupabaseClient.
+ *
+ * Covered per tool: happy path (ok:true + speakable text with the actual
+ * content), unauthenticated gate, and the honest empty-state paths.
+ */
+
+jest.mock('../../src/services/d32-situational-awareness-engine', () => ({
+  computeSituationalAwareness: jest.fn(),
+  toOrbSituationContext: jest.fn(),
+}));
+jest.mock('../../src/services/d33-availability-readiness-engine', () => ({
+  computeAvailabilityReadiness: jest.fn(),
+  getCurrentAvailability: jest.fn(),
+}));
+jest.mock('../../src/services/d34-environmental-mobility-engine', () => ({
+  computeContext: jest.fn(),
+}));
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  computeSituationalAwareness,
+  toOrbSituationContext,
+} from '../../src/services/d32-situational-awareness-engine';
+import {
+  computeAvailabilityReadiness,
+  getCurrentAvailability,
+} from '../../src/services/d33-availability-readiness-engine';
+import { computeContext } from '../../src/services/d34-environmental-mobility-engine';
+import {
+  AWARENESS_TOOL_HANDLERS,
+  AWARENESS_TOOL_DECLARATIONS,
+  tool_get_emotional_state,
+  tool_get_situational_awareness,
+  tool_get_availability,
+  tool_get_environmental_context,
+  tool_get_life_stage_context,
+} from '../../src/services/orb-tools/awareness-tools';
+
+const IDENT = {
+  user_id: 'u-1',
+  tenant_id: 't-1',
+  role: 'community',
+  session_id: 's-1',
+};
+const ANON = { user_id: '', tenant_id: null, role: null };
+
+type TableSpec = unknown[] | { error: string };
+
+/** Chainable SupabaseClient mock: every table resolves its configured rows. */
+function makeSb(tables: Record<string, TableSpec> = {}): SupabaseClient {
+  const from = (table: string) => {
+    const spec = tables[table];
+    const builder: Record<string, unknown> = {};
+    for (const m of ['select', 'eq', 'neq', 'is', 'not', 'in', 'gte', 'lte', 'gt', 'lt', 'order', 'limit']) {
+      builder[m] = jest.fn(() => builder);
+    }
+    const resolve = () =>
+      spec && !Array.isArray(spec)
+        ? Promise.resolve({ data: null, error: { message: spec.error } })
+        : Promise.resolve({ data: spec ?? [], error: null });
+    builder.maybeSingle = jest.fn(async () => {
+      const r = await resolve();
+      return { data: Array.isArray(r.data) ? (r.data[0] ?? null) : r.data, error: r.error };
+    });
+    (builder as { then?: unknown }).then = (onF: (v: unknown) => unknown, onR: (e: unknown) => unknown) =>
+      resolve().then(onF, onR);
+    return builder;
+  };
+  return { from: jest.fn(from) } as unknown as SupabaseClient;
+}
+
+const futureIso = (mins: number) => new Date(Date.now() + mins * 60000).toISOString();
+const pastIso = (mins: number) => new Date(Date.now() - mins * 60000).toISOString();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getCurrentAvailability as jest.Mock).mockResolvedValue({ ok: true, cached: false });
+});
+
+// ---------------------------------------------------------------------------
+// Exports / declarations shape
+// ---------------------------------------------------------------------------
+
+const NAMES = [
+  'get_emotional_state',
+  'get_situational_awareness',
+  'get_availability',
+  'get_environmental_context',
+  'get_life_stage_context',
+];
+
+describe('awareness tools — exports', () => {
+  it.each(NAMES)('%s is in AWARENESS_TOOL_HANDLERS', (name) => {
+    expect(typeof AWARENESS_TOOL_HANDLERS[name]).toBe('function');
+  });
+
+  it.each(NAMES)('%s is declared in AWARENESS_TOOL_DECLARATIONS', (name) => {
+    expect(AWARENESS_TOOL_DECLARATIONS.find((d) => d.name === name)).toBeDefined();
+  });
+
+  it('declarations use only the Vertex-safe OpenAPI subset (no default/minimum/maximum/format/examples)', () => {
+    const raw = JSON.stringify(AWARENESS_TOOL_DECLARATIONS.map((d) => d.parameters));
+    for (const banned of ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"']) {
+      expect(raw).not.toContain(banned);
+    }
+  });
+
+  it.each(NAMES)('%s rejects unauthenticated identities', async (name) => {
+    const res = await AWARENESS_TOOL_HANDLERS[name]({}, ANON as never, makeSb());
+    expect(res).toEqual({ ok: false, error: `${name} requires an authenticated user.` });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_emotional_state (D28)
+// ---------------------------------------------------------------------------
+
+describe('get_emotional_state', () => {
+  it('speaks the latest fresh D28 signal bundle', async () => {
+    const sb = makeSb({
+      emotional_cognitive_signals: [
+        {
+          emotional_states: [
+            { state: 'calm', score: 70, confidence: 80 },
+            { state: 'neutral', score: 40, confidence: 50 },
+          ],
+          cognitive_states: [{ state: 'focused', score: 65, confidence: 75 }],
+          engagement_level: 'high',
+          engagement_confidence: 80,
+          urgency_detected: false,
+          hesitation_detected: true,
+          created_at: pastIso(20),
+          decay_at: futureIso(40),
+        },
+      ],
+    });
+    const res = await tool_get_emotional_state({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('calm');
+    expect(res.text).toContain('focused');
+    expect(res.text).toContain('high engagement');
+    expect(res.text).toContain('hesitation');
+    expect(res.text).toContain('not a clinical assessment');
+    expect((res.result as { source: string }).source).toBe('conversation_signals');
+  });
+
+  it('falls back to recent diary moods when no live signal exists', async () => {
+    const sb = makeSb({
+      emotional_cognitive_signals: [],
+      memory_diary_entries: [
+        { mood: 'optimistic', energy_level: 7, entry_date: '2026-07-05' },
+        { mood: 'tired', energy_level: 5, entry_date: '2026-07-03' },
+      ],
+    });
+    const res = await tool_get_emotional_state({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('optimistic');
+    expect(res.text).toContain('diary');
+    expect(res.text).toContain('6 out of 10');
+    expect((res.result as { source: string }).source).toBe('diary');
+  });
+
+  it('returns an honest ok:true empty state when neither source has data', async () => {
+    const sb = makeSb({ emotional_cognitive_signals: [], memory_diary_entries: [] });
+    const res = await tool_get_emotional_state({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('no data yet');
+    expect((res.result as { source: string }).source).toBe('none');
+  });
+
+  it('returns ok:false when the signals query errors', async () => {
+    const sb = makeSb({ emotional_cognitive_signals: { error: 'boom' } });
+    const res = await tool_get_emotional_state({}, IDENT as never, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_situational_awareness (D32)
+// ---------------------------------------------------------------------------
+
+describe('get_situational_awareness', () => {
+  it('computes the D32 bundle with calendar hints and speaks the situation', async () => {
+    (computeSituationalAwareness as jest.Mock).mockResolvedValue({
+      ok: true,
+      bundle: { bundle_id: 'sa_1' },
+    });
+    (toOrbSituationContext as jest.Mock).mockReturnValue({
+      time_window: 'evening',
+      is_late_night: false,
+      availability: 'medium',
+      energy: 'moderate',
+      active_tags: [],
+      active_constraints: ['time_limited'],
+      suggested_depth: 'light',
+      confidence: 72,
+      disclaimer: 'd',
+    });
+    const sb = makeSb({
+      reminders: [{ user_tz: 'Europe/Berlin' }],
+      calendar_events: [
+        { id: 'e1', title: 'Yoga class', start_time: futureIso(45), end_time: futureIso(105), event_type: 'wellness' },
+      ],
+    });
+
+    const res = await tool_get_situational_awareness({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('evening');
+    expect(res.text).toContain('medium');
+    expect(res.text).toContain('Yoga class');
+    expect(res.text).toContain('time limited');
+    expect(res.text).toContain('72% confidence');
+
+    const input = (computeSituationalAwareness as jest.Mock).mock.calls[0][0];
+    expect(input.user_id).toBe('u-1');
+    expect(input.tenant_id).toBe('t-1');
+    expect(input.timezone).toBe('Europe/Berlin');
+    expect(input.calendar_hints.next_event_in_minutes).toBeGreaterThanOrEqual(44);
+    expect(input.calendar_hints.is_free_now).toBe(true);
+  });
+
+  it('propagates engine failure as ok:false', async () => {
+    (computeSituationalAwareness as jest.Mock).mockResolvedValue({ ok: false, error: 'engine down' });
+    const res = await tool_get_situational_awareness({}, IDENT as never, makeSb());
+    expect(res).toEqual({ ok: false, error: 'engine down' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_availability (D33)
+// ---------------------------------------------------------------------------
+
+const d33Bundle = {
+  availability: { level: 'medium', confidence: 70, factors: [] },
+  time_window: { window: 'short', confidence: 80, estimated_minutes: 8, factors: [] },
+  readiness: { score: 0.62, confidence: 70, factors: [], risk_flags: [] },
+  action_depth: { max_steps: 2, max_questions: 1, max_recommendations: 1, allow_booking: false, allow_payment: false },
+  availability_tag: 'light_flow_ok',
+  computed_at: new Date().toISOString(),
+  was_user_override: false,
+  disclaimer: 'd',
+};
+
+describe('get_availability', () => {
+  it('computes fresh availability with calendar density and reminders due', async () => {
+    (computeAvailabilityReadiness as jest.Mock).mockResolvedValue({ ok: true, bundle: d33Bundle });
+    const sb = makeSb({
+      calendar_events: [
+        { id: 'e1', title: 'Team standup', start_time: futureIso(25), end_time: futureIso(55), event_type: 'meeting' },
+      ],
+      reminders: [{ action_text: 'Drink water', next_fire_at: futureIso(30), user_tz: 'Europe/Berlin' }],
+    });
+
+    const res = await tool_get_availability({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('medium');
+    expect(res.text).toContain('62%');
+    expect(res.text).toContain('Team standup');
+    expect(res.text).toContain('Drink water');
+    expect(res.text).toContain('Based on');
+
+    const input = (computeAvailabilityReadiness as jest.Mock).mock.calls[0][0];
+    expect(input.calendar.has_upcoming_event).toBe(true);
+    expect(input.calendar.is_in_meeting).toBe(false);
+    expect(typeof input.time_context.current_hour).toBe('number');
+  });
+
+  it('prefers the cached in-session D33 bundle when present', async () => {
+    (getCurrentAvailability as jest.Mock).mockResolvedValue({ ok: true, cached: true, bundle: d33Bundle });
+    const sb = makeSb({ calendar_events: [], reminders: [] });
+    const res = await tool_get_availability({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(computeAvailabilityReadiness).not.toHaveBeenCalled();
+    expect(res.text).toContain('this session');
+    expect(res.text).toContain('clear for the next 12 hours');
+  });
+
+  it('detects an in-progress calendar event', async () => {
+    (computeAvailabilityReadiness as jest.Mock).mockResolvedValue({ ok: true, bundle: d33Bundle });
+    const sb = makeSb({
+      calendar_events: [
+        { id: 'e0', title: 'Deep work block', start_time: pastIso(30), end_time: futureIso(30), event_type: 'focus' },
+      ],
+      reminders: [],
+    });
+    const res = await tool_get_availability({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('Deep work block');
+    const input = (computeAvailabilityReadiness as jest.Mock).mock.calls[0][0];
+    expect(input.calendar.is_in_meeting).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_environmental_context (D34)
+// ---------------------------------------------------------------------------
+
+const d34Bundle = (overrides: Record<string, unknown> = {}) => ({
+  bundle_id: 'b-1',
+  bundle_hash: 'h',
+  computed_at: new Date().toISOString(),
+  location_context: {
+    city: 'Cologne',
+    region: null,
+    country: 'Germany',
+    timezone: 'Europe/Berlin',
+    travel_state: 'home',
+    urban_density: 'urban',
+    precision: 'city',
+    confidence: 90,
+    resolved_at: new Date().toISOString(),
+    source: 'explicit',
+  },
+  mobility_profile: {
+    mode_preference: 'walking',
+    distance_tolerance: 'local',
+    access_level: 'unknown',
+    confidence: 50,
+    inferred_from: [],
+  },
+  environmental_constraints: {
+    flags: [],
+    time_of_day_safety: 'safe',
+    weather_suitability: 'unknown',
+    indoor_outdoor_preference: 'either',
+    is_late_night: false,
+    is_early_morning: false,
+    cultural_considerations: [],
+    confidence: 60,
+  },
+  environment_tags: ['walkable'],
+  overall_confidence: 66,
+  data_freshness: 'fresh',
+  sources_used: ['explicit_location'],
+  fallback_applied: false,
+  fallback_reason: null,
+  disclaimer: 'd',
+  ...overrides,
+});
+
+describe('get_environmental_context', () => {
+  it('seeds the D34 engine with the stored residence fact and speaks the location', async () => {
+    (computeContext as jest.Mock).mockResolvedValue({ ok: true, bundle: d34Bundle() });
+    const sb = makeSb({ memory_facts: [{ fact_value: 'Cologne' }] });
+
+    const res = await tool_get_environmental_context({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('Cologne');
+    expect(res.text).toContain('location you shared');
+    expect(res.text).toContain('walking');
+    expect(res.text).toContain('walkable');
+    expect(res.text).toContain('66%');
+
+    const req = (computeContext as jest.Mock).mock.calls[0][0];
+    expect(req.explicit_location).toEqual({ city: 'Cologne' });
+    expect(req.user_id).toBe('u-1');
+  });
+
+  it('says honestly when the bundle is a neutral default', async () => {
+    (computeContext as jest.Mock).mockResolvedValue({
+      ok: true,
+      bundle: d34Bundle({
+        location_context: {
+          city: null,
+          region: null,
+          country: null,
+          timezone: null,
+          travel_state: 'unknown',
+          urban_density: 'unknown',
+          precision: 'unknown',
+          confidence: 10,
+          resolved_at: new Date().toISOString(),
+          source: 'default',
+        },
+        mobility_profile: {
+          mode_preference: 'unknown',
+          distance_tolerance: 'local',
+          access_level: 'unknown',
+          confidence: 20,
+          inferred_from: [],
+        },
+        environment_tags: [],
+        fallback_applied: true,
+        fallback_reason: 'No location or mobility data available',
+      }),
+    });
+    const sb = makeSb({ memory_facts: [] });
+    const res = await tool_get_environmental_context({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain("don't have a location");
+    expect(res.text).toContain('neutral default');
+    const req = (computeContext as jest.Mock).mock.calls[0][0];
+    expect(req.explicit_location).toBeUndefined();
+  });
+
+  it('propagates engine failure as ok:false', async () => {
+    (computeContext as jest.Mock).mockResolvedValue({ ok: false, error: 'INTERNAL_ERROR', message: 'nope' });
+    const res = await tool_get_environmental_context({}, IDENT as never, makeSb({ memory_facts: [] }));
+    expect(res).toEqual({ ok: false, error: 'nope' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_life_stage_context (D40)
+// ---------------------------------------------------------------------------
+
+describe('get_life_stage_context', () => {
+  it('speaks phase, compass goal, age band and tenure from the real tables', async () => {
+    const sb = makeSb({
+      life_stage_assessments: [
+        {
+          phase: 'optimizing',
+          phase_confidence: 74,
+          stability_level: 'high',
+          transition_flag: false,
+          transition_type: null,
+        },
+      ],
+      life_stage_goals: [
+        { category: 'health_longevity', description: 'Sleep 8 hours', priority: 8 },
+      ],
+      life_compass: [{ primary_goal: 'Run a marathon', category: 'longevity' }],
+      app_users: [{ created_at: pastIso(60 * 24 * 240) }], // ~8 months
+      memory_facts: [{ fact_value: '1969-09-09' }],
+    });
+
+    const res = await tool_get_life_stage_context({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('optimizing');
+    expect(res.text).toContain('high stability');
+    expect(res.text).toContain('Run a marathon');
+    expect(res.text).toContain('fifties');
+    expect(res.text).toContain('8 months');
+    expect(res.text).toContain('you know your life best');
+    const r = res.result as Record<string, unknown>;
+    expect(r.phase).toBe('optimizing');
+    expect(r.life_compass_goal).toBe('Run a marathon');
+  });
+
+  it('mentions an active transition when flagged', async () => {
+    const sb = makeSb({
+      life_stage_assessments: [
+        {
+          phase: 'transitioning',
+          phase_confidence: 60,
+          stability_level: 'medium',
+          transition_flag: true,
+          transition_type: 'new_city',
+        },
+      ],
+      life_stage_goals: [],
+      life_compass: [],
+      app_users: [],
+      memory_facts: [],
+    });
+    const res = await tool_get_life_stage_context({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('transition');
+    expect(res.text).toContain('new city');
+  });
+
+  it('returns an honest ok:true empty state and offers Life Compass setup', async () => {
+    const sb = makeSb({
+      life_stage_assessments: [],
+      life_stage_goals: [],
+      life_compass: [],
+      app_users: [],
+      memory_facts: [],
+    });
+    const res = await tool_get_life_stage_context({}, IDENT as never, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('Life Compass');
+    expect((res.result as { available: boolean }).available).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/calendar-management-tools.test.ts
+++ b/services/gateway/test/orb-tools/calendar-management-tools.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Calendar management voice tools (VTID-02761) — unit tests.
+ *
+ * Mocked SupabaseClient (chainable builder, thenable) for reads and a mocked
+ * calendar-service module for the write paths (reschedule/cancel/complete)
+ * and the conflict check — no network, no real DB.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+jest.mock('../../src/services/calendar-service', () => ({
+  rescheduleEvent: jest.fn(),
+  softDeleteEvent: jest.fn(),
+  markEventCompleted: jest.fn(),
+  checkConflicts: jest.fn(),
+}));
+
+import {
+  rescheduleEvent,
+  softDeleteEvent,
+  markEventCompleted,
+  checkConflicts,
+} from '../../src/services/calendar-service';
+import {
+  CALENDAR_MGMT_TOOL_HANDLERS,
+  CALENDAR_MGMT_TOOL_DECLARATIONS,
+  tool_reschedule_event,
+  tool_cancel_event,
+  tool_complete_event,
+  tool_find_free_slot,
+  tool_get_event_details,
+  tool_check_calendar_conflicts,
+} from '../../src/services/orb-tools/calendar-management-tools';
+
+const IDENT = { user_id: 'user-1', tenant_id: 'tenant-1', role: 'community' };
+const NO_USER = { user_id: '', tenant_id: 'tenant-1', role: 'community' } as any;
+
+function event(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ev-1',
+    title: 'Yoga class',
+    description: null,
+    location: 'Studio 3',
+    start_time: '2030-01-07T09:00:00.000Z',
+    end_time: '2030-01-07T10:00:00.000Z',
+    event_type: 'health',
+    status: 'confirmed',
+    completion_status: null,
+    completed_at: null,
+    completion_notes: null,
+    reschedule_count: 0,
+    original_start_time: null,
+    priority_score: 50,
+    wellness_tags: ['exercise'],
+    source_type: 'manual',
+    role_context: 'community',
+    ...overrides,
+  };
+}
+
+/** Chainable, thenable supabase mock resolving every query with `rows`. */
+function fakeSupabase(rows: unknown[], error: { message: string } | null = null) {
+  const builder: any = {};
+  for (const m of ['select', 'eq', 'neq', 'gt', 'lt', 'gte', 'lte', 'ilike', 'order', 'limit', 'is']) {
+    builder[m] = jest.fn(() => builder);
+  }
+  builder.then = (resolve: (v: unknown) => unknown) => resolve({ data: rows, error });
+  const from = jest.fn(() => builder);
+  return { sb: { from } as unknown as SupabaseClient, builder, from };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Registry shape
+// ---------------------------------------------------------------------------
+
+describe('calendar management tools — exports', () => {
+  const NAMES = [
+    'reschedule_event',
+    'cancel_event',
+    'complete_event',
+    'find_free_slot',
+    'get_event_details',
+    'check_calendar_conflicts',
+  ];
+
+  it.each(NAMES)('%s has a handler and a declaration', (name) => {
+    expect(typeof CALENDAR_MGMT_TOOL_HANDLERS[name]).toBe('function');
+    const decl = CALENDAR_MGMT_TOOL_DECLARATIONS.find((d) => d.name === name);
+    expect(decl).toBeDefined();
+    expect(typeof decl!.description).toBe('string');
+  });
+
+  it('declarations avoid Vertex-unsupported schema keys', () => {
+    const banned = ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"'];
+    const json = JSON.stringify(CALENDAR_MGMT_TOOL_DECLARATIONS.map((d) => d.parameters));
+    for (const key of banned) expect(json).not.toContain(key);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reschedule_event
+// ---------------------------------------------------------------------------
+
+describe('tool_reschedule_event', () => {
+  it('moves an event and keeps its duration when new_end is omitted', async () => {
+    const { sb } = fakeSupabase([event()]);
+    (rescheduleEvent as jest.Mock).mockResolvedValue(event({ start_time: '2030-01-08T14:00:00.000Z' }));
+
+    const res = await tool_reschedule_event(
+      { event_id: 'ev-1', new_start: '2030-01-08T14:00:00Z' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Yoga class');
+    expect((res as any).text).toContain('Jan 8');
+    // Original event was 60 min → new_end must preserve that duration.
+    expect(rescheduleEvent).toHaveBeenCalledWith(
+      'ev-1',
+      'user-1',
+      '2030-01-08T14:00:00.000Z',
+      '2030-01-08T15:00:00.000Z',
+    );
+  });
+
+  it('returns a disambiguation list when the title matches several upcoming events', async () => {
+    const { sb } = fakeSupabase([
+      event({ id: 'ev-1', title: 'Yoga class', start_time: '2030-01-07T09:00:00.000Z' }),
+      event({ id: 'ev-2', title: 'Yoga retreat', start_time: '2030-01-09T09:00:00.000Z' }),
+    ]);
+    const res = await tool_reschedule_event(
+      { title_query: 'yoga', new_start: '2030-01-10T09:00:00Z' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Yoga class');
+    expect((res as any).text).toContain('Yoga retreat');
+    expect((res as any).result.needs_disambiguation).toBe(true);
+    expect(rescheduleEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing/invalid new_start', async () => {
+    const { sb } = fakeSupabase([event()]);
+    const res = await tool_reschedule_event({ event_id: 'ev-1', new_start: 'not-a-date' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('new_start');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_reschedule_event({ new_start: '2030-01-08T14:00:00Z' }, NO_USER, sb);
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('authenticated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancel_event
+// ---------------------------------------------------------------------------
+
+describe('tool_cancel_event', () => {
+  it('asks for confirmation before cancelling', async () => {
+    const { sb } = fakeSupabase([event()]);
+    const res = await tool_cancel_event({ title_query: 'yoga' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).result.needs_confirmation).toBe(true);
+    expect((res as any).text).toContain('Yoga class');
+    expect((res as any).text).toContain('confirm');
+    expect(softDeleteEvent).not.toHaveBeenCalled();
+  });
+
+  it('cancels after confirm=true', async () => {
+    const { sb } = fakeSupabase([event()]);
+    (softDeleteEvent as jest.Mock).mockResolvedValue(event({ status: 'cancelled' }));
+    const res = await tool_cancel_event({ event_id: 'ev-1', confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Cancelled');
+    expect((res as any).text).toContain('Yoga class');
+    expect(softDeleteEvent).toHaveBeenCalledWith('ev-1', 'user-1');
+  });
+
+  it('says so when the event is already cancelled', async () => {
+    const { sb } = fakeSupabase([event({ status: 'cancelled' })]);
+    const res = await tool_cancel_event({ event_id: 'ev-1', confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('already cancelled');
+    expect(softDeleteEvent).not.toHaveBeenCalled();
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_cancel_event({ event_id: 'ev-1' }, NO_USER, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// complete_event
+// ---------------------------------------------------------------------------
+
+describe('tool_complete_event', () => {
+  it('marks an event as skipped with notes', async () => {
+    const { sb } = fakeSupabase([event()]);
+    (markEventCompleted as jest.Mock).mockResolvedValue(event({ completion_status: 'skipped' }));
+    const res = await tool_complete_event(
+      { event_id: 'ev-1', outcome: 'skipped', notes: 'felt tired' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Yoga class');
+    expect((res as any).text).toContain('skipped');
+    expect(markEventCompleted).toHaveBeenCalledWith('ev-1', 'user-1', 'skipped', 'felt tired');
+  });
+
+  it('defaults the outcome to completed', async () => {
+    const { sb } = fakeSupabase([event()]);
+    (markEventCompleted as jest.Mock).mockResolvedValue(event({ completion_status: 'completed' }));
+    const res = await tool_complete_event({ event_id: 'ev-1' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect(markEventCompleted).toHaveBeenCalledWith('ev-1', 'user-1', 'completed', null);
+  });
+
+  it('rejects an unknown outcome', async () => {
+    const { sb } = fakeSupabase([event()]);
+    const res = await tool_complete_event({ event_id: 'ev-1', outcome: 'done-ish' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('outcome');
+    expect(markEventCompleted).not.toHaveBeenCalled();
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_complete_event({ event_id: 'ev-1' }, NO_USER, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// find_free_slot
+// ---------------------------------------------------------------------------
+
+describe('tool_find_free_slot', () => {
+  it('finds the first gap between events within waking hours', async () => {
+    // Busy 08:00-09:00 and 09:30-12:00 UTC → first 30-min gap is 09:00-09:30.
+    const { sb } = fakeSupabase([
+      { id: 'a', title: 'A', start_time: '2030-01-07T08:00:00.000Z', end_time: '2030-01-07T09:00:00.000Z', status: 'confirmed' },
+      { id: 'b', title: 'B', start_time: '2030-01-07T09:30:00.000Z', end_time: '2030-01-07T12:00:00.000Z', status: 'confirmed' },
+    ]);
+    const res = await tool_find_free_slot(
+      { duration_minutes: 30, search_from: '2030-01-07T00:00:00Z', timezone: 'UTC' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).result.slot_start).toBe('2030-01-07T09:00:00.000Z');
+    expect((res as any).result.slot_end).toBe('2030-01-07T09:30:00.000Z');
+    expect((res as any).text).toContain('30 minutes');
+  });
+
+  it('starts at 8 AM local time in the requested timezone when the calendar is empty', async () => {
+    const { sb } = fakeSupabase([]);
+    // Berlin is UTC+1 in January → local 08:00 = 07:00Z.
+    const res = await tool_find_free_slot(
+      { duration_minutes: 60, search_from: '2030-01-07T00:00:00Z', timezone: 'Europe/Berlin' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).result.slot_start).toBe('2030-01-07T07:00:00.000Z');
+  });
+
+  it('rejects a missing duration', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_find_free_slot({}, IDENT, sb);
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('duration_minutes');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_find_free_slot({ duration_minutes: 30 }, NO_USER, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_event_details
+// ---------------------------------------------------------------------------
+
+describe('tool_get_event_details', () => {
+  it('speaks the full details of a single match', async () => {
+    const { sb } = fakeSupabase([event({ description: 'Bring your own mat' })]);
+    const res = await tool_get_event_details({ title_query: 'yoga' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Yoga class');
+    expect((res as any).text).toContain('Studio 3');
+    expect((res as any).text).toContain('Bring your own mat');
+    expect((res as any).result.found).toBe(true);
+  });
+
+  it('answers plainly when nothing matches', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_get_event_details({ title_query: 'unicorn parade' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('could not find');
+  });
+
+  it('errors without event_id or title_query', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_get_event_details({}, IDENT, sb);
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('event_id or title_query');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_get_event_details({ event_id: 'ev-1' }, NO_USER, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// check_calendar_conflicts
+// ---------------------------------------------------------------------------
+
+describe('tool_check_calendar_conflicts', () => {
+  it('names the overlapping events', async () => {
+    (checkConflicts as jest.Mock).mockResolvedValue([
+      event({ id: 'ev-9', title: 'Team standup', start_time: '2030-01-07T09:00:00.000Z' }),
+    ]);
+    const { sb } = fakeSupabase([]);
+    const res = await tool_check_calendar_conflicts(
+      { start_time: '2030-01-07T09:00:00Z', end_time: '2030-01-07T10:00:00Z' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).result.has_conflicts).toBe(true);
+    expect((res as any).text).toContain('Team standup');
+    expect(checkConflicts).toHaveBeenCalledWith(
+      'user-1',
+      'community',
+      '2030-01-07T09:00:00.000Z',
+      '2030-01-07T10:00:00.000Z',
+    );
+  });
+
+  it('defaults end_time to one hour after start_time and reports a free window', async () => {
+    (checkConflicts as jest.Mock).mockResolvedValue([]);
+    const { sb } = fakeSupabase([]);
+    const res = await tool_check_calendar_conflicts({ start_time: '2030-01-07T09:00:00Z' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).result.has_conflicts).toBe(false);
+    expect((res as any).text).toContain('free');
+    expect(checkConflicts).toHaveBeenCalledWith(
+      'user-1',
+      'community',
+      '2030-01-07T09:00:00.000Z',
+      '2030-01-07T10:00:00.000Z',
+    );
+  });
+
+  it('rejects a missing start_time', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_check_calendar_conflicts({}, IDENT, sb);
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('start_time');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = fakeSupabase([]);
+    const res = await tool_check_calendar_conflicts({ start_time: '2030-01-07T09:00:00Z' }, NO_USER, sb);
+    expect(res.ok).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/chat-privacy-tools.test.ts
+++ b/services/gateway/test/orb-tools/chat-privacy-tools.test.ts
@@ -1,0 +1,577 @@
+/**
+ * Chat management (VTID-02771) + Privacy (VTID-02776) voice tool tests.
+ *
+ * Mocked SupabaseClient only — no network, no real DB. Covers per tool the
+ * happy path (ok:true + speakable text containing the actual content) and
+ * the unauthenticated case where the tool touches user data. The graceful
+ * "not supported yet" answers (mute/archive — no backing column exists in
+ * the chat schema) are pinned so nobody silently starts pretending a chat
+ * was muted/archived without a real column behind it.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+jest.mock('../../src/services/orb-tools-shared', () => ({
+  tool_send_chat_message: jest.fn(),
+}));
+jest.mock('../../src/services/social-memory/social-read-tools', () => ({
+  runRecentConversations: jest.fn(),
+}));
+
+import { tool_send_chat_message } from '../../src/services/orb-tools-shared';
+import { runRecentConversations } from '../../src/services/social-memory/social-read-tools';
+import {
+  CHAT_PRIVACY_TOOL_HANDLERS,
+  CHAT_PRIVACY_TOOL_DECLARATIONS,
+  tool_start_conversation,
+  tool_list_conversations,
+  tool_mark_conversation_read,
+  tool_mute_conversation,
+  tool_archive_conversation,
+  tool_update_account_visibility,
+  tool_update_privacy_field,
+  tool_block_user,
+  tool_unblock_user,
+} from '../../src/services/orb-tools/chat-privacy-tools';
+
+// ---------------------------------------------------------------------------
+// Mock Supabase client
+// ---------------------------------------------------------------------------
+
+interface QueryResult {
+  data?: unknown;
+  error?: { message: string } | null;
+  count?: number | null;
+}
+
+/** Chainable, awaitable (thenable) query-builder mock. */
+function makeChain(result: QueryResult) {
+  const chain: any = {};
+  for (const m of [
+    'select',
+    'update',
+    'insert',
+    'upsert',
+    'delete',
+    'eq',
+    'is',
+    'or',
+    'in',
+    'order',
+    'limit',
+  ]) {
+    chain[m] = jest.fn(() => chain);
+  }
+  chain.maybeSingle = jest.fn(async () => ({ data: null, error: null, ...result }));
+  chain.single = jest.fn(async () => ({ data: null, error: null, ...result }));
+  chain.then = (resolve: any, reject: any) =>
+    Promise.resolve({ data: null, error: null, count: null, ...result }).then(resolve, reject);
+  return chain;
+}
+
+/**
+ * Table results: single result or a sequence (consumed per .from() call;
+ * the last entry repeats).
+ */
+function makeSb(config: {
+  rpc?: jest.Mock;
+  tables?: Record<string, QueryResult | QueryResult[]>;
+}): SupabaseClient {
+  const counters: Record<string, number> = {};
+  return {
+    rpc: config.rpc ?? jest.fn(async () => ({ data: [], error: null })),
+    from: jest.fn((table: string) => {
+      const conf = config.tables?.[table];
+      if (Array.isArray(conf)) {
+        counters[table] = (counters[table] ?? -1) + 1;
+        return makeChain(conf[Math.min(counters[table], conf.length - 1)]);
+      }
+      return makeChain(conf ?? {});
+    }),
+  } as unknown as SupabaseClient;
+}
+
+const ID = { user_id: 'a27552a3-0257-4305-8ed0-351a80fd3701', tenant_id: 't-1', role: 'community' };
+const ANON = { user_id: '', tenant_id: null, role: null };
+const MARIA_UUID = '11111111-2222-4333-8444-555555555555';
+
+const resolveMariaRpc = () =>
+  jest.fn(async () => ({
+    data: [
+      {
+        user_id: MARIA_UUID,
+        vitana_id: 'maria6',
+        display_name: 'Maria Lopez',
+        score: 1.0,
+        reason: 'vitana_id_exact',
+      },
+    ],
+    error: null,
+  }));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Exports contract
+// ---------------------------------------------------------------------------
+
+describe('module exports', () => {
+  const NAMES = [
+    'start_conversation',
+    'list_conversations',
+    'mark_conversation_read',
+    'mute_conversation',
+    'archive_conversation',
+    'update_account_visibility',
+    'update_privacy_field',
+    'block_user',
+    'unblock_user',
+  ];
+
+  it.each(NAMES)('%s has a handler', (name) => {
+    expect(typeof CHAT_PRIVACY_TOOL_HANDLERS[name]).toBe('function');
+  });
+
+  it.each(NAMES)('%s has a declaration', (name) => {
+    expect(CHAT_PRIVACY_TOOL_DECLARATIONS.find((d) => d.name === name)).toBeDefined();
+  });
+
+  it('declarations use only the Vertex-safe OpenAPI subset', () => {
+    const json = JSON.stringify(CHAT_PRIVACY_TOOL_DECLARATIONS.map((d) => d.parameters));
+    for (const banned of ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"']) {
+      expect(json).not.toContain(banned);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// start_conversation
+// ---------------------------------------------------------------------------
+
+describe('start_conversation', () => {
+  it('rejects unauthenticated users', async () => {
+    const res = await tool_start_conversation({ member: 'Maria' }, ANON, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+
+  it('resolves the member and reports an existing conversation (no message)', async () => {
+    const sb = makeSb({
+      rpc: resolveMariaRpc(),
+      tables: {
+        chat_messages: {
+          data: [{ id: 'm1', content: 'hi', created_at: '2026-07-01T10:00:00Z' }],
+        },
+      },
+    });
+    const res = await tool_start_conversation({ member: 'Maria' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Maria Lopez');
+      expect(res.text).toContain('already have a conversation');
+      expect((res.result as any).recipient_user_id).toBe(MARIA_UUID);
+      expect((res.result as any).existing_conversation).toBe(true);
+    }
+  });
+
+  it('reports a fresh thread when no messages exist yet', async () => {
+    const sb = makeSb({
+      rpc: resolveMariaRpc(),
+      tables: { chat_messages: { data: [] } },
+    });
+    const res = await tool_start_conversation({ member: 'Maria' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('no conversation yet');
+      expect((res.result as any).existing_conversation).toBe(false);
+    }
+  });
+
+  it('delegates to the canonical send path when a message is provided', async () => {
+    (tool_send_chat_message as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: 'Sent to Maria Lopez.',
+    });
+    const sb = makeSb({});
+    const res = await tool_start_conversation(
+      { member: 'Maria', message: 'Hi, how are you?' },
+      ID,
+      sb,
+    );
+    expect(tool_send_chat_message).toHaveBeenCalledWith(
+      expect.objectContaining({ recipient_label: 'Maria', body: 'Hi, how are you?' }),
+      ID,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('Sent to Maria Lopez');
+  });
+
+  it('asks for clarification when the resolver is ambiguous', async () => {
+    const sb = makeSb({
+      rpc: jest.fn(async () => ({
+        data: [
+          { user_id: 'u-a', vitana_id: 'maria1', display_name: 'Maria A', score: 0.7, reason: 'fuzzy_name' },
+          { user_id: 'u-b', vitana_id: 'maria2', display_name: 'Maria B', score: 0.68, reason: 'fuzzy_name' },
+        ],
+        error: null,
+      })),
+    });
+    const res = await tool_start_conversation({ member: 'Maria' }, ID, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('Which one');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_conversations
+// ---------------------------------------------------------------------------
+
+describe('list_conversations', () => {
+  it('rejects unauthenticated users', async () => {
+    const res = await tool_list_conversations({}, ANON, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+
+  it('delegates to runRecentConversations with the identity tenant', async () => {
+    (runRecentConversations as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: 'The user\'s most recent conversations, newest first: Maria Lopez (2h ago, they wrote last — "see you!").',
+      result: { count: 1, contacts: [] },
+    });
+    const res = await tool_list_conversations({ limit: 5 }, ID, makeSb({}));
+    expect(runRecentConversations).toHaveBeenCalledWith(
+      { limit: 5 },
+      { user_id: ID.user_id, tenant_id: 't-1' },
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('Maria Lopez');
+  });
+
+  it('backfills tenant from app_users when identity has none', async () => {
+    (runRecentConversations as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: 'no conversations',
+      result: { count: 0, contacts: [] },
+    });
+    const sb = makeSb({ tables: { app_users: { data: { tenant_id: 't-9' } } } });
+    const res = await tool_list_conversations({}, { ...ID, tenant_id: null }, sb);
+    expect(runRecentConversations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ tenant_id: 't-9' }),
+    );
+    expect(res.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mark_conversation_read
+// ---------------------------------------------------------------------------
+
+describe('mark_conversation_read', () => {
+  it('rejects unauthenticated users', async () => {
+    const res = await tool_mark_conversation_read({}, ANON, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+
+  it('marks a named conversation read and reports the count', async () => {
+    const sb = makeSb({
+      rpc: resolveMariaRpc(),
+      tables: { chat_messages: { count: 3, error: null } },
+    });
+    const res = await tool_mark_conversation_read({ member: 'Maria' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('3 message(s)');
+      expect(res.text).toContain('Maria Lopez');
+      expect((res.result as any).updated).toBe(3);
+    }
+  });
+
+  it('says so when nothing was unread', async () => {
+    const sb = makeSb({
+      rpc: resolveMariaRpc(),
+      tables: { chat_messages: { count: 0, error: null } },
+    });
+    const res = await tool_mark_conversation_read({ member: 'Maria' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('Nothing was unread from Maria Lopez');
+  });
+
+  it('marks everything read when no member is given', async () => {
+    const sb = makeSb({ tables: { chat_messages: { count: 7, error: null } } });
+    const res = await tool_mark_conversation_read({}, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('7 unread message(s)');
+      expect((res.result as any).scope).toBe('all');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mute_conversation / archive_conversation — honest "not supported"
+// ---------------------------------------------------------------------------
+
+describe('mute_conversation', () => {
+  it('returns an honest not-supported answer (no mute column exists)', async () => {
+    const res = await tool_mute_conversation({ member: 'Maria' }, ID, makeSb({}));
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain("isn't supported");
+      expect(res.text).toContain('block_user');
+      expect((res.result as any).supported).toBe(false);
+    }
+  });
+});
+
+describe('archive_conversation', () => {
+  it('returns an honest not-supported answer (no archived state exists)', async () => {
+    const res = await tool_archive_conversation({}, ID, makeSb({}));
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain("isn't supported");
+      expect((res.result as any).supported).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_account_visibility
+// ---------------------------------------------------------------------------
+
+describe('update_account_visibility', () => {
+  it('rejects unauthenticated users', async () => {
+    const res = await tool_update_account_visibility({ visibility: 'private' }, ANON, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+
+  it('asks for confirmation before writing', async () => {
+    const sb = makeSb({});
+    const res = await tool_update_account_visibility({ visibility: 'private' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as any).requires_confirmation).toBe(true);
+      expect(res.text).toContain('confirm=true');
+    }
+    expect((sb.from as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('writes every toggleable field on confirm and maps followers_only → connections', async () => {
+    let writtenMap: Record<string, string> | null = null;
+    const readChain = makeChain({ data: { account_visibility: {} } });
+    const writeChain = makeChain({ error: null });
+    (writeChain.update as jest.Mock).mockImplementation((payload: any) => {
+      writtenMap = payload.account_visibility;
+      return writeChain;
+    });
+    const chains = [readChain, writeChain];
+    const sb = {
+      rpc: jest.fn(),
+      from: jest.fn(() => chains.shift() ?? makeChain({})),
+    } as unknown as SupabaseClient;
+
+    const res = await tool_update_account_visibility(
+      { visibility: 'followers_only', confirm: true },
+      ID,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('connections');
+    expect(writtenMap).not.toBeNull();
+    expect(writtenMap!.dateOfBirth).toBe('connections');
+    expect(writtenMap!.city).toBe('connections');
+    // Hardcoded safety key must never be written.
+    expect(writtenMap!['myPosts.partnerSeek']).toBeUndefined();
+  });
+
+  it('rejects an unknown visibility value', async () => {
+    const res = await tool_update_account_visibility({ visibility: 'invisible' }, ID, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('public');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_privacy_field
+// ---------------------------------------------------------------------------
+
+describe('update_privacy_field', () => {
+  it('rejects unauthenticated users', async () => {
+    const res = await tool_update_privacy_field(
+      { field: 'age', visibility: 'private' },
+      ANON,
+      makeSb({}),
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+
+  it('maps a spoken field (age) to the real key and writes the tier', async () => {
+    let writtenMap: Record<string, string> | null = null;
+    const readChain = makeChain({ data: { account_visibility: { city: 'public' } } });
+    const writeChain = makeChain({ error: null });
+    (writeChain.update as jest.Mock).mockImplementation((payload: any) => {
+      writtenMap = payload.account_visibility;
+      return writeChain;
+    });
+    const chains = [readChain, writeChain];
+    const sb = {
+      rpc: jest.fn(),
+      from: jest.fn(() => chains.shift() ?? makeChain({})),
+    } as unknown as SupabaseClient;
+
+    const res = await tool_update_privacy_field({ field: 'age', visibility: 'private' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('age');
+    expect(writtenMap).not.toBeNull();
+    expect(writtenMap!.derivedAgeBand).toBe('private');
+    // Untouched keys are preserved.
+    expect(writtenMap!.city).toBe('public');
+  });
+
+  it('handles health honestly — always private, no setting', async () => {
+    const sb = makeSb({});
+    const res = await tool_update_privacy_field(
+      { field: 'health', visibility: 'private' },
+      ID,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('always private');
+    expect((sb.from as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown fields with the list of real ones', async () => {
+    const res = await tool_update_privacy_field(
+      { field: 'shoe_size', visibility: 'private' },
+      ID,
+      makeSb({}),
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('location');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// block_user
+// ---------------------------------------------------------------------------
+
+describe('block_user', () => {
+  it('rejects unauthenticated users', async () => {
+    const res = await tool_block_user({ member: 'Maria' }, ANON, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+
+  it('asks for confirmation with the resolved name first', async () => {
+    const sb = makeSb({ rpc: resolveMariaRpc() });
+    const res = await tool_block_user({ member: 'Maria' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as any).requires_confirmation).toBe(true);
+      expect((res.result as any).member_user_id).toBe(MARIA_UUID);
+      expect(res.text).toContain('Maria Lopez');
+    }
+  });
+
+  it('upserts into user_blocked_authors on confirm', async () => {
+    const upsertChain = makeChain({ error: null });
+    const sb = {
+      rpc: resolveMariaRpc(),
+      from: jest.fn((table: string) =>
+        table === 'user_blocked_authors' ? upsertChain : makeChain({}),
+      ),
+    } as unknown as SupabaseClient;
+
+    const res = await tool_block_user({ member: 'Maria', confirm: true }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('Maria Lopez is blocked');
+    expect(upsertChain.upsert).toHaveBeenCalledWith(
+      { user_id: ID.user_id, author_id: MARIA_UUID },
+      { onConflict: 'user_id,author_id' },
+    );
+  });
+
+  it('refuses to block yourself', async () => {
+    const sb = makeSb({
+      rpc: jest.fn(async () => ({
+        data: [
+          { user_id: ID.user_id, vitana_id: 'me', display_name: 'Me', score: 1.0, reason: 'vitana_id_exact' },
+        ],
+        error: null,
+      })),
+    });
+    const res = await tool_block_user({ member: 'me', confirm: true }, ID, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('yourself');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unblock_user
+// ---------------------------------------------------------------------------
+
+describe('unblock_user', () => {
+  it('rejects unauthenticated users', async () => {
+    const res = await tool_unblock_user({ member: 'Maria' }, ANON, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+
+  it('unblocks a member matched against the own blocked list', async () => {
+    const selectChain = makeChain({ data: [{ author_id: MARIA_UUID }] });
+    const deleteChain = makeChain({ error: null });
+    const blockedChains = [selectChain, deleteChain];
+    const sb = {
+      rpc: jest.fn(),
+      from: jest.fn((table: string) => {
+        if (table === 'user_blocked_authors') return blockedChains.shift() ?? makeChain({});
+        if (table === 'app_users') {
+          return makeChain({
+            data: [{ user_id: MARIA_UUID, display_name: 'Maria Lopez', vitana_id: 'maria6' }],
+          });
+        }
+        return makeChain({});
+      }),
+    } as unknown as SupabaseClient;
+
+    const res = await tool_unblock_user({ member: 'Maria' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Maria Lopez is unblocked');
+      expect((res.result as any).unblocked).toBe(true);
+    }
+    expect(deleteChain.delete).toHaveBeenCalled();
+  });
+
+  it('says so when nobody is blocked', async () => {
+    const sb = makeSb({ tables: { user_blocked_authors: { data: [] } } });
+    const res = await tool_unblock_user({ member: 'Maria' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain("haven't blocked anyone");
+  });
+
+  it('lists the blocked members when the name does not match', async () => {
+    const sb = makeSb({
+      tables: {
+        user_blocked_authors: { data: [{ author_id: 'u-x' }] },
+        app_users: {
+          data: [{ user_id: 'u-x', display_name: 'Peter Pan', vitana_id: 'peter1' }],
+        },
+      },
+    });
+    const res = await tool_unblock_user({ member: 'Maria' }, ID, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain("isn't on your blocked list");
+      expect(res.text).toContain('Peter Pan');
+      expect((res.result as any).unblocked).toBe(false);
+    }
+  });
+});

--- a/services/gateway/test/orb-tools/developer-tools.test.ts
+++ b/services/gateway/test/orb-tools/developer-tools.test.ts
@@ -1,0 +1,527 @@
+/**
+ * Developer voice tools (VTID-02782) — unit tests.
+ *
+ * Mocked SupabaseClient (chainable stub, no network) + mocked global fetch
+ * for the approvals-route self-calls. Covers per tool: happy path with
+ * speakable text containing the actual content, plus the server-side role
+ * gate (community role denied with developer_role_required, unauthenticated
+ * denied).
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  DEVELOPER_TOOL_HANDLERS,
+  DEVELOPER_TOOL_DECLARATIONS,
+  developerGate,
+  normalizeVtidCandidates,
+  approvalIdForVtid,
+  deriveAgentStatus,
+  dev_list_vtids,
+  dev_get_vtid_status,
+  dev_list_pending_approvals,
+  dev_count_approvals,
+  dev_approve_pr,
+  dev_reject_pr,
+  dev_list_voice_sessions,
+  dev_list_routines,
+  dev_get_routine_detail,
+  dev_list_active_healing,
+  dev_get_autonomy_pulse,
+  dev_list_agents,
+} from '../../src/services/orb-tools/developer-tools';
+
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer' };
+const ADMIN_ID: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'exafy_admin' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+// ---------------------------------------------------------------------------
+// Chainable Supabase stub. Per-table queue: each .from(table) call consumes
+// the next queued response (last one repeats).
+// ---------------------------------------------------------------------------
+
+interface StubResp {
+  data: unknown;
+  error: { message: string } | null;
+}
+
+function makeSb(tables: Record<string, StubResp[]> = {}): SupabaseClient {
+  const used: Record<string, number> = {};
+  const sb = {
+    from(table: string) {
+      const queue = tables[table] ?? [];
+      const i = used[table] ?? 0;
+      used[table] = i + 1;
+      const resp: StubResp = queue[Math.min(i, queue.length - 1)] ?? { data: [], error: null };
+      const chain: Record<string, unknown> = {};
+      for (const m of ['select', 'eq', 'in', 'gte', 'lte', 'order', 'limit', 'filter', 'or', 'ilike']) {
+        chain[m] = () => chain;
+      }
+      chain.maybeSingle = () =>
+        Promise.resolve({
+          data: Array.isArray(resp.data) ? ((resp.data as unknown[])[0] ?? null) : resp.data,
+          error: resp.error,
+        });
+      chain.then = (onOk: (v: StubResp) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(resp).then(onOk, onErr);
+      return chain;
+    },
+  };
+  return sb as unknown as SupabaseClient;
+}
+
+const ok = (data: unknown): StubResp => ({ data, error: null });
+
+// ---------------------------------------------------------------------------
+// fetch mock for the approvals self-calls
+// ---------------------------------------------------------------------------
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+// ---------------------------------------------------------------------------
+// Role gate — every tool must deny non-developer roles server-side
+// ---------------------------------------------------------------------------
+
+describe('developer role gate', () => {
+  const names = Object.keys(DEVELOPER_TOOL_HANDLERS);
+
+  it('exposes all 12 tools', () => {
+    expect(names).toHaveLength(12);
+  });
+
+  it.each(names)('%s denies community role with developer_role_required', async (name) => {
+    const r = await DEVELOPER_TOOL_HANDLERS[name]({ vtid: '1', name: 'x', reason: 'r' }, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('developer_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await DEVELOPER_TOOL_HANDLERS[name]({ vtid: '1', name: 'x', reason: 'r' }, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('authenticated');
+  });
+
+  it('allows developer, admin and exafy_admin', () => {
+    expect(developerGate(DEV_ID)).toBeNull();
+    expect(developerGate(ADMIN_ID)).toBeNull();
+    expect(developerGate({ ...DEV_ID, role: 'admin' })).toBeNull();
+    expect(developerGate({ ...DEV_ID, role: 'patient' })).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VTID helpers
+// ---------------------------------------------------------------------------
+
+describe('normalizeVtidCandidates', () => {
+  it('accepts loose spoken forms', () => {
+    expect(normalizeVtidCandidates('VTID-01234')).toContain('VTID-01234');
+    expect(normalizeVtidCandidates('vtid 1234')).toContain('VTID-01234');
+    expect(normalizeVtidCandidates('1234')).toContain('VTID-1234');
+    expect(normalizeVtidCandidates('1234')).toContain('VTID-01234');
+    expect(normalizeVtidCandidates('0542')).toContain('VTID-0542');
+    expect(normalizeVtidCandidates('nope')).toEqual([]);
+  });
+});
+
+describe('approvalIdForVtid', () => {
+  it('matches the routes/approvals.ts deterministic format', () => {
+    expect(approvalIdForVtid('VTID-01234')).toMatch(/^appr_VTID-01234_[0-9a-f]{6}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dev_list_vtids / dev_get_vtid_status
+// ---------------------------------------------------------------------------
+
+describe('dev_list_vtids', () => {
+  it('speaks id + title + status for recent ledger rows', async () => {
+    const sb = makeSb({
+      vtid_ledger: [ok([
+        { vtid: 'VTID-02782', title: 'Developer voice tools', status: 'in_progress', spec_status: 'approved', is_terminal: false, created_at: '2026-07-06T08:00:00Z', updated_at: null },
+        { vtid: 'VTID-02781', title: null, description: 'Health tools', status: 'completed', spec_status: 'approved', is_terminal: true, created_at: '2026-07-05T08:00:00Z', updated_at: null },
+      ])],
+    });
+    const r = await dev_list_vtids({ limit: 5 }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('VTID-02782');
+    expect(text).toContain('Developer voice tools');
+    expect(text).toContain('in_progress');
+    expect(text).toContain('Health tools');
+  });
+
+  it('speaks a plain empty state', async () => {
+    const r = await dev_list_vtids({ status: 'blocked' }, DEV_ID, makeSb({ vtid_ledger: [ok([])] }));
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('blocked');
+  });
+});
+
+describe('dev_get_vtid_status', () => {
+  it('normalizes loose ids and speaks the full status', async () => {
+    const sb = makeSb({
+      vtid_ledger: [ok([{
+        vtid: 'VTID-01200', title: 'Worker-Runner Execution Plane', status: 'completed',
+        spec_status: 'approved', is_terminal: true, terminal_outcome: 'success',
+        claimed_by: 'worker-1', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-02T00:00:00Z',
+      }])],
+    });
+    const r = await dev_get_vtid_status({ vtid: 'vtid 1200' }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('VTID-01200');
+    expect(text).toContain('Worker-Runner Execution Plane');
+    expect(text).toContain('completed');
+    expect(text).toContain('success');
+  });
+
+  it('answers plainly when the VTID is unknown', async () => {
+    const r = await dev_get_vtid_status({ vtid: '99999' }, DEV_ID, makeSb({ vtid_ledger: [ok([])] }));
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('could not find');
+  });
+
+  it('rejects input without digits', async () => {
+    const r = await dev_get_vtid_status({ vtid: 'the latest one' }, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approvals queue (read)
+// ---------------------------------------------------------------------------
+
+describe('dev_list_pending_approvals', () => {
+  it('speaks vtid, title, PR and checks per queue item', async () => {
+    mockFetch(200, {
+      ok: true,
+      items: [{
+        approval_id: 'appr_VTID-02700_abc123', vtid: 'VTID-02700', title: 'Fix voice quota guard',
+        pr_number: 2311, head_branch: 'claude/fix-quota', checks_status: 'pass', governance_status: 'pending',
+      }],
+    });
+    const r = await dev_list_pending_approvals({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('VTID-02700');
+    expect(text).toContain('Fix voice quota guard');
+    expect(text).toContain('PR #2311');
+    expect(text).toContain('checks pass');
+  });
+
+  it('speaks an empty queue plainly', async () => {
+    mockFetch(200, { ok: true, items: [] });
+    const r = await dev_list_pending_approvals({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('empty');
+  });
+
+  it('fails loudly when the approvals API errors', async () => {
+    mockFetch(500, { ok: false, error: 'boom' });
+    const r = await dev_list_pending_approvals({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_count_approvals', () => {
+  it('speaks the pending count', async () => {
+    mockFetch(200, { ok: true, pending_count: 3 });
+    const r = await dev_count_approvals({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('3 items');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approve / reject (confirm-gated mutations)
+// ---------------------------------------------------------------------------
+
+describe('dev_approve_pr', () => {
+  it('asks for confirmation before mutating', async () => {
+    const fetchFn = mockFetch(200, { ok: true });
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-02700' }])] });
+    const r = await dev_approve_pr({ vtid: '2700' }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+    expect((r as { text: string }).text.toLowerCase()).toContain('confirm');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('calls the Command Hub approve route after confirm', async () => {
+    const fetchFn = mockFetch(200, { ok: true, result: { merged: true } });
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-02700' }])] });
+    const r = await dev_approve_pr({ vtid: 'VTID-02700', confirm: true }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('merged');
+    const url = String(fetchFn.mock.calls[0][0]);
+    expect(url).toContain(`/api/v1/approvals/${approvalIdForVtid('VTID-02700')}/approve`);
+  });
+
+  it('reports a failed merge without throwing', async () => {
+    mockFetch(400, { ok: false, error: 'Cannot approve: CI is fail' });
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-02700' }])] });
+    const r = await dev_approve_pr({ vtid: '2700', confirm: true }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('did not go through');
+    expect((r as { text: string }).text).toContain('CI is fail');
+  });
+
+  it('errors when the VTID is not in the ledger', async () => {
+    const r = await dev_approve_pr({ vtid: '2700' }, DEV_ID, makeSb({ vtid_ledger: [ok([])] }));
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_reject_pr', () => {
+  it('requires a reason', async () => {
+    const r = await dev_reject_pr({ vtid: '2700', confirm: true }, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('reason');
+  });
+
+  it('asks for confirmation before mutating', async () => {
+    const fetchFn = mockFetch(200, { ok: true });
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-02700' }])] });
+    const r = await dev_reject_pr({ vtid: '2700', reason: 'wrong approach' }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('wrong approach');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('posts the rejection with reason after confirm', async () => {
+    const fetchFn = mockFetch(200, { ok: true });
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-02700' }])] });
+    const r = await dev_reject_pr({ vtid: '2700', reason: 'stale spec', confirm: true }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('rejected');
+    const url = String(fetchFn.mock.calls[0][0]);
+    expect(url).toContain(`/api/v1/approvals/${approvalIdForVtid('VTID-02700')}/reject`);
+    expect(String(fetchFn.mock.calls[0][1].body)).toContain('stale spec');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dev_list_voice_sessions
+// ---------------------------------------------------------------------------
+
+describe('dev_list_voice_sessions', () => {
+  const starts = ok([
+    { created_at: '2026-07-06T09:00:00Z', vitana_id: null, metadata: { session_id: 's-active', email: 'live@vitana.dev', active_role: 'community', lang: 'de' } },
+    { created_at: '2026-07-06T08:00:00Z', vitana_id: null, metadata: { session_id: 's-done', email: 'dev@vitana.dev', active_role: 'developer', lang: 'de' } },
+  ]);
+  const ends = ok([
+    { created_at: '2026-07-06T08:10:00Z', vitana_id: null, metadata: { session_id: 's-done', duration_ms: 600000, turn_count: 12 } },
+  ]);
+
+  it('speaks user, status and turns per session', async () => {
+    const sb = makeSb({ oasis_events: [starts, ends] });
+    const r = await dev_list_voice_sessions({}, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('live@vitana.dev');
+    expect(text).toContain('active');
+    expect(text).toContain('dev@vitana.dev');
+    expect(text).toContain('ended');
+    expect(text).toContain('12 turns');
+  });
+
+  it('filters to active sessions', async () => {
+    const sb = makeSb({ oasis_events: [starts, ends] });
+    const r = await dev_list_voice_sessions({ status: 'active' }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('live@vitana.dev');
+    expect(text).not.toContain('dev@vitana.dev');
+  });
+
+  it('speaks an empty state plainly', async () => {
+    const sb = makeSb({ oasis_events: [ok([]), ok([])] });
+    const r = await dev_list_voice_sessions({ status: 'active' }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('No ORB voice sessions');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routines
+// ---------------------------------------------------------------------------
+
+describe('dev_list_routines', () => {
+  it('speaks failing routines first with counts', async () => {
+    const sb = makeSb({
+      routines: [ok([
+        { name: 'a-ok', display_name: 'Morning Report', cron_schedule: '0 6 * * *', enabled: true, last_run_at: '2026-07-06T06:00:00Z', last_run_status: 'success', last_run_summary: null, consecutive_failures: 0 },
+        { name: 'z-bad', display_name: 'Nightly Audit', cron_schedule: '0 2 * * *', enabled: true, last_run_at: '2026-07-06T02:00:00Z', last_run_status: 'failure', last_run_summary: null, consecutive_failures: 3 },
+      ])],
+    });
+    const r = await dev_list_routines({}, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('2 routines');
+    expect(text).toContain('1 failing');
+    expect(text.indexOf('Nightly Audit')).toBeLessThan(text.indexOf('Morning Report'));
+    expect(text).toContain('3 consecutive failures');
+  });
+});
+
+describe('dev_get_routine_detail', () => {
+  it('speaks the routine plus its recent runs', async () => {
+    const sb = makeSb({
+      routines: [ok([{ name: 'morning-report', display_name: 'Morning Report', cron_schedule: '0 6 * * *', enabled: true, last_run_at: '2026-07-06T06:00:00Z', last_run_status: 'success', last_run_summary: 'All green', consecutive_failures: 0 }])],
+      routine_runs: [ok([
+        { id: 'r1', started_at: '2026-07-06T06:00:00Z', finished_at: '2026-07-06T06:04:00Z', status: 'success', trigger: 'cron', summary: 'All green', error: null, duration_ms: 240000 },
+        { id: 'r2', started_at: '2026-07-05T06:00:00Z', finished_at: '2026-07-05T06:05:00Z', status: 'failure', trigger: 'cron', summary: null, error: 'timeout on gateway', duration_ms: 300000 },
+      ])],
+    });
+    const r = await dev_get_routine_detail({ name: 'morning-report' }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('Morning Report');
+    expect(text).toContain('0 6 * * *');
+    expect(text).toContain('All green');
+    expect(text).toContain('timeout on gateway');
+  });
+
+  it('falls back to fuzzy match and reports unknown routines plainly', async () => {
+    const sb = makeSb({ routines: [ok([]), ok([])] });
+    const r = await dev_get_routine_detail({ name: 'does not exist' }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('could not find');
+  });
+
+  it('requires a name', async () => {
+    const r = await dev_get_routine_detail({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Self-healing + autonomy pulse
+// ---------------------------------------------------------------------------
+
+describe('dev_list_active_healing', () => {
+  it('speaks in-flight healing VTIDs and pending diagnoses', async () => {
+    const sb = makeSb({
+      vtid_ledger: [ok([{ vtid: 'VTID-02900', title: 'Heal /api/v1/diary', status: 'in_progress', spec_status: 'approved', created_at: '2026-07-06T07:00:00Z' }])],
+      self_healing_log: [ok([{ id: 'h1', vtid: 'VTID-02901', endpoint: '/api/v1/events', failure_class: '5xx', created_at: '2026-07-06T07:30:00Z' }])],
+    });
+    const r = await dev_list_active_healing({}, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('1 healing task');
+    expect(text).toContain('VTID-02900');
+    expect(text).toContain('Heal /api/v1/diary');
+    expect(text).toContain('1 pending diagnosis');
+    expect(text).toContain('/api/v1/events');
+  });
+
+  it('speaks a quiet state plainly', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([])], self_healing_log: [ok([])] });
+    const r = await dev_list_active_healing({}, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('quiet');
+  });
+});
+
+describe('dev_get_autonomy_pulse', () => {
+  it('composes counts across the four pulse sources plus terminalized VTIDs', async () => {
+    const sb = makeSb({
+      autopilot_recommendations: [ok([{ id: 'f1', title: 'Slow query on feed', summary: 's', risk_class: 'high', impact_score: 9, effort_score: 2, auto_exec_eligible: true, domain: 'gateway', first_seen_at: '2026-07-06T05:00:00Z', seen_count: 2, spec_snapshot: null }])],
+      self_healing_log: [ok([{ id: 'h1', vtid: 'VTID-02901', endpoint: '/api/v1/events', failure_class: 'timeout', created_at: '2026-07-06T07:30:00Z', diagnosis: { confidence: 0.9, summary: 'pool exhausted' }, attempt_number: 1 }])],
+      dev_autopilot_executions: [ok([{ id: 'e1e2e3e4-0000', finding_id: 'f1', status: 'ci', pr_url: null, pr_number: null, branch: 'claude/fix', execute_after: null, auto_fix_depth: 0, self_healing_vtid: null, created_at: '2026-07-06T06:00:00Z', updated_at: null }])],
+      test_contracts: [ok([])],
+      vtid_ledger: [ok([{ vtid: 'VTID-02890', title: 'Done thing', terminal_outcome: 'success', updated_at: '2026-07-06T04:00:00Z' }])],
+    });
+    const r = await dev_get_autonomy_pulse({}, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('1 pending findings');
+    expect(text).toContain('1 pending heals');
+    expect(text).toContain('1 executions in flight');
+    expect(text).toContain('0 failing contracts');
+    expect(text).toContain('1 VTIDs terminalized in the last 24 hours (1 succeeded)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agents registry
+// ---------------------------------------------------------------------------
+
+describe('deriveAgentStatus', () => {
+  it('decays stale service heartbeats like routes/agents-registry.ts', () => {
+    const now = new Date().toISOString();
+    const old = new Date(Date.now() - 10 * 60_000).toISOString();
+    expect(deriveAgentStatus({ agent_id: 'a', display_name: null, tier: 'service', status: 'healthy', last_heartbeat_at: now, llm_provider: null })).toBe('healthy');
+    expect(deriveAgentStatus({ agent_id: 'a', display_name: null, tier: 'service', status: 'healthy', last_heartbeat_at: old, llm_provider: null })).toBe('down');
+    expect(deriveAgentStatus({ agent_id: 'a', display_name: null, tier: 'embedded', status: 'healthy', last_heartbeat_at: old, llm_provider: null })).toBe('healthy');
+  });
+});
+
+describe('dev_list_agents', () => {
+  it('speaks health counts with problem agents first', async () => {
+    const fresh = new Date().toISOString();
+    const stale = new Date(Date.now() - 20 * 60_000).toISOString();
+    const sb = makeSb({
+      agents_registry: [ok([
+        { agent_id: 'gateway-conductor', display_name: 'Conductor', tier: 'embedded', status: 'healthy', last_heartbeat_at: fresh, llm_provider: 'gemini' },
+        { agent_id: 'worker-runner', display_name: 'Worker Runner', tier: 'service', status: 'healthy', last_heartbeat_at: stale, llm_provider: 'claude' },
+      ])],
+    });
+    const r = await dev_list_agents({}, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    const text = (r as { text: string }).text;
+    expect(text).toContain('2 agents');
+    expect(text).toContain('1 healthy');
+    expect(text).toContain('1 down');
+    expect(text.indexOf('Worker Runner')).toBeLessThan(text.indexOf('Conductor'));
+  });
+
+  it('speaks an empty registry plainly', async () => {
+    const r = await dev_list_agents({}, DEV_ID, makeSb({ agents_registry: [ok([])] }));
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('empty');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Declarations — Vertex/Gemini Live safety
+// ---------------------------------------------------------------------------
+
+describe('DEVELOPER_TOOL_DECLARATIONS', () => {
+  it('declares every handler and nothing else', () => {
+    const declared = DEVELOPER_TOOL_DECLARATIONS.map((d) => d.name).sort();
+    expect(declared).toEqual(Object.keys(DEVELOPER_TOOL_HANDLERS).sort());
+  });
+
+  it('uses only the OpenAPI-3.0 subset Vertex accepts (no default/minimum/maximum/format/examples)', () => {
+    for (const decl of DEVELOPER_TOOL_DECLARATIONS) {
+      const json = JSON.stringify(decl.parameters);
+      for (const banned of ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"']) {
+        expect(json).not.toContain(banned);
+      }
+    }
+  });
+
+  it('reject declares reason as required; confirm flow documented on both mutations', () => {
+    const reject = DEVELOPER_TOOL_DECLARATIONS.find((d) => d.name === 'dev_reject_pr') as { parameters: { required: string[] }; description: string };
+    expect(reject.parameters.required).toContain('reason');
+    const approve = DEVELOPER_TOOL_DECLARATIONS.find((d) => d.name === 'dev_approve_pr') as { description: string };
+    expect(approve.description).toContain('confirm=true');
+    expect(reject.description).toContain('confirm=true');
+  });
+});

--- a/services/gateway/test/orb-tools/diary-memory-tools.test.ts
+++ b/services/gateway/test/orb-tools/diary-memory-tools.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Diary + Memory voice tools (VTID-02757) — unit tests.
+ *
+ * Mocked SupabaseClient (no network). Per tool: happy path with speakable
+ * text containing the actual content, plus the unauthenticated gate and the
+ * key edge states (empty diary, broken streak, confirm-gated delete).
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  tool_list_diary_entries,
+  tool_get_diary_streak,
+  tool_get_memory_timeline,
+  tool_recall_memory_about,
+  tool_get_memory_garden_summary,
+  tool_forget_memory,
+  DIARY_MEMORY_TOOL_HANDLERS,
+  DIARY_MEMORY_TOOL_DECLARATIONS,
+} from '../../src/services/orb-tools/diary-memory-tools';
+
+const IDENT: OrbToolIdentity = { user_id: 'u-1', tenant_id: 't-1', role: 'community' };
+const NO_USER: OrbToolIdentity = { user_id: '', tenant_id: 't-1', role: null };
+const NO_TENANT: OrbToolIdentity = { user_id: 'u-1', tenant_id: null, role: null };
+
+// ---------------------------------------------------------------------------
+// Chainable fake SupabaseClient
+// ---------------------------------------------------------------------------
+
+interface TableResult {
+  data?: unknown;
+  error?: { message: string } | null;
+}
+
+interface CallRecord {
+  table: string;
+  op: 'select' | 'insert' | 'delete';
+  filters: Array<Record<string, unknown>>;
+  inserted?: unknown;
+}
+
+type TableConfig = TableResult | ((call: CallRecord) => TableResult);
+
+function fakeSb(config: Record<string, TableConfig>) {
+  const calls: CallRecord[] = [];
+  const client = {
+    from(table: string) {
+      const call: CallRecord = { table, op: 'select', filters: [] };
+      calls.push(call);
+      const resolveVal = () => {
+        const cfg = config[table];
+        const res = typeof cfg === 'function' ? cfg(call) : cfg ?? { data: [], error: null };
+        return { data: res.data ?? null, error: res.error ?? null };
+      };
+      const builder: Record<string, unknown> = {};
+      const chain = () => builder;
+      builder.select = chain;
+      builder.order = chain;
+      builder.limit = chain;
+      builder.gte = chain;
+      builder.lte = chain;
+      builder.is = chain;
+      builder.ilike = chain;
+      builder.eq = (k: string, v: unknown) => {
+        call.filters.push({ [k]: v });
+        return builder;
+      };
+      builder.in = (k: string, v: unknown) => {
+        call.filters.push({ [`in:${k}`]: v });
+        return builder;
+      };
+      builder.insert = (row: unknown) => {
+        call.op = 'insert';
+        call.inserted = row;
+        return builder;
+      };
+      builder.delete = () => {
+        call.op = 'delete';
+        return builder;
+      };
+      builder.maybeSingle = () => Promise.resolve(resolveVal());
+      builder.then = (
+        onFulfilled: (v: unknown) => unknown,
+        onRejected?: (e: unknown) => unknown,
+      ) => Promise.resolve(resolveVal()).then(onFulfilled, onRejected);
+      return builder;
+    },
+  };
+  return { sb: client as unknown as SupabaseClient, calls };
+}
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 86_400_000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Module shape
+// ---------------------------------------------------------------------------
+
+describe('diary-memory-tools module shape', () => {
+  const NAMES = [
+    'list_diary_entries',
+    'get_diary_streak',
+    'get_memory_timeline',
+    'recall_memory_about',
+    'get_memory_garden_summary',
+    'forget_memory',
+  ];
+
+  it.each(NAMES)('%s has a handler and a declaration', (name) => {
+    expect(typeof DIARY_MEMORY_TOOL_HANDLERS[name]).toBe('function');
+    expect(DIARY_MEMORY_TOOL_DECLARATIONS.find((d) => d.name === name)).toBeDefined();
+  });
+
+  it('declarations avoid Vertex-rejected OpenAPI keys (default/minimum/maximum/format)', () => {
+    const json = JSON.stringify(DIARY_MEMORY_TOOL_DECLARATIONS.map((d) => d.parameters));
+    for (const banned of ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"']) {
+      expect(json).not.toContain(banned);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_diary_entries
+// ---------------------------------------------------------------------------
+
+describe('tool_list_diary_entries', () => {
+  it('lists entries newest first with speakable content', async () => {
+    const { sb } = fakeSb({
+      diary_entries: {
+        data: [
+          { id: 'd-2', text: 'Ran 5km in the park and felt great', source: 'voice', tags: ['diary'], created_at: isoDaysAgo(0) },
+          { id: 'd-1', text: 'Drank 2 liters of water today', source: 'voice', tags: ['diary'], created_at: isoDaysAgo(1) },
+        ],
+      },
+    });
+    const res = await tool_list_diary_entries({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('2 diary entries');
+    expect(res.text).toContain('Ran 5km in the park');
+    expect(res.text).toContain('Drank 2 liters of water');
+    expect((res.result as { count: number }).count).toBe(2);
+  });
+
+  it('empty diary answers plainly and offers to log', async () => {
+    const { sb } = fakeSb({ diary_entries: { data: [] } });
+    const res = await tool_list_diary_entries(
+      { date_from: '2026-06-01', date_to: '2026-06-30' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('no diary entries');
+    expect(res.text).toContain('2026-06-01');
+  });
+
+  it('rejects malformed dates', async () => {
+    const { sb } = fakeSb({ diary_entries: { data: [] } });
+    const res = await tool_list_diary_entries({ date_from: 'last week' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = fakeSb({ diary_entries: { data: [] } });
+    const res = await tool_list_diary_entries({}, NO_USER, sb);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toContain('authenticated');
+  });
+
+  it('surfaces DB errors as ok:false without throwing', async () => {
+    const { sb } = fakeSb({ diary_entries: { error: { message: 'db down' } } });
+    const res = await tool_list_diary_entries({}, IDENT, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_diary_streak
+// ---------------------------------------------------------------------------
+
+describe('tool_get_diary_streak', () => {
+  it('computes current streak (today+yesterday) and longest run across a gap', async () => {
+    const { sb } = fakeSb({
+      diary_entries: {
+        data: [
+          { created_at: isoDaysAgo(0) },
+          { created_at: isoDaysAgo(0) }, // duplicate same day — counts once
+          { created_at: isoDaysAgo(1) },
+          // gap of 2+ days breaks the streak
+          { created_at: isoDaysAgo(10) },
+          { created_at: isoDaysAgo(11) },
+          { created_at: isoDaysAgo(12) },
+        ],
+      },
+    });
+    const res = await tool_get_diary_streak({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const r = res.result as { current_streak_days: number; longest_streak_days: number };
+    expect(r.current_streak_days).toBe(2);
+    expect(r.longest_streak_days).toBe(3);
+    expect(res.text).toContain('2 consecutive days');
+    expect(res.text).toContain('3 days');
+  });
+
+  it('broken streak reports the last entry day honestly', async () => {
+    const { sb } = fakeSb({
+      diary_entries: { data: [{ created_at: isoDaysAgo(5) }, { created_at: isoDaysAgo(6) }] },
+    });
+    const res = await tool_get_diary_streak({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect((res.result as { current_streak_days: number }).current_streak_days).toBe(0);
+    expect(res.text).toContain('broken');
+  });
+
+  it('no entries yet — zero streak with encouragement, not an error', async () => {
+    const { sb } = fakeSb({ diary_entries: { data: [] } });
+    const res = await tool_get_diary_streak({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('no diary entries');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = fakeSb({ diary_entries: { data: [] } });
+    const res = await tool_get_diary_streak({}, NO_USER, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_memory_timeline
+// ---------------------------------------------------------------------------
+
+describe('tool_get_memory_timeline', () => {
+  it('merges memory items, facts, and diary entries newest first', async () => {
+    const { sb } = fakeSb({
+      memory_items: {
+        data: [
+          { id: 'm-1', category_key: 'health', source: 'orb_voice', content: 'Started a new sleep routine', occurred_at: isoDaysAgo(3) },
+        ],
+      },
+      memory_facts: {
+        data: [
+          { id: 'f-1', fact_key: 'fiancee_name', fact_value: 'Mariia', extracted_at: isoDaysAgo(2) },
+        ],
+      },
+      diary_entries: {
+        data: [{ id: 'd-1', text: 'Morning yoga for 30 minutes', created_at: isoDaysAgo(1) }],
+      },
+    });
+    const res = await tool_get_memory_timeline({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const text = res.text as string;
+    expect(text).toContain('Morning yoga for 30 minutes');
+    expect(text).toContain('fiancee name: Mariia');
+    expect(text).toContain('Started a new sleep routine');
+    // Newest first: diary (1d) before fact (2d) before item (3d).
+    expect(text.indexOf('Morning yoga')).toBeLessThan(text.indexOf('Mariia'));
+    expect(text.indexOf('Mariia')).toBeLessThan(text.indexOf('sleep routine'));
+    expect((res.result as { count: number }).count).toBe(3);
+  });
+
+  it('empty window answers plainly', async () => {
+    const { sb } = fakeSb({
+      memory_items: { data: [] },
+      memory_facts: { data: [] },
+      diary_entries: { data: [] },
+    });
+    const res = await tool_get_memory_timeline(
+      { date_from: '2026-01-01', date_to: '2026-01-31' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('No memories');
+  });
+
+  it('requires user AND tenant (memory_items is tenant-scoped)', async () => {
+    const { sb } = fakeSb({});
+    expect((await tool_get_memory_timeline({}, NO_USER, sb)).ok).toBe(false);
+    expect((await tool_get_memory_timeline({}, NO_TENANT, sb)).ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recall_memory_about
+// ---------------------------------------------------------------------------
+
+describe('tool_recall_memory_about', () => {
+  it('returns facts and memories about the topic, speakable', async () => {
+    const { sb } = fakeSb({
+      memory_items: {
+        data: [
+          { id: 'm-1', category_key: 'network_relationships', content: 'My sister Anna lives in Berlin', occurred_at: isoDaysAgo(4) },
+        ],
+      },
+      memory_facts: {
+        data: [{ id: 'f-1', fact_key: 'sister_name', fact_value: 'Anna', extracted_at: isoDaysAgo(4) }],
+      },
+    });
+    const res = await tool_recall_memory_about({ topic: 'sister' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('sister name = Anna');
+    expect(res.text).toContain('My sister Anna lives in Berlin');
+    expect(res.text).toContain('only this content');
+  });
+
+  it('deduplicates facts matched by both key and value', async () => {
+    const fact = { id: 'f-1', fact_key: 'sister_name', fact_value: 'my sister Anna', extracted_at: isoDaysAgo(1) };
+    const { sb } = fakeSb({
+      memory_items: { data: [] },
+      memory_facts: { data: [fact] }, // same row returned for both ilike queries
+    });
+    const res = await tool_recall_memory_about({ topic: 'sister' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect((res.result as { facts: unknown[] }).facts).toHaveLength(1);
+  });
+
+  it('expands a garden category to its source categories for the filter', async () => {
+    const { sb, calls } = fakeSb({
+      memory_items: { data: [] },
+      memory_facts: { data: [] },
+      memory_category_mapping: {
+        data: [
+          { source_category: 'health', garden_category: 'health_wellness' },
+          { source_category: 'tasks', garden_category: 'business_projects' },
+        ],
+      },
+    });
+    const res = await tool_recall_memory_about(
+      { topic: 'sleep', category: 'health_wellness' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    const itemCall = calls.find((c) => c.table === 'memory_items');
+    const inFilter = itemCall?.filters.find((f) => 'in:category_key' in f);
+    expect(inFilter?.['in:category_key']).toEqual(
+      expect.arrayContaining(['health_wellness', 'health']),
+    );
+    expect(inFilter?.['in:category_key']).not.toEqual(expect.arrayContaining(['tasks']));
+  });
+
+  it('empty result is honest and forbids invention', async () => {
+    const { sb } = fakeSb({ memory_items: { data: [] }, memory_facts: { data: [] } });
+    const res = await tool_recall_memory_about({ topic: 'skydiving' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('No stored memories');
+    expect(res.text).toContain('do not invent');
+  });
+
+  it('requires a topic and an authenticated user+tenant', async () => {
+    const { sb } = fakeSb({});
+    expect((await tool_recall_memory_about({}, IDENT, sb)).ok).toBe(false);
+    expect((await tool_recall_memory_about({ topic: 'x' }, NO_USER, sb)).ok).toBe(false);
+    expect((await tool_recall_memory_about({ topic: 'x' }, NO_TENANT, sb)).ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_memory_garden_summary
+// ---------------------------------------------------------------------------
+
+describe('tool_get_memory_garden_summary', () => {
+  it('maps source categories to garden categories with labels and counts', async () => {
+    const { sb } = fakeSb({
+      memory_garden_config: {
+        data: [
+          { category_key: 'health_wellness', label: 'Health & Wellness', display_order: 2 },
+          { category_key: 'business_projects', label: 'Business & Projects', display_order: 6 },
+        ],
+      },
+      memory_category_mapping: {
+        data: [
+          { source_category: 'health', garden_category: 'health_wellness' },
+          { source_category: 'tasks', garden_category: 'business_projects' },
+        ],
+      },
+      memory_items: {
+        data: [
+          { category_key: 'health' },
+          { category_key: 'health' },
+          { category_key: 'tasks' },
+        ],
+      },
+    });
+    const res = await tool_get_memory_garden_summary({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('3 memories');
+    expect(res.text).toContain('Health & Wellness: 2');
+    expect(res.text).toContain('Business & Projects: 1');
+    const result = res.result as { total: number; categories: Array<{ count: number }> };
+    expect(result.total).toBe(3);
+    expect(result.categories[0].count).toBe(2); // sorted biggest first
+  });
+
+  it('empty garden explains how memories grow', async () => {
+    const { sb } = fakeSb({
+      memory_garden_config: { data: [] },
+      memory_category_mapping: { data: [] },
+      memory_items: { data: [] },
+    });
+    const res = await tool_get_memory_garden_summary({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('empty');
+  });
+
+  it('requires user AND tenant', async () => {
+    const { sb } = fakeSb({});
+    expect((await tool_get_memory_garden_summary({}, NO_USER, sb)).ok).toBe(false);
+    expect((await tool_get_memory_garden_summary({}, NO_TENANT, sb)).ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forget_memory
+// ---------------------------------------------------------------------------
+
+describe('tool_forget_memory', () => {
+  const ITEM = {
+    id: 'm-9',
+    category_key: 'notes',
+    content: 'I hate mornings',
+    occurred_at: isoDaysAgo(2),
+  };
+
+  it('without confirm: describes the memory and asks for confirmation (no delete)', async () => {
+    const { sb, calls } = fakeSb({
+      memory_items: (call) => (call.op === 'select' ? { data: ITEM } : { error: { message: 'should not delete' } }),
+    });
+    const res = await tool_forget_memory({ memory_id: 'm-9' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('I hate mornings');
+    expect(res.text).toContain('confirm=true');
+    expect((res.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+    expect(calls.some((c) => c.op === 'delete')).toBe(false);
+  });
+
+  it('with confirm=true: deletes the row and writes the memory_deletions ledger', async () => {
+    const { sb, calls } = fakeSb({
+      memory_items: (call) => (call.op === 'select' ? { data: ITEM } : { data: null, error: null }),
+      memory_deletions: { data: null, error: null },
+    });
+    const res = await tool_forget_memory({ memory_id: 'm-9', confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.text).toContain('forgotten');
+    expect(res.text).toContain('I hate mornings');
+    const del = calls.find((c) => c.table === 'memory_items' && c.op === 'delete');
+    expect(del).toBeDefined();
+    // Delete is scoped by id + tenant + user (service role bypasses RLS).
+    expect(del?.filters).toEqual(
+      expect.arrayContaining([{ id: 'm-9' }, { tenant_id: 't-1' }, { user_id: 'u-1' }]),
+    );
+    const ledger = calls.find((c) => c.table === 'memory_deletions' && c.op === 'insert');
+    expect(ledger).toBeDefined();
+    expect((ledger?.inserted as { entity_type: string }).entity_type).toBe('memory_item');
+  });
+
+  it('unknown memory_id returns ok:false, not a fake success', async () => {
+    const { sb } = fakeSb({ memory_items: { data: null } });
+    const res = await tool_forget_memory({ memory_id: 'nope', confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toContain('not found');
+  });
+
+  it('requires memory_id and an authenticated user+tenant', async () => {
+    const { sb } = fakeSb({});
+    expect((await tool_forget_memory({}, IDENT, sb)).ok).toBe(false);
+    expect((await tool_forget_memory({ memory_id: 'm-1' }, NO_USER, sb)).ok).toBe(false);
+    expect((await tool_forget_memory({ memory_id: 'm-1' }, NO_TENANT, sb)).ok).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/discovery-tools.test.ts
+++ b/services/gateway/test/orb-tools/discovery-tools.test.ts
@@ -1,0 +1,767 @@
+/**
+ * Discovery voice tools (VTID-02773 / 02775 / 02777 / 02780) — unit tests.
+ *
+ * The handlers adapt existing backings (social-memory repository, the
+ * autopilot_recommendations snooze/reject RPCs, user_intents board/PATCH/close
+ * semantics, intent-dispute-service, intent-find-match) into speakable
+ * OrbToolResults — so those service modules are mocked here and the direct
+ * table reads go through a chainable fake SupabaseClient.
+ *
+ * Covered per tool: happy path (ok:true + speakable text containing the real
+ * content), the unauthenticated gate, and the confirm-flow stages for the
+ * destructive tools.
+ */
+
+jest.mock('../../src/services/social-memory/social-memory-repository', () => ({
+  fetchExclusions: jest.fn(),
+  fetchFollowEdges: jest.fn(),
+  fetchCandidatePosts: jest.fn(),
+  fetchPeople: jest.fn(),
+}));
+jest.mock('../../src/services/intent-find-match', () => ({
+  runFindMatch: jest.fn(),
+}));
+jest.mock('../../src/services/intent-dispute-service', () => ({
+  raiseDispute: jest.fn(),
+}));
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  fetchExclusions,
+  fetchFollowEdges,
+  fetchCandidatePosts,
+  fetchPeople,
+} from '../../src/services/social-memory/social-memory-repository';
+import { runFindMatch } from '../../src/services/intent-find-match';
+import { raiseDispute } from '../../src/services/intent-dispute-service';
+import {
+  DISCOVERY_TOOL_HANDLERS,
+  DISCOVERY_TOOL_DECLARATIONS,
+  tool_global_search,
+  tool_browse_news_feed,
+  tool_snooze_recommendation,
+  tool_dismiss_recommendation,
+  tool_explain_recommendation,
+  tool_update_intent,
+  tool_delete_intent,
+  tool_browse_intent_board,
+  tool_dispute_match,
+  tool_find_perfect_match,
+} from '../../src/services/orb-tools/discovery-tools';
+
+const IDENT = { user_id: 'u-1', tenant_id: 't-1', role: 'community', vitana_id: '@dragan' };
+const ANON = { user_id: '', tenant_id: null, role: null };
+
+const UUID = '11111111-2222-3333-4444-555555555555';
+
+// ---------------------------------------------------------------------------
+// Chainable Supabase fake: per-table FIFO queues of {data, error} results.
+// ---------------------------------------------------------------------------
+
+type QResult = { data: unknown; error: { message: string } | null };
+
+interface SbLogEntry {
+  table: string;
+  method: string;
+  args: unknown[];
+}
+
+function makeSb(queues: Record<string, QResult[]>, rpcResults: Record<string, QResult> = {}) {
+  const log: SbLogEntry[] = [];
+  const from = jest.fn((table: string) => {
+    const q = queues[table];
+    const result: QResult = q && q.length > 0 ? q.shift()! : { data: [], error: null };
+    const builder: Record<string, unknown> = {};
+    for (const m of [
+      'select', 'eq', 'neq', 'in', 'is', 'or', 'ilike', 'gte', 'lte',
+      'order', 'limit', 'contains', 'update', 'insert',
+    ]) {
+      builder[m] = jest.fn((...args: unknown[]) => {
+        log.push({ table, method: m, args });
+        return builder;
+      });
+    }
+    builder.maybeSingle = jest.fn(async () => result);
+    builder.single = jest.fn(async () => result);
+    (builder as { then: unknown }).then = (
+      resolve: (v: QResult) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => Promise.resolve(result).then(resolve, reject);
+    return builder;
+  });
+  const rpc = jest.fn(async (name: string) => rpcResults[name] ?? { data: { ok: true }, error: null });
+  return { sb: { from, rpc } as unknown as SupabaseClient, from, rpc, log };
+}
+
+const noExclusions = { blocked: new Set<string>(), muted: new Set<string>(), hidden_posts: new Set<string>() };
+
+const person = (id: string, name: string) => ({
+  user_id: id,
+  display_name: name,
+  handle: null,
+  vitana_id: null,
+  avatar_url: null,
+  bio: null,
+  city: null,
+  country: null,
+  visibility: 'public',
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (fetchExclusions as jest.Mock).mockResolvedValue(noExclusions);
+  (fetchPeople as jest.Mock).mockResolvedValue(new Map());
+});
+
+// ---------------------------------------------------------------------------
+// Exports / declarations wall
+// ---------------------------------------------------------------------------
+
+describe('discovery tools — exports', () => {
+  const NAMES = [
+    'global_search',
+    'browse_news_feed',
+    'snooze_recommendation',
+    'dismiss_recommendation',
+    'explain_recommendation',
+    'update_intent',
+    'delete_intent',
+    'browse_intent_board',
+    'dispute_match',
+    'find_perfect_match',
+  ];
+
+  it.each(NAMES)('%s is in DISCOVERY_TOOL_HANDLERS', (name) => {
+    expect(typeof DISCOVERY_TOOL_HANDLERS[name]).toBe('function');
+  });
+
+  it.each(NAMES)('%s is declared in DISCOVERY_TOOL_DECLARATIONS', (name) => {
+    expect(DISCOVERY_TOOL_DECLARATIONS.find((d) => d.name === name)).toBeDefined();
+  });
+
+  it('declarations use only the Vertex-safe OpenAPI subset (no default/minimum/maximum/format/examples)', () => {
+    const raw = JSON.stringify(DISCOVERY_TOOL_DECLARATIONS.map((d) => d.parameters));
+    for (const banned of ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"']) {
+      expect(raw).not.toContain(banned);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// global_search
+// ---------------------------------------------------------------------------
+
+describe('global_search', () => {
+  it('returns grouped speakable results across categories', async () => {
+    (fetchPeople as jest.Mock).mockResolvedValue(new Map([['p-2', person('p-2', 'Kemal')]]));
+    const { sb } = makeSb({
+      profiles: [{ data: [{ user_id: 'p-9', display_name: 'Mariia Maksina', handle: 'mariia', vitana_id: '@mariia', city: 'Berlin' }], error: null }],
+      profile_posts: [{ data: [{ id: 'post-1', user_id: 'p-2', content: 'Yoga in the park was amazing today', created_at: new Date().toISOString() }], error: null }],
+      global_community_events: [{ data: [{ id: 'e-1', title: 'Sunrise Yoga', start_time: '2026-08-01T08:00:00Z', location: 'Berlin' }], error: null }],
+      community_groups: [{ data: [{ id: 'g-1', name: 'Yoga Lovers', topic_key: 'yoga', description: 'Weekly yoga sessions' }], error: null }],
+      products_catalog: [{ data: [{ id: 'pr-1', name: 'Yoga Mat Pro', product_type: 'device' }], error: null }],
+      services_catalog: [{ data: [{ id: 's-1', name: 'Yoga Coaching', service_type: 'coach', provider_name: 'Anna' }], error: null }],
+    });
+    const res = await tool_global_search({ query: 'yoga' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Mariia Maksina');
+      expect(res.text).toContain('Kemal');
+      expect(res.text).toContain('Sunrise Yoga');
+      expect(res.text).toContain('Yoga Lovers');
+      expect(res.text).toContain('Yoga Mat Pro');
+      expect(res.text).toContain('Yoga Coaching');
+      const r = res.result as { people: unknown[]; events: unknown[] };
+      expect(r.people).toHaveLength(1);
+      expect(r.events).toHaveLength(1);
+    }
+  });
+
+  it('excludes blocked authors and the viewer from people results', async () => {
+    (fetchExclusions as jest.Mock).mockResolvedValue({
+      blocked: new Set(['p-blocked']),
+      muted: new Set(),
+      hidden_posts: new Set(),
+    });
+    const { sb } = makeSb({
+      profiles: [{
+        data: [
+          { user_id: 'p-blocked', display_name: 'Blocked Person', handle: null, vitana_id: null, city: null },
+          { user_id: 'u-1', display_name: 'Me Myself', handle: null, vitana_id: null, city: null },
+          { user_id: 'p-3', display_name: 'Visible Friend', handle: null, vitana_id: null, city: null },
+        ],
+        error: null,
+      }],
+    });
+    const res = await tool_global_search({ query: 'person' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Visible Friend');
+      expect(res.text).not.toContain('Blocked Person');
+      expect(res.text).not.toContain('Me Myself');
+    }
+  });
+
+  it('answers plainly when nothing matches', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_global_search({ query: 'zzz-nothing' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('Nothing in the community matched');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_global_search({ query: 'yoga' }, ANON, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+
+  it('rejects too-short queries', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_global_search({ query: 'a' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browse_news_feed
+// ---------------------------------------------------------------------------
+
+describe('browse_news_feed', () => {
+  const post = (id: string, userId: string, content: string, agoMs: number, likes = 0) => ({
+    id,
+    user_id: userId,
+    content,
+    image_url: null,
+    video_url: null,
+    likes_count: likes,
+    comments_count: 0,
+    created_at: new Date(Date.now() - agoMs).toISOString(),
+  });
+
+  it('speaks the top posts with author names, newest first', async () => {
+    (fetchFollowEdges as jest.Mock).mockResolvedValue({
+      following: [{ person: person('p-2', 'Kemal'), since: '2026-06-01' }],
+      followers: [],
+    });
+    (fetchCandidatePosts as jest.Mock).mockResolvedValue([
+      post('post-old', 'p-3', 'An older post about hiking', 86400000, 2),
+      post('post-new', 'p-2', 'Just finished a 5k run, feeling great!', 3600000, 7),
+    ]);
+    (fetchPeople as jest.Mock).mockResolvedValue(
+      new Map([
+        ['p-2', person('p-2', 'Kemal')],
+        ['p-3', person('p-3', 'Mariia Maksina')],
+      ]),
+    );
+    const { sb } = makeSb({});
+    const res = await tool_browse_news_feed({ limit: 5 }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Kemal');
+      expect(res.text).toContain('5k run');
+      expect(res.text).toContain('Mariia Maksina');
+      // Newest first: the run post is more recent than the hiking post.
+      expect(res.text!.indexOf('5k run')).toBeLessThan(res.text!.indexOf('hiking'));
+    }
+  });
+
+  it('scope=following filters to followed authors only', async () => {
+    (fetchFollowEdges as jest.Mock).mockResolvedValue({
+      following: [{ person: person('p-2', 'Kemal'), since: '2026-06-01' }],
+      followers: [],
+    });
+    (fetchCandidatePosts as jest.Mock).mockResolvedValue([
+      post('post-1', 'p-2', 'Followed author post', 3600000),
+      post('post-2', 'p-3', 'Stranger post', 1800000),
+    ]);
+    (fetchPeople as jest.Mock).mockResolvedValue(new Map([['p-2', person('p-2', 'Kemal')]]));
+    const { sb } = makeSb({});
+    const res = await tool_browse_news_feed({ scope: 'following' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Followed author post');
+      expect(res.text).not.toContain('Stranger post');
+    }
+  });
+
+  it('scope=following with no follows answers plainly', async () => {
+    (fetchFollowEdges as jest.Mock).mockResolvedValue({ following: [], followers: [] });
+    const { sb } = makeSb({});
+    const res = await tool_browse_news_feed({ scope: 'following' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('does not follow anyone yet');
+  });
+
+  it('fails CLOSED when privacy filters cannot be loaded', async () => {
+    (fetchExclusions as jest.Mock).mockRejectedValue(new Error('db down'));
+    const { sb } = makeSb({});
+    const res = await tool_browse_news_feed({}, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('do not guess');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_browse_news_feed({}, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snooze_recommendation
+// ---------------------------------------------------------------------------
+
+const REC = {
+  id: UUID,
+  title: 'Implement Sleep Quality Tracking',
+  summary: 'Track sleep patterns for personalized improvements.',
+  domain: 'health',
+  risk_level: 'low',
+  impact_score: 9,
+  effort_score: 3,
+  status: 'new',
+  snoozed_until: null,
+  user_id: 'u-1',
+  source_type: 'community',
+  contribution_vector: { sleep: 0.7, mental: 0.2 },
+  economic_axis: 'none',
+  created_at: '2026-07-01T00:00:00Z',
+};
+
+describe('snooze_recommendation', () => {
+  it('snoozes by id via the Command Hub RPC and speaks the title', async () => {
+    const { sb, rpc } = makeSb(
+      { autopilot_recommendations: [{ data: REC, error: null }] },
+      { snooze_autopilot_recommendation: { data: { ok: true, snoozed_until: '2026-07-07T10:00:00Z' }, error: null } },
+    );
+    const res = await tool_snooze_recommendation({ recommendation: UUID, hours: 48 }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Implement Sleep Quality Tracking');
+      expect(res.text).toContain('48 hours');
+    }
+    expect(rpc).toHaveBeenCalledWith('snooze_autopilot_recommendation', {
+      p_recommendation_id: UUID,
+      p_hours: 48,
+    });
+  });
+
+  it('resolves a spoken title fragment when only one row matches', async () => {
+    const { sb, rpc } = makeSb(
+      { autopilot_recommendations: [{ data: [REC], error: null }] },
+      { snooze_autopilot_recommendation: { data: { ok: true }, error: null } },
+    );
+    const res = await tool_snooze_recommendation({ recommendation: 'sleep tracking' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    // Default + clamped hours.
+    expect(rpc).toHaveBeenCalledWith('snooze_autopilot_recommendation', {
+      p_recommendation_id: UUID,
+      p_hours: 24,
+    });
+  });
+
+  it('refuses to touch another user\'s recommendation', async () => {
+    const { sb, rpc } = makeSb({
+      autopilot_recommendations: [{ data: { ...REC, user_id: 'someone-else' }, error: null }],
+    });
+    const res = await tool_snooze_recommendation({ recommendation: UUID }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('another_user');
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('stays ok:true with an honest empty state when nothing matches', async () => {
+    const { sb, rpc } = makeSb({ autopilot_recommendations: [{ data: [], error: null }] });
+    const res = await tool_snooze_recommendation({ recommendation: 'nonexistent thing' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('No open recommendation matched');
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_snooze_recommendation({ recommendation: UUID }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dismiss_recommendation
+// ---------------------------------------------------------------------------
+
+describe('dismiss_recommendation', () => {
+  it('asks for confirmation first (no RPC call)', async () => {
+    const { sb, rpc } = makeSb({ autopilot_recommendations: [{ data: REC, error: null }] });
+    const res = await tool_dismiss_recommendation({ recommendation: UUID }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Confirm with the user first');
+      expect(res.text).toContain('Implement Sleep Quality Tracking');
+      expect((res.result as { stage: string }).stage).toBe('awaiting_confirmation');
+    }
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('dismisses via the reject RPC after confirm=true', async () => {
+    const { sb, rpc } = makeSb(
+      { autopilot_recommendations: [{ data: REC, error: null }] },
+      { reject_autopilot_recommendation: { data: { ok: true }, error: null } },
+    );
+    const res = await tool_dismiss_recommendation(
+      { recommendation: UUID, confirm: true, reason: 'not relevant' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('dismissed');
+    expect(rpc).toHaveBeenCalledWith('reject_autopilot_recommendation', {
+      p_recommendation_id: UUID,
+      p_reason: 'not relevant',
+    });
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_dismiss_recommendation({ recommendation: UUID }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// explain_recommendation
+// ---------------------------------------------------------------------------
+
+describe('explain_recommendation', () => {
+  it('narrates why: summary, pillars, impact vs effort, source', async () => {
+    const { sb } = makeSb({ autopilot_recommendations: [{ data: REC, error: null }] });
+    const res = await tool_explain_recommendation({ recommendation: UUID }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Implement Sleep Quality Tracking');
+      expect(res.text).toContain('sleep');
+      expect(res.text).toContain('9/10');
+      expect(res.text).toContain('3/10');
+      const r = res.result as { contribution_vector: Record<string, number> };
+      expect(r.contribution_vector.sleep).toBe(0.7);
+    }
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_explain_recommendation({ recommendation: UUID }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_intent
+// ---------------------------------------------------------------------------
+
+const INTENT = {
+  intent_id: UUID,
+  intent_kind: 'activity_seek',
+  category: 'sport.tennis',
+  title: 'Tennis partner in Berlin',
+  scope: 'Weekly tennis, intermediate level',
+  status: 'open',
+  created_at: '2026-07-01T00:00:00Z',
+};
+
+describe('update_intent', () => {
+  it('updates the resolved intent and confirms the change', async () => {
+    const { sb, log } = makeSb({
+      user_intents: [
+        { data: INTENT, error: null }, // resolve by uuid (maybeSingle)
+        { data: { intent_id: UUID, title: 'Tennis partner in Berlin', scope: 'Weekends only, intermediate level', category: 'sport.tennis' }, error: null }, // update
+      ],
+    });
+    const res = await tool_update_intent(
+      { intent: UUID, new_text: 'Weekends only, intermediate level' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('Weekends only');
+    const upd = log.find((l) => l.table === 'user_intents' && l.method === 'update');
+    expect(upd).toBeDefined();
+    expect(upd!.args[0]).toEqual({ scope: 'Weekends only, intermediate level' });
+  });
+
+  it('refuses when no field changes were given', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_update_intent({ intent: UUID }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('new_title');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_update_intent({ intent: UUID, new_title: 'x' }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete_intent
+// ---------------------------------------------------------------------------
+
+describe('delete_intent', () => {
+  it('asks for confirmation first (no write)', async () => {
+    const { sb, log } = makeSb({ user_intents: [{ data: INTENT, error: null }] });
+    const res = await tool_delete_intent({ intent: UUID }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Tennis partner in Berlin');
+      expect((res.result as { stage: string }).stage).toBe('awaiting_confirmation');
+    }
+    expect(log.find((l) => l.method === 'update')).toBeUndefined();
+  });
+
+  it('closes the intent after confirm=true (status=closed, owner-scoped)', async () => {
+    const { sb, log } = makeSb({
+      user_intents: [
+        { data: INTENT, error: null },
+        { data: { intent_id: UUID }, error: null },
+      ],
+    });
+    const res = await tool_delete_intent({ intent: UUID, confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('taken down');
+    const upd = log.find((l) => l.table === 'user_intents' && l.method === 'update');
+    expect(upd!.args[0]).toEqual({ status: 'closed' });
+    // Owner scoping: an .eq('requester_user_id', 'u-1') is applied after update.
+    const eqCalls = log.filter((l) => l.method === 'eq').map((l) => l.args);
+    expect(eqCalls).toEqual(expect.arrayContaining([['requester_user_id', 'u-1']]));
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_delete_intent({ intent: UUID }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browse_intent_board
+// ---------------------------------------------------------------------------
+
+describe('browse_intent_board', () => {
+  it('speaks open asks with titles and kind labels', async () => {
+    const { sb } = makeSb({
+      user_intents: [{
+        data: [
+          { intent_id: 'i-1', intent_kind: 'commercial_buy', category: 'gear.bike', title: 'Looking for a used e-bike', scope: 'Budget 800', created_at: new Date().toISOString() },
+          { intent_id: 'i-2', intent_kind: 'activity_seek', category: 'sport.running', title: 'Morning running buddy', scope: '5k pace', created_at: new Date().toISOString() },
+        ],
+        error: null,
+      }],
+    });
+    const res = await tool_browse_intent_board({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Looking for a used e-bike');
+      expect(res.text).toContain('looking to buy');
+      expect(res.text).toContain('Morning running buddy');
+      expect(res.text).toContain('activity partner wanted');
+    }
+  });
+
+  it('answers plainly when the board is empty', async () => {
+    const { sb } = makeSb({ user_intents: [{ data: [], error: null }] });
+    const res = await tool_browse_intent_board({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('no open asks');
+  });
+
+  it('requires an authenticated user with tenant', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_browse_intent_board({}, ANON, sb);
+    expect(res.ok).toBe(false);
+    const noTenant = await tool_browse_intent_board({}, { ...IDENT, tenant_id: null }, sb);
+    expect(noTenant.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispute_match
+// ---------------------------------------------------------------------------
+
+describe('dispute_match', () => {
+  it('collects the reason before anything else', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_dispute_match({ match_id: 'm-1' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { stage: string }).stage).toBe('needs_reason');
+      expect(res.text).toContain('what went wrong');
+    }
+    expect(raiseDispute).not.toHaveBeenCalled();
+  });
+
+  it('reads the dispute back before filing (no write without confirm)', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_dispute_match(
+      { match_id: 'm-1', reason: 'The seller never showed up', reason_category: 'no_show' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { stage: string }).stage).toBe('awaiting_confirmation');
+      expect(res.text).toContain('never showed up');
+    }
+    expect(raiseDispute).not.toHaveBeenCalled();
+  });
+
+  it('files via raiseDispute after confirm=true', async () => {
+    (raiseDispute as jest.Mock).mockResolvedValue({ dispute_id: 'd-1', status: 'open' });
+    const { sb } = makeSb({});
+    const res = await tool_dispute_match(
+      { match_id: 'm-1', reason: 'No-show at the court', reason_category: 'no_show', confirm: true },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('filed');
+      expect((res.result as { dispute_id: string }).dispute_id).toBe('d-1');
+    }
+    expect(raiseDispute).toHaveBeenCalledWith({
+      match_id: 'm-1',
+      raised_by: 'u-1',
+      reason_category: 'no_show',
+      reason_detail: 'No-show at the court',
+      vitana_id_hint: '@dragan',
+    });
+  });
+
+  it('auto-detects the match when the user has exactly one', async () => {
+    (raiseDispute as jest.Mock).mockResolvedValue({ dispute_id: 'd-2', status: 'open' });
+    const { sb } = makeSb({
+      user_intents: [{ data: [{ intent_id: 'i-1' }], error: null }],
+      intent_matches: [{ data: [{ match_id: 'm-only', intent_a_id: 'i-1', intent_b_id: 'i-9', state: 'surfaced', created_at: new Date().toISOString() }], error: null }],
+    });
+    const res = await tool_dispute_match({ reason: 'misrepresented offer', confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((raiseDispute as jest.Mock).mock.calls[0][0].match_id).toBe('m-only');
+  });
+
+  it('disambiguates when the user has several matches', async () => {
+    const { sb } = makeSb({
+      user_intents: [{ data: [{ intent_id: 'i-1' }], error: null }],
+      intent_matches: [{
+        data: [
+          { match_id: 'm-1', intent_a_id: 'i-1', intent_b_id: 'i-8', state: 'surfaced', created_at: new Date().toISOString() },
+          { match_id: 'm-2', intent_a_id: 'i-1', intent_b_id: 'i-9', state: 'mutual_interest', created_at: new Date().toISOString() },
+        ],
+        error: null,
+      }],
+    });
+    const res = await tool_dispute_match({ reason: 'issue' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { ambiguous: boolean }).ambiguous).toBe(true);
+      expect(res.text).toContain('several matches');
+    }
+    expect(raiseDispute).not.toHaveBeenCalled();
+  });
+
+  it('maps not_a_party to a clear error', async () => {
+    (raiseDispute as jest.Mock).mockRejectedValue(new Error('not_a_party'));
+    const { sb } = makeSb({});
+    const res = await tool_dispute_match(
+      { match_id: 'm-1', reason: 'x', confirm: true },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('not a participant');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_dispute_match({ match_id: 'm-1', reason: 'x' }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// find_perfect_match
+// ---------------------------------------------------------------------------
+
+describe('find_perfect_match', () => {
+  const compassQueues = () => ({
+    life_compass: [{ data: { primary_goal: 'Run a marathon at 60', category: 'longevity' }, error: null }],
+    vitana_index_scores: [{ data: { pillars: { exercise: 40, sleep: 85, nutrition: 70 } }, error: null }],
+  });
+
+  it('fuses the ask with Life Compass goal + weakest pillar and reuses the find-match engine', async () => {
+    (runFindMatch as jest.Mock).mockResolvedValue({
+      ok: true,
+      stage: 'matched',
+      text: 'MATCHES FOUND — recommend Kemal for tennis.',
+      data: { matches: [{ match_id: 'm-1', score: 0.91 }] },
+    });
+    const { sb } = makeSb(compassQueues());
+    const res = await tool_find_perfect_match({ ask: 'a workout partner for mornings' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Run a marathon at 60');
+      expect(res.text).toContain('exercise');
+      expect(res.text).toContain('MATCHES FOUND');
+      const r = res.result as { weakest_pillar: string; compass_goal: string; stage: string };
+      expect(r.weakest_pillar).toBe('exercise');
+      expect(r.compass_goal).toBe('Run a marathon at 60');
+      expect(r.stage).toBe('matched');
+    }
+    expect(runFindMatch).toHaveBeenCalledWith(
+      expect.objectContaining({ utterance: 'a workout partner for mornings' }),
+      expect.objectContaining({ user_id: 'u-1', tenant_id: 't-1' }),
+    );
+  });
+
+  it('derives a default ask from the weakest pillar when the user is vague', async () => {
+    (runFindMatch as jest.Mock).mockResolvedValue({
+      ok: true,
+      stage: 'awaiting_confirmation',
+      text: 'Read back the summary and confirm.',
+      data: {},
+    });
+    const { sb } = makeSb(compassQueues());
+    const res = await tool_find_perfect_match({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((runFindMatch as jest.Mock).mock.calls[0][0].utterance).toContain('workout partner');
+    if (res.ok) {
+      expect((res.result as { ask_derived_from_pillar: boolean }).ask_derived_from_pillar).toBe(true);
+    }
+  });
+
+  it('asks what the user wants when there is no ask and no pillar data', async () => {
+    const { sb } = makeSb({
+      life_compass: [{ data: null, error: null }],
+      vitana_index_scores: [{ data: null, error: null }],
+    });
+    const res = await tool_find_perfect_match({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { stage: string }).stage).toBe('needs_ask');
+      expect(res.text).toContain('what kind of person');
+    }
+    expect(runFindMatch).not.toHaveBeenCalled();
+  });
+
+  it('propagates engine failures as ok:false', async () => {
+    (runFindMatch as jest.Mock).mockResolvedValue({ ok: false, stage: 'incomplete', text: '', data: {}, error: 'insert_failed' });
+    const { sb } = makeSb(compassQueues());
+    const res = await tool_find_perfect_match({ ask: 'a mentor' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('insert_failed');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb({});
+    const res = await tool_find_perfect_match({ ask: 'a mentor' }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/feedback-settings-tools.test.ts
+++ b/services/gateway/test/orb-tools/feedback-settings-tools.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Feedback + Settings voice tools (VTID-02768 / VTID-02772).
+ *
+ * Mocked SupabaseClient + mocked service modules — no network, no real DB.
+ * Per tool: happy path (ok:true with speakable text containing the actual
+ * content) and the unauthenticated case where applicable.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+jest.mock('../../src/services/report-to-specialist-core', () => ({
+  executeReportToSpecialist: jest.fn(),
+}));
+jest.mock('../../src/services/persona-registry', () => ({
+  pickPersonaForKind: jest.fn(),
+  pickPersonaForKindForTenant: jest.fn(),
+}));
+jest.mock('../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn().mockResolvedValue({ ok: true }),
+}));
+jest.mock('../../src/services/social-connect-service', () => ({
+  SUPPORTED_PROVIDERS: [
+    'instagram', 'facebook', 'tiktok', 'youtube', 'linkedin', 'twitter', 'google',
+  ],
+  getUserConnections: jest.fn(),
+  disconnectSocialAccount: jest.fn(),
+}));
+jest.mock('../../src/i18n/server-locale', () => ({
+  invalidateUserLocale: jest.fn(),
+}));
+
+import { executeReportToSpecialist } from '../../src/services/report-to-specialist-core';
+import {
+  pickPersonaForKind,
+  pickPersonaForKindForTenant,
+} from '../../src/services/persona-registry';
+import { emitOasisEvent } from '../../src/services/oasis-event-service';
+import {
+  getUserConnections,
+  disconnectSocialAccount,
+} from '../../src/services/social-connect-service';
+import { invalidateUserLocale } from '../../src/i18n/server-locale';
+import {
+  FEEDBACK_SETTINGS_TOOL_HANDLERS,
+  FEEDBACK_SETTINGS_TOOL_DECLARATIONS,
+  tool_submit_bug_report,
+  tool_submit_support_ticket,
+  tool_submit_marketplace_dispute,
+  tool_submit_account_issue,
+  tool_list_my_tickets,
+  tool_set_language,
+  tool_set_theme,
+  tool_set_voice_preferences,
+  tool_list_connected_apps,
+  tool_disconnect_app,
+} from '../../src/services/orb-tools/feedback-settings-tools';
+
+const IDENT = { user_id: 'u-1', tenant_id: 't-1', role: 'community' };
+const ANON = { user_id: '', tenant_id: null, role: null };
+
+const LONG_BUG_SUMMARY =
+  'The save button on the profile edit screen does nothing when I tap it on my phone and my changes are lost';
+const LONG_SUMMARY_12 =
+  'I ordered a blue yoga mat two weeks ago and it still has not arrived';
+
+// ---------------------------------------------------------------------------
+// Chainable Supabase mock
+// ---------------------------------------------------------------------------
+
+type MockResult = { data?: unknown; error?: { message: string } | null };
+
+function makeBuilder(result: MockResult) {
+  const b: any = {};
+  for (const m of ['select', 'eq', 'not', 'order', 'limit', 'insert', 'update', 'upsert', 'delete', 'is', 'in']) {
+    b[m] = jest.fn(() => b);
+  }
+  b.single = jest.fn(async () => ({ data: result.data ?? null, error: result.error ?? null }));
+  b.maybeSingle = jest.fn(async () => ({ data: result.data ?? null, error: result.error ?? null }));
+  b.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+    Promise.resolve({ data: result.data ?? null, error: result.error ?? null }).then(resolve, reject);
+  return b;
+}
+
+/** from(table) → the builder registered for that table (default: empty ok). */
+function makeSb(tables: Record<string, any> = {}) {
+  return {
+    from: jest.fn((table: string) => tables[table] ?? makeBuilder({ data: null, error: null })),
+  } as unknown as SupabaseClient;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (emitOasisEvent as jest.Mock).mockResolvedValue({ ok: true });
+});
+
+// ---------------------------------------------------------------------------
+// Registry + declarations
+// ---------------------------------------------------------------------------
+
+const TOOL_NAMES = [
+  'submit_bug_report', 'submit_support_ticket', 'submit_marketplace_dispute',
+  'submit_account_issue', 'list_my_tickets',
+  'set_language', 'set_theme', 'set_voice_preferences',
+  'list_connected_apps', 'disconnect_app',
+];
+
+describe('exports', () => {
+  it.each(TOOL_NAMES)('%s has a handler and a declaration', (name) => {
+    expect(typeof FEEDBACK_SETTINGS_TOOL_HANDLERS[name]).toBe('function');
+    const decl = FEEDBACK_SETTINGS_TOOL_DECLARATIONS.find((d) => d.name === name);
+    expect(decl).toBeDefined();
+    expect(typeof decl!.description).toBe('string');
+  });
+
+  it('declarations use the Vertex-safe OpenAPI subset (no default/minimum/maximum/format)', () => {
+    const json = JSON.stringify(FEEDBACK_SETTINGS_TOOL_DECLARATIONS.map((d) => d.parameters));
+    for (const banned of ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"']) {
+      expect(json).not.toContain(banned);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submit_bug_report
+// ---------------------------------------------------------------------------
+
+describe('tool_submit_bug_report', () => {
+  it('routes to devon via the shared core and speaks the ticket number', async () => {
+    (pickPersonaForKindForTenant as jest.Mock).mockResolvedValue('devon');
+    (executeReportToSpecialist as jest.Mock).mockResolvedValue({
+      decision: 'created',
+      ticket: { id: 'tk-1', ticket_number: 'FB-2026-07-000123' },
+      persona: 'devon',
+      matched_keyword: null,
+      confidence: null,
+      rpc_decision: null,
+      rpc_gate: null,
+    });
+    const res = await tool_submit_bug_report(
+      { summary: LONG_BUG_SUMMARY, screen: '/profile/edit' }, IDENT, makeSb(),
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('FB-2026-07-000123');
+    expect((res as any).text).toContain('bug report');
+    expect((res as any).result.specialist).toBe('devon');
+    // Core called with the resolved specialist hint (gate deliberately skipped).
+    expect(executeReportToSpecialist).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'bug', specialist_hint: 'devon' }),
+      expect.objectContaining({ user_id: 'u-1', tenant_id: 't-1' }),
+      expect.anything(),
+      expect.objectContaining({ source: 'orb-voice-typed-tool', screen_path: '/profile/edit' }),
+    );
+  });
+
+  it('asks for specifics when the summary is under 15 words', async () => {
+    const res = await tool_submit_bug_report(
+      { summary: 'The app is broken please fix it now' }, IDENT, makeSb(),
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('ASK_FOR_SPECIFICS');
+    expect(executeReportToSpecialist).not.toHaveBeenCalled();
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_submit_bug_report({ summary: LONG_BUG_SUMMARY }, ANON as any, makeSb());
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('authenticated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submit_support_ticket / submit_marketplace_dispute / submit_account_issue
+// (unrouted path — VTID-03044 canary: sage/atlas/mira disabled)
+// ---------------------------------------------------------------------------
+
+describe('typed tickets without an enabled specialist (VTID-03044 canary)', () => {
+  function insertCapture() {
+    const builder = makeBuilder({ data: { id: 'tk-2', ticket_number: 'FB-2026-07-000124' }, error: null });
+    return { sb: makeSb({ feedback_tickets: builder }), builder };
+  }
+
+  it('submit_support_ticket files an unrouted ticket and confirms', async () => {
+    (pickPersonaForKindForTenant as jest.Mock).mockResolvedValue(null);
+    const { sb, builder } = insertCapture();
+    const res = await tool_submit_support_ticket(
+      { summary: 'How can I export all of my health data as a file from the app' }, IDENT, sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('FB-2026-07-000124');
+    expect((res as any).result.specialist).toBeNull();
+    expect(executeReportToSpecialist).not.toHaveBeenCalled();
+    const inserted = builder.insert.mock.calls[0][0];
+    expect(inserted).toMatchObject({
+      user_id: 'u-1',
+      kind: 'support_question',
+      status: 'new',
+      resolver_agent: null,
+    });
+    expect(inserted.structured_fields).toMatchObject({ voice_origin: true, source: 'orb-voice-typed-tool' });
+    expect(emitOasisEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'feedback.ticket.created' }),
+    );
+  });
+
+  it('submit_marketplace_dispute stores the order reference', async () => {
+    (pickPersonaForKindForTenant as jest.Mock).mockResolvedValue(null);
+    const { sb, builder } = insertCapture();
+    const res = await tool_submit_marketplace_dispute(
+      { summary: LONG_SUMMARY_12, order_reference: 'ORD-4711' }, IDENT, sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('marketplace dispute');
+    expect(builder.insert.mock.calls[0][0]).toMatchObject({ kind: 'marketplace_claim' });
+    expect(builder.insert.mock.calls[0][0].structured_fields).toMatchObject({ order_reference: 'ORD-4711' });
+  });
+
+  it('submit_account_issue files kind=account_issue', async () => {
+    (pickPersonaForKindForTenant as jest.Mock).mockResolvedValue(null);
+    const { sb, builder } = insertCapture();
+    const res = await tool_submit_account_issue(
+      { summary: 'I cannot log into my account since yesterday even after resetting the password' }, IDENT, sb,
+    );
+    expect(res.ok).toBe(true);
+    expect(builder.insert.mock.calls[0][0]).toMatchObject({ kind: 'account_issue' });
+  });
+
+  it('uses the platform-level resolver when there is no tenant', async () => {
+    (pickPersonaForKind as jest.Mock).mockResolvedValue(null);
+    const { sb } = insertCapture();
+    const res = await tool_submit_support_ticket(
+      { summary: 'How can I export all of my health data as a file from the app' },
+      { ...IDENT, tenant_id: null }, sb,
+    );
+    expect(res.ok).toBe(true);
+    expect(pickPersonaForKind).toHaveBeenCalledWith('support_question');
+    expect(pickPersonaForKindForTenant).not.toHaveBeenCalled();
+  });
+
+  it('surfaces insert failures as ok:false', async () => {
+    (pickPersonaForKindForTenant as jest.Mock).mockResolvedValue(null);
+    const sb = makeSb({ feedback_tickets: makeBuilder({ data: null, error: { message: 'boom' } }) });
+    const res = await tool_submit_account_issue(
+      { summary: 'I cannot log into my account since yesterday even after resetting the password' }, IDENT, sb,
+    );
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('boom');
+  });
+
+  it('requires an authenticated user', async () => {
+    for (const handler of [tool_submit_support_ticket, tool_submit_marketplace_dispute, tool_submit_account_issue]) {
+      const res = await handler({ summary: LONG_SUMMARY_12 }, ANON as any, makeSb());
+      expect(res.ok).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_my_tickets
+// ---------------------------------------------------------------------------
+
+describe('tool_list_my_tickets', () => {
+  it('lists open tickets with number, kind, and speakable status', async () => {
+    const rows = [
+      { id: 'tk-1', ticket_number: 'FB-2026-07-000123', kind: 'bug', status: 'in_progress', created_at: '2026-07-01T10:00:00Z' },
+      { id: 'tk-2', ticket_number: 'FB-2026-06-000090', kind: 'support_question', status: 'new', created_at: '2026-06-28T09:00:00Z' },
+    ];
+    const res = await tool_list_my_tickets({}, IDENT, makeSb({ feedback_tickets: makeBuilder({ data: rows, error: null }) }));
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('2 open ticket(s)');
+    expect((res as any).text).toContain('FB-2026-07-000123');
+    expect((res as any).text).toContain('bug report, in progress');
+    expect((res as any).text).toContain('FB-2026-06-000090');
+    expect((res as any).text).toContain('support question, received');
+  });
+
+  it('answers plainly when there are no open tickets', async () => {
+    const res = await tool_list_my_tickets({}, IDENT, makeSb({ feedback_tickets: makeBuilder({ data: [], error: null }) }));
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('NO open tickets');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_list_my_tickets({}, ANON as any, makeSb());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set_language
+// ---------------------------------------------------------------------------
+
+describe('tool_set_language', () => {
+  it('writes user_preferences.stt_language + app_users.locale and busts the cache', async () => {
+    const prefs = makeBuilder({ data: null, error: null });
+    const appUsers = makeBuilder({ data: null, error: null });
+    const res = await tool_set_language(
+      { language: 'de' }, IDENT, makeSb({ user_preferences: prefs, app_users: appUsers }),
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('German');
+    expect(prefs.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'u-1', stt_language: 'de-DE' }),
+      { onConflict: 'user_id' },
+    );
+    expect(appUsers.update).toHaveBeenCalledWith(expect.objectContaining({ locale: 'de' }));
+    expect(invalidateUserLocale).toHaveBeenCalledWith('u-1');
+    expect((res as any).result).toMatchObject({ language: 'de', stt_language: 'de-DE' });
+  });
+
+  it('accepts full locale codes like en-US', async () => {
+    const prefs = makeBuilder({ data: null, error: null });
+    const res = await tool_set_language({ language: 'en-US' }, IDENT, makeSb({ user_preferences: prefs }));
+    expect(res.ok).toBe(true);
+    expect(prefs.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ stt_language: 'en-US' }),
+      { onConflict: 'user_id' },
+    );
+  });
+
+  it('rejects unsupported languages', async () => {
+    const res = await tool_set_language({ language: 'fr' }, IDENT, makeSb());
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('Unsupported language');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_set_language({ language: 'de' }, ANON as any, makeSb());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set_theme (graceful — no server-side storage)
+// ---------------------------------------------------------------------------
+
+describe('tool_set_theme', () => {
+  it('explains the theme is a device setting and where to change it', async () => {
+    const sb = makeSb();
+    const res = await tool_set_theme({ theme: 'dark' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).result).toMatchObject({ persisted: false, requested_theme: 'dark' });
+    expect((res as any).text).toContain('device setting');
+    expect((res as any).text).toContain('Settings');
+    expect((sb as any).from).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown themes', async () => {
+    const res = await tool_set_theme({ theme: 'neon' }, IDENT, makeSb());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set_voice_preferences
+// ---------------------------------------------------------------------------
+
+describe('tool_set_voice_preferences', () => {
+  it('maps pace/voice/tone onto the real user_preferences tts_* columns', async () => {
+    const prefs = makeBuilder({ data: null, error: null });
+    const res = await tool_set_voice_preferences(
+      { pace: 'slow', tone: 'calm' }, IDENT, makeSb({ user_preferences: prefs }),
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('pace slow');
+    expect((res as any).text).toContain('"calm"');
+    expect(prefs.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'u-1', tts_speed: 0.8, tts_character: 'calm' }),
+      { onConflict: 'user_id' },
+    );
+  });
+
+  it('errors when nothing was provided to change', async () => {
+    const res = await tool_set_voice_preferences({}, IDENT, makeSb());
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('Nothing to change');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_set_voice_preferences({ pace: 'fast' }, ANON as any, makeSb());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_connected_apps
+// ---------------------------------------------------------------------------
+
+describe('tool_list_connected_apps', () => {
+  it('lists social + AI connections with display names', async () => {
+    (getUserConnections as jest.Mock).mockResolvedValue([
+      { provider: 'google', username: 'd', display_name: 'D', avatar_url: '', profile_url: '', enrichment_status: 'completed', connected_at: '2026-05-01T00:00:00Z' },
+      { provider: 'youtube', username: 'd', display_name: 'D', avatar_url: '', profile_url: '', enrichment_status: 'completed', connected_at: '2026-06-01T00:00:00Z' },
+    ]);
+    const ai = makeBuilder({ data: [{ connector_id: 'openai', connected_at: '2026-06-15T00:00:00Z' }], error: null });
+    const res = await tool_list_connected_apps({}, IDENT, makeSb({ user_connections: ai }));
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('3 connected app(s)');
+    expect((res as any).text).toContain('Google');
+    expect((res as any).text).toContain('YouTube');
+    expect((res as any).text).toContain('OpenAI (ChatGPT) (AI assistant)');
+  });
+
+  it('answers plainly when nothing is connected', async () => {
+    (getUserConnections as jest.Mock).mockResolvedValue([]);
+    const res = await tool_list_connected_apps({}, IDENT, makeSb({ user_connections: makeBuilder({ data: [], error: null }) }));
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('NO connected apps');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_list_connected_apps({}, ANON as any, makeSb());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// disconnect_app
+// ---------------------------------------------------------------------------
+
+describe('tool_disconnect_app', () => {
+  it('asks for confirmation before disconnecting', async () => {
+    const res = await tool_disconnect_app({ provider: 'google' }, IDENT, makeSb());
+    expect(res.ok).toBe(true);
+    expect((res as any).result.requires_confirmation).toBe(true);
+    expect((res as any).text).toContain('Google');
+    expect((res as any).text).toContain('confirm');
+    expect(disconnectSocialAccount).not.toHaveBeenCalled();
+  });
+
+  it('disconnects a social provider via disconnectSocialAccount after confirm', async () => {
+    (disconnectSocialAccount as jest.Mock).mockResolvedValue({ ok: true });
+    const social = makeBuilder({ data: { id: 'sc-1' }, error: null });
+    const res = await tool_disconnect_app(
+      { provider: 'google', confirm: true }, IDENT, makeSb({ social_connections: social }),
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).result).toMatchObject({ disconnected: true, provider: 'google', category: 'app' });
+    expect((res as any).text).toContain('Google is disconnected');
+    expect(disconnectSocialAccount).toHaveBeenCalledWith(expect.anything(), 'u-1', 'google');
+  });
+
+  it('soft-disconnects an AI assistant connection and purges its key', async () => {
+    const social = makeBuilder({ data: null, error: null });
+    const userConn = makeBuilder({ data: { id: 'uc-1' }, error: null });
+    const creds = makeBuilder({ data: null, error: null });
+    const res = await tool_disconnect_app(
+      { provider: 'chatgpt', confirm: true }, IDENT,
+      makeSb({ social_connections: social, user_connections: userConn, ai_assistant_credentials: creds }),
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).result).toMatchObject({ disconnected: true, provider: 'openai', category: 'ai_assistant' });
+    expect(userConn.update).toHaveBeenCalledWith(expect.objectContaining({ is_active: false }));
+    expect(creds.update).toHaveBeenCalledWith(expect.objectContaining({ last_verify_status: 'purged' }));
+  });
+
+  it('says so plainly when the provider is not connected', async () => {
+    const res = await tool_disconnect_app(
+      { provider: 'spotify', confirm: true }, IDENT,
+      makeSb({ social_connections: makeBuilder({ data: null, error: null }), user_connections: makeBuilder({ data: null, error: null }) }),
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).result).toMatchObject({ disconnected: false, reason: 'not_connected' });
+    expect((res as any).text).toContain('not connected');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_disconnect_app({ provider: 'google', confirm: true }, ANON as any, makeSb());
+    expect(res.ok).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/groups-events-tools.test.ts
+++ b/services/gateway/test/orb-tools/groups-events-tools.test.ts
@@ -324,11 +324,15 @@ describe('join_group', () => {
 // ---------------------------------------------------------------------------
 
 describe('invite_to_group', () => {
+  // global_community_group_members is queried TWICE: first to verify the
+  // CALLER is a member (security gate — see the dedicated test below), then
+  // to check whether the INVITEE is already a member. The first entry in
+  // the queue below is always the caller-membership check.
   it('resolves member by name via the canonical resolver RPC and sends the invitation', async () => {
     const { sb, rpc } = makeSb(
       {
         global_community_groups: [{ data: [walkersGroup] }],
-        global_community_group_members: [{ data: null }],
+        global_community_group_members: [{ data: { id: 'm-caller' } }, { data: null }],
         community_group_invitations: [{ data: null }],
       },
       { data: [{ user_id: U2, vitana_id: '@anna', display_name: 'Anna Schmidt', score: 0.95 }] },
@@ -348,9 +352,25 @@ describe('invite_to_group', () => {
     });
   });
 
+  it('caller is NOT a member of the group — refuses to invite (security)', async () => {
+    const { sb } = makeSb(
+      {
+        global_community_groups: [{ data: [walkersGroup] }],
+        global_community_group_members: [{ data: null }],
+      },
+      { data: [{ user_id: U2, vitana_id: '@anna', display_name: 'Anna Schmidt', score: 0.95 }] },
+    );
+    const res = await tool_invite_to_group({ group: 'walkers', member_name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/must be a member/i);
+  });
+
   it('ambiguous member resolution asks which one', async () => {
     const { sb } = makeSb(
-      { global_community_groups: [{ data: [walkersGroup] }] },
+      {
+        global_community_groups: [{ data: [walkersGroup] }],
+        global_community_group_members: [{ data: { id: 'm-caller' } }],
+      },
       {
         data: [
           { user_id: U2, vitana_id: '@anna1', display_name: 'Anna Schmidt', score: 0.9 },
@@ -371,7 +391,7 @@ describe('invite_to_group', () => {
     const { sb } = makeSb(
       {
         global_community_groups: [{ data: [walkersGroup] }],
-        global_community_group_members: [{ data: { id: 'm-2' } }],
+        global_community_group_members: [{ data: { id: 'm-caller' } }, { data: { id: 'm-2' } }],
       },
       { data: [{ user_id: U2, vitana_id: '@anna', display_name: 'Anna Schmidt', score: 0.95 }] },
     );
@@ -384,7 +404,7 @@ describe('invite_to_group', () => {
     const { sb } = makeSb(
       {
         global_community_groups: [{ data: [walkersGroup] }],
-        global_community_group_members: [{ data: null }],
+        global_community_group_members: [{ data: { id: 'm-caller' } }, { data: null }],
         community_group_invitations: [{ data: null, error: { message: 'dup', code: '23505' } }],
       },
       { data: [{ user_id: U2, vitana_id: '@anna', display_name: 'Anna Schmidt', score: 0.95 }] },

--- a/services/gateway/test/orb-tools/groups-events-tools.test.ts
+++ b/services/gateway/test/orb-tools/groups-events-tools.test.ts
@@ -1,0 +1,752 @@
+/**
+ * Community Groups (VTID-02764) + Events/RSVP (VTID-02774) voice tools — unit tests.
+ *
+ * The handlers talk straight to the live schemas (global_community_groups /
+ * global_community_group_members / community_group_invitations /
+ * global_community_events / global_event_participants / live_rooms), so the
+ * SupabaseClient is mocked with chainable per-table result queues — no
+ * network, no real DB. Covered per tool: happy path (ok:true + speakable
+ * text containing the actual names/titles), the unauthenticated gate, and
+ * the confirm-first flow for destructive actions.
+ */
+
+jest.mock('../../src/services/automation-executor', () => ({
+  dispatchEvent: jest.fn().mockResolvedValue({ dispatched: [], errors: [] }),
+}));
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { dispatchEvent } from '../../src/services/automation-executor';
+import {
+  GROUPS_EVENTS_TOOL_HANDLERS,
+  GROUPS_EVENTS_TOOL_DECLARATIONS,
+  tool_list_my_groups,
+  tool_create_group,
+  tool_join_group,
+  tool_invite_to_group,
+  tool_accept_invitation,
+  tool_decline_invitation,
+  tool_rsvp_event,
+  tool_cancel_rsvp,
+  tool_list_upcoming_meetups,
+  tool_join_live_room,
+} from '../../src/services/orb-tools/groups-events-tools';
+
+const IDENT = { user_id: 'a27552a3-0257-4305-8ed0-351a80fd3701', tenant_id: 't-1', role: 'community' };
+const ANON = { user_id: '', tenant_id: null, role: null };
+
+const G1 = '11111111-1111-4111-8111-111111111111';
+const G2 = '22222222-2222-4222-8222-222222222222';
+const E1 = '33333333-3333-4333-8333-333333333333';
+const U2 = '44444444-4444-4444-8444-444444444444';
+const INV1 = '55555555-5555-4555-8555-555555555555';
+const R1 = '66666666-6666-4666-8666-666666666666';
+
+interface MockResult {
+  data?: unknown;
+  error?: { message: string; code?: string } | null;
+}
+
+/** Chainable query builder that resolves (await / maybeSingle / single) to one result. */
+function makeBuilder(result: MockResult) {
+  const resolved = { data: result.data ?? null, error: result.error ?? null };
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    'select', 'eq', 'neq', 'in', 'gte', 'lte', 'ilike', 'or', 'order', 'limit',
+    'update', 'insert', 'upsert', 'delete',
+  ]) {
+    b[m] = jest.fn(() => b);
+  }
+  b.maybeSingle = jest.fn(async () => resolved);
+  b.single = jest.fn(async () => resolved);
+  b.then = (onFulfilled: (v: MockResult) => unknown, onRejected?: (e: unknown) => unknown) =>
+    Promise.resolve(resolved).then(onFulfilled, onRejected);
+  return b;
+}
+
+/**
+ * SupabaseClient mock: each from(table) call consumes the next queued result
+ * for that table (the last entry repeats when the queue runs out).
+ */
+function makeSb(tableResults: Record<string, MockResult[]> = {}, rpcResult: MockResult = { data: [] }) {
+  const counters: Record<string, number> = {};
+  const from = jest.fn((table: string) => {
+    const queue = tableResults[table] ?? [{ data: null, error: null }];
+    const i = counters[table] ?? 0;
+    counters[table] = i + 1;
+    return makeBuilder(queue[Math.min(i, queue.length - 1)]);
+  });
+  const rpc = jest.fn(async () => ({ data: rpcResult.data ?? null, error: rpcResult.error ?? null }));
+  const sb = { from, rpc } as unknown as SupabaseClient;
+  return { sb, from, rpc };
+}
+
+const futureIso = (days: number) => new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+const walkersGroup = { id: G1, name: 'Morning Walkers', description: 'Daily walks', member_count: 12, is_public: true };
+const sleepGroup = { id: G2, name: 'Sleep Better', description: null, member_count: 3, is_public: true };
+const yogaEvent = {
+  id: E1,
+  title: 'Sunrise Yoga',
+  start_time: futureIso(3),
+  location: 'Berlin Park',
+  participant_count: 4,
+  max_participants: 20,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Exports / registry shape
+// ---------------------------------------------------------------------------
+
+describe('groups+events tools — exports', () => {
+  const NAMES = [
+    'list_my_groups',
+    'create_group',
+    'join_group',
+    'invite_to_group',
+    'accept_invitation',
+    'decline_invitation',
+    'rsvp_event',
+    'cancel_rsvp',
+    'list_upcoming_meetups',
+    'join_live_room',
+  ];
+
+  it.each(NAMES)('%s is in GROUPS_EVENTS_TOOL_HANDLERS', (name) => {
+    expect(typeof GROUPS_EVENTS_TOOL_HANDLERS[name]).toBe('function');
+  });
+
+  it.each(NAMES)('%s is declared in GROUPS_EVENTS_TOOL_DECLARATIONS', (name) => {
+    expect(GROUPS_EVENTS_TOOL_DECLARATIONS.find((d) => d.name === name)).toBeDefined();
+  });
+
+  it('declarations use only the Vertex-safe OpenAPI subset (no default/minimum/maximum/format/examples)', () => {
+    const raw = JSON.stringify(GROUPS_EVENTS_TOOL_DECLARATIONS.map((d) => d.parameters));
+    for (const banned of ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"']) {
+      expect(raw).not.toContain(banned);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_my_groups
+// ---------------------------------------------------------------------------
+
+describe('list_my_groups', () => {
+  it('speaks group names with member counts', async () => {
+    const { sb } = makeSb({
+      global_community_group_members: [
+        { data: [{ group_id: G1, role: 'member', joined_at: '2026-01-01T00:00:00Z' }] },
+      ],
+      global_community_groups: [
+        { data: [walkersGroup] }, // membership details
+        { data: [] }, // created-by groups
+      ],
+    });
+    const res = await tool_list_my_groups({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Morning Walkers');
+      expect(res.text).toContain('12 members');
+      expect((res.result as { groups: unknown[] }).groups).toHaveLength(1);
+    }
+  });
+
+  it('merges groups the user created (as admin) even without a membership row', async () => {
+    const { sb } = makeSb({
+      global_community_group_members: [{ data: [] }],
+      global_community_groups: [{ data: [sleepGroup] }],
+    });
+    const res = await tool_list_my_groups({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Sleep Better');
+      expect(res.text).toContain("you're an admin");
+    }
+  });
+
+  it('empty state stays ok:true with an honest line', async () => {
+    const { sb } = makeSb({
+      global_community_group_members: [{ data: [] }],
+      global_community_groups: [{ data: [] }],
+    });
+    const res = await tool_list_my_groups({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/not in any community groups yet/i);
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb, from } = makeSb();
+    const res = await tool_list_my_groups({}, ANON, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+    expect(from).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create_group
+// ---------------------------------------------------------------------------
+
+describe('create_group', () => {
+  it('asks for confirmation before creating', async () => {
+    const { sb, from } = makeSb();
+    const res = await tool_create_group({ name: 'Trail Runners', privacy: 'private' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { needs_confirmation: boolean }).needs_confirmation).toBe(true);
+      expect(res.text).toContain('Trail Runners');
+      expect(res.text).toContain('private');
+      expect(res.text).toContain('confirm:true');
+    }
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('creates the group on confirm and returns a navigate directive', async () => {
+    const { sb } = makeSb({
+      global_community_groups: [{ data: { id: G1, name: 'Trail Runners' } }],
+      global_community_group_members: [{ data: null }, { data: null }],
+    });
+    const res = await tool_create_group({ name: 'Trail Runners', confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Trail Runners');
+      expect(res.text).toContain('admin');
+      const result = res.result as { directive: { route: string; screen_id: string }; redirect: { route: string } };
+      expect(result.directive.screen_id).toBe('COMM.GROUP_DETAIL');
+      expect(result.redirect.route).toBe(`/comm/groups/${G1}`);
+    }
+  });
+
+  it('requires a name', async () => {
+    const { sb } = makeSb();
+    const res = await tool_create_group({ confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('name');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb();
+    const res = await tool_create_group({ name: 'X', confirm: true }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+
+  it('surfaces the insert error as ok:false', async () => {
+    const { sb } = makeSb({
+      global_community_groups: [{ data: null, error: { message: 'insert denied' } }],
+    });
+    const res = await tool_create_group({ name: 'X', confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('insert denied');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// join_group
+// ---------------------------------------------------------------------------
+
+describe('join_group', () => {
+  it('joins a fuzzy-matched public group and navigates to it', async () => {
+    const { sb } = makeSb({
+      global_community_groups: [{ data: [walkersGroup] }],
+      global_community_group_members: [{ data: null }, { data: null }],
+    });
+    const res = await tool_join_group({ query: 'walkers' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Morning Walkers');
+      const result = res.result as { joined: boolean; redirect: { route: string } };
+      expect(result.joined).toBe(true);
+      expect(result.redirect.route).toBe(`/comm/groups/${G1}`);
+    }
+    // Welcome Squad automation is dispatched with the joiner's user_id.
+    expect(dispatchEvent).toHaveBeenCalledWith('t-1', 'community.member.joined', {
+      group_id: G1,
+      user_id: IDENT.user_id,
+    });
+  });
+
+  it('already a member — says so without re-joining', async () => {
+    const { sb } = makeSb({
+      global_community_groups: [{ data: [walkersGroup] }],
+      global_community_group_members: [{ data: { id: 'm-1' } }],
+    });
+    const res = await tool_join_group({ query: 'walkers' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toMatch(/already a member/i);
+      expect((res.result as { already_member: boolean }).already_member).toBe(true);
+    }
+    expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('private groups cannot be self-joined', async () => {
+    const { sb } = makeSb({
+      global_community_groups: [{ data: [{ ...walkersGroup, is_public: false }] }],
+    });
+    const res = await tool_join_group({ query: 'walkers' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/private group/i);
+  });
+
+  it('several matches — lists candidates and asks which', async () => {
+    const { sb } = makeSb({
+      global_community_groups: [{ data: [walkersGroup, sleepGroup] }],
+    });
+    const res = await tool_join_group({ query: 'group' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Morning Walkers');
+      expect(res.text).toContain('Sleep Better');
+      expect(res.text).toMatch(/which one/i);
+    }
+  });
+
+  it('no match — honest ok:true answer', async () => {
+    const { sb } = makeSb({ global_community_groups: [{ data: [] }] });
+    const res = await tool_join_group({ query: 'chess' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('chess');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb();
+    const res = await tool_join_group({ query: 'walkers' }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// invite_to_group
+// ---------------------------------------------------------------------------
+
+describe('invite_to_group', () => {
+  it('resolves member by name via the canonical resolver RPC and sends the invitation', async () => {
+    const { sb, rpc } = makeSb(
+      {
+        global_community_groups: [{ data: [walkersGroup] }],
+        global_community_group_members: [{ data: null }],
+        community_group_invitations: [{ data: null }],
+      },
+      { data: [{ user_id: U2, vitana_id: '@anna', display_name: 'Anna Schmidt', score: 0.95 }] },
+    );
+    const res = await tool_invite_to_group({ group: 'walkers', member_name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Anna Schmidt');
+      expect(res.text).toContain('Morning Walkers');
+      expect((res.result as { invited: boolean }).invited).toBe(true);
+    }
+    expect(rpc).toHaveBeenCalledWith('resolve_recipient_candidates', {
+      p_actor: IDENT.user_id,
+      p_token: 'Anna',
+      p_limit: 3,
+      p_global: true,
+    });
+  });
+
+  it('ambiguous member resolution asks which one', async () => {
+    const { sb } = makeSb(
+      { global_community_groups: [{ data: [walkersGroup] }] },
+      {
+        data: [
+          { user_id: U2, vitana_id: '@anna1', display_name: 'Anna Schmidt', score: 0.9 },
+          { user_id: G2, vitana_id: '@anna2', display_name: 'Anna Bauer', score: 0.88 },
+        ],
+      },
+    );
+    const res = await tool_invite_to_group({ group: 'walkers', member_name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Anna Schmidt');
+      expect(res.text).toContain('Anna Bauer');
+      expect((res.result as { invited: boolean }).invited).toBe(false);
+    }
+  });
+
+  it('invitee already a member — says so instead of inviting', async () => {
+    const { sb } = makeSb(
+      {
+        global_community_groups: [{ data: [walkersGroup] }],
+        global_community_group_members: [{ data: { id: 'm-2' } }],
+      },
+      { data: [{ user_id: U2, vitana_id: '@anna', display_name: 'Anna Schmidt', score: 0.95 }] },
+    );
+    const res = await tool_invite_to_group({ group: 'walkers', member_name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/already a member/i);
+  });
+
+  it('duplicate pending invitation (unique violation) stays ok:true', async () => {
+    const { sb } = makeSb(
+      {
+        global_community_groups: [{ data: [walkersGroup] }],
+        global_community_group_members: [{ data: null }],
+        community_group_invitations: [{ data: null, error: { message: 'dup', code: '23505' } }],
+      },
+      { data: [{ user_id: U2, vitana_id: '@anna', display_name: 'Anna Schmidt', score: 0.95 }] },
+    );
+    const res = await tool_invite_to_group({ group: 'walkers', member_name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/pending invitation/i);
+  });
+
+  it('requires the member name', async () => {
+    const { sb } = makeSb();
+    const res = await tool_invite_to_group({ group: 'walkers' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('name');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb();
+    const res = await tool_invite_to_group({ group: 'walkers', member_name: 'Anna' }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// accept_invitation / decline_invitation
+// ---------------------------------------------------------------------------
+
+const pendingInvitation = {
+  id: INV1,
+  group_id: G1,
+  invited_by: U2,
+  message: null,
+  created_at: '2026-07-01T00:00:00Z',
+};
+
+describe('accept_invitation', () => {
+  it('accepts the single pending invitation and joins the group', async () => {
+    const { sb } = makeSb({
+      community_group_invitations: [{ data: [pendingInvitation] }, { data: null }],
+      global_community_groups: [{ data: [{ id: G1, name: 'Morning Walkers' }] }],
+      global_community_group_members: [{ data: null }, { data: null }],
+    });
+    const res = await tool_accept_invitation({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Morning Walkers');
+      const result = res.result as { accepted: boolean; redirect: { route: string } };
+      expect(result.accepted).toBe(true);
+      expect(result.redirect.route).toBe(`/comm/groups/${G1}`);
+    }
+  });
+
+  it('no pending invitations — honest ok:true answer', async () => {
+    const { sb } = makeSb({ community_group_invitations: [{ data: [] }] });
+    const res = await tool_accept_invitation({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/don't have any pending/i);
+  });
+
+  it('several pending and no id — lists them and asks', async () => {
+    const inv2 = { ...pendingInvitation, id: G2, group_id: G2 };
+    const { sb } = makeSb({
+      community_group_invitations: [{ data: [pendingInvitation, inv2] }],
+      global_community_groups: [
+        { data: [{ id: G1, name: 'Morning Walkers' }, { id: G2, name: 'Sleep Better' }] },
+      ],
+    });
+    const res = await tool_accept_invitation({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Morning Walkers');
+      expect(res.text).toContain('Sleep Better');
+      expect(res.text).toMatch(/which one/i);
+    }
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb();
+    const res = await tool_accept_invitation({}, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('decline_invitation', () => {
+  it('asks for confirmation first', async () => {
+    const { sb } = makeSb({
+      community_group_invitations: [{ data: [pendingInvitation] }],
+      global_community_groups: [{ data: [{ id: G1, name: 'Morning Walkers' }] }],
+    });
+    const res = await tool_decline_invitation({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { needs_confirmation: boolean }).needs_confirmation).toBe(true);
+      expect(res.text).toContain('Morning Walkers');
+      expect(res.text).toContain('confirm:true');
+    }
+  });
+
+  it('declines on confirm', async () => {
+    const { sb } = makeSb({
+      community_group_invitations: [{ data: [pendingInvitation] }, { data: null }],
+      global_community_groups: [{ data: [{ id: G1, name: 'Morning Walkers' }] }],
+    });
+    const res = await tool_decline_invitation({ invitation_id: INV1, confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toMatch(/declined/i);
+      expect(res.text).toContain('Morning Walkers');
+      expect((res.result as { declined: boolean }).declined).toBe(true);
+    }
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb();
+    const res = await tool_decline_invitation({}, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rsvp_event
+// ---------------------------------------------------------------------------
+
+describe('rsvp_event', () => {
+  it('signs the user up for a fuzzy-matched upcoming event', async () => {
+    const { sb, from } = makeSb({
+      global_community_events: [{ data: [yogaEvent] }, { data: null }],
+      global_event_participants: [{ data: null }, { data: null }],
+    });
+    const res = await tool_rsvp_event({ query: 'yoga' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Sunrise Yoga');
+      expect(res.text).toContain('Berlin Park');
+      expect((res.result as { rsvped: boolean }).rsvped).toBe(true);
+    }
+    // participant row upsert + participant_count sync both happened
+    expect(from).toHaveBeenCalledWith('global_event_participants');
+    expect(from).toHaveBeenCalledWith('global_community_events');
+  });
+
+  it('already attending — says so without double-booking', async () => {
+    const { sb } = makeSb({
+      global_community_events: [{ data: [yogaEvent] }],
+      global_event_participants: [{ data: { id: 'p-1', status: 'attending' } }],
+    });
+    const res = await tool_rsvp_event({ query: 'yoga' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toMatch(/already signed up/i);
+      expect((res.result as { already_attending: boolean }).already_attending).toBe(true);
+    }
+  });
+
+  it('full event — refuses with capacity info', async () => {
+    const fullEvent = { ...yogaEvent, participant_count: 20, max_participants: 20 };
+    const { sb } = makeSb({
+      global_community_events: [{ data: [fullEvent] }],
+      global_event_participants: [{ data: null }],
+    });
+    const res = await tool_rsvp_event({ query: 'yoga' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toMatch(/full/i);
+      expect((res.result as { full: boolean }).full).toBe(true);
+    }
+  });
+
+  it('several matches — lists candidates', async () => {
+    const other = { ...yogaEvent, id: G2, title: 'Evening Yoga' };
+    const { sb } = makeSb({ global_community_events: [{ data: [yogaEvent, other] }] });
+    const res = await tool_rsvp_event({ query: 'yoga' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Sunrise Yoga');
+      expect(res.text).toContain('Evening Yoga');
+    }
+  });
+
+  it('no match — honest ok:true answer', async () => {
+    const { sb } = makeSb({ global_community_events: [{ data: [] }] });
+    const res = await tool_rsvp_event({ query: 'opera' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('opera');
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb();
+    const res = await tool_rsvp_event({ query: 'yoga' }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancel_rsvp
+// ---------------------------------------------------------------------------
+
+describe('cancel_rsvp', () => {
+  it('asks for confirmation before cancelling', async () => {
+    const { sb } = makeSb({
+      global_event_participants: [{ data: [{ event_id: E1 }] }],
+      global_community_events: [{ data: [yogaEvent] }],
+    });
+    const res = await tool_cancel_rsvp({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { needs_confirmation: boolean }).needs_confirmation).toBe(true);
+      expect(res.text).toContain('Sunrise Yoga');
+      expect(res.text).toContain('confirm:true');
+    }
+  });
+
+  it('cancels on confirm and speaks the event title', async () => {
+    const { sb } = makeSb({
+      global_event_participants: [{ data: [{ event_id: E1 }] }, { data: null }],
+      global_community_events: [{ data: [yogaEvent] }, { data: null }],
+    });
+    const res = await tool_cancel_rsvp({ event_id: E1, confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toMatch(/cancelled/i);
+      expect(res.text).toContain('Sunrise Yoga');
+      expect((res.result as { cancelled: boolean }).cancelled).toBe(true);
+    }
+  });
+
+  it('no RSVPs at all — honest ok:true answer', async () => {
+    const { sb } = makeSb({ global_event_participants: [{ data: [] }] });
+    const res = await tool_cancel_rsvp({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/don't have any event RSVPs/i);
+  });
+
+  it('several upcoming RSVPs and no query — lists them and asks which', async () => {
+    const other = { ...yogaEvent, id: G2, title: 'Evening Run' };
+    const { sb } = makeSb({
+      global_event_participants: [{ data: [{ event_id: E1 }, { event_id: G2 }] }],
+      global_community_events: [{ data: [yogaEvent, other] }],
+    });
+    const res = await tool_cancel_rsvp({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Sunrise Yoga');
+      expect(res.text).toContain('Evening Run');
+      expect(res.text).toMatch(/which/i);
+    }
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb();
+    const res = await tool_cancel_rsvp({ confirm: true }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_upcoming_meetups
+// ---------------------------------------------------------------------------
+
+describe('list_upcoming_meetups', () => {
+  it('lists titles with dates, near-you flag and attending marker', async () => {
+    const remote = { ...yogaEvent, id: G2, title: 'Online Breathwork', location: 'Online' };
+    const { sb } = makeSb({
+      global_community_events: [{ data: [remote, yogaEvent] }],
+      location_preferences: [{ data: { home_city: 'Berlin' } }],
+      global_event_participants: [{ data: [{ event_id: G2 }] }],
+    });
+    const res = await tool_list_upcoming_meetups({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Sunrise Yoga');
+      expect(res.text).toContain('Online Breathwork');
+      expect(res.text).toContain('(near you)');
+      expect(res.text).toContain("you're signed up");
+      // Near-user event is ordered first.
+      const events = (res.result as { events: Array<{ title: string; near_user: boolean }> }).events;
+      expect(events[0].title).toBe('Sunrise Yoga');
+      expect(events[0].near_user).toBe(true);
+    }
+  });
+
+  it('empty state stays ok:true with an honest line', async () => {
+    const { sb } = makeSb({ global_community_events: [{ data: [] }] });
+    const res = await tool_list_upcoming_meetups({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/no upcoming meetups/i);
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb();
+    const res = await tool_list_upcoming_meetups({}, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// join_live_room
+// ---------------------------------------------------------------------------
+
+describe('join_live_room', () => {
+  const liveRoom = { id: R1, title: 'Longevity Q&A', starts_at: futureIso(0), status: 'live' };
+
+  it('resolves a single room and returns the navigate directive to the viewer screen', async () => {
+    const { sb } = makeSb({ live_rooms: [{ data: [liveRoom] }] });
+    const res = await tool_join_live_room({ query: 'longevity' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Longevity Q&A');
+      expect(res.text).toMatch(/live right now/i);
+      const result = res.result as {
+        decision: string;
+        directive: { screen_id: string; route: string; directive: string };
+        redirect: { route: string };
+      };
+      expect(result.decision).toBe('auto_nav');
+      expect(result.directive.directive).toBe('navigate');
+      expect(result.directive.screen_id).toBe('COMM.LIVE_ROOM_VIEWER');
+      expect(result.redirect.route).toBe(`/comm/live-rooms/${R1}/view`);
+    }
+  });
+
+  it('several rooms without an exact match — lists candidates', async () => {
+    const scheduled = { id: G2, title: 'Sleep Talk', starts_at: futureIso(1), status: 'scheduled' };
+    const { sb } = makeSb({ live_rooms: [{ data: [liveRoom, scheduled] }] });
+    const res = await tool_join_live_room({ query: 'room' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Longevity Q&A');
+      expect(res.text).toContain('Sleep Talk');
+      expect((res.result as { decision: string }).decision).toBe('list_only');
+    }
+  });
+
+  it('with no query, the single live-now room wins over scheduled ones', async () => {
+    const scheduled = { id: G2, title: 'Sleep Talk', starts_at: futureIso(1), status: 'scheduled' };
+    const { sb } = makeSb({ live_rooms: [{ data: [liveRoom, scheduled] }] });
+    const res = await tool_join_live_room({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { room_id: string }).room_id).toBe(R1);
+      expect(res.text).toContain('Longevity Q&A');
+    }
+  });
+
+  it('no rooms — honest ok:true answer', async () => {
+    const { sb } = makeSb({ live_rooms: [{ data: [] }] });
+    const res = await tool_join_live_room({ query: 'zzz' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('zzz');
+  });
+
+  it('missing tenant context stays ok:true with an unavailable line', async () => {
+    const { sb, from } = makeSb();
+    const res = await tool_join_live_room({ query: 'x' }, { ...IDENT, tenant_id: null }, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/unavailable/i);
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('requires an authenticated user', async () => {
+    const { sb } = makeSb();
+    const res = await tool_join_live_room({ query: 'x' }, ANON, sb);
+    expect(res.ok).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/p0-gap-tools.test.ts
+++ b/services/gateway/test/orb-tools/p0-gap-tools.test.ts
@@ -1,0 +1,532 @@
+/**
+ * P0 coverage-gap voice tools (BOOTSTRAP-VOICE-P0-GAPS) — unit tests.
+ *
+ * All external backings are mocked: the social-memory member resolver, the
+ * wallet balance-service, and a chainable/thenable SupabaseClient stub. Per
+ * tool we cover the happy path (ok:true + speakable text with the actual
+ * content), the unauthenticated gate, and the confirm-gate contract for the
+ * gated mutations (unfollow_member, update_profile, comment_on_post).
+ */
+
+jest.mock('../../src/services/social-memory/social-memory-repository', () => ({
+  resolvePersonByName: jest.fn(),
+}));
+jest.mock('../../src/services/wallet/balance-service', () => ({
+  getAccountsForUser: jest.fn(),
+  getTransactionsForUser: jest.fn(),
+}));
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { resolvePersonByName } from '../../src/services/social-memory/social-memory-repository';
+import {
+  getAccountsForUser,
+  getTransactionsForUser,
+} from '../../src/services/wallet/balance-service';
+import {
+  P0_GAP_TOOL_HANDLERS,
+  P0_GAP_TOOL_DECLARATIONS,
+  tool_follow_member,
+  tool_unfollow_member,
+  tool_get_notifications,
+  tool_mark_notifications_read,
+  tool_get_wallet_balance,
+  tool_update_profile,
+  tool_play_podcast,
+  tool_like_post,
+  tool_comment_on_post,
+} from '../../src/services/orb-tools/p0-gap-tools';
+
+const IDENT = { user_id: 'u-1', tenant_id: 't-1', role: 'community' };
+const ANON = { user_id: '', tenant_id: null, role: null };
+
+// ---------------------------------------------------------------------------
+// Chainable + thenable Supabase query stub
+// ---------------------------------------------------------------------------
+
+interface QResult {
+  data?: unknown;
+  error?: { message: string } | null;
+}
+
+function makeQuery(result: QResult = {}) {
+  const q: Record<string, jest.Mock | unknown> = {};
+  const chainMethods = [
+    'select', 'eq', 'neq', 'is', 'not', 'or', 'in', 'ilike',
+    'order', 'limit', 'range', 'update', 'insert', 'delete', 'upsert',
+  ];
+  for (const m of chainMethods) q[m] = jest.fn(() => q);
+  const resolved = { data: result.data ?? null, error: result.error ?? null };
+  q.maybeSingle = jest.fn(async () => resolved);
+  q.single = jest.fn(async () => resolved);
+  (q as { then?: unknown }).then = (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+    Promise.resolve(resolved).then(onF, onR);
+  return q as Record<string, jest.Mock> & PromiseLike<typeof resolved>;
+}
+
+/** sb.from(table) pops queued query stubs per table (last one sticks). */
+function makeSb(queues: Record<string, Array<ReturnType<typeof makeQuery>>>) {
+  return {
+    from: jest.fn((table: string) => {
+      const queue = queues[table];
+      if (!queue || queue.length === 0) throw new Error(`unexpected query on table ${table}`);
+      return queue.length > 1 ? queue.shift() : queue[0];
+    }),
+  } as unknown as SupabaseClient;
+}
+
+const person = (user_id: string, display_name: string) => ({
+  user_id,
+  display_name,
+  handle: null,
+  vitana_id: null,
+  avatar_url: null,
+  bio: null,
+  city: null,
+  country: null,
+  visibility: 'public',
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Exports / declarations shape
+// ---------------------------------------------------------------------------
+
+describe('p0 gap tools — exports', () => {
+  const NAMES = [
+    'follow_member',
+    'unfollow_member',
+    'get_notifications',
+    'mark_notifications_read',
+    'get_wallet_balance',
+    'update_profile',
+    'play_podcast',
+    'like_post',
+    'comment_on_post',
+  ];
+
+  it.each(NAMES)('%s is in P0_GAP_TOOL_HANDLERS', (name) => {
+    expect(typeof P0_GAP_TOOL_HANDLERS[name]).toBe('function');
+  });
+
+  it.each(NAMES)('%s is declared in P0_GAP_TOOL_DECLARATIONS', (name) => {
+    expect(P0_GAP_TOOL_DECLARATIONS.find((d) => d.name === name)).toBeDefined();
+  });
+
+  it('declarations use only the Vertex-safe OpenAPI subset', () => {
+    const raw = JSON.stringify(P0_GAP_TOOL_DECLARATIONS.map((d) => d.parameters));
+    for (const banned of ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"']) {
+      expect(raw).not.toContain(banned);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// follow_member
+// ---------------------------------------------------------------------------
+
+describe('follow_member', () => {
+  it('resolves the member and inserts the follow edge', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const sb = makeSb({
+      user_follows: [makeQuery({ data: null }), makeQuery({})],
+    });
+    const res = await tool_follow_member({ name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Anna Schmidt');
+      expect(res.text).toMatch(/following/i);
+    }
+  });
+
+  it('is idempotent when already following', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const sb = makeSb({ user_follows: [makeQuery({ data: { id: 'f-1' } })] });
+    const res = await tool_follow_member({ name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('already follow');
+  });
+
+  it('soft-fails when the member is not found', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(null);
+    const sb = makeSb({});
+    const res = await tool_follow_member({ name: 'Zzyzx' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain("couldn't find");
+  });
+
+  it('refuses to follow yourself', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-1', 'Me Myself'));
+    const sb = makeSb({});
+    const res = await tool_follow_member({ name: 'Me' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/cannot follow yourself/i);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_follow_member({ name: 'Anna' }, ANON as never, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unfollow_member
+// ---------------------------------------------------------------------------
+
+describe('unfollow_member', () => {
+  it('asks for confirmation before deleting the follow edge', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const sb = makeSb({ user_follows: [makeQuery({ data: { id: 'f-1' } })] });
+    const res = await tool_unfollow_member({ name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { stage: string }).stage).toBe('awaiting_confirmation');
+      expect(res.text).toContain('Anna Schmidt');
+      expect(res.text).toContain('confirmed=true');
+    }
+  });
+
+  it('deletes the edge when confirmed=true', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const del = makeQuery({});
+    const sb = makeSb({ user_follows: [makeQuery({ data: { id: 'f-1' } }), del] });
+    const res = await tool_unfollow_member({ name: 'Anna', confirmed: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('no longer follow');
+    expect(del.delete).toHaveBeenCalled();
+  });
+
+  it('soft-fails when not following the member', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const sb = makeSb({ user_follows: [makeQuery({ data: null })] });
+    const res = await tool_unfollow_member({ name: 'Anna', confirmed: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('not following');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_unfollow_member({ name: 'Anna' }, ANON as never, makeSb({}));
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_notifications
+// ---------------------------------------------------------------------------
+
+describe('get_notifications', () => {
+  const rows = [
+    { id: 'n-1', type: 'new_match', title: 'New match found', body: 'Anna matches your intent', read_at: '2026-07-05T10:00:00Z', created_at: '2026-07-05T09:00:00Z' },
+    { id: 'n-2', type: 'live_room_starting', title: 'Live room starting', body: null, read_at: null, created_at: '2026-07-04T09:00:00Z' },
+  ];
+
+  it('speaks the unread count and titles, unread first', async () => {
+    const sb = makeSb({ user_notifications: [makeQuery({ data: rows })] });
+    const res = await tool_get_notifications({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('1 unread notification');
+      expect(res.text).toContain('Live room starting');
+      expect(res.text).toContain('New match found');
+      const list = (res.result as { notifications: Array<{ id: string }> }).notifications;
+      expect(list[0].id).toBe('n-2'); // unread first
+    }
+  });
+
+  it('answers plainly when there are no notifications', async () => {
+    const sb = makeSb({ user_notifications: [makeQuery({ data: [] })] });
+    const res = await tool_get_notifications({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/no notifications/i);
+  });
+
+  it('requires an authenticated user with tenant', async () => {
+    const res = await tool_get_notifications({}, { user_id: 'u-1', tenant_id: null, role: null } as never, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mark_notifications_read
+// ---------------------------------------------------------------------------
+
+describe('mark_notifications_read', () => {
+  it('marks all unread and speaks the count', async () => {
+    const q = makeQuery({ data: [{ id: 'n-1' }, { id: 'n-2' }] });
+    const sb = makeSb({ user_notifications: [q] });
+    const res = await tool_mark_notifications_read({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('all 2 unread notifications');
+      expect((res.result as { marked: number }).marked).toBe(2);
+    }
+    expect(q.update).toHaveBeenCalledWith(expect.objectContaining({ read_at: expect.any(String) }));
+    expect(q.ilike).not.toHaveBeenCalled();
+  });
+
+  it('scopes to a title reference when given', async () => {
+    const q = makeQuery({ data: [{ id: 'n-1' }] });
+    const sb = makeSb({ user_notifications: [q] });
+    const res = await tool_mark_notifications_read({ reference: 'match' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('"match"');
+    expect(q.ilike).toHaveBeenCalledWith('title', '%match%');
+  });
+
+  it('stays ok when nothing was unread', async () => {
+    const sb = makeSb({ user_notifications: [makeQuery({ data: [] })] });
+    const res = await tool_mark_notifications_read({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/no unread/i);
+  });
+
+  it('requires an authenticated user with tenant', async () => {
+    const res = await tool_mark_notifications_read({}, ANON as never, makeSb({}));
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_wallet_balance
+// ---------------------------------------------------------------------------
+
+describe('get_wallet_balance', () => {
+  it('speaks balances, subscription and recent transactions (read-only)', async () => {
+    (getAccountsForUser as jest.Mock).mockResolvedValue([
+      { currency: 'EUR', balance_minor: 12550, status: 'active', updated_at: 'x' },
+    ]);
+    (getTransactionsForUser as jest.Mock).mockResolvedValue({
+      entries: [
+        { id: 'l-1', entry_type: 'deposit', direction: 'credit', amount_minor: 5000, currency: 'EUR', description: 'Top-up', created_at: '2026-07-01T00:00:00Z' },
+      ],
+      next_cursor: null,
+    });
+    const sb = makeSb({
+      user_subscriptions: [makeQuery({ data: { plan_key: 'premium', status: 'active', current_period_end: '2026-08-01T00:00:00Z' } })],
+    });
+    const res = await tool_get_wallet_balance({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('125.50 EUR');
+      expect(res.text).toContain('premium');
+      expect(res.text).toContain('Top-up');
+      expect(res.text).toMatch(/read-only/i);
+    }
+    expect(getTransactionsForUser).toHaveBeenCalledWith({ user_id: 'u-1', limit: 3 });
+  });
+
+  it('handles an empty wallet honestly', async () => {
+    (getAccountsForUser as jest.Mock).mockResolvedValue([]);
+    (getTransactionsForUser as jest.Mock).mockResolvedValue({ entries: [], next_cursor: null });
+    const sb = makeSb({ user_subscriptions: [makeQuery({ data: null })] });
+    const res = await tool_get_wallet_balance({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/zero/i);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_get_wallet_balance({}, ANON as never, makeSb({}));
+    expect(res.ok).toBe(false);
+    expect(getAccountsForUser).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_profile
+// ---------------------------------------------------------------------------
+
+describe('update_profile', () => {
+  it('asks for confirmation with a verbatim read-back first', async () => {
+    const res = await tool_update_profile({ bio: 'Longevity nerd', city: 'Berlin' }, IDENT, makeSb({}));
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { stage: string }).stage).toBe('awaiting_confirmation');
+      expect(res.text).toContain('Longevity nerd');
+      expect(res.text).toContain('Berlin');
+      expect(res.text).toContain('confirmed=true');
+    }
+  });
+
+  it('updates the profiles row when confirmed', async () => {
+    const q = makeQuery({});
+    const sb = makeSb({ profiles: [q] });
+    const res = await tool_update_profile({ display_name: 'Anna S.', confirmed: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('Anna S.');
+    expect(q.update).toHaveBeenCalledWith({ display_name: 'Anna S.' });
+    expect(q.eq).toHaveBeenCalledWith('user_id', 'u-1');
+  });
+
+  it('never accepts role or visibility fields', async () => {
+    const res = await tool_update_profile({ role: 'admin', account_visibility: 'x' } as never, IDENT, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/display_name, bio, city, country or location/);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_update_profile({ bio: 'x' }, ANON as never, makeSb({}));
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// play_podcast
+// ---------------------------------------------------------------------------
+
+describe('play_podcast', () => {
+  it('returns an open_url directive and speaks the title', async () => {
+    const sb = makeSb({
+      media_uploads: [
+        makeQuery({
+          data: [
+            {
+              id: 'm-1',
+              title: 'Longevity Foundations',
+              description: 'Sleep deep dive',
+              file_url: 'https://cdn/x.mp3',
+              thumbnail_url: null,
+              duration: 1800,
+              podcast_metadata: { host_name: 'Dr. Weber', series_name: 'Vitana Talks' },
+            },
+          ],
+        }),
+      ],
+    });
+    const res = await tool_play_podcast({ query: 'longevity' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Longevity Foundations');
+      expect(res.text).toContain('Dr. Weber');
+      const result = res.result as { directive: { directive: string; url: string } };
+      expect(result.directive.directive).toBe('open_url');
+      expect(result.directive.url).toBe('https://cdn/x.mp3');
+    }
+  });
+
+  it('soft-fails with a Media Hub nudge when nothing matches', async () => {
+    const sb = makeSb({ media_uploads: [makeQuery({ data: [] })] });
+    const res = await tool_play_podcast({ query: 'zzz' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain("couldn't find");
+      expect((res.result as { played: boolean }).played).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// like_post
+// ---------------------------------------------------------------------------
+
+describe('like_post', () => {
+  const posts = [
+    { id: 'p-2', user_id: 'u-9', content: 'Morning run done, feeling great!', created_at: '2026-07-05T08:00:00Z' },
+    { id: 'p-1', user_id: 'u-9', content: 'Older post about supplements', created_at: '2026-07-01T08:00:00Z' },
+  ];
+
+  it("likes the author's most recent public post", async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const insertQ = makeQuery({});
+    const sb = makeSb({
+      profile_posts: [makeQuery({ data: posts })],
+      profile_post_likes: [makeQuery({ data: null }), insertQ],
+    });
+    const res = await tool_like_post({ author_name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Anna Schmidt');
+      expect(res.text).toContain('Morning run');
+    }
+    expect(insertQ.insert).toHaveBeenCalledWith({ post_id: 'p-2', user_id: 'u-1' });
+  });
+
+  it('picks a specific post via post_reference', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const insertQ = makeQuery({});
+    const sb = makeSb({
+      profile_posts: [makeQuery({ data: posts })],
+      profile_post_likes: [makeQuery({ data: null }), insertQ],
+    });
+    const res = await tool_like_post({ author_name: 'Anna', post_reference: 'supplements' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect(insertQ.insert).toHaveBeenCalledWith({ post_id: 'p-1', user_id: 'u-1' });
+  });
+
+  it('is idempotent when already liked', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const sb = makeSb({
+      profile_posts: [makeQuery({ data: posts })],
+      profile_post_likes: [makeQuery({ data: { id: 'l-1' } })],
+    });
+    const res = await tool_like_post({ author_name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('already liked');
+  });
+
+  it('soft-fails when the author has no public posts', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const sb = makeSb({ profile_posts: [makeQuery({ data: [] })] });
+    const res = await tool_like_post({ author_name: 'Anna' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('no public posts');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_like_post({ author_name: 'Anna' }, ANON as never, makeSb({}));
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// comment_on_post
+// ---------------------------------------------------------------------------
+
+describe('comment_on_post', () => {
+  const posts = [
+    { id: 'p-2', user_id: 'u-9', content: 'Morning run done!', created_at: '2026-07-05T08:00:00Z' },
+  ];
+
+  it('reads the comment back before posting (confirm gate)', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const sb = makeSb({ profile_posts: [makeQuery({ data: posts })] });
+    const res = await tool_comment_on_post({ author_name: 'Anna', text: 'Great pace!' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.result as { stage: string }).stage).toBe('awaiting_confirmation');
+      expect(res.text).toContain('Great pace!');
+      expect(res.text).toContain('confirmed=true');
+    }
+  });
+
+  it('inserts the comment when confirmed', async () => {
+    (resolvePersonByName as jest.Mock).mockResolvedValue(person('u-9', 'Anna Schmidt'));
+    const insertQ = makeQuery({});
+    const sb = makeSb({
+      profile_posts: [makeQuery({ data: posts })],
+      profile_post_comments: [insertQ],
+    });
+    const res = await tool_comment_on_post(
+      { author_name: 'Anna', text: 'Great pace!', confirmed: true },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/comment is live/i);
+    expect(insertQ.insert).toHaveBeenCalledWith({ post_id: 'p-2', user_id: 'u-1', content: 'Great pace!' });
+  });
+
+  it('requires comment text', async () => {
+    const res = await tool_comment_on_post({ author_name: 'Anna' }, IDENT, makeSb({}));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('text');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_comment_on_post({ author_name: 'Anna', text: 'x' }, ANON as never, makeSb({}));
+    expect(res.ok).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/reminders-clock-tools.test.ts
+++ b/services/gateway/test/orb-tools/reminders-clock-tools.test.ts
@@ -1,0 +1,605 @@
+/**
+ * Reminders lifecycle (VTID-02763) + Clock (VTID-02779) voice tools.
+ *
+ * Mocked SupabaseClient only — no network, no real DB. Each tool gets a
+ * happy path (ok:true + speakable text with real content) and, where the
+ * tool touches user data, the unauthenticated case.
+ */
+
+import {
+  REMINDERS_CLOCK_TOOL_HANDLERS,
+  REMINDERS_CLOCK_TOOL_DECLARATIONS,
+  tool_snooze_reminder,
+  tool_update_reminder,
+  tool_acknowledge_reminder,
+  tool_complete_reminder,
+  tool_list_missed_reminders,
+  tool_set_alarm,
+  tool_list_alarms,
+  tool_delete_alarm,
+  tool_start_timer,
+  tool_start_pomodoro,
+  tool_list_active_timers,
+  tool_get_world_time,
+  computeNextAlarmFire,
+} from '../../src/services/orb-tools/reminders-clock-tools';
+
+const IDENT: any = { user_id: 'u-1', tenant_id: 't-1', role: null, lang: 'en' };
+const ANON: any = { user_id: '', tenant_id: null, role: null };
+
+const TOOL_NAMES = [
+  'snooze_reminder',
+  'update_reminder',
+  'acknowledge_reminder',
+  'complete_reminder',
+  'list_missed_reminders',
+  'set_alarm',
+  'list_alarms',
+  'delete_alarm',
+  'start_timer',
+  'start_pomodoro',
+  'list_active_timers',
+  'get_world_time',
+];
+
+// ---------------------------------------------------------------------------
+// Chainable supabase mock. Every builder method returns the builder; awaiting
+// the builder (or .single()/.maybeSingle()) resolves to the given result.
+// sbWith(...) sequences one builder per .from() call.
+// ---------------------------------------------------------------------------
+
+function chain(result: { data?: unknown; error?: { message: string } | null }) {
+  const resolved = { data: result.data ?? null, error: result.error ?? null };
+  const b: any = {};
+  for (const m of ['select', 'eq', 'in', 'is', 'or', 'ilike', 'order', 'limit', 'update', 'insert']) {
+    b[m] = jest.fn(() => b);
+  }
+  b.maybeSingle = jest.fn(() => Promise.resolve(resolved));
+  b.single = jest.fn(() => Promise.resolve(resolved));
+  b.then = (res: any, rej: any) => Promise.resolve(resolved).then(res, rej);
+  return b;
+}
+
+function sbWith(...chains: any[]) {
+  const from = jest.fn();
+  for (const c of chains) from.mockReturnValueOnce(c);
+  return { from } as any;
+}
+
+function reminderRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'r-1',
+    user_id: 'u-1',
+    tenant_id: 't-1',
+    action_text: 'Take magnesium',
+    spoken_message: 'Time to take your magnesium',
+    description: null,
+    next_fire_at: new Date(Date.now() + 3_600_000).toISOString(),
+    user_tz: 'Europe/Berlin',
+    status: 'pending',
+    delivery_via: null,
+    fired_at: null,
+    acked_at: null,
+    snooze_count: 0,
+    tts_audio_b64: null,
+    tts_voice: null,
+    tts_lang: 'en',
+    calendar_event_id: null,
+    created_via: 'voice',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function clockRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'c-1',
+    tenant_id: 't-1',
+    user_id: 'u-1',
+    kind: 'alarm',
+    label: null,
+    fires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    recurrence: null,
+    duration_seconds: null,
+    status: 'active',
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exports contract
+// ---------------------------------------------------------------------------
+
+describe('exports', () => {
+  it.each(TOOL_NAMES)('%s is in REMINDERS_CLOCK_TOOL_HANDLERS', (name) => {
+    expect(typeof REMINDERS_CLOCK_TOOL_HANDLERS[name]).toBe('function');
+  });
+
+  it.each(TOOL_NAMES)('%s is declared', (name) => {
+    expect(REMINDERS_CLOCK_TOOL_DECLARATIONS.find((d) => d.name === name)).toBeDefined();
+  });
+
+  it('declarations avoid Vertex-fatal OpenAPI keys (default/minimum/maximum/format/examples)', () => {
+    const forbidden = ['default', 'minimum', 'maximum', 'format', 'examples'];
+    const walk = (node: unknown): void => {
+      if (!node || typeof node !== 'object') return;
+      for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+        expect(forbidden).not.toContain(k);
+        walk(v);
+      }
+    };
+    for (const d of REMINDERS_CLOCK_TOOL_DECLARATIONS) walk(d.parameters);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snooze_reminder
+// ---------------------------------------------------------------------------
+
+describe('tool_snooze_reminder', () => {
+  it('snoozes by reminder_id and speaks the new time', async () => {
+    const row = reminderRow({ status: 'fired', snooze_count: 1 });
+    const resolveChain = chain({ data: row });
+    const updateChain = chain({ data: { ...row, snooze_count: 2, status: 'pending' } });
+    const sb = sbWith(resolveChain, updateChain);
+
+    const res = await tool_snooze_reminder({ reminder_id: 'r-1', minutes: 15 }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Take magnesium');
+    expect((res as any).text).toContain('15 minutes');
+    // status machine reset matches the REST snooze route
+    const payload = updateChain.update.mock.calls[0][0];
+    expect(payload.status).toBe('pending');
+    expect(payload.fired_at).toBeNull();
+    expect(payload.acked_at).toBeNull();
+    expect(payload.snooze_count).toBe(2);
+  });
+
+  it('asks to disambiguate when text_query matches several reminders', async () => {
+    const rows = [reminderRow(), reminderRow({ id: 'r-2', action_text: 'Take vitamin D' })];
+    const sb = sbWith(chain({ data: rows }));
+    const res = await tool_snooze_reminder({ text_query: 'take' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('2 matching reminders');
+    expect((res as any).text).toContain('r-1');
+    expect((res as any).text).toContain('Take vitamin D');
+    expect((res as any).text).toContain('reminder_id');
+  });
+
+  it('errors when nothing matches', async () => {
+    const sb = sbWith(chain({ data: [] }));
+    const res = await tool_snooze_reminder({ text_query: 'nope' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('nope');
+  });
+
+  it('requires reminder_id or text_query', async () => {
+    const res = await tool_snooze_reminder({}, IDENT, sbWith());
+    expect(res.ok).toBe(false);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_snooze_reminder({ reminder_id: 'r-1' }, ANON, sbWith());
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('authenticated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update_reminder
+// ---------------------------------------------------------------------------
+
+describe('tool_update_reminder', () => {
+  it('updates text + time, resets delivery state, drops stale TTS', async () => {
+    const row = reminderRow();
+    const newIso = new Date(Date.now() + 7_200_000).toISOString();
+    const updateChain = chain({ data: { ...row, action_text: 'Take zinc', next_fire_at: newIso } });
+    const sb = sbWith(chain({ data: row }), updateChain);
+
+    const res = await tool_update_reminder(
+      { reminder_id: 'r-1', new_text: 'Take zinc', new_time: newIso },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Take zinc');
+    const payload = updateChain.update.mock.calls[0][0];
+    expect(payload.action_text).toBe('Take zinc');
+    expect(payload.spoken_message).toBe('Take zinc');
+    expect(payload.tts_audio_b64).toBeNull();
+    expect(payload.status).toBe('pending');
+    expect(payload.next_fire_at).toBe(newIso);
+  });
+
+  it('rejects a new_time in the past', async () => {
+    const sb = sbWith(chain({ data: reminderRow() }));
+    const res = await tool_update_reminder(
+      { reminder_id: 'r-1', new_time: new Date(Date.now() - 1000).toISOString() },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('60 seconds');
+  });
+
+  it('requires new_text or new_time', async () => {
+    const res = await tool_update_reminder({ reminder_id: 'r-1' }, IDENT, sbWith());
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('new_text');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_update_reminder({ reminder_id: 'r-1', new_text: 'x' }, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// acknowledge_reminder / complete_reminder
+// ---------------------------------------------------------------------------
+
+describe('tool_acknowledge_reminder', () => {
+  it('acks a fired reminder', async () => {
+    const row = reminderRow({ status: 'fired' });
+    const updateChain = chain({ data: { id: 'r-1', acked_at: new Date().toISOString(), delivery_via: 'manual' } });
+    const sb = sbWith(chain({ data: row }), updateChain);
+
+    const res = await tool_acknowledge_reminder({ reminder_id: 'r-1' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Acknowledged');
+    expect((res as any).text).toContain('Take magnesium');
+    expect(updateChain.update.mock.calls[0][0].delivery_via).toBe('manual');
+    expect(updateChain.update.mock.calls[0][0].acked_at).toBeTruthy();
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_acknowledge_reminder({ reminder_id: 'r-1' }, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('tool_complete_reminder', () => {
+  it('marks the reminder completed', async () => {
+    const row = reminderRow({ status: 'fired' });
+    const updateChain = chain({ data: { ...row, status: 'completed' } });
+    const sb = sbWith(chain({ data: row }), updateChain);
+
+    const res = await tool_complete_reminder({ reminder_id: 'r-1' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Take magnesium');
+    expect((res as any).text).toContain('completed');
+    expect(updateChain.update.mock.calls[0][0].status).toBe('completed');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_complete_reminder({ reminder_id: 'r-1' }, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_missed_reminders
+// ---------------------------------------------------------------------------
+
+describe('tool_list_missed_reminders', () => {
+  it('lists fired-but-unacked reminders with their content', async () => {
+    const rows = [
+      reminderRow({ status: 'fired', fired_at: new Date(Date.now() - 3_600_000).toISOString() }),
+      reminderRow({
+        id: 'r-2',
+        action_text: 'Call the doctor',
+        status: 'fired',
+        fired_at: new Date(Date.now() - 7_200_000).toISOString(),
+      }),
+    ];
+    const sb = sbWith(chain({ data: rows }));
+    const res = await tool_list_missed_reminders({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('2 missed reminder(s)');
+    expect((res as any).text).toContain('Take magnesium');
+    expect((res as any).text).toContain('Call the doctor');
+  });
+
+  it('answers plainly when there are none', async () => {
+    const sb = sbWith(chain({ data: [] }));
+    const res = await tool_list_missed_reminders({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('no missed reminders');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_list_missed_reminders({}, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeNextAlarmFire (pure)
+// ---------------------------------------------------------------------------
+
+describe('computeNextAlarmFire', () => {
+  it('returns a future instant whose wall clock in tz matches HH:MM', () => {
+    const out = computeNextAlarmFire('07:30', 'Europe/Berlin', null);
+    expect(out.fires_at).toBeDefined();
+    expect(out.fires_at!.getTime()).toBeGreaterThan(Date.now());
+    const wall = new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'Europe/Berlin',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(out.fires_at!);
+    expect(wall).toBe('07:30');
+    // next occurrence is within 24h
+    expect(out.fires_at!.getTime() - Date.now()).toBeLessThanOrEqual(24 * 3_600_000);
+  });
+
+  it('weekdays recurrence never lands on a weekend', () => {
+    const out = computeNextAlarmFire('06:00', 'Europe/Berlin', 'weekdays');
+    expect(out.fires_at).toBeDefined();
+    const weekday = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'Europe/Berlin',
+      weekday: 'short',
+    }).format(out.fires_at!);
+    expect(['Sat', 'Sun']).not.toContain(weekday);
+  });
+
+  it('accepts a future ISO timestamp as-is', () => {
+    const iso = new Date(Date.now() + 86_400_000).toISOString();
+    const out = computeNextAlarmFire(iso, 'UTC', null);
+    expect(out.fires_at!.toISOString()).toBe(iso);
+  });
+
+  it('rejects garbage and past ISO times', () => {
+    expect(computeNextAlarmFire('25:99', 'UTC', null).error).toBeDefined();
+    expect(computeNextAlarmFire('not a time', 'UTC', null).error).toBeDefined();
+    expect(
+      computeNextAlarmFire(new Date(Date.now() - 60_000).toISOString(), 'UTC', null).error,
+    ).toContain('past');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// set_alarm / list_alarms / delete_alarm
+// ---------------------------------------------------------------------------
+
+describe('tool_set_alarm', () => {
+  it('creates a daily alarm and speaks the local time', async () => {
+    const insertChain = chain({ data: clockRow({ label: 'Gym', recurrence: 'daily' }) });
+    const sb = sbWith(insertChain);
+    const res = await tool_set_alarm(
+      { time: '07:00', label: 'Gym', recurrence: 'daily', timezone: 'Europe/Berlin' },
+      IDENT,
+      sb,
+    );
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Gym');
+    expect((res as any).text).toContain('repeating daily');
+    const payload = insertChain.insert.mock.calls[0][0];
+    expect(payload.kind).toBe('alarm');
+    expect(payload.user_id).toBe('u-1');
+    expect(payload.recurrence).toBe('daily');
+    expect(new Date(payload.fires_at).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('rejects an unsupported recurrence', async () => {
+    const res = await tool_set_alarm({ time: '07:00', recurrence: 'monthly' }, IDENT, sbWith());
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('monthly');
+  });
+
+  it('rejects an invalid timezone', async () => {
+    const res = await tool_set_alarm({ time: '07:00', timezone: 'Mars/Olympus' }, IDENT, sbWith());
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('Mars/Olympus');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_set_alarm({ time: '07:00' }, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('tool_list_alarms', () => {
+  it('lists active alarms speakably', async () => {
+    const rows = [
+      clockRow({ label: 'Gym', recurrence: 'weekdays' }),
+      clockRow({ id: 'c-2', label: null, fires_at: new Date(Date.now() + 7_200_000).toISOString() }),
+    ];
+    const sb = sbWith(chain({ data: rows }));
+    const res = await tool_list_alarms({ timezone: 'Europe/Berlin' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('2 active alarm(s)');
+    expect((res as any).text).toContain('Gym');
+    expect((res as any).text).toContain('weekdays');
+  });
+
+  it('answers plainly when there are none', async () => {
+    const sb = sbWith(chain({ data: [] }));
+    const res = await tool_list_alarms({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('no active alarms');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_list_alarms({}, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('tool_delete_alarm', () => {
+  it('asks for confirmation before deleting', async () => {
+    const sb = sbWith(chain({ data: [clockRow({ label: 'Gym' })] }));
+    const res = await tool_delete_alarm({ label: 'gym' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).result.needs_confirmation).toBe(true);
+    expect((res as any).text).toContain('Gym');
+    expect((res as any).text).toContain('confirm=true');
+    expect((res as any).text).toContain('c-1');
+  });
+
+  it('cancels after confirm=true', async () => {
+    const listChain = chain({ data: [clockRow({ label: 'Gym' })] });
+    const cancelChain = chain({ data: { id: 'c-1' } });
+    const sb = sbWith(listChain, cancelChain);
+    const res = await tool_delete_alarm({ alarm_id: 'c-1', confirm: true }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Deleted the alarm');
+    expect(cancelChain.update.mock.calls[0][0].status).toBe('cancelled');
+  });
+
+  it('asks to disambiguate when several alarms match', async () => {
+    const sb = sbWith(
+      chain({ data: [clockRow({ label: 'Gym' }), clockRow({ id: 'c-2', label: 'Gym session' })] }),
+    );
+    const res = await tool_delete_alarm({ label: 'gym' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('2 matching alarms');
+  });
+
+  it('errors when nothing matches', async () => {
+    const sb = sbWith(chain({ data: [] }));
+    const res = await tool_delete_alarm({ label: 'nope' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_delete_alarm({ alarm_id: 'c-1' }, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// start_timer / start_pomodoro / list_active_timers
+// ---------------------------------------------------------------------------
+
+describe('tool_start_timer', () => {
+  it('starts a countdown with label', async () => {
+    const insertChain = chain({
+      data: clockRow({ kind: 'timer', label: 'Pasta', duration_seconds: 600 }),
+    });
+    const sb = sbWith(insertChain);
+    const res = await tool_start_timer({ duration_minutes: 10, label: 'Pasta' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('10 minutes');
+    expect((res as any).text).toContain('Pasta');
+    const payload = insertChain.insert.mock.calls[0][0];
+    expect(payload.kind).toBe('timer');
+    expect(payload.duration_seconds).toBe(600);
+  });
+
+  it('rejects out-of-range durations', async () => {
+    expect((await tool_start_timer({ duration_minutes: 0 }, IDENT, sbWith())).ok).toBe(false);
+    expect((await tool_start_timer({ duration_minutes: 2000 }, IDENT, sbWith())).ok).toBe(false);
+    expect((await tool_start_timer({}, IDENT, sbWith())).ok).toBe(false);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_start_timer({ duration_minutes: 10 }, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('tool_start_pomodoro', () => {
+  it('defaults to 25 minutes', async () => {
+    const insertChain = chain({
+      data: clockRow({ kind: 'pomodoro', duration_seconds: 1500 }),
+    });
+    const sb = sbWith(insertChain);
+    const res = await tool_start_pomodoro({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('25 minutes');
+    const payload = insertChain.insert.mock.calls[0][0];
+    expect(payload.kind).toBe('pomodoro');
+    expect(payload.duration_seconds).toBe(1500);
+  });
+
+  it('rejects durations outside 5-90', async () => {
+    expect((await tool_start_pomodoro({ duration_minutes: 3 }, IDENT, sbWith())).ok).toBe(false);
+    expect((await tool_start_pomodoro({ duration_minutes: 120 }, IDENT, sbWith())).ok).toBe(false);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_start_pomodoro({}, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('tool_list_active_timers', () => {
+  it('speaks remaining time per timer/pomodoro', async () => {
+    const rows = [
+      clockRow({
+        kind: 'pomodoro',
+        label: 'Deep work',
+        fires_at: new Date(Date.now() + 18 * 60_000).toISOString(),
+      }),
+      clockRow({
+        id: 'c-2',
+        kind: 'timer',
+        label: 'Tea',
+        fires_at: new Date(Date.now() + 2 * 60_000 + 500).toISOString(),
+      }),
+    ];
+    const sb = sbWith(chain({ data: rows }));
+    const res = await tool_list_active_timers({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('Pomodoro "Deep work"');
+    expect((res as any).text).toContain('Timer "Tea"');
+    expect((res as any).text).toContain('18 minutes remaining');
+  });
+
+  it('marks overdue items as finished', async () => {
+    const rows = [
+      clockRow({ kind: 'timer', label: 'Tea', fires_at: new Date(Date.now() - 60_000).toISOString() }),
+    ];
+    const sb = sbWith(chain({ data: rows }));
+    const res = await tool_list_active_timers({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('finished');
+  });
+
+  it('answers plainly when nothing is running', async () => {
+    const sb = sbWith(chain({ data: [] }));
+    const res = await tool_list_active_timers({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect((res as any).text).toContain('no running timers');
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_list_active_timers({}, ANON, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_world_time
+// ---------------------------------------------------------------------------
+
+describe('tool_get_world_time', () => {
+  it('maps a known city (case/diacritic insensitive) to its IANA zone', async () => {
+    const res = await tool_get_world_time({ location: 'Berlin' }, IDENT, sbWith());
+    expect(res.ok).toBe(true);
+    expect((res as any).result.timezone).toBe('Europe/Berlin');
+    expect((res as any).text).toContain('Berlin');
+    expect((res as any).text).toMatch(/\d/); // contains an actual time
+  });
+
+  it('accepts a raw IANA timezone', async () => {
+    const res = await tool_get_world_time({ location: 'Europe/Belgrade' }, IDENT, sbWith());
+    expect(res.ok).toBe(true);
+    expect((res as any).result.timezone).toBe('Europe/Belgrade');
+  });
+
+  it('gives a helpful error for unknown input', async () => {
+    const res = await tool_get_world_time({ location: 'Atlantis' }, IDENT, sbWith());
+    expect(res.ok).toBe(false);
+    expect((res as any).error).toContain('Atlantis');
+    expect((res as any).error).toContain('Europe/Berlin');
+  });
+
+  it('requires a location', async () => {
+    const res = await tool_get_world_time({}, IDENT, sbWith());
+    expect(res.ok).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/superlatives-tools.test.ts
+++ b/services/gateway/test/orb-tools/superlatives-tools.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Superlatives voice tools (VTID-02754) — unit tests.
+ *
+ * The handlers adapt the existing VTID-02754 service layer
+ * (services/voice-tools/superlatives.ts + community-member-ranker.ts) into
+ * speakable OrbToolResults, so both service modules are mocked here — the
+ * service logic itself is covered by test/community-member-ranker.test.ts.
+ *
+ * Covered per tool: happy path (ok:true + speakable text with the person's
+ * name and metric value), unauthenticated gate, empty-community soft state,
+ * and the ask_who_is routing/fallback paths.
+ */
+
+jest.mock('../../src/services/voice-tools/superlatives', () => ({
+  getHighestVitanaIndex: jest.fn(),
+  getTopInPillar: jest.fn(),
+  getMemberByRegistration: jest.fn(),
+  getMostFollowed: jest.fn(),
+  askWhoIs: jest.fn(),
+}));
+jest.mock('../../src/services/voice-tools/community-member-ranker', () => ({
+  findCommunityMember: jest.fn(),
+}));
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  getHighestVitanaIndex,
+  getTopInPillar,
+  getMemberByRegistration,
+  getMostFollowed,
+  askWhoIs,
+} from '../../src/services/voice-tools/superlatives';
+import { findCommunityMember } from '../../src/services/voice-tools/community-member-ranker';
+import {
+  SUPERLATIVES_TOOL_HANDLERS,
+  SUPERLATIVES_TOOL_DECLARATIONS,
+  tool_get_highest_vitana_index,
+  tool_get_top_in_pillar,
+  tool_get_first_member,
+  tool_get_newest_member,
+  tool_get_most_followed,
+  tool_ask_who_is,
+} from '../../src/services/orb-tools/superlatives-tools';
+
+const sb = {} as unknown as SupabaseClient;
+const IDENT = { user_id: 'u-1', tenant_id: 't-1', role: 'community' };
+const ANON = { user_id: '', tenant_id: null, role: null };
+
+const profile = (name: string, overrides: Record<string, unknown> = {}) => ({
+  vitana_id: '@' + name.toLowerCase().replace(/\s+/g, ''),
+  display_name: name,
+  avatar_url: null,
+  location: null,
+  registration_seq: 1,
+  member_since: '2025-03-10T00:00:00.000Z',
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Exports / registry shape
+// ---------------------------------------------------------------------------
+
+describe('superlatives tools — exports', () => {
+  const NAMES = [
+    'get_highest_vitana_index',
+    'get_top_in_pillar',
+    'get_first_member',
+    'get_newest_member',
+    'get_most_followed',
+    'ask_who_is',
+  ];
+
+  it.each(NAMES)('%s is in SUPERLATIVES_TOOL_HANDLERS', (name) => {
+    expect(typeof SUPERLATIVES_TOOL_HANDLERS[name]).toBe('function');
+  });
+
+  it.each(NAMES)('%s is declared in SUPERLATIVES_TOOL_DECLARATIONS', (name) => {
+    expect(SUPERLATIVES_TOOL_DECLARATIONS.find((d) => d.name === name)).toBeDefined();
+  });
+
+  it('declarations use only the Vertex-safe OpenAPI subset (no default/minimum/maximum/format)', () => {
+    const raw = JSON.stringify(SUPERLATIVES_TOOL_DECLARATIONS.map((d) => d.parameters));
+    for (const banned of ['"default"', '"minimum"', '"maximum"', '"format"', '"examples"']) {
+      expect(raw).not.toContain(banned);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_highest_vitana_index
+// ---------------------------------------------------------------------------
+
+describe('get_highest_vitana_index', () => {
+  it('speaks the top scorer name and score', async () => {
+    (getHighestVitanaIndex as jest.Mock).mockResolvedValue({
+      ok: true,
+      metric: 'vitana_index_total',
+      metric_value: 871,
+      metric_unit: 'points',
+      profile: profile('Mariia Maksina'),
+      total_eligible: 12,
+    });
+    const res = await tool_get_highest_vitana_index({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Mariia Maksina');
+      expect(res.text).toContain('871');
+      expect(res.text).toContain('Vitana Index');
+      expect((res.result as any).vitana_id).toBe('@mariiamaksina');
+    }
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_get_highest_vitana_index({}, ANON as any, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+    expect(getHighestVitanaIndex).not.toHaveBeenCalled();
+  });
+
+  it('empty leaderboard stays ok:true with an honest line', async () => {
+    (getHighestVitanaIndex as jest.Mock).mockResolvedValue({ ok: false, error: 'no_eligible_candidates' });
+    const res = await tool_get_highest_vitana_index({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/no community member/i);
+  });
+
+  it('never throws — service exception becomes ok:false', async () => {
+    (getHighestVitanaIndex as jest.Mock).mockRejectedValue(new Error('boom'));
+    const res = await tool_get_highest_vitana_index({}, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('boom');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_top_in_pillar
+// ---------------------------------------------------------------------------
+
+describe('get_top_in_pillar', () => {
+  it('speaks the pillar leader with score', async () => {
+    (getTopInPillar as jest.Mock).mockResolvedValue({
+      ok: true,
+      metric: 'pillar_sleep',
+      metric_value: 93,
+      metric_unit: 'points',
+      profile: profile('Patrick Weber'),
+      total_eligible: 8,
+    });
+    const res = await tool_get_top_in_pillar({ pillar: 'sleep' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Patrick Weber');
+      expect(res.text).toContain('sleep');
+      expect(res.text).toContain('93');
+    }
+    expect(getTopInPillar).toHaveBeenCalledWith(sb, 'sleep', 1);
+  });
+
+  it('maps a German spoken synonym ("Schlaf") to the canonical pillar', async () => {
+    (getTopInPillar as jest.Mock).mockResolvedValue({
+      ok: true,
+      metric: 'pillar_sleep',
+      metric_value: 90,
+      profile: profile('Patrick Weber'),
+      total_eligible: 8,
+    });
+    const res = await tool_get_top_in_pillar({ pillar: 'Schlaf' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect(getTopInPillar).toHaveBeenCalledWith(sb, 'sleep', 1);
+  });
+
+  it('rejects an unknown pillar without calling the service', async () => {
+    const res = await tool_get_top_in_pillar({ pillar: 'charisma' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('nutrition');
+    expect(getTopInPillar).not.toHaveBeenCalled();
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_get_top_in_pillar({ pillar: 'sleep' }, ANON as any, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_first_member / get_newest_member
+// ---------------------------------------------------------------------------
+
+describe('get_first_member', () => {
+  it('speaks the OG member with member-since phrasing', async () => {
+    (getMemberByRegistration as jest.Mock).mockResolvedValue({
+      ok: true,
+      metric: 'first_member_registered',
+      metric_value: 1,
+      profile: profile('Dragan Alexander', { member_since: '2025-03-10T00:00:00.000Z' }),
+      total_eligible: 40,
+    });
+    const res = await tool_get_first_member({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Dragan Alexander');
+      expect(res.text).toMatch(/first member/i);
+      expect(res.text).toContain('March 2025');
+    }
+    expect(getMemberByRegistration).toHaveBeenCalledWith(sb, 'first', 1);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_get_first_member({}, ANON as any, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('get_newest_member', () => {
+  it('speaks the newest member with a relative joined phrase', async () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    (getMemberByRegistration as jest.Mock).mockResolvedValue({
+      ok: true,
+      metric: 'newest_member_registered',
+      metric_value: 40,
+      profile: profile('Nina Novak', { member_since: threeDaysAgo }),
+      total_eligible: 40,
+    });
+    const res = await tool_get_newest_member({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Nina Novak');
+      expect(res.text).toMatch(/newest/i);
+      expect(res.text).toContain('3 days ago');
+    }
+    expect(getMemberByRegistration).toHaveBeenCalledWith(sb, 'newest', 1);
+  });
+
+  it('empty community stays ok:true', async () => {
+    (getMemberByRegistration as jest.Mock).mockResolvedValue({ ok: false, error: 'no_eligible_candidates' });
+    const res = await tool_get_newest_member({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/no visible community members/i);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_get_newest_member({}, ANON as any, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_most_followed
+// ---------------------------------------------------------------------------
+
+describe('get_most_followed', () => {
+  it('speaks the most followed member with follower count', async () => {
+    (getMostFollowed as jest.Mock).mockResolvedValue({
+      ok: true,
+      metric: 'follower_count',
+      metric_value: 27,
+      metric_unit: 'followers',
+      profile: profile('Mariia Maksina'),
+      total_eligible: 15,
+    });
+    const res = await tool_get_most_followed({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Mariia Maksina');
+      expect(res.text).toContain('27 followers');
+    }
+  });
+
+  it('singular follower phrasing', async () => {
+    (getMostFollowed as jest.Mock).mockResolvedValue({
+      ok: true,
+      metric: 'follower_count',
+      metric_value: 1,
+      profile: profile('Nina Novak'),
+      total_eligible: 2,
+    });
+    const res = await tool_get_most_followed({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('1 follower');
+  });
+
+  it('no followers data stays ok:true with an honest line', async () => {
+    (getMostFollowed as jest.Mock).mockResolvedValue({ ok: false, error: 'no_followers_data: relation missing' });
+    const res = await tool_get_most_followed({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toMatch(/followers/i);
+  });
+
+  it('requires an authenticated user', async () => {
+    const res = await tool_get_most_followed({}, ANON as any, sb);
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ask_who_is
+// ---------------------------------------------------------------------------
+
+describe('ask_who_is', () => {
+  it('routes to a superlative and speaks its answer', async () => {
+    (askWhoIs as jest.Mock).mockResolvedValue({
+      ok: true,
+      metric: 'pillar_exercise',
+      metric_value: 88,
+      profile: profile('Patrick Weber'),
+      total_eligible: 9,
+    });
+    const res = await tool_ask_who_is({ query: 'who is the fittest?' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Patrick Weber');
+      expect(res.text).toContain('exercise');
+      expect((res.result as any).routed_to).toBe('pillar_exercise');
+    }
+    expect(findCommunityMember).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the find_community_member ranking on clarify', async () => {
+    (askWhoIs as jest.Mock).mockResolvedValue({ ok: 'clarify', question: 'Which metric do you mean?' });
+    (findCommunityMember as jest.Mock).mockResolvedValue({
+      tier: 3,
+      lane: 'motivation',
+      winnerUserId: 'u-9',
+      result: {
+        ok: true,
+        vitana_id: '@ninanovak',
+        display_name: 'Nina Novak',
+        voice_summary: 'Nina Novak is on the most inspiring trajectory we can see right now. Opening their profile.',
+        match_recipe: { interpreted_intent: 'x', tier: 3, lane: 'motivation', ethics_reroute: false, signals_considered: [] },
+        redirect: { screen: 'profile_with_match', route: '/u/@ninanovak' },
+      },
+    });
+    const res = await tool_ask_who_is({ query: 'who is the most inspiring?' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.text).toContain('Nina Novak');
+      expect((res.result as any).routed_to).toBe('find_community_member');
+    }
+    expect(findCommunityMember).toHaveBeenCalledWith(sb, expect.objectContaining({
+      viewer_user_id: 'u-1',
+      viewer_tenant_id: 't-1',
+      query: 'who is the most inspiring?',
+    }));
+  });
+
+  it('speaks the clarify question when the ranker fallback also fails', async () => {
+    (askWhoIs as jest.Mock).mockResolvedValue({ ok: 'clarify', question: 'Which metric do you mean?' });
+    (findCommunityMember as jest.Mock).mockRejectedValue(new Error('db down'));
+    const res = await tool_ask_who_is({ query: 'who is the best?' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toBe('Which metric do you mean?');
+  });
+
+  it('errors when both router and fallback fail with no clarify text', async () => {
+    (askWhoIs as jest.Mock).mockResolvedValue({ ok: false, error: 'index_query_failed: x' });
+    (findCommunityMember as jest.Mock).mockRejectedValue(new Error('db down'));
+    const res = await tool_ask_who_is({ query: 'who is the healthiest?' }, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('db down');
+  });
+
+  it('accepts question as an alias arg for query', async () => {
+    (askWhoIs as jest.Mock).mockResolvedValue({
+      ok: true,
+      metric: 'follower_count',
+      metric_value: 5,
+      profile: profile('Mariia Maksina'),
+      total_eligible: 3,
+    });
+    const res = await tool_ask_who_is({ question: 'who is the most popular?' }, IDENT, sb);
+    expect(res.ok).toBe(true);
+    expect(askWhoIs).toHaveBeenCalledWith(sb, { question: 'who is the most popular?' });
+  });
+
+  it('requires a non-empty query', async () => {
+    const res = await tool_ask_who_is({}, IDENT, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('query');
+  });
+
+  it('requires an authenticated user with tenant', async () => {
+    const res = await tool_ask_who_is({ query: 'who is the fittest?' }, { user_id: 'u-1', tenant_id: null, role: null } as any, sb);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('authenticated');
+  });
+});

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -1695,7 +1695,659 @@ overlay UI listens for this directive and fades out the chime.
 Call this when the user says any kind of "I'm done" / "nein
 danke" / "enough" — interpret IN CONTEXT, not by keyword match.
 If the user is ambiguous, ask a clarifying question first; only
-call this when you are confident the session should end."
+call this when you are confident the session should end.
+
+### get_highest_vitana_index
+Get the community member with the highest Vitana Index right now.
+Returns their name and score; private profiles are never revealed.
+CALL WHEN the user asks: "who has the highest Vitana Index?",
+"who is the healthiest member?", "wer hat den höchsten Vitana Index?",
+"wer ist am gesündesten?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### get_top_in_pillar
+Get the community member with the top score in ONE Vitana Index pillar.
+pillar must be one of: nutrition, hydration, exercise, sleep, mental.
+CALL WHEN the user asks: "who has the best sleep?", "who is the
+fittest?", "wer schläft am besten?", "wer ist am fittesten?",
+"wer trinkt am meisten Wasser?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### get_first_member
+Get the very first (earliest-registered / OG) community member.
+CALL WHEN the user asks: "who was the first member?", "who is the
+longest-standing / OG member?", "wer war das erste Mitglied?",
+"wer ist am längsten dabei?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### get_newest_member
+Get the most recently joined community member.
+CALL WHEN the user asks: "who is the newest member?", "who just
+joined?", "wer ist das neueste Mitglied?", "wer ist gerade beigetreten?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### get_most_followed
+Get the community member with the most followers.
+CALL WHEN the user asks: "who has the most followers?", "who is the
+most popular member?", "wer hat die meisten Follower?", "wer ist am
+beliebtesten?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### ask_who_is
+Answer ANY free-form "who is...?" superlative question about the
+community that the specific superlative tools above do not cover.
+Routes to the matching leaderboard (index, pillar, tenure, followers)
+or falls back to the general community-member ranking.
+CALL WHEN the user asks e.g.: "who is the most inspiring?", "who is
+the best runner?", "wer ist der/die inspirierendste?", "wer ist am
+aktivsten?". Pass the user's question verbatim as query.
+After the tool runs, read the returned text aloud, then stop.
+
+### list_diary_entries
+List the user's Daily Diary entries, newest first, optionally within a date window.
+CALL THIS WHEN the user says:
+  - "What did I write in my diary?" / "Was steht in meinem Tagebuch?"
+  - "Show my diary entries from last week" / "Zeig meine Tagebucheinträge"
+  - "What did I log yesterday?" / "Was habe ich gestern eingetragen?"
+Then summarize the entries naturally — do not read them verbatim or mention IDs.
+
+### get_diary_streak
+Get the user's diary streak: current consecutive days with an entry plus their longest streak ever.
+CALL THIS WHEN the user asks:
+  - "What's my diary streak?" / "Wie lang ist meine Tagebuch-Serie?"
+  - "How many days in a row have I journaled?" / "Wie viele Tage am Stück?"
+Then celebrate an active streak, or encourage a restart if it broke.
+
+### get_memory_timeline
+Chronological timeline of what Vitana remembers: memory items, extracted facts, and diary entries, newest first.
+CALL THIS WHEN the user asks:
+  - "What happened last month?" / "Was ist letzten Monat passiert?"
+  - "Show my memory timeline" / "Zeig meine Erinnerungs-Zeitleiste"
+  - "What did we talk about in June?" / "Worüber haben wir im Juni gesprochen?"
+Then retell the timeline as a short narrative in the user's language.
+
+### recall_memory_about
+Search stored memories and facts about ONE specific topic, person, or thing.
+CALL THIS WHEN the user asks:
+  - "What do you know about my sister?" / "Was weißt du über meine Schwester?"
+  - "Do you remember my trip to Rome?" / "Erinnerst du dich an meine Rom-Reise?"
+  - "What did I tell you about my project?" / "Was habe ich dir über mein Projekt erzählt?"
+Answer ONLY from the returned content — never invent memories. If empty, say so and offer to remember it now.
+Optional category filter: personal_identity, health_wellness, lifestyle_routines, network_relationships,
+learning_knowledge, business_projects, finance_assets, location_environment, digital_footprint,
+values_aspirations, autopilot_context, future_plans, uncategorized.
+
+### get_memory_garden_summary
+Overview of the user's Memory Garden: how many memories are stored per category.
+CALL THIS WHEN the user asks:
+  - "What do you remember about me?" / "Was weißt du alles über mich?"
+  - "How full is my Memory Garden?" / "Wie sieht mein Memory Garden aus?"
+  - "What kind of things have you saved?" / "Was hast du über mich gespeichert?"
+Then summarize warmly: total memories and the biggest categories first.
+For details on a specific topic, use recall_memory_about instead.
+
+### forget_memory
+Permanently delete ONE stored memory, only after the user explicitly confirms.
+CALL THIS WHEN the user says:
+  - "Forget that" / "Vergiss das" / "Lösch diese Erinnerung"
+  - "Delete what you saved about X" / "Lösch, was du über X gespeichert hast"
+Flow: find the memory_id via recall_memory_about, call WITHOUT confirm first —
+the tool returns the memory text; read it back and ask the user to confirm.
+Only when they clearly say yes, call again with confirm=true. Deletion is permanent.
+
+### reschedule_event
+Move an existing calendar event to a new start time (duration is kept unless new_end is given).
+WHEN TO CALL: "move my yoga to 6 pm", "reschedule my doctor appointment to Friday",
+"Verschieb mein Meeting auf morgen 10 Uhr", "Kannst du das Training auf Freitag legen?".
+Identify the event by event_id (preferred) or title_query (fuzzy title match).
+If multiple events match, the result lists candidates — ask the user which one, then call again with event_id.
+After success, confirm the new day and time back to the user.
+
+### cancel_event
+Cancel (soft-delete) a calendar event — the event stays in history with status "cancelled".
+WHEN TO CALL: "cancel my yoga class", "delete the dentist appointment",
+"Sag das Meeting morgen ab", "Lösch den Termin am Freitag".
+Destructive: first call WITHOUT confirm to fetch the event, ask the user to confirm,
+then call again with confirm=true and the event_id. Speak the cancelled title back.
+
+### complete_event
+Mark a calendar event as completed, skipped, or partially done.
+WHEN TO CALL: "I finished my workout", "mark the meditation as done", "I skipped my run today",
+"Ich habe das Training gemacht", "Hab die Meditation ausgelassen".
+outcome must be one of: completed, skipped, partial (default completed).
+After success, acknowledge briefly — completed health events feed the Vitana Index.
+
+### find_free_slot
+Find the next free slot of a given length in the user's calendar, within waking hours (8 AM-10 PM user-local).
+WHEN TO CALL: "when am I free for an hour?", "find me 30 minutes tomorrow",
+"Wann habe ich morgen Zeit?", "Finde mir eine freie Stunde diese Woche".
+duration_minutes is required (5-720). search_from/search_to are ISO 8601; default is the next 7 days.
+Pass the user's IANA timezone so waking hours and spoken times are local.
+Speak the found day + time back, or say nothing was free and offer to look further out.
+
+### get_event_details
+Read the full details of ONE calendar event: exact time, end, location, type, status, notes.
+WHEN TO CALL: "when exactly is my dentist appointment?", "where is the meetup?",
+"Wann genau ist mein Zahnarzttermin?", "Wo findet das Treffen statt?".
+Identify by event_id or title_query (fuzzy). If several match, the result lists candidates — ask which one.
+Speak the concrete details (day, time, place); never a raw data dump.
+
+### check_calendar_conflicts
+Check whether a proposed time window overlaps existing confirmed calendar events.
+WHEN TO CALL: before creating or rescheduling an event, or when the user asks
+"does 3 pm work on Friday?", "Passt Dienstag 10 Uhr?", "Habe ich da schon etwas?".
+start_time is required (ISO 8601); end_time defaults to one hour after start_time.
+If there are conflicts, name the overlapping events and suggest checking another time.
+
+### snooze_reminder
+Push an existing reminder out by N minutes (default 10, max 1440).
+CALL WHEN the user says 'snooze it', 'remind me again in 15 minutes',
+'verschieb die Erinnerung', 'erinnere mich später nochmal'.
+Pass reminder_id when known (e.g. a reminder just fired), otherwise
+text_query with words from the reminder. If the tool reports multiple
+matches, ask the user which one and call again with that reminder_id.
+After success, speak the confirmation with the new time from \`text\`.
+
+### update_reminder
+Edit an existing reminder's text and/or time.
+CALL WHEN the user says 'change my reminder to 9pm', 'make it say X',
+'ändere meine Erinnerung', 'verschiebe die Erinnerung auf 21 Uhr'.
+Identify via reminder_id or text_query. new_time is an absolute UTC ISO
+timestamp YOU compute from their words + timezone (min 60s in future).
+If multiple reminders match, ask which one, then call again with the id.
+After success, confirm the change using \`text\`.
+
+### acknowledge_reminder
+Mark a fired reminder as heard/acknowledged so it stops being re-delivered.
+CALL WHEN the user says 'got it', 'okay, I heard the reminder', 'dismiss it',
+'alles klar, habs gehört' after a reminder fired — but the task is NOT done yet.
+Use complete_reminder instead when the user actually DID the thing.
+Identify via reminder_id (preferred, e.g. from the fire event) or text_query.
+
+### complete_reminder
+Mark a reminder as DONE (the user did the thing). Sets status=completed.
+CALL WHEN the user says 'done', 'I took my magnesium, check it off',
+'erledigt', 'hab ich gemacht' about a reminder.
+Identify via reminder_id or text_query. If multiple match, ask which one.
+After success, give a short positive confirmation from \`text\`.
+
+### list_missed_reminders
+List reminders that fired but were never acknowledged (the user missed them).
+CALL WHEN the user asks 'did I miss anything?', 'what reminders did I miss?',
+'habe ich Erinnerungen verpasst?', or at the start of a session catch-up.
+Speak each missed reminder with its text and when it fired, then offer to
+snooze, complete, or acknowledge them.
+
+### set_alarm
+Set a wake-up/clock alarm at a specific time of day (optionally recurring).
+CALL WHEN the user says 'wake me at 7', 'set an alarm for 6:30 on weekdays',
+'stell einen Wecker auf 7 Uhr', 'weck mich um halb sieben'.
+time is 'HH:MM' (24h, interpreted in the given timezone — next occurrence)
+or an absolute ISO timestamp. ALWAYS pass the user timezone from context;
+UTC is assumed when omitted. recurrence: daily, weekdays, or omit for once.
+Prefer alarms for time-of-day wake-ups; use set_reminder for task reminders.
+After success, confirm with the day + time from \`text\`.
+
+### list_alarms
+List the user's active alarms with times and labels.
+CALL WHEN the user asks 'what alarms do I have?', 'when is my alarm?',
+'welche Wecker habe ich?', or before deleting/changing an alarm.
+Pass timezone so times are spoken in local wall-clock time.
+
+### delete_alarm
+Cancel an alarm. Two-step confirm flow: first call WITHOUT confirm to find
+the alarm (by alarm_id, label, or HH:MM time) — the tool answers with the
+match and asks you to confirm with the user. After the user explicitly says
+yes, call again with that alarm_id and confirm=true.
+CALL WHEN the user says 'delete my alarm', 'cancel the 7am alarm',
+'lösch den Wecker', 'Wecker ausschalten'.
+
+### start_timer
+Start a countdown timer (1-1440 minutes).
+CALL WHEN the user says 'set a timer for 10 minutes', 'timer for the pasta',
+'stell einen Timer auf 10 Minuten', 'Countdown 20 Minuten'.
+For focused work blocks prefer start_pomodoro. After success, confirm the
+duration and label from \`text\`.
+
+### start_pomodoro
+Start a pomodoro focus block (5-90 minutes; 25 if omitted).
+CALL WHEN the user says 'start a pomodoro', 'let's do a focus session',
+'starte eine Pomodoro-Einheit', '45 Minuten Fokuszeit'.
+After success, confirm the length and encourage focused work.
+
+### list_active_timers
+List running timers and pomodoros with the remaining time on each.
+CALL WHEN the user asks 'how much time is left?', 'is my timer still running?',
+'wie lange läuft mein Timer noch?', 'wie viel Zeit habe ich noch?'.
+Speak each entry with its label and remaining time from \`text\`.
+
+### get_world_time
+Get the current local time in a city or IANA timezone (no internet needed).
+CALL WHEN the user asks 'what time is it in Tokyo?', 'wie spät ist es in
+Belgrad?', 'what's the time in New York right now?'.
+location accepts a major city name (Berlin, Belgrade, London, New York,
+Tokyo, ...) or any IANA zone like 'Europe/Berlin'. Speak the \`text\` answer.
+
+### list_my_groups
+List the community groups the user belongs to, with member counts.
+CALL WHEN the user asks: "what groups am I in?", "show my groups",
+"in welchen Gruppen bin ich?", "zeig mir meine Gruppen".
+After the tool runs, read the group names and member counts aloud.
+
+### create_group
+Create a new community group. Requires a name; privacy is public or
+private (default public). ALWAYS call once WITHOUT confirm first —
+the tool returns a confirmation question; after the user says yes,
+call again with confirm:true.
+CALL WHEN the user says: "create a group called ...", "start a new
+group", "erstelle eine Gruppe ...", "gründe eine neue Gruppe".
+
+### join_group
+Join a community group by name or group_id. Resolves fuzzy names and
+lists candidates when several match. Private groups cannot be self-joined.
+CALL WHEN the user says: "join the sleep group", "I want to join ...",
+"tritt der Gruppe ... bei", "ich möchte der Gruppe beitreten".
+After joining, tell the user they are in and the app is opening the group.
+
+### invite_to_group
+Invite another community member to a group. Resolves the member by
+spoken name and the group by name; the member gets a notification.
+CALL WHEN the user says: "invite Anna to my walking group",
+"lade Anna in die Gruppe ... ein".
+If the tool lists several member or group candidates, ask which one.
+
+### accept_invitation
+Accept a pending group invitation (joins the group). With no
+invitation_id it lists the pending invitations, or acts when only one.
+CALL WHEN the user says: "accept the invitation", "yes, join that group",
+"nimm die Einladung an", "Einladung annehmen".
+
+### decline_invitation
+Decline a pending group invitation. ALWAYS call once WITHOUT confirm
+first — the tool returns a confirmation question; after the user says
+yes, call again with the invitation_id and confirm:true.
+CALL WHEN the user says: "decline the invitation", "no thanks, decline
+it", "lehne die Einladung ab", "Einladung ablehnen".
+
+### rsvp_event
+RSVP / sign the user up for a community event or meetup, by event_id
+or fuzzy title. Checks capacity and existing signup first.
+CALL WHEN the user says: "sign me up for ...", "RSVP to the yoga
+meetup", "melde mich für ... an", "ich will beim Event ... dabei sein".
+If several events match, read the candidates and ask which one.
+
+### cancel_rsvp
+Cancel the user's RSVP for an upcoming event. ALWAYS call once
+WITHOUT confirm first — the tool returns a confirmation question;
+after the user says yes, call again with the event_id and confirm:true.
+CALL WHEN the user says: "cancel my RSVP", "I can't make it to ...",
+"melde mich vom Event ... ab", "storniere meine Anmeldung".
+
+### list_upcoming_meetups
+List upcoming community meetups/events the user could attend, soonest
+first; events in the user's home city are flagged "near you" and
+events they already RSVP'd are marked.
+CALL WHEN the user asks: "what meetups are coming up?", "any events
+this week?", "welche Meetups stehen an?", "gibt es bald Events?".
+Read the titles with dates aloud, then offer to sign them up.
+
+### join_live_room
+Join/open a community live room by name or room_id. Returns a
+navigation directive that opens the room screen — the app navigates
+automatically; do not describe the navigation mechanics.
+CALL WHEN the user says: "join the live room", "take me into the ...
+room", "bring mich in den Live-Raum", "öffne den Live-Raum ...".
+If several rooms match, read the candidates and ask which one.
+
+### start_conversation
+Start (or reuse) a direct-message conversation with a named community member,
+optionally sending the first message in the same call.
+WHEN: "start a chat with Maria", "message Alex for the first time",
+"schreib Maria an", "starte eine Unterhaltung mit Alex".
+Pass member (spoken name or Vitana ID) or member_user_id (UUID from resolve_recipient).
+With message set, it sends immediately via the canonical send path.
+Without message, it resolves the member, says whether a conversation already
+exists, and returns recipient_user_id — read back the name, ask what to say,
+then send with send_chat_message or call this again with message set.
+
+### list_conversations
+List the user's recent direct-message conversations, newest first, with
+who wrote last and a short snippet.
+WHEN: "show my conversations", "who have I been chatting with?",
+"zeig meine Chats", "mit wem habe ich geschrieben?".
+These are internal Maxina messages — no Google account involved.
+Speak the names and snippets naturally; to continue one, use send_chat_message.
+
+### mark_conversation_read
+Mark direct messages as read. With member set, marks that conversation;
+without it (or with all=true), marks ALL unread messages.
+WHEN: "mark my chat with Maria as read", "mark everything read",
+"markiere den Chat mit Maria als gelesen", "alles als gelesen markieren".
+Afterwards, confirm how many messages were marked.
+
+### mute_conversation
+Mute a chat conversation. NOTE: chat muting is not supported in Vitana yet —
+this tool answers honestly and suggests block_user as the stronger alternative.
+WHEN: "mute this chat", "mute Maria", "schalte den Chat stumm".
+Relay the returned text plainly; never claim the chat was muted.
+
+### archive_conversation
+Archive a chat conversation. NOTE: chat archiving does not exist in Vitana —
+this tool answers honestly. Never invent or offer "archived messages".
+WHEN: "archive this chat", "archiviere den Chat mit Maria".
+Relay the returned text plainly; suggest mark_conversation_read or block_user instead.
+
+### update_account_visibility
+Set the visibility of the user's WHOLE profile: public, followers_only, or private.
+Writes every per-field visibility setting at once (partner-search posts stay private).
+WHEN: "make my profile private", "set my account to public",
+"mach mein Profil privat", "stell mein Konto auf öffentlich".
+Two-step: first call returns a confirmation request — read it back, get an
+explicit yes, then call again with confirm=true. Then confirm the change out loud.
+
+### update_privacy_field
+Set the visibility of ONE profile field: public, followers_only, or private.
+Fields: age, birthday, location (city), country, address, email, phone, gender,
+first/last name, marital status, dance/partner preferences, service offerings, posts.
+WHEN: "hide my age", "make my location visible to followers only",
+"verstecke mein Alter", "zeig meine Stadt nur meinen Kontakten".
+Health data is always private and has no setting. Confirm the change out loud after.
+
+### block_user
+Block a community member so their posts and messages are hidden from the user.
+WHEN: "block Maria", "I don't want to see Alex anymore",
+"blockiere Maria", "ich will nichts mehr von Alex sehen".
+Two-step: the first call resolves the member and returns a confirmation request —
+read the name back, get an explicit yes, then call again with confirm=true and
+the returned member_user_id. Afterwards, confirm the block and mention it can be undone.
+
+### unblock_user
+Unblock a previously blocked member so their posts and messages show again.
+Matches the name against the user's own blocked list only.
+WHEN: "unblock Maria", "entblockiere Maria", "hebe die Blockierung von Alex auf".
+If the name is not on the blocked list, the tool says who currently is —
+relay that plainly. Afterwards, confirm the unblock out loud.
+
+### submit_bug_report
+File a bug ticket (kind=bug) in the feedback pipeline. No persona swap —
+just files and confirms. Call when the user describes something BROKEN and
+wants it reported: "melde diesen Fehler", "die App stürzt ab, bitte melden",
+"report this bug", "the button does nothing, file it".
+The summary must be a concrete description of at least 15 words in the
+user's own words — which screen, what happened, what was expected.
+AFTER: speak the ticket number once and say the team will follow up.
+For live handoff to a specialist use report_to_specialist instead.
+
+### submit_support_ticket
+File a support ticket (kind=support_question) for a question the team
+should answer offline. Call when the user explicitly wants their question
+logged for support: "erstell ein Support-Ticket", "leite meine Frage an den
+Support weiter", "open a support ticket", "log this question for support".
+Do NOT call for how-to questions you can answer yourself — answer inline.
+Summary: at least 12 words describing the question and context.
+AFTER: speak the ticket number once and say support will follow up.
+
+### submit_marketplace_dispute
+File a marketplace dispute ticket (kind=marketplace_claim): refunds, wrong
+or damaged items, orders that never arrived, seller issues, overcharges.
+Triggers: "ich will mein Geld zurück", "die Bestellung ist nie angekommen",
+"I want a refund", "the seller sent the wrong item, file a claim".
+Summary: at least 12 words — what was ordered, what went wrong, what the
+user wants (refund / replacement). Include the order number if they have it.
+AFTER: speak the ticket number once and say the team will review the claim.
+
+### submit_account_issue
+File an account ticket (kind=account_issue): login problems, password or
+email trouble, role/permission issues, profile data corrections, lockouts.
+Triggers: "ich komme nicht in mein Konto", "meine E-Mail stimmt nicht,
+bitte melden", "I'm locked out", "report my login problem".
+NEVER ask for or record passwords. Summary: at least 12 words describing
+the account problem and what the user already tried.
+AFTER: speak the ticket number once and say the team will follow up.
+
+### list_my_tickets
+List the user's OPEN feedback tickets (bugs, support, disputes, account)
+with number and status. Call when the user asks about their reports:
+"was ist mit meinen Tickets?", "wie steht es um meine Fehlermeldung?",
+"what happened to my bug report?", "show my open tickets".
+AFTER: read back ticket number, what it is, and its status in the user's
+language. Never mention internal specialist names.
+
+### set_language
+Set the user's app + voice language. Persists the same setting the app's
+Language picker writes, so screens and notifications follow. Call when the
+user asks to switch language: "stell auf Deutsch um", "sprich Englisch mit
+mir", "switch the app to English", "cambia a español".
+AFTER: respond ONLY in the new language from that moment on and confirm
+the change; the app screens follow on the next reload.
+
+### set_theme
+Handle a request to change the visual theme (light / dark / system).
+Triggers: "mach den Dunkelmodus an", "stell auf hell", "switch to dark
+mode", "use the system theme".
+NOTE: the theme is stored on the device, not on the server — this tool
+explains where to flip it (Settings → Preferences → Theme). Relay that
+guidance in the user's language; do not promise the theme changed.
+
+### set_voice_preferences
+Tune the app's spoken-voice settings: pace (slow / normal / fast), voice
+name, and tone/character. Persists to the same voice settings the app's
+Voice & AI screen uses. Triggers: "sprich langsamer", "sprich schneller",
+"klinge ruhiger", "speak slower please", "use a calmer tone".
+Provide only the fields the user asked to change.
+AFTER: confirm briefly what changed, in the user's language.
+
+### list_connected_apps
+List the user's connected integrations: Google, YouTube, social accounts,
+and AI assistants (OpenAI, Anthropic, Gemini). Call when the user asks:
+"welche Apps sind verbunden?", "ist mein Google-Konto verknüpft?",
+"what apps are connected?", "is Spotify linked?".
+AFTER: name each connected app naturally in the user's language; if none,
+say so and mention Settings → Connected Apps.
+
+### disconnect_app
+Disconnect one connected integration (Google, YouTube, Instagram, an AI
+assistant, ...). Triggers: "trenne mein Google-Konto", "entferne YouTube",
+"disconnect my Google account", "unlink ChatGPT".
+TWO-STEP: first call WITHOUT confirm — the tool returns a confirmation
+question to relay. Only after the user explicitly says yes, call again
+with confirm=true. Never disconnect without that explicit yes.
+AFTER (confirmed): confirm it is disconnected and reconnectable in
+Settings → Connected Apps.
+
+### global_search
+Unified community search across people, posts, events, groups, products,
+and services in one call. Returns the top hits per category.
+CALL WHEN the user asks a broad "find/search" question: "search for yoga",
+"find anything about fasting", "such nach Tennis", "gibt es was zu Schlaf?".
+For a specific person prefer find_community_member; for events only,
+search_events. After the tool runs, present the most relevant category
+first — top two or three hits, never the raw list.
+
+### browse_news_feed
+Read the community news feed aloud: recent posts with author and a
+one-line summary. scope "following" limits to people the user follows;
+"all" is the whole community (default).
+CALL WHEN the user asks: "what's new in the community?", "read me the
+feed", "was gibt es Neues?", "zeig mir die Neuigkeiten von Leuten denen
+ich folge". After the tool runs, speak each post as author plus a short
+summary — never read long posts word for word.
+
+### snooze_recommendation
+Snooze an Autopilot recommendation so it resurfaces later (default 24h,
+max one week). Accepts the recommendation id or a spoken title fragment.
+CALL WHEN the user says: "remind me about that later", "snooze the sleep
+recommendation", "später erinnern", "leg das auf Wiedervorlage".
+After the tool runs, confirm the title and when it will come back.
+
+### dismiss_recommendation
+Dismiss an Autopilot recommendation for good (it will not come back).
+TWO-STEP: first call returns a confirmation question — read it back;
+only after a clear yes call again with confirm=true.
+CALL WHEN the user says: "not interested", "dismiss that suggestion",
+"das interessiert mich nicht", "weg damit".
+If the user just wants it later, use snooze_recommendation instead.
+
+### explain_recommendation
+Explain WHY a specific Autopilot recommendation was suggested: its
+rationale, which Vitana pillars it strengthens, impact vs effort, and
+where it came from. Accepts an id or a spoken title fragment.
+CALL WHEN the user asks: "why are you suggesting this?", "what's that
+recommendation about?", "warum schlägst du mir das vor?", "was bringt
+mir das?". After the tool runs, narrate the reason in 2-3 sentences and
+offer to activate, snooze, or dismiss it.
+
+### update_intent
+Edit one of the user's OWN intent posts (title, description text, or
+category). Accepts the intent id or a spoken title fragment.
+CALL WHEN the user says: "change my tennis post to say weekends only",
+"update the title of my ask", "ändere meinen Beitrag", "mach aus meinem
+Post ...". Pass ONLY the fields that change. After the tool runs,
+confirm what was updated in one sentence.
+
+### delete_intent
+Take down one of the user's OWN intent posts from the board (closes it;
+matching stops). TWO-STEP: first call returns a confirmation question —
+read it back; only after a clear yes call again with confirm=true.
+CALL WHEN the user says: "delete my post", "remove my tennis ask",
+"lösch meinen Beitrag", "nimm das vom Brett".
+If the ask was fulfilled, prefer mark_intent_fulfilled instead.
+
+### browse_intent_board
+Browse the open community intent board (Open Asks): what other members
+are looking for, buying, selling, or offering right now. Optional query
+filters by topic. Never shows the user's own posts.
+CALL WHEN the user asks: "what are people looking for?", "browse the
+asks board", "was suchen andere gerade?", "zeig mir das Schwarze Brett".
+After the tool runs, present the top asks (title + kind) and offer to
+respond to one or post the user's own ask.
+
+### dispute_match
+Open a dispute on a match the user is part of (no-show, misrepresented,
+safety, payment, other). MULTI-STEP: the tool first collects the reason,
+then returns a confirmation question — only after a clear yes call again
+with confirm=true. CALL WHEN the user says: "the seller never showed up",
+"I want to report this match", "der Kontakt war fake", "ich möchte das
+Match melden". Stay neutral and factual — never promise an outcome.
+
+### find_perfect_match
+Flagship people-match: find the PERFECT person for the user — workout
+partner, accountability buddy, mentor, learning partner — personalized
+with their Life Compass goal and weakest Vitana pillar. Searches the
+live community asks and, per the confirm flow, also posts the request
+so the user becomes discoverable.
+CALL WHEN the user says: "find me a workout partner", "who would be my
+perfect accountability buddy?", "find den perfekten Trainingspartner
+für mich", "such mir einen Mentor".
+Follow the returned text exactly — it tells you whether matches were
+found or a read-back confirmation is needed (then call again with
+confirmed=true).
+
+### get_emotional_state
+Read the user's current emotional and cognitive signals (D28): mood,
+focus, engagement, urgency, hesitation — from analyzed conversation
+signals, or recent diary moods/energy when no live signals exist.
+CALL WHEN the user asks: "how am I doing?", "how do I seem to you?",
+"wie wirke ich gerade?", "wie geht es mir laut meinen Daten?".
+Speak the returned text as-is — it already names the data source.
+Never diagnose; these are light behavioral observations only.
+
+### get_situational_awareness
+Summarize the user's current situation (D32): time-of-day window,
+availability, energy, suggested conversation depth and any active
+constraints, enriched with their next calendar commitment.
+CALL WHEN the user asks: "what's my situation right now?", "is this
+a good moment?", "wie sieht meine Lage gerade aus?", "passt es gerade?".
+Optionally pass timezone (IANA name like Europe/Berlin) if known.
+Speak the returned text; it states what the summary is based on.
+
+### get_availability
+Check how available and ready the user is right now (D33): availability
+level, time window, readiness score, calendar density for the next
+hours, whether they are in an event, and reminders due soon.
+CALL WHEN the user asks: "do I have time right now?", "is now a good
+time?", "habe ich gerade Zeit?", "ist jetzt ein guter Zeitpunkt?",
+or BEFORE proposing a long activity or deep session.
+Optionally pass timezone (IANA name) if known. Speak the returned text.
+
+### get_environmental_context
+Read the user's environment and mobility context (D34): where they
+are based or traveling, how they get around, late-night/early-morning
+flags and indoor/outdoor suitability — from stored location facts,
+preferences and visit history. Never invents a location.
+CALL WHEN the user asks: "what do you know about where I am?",
+"was weißt du über meine Umgebung?", or before suggesting nearby or
+outdoor activities. Speak the returned text; it names its sources.
+
+### get_life_stage_context
+Read the user's life-stage context (D40): life phase and stability,
+any transition, Life Compass goal and category, age band (from their
+stated birthday) and community tenure.
+CALL WHEN the user asks: "where am I in life?", "what stage am I in?",
+"wo stehe ich gerade im Leben?", "in welcher Lebensphase bin ich?",
+or when tailoring long-term advice to their life situation.
+Speak the returned text; it is non-prescriptive — the user knows
+their life best. If nothing is on record, offer to set up Life Compass.
+
+### follow_member
+FOLLOW a community member by their spoken name.
+CALL THIS for: "Follow Anna" / "Folge Anna" / "Ich möchte Peter folgen" /
+"Follow that member".
+Resolves the name to a member; if no match, ask the user to repeat the name.
+After success, confirm in one short sentence.
+
+### unfollow_member
+UNFOLLOW a community member by name. Two-step confirm:
+first call returns a confirmation question — ask it, then call again with
+confirmed=true after the user says yes.
+CALL THIS for: "Unfollow Anna" / "Entfolge Anna" / "Ich will Peter nicht mehr folgen".
+
+### get_notifications
+READ the user's recent notifications, unread first. Speakable.
+CALL THIS for: "Any notifications?" / "Habe ich Benachrichtigungen?" /
+"Was gibt es Neues für mich?" / "Read my notifications".
+Speak the unread count and the top titles — never deflect to the bell icon.
+
+### mark_notifications_read
+MARK notifications as read — all unread ones, or only those whose title
+matches a spoken reference.
+CALL THIS for: "Mark all as read" / "Alle als gelesen markieren" /
+"Clear my notifications" / "Mark the match notification as read".
+
+### get_wallet_balance
+READ-ONLY wallet snapshot: balance per currency, active subscription,
+last 3 transactions. NEVER moves money — payments happen in the Wallet screen.
+CALL THIS for: "What is my wallet balance?" / "Wie viel Guthaben habe ich?" /
+"Was ist auf meinem Wallet?" / "My last transactions".
+
+### update_profile
+UPDATE simple own-profile fields: display_name, bio, city, country, location.
+Two-step confirm: first call returns a verbatim read-back — speak it, then
+call again with confirmed=true after the user agrees.
+CALL THIS for: "Change my bio to …" / "Ändere meinen Namen zu …" /
+"Setze meine Stadt auf Berlin".
+NEVER use this for role or profile visibility — privacy settings own those.
+
+### play_podcast
+PLAY an internal Vitana Media Hub podcast by title or topic. Returns an
+open_url directive the app uses to start playback.
+CALL THIS for: "Play the longevity podcast" / "Spiel den Vitana Podcast" /
+"Play a podcast about sleep".
+For music use play_music instead. After success, say what is now playing.
+
+### like_post
+LIKE a community feed post — resolves "the last post from <name>" to that
+member's most recent public post.
+CALL THIS for: "Like Anna's post" / "Like den letzten Beitrag von Anna" /
+"Gefällt mir für Peters Post".
+After success, confirm which post was liked in one sentence.
+
+### comment_on_post
+COMMENT on a community feed post (public text). Two-step confirm:
+first call returns the comment for verbatim read-back — speak it, then call
+again with confirmed=true after the user says post/yes.
+CALL THIS for: "Comment on Anna's post: great work" /
+"Kommentiere Peters Beitrag mit …"."
 `;
 
 exports[`A0.1 characterization: buildLiveSystemInstruction renders a stable system instruction for persona "day-180-veteran-reconnect": persona:day-180-veteran-reconnect 1`] = `
@@ -3135,5 +3787,657 @@ overlay UI listens for this directive and fades out the chime.
 Call this when the user says any kind of "I'm done" / "nein
 danke" / "enough" — interpret IN CONTEXT, not by keyword match.
 If the user is ambiguous, ask a clarifying question first; only
-call this when you are confident the session should end."
+call this when you are confident the session should end.
+
+### get_highest_vitana_index
+Get the community member with the highest Vitana Index right now.
+Returns their name and score; private profiles are never revealed.
+CALL WHEN the user asks: "who has the highest Vitana Index?",
+"who is the healthiest member?", "wer hat den höchsten Vitana Index?",
+"wer ist am gesündesten?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### get_top_in_pillar
+Get the community member with the top score in ONE Vitana Index pillar.
+pillar must be one of: nutrition, hydration, exercise, sleep, mental.
+CALL WHEN the user asks: "who has the best sleep?", "who is the
+fittest?", "wer schläft am besten?", "wer ist am fittesten?",
+"wer trinkt am meisten Wasser?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### get_first_member
+Get the very first (earliest-registered / OG) community member.
+CALL WHEN the user asks: "who was the first member?", "who is the
+longest-standing / OG member?", "wer war das erste Mitglied?",
+"wer ist am längsten dabei?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### get_newest_member
+Get the most recently joined community member.
+CALL WHEN the user asks: "who is the newest member?", "who just
+joined?", "wer ist das neueste Mitglied?", "wer ist gerade beigetreten?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### get_most_followed
+Get the community member with the most followers.
+CALL WHEN the user asks: "who has the most followers?", "who is the
+most popular member?", "wer hat die meisten Follower?", "wer ist am
+beliebtesten?".
+After the tool runs, read the returned text aloud (one sentence).
+
+### ask_who_is
+Answer ANY free-form "who is...?" superlative question about the
+community that the specific superlative tools above do not cover.
+Routes to the matching leaderboard (index, pillar, tenure, followers)
+or falls back to the general community-member ranking.
+CALL WHEN the user asks e.g.: "who is the most inspiring?", "who is
+the best runner?", "wer ist der/die inspirierendste?", "wer ist am
+aktivsten?". Pass the user's question verbatim as query.
+After the tool runs, read the returned text aloud, then stop.
+
+### list_diary_entries
+List the user's Daily Diary entries, newest first, optionally within a date window.
+CALL THIS WHEN the user says:
+  - "What did I write in my diary?" / "Was steht in meinem Tagebuch?"
+  - "Show my diary entries from last week" / "Zeig meine Tagebucheinträge"
+  - "What did I log yesterday?" / "Was habe ich gestern eingetragen?"
+Then summarize the entries naturally — do not read them verbatim or mention IDs.
+
+### get_diary_streak
+Get the user's diary streak: current consecutive days with an entry plus their longest streak ever.
+CALL THIS WHEN the user asks:
+  - "What's my diary streak?" / "Wie lang ist meine Tagebuch-Serie?"
+  - "How many days in a row have I journaled?" / "Wie viele Tage am Stück?"
+Then celebrate an active streak, or encourage a restart if it broke.
+
+### get_memory_timeline
+Chronological timeline of what Vitana remembers: memory items, extracted facts, and diary entries, newest first.
+CALL THIS WHEN the user asks:
+  - "What happened last month?" / "Was ist letzten Monat passiert?"
+  - "Show my memory timeline" / "Zeig meine Erinnerungs-Zeitleiste"
+  - "What did we talk about in June?" / "Worüber haben wir im Juni gesprochen?"
+Then retell the timeline as a short narrative in the user's language.
+
+### recall_memory_about
+Search stored memories and facts about ONE specific topic, person, or thing.
+CALL THIS WHEN the user asks:
+  - "What do you know about my sister?" / "Was weißt du über meine Schwester?"
+  - "Do you remember my trip to Rome?" / "Erinnerst du dich an meine Rom-Reise?"
+  - "What did I tell you about my project?" / "Was habe ich dir über mein Projekt erzählt?"
+Answer ONLY from the returned content — never invent memories. If empty, say so and offer to remember it now.
+Optional category filter: personal_identity, health_wellness, lifestyle_routines, network_relationships,
+learning_knowledge, business_projects, finance_assets, location_environment, digital_footprint,
+values_aspirations, autopilot_context, future_plans, uncategorized.
+
+### get_memory_garden_summary
+Overview of the user's Memory Garden: how many memories are stored per category.
+CALL THIS WHEN the user asks:
+  - "What do you remember about me?" / "Was weißt du alles über mich?"
+  - "How full is my Memory Garden?" / "Wie sieht mein Memory Garden aus?"
+  - "What kind of things have you saved?" / "Was hast du über mich gespeichert?"
+Then summarize warmly: total memories and the biggest categories first.
+For details on a specific topic, use recall_memory_about instead.
+
+### forget_memory
+Permanently delete ONE stored memory, only after the user explicitly confirms.
+CALL THIS WHEN the user says:
+  - "Forget that" / "Vergiss das" / "Lösch diese Erinnerung"
+  - "Delete what you saved about X" / "Lösch, was du über X gespeichert hast"
+Flow: find the memory_id via recall_memory_about, call WITHOUT confirm first —
+the tool returns the memory text; read it back and ask the user to confirm.
+Only when they clearly say yes, call again with confirm=true. Deletion is permanent.
+
+### reschedule_event
+Move an existing calendar event to a new start time (duration is kept unless new_end is given).
+WHEN TO CALL: "move my yoga to 6 pm", "reschedule my doctor appointment to Friday",
+"Verschieb mein Meeting auf morgen 10 Uhr", "Kannst du das Training auf Freitag legen?".
+Identify the event by event_id (preferred) or title_query (fuzzy title match).
+If multiple events match, the result lists candidates — ask the user which one, then call again with event_id.
+After success, confirm the new day and time back to the user.
+
+### cancel_event
+Cancel (soft-delete) a calendar event — the event stays in history with status "cancelled".
+WHEN TO CALL: "cancel my yoga class", "delete the dentist appointment",
+"Sag das Meeting morgen ab", "Lösch den Termin am Freitag".
+Destructive: first call WITHOUT confirm to fetch the event, ask the user to confirm,
+then call again with confirm=true and the event_id. Speak the cancelled title back.
+
+### complete_event
+Mark a calendar event as completed, skipped, or partially done.
+WHEN TO CALL: "I finished my workout", "mark the meditation as done", "I skipped my run today",
+"Ich habe das Training gemacht", "Hab die Meditation ausgelassen".
+outcome must be one of: completed, skipped, partial (default completed).
+After success, acknowledge briefly — completed health events feed the Vitana Index.
+
+### find_free_slot
+Find the next free slot of a given length in the user's calendar, within waking hours (8 AM-10 PM user-local).
+WHEN TO CALL: "when am I free for an hour?", "find me 30 minutes tomorrow",
+"Wann habe ich morgen Zeit?", "Finde mir eine freie Stunde diese Woche".
+duration_minutes is required (5-720). search_from/search_to are ISO 8601; default is the next 7 days.
+Pass the user's IANA timezone so waking hours and spoken times are local.
+Speak the found day + time back, or say nothing was free and offer to look further out.
+
+### get_event_details
+Read the full details of ONE calendar event: exact time, end, location, type, status, notes.
+WHEN TO CALL: "when exactly is my dentist appointment?", "where is the meetup?",
+"Wann genau ist mein Zahnarzttermin?", "Wo findet das Treffen statt?".
+Identify by event_id or title_query (fuzzy). If several match, the result lists candidates — ask which one.
+Speak the concrete details (day, time, place); never a raw data dump.
+
+### check_calendar_conflicts
+Check whether a proposed time window overlaps existing confirmed calendar events.
+WHEN TO CALL: before creating or rescheduling an event, or when the user asks
+"does 3 pm work on Friday?", "Passt Dienstag 10 Uhr?", "Habe ich da schon etwas?".
+start_time is required (ISO 8601); end_time defaults to one hour after start_time.
+If there are conflicts, name the overlapping events and suggest checking another time.
+
+### snooze_reminder
+Push an existing reminder out by N minutes (default 10, max 1440).
+CALL WHEN the user says 'snooze it', 'remind me again in 15 minutes',
+'verschieb die Erinnerung', 'erinnere mich später nochmal'.
+Pass reminder_id when known (e.g. a reminder just fired), otherwise
+text_query with words from the reminder. If the tool reports multiple
+matches, ask the user which one and call again with that reminder_id.
+After success, speak the confirmation with the new time from \`text\`.
+
+### update_reminder
+Edit an existing reminder's text and/or time.
+CALL WHEN the user says 'change my reminder to 9pm', 'make it say X',
+'ändere meine Erinnerung', 'verschiebe die Erinnerung auf 21 Uhr'.
+Identify via reminder_id or text_query. new_time is an absolute UTC ISO
+timestamp YOU compute from their words + timezone (min 60s in future).
+If multiple reminders match, ask which one, then call again with the id.
+After success, confirm the change using \`text\`.
+
+### acknowledge_reminder
+Mark a fired reminder as heard/acknowledged so it stops being re-delivered.
+CALL WHEN the user says 'got it', 'okay, I heard the reminder', 'dismiss it',
+'alles klar, habs gehört' after a reminder fired — but the task is NOT done yet.
+Use complete_reminder instead when the user actually DID the thing.
+Identify via reminder_id (preferred, e.g. from the fire event) or text_query.
+
+### complete_reminder
+Mark a reminder as DONE (the user did the thing). Sets status=completed.
+CALL WHEN the user says 'done', 'I took my magnesium, check it off',
+'erledigt', 'hab ich gemacht' about a reminder.
+Identify via reminder_id or text_query. If multiple match, ask which one.
+After success, give a short positive confirmation from \`text\`.
+
+### list_missed_reminders
+List reminders that fired but were never acknowledged (the user missed them).
+CALL WHEN the user asks 'did I miss anything?', 'what reminders did I miss?',
+'habe ich Erinnerungen verpasst?', or at the start of a session catch-up.
+Speak each missed reminder with its text and when it fired, then offer to
+snooze, complete, or acknowledge them.
+
+### set_alarm
+Set a wake-up/clock alarm at a specific time of day (optionally recurring).
+CALL WHEN the user says 'wake me at 7', 'set an alarm for 6:30 on weekdays',
+'stell einen Wecker auf 7 Uhr', 'weck mich um halb sieben'.
+time is 'HH:MM' (24h, interpreted in the given timezone — next occurrence)
+or an absolute ISO timestamp. ALWAYS pass the user timezone from context;
+UTC is assumed when omitted. recurrence: daily, weekdays, or omit for once.
+Prefer alarms for time-of-day wake-ups; use set_reminder for task reminders.
+After success, confirm with the day + time from \`text\`.
+
+### list_alarms
+List the user's active alarms with times and labels.
+CALL WHEN the user asks 'what alarms do I have?', 'when is my alarm?',
+'welche Wecker habe ich?', or before deleting/changing an alarm.
+Pass timezone so times are spoken in local wall-clock time.
+
+### delete_alarm
+Cancel an alarm. Two-step confirm flow: first call WITHOUT confirm to find
+the alarm (by alarm_id, label, or HH:MM time) — the tool answers with the
+match and asks you to confirm with the user. After the user explicitly says
+yes, call again with that alarm_id and confirm=true.
+CALL WHEN the user says 'delete my alarm', 'cancel the 7am alarm',
+'lösch den Wecker', 'Wecker ausschalten'.
+
+### start_timer
+Start a countdown timer (1-1440 minutes).
+CALL WHEN the user says 'set a timer for 10 minutes', 'timer for the pasta',
+'stell einen Timer auf 10 Minuten', 'Countdown 20 Minuten'.
+For focused work blocks prefer start_pomodoro. After success, confirm the
+duration and label from \`text\`.
+
+### start_pomodoro
+Start a pomodoro focus block (5-90 minutes; 25 if omitted).
+CALL WHEN the user says 'start a pomodoro', 'let's do a focus session',
+'starte eine Pomodoro-Einheit', '45 Minuten Fokuszeit'.
+After success, confirm the length and encourage focused work.
+
+### list_active_timers
+List running timers and pomodoros with the remaining time on each.
+CALL WHEN the user asks 'how much time is left?', 'is my timer still running?',
+'wie lange läuft mein Timer noch?', 'wie viel Zeit habe ich noch?'.
+Speak each entry with its label and remaining time from \`text\`.
+
+### get_world_time
+Get the current local time in a city or IANA timezone (no internet needed).
+CALL WHEN the user asks 'what time is it in Tokyo?', 'wie spät ist es in
+Belgrad?', 'what's the time in New York right now?'.
+location accepts a major city name (Berlin, Belgrade, London, New York,
+Tokyo, ...) or any IANA zone like 'Europe/Berlin'. Speak the \`text\` answer.
+
+### list_my_groups
+List the community groups the user belongs to, with member counts.
+CALL WHEN the user asks: "what groups am I in?", "show my groups",
+"in welchen Gruppen bin ich?", "zeig mir meine Gruppen".
+After the tool runs, read the group names and member counts aloud.
+
+### create_group
+Create a new community group. Requires a name; privacy is public or
+private (default public). ALWAYS call once WITHOUT confirm first —
+the tool returns a confirmation question; after the user says yes,
+call again with confirm:true.
+CALL WHEN the user says: "create a group called ...", "start a new
+group", "erstelle eine Gruppe ...", "gründe eine neue Gruppe".
+
+### join_group
+Join a community group by name or group_id. Resolves fuzzy names and
+lists candidates when several match. Private groups cannot be self-joined.
+CALL WHEN the user says: "join the sleep group", "I want to join ...",
+"tritt der Gruppe ... bei", "ich möchte der Gruppe beitreten".
+After joining, tell the user they are in and the app is opening the group.
+
+### invite_to_group
+Invite another community member to a group. Resolves the member by
+spoken name and the group by name; the member gets a notification.
+CALL WHEN the user says: "invite Anna to my walking group",
+"lade Anna in die Gruppe ... ein".
+If the tool lists several member or group candidates, ask which one.
+
+### accept_invitation
+Accept a pending group invitation (joins the group). With no
+invitation_id it lists the pending invitations, or acts when only one.
+CALL WHEN the user says: "accept the invitation", "yes, join that group",
+"nimm die Einladung an", "Einladung annehmen".
+
+### decline_invitation
+Decline a pending group invitation. ALWAYS call once WITHOUT confirm
+first — the tool returns a confirmation question; after the user says
+yes, call again with the invitation_id and confirm:true.
+CALL WHEN the user says: "decline the invitation", "no thanks, decline
+it", "lehne die Einladung ab", "Einladung ablehnen".
+
+### rsvp_event
+RSVP / sign the user up for a community event or meetup, by event_id
+or fuzzy title. Checks capacity and existing signup first.
+CALL WHEN the user says: "sign me up for ...", "RSVP to the yoga
+meetup", "melde mich für ... an", "ich will beim Event ... dabei sein".
+If several events match, read the candidates and ask which one.
+
+### cancel_rsvp
+Cancel the user's RSVP for an upcoming event. ALWAYS call once
+WITHOUT confirm first — the tool returns a confirmation question;
+after the user says yes, call again with the event_id and confirm:true.
+CALL WHEN the user says: "cancel my RSVP", "I can't make it to ...",
+"melde mich vom Event ... ab", "storniere meine Anmeldung".
+
+### list_upcoming_meetups
+List upcoming community meetups/events the user could attend, soonest
+first; events in the user's home city are flagged "near you" and
+events they already RSVP'd are marked.
+CALL WHEN the user asks: "what meetups are coming up?", "any events
+this week?", "welche Meetups stehen an?", "gibt es bald Events?".
+Read the titles with dates aloud, then offer to sign them up.
+
+### join_live_room
+Join/open a community live room by name or room_id. Returns a
+navigation directive that opens the room screen — the app navigates
+automatically; do not describe the navigation mechanics.
+CALL WHEN the user says: "join the live room", "take me into the ...
+room", "bring mich in den Live-Raum", "öffne den Live-Raum ...".
+If several rooms match, read the candidates and ask which one.
+
+### start_conversation
+Start (or reuse) a direct-message conversation with a named community member,
+optionally sending the first message in the same call.
+WHEN: "start a chat with Maria", "message Alex for the first time",
+"schreib Maria an", "starte eine Unterhaltung mit Alex".
+Pass member (spoken name or Vitana ID) or member_user_id (UUID from resolve_recipient).
+With message set, it sends immediately via the canonical send path.
+Without message, it resolves the member, says whether a conversation already
+exists, and returns recipient_user_id — read back the name, ask what to say,
+then send with send_chat_message or call this again with message set.
+
+### list_conversations
+List the user's recent direct-message conversations, newest first, with
+who wrote last and a short snippet.
+WHEN: "show my conversations", "who have I been chatting with?",
+"zeig meine Chats", "mit wem habe ich geschrieben?".
+These are internal Maxina messages — no Google account involved.
+Speak the names and snippets naturally; to continue one, use send_chat_message.
+
+### mark_conversation_read
+Mark direct messages as read. With member set, marks that conversation;
+without it (or with all=true), marks ALL unread messages.
+WHEN: "mark my chat with Maria as read", "mark everything read",
+"markiere den Chat mit Maria als gelesen", "alles als gelesen markieren".
+Afterwards, confirm how many messages were marked.
+
+### mute_conversation
+Mute a chat conversation. NOTE: chat muting is not supported in Vitana yet —
+this tool answers honestly and suggests block_user as the stronger alternative.
+WHEN: "mute this chat", "mute Maria", "schalte den Chat stumm".
+Relay the returned text plainly; never claim the chat was muted.
+
+### archive_conversation
+Archive a chat conversation. NOTE: chat archiving does not exist in Vitana —
+this tool answers honestly. Never invent or offer "archived messages".
+WHEN: "archive this chat", "archiviere den Chat mit Maria".
+Relay the returned text plainly; suggest mark_conversation_read or block_user instead.
+
+### update_account_visibility
+Set the visibility of the user's WHOLE profile: public, followers_only, or private.
+Writes every per-field visibility setting at once (partner-search posts stay private).
+WHEN: "make my profile private", "set my account to public",
+"mach mein Profil privat", "stell mein Konto auf öffentlich".
+Two-step: first call returns a confirmation request — read it back, get an
+explicit yes, then call again with confirm=true. Then confirm the change out loud.
+
+### update_privacy_field
+Set the visibility of ONE profile field: public, followers_only, or private.
+Fields: age, birthday, location (city), country, address, email, phone, gender,
+first/last name, marital status, dance/partner preferences, service offerings, posts.
+WHEN: "hide my age", "make my location visible to followers only",
+"verstecke mein Alter", "zeig meine Stadt nur meinen Kontakten".
+Health data is always private and has no setting. Confirm the change out loud after.
+
+### block_user
+Block a community member so their posts and messages are hidden from the user.
+WHEN: "block Maria", "I don't want to see Alex anymore",
+"blockiere Maria", "ich will nichts mehr von Alex sehen".
+Two-step: the first call resolves the member and returns a confirmation request —
+read the name back, get an explicit yes, then call again with confirm=true and
+the returned member_user_id. Afterwards, confirm the block and mention it can be undone.
+
+### unblock_user
+Unblock a previously blocked member so their posts and messages show again.
+Matches the name against the user's own blocked list only.
+WHEN: "unblock Maria", "entblockiere Maria", "hebe die Blockierung von Alex auf".
+If the name is not on the blocked list, the tool says who currently is —
+relay that plainly. Afterwards, confirm the unblock out loud.
+
+### submit_bug_report
+File a bug ticket (kind=bug) in the feedback pipeline. No persona swap —
+just files and confirms. Call when the user describes something BROKEN and
+wants it reported: "melde diesen Fehler", "die App stürzt ab, bitte melden",
+"report this bug", "the button does nothing, file it".
+The summary must be a concrete description of at least 15 words in the
+user's own words — which screen, what happened, what was expected.
+AFTER: speak the ticket number once and say the team will follow up.
+For live handoff to a specialist use report_to_specialist instead.
+
+### submit_support_ticket
+File a support ticket (kind=support_question) for a question the team
+should answer offline. Call when the user explicitly wants their question
+logged for support: "erstell ein Support-Ticket", "leite meine Frage an den
+Support weiter", "open a support ticket", "log this question for support".
+Do NOT call for how-to questions you can answer yourself — answer inline.
+Summary: at least 12 words describing the question and context.
+AFTER: speak the ticket number once and say support will follow up.
+
+### submit_marketplace_dispute
+File a marketplace dispute ticket (kind=marketplace_claim): refunds, wrong
+or damaged items, orders that never arrived, seller issues, overcharges.
+Triggers: "ich will mein Geld zurück", "die Bestellung ist nie angekommen",
+"I want a refund", "the seller sent the wrong item, file a claim".
+Summary: at least 12 words — what was ordered, what went wrong, what the
+user wants (refund / replacement). Include the order number if they have it.
+AFTER: speak the ticket number once and say the team will review the claim.
+
+### submit_account_issue
+File an account ticket (kind=account_issue): login problems, password or
+email trouble, role/permission issues, profile data corrections, lockouts.
+Triggers: "ich komme nicht in mein Konto", "meine E-Mail stimmt nicht,
+bitte melden", "I'm locked out", "report my login problem".
+NEVER ask for or record passwords. Summary: at least 12 words describing
+the account problem and what the user already tried.
+AFTER: speak the ticket number once and say the team will follow up.
+
+### list_my_tickets
+List the user's OPEN feedback tickets (bugs, support, disputes, account)
+with number and status. Call when the user asks about their reports:
+"was ist mit meinen Tickets?", "wie steht es um meine Fehlermeldung?",
+"what happened to my bug report?", "show my open tickets".
+AFTER: read back ticket number, what it is, and its status in the user's
+language. Never mention internal specialist names.
+
+### set_language
+Set the user's app + voice language. Persists the same setting the app's
+Language picker writes, so screens and notifications follow. Call when the
+user asks to switch language: "stell auf Deutsch um", "sprich Englisch mit
+mir", "switch the app to English", "cambia a español".
+AFTER: respond ONLY in the new language from that moment on and confirm
+the change; the app screens follow on the next reload.
+
+### set_theme
+Handle a request to change the visual theme (light / dark / system).
+Triggers: "mach den Dunkelmodus an", "stell auf hell", "switch to dark
+mode", "use the system theme".
+NOTE: the theme is stored on the device, not on the server — this tool
+explains where to flip it (Settings → Preferences → Theme). Relay that
+guidance in the user's language; do not promise the theme changed.
+
+### set_voice_preferences
+Tune the app's spoken-voice settings: pace (slow / normal / fast), voice
+name, and tone/character. Persists to the same voice settings the app's
+Voice & AI screen uses. Triggers: "sprich langsamer", "sprich schneller",
+"klinge ruhiger", "speak slower please", "use a calmer tone".
+Provide only the fields the user asked to change.
+AFTER: confirm briefly what changed, in the user's language.
+
+### list_connected_apps
+List the user's connected integrations: Google, YouTube, social accounts,
+and AI assistants (OpenAI, Anthropic, Gemini). Call when the user asks:
+"welche Apps sind verbunden?", "ist mein Google-Konto verknüpft?",
+"what apps are connected?", "is Spotify linked?".
+AFTER: name each connected app naturally in the user's language; if none,
+say so and mention Settings → Connected Apps.
+
+### disconnect_app
+Disconnect one connected integration (Google, YouTube, Instagram, an AI
+assistant, ...). Triggers: "trenne mein Google-Konto", "entferne YouTube",
+"disconnect my Google account", "unlink ChatGPT".
+TWO-STEP: first call WITHOUT confirm — the tool returns a confirmation
+question to relay. Only after the user explicitly says yes, call again
+with confirm=true. Never disconnect without that explicit yes.
+AFTER (confirmed): confirm it is disconnected and reconnectable in
+Settings → Connected Apps.
+
+### global_search
+Unified community search across people, posts, events, groups, products,
+and services in one call. Returns the top hits per category.
+CALL WHEN the user asks a broad "find/search" question: "search for yoga",
+"find anything about fasting", "such nach Tennis", "gibt es was zu Schlaf?".
+For a specific person prefer find_community_member; for events only,
+search_events. After the tool runs, present the most relevant category
+first — top two or three hits, never the raw list.
+
+### browse_news_feed
+Read the community news feed aloud: recent posts with author and a
+one-line summary. scope "following" limits to people the user follows;
+"all" is the whole community (default).
+CALL WHEN the user asks: "what's new in the community?", "read me the
+feed", "was gibt es Neues?", "zeig mir die Neuigkeiten von Leuten denen
+ich folge". After the tool runs, speak each post as author plus a short
+summary — never read long posts word for word.
+
+### snooze_recommendation
+Snooze an Autopilot recommendation so it resurfaces later (default 24h,
+max one week). Accepts the recommendation id or a spoken title fragment.
+CALL WHEN the user says: "remind me about that later", "snooze the sleep
+recommendation", "später erinnern", "leg das auf Wiedervorlage".
+After the tool runs, confirm the title and when it will come back.
+
+### dismiss_recommendation
+Dismiss an Autopilot recommendation for good (it will not come back).
+TWO-STEP: first call returns a confirmation question — read it back;
+only after a clear yes call again with confirm=true.
+CALL WHEN the user says: "not interested", "dismiss that suggestion",
+"das interessiert mich nicht", "weg damit".
+If the user just wants it later, use snooze_recommendation instead.
+
+### explain_recommendation
+Explain WHY a specific Autopilot recommendation was suggested: its
+rationale, which Vitana pillars it strengthens, impact vs effort, and
+where it came from. Accepts an id or a spoken title fragment.
+CALL WHEN the user asks: "why are you suggesting this?", "what's that
+recommendation about?", "warum schlägst du mir das vor?", "was bringt
+mir das?". After the tool runs, narrate the reason in 2-3 sentences and
+offer to activate, snooze, or dismiss it.
+
+### update_intent
+Edit one of the user's OWN intent posts (title, description text, or
+category). Accepts the intent id or a spoken title fragment.
+CALL WHEN the user says: "change my tennis post to say weekends only",
+"update the title of my ask", "ändere meinen Beitrag", "mach aus meinem
+Post ...". Pass ONLY the fields that change. After the tool runs,
+confirm what was updated in one sentence.
+
+### delete_intent
+Take down one of the user's OWN intent posts from the board (closes it;
+matching stops). TWO-STEP: first call returns a confirmation question —
+read it back; only after a clear yes call again with confirm=true.
+CALL WHEN the user says: "delete my post", "remove my tennis ask",
+"lösch meinen Beitrag", "nimm das vom Brett".
+If the ask was fulfilled, prefer mark_intent_fulfilled instead.
+
+### browse_intent_board
+Browse the open community intent board (Open Asks): what other members
+are looking for, buying, selling, or offering right now. Optional query
+filters by topic. Never shows the user's own posts.
+CALL WHEN the user asks: "what are people looking for?", "browse the
+asks board", "was suchen andere gerade?", "zeig mir das Schwarze Brett".
+After the tool runs, present the top asks (title + kind) and offer to
+respond to one or post the user's own ask.
+
+### dispute_match
+Open a dispute on a match the user is part of (no-show, misrepresented,
+safety, payment, other). MULTI-STEP: the tool first collects the reason,
+then returns a confirmation question — only after a clear yes call again
+with confirm=true. CALL WHEN the user says: "the seller never showed up",
+"I want to report this match", "der Kontakt war fake", "ich möchte das
+Match melden". Stay neutral and factual — never promise an outcome.
+
+### find_perfect_match
+Flagship people-match: find the PERFECT person for the user — workout
+partner, accountability buddy, mentor, learning partner — personalized
+with their Life Compass goal and weakest Vitana pillar. Searches the
+live community asks and, per the confirm flow, also posts the request
+so the user becomes discoverable.
+CALL WHEN the user says: "find me a workout partner", "who would be my
+perfect accountability buddy?", "find den perfekten Trainingspartner
+für mich", "such mir einen Mentor".
+Follow the returned text exactly — it tells you whether matches were
+found or a read-back confirmation is needed (then call again with
+confirmed=true).
+
+### get_emotional_state
+Read the user's current emotional and cognitive signals (D28): mood,
+focus, engagement, urgency, hesitation — from analyzed conversation
+signals, or recent diary moods/energy when no live signals exist.
+CALL WHEN the user asks: "how am I doing?", "how do I seem to you?",
+"wie wirke ich gerade?", "wie geht es mir laut meinen Daten?".
+Speak the returned text as-is — it already names the data source.
+Never diagnose; these are light behavioral observations only.
+
+### get_situational_awareness
+Summarize the user's current situation (D32): time-of-day window,
+availability, energy, suggested conversation depth and any active
+constraints, enriched with their next calendar commitment.
+CALL WHEN the user asks: "what's my situation right now?", "is this
+a good moment?", "wie sieht meine Lage gerade aus?", "passt es gerade?".
+Optionally pass timezone (IANA name like Europe/Berlin) if known.
+Speak the returned text; it states what the summary is based on.
+
+### get_availability
+Check how available and ready the user is right now (D33): availability
+level, time window, readiness score, calendar density for the next
+hours, whether they are in an event, and reminders due soon.
+CALL WHEN the user asks: "do I have time right now?", "is now a good
+time?", "habe ich gerade Zeit?", "ist jetzt ein guter Zeitpunkt?",
+or BEFORE proposing a long activity or deep session.
+Optionally pass timezone (IANA name) if known. Speak the returned text.
+
+### get_environmental_context
+Read the user's environment and mobility context (D34): where they
+are based or traveling, how they get around, late-night/early-morning
+flags and indoor/outdoor suitability — from stored location facts,
+preferences and visit history. Never invents a location.
+CALL WHEN the user asks: "what do you know about where I am?",
+"was weißt du über meine Umgebung?", or before suggesting nearby or
+outdoor activities. Speak the returned text; it names its sources.
+
+### get_life_stage_context
+Read the user's life-stage context (D40): life phase and stability,
+any transition, Life Compass goal and category, age band (from their
+stated birthday) and community tenure.
+CALL WHEN the user asks: "where am I in life?", "what stage am I in?",
+"wo stehe ich gerade im Leben?", "in welcher Lebensphase bin ich?",
+or when tailoring long-term advice to their life situation.
+Speak the returned text; it is non-prescriptive — the user knows
+their life best. If nothing is on record, offer to set up Life Compass.
+
+### follow_member
+FOLLOW a community member by their spoken name.
+CALL THIS for: "Follow Anna" / "Folge Anna" / "Ich möchte Peter folgen" /
+"Follow that member".
+Resolves the name to a member; if no match, ask the user to repeat the name.
+After success, confirm in one short sentence.
+
+### unfollow_member
+UNFOLLOW a community member by name. Two-step confirm:
+first call returns a confirmation question — ask it, then call again with
+confirmed=true after the user says yes.
+CALL THIS for: "Unfollow Anna" / "Entfolge Anna" / "Ich will Peter nicht mehr folgen".
+
+### get_notifications
+READ the user's recent notifications, unread first. Speakable.
+CALL THIS for: "Any notifications?" / "Habe ich Benachrichtigungen?" /
+"Was gibt es Neues für mich?" / "Read my notifications".
+Speak the unread count and the top titles — never deflect to the bell icon.
+
+### mark_notifications_read
+MARK notifications as read — all unread ones, or only those whose title
+matches a spoken reference.
+CALL THIS for: "Mark all as read" / "Alle als gelesen markieren" /
+"Clear my notifications" / "Mark the match notification as read".
+
+### get_wallet_balance
+READ-ONLY wallet snapshot: balance per currency, active subscription,
+last 3 transactions. NEVER moves money — payments happen in the Wallet screen.
+CALL THIS for: "What is my wallet balance?" / "Wie viel Guthaben habe ich?" /
+"Was ist auf meinem Wallet?" / "My last transactions".
+
+### update_profile
+UPDATE simple own-profile fields: display_name, bio, city, country, location.
+Two-step confirm: first call returns a verbatim read-back — speak it, then
+call again with confirmed=true after the user agrees.
+CALL THIS for: "Change my bio to …" / "Ändere meinen Namen zu …" /
+"Setze meine Stadt auf Berlin".
+NEVER use this for role or profile visibility — privacy settings own those.
+
+### play_podcast
+PLAY an internal Vitana Media Hub podcast by title or topic. Returns an
+open_url directive the app uses to start playback.
+CALL THIS for: "Play the longevity podcast" / "Spiel den Vitana Podcast" /
+"Play a podcast about sleep".
+For music use play_music instead. After success, say what is now playing.
+
+### like_post
+LIKE a community feed post — resolves "the last post from <name>" to that
+member's most recent public post.
+CALL THIS for: "Like Anna's post" / "Like den letzten Beitrag von Anna" /
+"Gefällt mir für Peters Post".
+After success, confirm which post was liked in one sentence.
+
+### comment_on_post
+COMMENT on a community feed post (public text). Two-step confirm:
+first call returns the comment for verbatim read-back — speak it, then call
+again with confirmed=true after the user says post/yes.
+CALL THIS for: "Comment on Anna's post: great work" /
+"Kommentiere Peters Beitrag mit …"."
 `;

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -2525,6 +2525,1953 @@ call this when you are confident the session should end.",
         },
       },
       {
+        "description": "Get the community member with the highest Vitana Index right now.
+Returns their name and score; private profiles are never revealed.
+CALL WHEN the user asks: "who has the highest Vitana Index?",
+"who is the healthiest member?", "wer hat den höchsten Vitana Index?",
+"wer ist am gesündesten?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_highest_vitana_index",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the community member with the top score in ONE Vitana Index pillar.
+pillar must be one of: nutrition, hydration, exercise, sleep, mental.
+CALL WHEN the user asks: "who has the best sleep?", "who is the
+fittest?", "wer schläft am besten?", "wer ist am fittesten?",
+"wer trinkt am meisten Wasser?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_top_in_pillar",
+        "parameters": {
+          "properties": {
+            "pillar": {
+              "description": "One of: nutrition, hydration, exercise, sleep, mental.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "pillar",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the very first (earliest-registered / OG) community member.
+CALL WHEN the user asks: "who was the first member?", "who is the
+longest-standing / OG member?", "wer war das erste Mitglied?",
+"wer ist am längsten dabei?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_first_member",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the most recently joined community member.
+CALL WHEN the user asks: "who is the newest member?", "who just
+joined?", "wer ist das neueste Mitglied?", "wer ist gerade beigetreten?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_newest_member",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the community member with the most followers.
+CALL WHEN the user asks: "who has the most followers?", "who is the
+most popular member?", "wer hat die meisten Follower?", "wer ist am
+beliebtesten?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_most_followed",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Answer ANY free-form "who is...?" superlative question about the
+community that the specific superlative tools above do not cover.
+Routes to the matching leaderboard (index, pillar, tenure, followers)
+or falls back to the general community-member ranking.
+CALL WHEN the user asks e.g.: "who is the most inspiring?", "who is
+the best runner?", "wer ist der/die inspirierendste?", "wer ist am
+aktivsten?". Pass the user's question verbatim as query.
+After the tool runs, read the returned text aloud, then stop.",
+        "name": "ask_who_is",
+        "parameters": {
+          "properties": {
+            "query": {
+              "description": "The user's "who is...?" question, verbatim.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "query",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's Daily Diary entries, newest first, optionally within a date window.
+CALL THIS WHEN the user says:
+  - "What did I write in my diary?" / "Was steht in meinem Tagebuch?"
+  - "Show my diary entries from last week" / "Zeig meine Tagebucheinträge"
+  - "What did I log yesterday?" / "Was habe ich gestern eingetragen?"
+Then summarize the entries naturally — do not read them verbatim or mention IDs.",
+        "name": "list_diary_entries",
+        "parameters": {
+          "properties": {
+            "date_from": {
+              "description": "Optional start date, YYYY-MM-DD (inclusive).",
+              "type": "string",
+            },
+            "date_to": {
+              "description": "Optional end date, YYYY-MM-DD (inclusive).",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max entries to return, 1-30. Omit for 10.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the user's diary streak: current consecutive days with an entry plus their longest streak ever.
+CALL THIS WHEN the user asks:
+  - "What's my diary streak?" / "Wie lang ist meine Tagebuch-Serie?"
+  - "How many days in a row have I journaled?" / "Wie viele Tage am Stück?"
+Then celebrate an active streak, or encourage a restart if it broke.",
+        "name": "get_diary_streak",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Chronological timeline of what Vitana remembers: memory items, extracted facts, and diary entries, newest first.
+CALL THIS WHEN the user asks:
+  - "What happened last month?" / "Was ist letzten Monat passiert?"
+  - "Show my memory timeline" / "Zeig meine Erinnerungs-Zeitleiste"
+  - "What did we talk about in June?" / "Worüber haben wir im Juni gesprochen?"
+Then retell the timeline as a short narrative in the user's language.",
+        "name": "get_memory_timeline",
+        "parameters": {
+          "properties": {
+            "date_from": {
+              "description": "Optional start date, YYYY-MM-DD (inclusive).",
+              "type": "string",
+            },
+            "date_to": {
+              "description": "Optional end date, YYYY-MM-DD (inclusive).",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max timeline entries, 1-40. Omit for 15.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Search stored memories and facts about ONE specific topic, person, or thing.
+CALL THIS WHEN the user asks:
+  - "What do you know about my sister?" / "Was weißt du über meine Schwester?"
+  - "Do you remember my trip to Rome?" / "Erinnerst du dich an meine Rom-Reise?"
+  - "What did I tell you about my project?" / "Was habe ich dir über mein Projekt erzählt?"
+Answer ONLY from the returned content — never invent memories. If empty, say so and offer to remember it now.
+Optional category filter: personal_identity, health_wellness, lifestyle_routines, network_relationships,
+learning_knowledge, business_projects, finance_assets, location_environment, digital_footprint,
+values_aspirations, autopilot_context, future_plans, uncategorized.",
+        "name": "recall_memory_about",
+        "parameters": {
+          "properties": {
+            "category": {
+              "description": "Optional Memory Garden category key to narrow the search.",
+              "type": "string",
+            },
+            "topic": {
+              "description": "The topic, person, or thing to recall (a word or short phrase).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "topic",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Overview of the user's Memory Garden: how many memories are stored per category.
+CALL THIS WHEN the user asks:
+  - "What do you remember about me?" / "Was weißt du alles über mich?"
+  - "How full is my Memory Garden?" / "Wie sieht mein Memory Garden aus?"
+  - "What kind of things have you saved?" / "Was hast du über mich gespeichert?"
+Then summarize warmly: total memories and the biggest categories first.
+For details on a specific topic, use recall_memory_about instead.",
+        "name": "get_memory_garden_summary",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Permanently delete ONE stored memory, only after the user explicitly confirms.
+CALL THIS WHEN the user says:
+  - "Forget that" / "Vergiss das" / "Lösch diese Erinnerung"
+  - "Delete what you saved about X" / "Lösch, was du über X gespeichert hast"
+Flow: find the memory_id via recall_memory_about, call WITHOUT confirm first —
+the tool returns the memory text; read it back and ask the user to confirm.
+Only when they clearly say yes, call again with confirm=true. Deletion is permanent.",
+        "name": "forget_memory",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user explicitly confirmed the deletion.",
+              "type": "boolean",
+            },
+            "memory_id": {
+              "description": "The id of the memory item to delete (from recall_memory_about results).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "memory_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Move an existing calendar event to a new start time (duration is kept unless new_end is given).
+WHEN TO CALL: "move my yoga to 6 pm", "reschedule my doctor appointment to Friday",
+"Verschieb mein Meeting auf morgen 10 Uhr", "Kannst du das Training auf Freitag legen?".
+Identify the event by event_id (preferred) or title_query (fuzzy title match).
+If multiple events match, the result lists candidates — ask the user which one, then call again with event_id.
+After success, confirm the new day and time back to the user.",
+        "name": "reschedule_event",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact calendar event id (UUID), if known.",
+              "type": "string",
+            },
+            "new_end": {
+              "description": "Optional new end time, ISO 8601. Omit to keep the original duration.",
+              "type": "string",
+            },
+            "new_start": {
+              "description": "New start time, ISO 8601 (e.g. "2026-07-10T18:00:00Z").",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times, e.g. "Europe/Berlin".",
+              "type": "string",
+            },
+            "title_query": {
+              "description": "Fuzzy title to find the event, e.g. "yoga" or "dentist". Use when event_id is unknown.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "new_start",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Cancel (soft-delete) a calendar event — the event stays in history with status "cancelled".
+WHEN TO CALL: "cancel my yoga class", "delete the dentist appointment",
+"Sag das Meeting morgen ab", "Lösch den Termin am Freitag".
+Destructive: first call WITHOUT confirm to fetch the event, ask the user to confirm,
+then call again with confirm=true and the event_id. Speak the cancelled title back.",
+        "name": "cancel_event",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true ONLY after the user has verbally confirmed the cancellation.",
+              "type": "boolean",
+            },
+            "event_id": {
+              "description": "Exact calendar event id (UUID), if known.",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times.",
+              "type": "string",
+            },
+            "title_query": {
+              "description": "Fuzzy title to find the event when event_id is unknown.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mark a calendar event as completed, skipped, or partially done.
+WHEN TO CALL: "I finished my workout", "mark the meditation as done", "I skipped my run today",
+"Ich habe das Training gemacht", "Hab die Meditation ausgelassen".
+outcome must be one of: completed, skipped, partial (default completed).
+After success, acknowledge briefly — completed health events feed the Vitana Index.",
+        "name": "complete_event",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact calendar event id (UUID), if known.",
+              "type": "string",
+            },
+            "notes": {
+              "description": "Optional short completion note from the user.",
+              "type": "string",
+            },
+            "outcome": {
+              "description": "One of: completed, skipped, partial. Defaults to completed.",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times.",
+              "type": "string",
+            },
+            "title_query": {
+              "description": "Fuzzy title to find the event when event_id is unknown.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Find the next free slot of a given length in the user's calendar, within waking hours (8 AM-10 PM user-local).
+WHEN TO CALL: "when am I free for an hour?", "find me 30 minutes tomorrow",
+"Wann habe ich morgen Zeit?", "Finde mir eine freie Stunde diese Woche".
+duration_minutes is required (5-720). search_from/search_to are ISO 8601; default is the next 7 days.
+Pass the user's IANA timezone so waking hours and spoken times are local.
+Speak the found day + time back, or say nothing was free and offer to look further out.",
+        "name": "find_free_slot",
+        "parameters": {
+          "properties": {
+            "duration_minutes": {
+              "description": "Required slot length in minutes (5 to 720).",
+              "type": "number",
+            },
+            "search_from": {
+              "description": "Optional ISO 8601 start of the search window. Defaults to now.",
+              "type": "string",
+            },
+            "search_to": {
+              "description": "Optional ISO 8601 end of the search window. Defaults to 7 days after search_from (max 30).",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone, e.g. "Europe/Berlin". Defaults to UTC.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "duration_minutes",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the full details of ONE calendar event: exact time, end, location, type, status, notes.
+WHEN TO CALL: "when exactly is my dentist appointment?", "where is the meetup?",
+"Wann genau ist mein Zahnarzttermin?", "Wo findet das Treffen statt?".
+Identify by event_id or title_query (fuzzy). If several match, the result lists candidates — ask which one.
+Speak the concrete details (day, time, place); never a raw data dump.",
+        "name": "get_event_details",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact calendar event id (UUID), if known.",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times.",
+              "type": "string",
+            },
+            "title_query": {
+              "description": "Fuzzy title to find the event when event_id is unknown.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check whether a proposed time window overlaps existing confirmed calendar events.
+WHEN TO CALL: before creating or rescheduling an event, or when the user asks
+"does 3 pm work on Friday?", "Passt Dienstag 10 Uhr?", "Habe ich da schon etwas?".
+start_time is required (ISO 8601); end_time defaults to one hour after start_time.
+If there are conflicts, name the overlapping events and suggest checking another time.",
+        "name": "check_calendar_conflicts",
+        "parameters": {
+          "properties": {
+            "end_time": {
+              "description": "Proposed end, ISO 8601. Defaults to 1 hour after start_time.",
+              "type": "string",
+            },
+            "start_time": {
+              "description": "Proposed start, ISO 8601 (e.g. "2026-07-10T15:00:00Z").",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "start_time",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Push an existing reminder out by N minutes (default 10, max 1440).
+CALL WHEN the user says 'snooze it', 'remind me again in 15 minutes',
+'verschieb die Erinnerung', 'erinnere mich später nochmal'.
+Pass reminder_id when known (e.g. a reminder just fired), otherwise
+text_query with words from the reminder. If the tool reports multiple
+matches, ask the user which one and call again with that reminder_id.
+After success, speak the confirmation with the new time from \`text\`.",
+        "name": "snooze_reminder",
+        "parameters": {
+          "properties": {
+            "minutes": {
+              "description": "How many minutes to push it out. 1-1440; 10 if omitted.",
+              "type": "number",
+            },
+            "reminder_id": {
+              "description": "UUID of the reminder, if known.",
+              "type": "string",
+            },
+            "text_query": {
+              "description": "Free-text to find the reminder (e.g. 'magnesium').",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Edit an existing reminder's text and/or time.
+CALL WHEN the user says 'change my reminder to 9pm', 'make it say X',
+'ändere meine Erinnerung', 'verschiebe die Erinnerung auf 21 Uhr'.
+Identify via reminder_id or text_query. new_time is an absolute UTC ISO
+timestamp YOU compute from their words + timezone (min 60s in future).
+If multiple reminders match, ask which one, then call again with the id.
+After success, confirm the change using \`text\`.",
+        "name": "update_reminder",
+        "parameters": {
+          "properties": {
+            "new_text": {
+              "description": "New reminder text (max 200 chars). Also becomes the spoken message.",
+              "type": "string",
+            },
+            "new_time": {
+              "description": "New absolute UTC ISO 8601 timestamp. Min 60s in the future.",
+              "type": "string",
+            },
+            "reminder_id": {
+              "description": "UUID of the reminder, if known.",
+              "type": "string",
+            },
+            "text_query": {
+              "description": "Free-text to find the reminder.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mark a fired reminder as heard/acknowledged so it stops being re-delivered.
+CALL WHEN the user says 'got it', 'okay, I heard the reminder', 'dismiss it',
+'alles klar, habs gehört' after a reminder fired — but the task is NOT done yet.
+Use complete_reminder instead when the user actually DID the thing.
+Identify via reminder_id (preferred, e.g. from the fire event) or text_query.",
+        "name": "acknowledge_reminder",
+        "parameters": {
+          "properties": {
+            "reminder_id": {
+              "description": "UUID of the reminder, if known.",
+              "type": "string",
+            },
+            "text_query": {
+              "description": "Free-text to find the reminder.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mark a reminder as DONE (the user did the thing). Sets status=completed.
+CALL WHEN the user says 'done', 'I took my magnesium, check it off',
+'erledigt', 'hab ich gemacht' about a reminder.
+Identify via reminder_id or text_query. If multiple match, ask which one.
+After success, give a short positive confirmation from \`text\`.",
+        "name": "complete_reminder",
+        "parameters": {
+          "properties": {
+            "reminder_id": {
+              "description": "UUID of the reminder, if known.",
+              "type": "string",
+            },
+            "text_query": {
+              "description": "Free-text to find the reminder.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List reminders that fired but were never acknowledged (the user missed them).
+CALL WHEN the user asks 'did I miss anything?', 'what reminders did I miss?',
+'habe ich Erinnerungen verpasst?', or at the start of a session catch-up.
+Speak each missed reminder with its text and when it fired, then offer to
+snooze, complete, or acknowledge them.",
+        "name": "list_missed_reminders",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set a wake-up/clock alarm at a specific time of day (optionally recurring).
+CALL WHEN the user says 'wake me at 7', 'set an alarm for 6:30 on weekdays',
+'stell einen Wecker auf 7 Uhr', 'weck mich um halb sieben'.
+time is 'HH:MM' (24h, interpreted in the given timezone — next occurrence)
+or an absolute ISO timestamp. ALWAYS pass the user timezone from context;
+UTC is assumed when omitted. recurrence: daily, weekdays, or omit for once.
+Prefer alarms for time-of-day wake-ups; use set_reminder for task reminders.
+After success, confirm with the day + time from \`text\`.",
+        "name": "set_alarm",
+        "parameters": {
+          "properties": {
+            "label": {
+              "description": "Optional label, e.g. 'Gym'.",
+              "type": "string",
+            },
+            "recurrence": {
+              "description": "Omit for a one-time alarm.",
+              "enum": [
+                "daily",
+                "weekdays",
+              ],
+              "type": "string",
+            },
+            "time": {
+              "description": "'HH:MM' 24h wall-clock time, or absolute ISO 8601 timestamp.",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "User's IANA timezone, e.g. Europe/Berlin. UTC assumed if omitted.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "time",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's active alarms with times and labels.
+CALL WHEN the user asks 'what alarms do I have?', 'when is my alarm?',
+'welche Wecker habe ich?', or before deleting/changing an alarm.
+Pass timezone so times are spoken in local wall-clock time.",
+        "name": "list_alarms",
+        "parameters": {
+          "properties": {
+            "timezone": {
+              "description": "User's IANA timezone for display. UTC assumed if omitted.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Cancel an alarm. Two-step confirm flow: first call WITHOUT confirm to find
+the alarm (by alarm_id, label, or HH:MM time) — the tool answers with the
+match and asks you to confirm with the user. After the user explicitly says
+yes, call again with that alarm_id and confirm=true.
+CALL WHEN the user says 'delete my alarm', 'cancel the 7am alarm',
+'lösch den Wecker', 'Wecker ausschalten'.",
+        "name": "delete_alarm",
+        "parameters": {
+          "properties": {
+            "alarm_id": {
+              "description": "UUID from list_alarms / a previous delete_alarm match.",
+              "type": "string",
+            },
+            "confirm": {
+              "description": "true ONLY after the user explicitly confirmed the deletion.",
+              "type": "boolean",
+            },
+            "label": {
+              "description": "Match by label substring instead of id.",
+              "type": "string",
+            },
+            "time": {
+              "description": "Match by 'HH:MM' local time instead of id (pass timezone too).",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "User's IANA timezone for the time match. UTC assumed if omitted.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Start a countdown timer (1-1440 minutes).
+CALL WHEN the user says 'set a timer for 10 minutes', 'timer for the pasta',
+'stell einen Timer auf 10 Minuten', 'Countdown 20 Minuten'.
+For focused work blocks prefer start_pomodoro. After success, confirm the
+duration and label from \`text\`.",
+        "name": "start_timer",
+        "parameters": {
+          "properties": {
+            "duration_minutes": {
+              "description": "Countdown length in minutes, 1-1440.",
+              "type": "number",
+            },
+            "label": {
+              "description": "Optional label, e.g. 'Pasta'.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "duration_minutes",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Start a pomodoro focus block (5-90 minutes; 25 if omitted).
+CALL WHEN the user says 'start a pomodoro', 'let's do a focus session',
+'starte eine Pomodoro-Einheit', '45 Minuten Fokuszeit'.
+After success, confirm the length and encourage focused work.",
+        "name": "start_pomodoro",
+        "parameters": {
+          "properties": {
+            "duration_minutes": {
+              "description": "Work block length in minutes, 5-90. 25 if omitted.",
+              "type": "number",
+            },
+            "label": {
+              "description": "Optional focus topic, e.g. 'Deep work on the report'.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List running timers and pomodoros with the remaining time on each.
+CALL WHEN the user asks 'how much time is left?', 'is my timer still running?',
+'wie lange läuft mein Timer noch?', 'wie viel Zeit habe ich noch?'.
+Speak each entry with its label and remaining time from \`text\`.",
+        "name": "list_active_timers",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the current local time in a city or IANA timezone (no internet needed).
+CALL WHEN the user asks 'what time is it in Tokyo?', 'wie spät ist es in
+Belgrad?', 'what's the time in New York right now?'.
+location accepts a major city name (Berlin, Belgrade, London, New York,
+Tokyo, ...) or any IANA zone like 'Europe/Berlin'. Speak the \`text\` answer.",
+        "name": "get_world_time",
+        "parameters": {
+          "properties": {
+            "location": {
+              "description": "City name or IANA timezone, e.g. 'Berlin' or 'Europe/Berlin'.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "location",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the community groups the user belongs to, with member counts.
+CALL WHEN the user asks: "what groups am I in?", "show my groups",
+"in welchen Gruppen bin ich?", "zeig mir meine Gruppen".
+After the tool runs, read the group names and member counts aloud.",
+        "name": "list_my_groups",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a new community group. Requires a name; privacy is public or
+private (default public). ALWAYS call once WITHOUT confirm first —
+the tool returns a confirmation question; after the user says yes,
+call again with confirm:true.
+CALL WHEN the user says: "create a group called ...", "start a new
+group", "erstelle eine Gruppe ...", "gründe eine neue Gruppe".",
+        "name": "create_group",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the creation.",
+              "type": "boolean",
+            },
+            "description": {
+              "description": "Optional short group description.",
+              "type": "string",
+            },
+            "name": {
+              "description": "The group name.",
+              "type": "string",
+            },
+            "privacy": {
+              "description": "Either 'public' or 'private'. Public if omitted.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Join a community group by name or group_id. Resolves fuzzy names and
+lists candidates when several match. Private groups cannot be self-joined.
+CALL WHEN the user says: "join the sleep group", "I want to join ...",
+"tritt der Gruppe ... bei", "ich möchte der Gruppe beitreten".
+After joining, tell the user they are in and the app is opening the group.",
+        "name": "join_group",
+        "parameters": {
+          "properties": {
+            "group_id": {
+              "description": "Exact group UUID when already known from a previous tool result.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken group name (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Invite another community member to a group. Resolves the member by
+spoken name and the group by name; the member gets a notification.
+CALL WHEN the user says: "invite Anna to my walking group",
+"lade Anna in die Gruppe ... ein".
+If the tool lists several member or group candidates, ask which one.",
+        "name": "invite_to_group",
+        "parameters": {
+          "properties": {
+            "group": {
+              "description": "Spoken group name (fuzzy matched).",
+              "type": "string",
+            },
+            "group_id": {
+              "description": "Exact group UUID when known.",
+              "type": "string",
+            },
+            "member_name": {
+              "description": "Spoken name of the member to invite.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "Exact user UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "message": {
+              "description": "Optional personal message to include.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Accept a pending group invitation (joins the group). With no
+invitation_id it lists the pending invitations, or acts when only one.
+CALL WHEN the user says: "accept the invitation", "yes, join that group",
+"nimm die Einladung an", "Einladung annehmen".",
+        "name": "accept_invitation",
+        "parameters": {
+          "properties": {
+            "group": {
+              "description": "Spoken group name to pick among several pending invitations.",
+              "type": "string",
+            },
+            "invitation_id": {
+              "description": "The invitation UUID from a previous tool result, if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Decline a pending group invitation. ALWAYS call once WITHOUT confirm
+first — the tool returns a confirmation question; after the user says
+yes, call again with the invitation_id and confirm:true.
+CALL WHEN the user says: "decline the invitation", "no thanks, decline
+it", "lehne die Einladung ab", "Einladung ablehnen".",
+        "name": "decline_invitation",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed declining.",
+              "type": "boolean",
+            },
+            "group": {
+              "description": "Spoken group name to pick among several pending invitations.",
+              "type": "string",
+            },
+            "invitation_id": {
+              "description": "The invitation UUID from a previous tool result, if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "RSVP / sign the user up for a community event or meetup, by event_id
+or fuzzy title. Checks capacity and existing signup first.
+CALL WHEN the user says: "sign me up for ...", "RSVP to the yoga
+meetup", "melde mich für ... an", "ich will beim Event ... dabei sein".
+If several events match, read the candidates and ask which one.",
+        "name": "rsvp_event",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact event UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken event title (fuzzy matched against upcoming events).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Cancel the user's RSVP for an upcoming event. ALWAYS call once
+WITHOUT confirm first — the tool returns a confirmation question;
+after the user says yes, call again with the event_id and confirm:true.
+CALL WHEN the user says: "cancel my RSVP", "I can't make it to ...",
+"melde mich vom Event ... ab", "storniere meine Anmeldung".",
+        "name": "cancel_rsvp",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the cancellation.",
+              "type": "boolean",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken event title (matched against the user's RSVPs).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List upcoming community meetups/events the user could attend, soonest
+first; events in the user's home city are flagged "near you" and
+events they already RSVP'd are marked.
+CALL WHEN the user asks: "what meetups are coming up?", "any events
+this week?", "welche Meetups stehen an?", "gibt es bald Events?".
+Read the titles with dates aloud, then offer to sign them up.",
+        "name": "list_upcoming_meetups",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Join/open a community live room by name or room_id. Returns a
+navigation directive that opens the room screen — the app navigates
+automatically; do not describe the navigation mechanics.
+CALL WHEN the user says: "join the live room", "take me into the ...
+room", "bring mich in den Live-Raum", "öffne den Live-Raum ...".
+If several rooms match, read the candidates and ask which one.",
+        "name": "join_live_room",
+        "parameters": {
+          "properties": {
+            "query": {
+              "description": "Spoken room title (fuzzy matched against live and scheduled rooms).",
+              "type": "string",
+            },
+            "room_id": {
+              "description": "Exact live room UUID when known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Start (or reuse) a direct-message conversation with a named community member,
+optionally sending the first message in the same call.
+WHEN: "start a chat with Maria", "message Alex for the first time",
+"schreib Maria an", "starte eine Unterhaltung mit Alex".
+Pass member (spoken name or Vitana ID) or member_user_id (UUID from resolve_recipient).
+With message set, it sends immediately via the canonical send path.
+Without message, it resolves the member, says whether a conversation already
+exists, and returns recipient_user_id — read back the name, ask what to say,
+then send with send_chat_message or call this again with message set.",
+        "name": "start_conversation",
+        "parameters": {
+          "properties": {
+            "member": {
+              "description": "Spoken name or Vitana ID of the member to chat with.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if already resolved (preferred over member).",
+              "type": "string",
+            },
+            "message": {
+              "description": "Optional first message to send immediately. Only pass after the user confirmed the wording.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's recent direct-message conversations, newest first, with
+who wrote last and a short snippet.
+WHEN: "show my conversations", "who have I been chatting with?",
+"zeig meine Chats", "mit wem habe ich geschrieben?".
+These are internal Maxina messages — no Google account involved.
+Speak the names and snippets naturally; to continue one, use send_chat_message.",
+        "name": "list_conversations",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "How many conversations to return, 1-15. Uses a sensible default when omitted.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mark direct messages as read. With member set, marks that conversation;
+without it (or with all=true), marks ALL unread messages.
+WHEN: "mark my chat with Maria as read", "mark everything read",
+"markiere den Chat mit Maria als gelesen", "alles als gelesen markieren".
+Afterwards, confirm how many messages were marked.",
+        "name": "mark_conversation_read",
+        "parameters": {
+          "properties": {
+            "all": {
+              "description": "Set true to mark every unread message as read.",
+              "type": "boolean",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the conversation partner. Omit to mark everything.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the conversation partner if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mute a chat conversation. NOTE: chat muting is not supported in Vitana yet —
+this tool answers honestly and suggests block_user as the stronger alternative.
+WHEN: "mute this chat", "mute Maria", "schalte den Chat stumm".
+Relay the returned text plainly; never claim the chat was muted.",
+        "name": "mute_conversation",
+        "parameters": {
+          "properties": {
+            "member": {
+              "description": "Spoken name of the conversation partner (used to word the answer).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Archive a chat conversation. NOTE: chat archiving does not exist in Vitana —
+this tool answers honestly. Never invent or offer "archived messages".
+WHEN: "archive this chat", "archiviere den Chat mit Maria".
+Relay the returned text plainly; suggest mark_conversation_read or block_user instead.",
+        "name": "archive_conversation",
+        "parameters": {
+          "properties": {
+            "member": {
+              "description": "Spoken name of the conversation partner (used to word the answer).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set the visibility of the user's WHOLE profile: public, followers_only, or private.
+Writes every per-field visibility setting at once (partner-search posts stay private).
+WHEN: "make my profile private", "set my account to public",
+"mach mein Profil privat", "stell mein Konto auf öffentlich".
+Two-step: first call returns a confirmation request — read it back, get an
+explicit yes, then call again with confirm=true. Then confirm the change out loud.",
+        "name": "update_account_visibility",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true only after the user explicitly confirmed the change.",
+              "type": "boolean",
+            },
+            "visibility": {
+              "description": "One of: public, followers_only, private.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "visibility",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set the visibility of ONE profile field: public, followers_only, or private.
+Fields: age, birthday, location (city), country, address, email, phone, gender,
+first/last name, marital status, dance/partner preferences, service offerings, posts.
+WHEN: "hide my age", "make my location visible to followers only",
+"verstecke mein Alter", "zeig meine Stadt nur meinen Kontakten".
+Health data is always private and has no setting. Confirm the change out loud after.",
+        "name": "update_privacy_field",
+        "parameters": {
+          "properties": {
+            "field": {
+              "description": "The field to change, e.g. "age", "location", "email", "phone", "birthday".",
+              "type": "string",
+            },
+            "visibility": {
+              "description": "One of: public, followers_only, private.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "field",
+            "visibility",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Block a community member so their posts and messages are hidden from the user.
+WHEN: "block Maria", "I don't want to see Alex anymore",
+"blockiere Maria", "ich will nichts mehr von Alex sehen".
+Two-step: the first call resolves the member and returns a confirmation request —
+read the name back, get an explicit yes, then call again with confirm=true and
+the returned member_user_id. Afterwards, confirm the block and mention it can be undone.",
+        "name": "block_user",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true only after the user explicitly confirmed the block.",
+              "type": "boolean",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the member to block.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member (from the confirmation step or resolve_recipient).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Unblock a previously blocked member so their posts and messages show again.
+Matches the name against the user's own blocked list only.
+WHEN: "unblock Maria", "entblockiere Maria", "hebe die Blockierung von Alex auf".
+If the name is not on the blocked list, the tool says who currently is —
+relay that plainly. Afterwards, confirm the unblock out loud.",
+        "name": "unblock_user",
+        "parameters": {
+          "properties": {
+            "member": {
+              "description": "Spoken name or Vitana ID of the member to unblock.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "File a bug ticket (kind=bug) in the feedback pipeline. No persona swap —
+just files and confirms. Call when the user describes something BROKEN and
+wants it reported: "melde diesen Fehler", "die App stürzt ab, bitte melden",
+"report this bug", "the button does nothing, file it".
+The summary must be a concrete description of at least 15 words in the
+user's own words — which screen, what happened, what was expected.
+AFTER: speak the ticket number once and say the team will follow up.
+For live handoff to a specialist use report_to_specialist instead.",
+        "name": "submit_bug_report",
+        "parameters": {
+          "properties": {
+            "screen": {
+              "description": "Optional: the screen or feature where the bug happened (e.g. /events, profile page).",
+              "type": "string",
+            },
+            "summary": {
+              "description": "Concrete bug description, at least 15 words, in the user's own words (what broke, where, what was expected).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "summary",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "File a support ticket (kind=support_question) for a question the team
+should answer offline. Call when the user explicitly wants their question
+logged for support: "erstell ein Support-Ticket", "leite meine Frage an den
+Support weiter", "open a support ticket", "log this question for support".
+Do NOT call for how-to questions you can answer yourself — answer inline.
+Summary: at least 12 words describing the question and context.
+AFTER: speak the ticket number once and say support will follow up.",
+        "name": "submit_support_ticket",
+        "parameters": {
+          "properties": {
+            "summary": {
+              "description": "The user's question with context, at least 12 words.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "summary",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "File a marketplace dispute ticket (kind=marketplace_claim): refunds, wrong
+or damaged items, orders that never arrived, seller issues, overcharges.
+Triggers: "ich will mein Geld zurück", "die Bestellung ist nie angekommen",
+"I want a refund", "the seller sent the wrong item, file a claim".
+Summary: at least 12 words — what was ordered, what went wrong, what the
+user wants (refund / replacement). Include the order number if they have it.
+AFTER: speak the ticket number once and say the team will review the claim.",
+        "name": "submit_marketplace_dispute",
+        "parameters": {
+          "properties": {
+            "order_reference": {
+              "description": "Optional: order number or reference the user mentions.",
+              "type": "string",
+            },
+            "summary": {
+              "description": "Dispute description, at least 12 words: item, problem, desired outcome.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "summary",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "File an account ticket (kind=account_issue): login problems, password or
+email trouble, role/permission issues, profile data corrections, lockouts.
+Triggers: "ich komme nicht in mein Konto", "meine E-Mail stimmt nicht,
+bitte melden", "I'm locked out", "report my login problem".
+NEVER ask for or record passwords. Summary: at least 12 words describing
+the account problem and what the user already tried.
+AFTER: speak the ticket number once and say the team will follow up.",
+        "name": "submit_account_issue",
+        "parameters": {
+          "properties": {
+            "summary": {
+              "description": "Account problem description, at least 12 words. Never include passwords.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "summary",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's OPEN feedback tickets (bugs, support, disputes, account)
+with number and status. Call when the user asks about their reports:
+"was ist mit meinen Tickets?", "wie steht es um meine Fehlermeldung?",
+"what happened to my bug report?", "show my open tickets".
+AFTER: read back ticket number, what it is, and its status in the user's
+language. Never mention internal specialist names.",
+        "name": "list_my_tickets",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set the user's app + voice language. Persists the same setting the app's
+Language picker writes, so screens and notifications follow. Call when the
+user asks to switch language: "stell auf Deutsch um", "sprich Englisch mit
+mir", "switch the app to English", "cambia a español".
+AFTER: respond ONLY in the new language from that moment on and confirm
+the change; the app screens follow on the next reload.",
+        "name": "set_language",
+        "parameters": {
+          "properties": {
+            "language": {
+              "description": "Target language code: de (German), en (English), es (Spanish), sr (Serbian).",
+              "enum": [
+                "de",
+                "en",
+                "es",
+                "sr",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "language",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Handle a request to change the visual theme (light / dark / system).
+Triggers: "mach den Dunkelmodus an", "stell auf hell", "switch to dark
+mode", "use the system theme".
+NOTE: the theme is stored on the device, not on the server — this tool
+explains where to flip it (Settings → Preferences → Theme). Relay that
+guidance in the user's language; do not promise the theme changed.",
+        "name": "set_theme",
+        "parameters": {
+          "properties": {
+            "theme": {
+              "description": "The theme the user asked for.",
+              "enum": [
+                "light",
+                "dark",
+                "system",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Tune the app's spoken-voice settings: pace (slow / normal / fast), voice
+name, and tone/character. Persists to the same voice settings the app's
+Voice & AI screen uses. Triggers: "sprich langsamer", "sprich schneller",
+"klinge ruhiger", "speak slower please", "use a calmer tone".
+Provide only the fields the user asked to change.
+AFTER: confirm briefly what changed, in the user's language.",
+        "name": "set_voice_preferences",
+        "parameters": {
+          "properties": {
+            "pace": {
+              "description": "Speaking speed the user asked for.",
+              "enum": [
+                "slow",
+                "normal",
+                "fast",
+              ],
+              "type": "string",
+            },
+            "tone": {
+              "description": "Optional: tone/character, e.g. friendly, calm, energetic, professional.",
+              "type": "string",
+            },
+            "voice": {
+              "description": "Optional: a specific voice name the user asked for.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's connected integrations: Google, YouTube, social accounts,
+and AI assistants (OpenAI, Anthropic, Gemini). Call when the user asks:
+"welche Apps sind verbunden?", "ist mein Google-Konto verknüpft?",
+"what apps are connected?", "is Spotify linked?".
+AFTER: name each connected app naturally in the user's language; if none,
+say so and mention Settings → Connected Apps.",
+        "name": "list_connected_apps",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Disconnect one connected integration (Google, YouTube, Instagram, an AI
+assistant, ...). Triggers: "trenne mein Google-Konto", "entferne YouTube",
+"disconnect my Google account", "unlink ChatGPT".
+TWO-STEP: first call WITHOUT confirm — the tool returns a confirmation
+question to relay. Only after the user explicitly says yes, call again
+with confirm=true. Never disconnect without that explicit yes.
+AFTER (confirmed): confirm it is disconnected and reconnectable in
+Settings → Connected Apps.",
+        "name": "disconnect_app",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user explicitly confirmed the disconnect out loud.",
+              "type": "boolean",
+            },
+            "provider": {
+              "description": "Which integration to disconnect, e.g. google, youtube, instagram, facebook, tiktok, linkedin, twitter, openai, anthropic, gemini.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "provider",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Unified community search across people, posts, events, groups, products,
+and services in one call. Returns the top hits per category.
+CALL WHEN the user asks a broad "find/search" question: "search for yoga",
+"find anything about fasting", "such nach Tennis", "gibt es was zu Schlaf?".
+For a specific person prefer find_community_member; for events only,
+search_events. After the tool runs, present the most relevant category
+first — top two or three hits, never the raw list.",
+        "name": "global_search",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max hits per category, 1-5. Omit for 3.",
+              "type": "number",
+            },
+            "query": {
+              "description": "What the user is looking for, verbatim.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "query",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the community news feed aloud: recent posts with author and a
+one-line summary. scope "following" limits to people the user follows;
+"all" is the whole community (default).
+CALL WHEN the user asks: "what's new in the community?", "read me the
+feed", "was gibt es Neues?", "zeig mir die Neuigkeiten von Leuten denen
+ich folge". After the tool runs, speak each post as author plus a short
+summary — never read long posts word for word.",
+        "name": "browse_news_feed",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "How many posts to read, 1-10. Omit for 5.",
+              "type": "number",
+            },
+            "scope": {
+              "description": ""following" = only people the user follows; "all" = whole community (default).",
+              "enum": [
+                "following",
+                "all",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Snooze an Autopilot recommendation so it resurfaces later (default 24h,
+max one week). Accepts the recommendation id or a spoken title fragment.
+CALL WHEN the user says: "remind me about that later", "snooze the sleep
+recommendation", "später erinnern", "leg das auf Wiedervorlage".
+After the tool runs, confirm the title and when it will come back.",
+        "name": "snooze_recommendation",
+        "parameters": {
+          "properties": {
+            "hours": {
+              "description": "Hours to snooze, 1-168. Omit for 24.",
+              "type": "number",
+            },
+            "recommendation": {
+              "description": "Recommendation id (UUID) or a title fragment the user said.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "recommendation",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Dismiss an Autopilot recommendation for good (it will not come back).
+TWO-STEP: first call returns a confirmation question — read it back;
+only after a clear yes call again with confirm=true.
+CALL WHEN the user says: "not interested", "dismiss that suggestion",
+"das interessiert mich nicht", "weg damit".
+If the user just wants it later, use snooze_recommendation instead.",
+        "name": "dismiss_recommendation",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user verbally confirmed the dismissal.",
+              "type": "boolean",
+            },
+            "reason": {
+              "description": "OPTIONAL — why the user dismisses it, in their words.",
+              "type": "string",
+            },
+            "recommendation": {
+              "description": "Recommendation id (UUID) or a title fragment the user said.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "recommendation",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Explain WHY a specific Autopilot recommendation was suggested: its
+rationale, which Vitana pillars it strengthens, impact vs effort, and
+where it came from. Accepts an id or a spoken title fragment.
+CALL WHEN the user asks: "why are you suggesting this?", "what's that
+recommendation about?", "warum schlägst du mir das vor?", "was bringt
+mir das?". After the tool runs, narrate the reason in 2-3 sentences and
+offer to activate, snooze, or dismiss it.",
+        "name": "explain_recommendation",
+        "parameters": {
+          "properties": {
+            "recommendation": {
+              "description": "Recommendation id (UUID) or a title fragment the user said.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "recommendation",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Edit one of the user's OWN intent posts (title, description text, or
+category). Accepts the intent id or a spoken title fragment.
+CALL WHEN the user says: "change my tennis post to say weekends only",
+"update the title of my ask", "ändere meinen Beitrag", "mach aus meinem
+Post ...". Pass ONLY the fields that change. After the tool runs,
+confirm what was updated in one sentence.",
+        "name": "update_intent",
+        "parameters": {
+          "properties": {
+            "intent": {
+              "description": "Intent id (UUID) or a title fragment identifying the user's post.",
+              "type": "string",
+            },
+            "new_category": {
+              "description": "OPTIONAL — the new dotted category, e.g. sport.tennis.",
+              "type": "string",
+            },
+            "new_text": {
+              "description": "OPTIONAL — the new description / scope text.",
+              "type": "string",
+            },
+            "new_title": {
+              "description": "OPTIONAL — the new title.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "intent",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Take down one of the user's OWN intent posts from the board (closes it;
+matching stops). TWO-STEP: first call returns a confirmation question —
+read it back; only after a clear yes call again with confirm=true.
+CALL WHEN the user says: "delete my post", "remove my tennis ask",
+"lösch meinen Beitrag", "nimm das vom Brett".
+If the ask was fulfilled, prefer mark_intent_fulfilled instead.",
+        "name": "delete_intent",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user verbally confirmed the removal.",
+              "type": "boolean",
+            },
+            "intent": {
+              "description": "Intent id (UUID) or a title fragment identifying the user's post.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "intent",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse the open community intent board (Open Asks): what other members
+are looking for, buying, selling, or offering right now. Optional query
+filters by topic. Never shows the user's own posts.
+CALL WHEN the user asks: "what are people looking for?", "browse the
+asks board", "was suchen andere gerade?", "zeig mir das Schwarze Brett".
+After the tool runs, present the top asks (title + kind) and offer to
+respond to one or post the user's own ask.",
+        "name": "browse_intent_board",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max asks to return, 1-10. Omit for 5.",
+              "type": "number",
+            },
+            "query": {
+              "description": "OPTIONAL — topic filter, e.g. "tennis" or "babysitting".",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Open a dispute on a match the user is part of (no-show, misrepresented,
+safety, payment, other). MULTI-STEP: the tool first collects the reason,
+then returns a confirmation question — only after a clear yes call again
+with confirm=true. CALL WHEN the user says: "the seller never showed up",
+"I want to report this match", "der Kontakt war fake", "ich möchte das
+Match melden". Stay neutral and factual — never promise an outcome.",
+        "name": "dispute_match",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user verbally confirmed filing the dispute.",
+              "type": "boolean",
+            },
+            "match_id": {
+              "description": "The match id if known. Omit to auto-detect from the user's recent matches.",
+              "type": "string",
+            },
+            "reason": {
+              "description": "What happened, in the user's words.",
+              "type": "string",
+            },
+            "reason_category": {
+              "description": "Best-fitting category for what happened.",
+              "enum": [
+                "no_show",
+                "misrepresented",
+                "safety",
+                "payment",
+                "other",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Flagship people-match: find the PERFECT person for the user — workout
+partner, accountability buddy, mentor, learning partner — personalized
+with their Life Compass goal and weakest Vitana pillar. Searches the
+live community asks and, per the confirm flow, also posts the request
+so the user becomes discoverable.
+CALL WHEN the user says: "find me a workout partner", "who would be my
+perfect accountability buddy?", "find den perfekten Trainingspartner
+für mich", "such mir einen Mentor".
+Follow the returned text exactly — it tells you whether matches were
+found or a read-back confirmation is needed (then call again with
+confirmed=true).",
+        "name": "find_perfect_match",
+        "parameters": {
+          "properties": {
+            "ask": {
+              "description": "What kind of person the user wants, verbatim. May be omitted — then the weakest pillar suggests one.",
+              "type": "string",
+            },
+            "confirmed": {
+              "description": "Pass true ONLY after the user confirmed posting the request (second call).",
+              "type": "boolean",
+            },
+            "kind_hint": {
+              "description": "OPTIONAL intent kind hint, e.g. activity_seek or social_seek.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's current emotional and cognitive signals (D28): mood,
+focus, engagement, urgency, hesitation — from analyzed conversation
+signals, or recent diary moods/energy when no live signals exist.
+CALL WHEN the user asks: "how am I doing?", "how do I seem to you?",
+"wie wirke ich gerade?", "wie geht es mir laut meinen Daten?".
+Speak the returned text as-is — it already names the data source.
+Never diagnose; these are light behavioral observations only.",
+        "name": "get_emotional_state",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Summarize the user's current situation (D32): time-of-day window,
+availability, energy, suggested conversation depth and any active
+constraints, enriched with their next calendar commitment.
+CALL WHEN the user asks: "what's my situation right now?", "is this
+a good moment?", "wie sieht meine Lage gerade aus?", "passt es gerade?".
+Optionally pass timezone (IANA name like Europe/Berlin) if known.
+Speak the returned text; it states what the summary is based on.",
+        "name": "get_situational_awareness",
+        "parameters": {
+          "properties": {
+            "timezone": {
+              "description": "The user's IANA timezone (e.g. Europe/Berlin), only if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check how available and ready the user is right now (D33): availability
+level, time window, readiness score, calendar density for the next
+hours, whether they are in an event, and reminders due soon.
+CALL WHEN the user asks: "do I have time right now?", "is now a good
+time?", "habe ich gerade Zeit?", "ist jetzt ein guter Zeitpunkt?",
+or BEFORE proposing a long activity or deep session.
+Optionally pass timezone (IANA name) if known. Speak the returned text.",
+        "name": "get_availability",
+        "parameters": {
+          "properties": {
+            "timezone": {
+              "description": "The user's IANA timezone (e.g. Europe/Berlin), only if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's environment and mobility context (D34): where they
+are based or traveling, how they get around, late-night/early-morning
+flags and indoor/outdoor suitability — from stored location facts,
+preferences and visit history. Never invents a location.
+CALL WHEN the user asks: "what do you know about where I am?",
+"was weißt du über meine Umgebung?", or before suggesting nearby or
+outdoor activities. Speak the returned text; it names its sources.",
+        "name": "get_environmental_context",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's life-stage context (D40): life phase and stability,
+any transition, Life Compass goal and category, age band (from their
+stated birthday) and community tenure.
+CALL WHEN the user asks: "where am I in life?", "what stage am I in?",
+"wo stehe ich gerade im Leben?", "in welcher Lebensphase bin ich?",
+or when tailoring long-term advice to their life situation.
+Speak the returned text; it is non-prescriptive — the user knows
+their life best. If nothing is on record, offer to set up Life Compass.",
+        "name": "get_life_stage_context",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "FOLLOW a community member by their spoken name.
+CALL THIS for: "Follow Anna" / "Folge Anna" / "Ich möchte Peter folgen" /
+"Follow that member".
+Resolves the name to a member; if no match, ask the user to repeat the name.
+After success, confirm in one short sentence.",
+        "name": "follow_member",
+        "parameters": {
+          "properties": {
+            "name": {
+              "description": "Spoken name (or handle) of the member to follow.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "UNFOLLOW a community member by name. Two-step confirm:
+first call returns a confirmation question — ask it, then call again with
+confirmed=true after the user says yes.
+CALL THIS for: "Unfollow Anna" / "Entfolge Anna" / "Ich will Peter nicht mehr folgen".",
+        "name": "unfollow_member",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "true only after the user verbally confirmed.",
+              "type": "boolean",
+            },
+            "name": {
+              "description": "Spoken name of the member to unfollow.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ the user's recent notifications, unread first. Speakable.
+CALL THIS for: "Any notifications?" / "Habe ich Benachrichtigungen?" /
+"Was gibt es Neues für mich?" / "Read my notifications".
+Speak the unread count and the top titles — never deflect to the bell icon.",
+        "name": "get_notifications",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "How many to read out, 1-20. Uses 10 when omitted.",
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "MARK notifications as read — all unread ones, or only those whose title
+matches a spoken reference.
+CALL THIS for: "Mark all as read" / "Alle als gelesen markieren" /
+"Clear my notifications" / "Mark the match notification as read".",
+        "name": "mark_notifications_read",
+        "parameters": {
+          "properties": {
+            "reference": {
+              "description": "Optional words from one notification title to mark only that one. Omit to mark all.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY wallet snapshot: balance per currency, active subscription,
+last 3 transactions. NEVER moves money — payments happen in the Wallet screen.
+CALL THIS for: "What is my wallet balance?" / "Wie viel Guthaben habe ich?" /
+"Was ist auf meinem Wallet?" / "My last transactions".",
+        "name": "get_wallet_balance",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "UPDATE simple own-profile fields: display_name, bio, city, country, location.
+Two-step confirm: first call returns a verbatim read-back — speak it, then
+call again with confirmed=true after the user agrees.
+CALL THIS for: "Change my bio to …" / "Ändere meinen Namen zu …" /
+"Setze meine Stadt auf Berlin".
+NEVER use this for role or profile visibility — privacy settings own those.",
+        "name": "update_profile",
+        "parameters": {
+          "properties": {
+            "bio": {
+              "description": "New bio text.",
+              "type": "string",
+            },
+            "city": {
+              "description": "New city.",
+              "type": "string",
+            },
+            "confirmed": {
+              "description": "true only after the user confirmed the read-back.",
+              "type": "boolean",
+            },
+            "country": {
+              "description": "New country.",
+              "type": "string",
+            },
+            "display_name": {
+              "description": "New display name.",
+              "type": "string",
+            },
+            "location": {
+              "description": "New free-text location, e.g. "Berlin, Germany".",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "PLAY an internal Vitana Media Hub podcast by title or topic. Returns an
+open_url directive the app uses to start playback.
+CALL THIS for: "Play the longevity podcast" / "Spiel den Vitana Podcast" /
+"Play a podcast about sleep".
+For music use play_music instead. After success, say what is now playing.",
+        "name": "play_podcast",
+        "parameters": {
+          "properties": {
+            "query": {
+              "description": "Podcast title or topic. Omit to play the most popular one.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "LIKE a community feed post — resolves "the last post from <name>" to that
+member's most recent public post.
+CALL THIS for: "Like Anna's post" / "Like den letzten Beitrag von Anna" /
+"Gefällt mir für Peters Post".
+After success, confirm which post was liked in one sentence.",
+        "name": "like_post",
+        "parameters": {
+          "properties": {
+            "author_name": {
+              "description": "Spoken name of the post's author.",
+              "type": "string",
+            },
+            "post_reference": {
+              "description": "Optional words from the post content to pick a specific post instead of the latest.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "author_name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "COMMENT on a community feed post (public text). Two-step confirm:
+first call returns the comment for verbatim read-back — speak it, then call
+again with confirmed=true after the user says post/yes.
+CALL THIS for: "Comment on Anna's post: great work" /
+"Kommentiere Peters Beitrag mit …".",
+        "name": "comment_on_post",
+        "parameters": {
+          "properties": {
+            "author_name": {
+              "description": "Spoken name of the post's author.",
+              "type": "string",
+            },
+            "confirmed": {
+              "description": "true only after the user confirmed the read-back.",
+              "type": "boolean",
+            },
+            "post_reference": {
+              "description": "Optional words from the post content to pick a specific post instead of the latest.",
+              "type": "string",
+            },
+            "text": {
+              "description": "The comment text to post.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "author_name",
+            "text",
+          ],
+          "type": "object",
+        },
+      },
+      {
         "description": "Return the top open admin_insights for this tenant, ranked by severity × confidence. Call this AT THE START of every admin orb session to know what needs attention. The bootstrap context already includes the briefing on session-open; only call again if the admin asks "what else?", "anything new?", or "give me the briefing again".",
         "name": "admin_briefing",
         "parameters": {
@@ -2653,6 +4600,223 @@ call this when you are confident the session should end.",
             "hours": {
               "description": "1-168, default 24.",
               "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List recent VTID tasks from the ledger (id, title, status).
+Call when the developer asks: "what are the latest VTIDs", "show open tasks",
+"welche VTIDs laufen gerade", "zeig mir die letzten Tasks".
+Optionally filter by status (scheduled, in_progress, completed, pending, blocked, cancelled).
+Speak each VTID id with its title and status.",
+        "name": "dev_list_vtids",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max rows, 1-20. Use 5 unless the developer asks for more.",
+              "type": "integer",
+            },
+            "status": {
+              "description": "Optional status filter: scheduled, in_progress, completed, pending, blocked, cancelled.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Get one VTID task by id — status, spec status, terminal state, claim.
+Call when the developer asks: "what is the status of VTID 1234", "is 2782 done",
+"wie steht es um VTID 1234", "ist die Task fertig".
+Accepts loose ids: "VTID-01234", "vtid 1234" or just "1234".
+Speak the title, status, spec status and whether it is terminal.",
+        "name": "dev_get_vtid_status",
+        "parameters": {
+          "properties": {
+            "vtid": {
+              "description": "VTID reference, e.g. "VTID-01234" or "1234".",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List PRs/actions waiting in the approvals queue (same queue as the Command Hub approvals view).
+Call when the developer asks: "what is waiting for approval", "any PRs to approve",
+"was wartet auf Freigabe", "gibt es offene Approvals".
+Speak VTID, title, PR number and checks status for each item; then offer to approve or reject.",
+        "name": "dev_list_pending_approvals",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max items, 1-20. Use 5 unless asked for more.",
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Count how many items are pending approval.
+Call when the developer asks: "how many approvals are pending",
+"wie viele Freigaben stehen an". Speak just the number.",
+        "name": "dev_count_approvals",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Approve a queued approval — merges its PR via the governed pipeline.
+Call when the developer says: "approve VTID 1234", "merge that PR", "gib 1234 frei".
+TWO-STEP: first call WITHOUT confirm to get the confirmation text, read it to the
+developer, and only after an explicit yes call again with confirm=true.
+Identify the item by vtid (preferred, from dev_list_pending_approvals) or approval_id.",
+        "name": "dev_approve_pr",
+        "parameters": {
+          "properties": {
+            "approval_id": {
+              "description": "Exact approval id (appr_VTID-XXXXX_hash) if known.",
+              "type": "string",
+            },
+            "confirm": {
+              "description": "Set true ONLY after the developer explicitly confirmed.",
+              "type": "boolean",
+            },
+            "vtid": {
+              "description": "VTID of the queued item, e.g. "VTID-01234".",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Reject a queued approval and record why.
+Call when the developer says: "reject VTID 1234 because ...", "lehne 1234 ab, weil ...".
+A reason is REQUIRED — ask for one if the developer did not give it.
+TWO-STEP: first call WITHOUT confirm, read the confirmation back, then call
+again with confirm=true after an explicit yes.",
+        "name": "dev_reject_pr",
+        "parameters": {
+          "properties": {
+            "approval_id": {
+              "description": "Exact approval id if known.",
+              "type": "string",
+            },
+            "confirm": {
+              "description": "Set true ONLY after the developer explicitly confirmed.",
+              "type": "boolean",
+            },
+            "reason": {
+              "description": "Why it is being rejected. Required.",
+              "type": "string",
+            },
+            "vtid": {
+              "description": "VTID of the queued item.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "reason",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List recent ORB voice sessions from the Voice Lab (who, when, duration, turns).
+Call when the developer asks: "who used voice recently", "any active voice sessions",
+"welche Voice-Sessions liefen zuletzt", "läuft gerade eine Session".
+Optionally filter to active or ended sessions. Speak user, status and start time.",
+        "name": "dev_list_voice_sessions",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max sessions, 1-10. Use 5 unless asked for more.",
+              "type": "integer",
+            },
+            "status": {
+              "description": "Filter: active, ended, or all (all when omitted).",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List the daily Claude routines with last-run status.
+Call when the developer asks: "how are the routines doing", "did the nightly routines run",
+"wie laufen die Routinen", "sind die Routinen durchgelaufen".
+Speak failing routines first, then the rest, with last run result and age.",
+        "name": "dev_list_routines",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Detail one routine plus its last runs.
+Call when the developer asks: "what happened in the morning-report routine",
+"warum ist die Routine fehlgeschlagen", "zeig mir die letzten Läufe von X".
+Accepts the routine name or a close spoken match. Speak schedule, last status and recent runs.",
+        "name": "dev_get_routine_detail",
+        "parameters": {
+          "properties": {
+            "name": {
+              "description": "Routine name or display name (fuzzy match allowed).",
+              "type": "string",
+            },
+            "runs_limit": {
+              "description": "How many recent runs to include, 1-10. Use 5.",
+              "type": "integer",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Show self-healing work currently in flight: active healing VTIDs and pending diagnoses.
+Call when the developer asks: "is self-healing doing anything", "any heals running",
+"läuft gerade ein Self-Healing", "gibt es offene Heilungen".
+Speak counts plus the endpoints/VTIDs involved.",
+        "name": "dev_list_active_healing",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. One-shot autonomy status: pending findings, pending heals, executions
+in flight, failing test contracts, and VTIDs terminalized in the last 24 hours.
+Call when the developer asks: "give me the autonomy pulse", "how is the autopilot doing",
+"wie steht die Autonomie", "was macht der Autopilot gerade".
+Speak the counts and the top attention items.",
+        "name": "dev_get_autonomy_pulse",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List registered agents with heartbeat-derived health (healthy/degraded/down).
+Call when the developer asks: "are all agents up", "which agents are down",
+"sind alle Agenten gesund", "welche Agents laufen".
+Optionally filter by tier (service, embedded, scheduled). Speak problem agents first.",
+        "name": "dev_list_agents",
+        "parameters": {
+          "properties": {
+            "tier": {
+              "description": "Optional tier filter: service, embedded, scheduled.",
+              "type": "string",
             },
           },
           "type": "object",
@@ -5098,6 +7262,1953 @@ call this when you are confident the session should end.",
             },
           },
           "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the community member with the highest Vitana Index right now.
+Returns their name and score; private profiles are never revealed.
+CALL WHEN the user asks: "who has the highest Vitana Index?",
+"who is the healthiest member?", "wer hat den höchsten Vitana Index?",
+"wer ist am gesündesten?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_highest_vitana_index",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the community member with the top score in ONE Vitana Index pillar.
+pillar must be one of: nutrition, hydration, exercise, sleep, mental.
+CALL WHEN the user asks: "who has the best sleep?", "who is the
+fittest?", "wer schläft am besten?", "wer ist am fittesten?",
+"wer trinkt am meisten Wasser?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_top_in_pillar",
+        "parameters": {
+          "properties": {
+            "pillar": {
+              "description": "One of: nutrition, hydration, exercise, sleep, mental.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "pillar",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the very first (earliest-registered / OG) community member.
+CALL WHEN the user asks: "who was the first member?", "who is the
+longest-standing / OG member?", "wer war das erste Mitglied?",
+"wer ist am längsten dabei?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_first_member",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the most recently joined community member.
+CALL WHEN the user asks: "who is the newest member?", "who just
+joined?", "wer ist das neueste Mitglied?", "wer ist gerade beigetreten?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_newest_member",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the community member with the most followers.
+CALL WHEN the user asks: "who has the most followers?", "who is the
+most popular member?", "wer hat die meisten Follower?", "wer ist am
+beliebtesten?".
+After the tool runs, read the returned text aloud (one sentence).",
+        "name": "get_most_followed",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Answer ANY free-form "who is...?" superlative question about the
+community that the specific superlative tools above do not cover.
+Routes to the matching leaderboard (index, pillar, tenure, followers)
+or falls back to the general community-member ranking.
+CALL WHEN the user asks e.g.: "who is the most inspiring?", "who is
+the best runner?", "wer ist der/die inspirierendste?", "wer ist am
+aktivsten?". Pass the user's question verbatim as query.
+After the tool runs, read the returned text aloud, then stop.",
+        "name": "ask_who_is",
+        "parameters": {
+          "properties": {
+            "query": {
+              "description": "The user's "who is...?" question, verbatim.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "query",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's Daily Diary entries, newest first, optionally within a date window.
+CALL THIS WHEN the user says:
+  - "What did I write in my diary?" / "Was steht in meinem Tagebuch?"
+  - "Show my diary entries from last week" / "Zeig meine Tagebucheinträge"
+  - "What did I log yesterday?" / "Was habe ich gestern eingetragen?"
+Then summarize the entries naturally — do not read them verbatim or mention IDs.",
+        "name": "list_diary_entries",
+        "parameters": {
+          "properties": {
+            "date_from": {
+              "description": "Optional start date, YYYY-MM-DD (inclusive).",
+              "type": "string",
+            },
+            "date_to": {
+              "description": "Optional end date, YYYY-MM-DD (inclusive).",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max entries to return, 1-30. Omit for 10.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the user's diary streak: current consecutive days with an entry plus their longest streak ever.
+CALL THIS WHEN the user asks:
+  - "What's my diary streak?" / "Wie lang ist meine Tagebuch-Serie?"
+  - "How many days in a row have I journaled?" / "Wie viele Tage am Stück?"
+Then celebrate an active streak, or encourage a restart if it broke.",
+        "name": "get_diary_streak",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Chronological timeline of what Vitana remembers: memory items, extracted facts, and diary entries, newest first.
+CALL THIS WHEN the user asks:
+  - "What happened last month?" / "Was ist letzten Monat passiert?"
+  - "Show my memory timeline" / "Zeig meine Erinnerungs-Zeitleiste"
+  - "What did we talk about in June?" / "Worüber haben wir im Juni gesprochen?"
+Then retell the timeline as a short narrative in the user's language.",
+        "name": "get_memory_timeline",
+        "parameters": {
+          "properties": {
+            "date_from": {
+              "description": "Optional start date, YYYY-MM-DD (inclusive).",
+              "type": "string",
+            },
+            "date_to": {
+              "description": "Optional end date, YYYY-MM-DD (inclusive).",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max timeline entries, 1-40. Omit for 15.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Search stored memories and facts about ONE specific topic, person, or thing.
+CALL THIS WHEN the user asks:
+  - "What do you know about my sister?" / "Was weißt du über meine Schwester?"
+  - "Do you remember my trip to Rome?" / "Erinnerst du dich an meine Rom-Reise?"
+  - "What did I tell you about my project?" / "Was habe ich dir über mein Projekt erzählt?"
+Answer ONLY from the returned content — never invent memories. If empty, say so and offer to remember it now.
+Optional category filter: personal_identity, health_wellness, lifestyle_routines, network_relationships,
+learning_knowledge, business_projects, finance_assets, location_environment, digital_footprint,
+values_aspirations, autopilot_context, future_plans, uncategorized.",
+        "name": "recall_memory_about",
+        "parameters": {
+          "properties": {
+            "category": {
+              "description": "Optional Memory Garden category key to narrow the search.",
+              "type": "string",
+            },
+            "topic": {
+              "description": "The topic, person, or thing to recall (a word or short phrase).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "topic",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Overview of the user's Memory Garden: how many memories are stored per category.
+CALL THIS WHEN the user asks:
+  - "What do you remember about me?" / "Was weißt du alles über mich?"
+  - "How full is my Memory Garden?" / "Wie sieht mein Memory Garden aus?"
+  - "What kind of things have you saved?" / "Was hast du über mich gespeichert?"
+Then summarize warmly: total memories and the biggest categories first.
+For details on a specific topic, use recall_memory_about instead.",
+        "name": "get_memory_garden_summary",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Permanently delete ONE stored memory, only after the user explicitly confirms.
+CALL THIS WHEN the user says:
+  - "Forget that" / "Vergiss das" / "Lösch diese Erinnerung"
+  - "Delete what you saved about X" / "Lösch, was du über X gespeichert hast"
+Flow: find the memory_id via recall_memory_about, call WITHOUT confirm first —
+the tool returns the memory text; read it back and ask the user to confirm.
+Only when they clearly say yes, call again with confirm=true. Deletion is permanent.",
+        "name": "forget_memory",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user explicitly confirmed the deletion.",
+              "type": "boolean",
+            },
+            "memory_id": {
+              "description": "The id of the memory item to delete (from recall_memory_about results).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "memory_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Move an existing calendar event to a new start time (duration is kept unless new_end is given).
+WHEN TO CALL: "move my yoga to 6 pm", "reschedule my doctor appointment to Friday",
+"Verschieb mein Meeting auf morgen 10 Uhr", "Kannst du das Training auf Freitag legen?".
+Identify the event by event_id (preferred) or title_query (fuzzy title match).
+If multiple events match, the result lists candidates — ask the user which one, then call again with event_id.
+After success, confirm the new day and time back to the user.",
+        "name": "reschedule_event",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact calendar event id (UUID), if known.",
+              "type": "string",
+            },
+            "new_end": {
+              "description": "Optional new end time, ISO 8601. Omit to keep the original duration.",
+              "type": "string",
+            },
+            "new_start": {
+              "description": "New start time, ISO 8601 (e.g. "2026-07-10T18:00:00Z").",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times, e.g. "Europe/Berlin".",
+              "type": "string",
+            },
+            "title_query": {
+              "description": "Fuzzy title to find the event, e.g. "yoga" or "dentist". Use when event_id is unknown.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "new_start",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Cancel (soft-delete) a calendar event — the event stays in history with status "cancelled".
+WHEN TO CALL: "cancel my yoga class", "delete the dentist appointment",
+"Sag das Meeting morgen ab", "Lösch den Termin am Freitag".
+Destructive: first call WITHOUT confirm to fetch the event, ask the user to confirm,
+then call again with confirm=true and the event_id. Speak the cancelled title back.",
+        "name": "cancel_event",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true ONLY after the user has verbally confirmed the cancellation.",
+              "type": "boolean",
+            },
+            "event_id": {
+              "description": "Exact calendar event id (UUID), if known.",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times.",
+              "type": "string",
+            },
+            "title_query": {
+              "description": "Fuzzy title to find the event when event_id is unknown.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mark a calendar event as completed, skipped, or partially done.
+WHEN TO CALL: "I finished my workout", "mark the meditation as done", "I skipped my run today",
+"Ich habe das Training gemacht", "Hab die Meditation ausgelassen".
+outcome must be one of: completed, skipped, partial (default completed).
+After success, acknowledge briefly — completed health events feed the Vitana Index.",
+        "name": "complete_event",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact calendar event id (UUID), if known.",
+              "type": "string",
+            },
+            "notes": {
+              "description": "Optional short completion note from the user.",
+              "type": "string",
+            },
+            "outcome": {
+              "description": "One of: completed, skipped, partial. Defaults to completed.",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times.",
+              "type": "string",
+            },
+            "title_query": {
+              "description": "Fuzzy title to find the event when event_id is unknown.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Find the next free slot of a given length in the user's calendar, within waking hours (8 AM-10 PM user-local).
+WHEN TO CALL: "when am I free for an hour?", "find me 30 minutes tomorrow",
+"Wann habe ich morgen Zeit?", "Finde mir eine freie Stunde diese Woche".
+duration_minutes is required (5-720). search_from/search_to are ISO 8601; default is the next 7 days.
+Pass the user's IANA timezone so waking hours and spoken times are local.
+Speak the found day + time back, or say nothing was free and offer to look further out.",
+        "name": "find_free_slot",
+        "parameters": {
+          "properties": {
+            "duration_minutes": {
+              "description": "Required slot length in minutes (5 to 720).",
+              "type": "number",
+            },
+            "search_from": {
+              "description": "Optional ISO 8601 start of the search window. Defaults to now.",
+              "type": "string",
+            },
+            "search_to": {
+              "description": "Optional ISO 8601 end of the search window. Defaults to 7 days after search_from (max 30).",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone, e.g. "Europe/Berlin". Defaults to UTC.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "duration_minutes",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the full details of ONE calendar event: exact time, end, location, type, status, notes.
+WHEN TO CALL: "when exactly is my dentist appointment?", "where is the meetup?",
+"Wann genau ist mein Zahnarzttermin?", "Wo findet das Treffen statt?".
+Identify by event_id or title_query (fuzzy). If several match, the result lists candidates — ask which one.
+Speak the concrete details (day, time, place); never a raw data dump.",
+        "name": "get_event_details",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact calendar event id (UUID), if known.",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times.",
+              "type": "string",
+            },
+            "title_query": {
+              "description": "Fuzzy title to find the event when event_id is unknown.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check whether a proposed time window overlaps existing confirmed calendar events.
+WHEN TO CALL: before creating or rescheduling an event, or when the user asks
+"does 3 pm work on Friday?", "Passt Dienstag 10 Uhr?", "Habe ich da schon etwas?".
+start_time is required (ISO 8601); end_time defaults to one hour after start_time.
+If there are conflicts, name the overlapping events and suggest checking another time.",
+        "name": "check_calendar_conflicts",
+        "parameters": {
+          "properties": {
+            "end_time": {
+              "description": "Proposed end, ISO 8601. Defaults to 1 hour after start_time.",
+              "type": "string",
+            },
+            "start_time": {
+              "description": "Proposed start, ISO 8601 (e.g. "2026-07-10T15:00:00Z").",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "IANA timezone for spoken times.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "start_time",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Push an existing reminder out by N minutes (default 10, max 1440).
+CALL WHEN the user says 'snooze it', 'remind me again in 15 minutes',
+'verschieb die Erinnerung', 'erinnere mich später nochmal'.
+Pass reminder_id when known (e.g. a reminder just fired), otherwise
+text_query with words from the reminder. If the tool reports multiple
+matches, ask the user which one and call again with that reminder_id.
+After success, speak the confirmation with the new time from \`text\`.",
+        "name": "snooze_reminder",
+        "parameters": {
+          "properties": {
+            "minutes": {
+              "description": "How many minutes to push it out. 1-1440; 10 if omitted.",
+              "type": "number",
+            },
+            "reminder_id": {
+              "description": "UUID of the reminder, if known.",
+              "type": "string",
+            },
+            "text_query": {
+              "description": "Free-text to find the reminder (e.g. 'magnesium').",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Edit an existing reminder's text and/or time.
+CALL WHEN the user says 'change my reminder to 9pm', 'make it say X',
+'ändere meine Erinnerung', 'verschiebe die Erinnerung auf 21 Uhr'.
+Identify via reminder_id or text_query. new_time is an absolute UTC ISO
+timestamp YOU compute from their words + timezone (min 60s in future).
+If multiple reminders match, ask which one, then call again with the id.
+After success, confirm the change using \`text\`.",
+        "name": "update_reminder",
+        "parameters": {
+          "properties": {
+            "new_text": {
+              "description": "New reminder text (max 200 chars). Also becomes the spoken message.",
+              "type": "string",
+            },
+            "new_time": {
+              "description": "New absolute UTC ISO 8601 timestamp. Min 60s in the future.",
+              "type": "string",
+            },
+            "reminder_id": {
+              "description": "UUID of the reminder, if known.",
+              "type": "string",
+            },
+            "text_query": {
+              "description": "Free-text to find the reminder.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mark a fired reminder as heard/acknowledged so it stops being re-delivered.
+CALL WHEN the user says 'got it', 'okay, I heard the reminder', 'dismiss it',
+'alles klar, habs gehört' after a reminder fired — but the task is NOT done yet.
+Use complete_reminder instead when the user actually DID the thing.
+Identify via reminder_id (preferred, e.g. from the fire event) or text_query.",
+        "name": "acknowledge_reminder",
+        "parameters": {
+          "properties": {
+            "reminder_id": {
+              "description": "UUID of the reminder, if known.",
+              "type": "string",
+            },
+            "text_query": {
+              "description": "Free-text to find the reminder.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mark a reminder as DONE (the user did the thing). Sets status=completed.
+CALL WHEN the user says 'done', 'I took my magnesium, check it off',
+'erledigt', 'hab ich gemacht' about a reminder.
+Identify via reminder_id or text_query. If multiple match, ask which one.
+After success, give a short positive confirmation from \`text\`.",
+        "name": "complete_reminder",
+        "parameters": {
+          "properties": {
+            "reminder_id": {
+              "description": "UUID of the reminder, if known.",
+              "type": "string",
+            },
+            "text_query": {
+              "description": "Free-text to find the reminder.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List reminders that fired but were never acknowledged (the user missed them).
+CALL WHEN the user asks 'did I miss anything?', 'what reminders did I miss?',
+'habe ich Erinnerungen verpasst?', or at the start of a session catch-up.
+Speak each missed reminder with its text and when it fired, then offer to
+snooze, complete, or acknowledge them.",
+        "name": "list_missed_reminders",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set a wake-up/clock alarm at a specific time of day (optionally recurring).
+CALL WHEN the user says 'wake me at 7', 'set an alarm for 6:30 on weekdays',
+'stell einen Wecker auf 7 Uhr', 'weck mich um halb sieben'.
+time is 'HH:MM' (24h, interpreted in the given timezone — next occurrence)
+or an absolute ISO timestamp. ALWAYS pass the user timezone from context;
+UTC is assumed when omitted. recurrence: daily, weekdays, or omit for once.
+Prefer alarms for time-of-day wake-ups; use set_reminder for task reminders.
+After success, confirm with the day + time from \`text\`.",
+        "name": "set_alarm",
+        "parameters": {
+          "properties": {
+            "label": {
+              "description": "Optional label, e.g. 'Gym'.",
+              "type": "string",
+            },
+            "recurrence": {
+              "description": "Omit for a one-time alarm.",
+              "enum": [
+                "daily",
+                "weekdays",
+              ],
+              "type": "string",
+            },
+            "time": {
+              "description": "'HH:MM' 24h wall-clock time, or absolute ISO 8601 timestamp.",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "User's IANA timezone, e.g. Europe/Berlin. UTC assumed if omitted.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "time",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's active alarms with times and labels.
+CALL WHEN the user asks 'what alarms do I have?', 'when is my alarm?',
+'welche Wecker habe ich?', or before deleting/changing an alarm.
+Pass timezone so times are spoken in local wall-clock time.",
+        "name": "list_alarms",
+        "parameters": {
+          "properties": {
+            "timezone": {
+              "description": "User's IANA timezone for display. UTC assumed if omitted.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Cancel an alarm. Two-step confirm flow: first call WITHOUT confirm to find
+the alarm (by alarm_id, label, or HH:MM time) — the tool answers with the
+match and asks you to confirm with the user. After the user explicitly says
+yes, call again with that alarm_id and confirm=true.
+CALL WHEN the user says 'delete my alarm', 'cancel the 7am alarm',
+'lösch den Wecker', 'Wecker ausschalten'.",
+        "name": "delete_alarm",
+        "parameters": {
+          "properties": {
+            "alarm_id": {
+              "description": "UUID from list_alarms / a previous delete_alarm match.",
+              "type": "string",
+            },
+            "confirm": {
+              "description": "true ONLY after the user explicitly confirmed the deletion.",
+              "type": "boolean",
+            },
+            "label": {
+              "description": "Match by label substring instead of id.",
+              "type": "string",
+            },
+            "time": {
+              "description": "Match by 'HH:MM' local time instead of id (pass timezone too).",
+              "type": "string",
+            },
+            "timezone": {
+              "description": "User's IANA timezone for the time match. UTC assumed if omitted.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Start a countdown timer (1-1440 minutes).
+CALL WHEN the user says 'set a timer for 10 minutes', 'timer for the pasta',
+'stell einen Timer auf 10 Minuten', 'Countdown 20 Minuten'.
+For focused work blocks prefer start_pomodoro. After success, confirm the
+duration and label from \`text\`.",
+        "name": "start_timer",
+        "parameters": {
+          "properties": {
+            "duration_minutes": {
+              "description": "Countdown length in minutes, 1-1440.",
+              "type": "number",
+            },
+            "label": {
+              "description": "Optional label, e.g. 'Pasta'.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "duration_minutes",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Start a pomodoro focus block (5-90 minutes; 25 if omitted).
+CALL WHEN the user says 'start a pomodoro', 'let's do a focus session',
+'starte eine Pomodoro-Einheit', '45 Minuten Fokuszeit'.
+After success, confirm the length and encourage focused work.",
+        "name": "start_pomodoro",
+        "parameters": {
+          "properties": {
+            "duration_minutes": {
+              "description": "Work block length in minutes, 5-90. 25 if omitted.",
+              "type": "number",
+            },
+            "label": {
+              "description": "Optional focus topic, e.g. 'Deep work on the report'.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List running timers and pomodoros with the remaining time on each.
+CALL WHEN the user asks 'how much time is left?', 'is my timer still running?',
+'wie lange läuft mein Timer noch?', 'wie viel Zeit habe ich noch?'.
+Speak each entry with its label and remaining time from \`text\`.",
+        "name": "list_active_timers",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the current local time in a city or IANA timezone (no internet needed).
+CALL WHEN the user asks 'what time is it in Tokyo?', 'wie spät ist es in
+Belgrad?', 'what's the time in New York right now?'.
+location accepts a major city name (Berlin, Belgrade, London, New York,
+Tokyo, ...) or any IANA zone like 'Europe/Berlin'. Speak the \`text\` answer.",
+        "name": "get_world_time",
+        "parameters": {
+          "properties": {
+            "location": {
+              "description": "City name or IANA timezone, e.g. 'Berlin' or 'Europe/Berlin'.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "location",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the community groups the user belongs to, with member counts.
+CALL WHEN the user asks: "what groups am I in?", "show my groups",
+"in welchen Gruppen bin ich?", "zeig mir meine Gruppen".
+After the tool runs, read the group names and member counts aloud.",
+        "name": "list_my_groups",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a new community group. Requires a name; privacy is public or
+private (default public). ALWAYS call once WITHOUT confirm first —
+the tool returns a confirmation question; after the user says yes,
+call again with confirm:true.
+CALL WHEN the user says: "create a group called ...", "start a new
+group", "erstelle eine Gruppe ...", "gründe eine neue Gruppe".",
+        "name": "create_group",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the creation.",
+              "type": "boolean",
+            },
+            "description": {
+              "description": "Optional short group description.",
+              "type": "string",
+            },
+            "name": {
+              "description": "The group name.",
+              "type": "string",
+            },
+            "privacy": {
+              "description": "Either 'public' or 'private'. Public if omitted.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Join a community group by name or group_id. Resolves fuzzy names and
+lists candidates when several match. Private groups cannot be self-joined.
+CALL WHEN the user says: "join the sleep group", "I want to join ...",
+"tritt der Gruppe ... bei", "ich möchte der Gruppe beitreten".
+After joining, tell the user they are in and the app is opening the group.",
+        "name": "join_group",
+        "parameters": {
+          "properties": {
+            "group_id": {
+              "description": "Exact group UUID when already known from a previous tool result.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken group name (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Invite another community member to a group. Resolves the member by
+spoken name and the group by name; the member gets a notification.
+CALL WHEN the user says: "invite Anna to my walking group",
+"lade Anna in die Gruppe ... ein".
+If the tool lists several member or group candidates, ask which one.",
+        "name": "invite_to_group",
+        "parameters": {
+          "properties": {
+            "group": {
+              "description": "Spoken group name (fuzzy matched).",
+              "type": "string",
+            },
+            "group_id": {
+              "description": "Exact group UUID when known.",
+              "type": "string",
+            },
+            "member_name": {
+              "description": "Spoken name of the member to invite.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "Exact user UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "message": {
+              "description": "Optional personal message to include.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Accept a pending group invitation (joins the group). With no
+invitation_id it lists the pending invitations, or acts when only one.
+CALL WHEN the user says: "accept the invitation", "yes, join that group",
+"nimm die Einladung an", "Einladung annehmen".",
+        "name": "accept_invitation",
+        "parameters": {
+          "properties": {
+            "group": {
+              "description": "Spoken group name to pick among several pending invitations.",
+              "type": "string",
+            },
+            "invitation_id": {
+              "description": "The invitation UUID from a previous tool result, if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Decline a pending group invitation. ALWAYS call once WITHOUT confirm
+first — the tool returns a confirmation question; after the user says
+yes, call again with the invitation_id and confirm:true.
+CALL WHEN the user says: "decline the invitation", "no thanks, decline
+it", "lehne die Einladung ab", "Einladung ablehnen".",
+        "name": "decline_invitation",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed declining.",
+              "type": "boolean",
+            },
+            "group": {
+              "description": "Spoken group name to pick among several pending invitations.",
+              "type": "string",
+            },
+            "invitation_id": {
+              "description": "The invitation UUID from a previous tool result, if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "RSVP / sign the user up for a community event or meetup, by event_id
+or fuzzy title. Checks capacity and existing signup first.
+CALL WHEN the user says: "sign me up for ...", "RSVP to the yoga
+meetup", "melde mich für ... an", "ich will beim Event ... dabei sein".
+If several events match, read the candidates and ask which one.",
+        "name": "rsvp_event",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact event UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken event title (fuzzy matched against upcoming events).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Cancel the user's RSVP for an upcoming event. ALWAYS call once
+WITHOUT confirm first — the tool returns a confirmation question;
+after the user says yes, call again with the event_id and confirm:true.
+CALL WHEN the user says: "cancel my RSVP", "I can't make it to ...",
+"melde mich vom Event ... ab", "storniere meine Anmeldung".",
+        "name": "cancel_rsvp",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the cancellation.",
+              "type": "boolean",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken event title (matched against the user's RSVPs).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List upcoming community meetups/events the user could attend, soonest
+first; events in the user's home city are flagged "near you" and
+events they already RSVP'd are marked.
+CALL WHEN the user asks: "what meetups are coming up?", "any events
+this week?", "welche Meetups stehen an?", "gibt es bald Events?".
+Read the titles with dates aloud, then offer to sign them up.",
+        "name": "list_upcoming_meetups",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Join/open a community live room by name or room_id. Returns a
+navigation directive that opens the room screen — the app navigates
+automatically; do not describe the navigation mechanics.
+CALL WHEN the user says: "join the live room", "take me into the ...
+room", "bring mich in den Live-Raum", "öffne den Live-Raum ...".
+If several rooms match, read the candidates and ask which one.",
+        "name": "join_live_room",
+        "parameters": {
+          "properties": {
+            "query": {
+              "description": "Spoken room title (fuzzy matched against live and scheduled rooms).",
+              "type": "string",
+            },
+            "room_id": {
+              "description": "Exact live room UUID when known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Start (or reuse) a direct-message conversation with a named community member,
+optionally sending the first message in the same call.
+WHEN: "start a chat with Maria", "message Alex for the first time",
+"schreib Maria an", "starte eine Unterhaltung mit Alex".
+Pass member (spoken name or Vitana ID) or member_user_id (UUID from resolve_recipient).
+With message set, it sends immediately via the canonical send path.
+Without message, it resolves the member, says whether a conversation already
+exists, and returns recipient_user_id — read back the name, ask what to say,
+then send with send_chat_message or call this again with message set.",
+        "name": "start_conversation",
+        "parameters": {
+          "properties": {
+            "member": {
+              "description": "Spoken name or Vitana ID of the member to chat with.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if already resolved (preferred over member).",
+              "type": "string",
+            },
+            "message": {
+              "description": "Optional first message to send immediately. Only pass after the user confirmed the wording.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's recent direct-message conversations, newest first, with
+who wrote last and a short snippet.
+WHEN: "show my conversations", "who have I been chatting with?",
+"zeig meine Chats", "mit wem habe ich geschrieben?".
+These are internal Maxina messages — no Google account involved.
+Speak the names and snippets naturally; to continue one, use send_chat_message.",
+        "name": "list_conversations",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "How many conversations to return, 1-15. Uses a sensible default when omitted.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mark direct messages as read. With member set, marks that conversation;
+without it (or with all=true), marks ALL unread messages.
+WHEN: "mark my chat with Maria as read", "mark everything read",
+"markiere den Chat mit Maria als gelesen", "alles als gelesen markieren".
+Afterwards, confirm how many messages were marked.",
+        "name": "mark_conversation_read",
+        "parameters": {
+          "properties": {
+            "all": {
+              "description": "Set true to mark every unread message as read.",
+              "type": "boolean",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the conversation partner. Omit to mark everything.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the conversation partner if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Mute a chat conversation. NOTE: chat muting is not supported in Vitana yet —
+this tool answers honestly and suggests block_user as the stronger alternative.
+WHEN: "mute this chat", "mute Maria", "schalte den Chat stumm".
+Relay the returned text plainly; never claim the chat was muted.",
+        "name": "mute_conversation",
+        "parameters": {
+          "properties": {
+            "member": {
+              "description": "Spoken name of the conversation partner (used to word the answer).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Archive a chat conversation. NOTE: chat archiving does not exist in Vitana —
+this tool answers honestly. Never invent or offer "archived messages".
+WHEN: "archive this chat", "archiviere den Chat mit Maria".
+Relay the returned text plainly; suggest mark_conversation_read or block_user instead.",
+        "name": "archive_conversation",
+        "parameters": {
+          "properties": {
+            "member": {
+              "description": "Spoken name of the conversation partner (used to word the answer).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set the visibility of the user's WHOLE profile: public, followers_only, or private.
+Writes every per-field visibility setting at once (partner-search posts stay private).
+WHEN: "make my profile private", "set my account to public",
+"mach mein Profil privat", "stell mein Konto auf öffentlich".
+Two-step: first call returns a confirmation request — read it back, get an
+explicit yes, then call again with confirm=true. Then confirm the change out loud.",
+        "name": "update_account_visibility",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true only after the user explicitly confirmed the change.",
+              "type": "boolean",
+            },
+            "visibility": {
+              "description": "One of: public, followers_only, private.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "visibility",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set the visibility of ONE profile field: public, followers_only, or private.
+Fields: age, birthday, location (city), country, address, email, phone, gender,
+first/last name, marital status, dance/partner preferences, service offerings, posts.
+WHEN: "hide my age", "make my location visible to followers only",
+"verstecke mein Alter", "zeig meine Stadt nur meinen Kontakten".
+Health data is always private and has no setting. Confirm the change out loud after.",
+        "name": "update_privacy_field",
+        "parameters": {
+          "properties": {
+            "field": {
+              "description": "The field to change, e.g. "age", "location", "email", "phone", "birthday".",
+              "type": "string",
+            },
+            "visibility": {
+              "description": "One of: public, followers_only, private.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "field",
+            "visibility",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Block a community member so their posts and messages are hidden from the user.
+WHEN: "block Maria", "I don't want to see Alex anymore",
+"blockiere Maria", "ich will nichts mehr von Alex sehen".
+Two-step: the first call resolves the member and returns a confirmation request —
+read the name back, get an explicit yes, then call again with confirm=true and
+the returned member_user_id. Afterwards, confirm the block and mention it can be undone.",
+        "name": "block_user",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true only after the user explicitly confirmed the block.",
+              "type": "boolean",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the member to block.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member (from the confirmation step or resolve_recipient).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Unblock a previously blocked member so their posts and messages show again.
+Matches the name against the user's own blocked list only.
+WHEN: "unblock Maria", "entblockiere Maria", "hebe die Blockierung von Alex auf".
+If the name is not on the blocked list, the tool says who currently is —
+relay that plainly. Afterwards, confirm the unblock out loud.",
+        "name": "unblock_user",
+        "parameters": {
+          "properties": {
+            "member": {
+              "description": "Spoken name or Vitana ID of the member to unblock.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "File a bug ticket (kind=bug) in the feedback pipeline. No persona swap —
+just files and confirms. Call when the user describes something BROKEN and
+wants it reported: "melde diesen Fehler", "die App stürzt ab, bitte melden",
+"report this bug", "the button does nothing, file it".
+The summary must be a concrete description of at least 15 words in the
+user's own words — which screen, what happened, what was expected.
+AFTER: speak the ticket number once and say the team will follow up.
+For live handoff to a specialist use report_to_specialist instead.",
+        "name": "submit_bug_report",
+        "parameters": {
+          "properties": {
+            "screen": {
+              "description": "Optional: the screen or feature where the bug happened (e.g. /events, profile page).",
+              "type": "string",
+            },
+            "summary": {
+              "description": "Concrete bug description, at least 15 words, in the user's own words (what broke, where, what was expected).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "summary",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "File a support ticket (kind=support_question) for a question the team
+should answer offline. Call when the user explicitly wants their question
+logged for support: "erstell ein Support-Ticket", "leite meine Frage an den
+Support weiter", "open a support ticket", "log this question for support".
+Do NOT call for how-to questions you can answer yourself — answer inline.
+Summary: at least 12 words describing the question and context.
+AFTER: speak the ticket number once and say support will follow up.",
+        "name": "submit_support_ticket",
+        "parameters": {
+          "properties": {
+            "summary": {
+              "description": "The user's question with context, at least 12 words.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "summary",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "File a marketplace dispute ticket (kind=marketplace_claim): refunds, wrong
+or damaged items, orders that never arrived, seller issues, overcharges.
+Triggers: "ich will mein Geld zurück", "die Bestellung ist nie angekommen",
+"I want a refund", "the seller sent the wrong item, file a claim".
+Summary: at least 12 words — what was ordered, what went wrong, what the
+user wants (refund / replacement). Include the order number if they have it.
+AFTER: speak the ticket number once and say the team will review the claim.",
+        "name": "submit_marketplace_dispute",
+        "parameters": {
+          "properties": {
+            "order_reference": {
+              "description": "Optional: order number or reference the user mentions.",
+              "type": "string",
+            },
+            "summary": {
+              "description": "Dispute description, at least 12 words: item, problem, desired outcome.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "summary",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "File an account ticket (kind=account_issue): login problems, password or
+email trouble, role/permission issues, profile data corrections, lockouts.
+Triggers: "ich komme nicht in mein Konto", "meine E-Mail stimmt nicht,
+bitte melden", "I'm locked out", "report my login problem".
+NEVER ask for or record passwords. Summary: at least 12 words describing
+the account problem and what the user already tried.
+AFTER: speak the ticket number once and say the team will follow up.",
+        "name": "submit_account_issue",
+        "parameters": {
+          "properties": {
+            "summary": {
+              "description": "Account problem description, at least 12 words. Never include passwords.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "summary",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's OPEN feedback tickets (bugs, support, disputes, account)
+with number and status. Call when the user asks about their reports:
+"was ist mit meinen Tickets?", "wie steht es um meine Fehlermeldung?",
+"what happened to my bug report?", "show my open tickets".
+AFTER: read back ticket number, what it is, and its status in the user's
+language. Never mention internal specialist names.",
+        "name": "list_my_tickets",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set the user's app + voice language. Persists the same setting the app's
+Language picker writes, so screens and notifications follow. Call when the
+user asks to switch language: "stell auf Deutsch um", "sprich Englisch mit
+mir", "switch the app to English", "cambia a español".
+AFTER: respond ONLY in the new language from that moment on and confirm
+the change; the app screens follow on the next reload.",
+        "name": "set_language",
+        "parameters": {
+          "properties": {
+            "language": {
+              "description": "Target language code: de (German), en (English), es (Spanish), sr (Serbian).",
+              "enum": [
+                "de",
+                "en",
+                "es",
+                "sr",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "language",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Handle a request to change the visual theme (light / dark / system).
+Triggers: "mach den Dunkelmodus an", "stell auf hell", "switch to dark
+mode", "use the system theme".
+NOTE: the theme is stored on the device, not on the server — this tool
+explains where to flip it (Settings → Preferences → Theme). Relay that
+guidance in the user's language; do not promise the theme changed.",
+        "name": "set_theme",
+        "parameters": {
+          "properties": {
+            "theme": {
+              "description": "The theme the user asked for.",
+              "enum": [
+                "light",
+                "dark",
+                "system",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Tune the app's spoken-voice settings: pace (slow / normal / fast), voice
+name, and tone/character. Persists to the same voice settings the app's
+Voice & AI screen uses. Triggers: "sprich langsamer", "sprich schneller",
+"klinge ruhiger", "speak slower please", "use a calmer tone".
+Provide only the fields the user asked to change.
+AFTER: confirm briefly what changed, in the user's language.",
+        "name": "set_voice_preferences",
+        "parameters": {
+          "properties": {
+            "pace": {
+              "description": "Speaking speed the user asked for.",
+              "enum": [
+                "slow",
+                "normal",
+                "fast",
+              ],
+              "type": "string",
+            },
+            "tone": {
+              "description": "Optional: tone/character, e.g. friendly, calm, energetic, professional.",
+              "type": "string",
+            },
+            "voice": {
+              "description": "Optional: a specific voice name the user asked for.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's connected integrations: Google, YouTube, social accounts,
+and AI assistants (OpenAI, Anthropic, Gemini). Call when the user asks:
+"welche Apps sind verbunden?", "ist mein Google-Konto verknüpft?",
+"what apps are connected?", "is Spotify linked?".
+AFTER: name each connected app naturally in the user's language; if none,
+say so and mention Settings → Connected Apps.",
+        "name": "list_connected_apps",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Disconnect one connected integration (Google, YouTube, Instagram, an AI
+assistant, ...). Triggers: "trenne mein Google-Konto", "entferne YouTube",
+"disconnect my Google account", "unlink ChatGPT".
+TWO-STEP: first call WITHOUT confirm — the tool returns a confirmation
+question to relay. Only after the user explicitly says yes, call again
+with confirm=true. Never disconnect without that explicit yes.
+AFTER (confirmed): confirm it is disconnected and reconnectable in
+Settings → Connected Apps.",
+        "name": "disconnect_app",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user explicitly confirmed the disconnect out loud.",
+              "type": "boolean",
+            },
+            "provider": {
+              "description": "Which integration to disconnect, e.g. google, youtube, instagram, facebook, tiktok, linkedin, twitter, openai, anthropic, gemini.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "provider",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Unified community search across people, posts, events, groups, products,
+and services in one call. Returns the top hits per category.
+CALL WHEN the user asks a broad "find/search" question: "search for yoga",
+"find anything about fasting", "such nach Tennis", "gibt es was zu Schlaf?".
+For a specific person prefer find_community_member; for events only,
+search_events. After the tool runs, present the most relevant category
+first — top two or three hits, never the raw list.",
+        "name": "global_search",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max hits per category, 1-5. Omit for 3.",
+              "type": "number",
+            },
+            "query": {
+              "description": "What the user is looking for, verbatim.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "query",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the community news feed aloud: recent posts with author and a
+one-line summary. scope "following" limits to people the user follows;
+"all" is the whole community (default).
+CALL WHEN the user asks: "what's new in the community?", "read me the
+feed", "was gibt es Neues?", "zeig mir die Neuigkeiten von Leuten denen
+ich folge". After the tool runs, speak each post as author plus a short
+summary — never read long posts word for word.",
+        "name": "browse_news_feed",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "How many posts to read, 1-10. Omit for 5.",
+              "type": "number",
+            },
+            "scope": {
+              "description": ""following" = only people the user follows; "all" = whole community (default).",
+              "enum": [
+                "following",
+                "all",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Snooze an Autopilot recommendation so it resurfaces later (default 24h,
+max one week). Accepts the recommendation id or a spoken title fragment.
+CALL WHEN the user says: "remind me about that later", "snooze the sleep
+recommendation", "später erinnern", "leg das auf Wiedervorlage".
+After the tool runs, confirm the title and when it will come back.",
+        "name": "snooze_recommendation",
+        "parameters": {
+          "properties": {
+            "hours": {
+              "description": "Hours to snooze, 1-168. Omit for 24.",
+              "type": "number",
+            },
+            "recommendation": {
+              "description": "Recommendation id (UUID) or a title fragment the user said.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "recommendation",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Dismiss an Autopilot recommendation for good (it will not come back).
+TWO-STEP: first call returns a confirmation question — read it back;
+only after a clear yes call again with confirm=true.
+CALL WHEN the user says: "not interested", "dismiss that suggestion",
+"das interessiert mich nicht", "weg damit".
+If the user just wants it later, use snooze_recommendation instead.",
+        "name": "dismiss_recommendation",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user verbally confirmed the dismissal.",
+              "type": "boolean",
+            },
+            "reason": {
+              "description": "OPTIONAL — why the user dismisses it, in their words.",
+              "type": "string",
+            },
+            "recommendation": {
+              "description": "Recommendation id (UUID) or a title fragment the user said.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "recommendation",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Explain WHY a specific Autopilot recommendation was suggested: its
+rationale, which Vitana pillars it strengthens, impact vs effort, and
+where it came from. Accepts an id or a spoken title fragment.
+CALL WHEN the user asks: "why are you suggesting this?", "what's that
+recommendation about?", "warum schlägst du mir das vor?", "was bringt
+mir das?". After the tool runs, narrate the reason in 2-3 sentences and
+offer to activate, snooze, or dismiss it.",
+        "name": "explain_recommendation",
+        "parameters": {
+          "properties": {
+            "recommendation": {
+              "description": "Recommendation id (UUID) or a title fragment the user said.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "recommendation",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Edit one of the user's OWN intent posts (title, description text, or
+category). Accepts the intent id or a spoken title fragment.
+CALL WHEN the user says: "change my tennis post to say weekends only",
+"update the title of my ask", "ändere meinen Beitrag", "mach aus meinem
+Post ...". Pass ONLY the fields that change. After the tool runs,
+confirm what was updated in one sentence.",
+        "name": "update_intent",
+        "parameters": {
+          "properties": {
+            "intent": {
+              "description": "Intent id (UUID) or a title fragment identifying the user's post.",
+              "type": "string",
+            },
+            "new_category": {
+              "description": "OPTIONAL — the new dotted category, e.g. sport.tennis.",
+              "type": "string",
+            },
+            "new_text": {
+              "description": "OPTIONAL — the new description / scope text.",
+              "type": "string",
+            },
+            "new_title": {
+              "description": "OPTIONAL — the new title.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "intent",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Take down one of the user's OWN intent posts from the board (closes it;
+matching stops). TWO-STEP: first call returns a confirmation question —
+read it back; only after a clear yes call again with confirm=true.
+CALL WHEN the user says: "delete my post", "remove my tennis ask",
+"lösch meinen Beitrag", "nimm das vom Brett".
+If the ask was fulfilled, prefer mark_intent_fulfilled instead.",
+        "name": "delete_intent",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user verbally confirmed the removal.",
+              "type": "boolean",
+            },
+            "intent": {
+              "description": "Intent id (UUID) or a title fragment identifying the user's post.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "intent",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse the open community intent board (Open Asks): what other members
+are looking for, buying, selling, or offering right now. Optional query
+filters by topic. Never shows the user's own posts.
+CALL WHEN the user asks: "what are people looking for?", "browse the
+asks board", "was suchen andere gerade?", "zeig mir das Schwarze Brett".
+After the tool runs, present the top asks (title + kind) and offer to
+respond to one or post the user's own ask.",
+        "name": "browse_intent_board",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max asks to return, 1-10. Omit for 5.",
+              "type": "number",
+            },
+            "query": {
+              "description": "OPTIONAL — topic filter, e.g. "tennis" or "babysitting".",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Open a dispute on a match the user is part of (no-show, misrepresented,
+safety, payment, other). MULTI-STEP: the tool first collects the reason,
+then returns a confirmation question — only after a clear yes call again
+with confirm=true. CALL WHEN the user says: "the seller never showed up",
+"I want to report this match", "der Kontakt war fake", "ich möchte das
+Match melden". Stay neutral and factual — never promise an outcome.",
+        "name": "dispute_match",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user verbally confirmed filing the dispute.",
+              "type": "boolean",
+            },
+            "match_id": {
+              "description": "The match id if known. Omit to auto-detect from the user's recent matches.",
+              "type": "string",
+            },
+            "reason": {
+              "description": "What happened, in the user's words.",
+              "type": "string",
+            },
+            "reason_category": {
+              "description": "Best-fitting category for what happened.",
+              "enum": [
+                "no_show",
+                "misrepresented",
+                "safety",
+                "payment",
+                "other",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Flagship people-match: find the PERFECT person for the user — workout
+partner, accountability buddy, mentor, learning partner — personalized
+with their Life Compass goal and weakest Vitana pillar. Searches the
+live community asks and, per the confirm flow, also posts the request
+so the user becomes discoverable.
+CALL WHEN the user says: "find me a workout partner", "who would be my
+perfect accountability buddy?", "find den perfekten Trainingspartner
+für mich", "such mir einen Mentor".
+Follow the returned text exactly — it tells you whether matches were
+found or a read-back confirmation is needed (then call again with
+confirmed=true).",
+        "name": "find_perfect_match",
+        "parameters": {
+          "properties": {
+            "ask": {
+              "description": "What kind of person the user wants, verbatim. May be omitted — then the weakest pillar suggests one.",
+              "type": "string",
+            },
+            "confirmed": {
+              "description": "Pass true ONLY after the user confirmed posting the request (second call).",
+              "type": "boolean",
+            },
+            "kind_hint": {
+              "description": "OPTIONAL intent kind hint, e.g. activity_seek or social_seek.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's current emotional and cognitive signals (D28): mood,
+focus, engagement, urgency, hesitation — from analyzed conversation
+signals, or recent diary moods/energy when no live signals exist.
+CALL WHEN the user asks: "how am I doing?", "how do I seem to you?",
+"wie wirke ich gerade?", "wie geht es mir laut meinen Daten?".
+Speak the returned text as-is — it already names the data source.
+Never diagnose; these are light behavioral observations only.",
+        "name": "get_emotional_state",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Summarize the user's current situation (D32): time-of-day window,
+availability, energy, suggested conversation depth and any active
+constraints, enriched with their next calendar commitment.
+CALL WHEN the user asks: "what's my situation right now?", "is this
+a good moment?", "wie sieht meine Lage gerade aus?", "passt es gerade?".
+Optionally pass timezone (IANA name like Europe/Berlin) if known.
+Speak the returned text; it states what the summary is based on.",
+        "name": "get_situational_awareness",
+        "parameters": {
+          "properties": {
+            "timezone": {
+              "description": "The user's IANA timezone (e.g. Europe/Berlin), only if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check how available and ready the user is right now (D33): availability
+level, time window, readiness score, calendar density for the next
+hours, whether they are in an event, and reminders due soon.
+CALL WHEN the user asks: "do I have time right now?", "is now a good
+time?", "habe ich gerade Zeit?", "ist jetzt ein guter Zeitpunkt?",
+or BEFORE proposing a long activity or deep session.
+Optionally pass timezone (IANA name) if known. Speak the returned text.",
+        "name": "get_availability",
+        "parameters": {
+          "properties": {
+            "timezone": {
+              "description": "The user's IANA timezone (e.g. Europe/Berlin), only if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's environment and mobility context (D34): where they
+are based or traveling, how they get around, late-night/early-morning
+flags and indoor/outdoor suitability — from stored location facts,
+preferences and visit history. Never invents a location.
+CALL WHEN the user asks: "what do you know about where I am?",
+"was weißt du über meine Umgebung?", or before suggesting nearby or
+outdoor activities. Speak the returned text; it names its sources.",
+        "name": "get_environmental_context",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's life-stage context (D40): life phase and stability,
+any transition, Life Compass goal and category, age band (from their
+stated birthday) and community tenure.
+CALL WHEN the user asks: "where am I in life?", "what stage am I in?",
+"wo stehe ich gerade im Leben?", "in welcher Lebensphase bin ich?",
+or when tailoring long-term advice to their life situation.
+Speak the returned text; it is non-prescriptive — the user knows
+their life best. If nothing is on record, offer to set up Life Compass.",
+        "name": "get_life_stage_context",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "FOLLOW a community member by their spoken name.
+CALL THIS for: "Follow Anna" / "Folge Anna" / "Ich möchte Peter folgen" /
+"Follow that member".
+Resolves the name to a member; if no match, ask the user to repeat the name.
+After success, confirm in one short sentence.",
+        "name": "follow_member",
+        "parameters": {
+          "properties": {
+            "name": {
+              "description": "Spoken name (or handle) of the member to follow.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "UNFOLLOW a community member by name. Two-step confirm:
+first call returns a confirmation question — ask it, then call again with
+confirmed=true after the user says yes.
+CALL THIS for: "Unfollow Anna" / "Entfolge Anna" / "Ich will Peter nicht mehr folgen".",
+        "name": "unfollow_member",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "true only after the user verbally confirmed.",
+              "type": "boolean",
+            },
+            "name": {
+              "description": "Spoken name of the member to unfollow.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ the user's recent notifications, unread first. Speakable.
+CALL THIS for: "Any notifications?" / "Habe ich Benachrichtigungen?" /
+"Was gibt es Neues für mich?" / "Read my notifications".
+Speak the unread count and the top titles — never deflect to the bell icon.",
+        "name": "get_notifications",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "How many to read out, 1-20. Uses 10 when omitted.",
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "MARK notifications as read — all unread ones, or only those whose title
+matches a spoken reference.
+CALL THIS for: "Mark all as read" / "Alle als gelesen markieren" /
+"Clear my notifications" / "Mark the match notification as read".",
+        "name": "mark_notifications_read",
+        "parameters": {
+          "properties": {
+            "reference": {
+              "description": "Optional words from one notification title to mark only that one. Omit to mark all.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY wallet snapshot: balance per currency, active subscription,
+last 3 transactions. NEVER moves money — payments happen in the Wallet screen.
+CALL THIS for: "What is my wallet balance?" / "Wie viel Guthaben habe ich?" /
+"Was ist auf meinem Wallet?" / "My last transactions".",
+        "name": "get_wallet_balance",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "UPDATE simple own-profile fields: display_name, bio, city, country, location.
+Two-step confirm: first call returns a verbatim read-back — speak it, then
+call again with confirmed=true after the user agrees.
+CALL THIS for: "Change my bio to …" / "Ändere meinen Namen zu …" /
+"Setze meine Stadt auf Berlin".
+NEVER use this for role or profile visibility — privacy settings own those.",
+        "name": "update_profile",
+        "parameters": {
+          "properties": {
+            "bio": {
+              "description": "New bio text.",
+              "type": "string",
+            },
+            "city": {
+              "description": "New city.",
+              "type": "string",
+            },
+            "confirmed": {
+              "description": "true only after the user confirmed the read-back.",
+              "type": "boolean",
+            },
+            "country": {
+              "description": "New country.",
+              "type": "string",
+            },
+            "display_name": {
+              "description": "New display name.",
+              "type": "string",
+            },
+            "location": {
+              "description": "New free-text location, e.g. "Berlin, Germany".",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "PLAY an internal Vitana Media Hub podcast by title or topic. Returns an
+open_url directive the app uses to start playback.
+CALL THIS for: "Play the longevity podcast" / "Spiel den Vitana Podcast" /
+"Play a podcast about sleep".
+For music use play_music instead. After success, say what is now playing.",
+        "name": "play_podcast",
+        "parameters": {
+          "properties": {
+            "query": {
+              "description": "Podcast title or topic. Omit to play the most popular one.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "LIKE a community feed post — resolves "the last post from <name>" to that
+member's most recent public post.
+CALL THIS for: "Like Anna's post" / "Like den letzten Beitrag von Anna" /
+"Gefällt mir für Peters Post".
+After success, confirm which post was liked in one sentence.",
+        "name": "like_post",
+        "parameters": {
+          "properties": {
+            "author_name": {
+              "description": "Spoken name of the post's author.",
+              "type": "string",
+            },
+            "post_reference": {
+              "description": "Optional words from the post content to pick a specific post instead of the latest.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "author_name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "COMMENT on a community feed post (public text). Two-step confirm:
+first call returns the comment for verbatim read-back — speak it, then call
+again with confirmed=true after the user says post/yes.
+CALL THIS for: "Comment on Anna's post: great work" /
+"Kommentiere Peters Beitrag mit …".",
+        "name": "comment_on_post",
+        "parameters": {
+          "properties": {
+            "author_name": {
+              "description": "Spoken name of the post's author.",
+              "type": "string",
+            },
+            "confirmed": {
+              "description": "true only after the user confirmed the read-back.",
+              "type": "boolean",
+            },
+            "post_reference": {
+              "description": "Optional words from the post content to pick a specific post instead of the latest.",
+              "type": "string",
+            },
+            "text": {
+              "description": "The comment text to post.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "author_name",
+            "text",
+          ],
           "type": "object",
         },
       },

--- a/supabase/migrations/20260706100000_vtid_02779_voice_clock.sql
+++ b/supabase/migrations/20260706100000_vtid_02779_voice_clock.sql
@@ -1,0 +1,59 @@
+-- =============================================================================
+-- VTID-02779 — Voice clock: alarms, countdown timers, pomodoro blocks
+--
+-- Backing table for the ORB voice tools set_alarm / list_alarms / delete_alarm /
+-- start_timer / start_pomodoro / list_active_timers
+-- (services/gateway/src/services/orb-tools/reminders-clock-tools.ts).
+--
+-- One row per clock item. `fires_at` is the absolute UTC instant the item
+-- should ring; `recurrence` ('daily'|'weekdays', NULL = one-shot) applies to
+-- alarms only; `duration_seconds` applies to timers/pomodoros only.
+--
+-- NOTE: FIRING is a follow-up — a cron/tick job (like /reminders-tick for the
+-- reminders table) must claim rows whose fires_at has passed, deliver a push /
+-- chime, and transition status active→fired. This migration + the voice tools
+-- ship the data layer and read/write paths only.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS voice_clock_items (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id        uuid,
+  user_id          uuid NOT NULL,
+  kind             text NOT NULL CHECK (kind IN ('alarm','timer','pomodoro')),
+  label            text,
+  fires_at         timestamptz,
+  recurrence       text,           -- 'daily' | 'weekdays' | NULL = one-shot (alarms only)
+  duration_seconds int,            -- timers/pomodoros only
+  status           text NOT NULL DEFAULT 'active'
+                   CHECK (status IN ('active','fired','cancelled','completed')),
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- Voice tool list/delete queries: WHERE user_id = X AND status = 'active'
+CREATE INDEX IF NOT EXISTS idx_voice_clock_items_user_status
+  ON voice_clock_items (user_id, status);
+
+-- Future tick job: fast lookup of active rows past their fire time
+CREATE INDEX IF NOT EXISTS idx_voice_clock_items_tick
+  ON voice_clock_items (fires_at)
+  WHERE status = 'active';
+
+ALTER TABLE voice_clock_items ENABLE ROW LEVEL SECURITY;
+
+-- Users manage their own clock items (direct client access, e.g. UI list).
+CREATE POLICY "Users manage own voice clock items"
+  ON voice_clock_items FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Gateway service-role access (voice tools run with the service-role client;
+-- their WHERE user_id clauses are the tenant isolation).
+CREATE POLICY "Service role full access on voice_clock_items"
+  ON voice_clock_items FOR ALL
+  USING (true) WITH CHECK (true);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON voice_clock_items TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON voice_clock_items TO service_role;
+
+COMMENT ON TABLE voice_clock_items IS
+  'VTID-02779 voice-created alarms/timers/pomodoros. Written by ORB voice tools (set_alarm, start_timer, start_pomodoro). Firing/delivery is a cron follow-up.';

--- a/supabase/migrations/20260706100000_vtid_02779_voice_clock.sql
+++ b/supabase/migrations/20260706100000_vtid_02779_voice_clock.sql
@@ -47,9 +47,15 @@ CREATE POLICY "Users manage own voice clock items"
   WITH CHECK (auth.uid() = user_id);
 
 -- Gateway service-role access (voice tools run with the service-role client;
--- their WHERE user_id clauses are the tenant isolation).
+-- their WHERE user_id clauses are the tenant isolation). Restricted TO
+-- service_role — without this clause the policy applies to EVERY role
+-- (including `authenticated`), letting any logged-in user read/write any
+-- other user's alarms/timers since USING(true)/WITH CHECK(true) has no
+-- owner constraint. The service-role client already bypasses RLS entirely,
+-- so this policy is defense-in-depth, not the enforcement mechanism.
 CREATE POLICY "Service role full access on voice_clock_items"
   ON voice_clock_items FOR ALL
+  TO service_role
   USING (true) WITH CHECK (true);
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON voice_clock_items TO authenticated;

--- a/voice-pipeline-spec/spec.json
+++ b/voice-pipeline-spec/spec.json
@@ -11,161 +11,1852 @@
     "livekit_source": "services/agents/orb-agent/",
     "livekit_status": "not_yet_implemented"
   },
-
   "tools": [
-    { "name": "recall_conversation_at_time", "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-02052", "notes": "Time-anchored conversation recall." },
-    { "name": "search_memory",                "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-01152", "notes": "Mem0/Qdrant semantic memory search via memory-indexer service." },
-    { "name": "search_knowledge",             "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-0135",  "notes": "Knowledge Hub retrieval via gateway retrieval-router." },
-    { "name": "search_web",                   "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-    { "name": "switch_persona",               "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": null,         "notes": "Within-Vitana style/persona switch (NOT specialist handoff). Specialist handoff is `report_to_specialist`." },
-    { "name": "report_to_specialist",         "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": null,         "notes": "Unified Feedback Pipeline persona handoff (Sage / Devon / Atlas / Mira / Vitana)." },
-
-    { "name": "search_calendar",              "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-    { "name": "create_calendar_event",        "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-    { "name": "add_to_calendar",              "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01943" },
-    { "name": "get_schedule",                 "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01943" },
-
-    { "name": "search_events",                "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01270A" },
-    { "name": "search_community",             "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01270A" },
-    { "name": "get_recommendations",          "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01180" },
-
-    { "name": "play_music",                   "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01941" },
-    { "name": "set_capability_preference",    "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01942" },
-
-    { "name": "read_email",                   "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01943" },
-    { "name": "find_contact",                 "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01943" },
-
-    { "name": "consult_external_ai",          "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null,         "notes": "Forward to user's connected ChatGPT/Claude/Gemini account." },
-
-    { "name": "get_life_compass",                 "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": "VTID-03010", "notes": "Returns the user's active Life Compass row (goal + why + target_date). Read-only. Shared dispatcher route." },
-    { "name": "get_vitana_index",                 "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01983" },
-    { "name": "get_index_improvement_suggestions","implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01983" },
-    { "name": "create_index_improvement_plan",    "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01983" },
-
-    { "name": "save_diary_entry",             "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-01983", "notes": "Persists diary entry AND triggers Vitana Index recompute via /memory/diary/sync-index." },
-
-    { "name": "set_reminder",                 "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-02601" },
-    { "name": "find_reminders",               "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-02601" },
-    { "name": "delete_reminder",              "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-02601" },
-
-    { "name": "ask_pillar_agent",             "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-    { "name": "explain_feature",              "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-
-    { "name": "resolve_recipient",            "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": null,         "notes": "Step 1 of 3-step send_message flow." },
-    { "name": "send_chat_message",            "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": null,         "notes": "Step 3 of send_message flow." },
-
-    { "name": "activate_recommendation",      "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01180" },
-    { "name": "get_autopilot_recommendations", "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-03201", "notes": "Read the user's Autopilot queue aloud — same list as the popup. Session-state-coupled (remembers listed ids)." },
-    { "name": "activate_autopilot_recommendations", "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-03201", "notes": "Activate Autopilot recommendations on the user's behalf via the shared popup flow. Resolves 'activate those' to the last listed ids." },
-    { "name": "share_link",                   "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-
-    { "name": "post_intent",                  "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-01975" },
-    { "name": "view_intent_matches",          "implementations": ["vertex"], "safety_critical": false, "owner_vtid": "VTID-01976" },
-    { "name": "find_match",                   "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null, "notes": "BOOTSTRAP-FIND-MATCH-VOICE: search-first 'find me a match' — searches the catalog and recommends matches (also posting so the user is discoverable) or posts on confirmation. In the shared ORB registry; LiveKit can dispatch it but does not declare it yet (mirrors view_intent_matches)." },
-    { "name": "list_my_intents",              "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-    { "name": "respond_to_match",             "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-01976" },
-    { "name": "mark_intent_fulfilled",        "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-    { "name": "share_intent_post",            "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-
-    { "name": "scan_existing_matches",        "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-    { "name": "get_matchmaker_result",        "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
-
-    { "name": "find_perfect_product",         "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": "VTID-03048", "notes": "Recommends a product (supplement/gear/food) fusing weakest pillar + Life Compass goal. Shared dispatcher tool_find_perfect_product. Surfaced to LiveKit in VTID-03048 (previously Vertex-only catalog despite shared impl)." },
-    { "name": "find_perfect_practitioner",    "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": "VTID-03048", "notes": "Recommends a practitioner/coach/doctor (specialty + language + telehealth + price). Shared dispatcher tool_find_perfect_practitioner. Surfaced to LiveKit in VTID-03048 (previously Vertex-only catalog despite shared impl)." },
-
-    { "name": "navigate",                     "implementations": ["vertex", "livekit"], "safety_critical": true,  "owner_vtid": null,        "notes": "Unified surface-aware navigation tool exposed to the model (VTID-NAV-UNIFIED — replaces the old navigator_consult + navigate_to_screen dance). Cross-surface routes (vitanaland→/admin or /command-hub) MUST be rejected per feedback_navigator_surface_scoping memory rule. Vertex dispatches via toolName if-chain (not a switch), so the ts-morph extractor cannot see it; LiveKit declares it as @function_tool navigate." },
-    { "name": "get_current_screen",           "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": "VTID-NAV-TIMEJOURNEY", "notes": "Identity-free read of session.current_route — safe for anonymous sessions. Vertex dispatches via toolName if-chain (not extracted by ts-morph); LiveKit declares it as @function_tool get_current_screen." },
-    { "name": "navigate_to_screen",           "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": "VTID-02770",  "notes": "INTENTIONALLY ONE-SIDED (Vertex-only): catalog-aware navigation taking a screen_id/alias, preserving parameterized routes (intent_id, match_id) and overlay support that the free-text `navigate` tool does not. LiveKit exposes only `navigate`. Cross-surface routes MUST be rejected per feedback_navigator_surface_scoping memory rule." },
-    { "name": "navigator_consult",            "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null,         "notes": "INTENTIONALLY ONE-SIDED (Vertex-only): legacy consult-then-narrate path that predates the unified `navigate` tool. Still routed to handleNavigate for in-flight sessions that cached the old tool declarations. No LiveKit equivalent. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit." },
-
-    { "name": "find_community_member",        "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": null, "notes": "Shared dispatcher tool — implemented on both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY parity-scan audit (was undeclared)." },
-    { "name": "log_water",                    "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": null, "notes": "Diary quick-log: water. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit." },
-    { "name": "log_sleep",                    "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": null, "notes": "Diary quick-log: sleep. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit." },
-    { "name": "log_exercise",                 "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": null, "notes": "Diary quick-log: exercise. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit." },
-    { "name": "log_meditation",               "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": null, "notes": "Diary quick-log: meditation. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit." },
-    { "name": "get_pillar_subscores",         "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": "VTID-01983", "notes": "Returns per-pillar Vitana Index subscores. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit." },
-
-    { "name": "teacher_event",                "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null, "notes": "INTENTIONALLY ONE-SIDED (Vertex-only): teaching-session telemetry event. No LiveKit @function_tool equivalent has shipped. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit." },
-    { "name": "end_teaching_session",         "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null, "notes": "INTENTIONALLY ONE-SIDED (Vertex-only): closes an active teaching session. No LiveKit @function_tool equivalent has shipped. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit." },
-
-    { "name": "get_social_context",           "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null, "notes": "BOOTSTRAP-SOCIAL-MEMORY: live privacy-filtered Social Context Pack (follows, matches, messages, groups, person intelligence, ranked posts/events). In the shared registry (reachable via /api/v1/orb/tool); LiveKit @function_tool wrapper not yet shipped — Vertex-only until it is." },
-    { "name": "view_messages",                "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null, "notes": "BOOTSTRAP-SOCIAL-READ-TOOLS: speakable read of the user's own INTERNAL community inbox (unread/all, grouped by sender). Never Google-bound; 'archived' does not exist. In the shared registry; LiveKit @function_tool wrapper not yet shipped — Vertex-only until it is." },
-    { "name": "list_followers",               "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null, "notes": "BOOTSTRAP-SOCIAL-READ-TOOLS: who follows the user (count, names, mutuals) — direct answer, never deflects. In the shared registry; LiveKit @function_tool wrapper not yet shipped — Vertex-only until it is." },
-    { "name": "list_following",               "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null, "notes": "BOOTSTRAP-SOCIAL-READ-TOOLS: who the user follows (count and names). In the shared registry; LiveKit @function_tool wrapper not yet shipped — Vertex-only until it is." },
-    { "name": "recent_conversations",         "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null, "notes": "BOOTSTRAP-SOCIAL-READ-TOOLS: newest-first DM contacts; first entry answers 'who did I last chat with'. In the shared registry; LiveKit @function_tool wrapper not yet shipped — Vertex-only until it is." }
+    {
+      "name": "recall_conversation_at_time",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02052",
+      "notes": "Time-anchored conversation recall."
+    },
+    {
+      "name": "search_memory",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-01152",
+      "notes": "Mem0/Qdrant semantic memory search via memory-indexer service."
+    },
+    {
+      "name": "search_knowledge",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-0135",
+      "notes": "Knowledge Hub retrieval via gateway retrieval-router."
+    },
+    {
+      "name": "search_web",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "switch_persona",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": null,
+      "notes": "Within-Vitana style/persona switch (NOT specialist handoff). Specialist handoff is `report_to_specialist`."
+    },
+    {
+      "name": "report_to_specialist",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": null,
+      "notes": "Unified Feedback Pipeline persona handoff (Sage / Devon / Atlas / Mira / Vitana)."
+    },
+    {
+      "name": "search_calendar",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "create_calendar_event",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "add_to_calendar",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01943"
+    },
+    {
+      "name": "get_schedule",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01943"
+    },
+    {
+      "name": "search_events",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01270A"
+    },
+    {
+      "name": "search_community",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01270A"
+    },
+    {
+      "name": "get_recommendations",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01180"
+    },
+    {
+      "name": "play_music",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01941"
+    },
+    {
+      "name": "set_capability_preference",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01942"
+    },
+    {
+      "name": "read_email",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01943"
+    },
+    {
+      "name": "find_contact",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01943"
+    },
+    {
+      "name": "consult_external_ai",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "Forward to user's connected ChatGPT/Claude/Gemini account."
+    },
+    {
+      "name": "get_life_compass",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-03010",
+      "notes": "Returns the user's active Life Compass row (goal + why + target_date). Read-only. Shared dispatcher route."
+    },
+    {
+      "name": "get_vitana_index",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01983"
+    },
+    {
+      "name": "get_index_improvement_suggestions",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01983"
+    },
+    {
+      "name": "create_index_improvement_plan",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01983"
+    },
+    {
+      "name": "save_diary_entry",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-01983",
+      "notes": "Persists diary entry AND triggers Vitana Index recompute via /memory/diary/sync-index."
+    },
+    {
+      "name": "set_reminder",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02601"
+    },
+    {
+      "name": "find_reminders",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02601"
+    },
+    {
+      "name": "delete_reminder",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02601"
+    },
+    {
+      "name": "ask_pillar_agent",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "explain_feature",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "resolve_recipient",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": null,
+      "notes": "Step 1 of 3-step send_message flow."
+    },
+    {
+      "name": "send_chat_message",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": null,
+      "notes": "Step 3 of send_message flow."
+    },
+    {
+      "name": "activate_recommendation",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01180"
+    },
+    {
+      "name": "get_autopilot_recommendations",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-03201",
+      "notes": "Read the user's Autopilot queue aloud \u2014 same list as the popup. Session-state-coupled (remembers listed ids)."
+    },
+    {
+      "name": "activate_autopilot_recommendations",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-03201",
+      "notes": "Activate Autopilot recommendations on the user's behalf via the shared popup flow. Resolves 'activate those' to the last listed ids."
+    },
+    {
+      "name": "share_link",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "post_intent",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-01975"
+    },
+    {
+      "name": "view_intent_matches",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01976"
+    },
+    {
+      "name": "find_match",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "BOOTSTRAP-FIND-MATCH-VOICE: search-first 'find me a match' \u2014 searches the catalog and recommends matches (also posting so the user is discoverable) or posts on confirmation. In the shared ORB registry; LiveKit can dispatch it but does not declare it yet (mirrors view_intent_matches)."
+    },
+    {
+      "name": "list_my_intents",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "respond_to_match",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-01976"
+    },
+    {
+      "name": "mark_intent_fulfilled",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "share_intent_post",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "scan_existing_matches",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "get_matchmaker_result",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null
+    },
+    {
+      "name": "find_perfect_product",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-03048",
+      "notes": "Recommends a product (supplement/gear/food) fusing weakest pillar + Life Compass goal. Shared dispatcher tool_find_perfect_product. Surfaced to LiveKit in VTID-03048 (previously Vertex-only catalog despite shared impl)."
+    },
+    {
+      "name": "find_perfect_practitioner",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-03048",
+      "notes": "Recommends a practitioner/coach/doctor (specialty + language + telehealth + price). Shared dispatcher tool_find_perfect_practitioner. Surfaced to LiveKit in VTID-03048 (previously Vertex-only catalog despite shared impl)."
+    },
+    {
+      "name": "navigate",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": null,
+      "notes": "Unified surface-aware navigation tool exposed to the model (VTID-NAV-UNIFIED \u2014 replaces the old navigator_consult + navigate_to_screen dance). Cross-surface routes (vitanaland\u2192/admin or /command-hub) MUST be rejected per feedback_navigator_surface_scoping memory rule. Vertex dispatches via toolName if-chain (not a switch), so the ts-morph extractor cannot see it; LiveKit declares it as @function_tool navigate."
+    },
+    {
+      "name": "get_current_screen",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-NAV-TIMEJOURNEY",
+      "notes": "Identity-free read of session.current_route \u2014 safe for anonymous sessions. Vertex dispatches via toolName if-chain (not extracted by ts-morph); LiveKit declares it as @function_tool get_current_screen."
+    },
+    {
+      "name": "navigate_to_screen",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02770",
+      "notes": "INTENTIONALLY ONE-SIDED (Vertex-only): catalog-aware navigation taking a screen_id/alias, preserving parameterized routes (intent_id, match_id) and overlay support that the free-text `navigate` tool does not. LiveKit exposes only `navigate`. Cross-surface routes MUST be rejected per feedback_navigator_surface_scoping memory rule."
+    },
+    {
+      "name": "navigator_consult",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "INTENTIONALLY ONE-SIDED (Vertex-only): legacy consult-then-narrate path that predates the unified `navigate` tool. Still routed to handleNavigate for in-flight sessions that cached the old tool declarations. No LiveKit equivalent. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit."
+    },
+    {
+      "name": "find_community_member",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "Shared dispatcher tool \u2014 implemented on both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY parity-scan audit (was undeclared)."
+    },
+    {
+      "name": "log_water",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "Diary quick-log: water. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit."
+    },
+    {
+      "name": "log_sleep",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "Diary quick-log: sleep. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit."
+    },
+    {
+      "name": "log_exercise",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "Diary quick-log: exercise. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit."
+    },
+    {
+      "name": "log_meditation",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "Diary quick-log: meditation. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit."
+    },
+    {
+      "name": "get_pillar_subscores",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-01983",
+      "notes": "Returns per-pillar Vitana Index subscores. Shared dispatcher tool, both sides. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit."
+    },
+    {
+      "name": "teacher_event",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "INTENTIONALLY ONE-SIDED (Vertex-only): teaching-session telemetry event. No LiveKit @function_tool equivalent has shipped. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit."
+    },
+    {
+      "name": "end_teaching_session",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "INTENTIONALLY ONE-SIDED (Vertex-only): closes an active teaching session. No LiveKit @function_tool equivalent has shipped. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit."
+    },
+    {
+      "name": "get_social_context",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "BOOTSTRAP-SOCIAL-MEMORY: live privacy-filtered Social Context Pack (follows, matches, messages, groups, person intelligence, ranked posts/events). In the shared registry (reachable via /api/v1/orb/tool); LiveKit @function_tool wrapper not yet shipped \u2014 Vertex-only until it is."
+    },
+    {
+      "name": "view_messages",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "BOOTSTRAP-SOCIAL-READ-TOOLS: speakable read of the user's own INTERNAL community inbox (unread/all, grouped by sender). Never Google-bound; 'archived' does not exist. In the shared registry; LiveKit @function_tool wrapper not yet shipped \u2014 Vertex-only until it is."
+    },
+    {
+      "name": "list_followers",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "BOOTSTRAP-SOCIAL-READ-TOOLS: who follows the user (count, names, mutuals) \u2014 direct answer, never deflects. In the shared registry; LiveKit @function_tool wrapper not yet shipped \u2014 Vertex-only until it is."
+    },
+    {
+      "name": "list_following",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "BOOTSTRAP-SOCIAL-READ-TOOLS: who the user follows (count and names). In the shared registry; LiveKit @function_tool wrapper not yet shipped \u2014 Vertex-only until it is."
+    },
+    {
+      "name": "recent_conversations",
+      "implementations": [
+        "vertex"
+      ],
+      "safety_critical": false,
+      "owner_vtid": null,
+      "notes": "BOOTSTRAP-SOCIAL-READ-TOOLS: newest-first DM contacts; first entry answers 'who did I last chat with'. In the shared registry; LiveKit @function_tool wrapper not yet shipped \u2014 Vertex-only until it is."
+    },
+    {
+      "name": "get_highest_vitana_index",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02754",
+      "notes": "Get the community member with the highest Vitana Index right now."
+    },
+    {
+      "name": "get_top_in_pillar",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02754",
+      "notes": "Get the community member with the top score in ONE Vitana Index pillar."
+    },
+    {
+      "name": "get_first_member",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02754",
+      "notes": "Get the very first (earliest-registered / OG) community member."
+    },
+    {
+      "name": "get_newest_member",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02754",
+      "notes": "Get the most recently joined community member."
+    },
+    {
+      "name": "get_most_followed",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02754",
+      "notes": "Get the community member with the most followers."
+    },
+    {
+      "name": "ask_who_is",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02754",
+      "notes": "Answer ANY free-form 'who is...?' superlative question about the"
+    },
+    {
+      "name": "list_diary_entries",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02757",
+      "notes": "List the user's Daily Diary entries, newest first, optionally within a date window."
+    },
+    {
+      "name": "get_diary_streak",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02757",
+      "notes": "Get the user's diary streak: current consecutive days with an entry plus their longest streak ever."
+    },
+    {
+      "name": "get_memory_timeline",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02757",
+      "notes": "Chronological timeline of what Vitana remembers: memory items, extracted facts, and diary entries, newest first."
+    },
+    {
+      "name": "recall_memory_about",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02757",
+      "notes": "Search stored memories and facts about ONE specific topic, person, or thing."
+    },
+    {
+      "name": "get_memory_garden_summary",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02757",
+      "notes": "Overview of the user's Memory Garden: how many memories are stored per category."
+    },
+    {
+      "name": "forget_memory",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02757",
+      "notes": "Permanently delete ONE stored memory, only after the user explicitly confirms."
+    },
+    {
+      "name": "reschedule_event",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02761",
+      "notes": "Move an existing calendar event to a new start time (duration is kept unless new_end is given)."
+    },
+    {
+      "name": "cancel_event",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02761",
+      "notes": "Cancel (soft-delete) a calendar event \u2014 the event stays in history with status 'cancelled'."
+    },
+    {
+      "name": "complete_event",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02761",
+      "notes": "Mark a calendar event as completed, skipped, or partially done."
+    },
+    {
+      "name": "find_free_slot",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02761",
+      "notes": "Find the next free slot of a given length in the user's calendar, within waking hours (8 AM-10 PM user-local)."
+    },
+    {
+      "name": "get_event_details",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02761",
+      "notes": "Read the full details of ONE calendar event: exact time, end, location, type, status, notes."
+    },
+    {
+      "name": "check_calendar_conflicts",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02761",
+      "notes": "Check whether a proposed time window overlaps existing confirmed calendar events."
+    },
+    {
+      "name": "snooze_reminder",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02763",
+      "notes": "Push an existing reminder out by N minutes (default 10, max 1440)."
+    },
+    {
+      "name": "update_reminder",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02763",
+      "notes": "Edit an existing reminder's text and/or time."
+    },
+    {
+      "name": "acknowledge_reminder",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02763",
+      "notes": "Mark a fired reminder as heard/acknowledged so it stops being re-delivered."
+    },
+    {
+      "name": "complete_reminder",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02763",
+      "notes": "Mark a reminder as DONE (the user did the thing). Sets status=completed."
+    },
+    {
+      "name": "list_missed_reminders",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02763",
+      "notes": "List reminders that fired but were never acknowledged (the user missed them)."
+    },
+    {
+      "name": "set_alarm",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02779",
+      "notes": "Set a wake-up/clock alarm at a specific time of day (optionally recurring)."
+    },
+    {
+      "name": "list_alarms",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02779",
+      "notes": "List the user's active alarms with times and labels."
+    },
+    {
+      "name": "delete_alarm",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02779",
+      "notes": "Cancel an alarm. Two-step confirm flow: first call WITHOUT confirm to find"
+    },
+    {
+      "name": "start_timer",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02779",
+      "notes": "Start a countdown timer (1-1440 minutes)."
+    },
+    {
+      "name": "start_pomodoro",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02779",
+      "notes": "Start a pomodoro focus block (5-90 minutes; 25 if omitted)."
+    },
+    {
+      "name": "list_active_timers",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02779",
+      "notes": "List running timers and pomodoros with the remaining time on each."
+    },
+    {
+      "name": "get_world_time",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02779",
+      "notes": "Get the current local time in a city or IANA timezone (no internet needed)."
+    },
+    {
+      "name": "list_my_groups",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02764",
+      "notes": "List the community groups the user belongs to, with member counts."
+    },
+    {
+      "name": "create_group",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02764",
+      "notes": "Create a new community group. Requires a name; privacy is public or"
+    },
+    {
+      "name": "join_group",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02764",
+      "notes": "Join a community group by name or group_id. Resolves fuzzy names and"
+    },
+    {
+      "name": "invite_to_group",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02764",
+      "notes": "Invite another community member to a group. Resolves the member by"
+    },
+    {
+      "name": "accept_invitation",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02764",
+      "notes": "Accept a pending group invitation (joins the group). With no"
+    },
+    {
+      "name": "decline_invitation",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02764",
+      "notes": "Decline a pending group invitation. ALWAYS call once WITHOUT confirm"
+    },
+    {
+      "name": "rsvp_event",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02774",
+      "notes": "RSVP / sign the user up for a community event or meetup, by event_id"
+    },
+    {
+      "name": "cancel_rsvp",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02774",
+      "notes": "Cancel the user's RSVP for an upcoming event. ALWAYS call once"
+    },
+    {
+      "name": "list_upcoming_meetups",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02774",
+      "notes": "List upcoming community meetups/events the user could attend, soonest"
+    },
+    {
+      "name": "join_live_room",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02774",
+      "notes": "Join/open a community live room by name or room_id. Returns a"
+    },
+    {
+      "name": "start_conversation",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02771",
+      "notes": "Start (or reuse) a direct-message conversation with a named community member,"
+    },
+    {
+      "name": "list_conversations",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02771",
+      "notes": "List the user's recent direct-message conversations, newest first, with"
+    },
+    {
+      "name": "mark_conversation_read",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02771",
+      "notes": "Mark direct messages as read. With member set, marks that conversation;"
+    },
+    {
+      "name": "mute_conversation",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02771",
+      "notes": "Mute a chat conversation. NOTE: chat muting is not supported in Vitana yet \u2014"
+    },
+    {
+      "name": "archive_conversation",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02771",
+      "notes": "Archive a chat conversation. NOTE: chat archiving does not exist in Vitana \u2014"
+    },
+    {
+      "name": "update_account_visibility",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02776",
+      "notes": "Set the visibility of the user's WHOLE profile: public, followers_only, or private."
+    },
+    {
+      "name": "update_privacy_field",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02776",
+      "notes": "Set the visibility of ONE profile field: public, followers_only, or private."
+    },
+    {
+      "name": "block_user",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02776",
+      "notes": "Block a community member so their posts and messages are hidden from the user."
+    },
+    {
+      "name": "unblock_user",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02776",
+      "notes": "Unblock a previously blocked member so their posts and messages show again."
+    },
+    {
+      "name": "submit_bug_report",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02768",
+      "notes": "File a bug ticket (kind=bug) in the feedback pipeline. No persona swap \u2014"
+    },
+    {
+      "name": "submit_support_ticket",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02768",
+      "notes": "File a support ticket (kind=support_question) for a question the team"
+    },
+    {
+      "name": "submit_marketplace_dispute",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02768",
+      "notes": "File a marketplace dispute ticket (kind=marketplace_claim): refunds, wrong"
+    },
+    {
+      "name": "submit_account_issue",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02768",
+      "notes": "File an account ticket (kind=account_issue): login problems, password or"
+    },
+    {
+      "name": "list_my_tickets",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02768",
+      "notes": "List the user's OPEN feedback tickets (bugs, support, disputes, account)"
+    },
+    {
+      "name": "set_language",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02772",
+      "notes": "Set the user's app + voice language. Persists the same setting the app's"
+    },
+    {
+      "name": "set_theme",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02772",
+      "notes": "Handle a request to change the visual theme (light / dark / system)."
+    },
+    {
+      "name": "set_voice_preferences",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02772",
+      "notes": "Tune the app's spoken-voice settings: pace (slow / normal / fast), voice"
+    },
+    {
+      "name": "list_connected_apps",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02772",
+      "notes": "List the user's connected integrations: Google, YouTube, social accounts,"
+    },
+    {
+      "name": "disconnect_app",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02772",
+      "notes": "Disconnect one connected integration (Google, YouTube, Instagram, an AI"
+    },
+    {
+      "name": "global_search",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02773",
+      "notes": "Unified community search across people, posts, events, groups, products,"
+    },
+    {
+      "name": "browse_news_feed",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02773",
+      "notes": "Read the community news feed aloud: recent posts with author and a"
+    },
+    {
+      "name": "snooze_recommendation",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02775",
+      "notes": "Snooze an Autopilot recommendation so it resurfaces later (default 24h,"
+    },
+    {
+      "name": "dismiss_recommendation",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02775",
+      "notes": "Dismiss an Autopilot recommendation for good (it will not come back)."
+    },
+    {
+      "name": "explain_recommendation",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02775",
+      "notes": "Explain WHY a specific Autopilot recommendation was suggested: its"
+    },
+    {
+      "name": "update_intent",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02777",
+      "notes": "Edit one of the user's OWN intent posts (title, description text, or"
+    },
+    {
+      "name": "delete_intent",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02777",
+      "notes": "Take down one of the user's OWN intent posts from the board (closes it;"
+    },
+    {
+      "name": "browse_intent_board",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02777",
+      "notes": "Browse the open community intent board (Open Asks): what other members"
+    },
+    {
+      "name": "dispute_match",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02777",
+      "notes": "Open a dispute on a match the user is part of (no-show, misrepresented,"
+    },
+    {
+      "name": "find_perfect_match",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02780",
+      "notes": "Flagship people-match: find the PERFECT person for the user \u2014 workout"
+    },
+    {
+      "name": "get_emotional_state",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02778",
+      "notes": "Read the user's current emotional and cognitive signals (D28): mood,"
+    },
+    {
+      "name": "get_situational_awareness",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02778",
+      "notes": "Summarize the user's current situation (D32): time-of-day window,"
+    },
+    {
+      "name": "get_availability",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02778",
+      "notes": "Check how available and ready the user is right now (D33): availability"
+    },
+    {
+      "name": "get_environmental_context",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02778",
+      "notes": "Read the user's environment and mobility context (D34): where they"
+    },
+    {
+      "name": "get_life_stage_context",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02778",
+      "notes": "Read the user's life-stage context (D40): life phase and stability,"
+    },
+    {
+      "name": "follow_member",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "BOOTSTRAP-VOICE-P0-GAPS",
+      "notes": "FOLLOW a community member by their spoken name."
+    },
+    {
+      "name": "unfollow_member",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "BOOTSTRAP-VOICE-P0-GAPS",
+      "notes": "UNFOLLOW a community member by name. Two-step confirm:"
+    },
+    {
+      "name": "get_notifications",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "BOOTSTRAP-VOICE-P0-GAPS",
+      "notes": "READ the user's recent notifications, unread first. Speakable."
+    },
+    {
+      "name": "mark_notifications_read",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "BOOTSTRAP-VOICE-P0-GAPS",
+      "notes": "MARK notifications as read \u2014 all unread ones, or only those whose title"
+    },
+    {
+      "name": "get_wallet_balance",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "BOOTSTRAP-VOICE-P0-GAPS",
+      "notes": "READ-ONLY wallet snapshot: balance per currency, active subscription,"
+    },
+    {
+      "name": "update_profile",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "BOOTSTRAP-VOICE-P0-GAPS",
+      "notes": "UPDATE simple own-profile fields: display_name, bio, city, country, location."
+    },
+    {
+      "name": "play_podcast",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "BOOTSTRAP-VOICE-P0-GAPS",
+      "notes": "PLAY an internal Vitana Media Hub podcast by title or topic. Returns an"
+    },
+    {
+      "name": "like_post",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "BOOTSTRAP-VOICE-P0-GAPS",
+      "notes": "LIKE a community feed post \u2014 resolves 'the last post from <name>' to that"
+    },
+    {
+      "name": "comment_on_post",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "BOOTSTRAP-VOICE-P0-GAPS",
+      "notes": "COMMENT on a community feed post (public text). Two-step confirm:"
+    },
+    {
+      "name": "dev_list_vtids",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. List recent VTID tasks from the ledger (id, title, status)."
+    },
+    {
+      "name": "dev_get_vtid_status",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. Get one VTID task by id \u2014 status, spec status, terminal state, claim."
+    },
+    {
+      "name": "dev_list_pending_approvals",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. List PRs/actions waiting in the approvals queue (same queue as the Command Hub approvals view)."
+    },
+    {
+      "name": "dev_count_approvals",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. Count how many items are pending approval."
+    },
+    {
+      "name": "dev_approve_pr",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. Approve a queued approval \u2014 merges its PR via the governed pipeline."
+    },
+    {
+      "name": "dev_reject_pr",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": true,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. Reject a queued approval and record why."
+    },
+    {
+      "name": "dev_list_voice_sessions",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. List recent ORB voice sessions from the Voice Lab (who, when, duration, turns)."
+    },
+    {
+      "name": "dev_list_routines",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. List the daily Claude routines with last-run status."
+    },
+    {
+      "name": "dev_get_routine_detail",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. Detail one routine plus its last runs."
+    },
+    {
+      "name": "dev_list_active_healing",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. Show self-healing work currently in flight: active healing VTIDs and pending diagnoses."
+    },
+    {
+      "name": "dev_get_autonomy_pulse",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. One-shot autonomy status: pending findings, pending heals, executions"
+    },
+    {
+      "name": "dev_list_agents",
+      "implementations": [
+        "vertex",
+        "livekit"
+      ],
+      "safety_critical": false,
+      "owner_vtid": "VTID-02782",
+      "notes": "DEVELOPER ONLY. List registered agents with heartbeat-derived health (healthy/degraded/down)."
+    }
   ],
-
   "oasis_topics": [
-    { "topic": "orb.session.started",                "implementations": ["vertex"] },
-    { "topic": "orb.session.ended",                  "implementations": ["vertex"] },
-    { "topic": "orb.session.summary",                "implementations": ["vertex"] },
-    { "topic": "orb.turn.received",                  "implementations": ["vertex"] },
-    { "topic": "orb.turn.responded",                 "implementations": ["vertex"] },
-
-    { "topic": "orb.live.context.bootstrap",         "implementations": ["vertex"] },
-    { "topic": "orb.live.context.bootstrap.skipped", "implementations": ["vertex"] },
-    { "topic": "orb.live.startup.config_missing",    "implementations": ["vertex"] },
-    { "topic": "orb.live.tool.executed",             "implementations": ["vertex"] },
-
-    { "topic": "orb.memory.context_injected",        "implementations": ["vertex"] },
-    { "topic": "orb.memory.debug_requested",         "implementations": ["vertex"] },
-    { "topic": "orb.memory.debug_snapshot",          "implementations": ["vertex"] },
-
-    { "topic": "orb.navigator.consulted",            "implementations": ["vertex"] },
-    { "topic": "orb.navigator.requested",            "implementations": ["vertex"] },
-    { "topic": "orb.navigator.dispatched",           "implementations": ["vertex"] },
-    { "topic": "orb.navigator.blocked",              "implementations": ["vertex"] },
-
-    { "topic": "orb.intent.debug_requested",         "implementations": ["vertex"] },
-    { "topic": "orb.intent.debug_result",            "implementations": ["vertex"] },
-    { "topic": "orb.task_state_query.completed",     "implementations": ["vertex"] },
-
-    { "topic": "orb.session.continuity.cleared",     "implementations": ["vertex"] },
-    { "topic": "orb.session.continuity.persisted",   "implementations": ["vertex"] },
-    { "topic": "orb.session.audio_ready.acked",      "implementations": ["vertex"] },
-
-    { "topic": "admin.briefing.injected",            "implementations": ["vertex"] },
-    { "topic": "calendar.event.created",             "implementations": ["vertex"] },
-    { "topic": "feedback.ticket.created",            "implementations": ["vertex"] },
-    { "topic": "voice.message.sent",                 "implementations": ["vertex"] },
-
-    { "topic": "orb.livekit.tool.switch_persona.called",       "implementations": ["livekit"], "notes": "INTENTIONALLY ONE-SIDED (LiveKit-only): per-tool call/result telemetry namespace. Vertex emits the unified orb.live.tool.executed instead. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit." },
-    { "topic": "orb.livekit.tool.switch_persona.result",       "implementations": ["livekit"] },
-    { "topic": "orb.livekit.tool.report_to_specialist.called", "implementations": ["livekit"] },
-    { "topic": "orb.livekit.tool.report_to_specialist.result", "implementations": ["livekit"] },
-    { "topic": "orb.livekit.tool.resolve_recipient.called",    "implementations": ["livekit"] },
-    { "topic": "orb.livekit.tool.resolve_recipient.result",    "implementations": ["livekit"] },
-    { "topic": "orb.livekit.tool.send_chat_message.called",    "implementations": ["livekit"] },
-    { "topic": "orb.livekit.tool.send_chat_message.result",    "implementations": ["livekit"] }
+    {
+      "topic": "orb.session.started",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.session.ended",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.session.summary",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.turn.received",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.turn.responded",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.live.context.bootstrap",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.live.context.bootstrap.skipped",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.live.startup.config_missing",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.live.tool.executed",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.memory.context_injected",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.memory.debug_requested",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.memory.debug_snapshot",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.navigator.consulted",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.navigator.requested",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.navigator.dispatched",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.navigator.blocked",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.intent.debug_requested",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.intent.debug_result",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.task_state_query.completed",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.session.continuity.cleared",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.session.continuity.persisted",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.session.audio_ready.acked",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "admin.briefing.injected",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "calendar.event.created",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "feedback.ticket.created",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "voice.message.sent",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "topic": "orb.livekit.tool.switch_persona.called",
+      "implementations": [
+        "livekit"
+      ],
+      "notes": "INTENTIONALLY ONE-SIDED (LiveKit-only): per-tool call/result telemetry namespace. Vertex emits the unified orb.live.tool.executed instead. Declared in BOOTSTRAP-VOICE-TOOL-PARITY audit."
+    },
+    {
+      "topic": "orb.livekit.tool.switch_persona.result",
+      "implementations": [
+        "livekit"
+      ]
+    },
+    {
+      "topic": "orb.livekit.tool.report_to_specialist.called",
+      "implementations": [
+        "livekit"
+      ]
+    },
+    {
+      "topic": "orb.livekit.tool.report_to_specialist.result",
+      "implementations": [
+        "livekit"
+      ]
+    },
+    {
+      "topic": "orb.livekit.tool.resolve_recipient.called",
+      "implementations": [
+        "livekit"
+      ]
+    },
+    {
+      "topic": "orb.livekit.tool.resolve_recipient.result",
+      "implementations": [
+        "livekit"
+      ]
+    },
+    {
+      "topic": "orb.livekit.tool.send_chat_message.called",
+      "implementations": [
+        "livekit"
+      ]
+    },
+    {
+      "topic": "orb.livekit.tool.send_chat_message.result",
+      "implementations": [
+        "livekit"
+      ]
+    }
   ],
-
   "watchdogs": [
-    { "name": "session_timeout_ms",         "value": 1800000,  "description": "30 min", "implementations": ["vertex"] },
-    { "name": "max_session_age_ms",         "value": 1800000,  "description": "30 min, equal to session_timeout_ms", "implementations": ["vertex"] },
-    { "name": "conversation_timeout_ms",    "value": 86400000, "description": "24 h",   "implementations": ["vertex"] },
-    { "name": "transcript_retention_ms",    "value": 3600000,  "description": "1 h",    "implementations": ["vertex"] },
-    { "name": "ip_geo_cache_ttl_ms",        "value": 21600000, "description": "6 h — IP_GEO_CACHE_TTL_MS in orb-live.ts (`// 6 hours`) is canonical; spec previously claimed 1 h (BOOTSTRAP-VOICE-TOOL-PARITY value_mismatch fix). LiveKit's watchdogs.py uses 1 h but does not gate this constant via the spec (implementations: vertex only).", "implementations": ["vertex"] },
-    { "name": "max_connections_per_ip",     "value": 5,        "description": "DoS guard", "implementations": ["vertex"] },
-    { "name": "max_reconnects",             "value": 10,       "description": "Max reconnects per session (~50 min total). VTID-STREAM-RECONNECT.", "implementations": ["vertex"] },
-    { "name": "max_tool_response_chars",    "value": 4000,     "description": "Default cap; some sites use 2000/3000", "implementations": ["vertex"] },
-    { "name": "max_history_chars",          "value": 4000,     "description": "System-instruction last-turns budget", "implementations": ["vertex"] },
-    { "name": "extraction_throttle_ms",     "value": 60000,    "description": "Cognee fact-extraction debounce", "implementations": ["vertex"] },
-    { "name": "greeting_prebuffer_fallback_ms","value": 1500,   "description": "DEV-COMHU-0513 — GREETING_PREBUFFER_FALLBACK_MS in orb-live.ts. When FEATURE_ORB_GREETING_PREBUFFER_ENV is live, the WS greeting prompt is dispatched on connect and its audio held until the client's audio_ready; if that ack never arrives, the held greeting is flushed after this timeout so the user is never left in silence.", "implementations": ["vertex"] },
-    { "name": "bootstrap_rebuild_min_age_ms","value": 60000,   "description": "Re-bootstrap floor on reconnect", "implementations": ["vertex"] },
-    { "name": "token_refresh_skew_ms",      "value": 300000,   "description": "5 min — refresh the cached ADC access token this far ahead of expiry so getAccessToken() never blocks the live-connect path", "implementations": ["vertex"] },
-    { "name": "token_default_ttl_ms",       "value": 3300000,  "description": "55 min — fallback ADC token TTL when the auth client doesn't expose expiry_date", "implementations": ["vertex"] },
-    { "name": "tool_cache_ttl_ms",          "value": 120000,   "description": "2 min — per-session cache TTL for read-only retrieval tools (search_memory/search_knowledge); repeat lookups skip the blocking function_response round-trip (BOOTSTRAP-ORB-LATENCY-PHASE2)", "implementations": ["vertex"] },
-    { "name": "vertex_bootstrap_cache_ttl_ms", "value": 300000, "description": "5 min — per-identity cache TTL for buildBootstrapContextPack on the Vertex session-start path; filled by /live/session/prewarm so the first tap skips the 400-800ms context build (BOOTSTRAP-ORB-LATENCY-PHASE2)", "implementations": ["vertex"] }
+    {
+      "name": "session_timeout_ms",
+      "value": 1800000,
+      "description": "30 min",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "max_session_age_ms",
+      "value": 1800000,
+      "description": "30 min, equal to session_timeout_ms",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "conversation_timeout_ms",
+      "value": 86400000,
+      "description": "24 h",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "transcript_retention_ms",
+      "value": 3600000,
+      "description": "1 h",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "ip_geo_cache_ttl_ms",
+      "value": 21600000,
+      "description": "6 h \u2014 IP_GEO_CACHE_TTL_MS in orb-live.ts (`// 6 hours`) is canonical; spec previously claimed 1 h (BOOTSTRAP-VOICE-TOOL-PARITY value_mismatch fix). LiveKit's watchdogs.py uses 1 h but does not gate this constant via the spec (implementations: vertex only).",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "max_connections_per_ip",
+      "value": 5,
+      "description": "DoS guard",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "max_reconnects",
+      "value": 10,
+      "description": "Max reconnects per session (~50 min total). VTID-STREAM-RECONNECT.",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "max_tool_response_chars",
+      "value": 4000,
+      "description": "Default cap; some sites use 2000/3000",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "max_history_chars",
+      "value": 4000,
+      "description": "System-instruction last-turns budget",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "extraction_throttle_ms",
+      "value": 60000,
+      "description": "Cognee fact-extraction debounce",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "greeting_prebuffer_fallback_ms",
+      "value": 1500,
+      "description": "DEV-COMHU-0513 \u2014 GREETING_PREBUFFER_FALLBACK_MS in orb-live.ts. When FEATURE_ORB_GREETING_PREBUFFER_ENV is live, the WS greeting prompt is dispatched on connect and its audio held until the client's audio_ready; if that ack never arrives, the held greeting is flushed after this timeout so the user is never left in silence.",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "bootstrap_rebuild_min_age_ms",
+      "value": 60000,
+      "description": "Re-bootstrap floor on reconnect",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "token_refresh_skew_ms",
+      "value": 300000,
+      "description": "5 min \u2014 refresh the cached ADC access token this far ahead of expiry so getAccessToken() never blocks the live-connect path",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "token_default_ttl_ms",
+      "value": 3300000,
+      "description": "55 min \u2014 fallback ADC token TTL when the auth client doesn't expose expiry_date",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "tool_cache_ttl_ms",
+      "value": 120000,
+      "description": "2 min \u2014 per-session cache TTL for read-only retrieval tools (search_memory/search_knowledge); repeat lookups skip the blocking function_response round-trip (BOOTSTRAP-ORB-LATENCY-PHASE2)",
+      "implementations": [
+        "vertex"
+      ]
+    },
+    {
+      "name": "vertex_bootstrap_cache_ttl_ms",
+      "value": 300000,
+      "description": "5 min \u2014 per-identity cache TTL for buildBootstrapContextPack on the Vertex session-start path; filled by /live/session/prewarm so the first tap skips the 400-800ms context build (BOOTSTRAP-ORB-LATENCY-PHASE2)",
+      "implementations": [
+        "vertex"
+      ]
+    }
   ],
-
   "documented_invariants": {
-    "description": "Behaviours required by both implementations but enforced by inline checks rather than named constants. The parity scanner does not statically verify these (yet) — they live in spec.json so reviewers know the invariant exists, and to anchor future PRs that promote them to named constants.",
+    "description": "Behaviours required by both implementations but enforced by inline checks rather than named constants. The parity scanner does not statically verify these (yet) \u2014 they live in spec.json so reviewers know the invariant exists, and to anchor future PRs that promote them to named constants.",
     "items": [
-      { "name": "vad_silence_ms_range",            "value": "500..3000", "description": "VAD silence-duration tunable bounds (VTID-RESPONSE-DELAY). Inline range check in /live/session/start payload validation.", "implementations": ["vertex"] },
-      { "name": "tool_loop_guard_max_consecutive", "value": 5, "description": "Force-flush after 5 consecutive tool calls without user-visible audio output (VTID-TOOLGUARD). On LiveKit, equivalent is AgentSession(max_tool_steps=5)." }
+      {
+        "name": "vad_silence_ms_range",
+        "value": "500..3000",
+        "description": "VAD silence-duration tunable bounds (VTID-RESPONSE-DELAY). Inline range check in /live/session/start payload validation.",
+        "implementations": [
+          "vertex"
+        ]
+      },
+      {
+        "name": "tool_loop_guard_max_consecutive",
+        "value": 5,
+        "description": "Force-flush after 5 consecutive tool calls without user-visible audio output (VTID-TOOLGUARD). On LiveKit, equivalent is AgentSession(max_tool_steps=5)."
+      }
     ]
   },
-
   "system_instruction_params": {
     "authenticated_signature": [
       "lang",
@@ -191,8 +1882,14 @@
     "impl_specific_optional": {
       "description": "Trailing OPTIONAL parameters that exist on only one implementation and are intentionally NOT part of the shared contract. The scanner strips these (after case-normalisation) before comparing signatures, so they do not register as drift. Adding a new name here is an explicit declaration that a parameter is one-sided on purpose.",
       "authenticated": {
-        "vertex": ["omitGreetingPolicy", "surface"],
-        "livekit": ["firstName", "displayName"]
+        "vertex": [
+          "omitGreetingPolicy",
+          "surface"
+        ],
+        "livekit": [
+          "firstName",
+          "displayName"
+        ]
       },
       "anonymous": {
         "vertex": [],
@@ -202,25 +1899,37 @@
     "case_convention": "snake_case",
     "notes": "These are the parameter NAMES, not the prompt template. Each implementation owns its own template; only the shared parameter list must match across implementations. Cross-language case convention is NOT drift: the scanner normalises every name to `case_convention` (snake_case) before comparing, so TS `voiceStyle` and Python `voice_style` are considered equal. Names listed in `impl_specific_optional` are stripped before comparison (intentional one-sided params). Drift in any remaining shared name is a parity violation; drift in the template is not (the system_instruction golden-file test catches template drift separately, on the same fixed input)."
   },
-
-  "supported_languages": ["en", "de", "fr", "es", "ar", "zh", "ru", "sr"],
-
+  "supported_languages": [
+    "en",
+    "de",
+    "fr",
+    "es",
+    "ar",
+    "zh",
+    "ru",
+    "sr"
+  ],
   "audio": {
     "input_sample_rate_hz": 16000,
     "input_format": "PCM",
     "output_sample_rate_hz": 24000,
     "output_format": "PCM",
     "video_input_format": "JPEG 768x768 @ 1 FPS",
-    "implementations": ["vertex"]
+    "implementations": [
+      "vertex"
+    ]
   },
-
   "active_provider_switch": {
     "global_flag_key": "voice.active_provider",
-    "values": ["vertex", "livekit"],
+    "values": [
+      "vertex",
+      "livekit"
+    ],
     "anti_flap_cooldown_seconds": 3600,
-    "implementations": ["vertex"]
+    "implementations": [
+      "vertex"
+    ]
   },
-
   "_meta": {
     "spec_status": "draft",
     "next_steps": [
@@ -228,7 +1937,7 @@
       "extract real arg JSON Schemas for each tool from orb-live.ts (this v0.1 has names + flags but not arg schemas)",
       "wire the LiveKit-side codegen target once services/agents/orb-agent/ ships",
       "promote the CI from report-only to merge gate once 30 days of green runs are recorded",
-      "EXTRACTOR GAP (BOOTSTRAP-VOICE-TOOL-PARITY): extract-ts.ts only walks orb-live.ts. The 11 remaining `missing_in_vertex` items are false negatives — they ARE implemented on the Vertex side, just outside that single file: (a) OASIS topics orb.live.tool.executed (orb/live/session/upstream-message-handler.ts), orb.navigator.requested/dispatched/blocked (services/orb-tools-shared.ts, upstream-message-handler.ts), feedback.ticket.created (services/report-to-specialist-core.ts); (b) watchdogs session_timeout_ms, conversation_timeout_ms, max_connections_per_ip, max_reconnects, max_history_chars, extraction_throttle_ms — all imported from ../orb/live/config. Fix is to widen the extractor's file set to the orb/live module tree (separate PR — out of scope for the spec-reconciliation pass). These stay declared as vertex because they are genuinely implemented."
+      "EXTRACTOR GAP (BOOTSTRAP-VOICE-TOOL-PARITY): extract-ts.ts only walks orb-live.ts. The 11 remaining `missing_in_vertex` items are false negatives \u2014 they ARE implemented on the Vertex side, just outside that single file: (a) OASIS topics orb.live.tool.executed (orb/live/session/upstream-message-handler.ts), orb.navigator.requested/dispatched/blocked (services/orb-tools-shared.ts, upstream-message-handler.ts), feedback.ticket.created (services/report-to-specialist-core.ts); (b) watchdogs session_timeout_ms, conversation_timeout_ms, max_connections_per_ip, max_reconnects, max_history_chars, extraction_throttle_ms \u2014 all imported from ../orb/live/config. Fix is to widen the extractor's file set to the orb/live module tree (separate PR \u2014 out of scope for the spec-reconciliation pass). These stay declared as vertex because they are genuinely implemented."
     ],
     "owners": "ORB Voice team",
     "related_memory": [

--- a/voice-pipeline-spec/tools/extract-ts.ts
+++ b/voice-pipeline-spec/tools/extract-ts.ts
@@ -13,13 +13,14 @@
  * Run: npm run extract:ts
  */
 import { Project, Node, SyntaxKind, type CaseClause, type SwitchStatement } from 'ts-morph';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..', '..');
 const ORB_LIVE = resolve(REPO_ROOT, 'services', 'gateway', 'src', 'routes', 'orb-live.ts');
+const ORB_TOOLS_SHARED = resolve(REPO_ROOT, 'services', 'gateway', 'src', 'services', 'orb-tools-shared.ts');
 const OUT_PATH = resolve(__dirname, '..', 'extracted', 'vertex.json');
 
 // Only switch statements with these discriminants count as tool dispatchers.
@@ -131,6 +132,20 @@ function main(): void {
     }
   }
 
+  // BOOTSTRAP-VOICE-CATALOG-COMPLETE: orb-live.ts's default case has a
+  // generic dispatch fallback — `if (ORB_TOOL_NAMES.includes(toolName))
+  // { … dispatchOrbToolForVertex … }` — so every tool in the shared
+  // ORB_TOOL_REGISTRY is Vertex-reachable even without its own `case` arm
+  // or `toolName === '...'` comparison. Without this, every tool added via
+  // the shared registry (the intended pattern going forward) shows up as a
+  // false-positive `missing_in_vertex` drift on every PR. Detect the idiom
+  // and, when present, count every shared-registry tool as covered.
+  if (/ORB_TOOL_NAMES\.includes\(\s*toolName\s*\)/.test(sf.getFullText())) {
+    for (const name of extractSharedRegistryNames(readSharedSource())) {
+      tools.push({ name, line: 0 });
+    }
+  }
+
   const out: ExtractedSurface = {
     source: 'services/gateway/src/routes/orb-live.ts',
     extracted_at: new Date().toISOString(),
@@ -207,6 +222,80 @@ function dedupeBy<T, K>(arr: T[], key: (x: T) => K): T[] {
     }
   }
   return out;
+}
+
+function readSharedSource(): string {
+  return readFileSync(ORB_TOOLS_SHARED, 'utf8');
+}
+
+// Regex-based extraction (not ts-morph) to match the sibling implementation
+// in scripts/voice-tools-manifest-reconcile.mjs — same source, same logic,
+// kept in sync deliberately. Pulls every literal key AND every
+// `...FOO_TOOL_HANDLERS` spread's own keys (resolved via its import path)
+// out of `export const ORB_TOOL_REGISTRY = { … }`.
+function extractSharedRegistryNames(src: string): Set<string> {
+  const idx = src.indexOf('export const ORB_TOOL_REGISTRY');
+  if (idx < 0) return new Set();
+  const open = src.indexOf('{', idx);
+  if (open < 0) return new Set();
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close < 0) return new Set();
+  const body = src.slice(open + 1, close);
+  const keys = new Set<string>();
+  const pat = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)\s*(?::\s*[(a-zA-Z_]|,)/gm;
+  let m: RegExpExecArray | null;
+  while ((m = pat.exec(body)) !== null) keys.add(m[1]);
+
+  const spreadPat = /^[ \t]*\.\.\.([A-Z][A-Z0-9_]*)\s*,/gm;
+  const spreadNames = new Set<string>();
+  let sm: RegExpExecArray | null;
+  while ((sm = spreadPat.exec(body)) !== null) spreadNames.add(sm[1]);
+
+  for (const spreadName of spreadNames) {
+    const importRe = new RegExp(`import\\s*\\{[^}]*\\b${spreadName}\\b[^}]*\\}\\s*from\\s*'([^']+)'`);
+    const importMatch = src.match(importRe);
+    if (!importMatch) continue;
+    const modPath = resolve(dirname(ORB_TOOLS_SHARED), importMatch[1].replace(/^\.\//, '') + '.ts');
+    let modSrc: string;
+    try {
+      modSrc = readFileSync(modPath, 'utf8');
+    } catch {
+      continue;
+    }
+    const declIdx = modSrc.indexOf(`export const ${spreadName}`);
+    if (declIdx < 0) continue;
+    const modOpen = modSrc.indexOf('{', declIdx);
+    if (modOpen < 0) continue;
+    let modDepth = 0;
+    let modClose = -1;
+    for (let i = modOpen; i < modSrc.length; i++) {
+      if (modSrc[i] === '{') modDepth++;
+      else if (modSrc[i] === '}') {
+        modDepth--;
+        if (modDepth === 0) {
+          modClose = i;
+          break;
+        }
+      }
+    }
+    if (modClose < 0) continue;
+    const modBody = modSrc.slice(modOpen + 1, modClose);
+    let mm: RegExpExecArray | null;
+    const modPat = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)\s*(?::\s*[(a-zA-Z_]|,)/gm;
+    while ((mm = modPat.exec(modBody)) !== null) keys.add(mm[1]);
+  }
+  return keys;
 }
 
 main();


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-02754, VTID-02757, VTID-02761, VTID-02763, VTID-02764, VTID-02768, VTID-02771, VTID-02772, VTID-02773, VTID-02774, VTID-02775, VTID-02776, VTID-02777, VTID-02778, VTID-02779, VTID-02780, VTID-02782, BOOTSTRAP-VOICE-P0-GAPS`

**Layer:** APIL (gateway voice tools)

**Priority:** P1

---

## 📋 Summary

Completes the Voice Tools Catalog. Every tool that was `status: planned` (97 of them) is now implemented and wired into both voice pipelines, plus 9 additional P0 tools for community-feature gaps found in a companion audit (follow/unfollow, notifications, wallet read, profile edit, internal media playback, post like/comment).

**Catalog result: 169/169 tools now `live`** (was 51/148 planned before this PR). Verified with `node scripts/voice-tools-manifest-reconcile.mjs --check`.

---

## ✅ Changes

**11 new per-domain tool modules** under `services/gateway/src/services/orb-tools/`, each backed by real existing tables/services (never invented schema) and covered by its own jest suite:

| Module | Tools | VTID |
|---|---|---|
| `superlatives-tools.ts` | 6 | VTID-02754 |
| `diary-memory-tools.ts` | 6 | VTID-02757 |
| `calendar-management-tools.ts` | 6 | VTID-02761 |
| `reminders-clock-tools.ts` | 12 | VTID-02763, VTID-02779 |
| `groups-events-tools.ts` | 10 | VTID-02764, VTID-02774 |
| `chat-privacy-tools.ts` | 9 | VTID-02771, VTID-02776 |
| `feedback-settings-tools.ts` | 10 | VTID-02768, VTID-02772 |
| `discovery-tools.ts` | 10 | VTID-02773, VTID-02775, VTID-02777, VTID-02780 |
| `awareness-tools.ts` | 5 | VTID-02778 |
| `developer-tools.ts` | 12 (role-gated) | VTID-02782 |
| `p0-gap-tools.ts` | 9 | BOOTSTRAP-VOICE-P0-GAPS |

**Integration:**
- `orb-tools-shared.ts` — spreads every module's handlers into `ORB_TOOL_REGISTRY`; exposes `NEW_DOMAIN_TOOL_DECLARATIONS` / `DEVELOPER_DOMAIN_TOOL_DECLARATIONS`.
- `live-tool-catalog.ts` — declares the new tools to Gemini Live for authenticated sessions; developer tools stay role-gated the same way `ADMIN_TOOL_SCHEMAS` already is.
- `orb-live.ts` — generic Vertex dispatch fallback: any name in `ORB_TOOL_NAMES` now routes through `dispatchOrbToolForVertex` from the `default:` case, so new tools need no per-tool `case` arm.
- `orb_agent/tools.py` — 95 generated `@function_tool` wrappers over the existing shared HTTP dispatcher; `all_tool_names()` extended.
- `tool-manifest.json` — fully reconciled; duplicate `ask_who_is` entry removed; 21 previously-uncatalogued *already-live* tools added (`create_community_post`, `get_life_compass`, the `admin_*` suite, etc.).
- `voice-tools-manifest-reconcile.mjs` — fixed two pre-existing detection bugs (an `ORB_TOOL_REGISTRY` self-reference confusing the extractor, and no support for `...FOO_TOOL_HANDLERS` spreads or the separate `admin-voice-tools.ts` dispatch path) so the reconciler stays accurate for this PR's tools and any future domain module.
- `voice-pipeline-spec/spec.json` — parity entries added for all 95 new tools.
- `DATABASE_SCHEMA.md` — documented the new `voice_clock_items` table.
- `supabase/migrations/20260706100000_vtid_02779_voice_clock.sql` — new table for alarms/timers/pomodoro (RLS-on, indexed for the future firing tick job).

**Known follow-up (flagged in code):** alarm/timer/pomodoro *firing* (push/chime delivery) needs a cron tick job analogous to `/reminders-tick` — this PR ships the data layer and voice read/write tools only.

---

## 🧪 Testing

- [x] Automated tests added/updated — 534/534 new orb-tools jest tests passing
- [x] `npx tsc --noEmit` clean
- [x] Full gateway suite: 7105/7118 tests, 420/421 suites passing. The one remaining failure (`nav-manifest-sync.test.ts`) is pre-existing drift between this repo's `navigation-catalog.ts` and the `vitana-v1` sibling checkout, untouched by this diff.
- [x] Tool-catalog + system-instruction characterization snapshots updated to reflect the expanded catalog
- [ ] Verified in staging/dev environment (post-merge staging verification on `preview-gateway.vitanaland.com`)

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] No workflow changes in this PR

### File Names
- [x] kebab-case throughout (`orb-tools/`)

### Code Standards
- [x] VTID constants uppercase, event types snake_case, status values lowercase

### Cloud Run Deployments
- [x] No new Cloud Run services

### Documentation
- [x] VTID mentioned in commit messages
- [x] `DATABASE_SCHEMA.md` updated for `voice_clock_items`

---

## 🚨 Breaking Changes

None — additive only.

---

## 📌 Additional Notes

A companion feature-coverage audit found several important gaps **beyond** the original 97-tool backlog — commerce (cart/checkout/orders/booking), Business Hub provider CRUD, live-room hosting, group-chat send, subscriptions, and a few P2 items. The 9 highest-value P0 items from that audit are included here (`p0-gap-tools.ts`). The remaining P1/P2 items are **not** in this PR — several touch payments and public-artifact creation and deserve an explicit go/no-go on the confirm-gating model before being built. Happy to open a follow-up VTID for those on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX