### PR TITLE
feat(memory): DeepSeek as primary LLM provider + wire OpenAI/DeepSeek keys into staging deploy (BOOTSTRAP-MEMORY-DAILY-LEARNING)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -169,6 +169,16 @@ jobs:
             #                           (offer_action + auto-capture + turn_complete)
             "NAV_GUIDED_JOURNEY=true"
             "NAV_CONTINUATION_BIND=true"
+            # BOOTSTRAP-MEMORY-DAILY-LEARNING: OpenAI (fact-embedding backfill,
+            # AP-0910) and DeepSeek (primary provider for inline fact
+            # extraction + AP-0911 user-model synthesis — Vertex was failing
+            # at runtime on gateway-staging) keys. Bound as plain GitHub
+            # Actions secrets, same pattern EXEC-DEPLOY.yml already uses for
+            # prod (no GCP Secret Manager entry needed) — added here because
+            # staging previously bound neither, so both features silently
+            # no-op'd on preview-gateway.vitanaland.com.
+            "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
+            "DEEPSEEK_API_KEY=${{ secrets.DEEPSEEK_API_KEY }}"
           )
 
           # Comma-joined for --set-env-vars (replaces, not merges — we want the

--- a/services/gateway/src/services/inline-fact-extractor.ts
+++ b/services/gateway/src/services/inline-fact-extractor.ts
@@ -30,10 +30,19 @@ import { recordAgentHeartbeat } from '../routes/agents-registry';
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
 const GOOGLE_GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY;
+const DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY;
 const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
 const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
 // Use flash model for extraction - faster and cheaper than pro
 const EXTRACTION_MODEL = 'gemini-2.0-flash';
+// BOOTSTRAP-MEMORY-DAILY-LEARNING: DeepSeek is now the PRIMARY extraction
+// provider — Vertex calls were failing at runtime on gateway-staging
+// (env reports GOOGLE_CLOUD_PROJECT set, but actual invocation returned
+// empty/errored for every tested conversation) while providers/health
+// cannot distinguish "configured" from "actually reachable". DeepSeek
+// (deepseek-chat, cheap + fast, matches llm-router.ts's adapter shape)
+// tries first; Vertex and the Gemini API key remain as fallbacks.
+const DEEPSEEK_MODEL = 'deepseek-chat';
 
 let vertexAI: VertexAI | null = null;
 try {
@@ -115,10 +124,55 @@ const CONFIDENCE_CAP = 0.98;
 // Core: Extract facts using Gemini
 // =============================================================================
 
-async function callGeminiForExtraction(conversationText: string): Promise<ExtractedFact[]> {
-  console.log(`[VTID-01225-inline] Extracting from ${conversationText.length} chars, vertexAI=${!!vertexAI}, apiKey=${!!GOOGLE_GEMINI_API_KEY}`);
+async function callDeepSeekForExtraction(conversationText: string): Promise<ExtractedFact[]> {
+  if (!DEEPSEEK_API_KEY) return [];
+  try {
+    const response = await fetch('https://api.deepseek.com/chat/completions', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${DEEPSEEK_API_KEY}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: DEEPSEEK_MODEL,
+        messages: [
+          { role: 'system', content: EXTRACTION_SYSTEM_PROMPT },
+          { role: 'user', content: conversationText },
+        ],
+        temperature: 0.1,
+        max_tokens: 512,
+      }),
+    });
+    if (!response.ok) {
+      const errBody = await response.text();
+      throw new Error(`DeepSeek returned ${response.status}: ${errBody.substring(0, 200)}`);
+    }
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const rawText = data.choices?.[0]?.message?.content || '[]';
+    console.log(`[VTID-01225-inline] DeepSeek response: ${rawText.substring(0, 200)}`);
+    return parseFactsResponse(rawText);
+  } catch (err: any) {
+    console.warn(`[VTID-01225-inline] DeepSeek extraction failed: ${err.message}`);
+    return [];
+  }
+}
 
-  // Try Vertex AI first (primary on Cloud Run)
+async function callGeminiForExtraction(conversationText: string): Promise<ExtractedFact[]> {
+  console.log(
+    `[VTID-01225-inline] Extracting from ${conversationText.length} chars, ` +
+      `deepseek=${!!DEEPSEEK_API_KEY}, vertexAI=${!!vertexAI}, apiKey=${!!GOOGLE_GEMINI_API_KEY}`,
+  );
+
+  // DeepSeek first (primary — see DEEPSEEK_MODEL comment above).
+  if (DEEPSEEK_API_KEY) {
+    const facts = await callDeepSeekForExtraction(conversationText);
+    if (facts.length > 0) return facts;
+    console.warn(`[VTID-01225-inline] DeepSeek returned 0 parseable facts, trying Vertex`);
+  }
+
+  // Try Vertex AI next
   if (vertexAI) {
     try {
       const model = vertexAI.getGenerativeModel({
@@ -443,7 +497,7 @@ export async function extractAndPersistFacts(input: {
  * Check if inline extraction is available (has LLM + Supabase config)
  */
 export function isInlineExtractionAvailable(): boolean {
-  const hasLLM = !!vertexAI || !!GOOGLE_GEMINI_API_KEY;
+  const hasLLM = !!DEEPSEEK_API_KEY || !!vertexAI || !!GOOGLE_GEMINI_API_KEY;
   const hasSupabase = !!SUPABASE_URL && !!SUPABASE_SERVICE_ROLE;
   return hasLLM && hasSupabase;
 }

--- a/services/gateway/src/services/user-model-synthesis.ts
+++ b/services/gateway/src/services/user-model-synthesis.ts
@@ -157,10 +157,43 @@ async function callSynthesisModel(inputs: SynthesisInputs): Promise<string | nul
 
   const prompt = lines.join('\n');
 
-  // Vertex first (Cloud Run ADC), Gemini API key as fallback — the same
-  // two-provider ladder inline-fact-extractor uses. Staging verification
-  // (run a6811834, 2026-07-06) showed the Vertex path failing there for
-  // all 26 users, so the fallback is required for staging parity.
+  // BOOTSTRAP-MEMORY-DAILY-LEARNING: DeepSeek is now PRIMARY — staging
+  // verification (runs a6811834 and 2f1f51e3, 2026-07-06) showed Vertex
+  // returning nothing for all 26 eligible users even with the Gemini
+  // API-key fallback in place. Vertex/Gemini remain as fallbacks below.
+  const deepseekKey = process.env.DEEPSEEK_API_KEY;
+  if (deepseekKey) {
+    try {
+      const response = await fetch('https://api.deepseek.com/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${deepseekKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'deepseek-chat',
+          messages: [
+            { role: 'system', content: SYNTHESIS_SYSTEM_PROMPT },
+            { role: 'user', content: prompt },
+          ],
+          temperature: 0.3,
+          max_tokens: 400,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`DeepSeek returned ${response.status}`);
+      }
+      const data = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      const text = data.choices?.[0]?.message?.content;
+      const narrative = typeof text === 'string' ? text.trim() : '';
+      if (narrative.length >= 40) return narrative;
+    } catch (err: any) {
+      console.warn(`[user-model-synthesis] DeepSeek call failed: ${err?.message}`);
+    }
+  }
+
   if (vertexAI) {
     try {
       const model = vertexAI.getGenerativeModel({

--- a/services/gateway/test/inline-fact-extractor-deepseek.test.ts
+++ b/services/gateway/test/inline-fact-extractor-deepseek.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Inline Fact Extractor — DeepSeek primary provider
+ * (BOOTSTRAP-MEMORY-DAILY-LEARNING)
+ *
+ * DeepSeek was made the PRIMARY extraction provider after Vertex calls
+ * were found failing at runtime on gateway-staging (env reports Vertex
+ * "configured" but the actual call returned nothing for every tested
+ * conversation). This is a separate test file (not added to
+ * inline-fact-extractor.test.ts) because DEEPSEEK_API_KEY must be set
+ * BEFORE the module is imported — top-level module consts read env vars
+ * once at import time, and the existing suite deliberately leaves
+ * DEEPSEEK_API_KEY unset to test the pre-DeepSeek fallback chain.
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SUPABASE_URL = 'http://localhost:54321';
+process.env.SUPABASE_SERVICE_ROLE = 'test-service-role-key';
+process.env.DEEPSEEK_API_KEY = 'test-deepseek-key';
+process.env.GOOGLE_GEMINI_API_KEY = 'test-gemini-key';
+
+const fetchCalls: Array<{ url: string; method: string; body?: any }> = [];
+let deepseekResponseText = JSON.stringify([
+  { fact_key: 'user_name', fact_value: 'Dragan', entity: 'self', fact_value_type: 'text', stated: true },
+]);
+let deepseekShouldFail = false;
+
+jest.mock('@google-cloud/vertexai', () => ({
+  VertexAI: jest.fn().mockImplementation(() => ({
+    getGenerativeModel: jest.fn().mockReturnValue({
+      generateContent: jest.fn().mockImplementation(async () => ({
+        response: {
+          candidates: [{ content: { parts: [{ text: '[]' }] } }],
+        },
+      })),
+    }),
+  })),
+}));
+
+const mockFetch = jest.fn().mockImplementation(async (url: string, options?: RequestInit) => {
+  const method = options?.method || 'GET';
+  const body = options?.body ? JSON.parse(options.body as string) : undefined;
+  fetchCalls.push({ url, method, body });
+
+  if (url.includes('api.deepseek.com')) {
+    if (deepseekShouldFail) {
+      return { ok: false, status: 500, text: async () => 'DeepSeek down' };
+    }
+    return {
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: deepseekResponseText } }] }),
+    };
+  }
+  if (url.includes('/rest/v1/rpc/write_fact')) {
+    return { ok: true, json: async () => 'fact-uuid-ds' };
+  }
+  if (url.includes('/rest/v1/memory_facts?')) {
+    return { ok: true, json: async () => [] };
+  }
+  if (url.includes('check_canonical_fact_key')) {
+    return { ok: true, json: async () => ({ ok: true, mapped: false }) };
+  }
+  return { ok: true, json: async () => ({}), text: async () => '' };
+});
+global.fetch = mockFetch as any;
+
+import { extractAndPersistFacts } from '../src/services/inline-fact-extractor';
+
+describe('inline-fact-extractor: DeepSeek as primary provider', () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    mockFetch.mockClear();
+    deepseekShouldFail = false;
+    deepseekResponseText = JSON.stringify([
+      { fact_key: 'user_name', fact_value: 'Dragan', entity: 'self', fact_value_type: 'text', stated: true },
+    ]);
+  });
+
+  it('calls DeepSeek chat completions first and persists the extracted fact', async () => {
+    await extractAndPersistFacts({
+      conversationText: 'User: My name is Dragan and I live in Aachen.\nAssistant: Nice to meet you!',
+      tenant_id: 'tenant-123',
+      user_id: 'user-456',
+      session_id: 'session-789',
+    });
+
+    const dsCall = fetchCalls.find((c) => c.url.includes('api.deepseek.com'));
+    expect(dsCall).toBeDefined();
+    expect(dsCall!.method).toBe('POST');
+    expect(dsCall!.body.model).toBe('deepseek-chat');
+    expect(dsCall!.body.messages[0]).toEqual({ role: 'system', content: expect.any(String) });
+    expect(dsCall!.body.messages[1]).toEqual({
+      role: 'user',
+      content: expect.stringContaining('Dragan'),
+    });
+
+    const writeFactCall = fetchCalls.find((c) => c.url.includes('rpc/write_fact'));
+    expect(writeFactCall).toBeDefined();
+    expect(writeFactCall!.body.p_fact_value).toBe('Dragan');
+    expect(writeFactCall!.body.p_provenance_source).toBe('user_stated');
+  });
+
+  it('falls through to Vertex when DeepSeek errors', async () => {
+    deepseekShouldFail = true;
+    await extractAndPersistFacts({
+      conversationText: 'User: My name is Dragan and I live in Aachen.\nAssistant: Nice to meet you!',
+      tenant_id: 'tenant-123',
+      user_id: 'user-456',
+      session_id: 'session-789',
+    });
+    const dsCall = fetchCalls.find((c) => c.url.includes('api.deepseek.com'));
+    expect(dsCall).toBeDefined();
+    // Vertex mock (above) returns '[]' → 0 facts → no write_fact call, but no throw either.
+    const writeFactCall = fetchCalls.find((c) => c.url.includes('rpc/write_fact'));
+    expect(writeFactCall).toBeUndefined();
+  });
+
+  it('falls through to Vertex when DeepSeek returns 0 parseable facts', async () => {
+    deepseekResponseText = '[]';
+    await extractAndPersistFacts({
+      conversationText: 'User: Just saying hello, nothing specific.\nAssistant: Hi there!',
+      tenant_id: 'tenant-123',
+      user_id: 'user-456',
+      session_id: 'session-789',
+    });
+    const dsCall = fetchCalls.find((c) => c.url.includes('api.deepseek.com'));
+    expect(dsCall).toBeDefined();
+  });
+});

--- a/services/gateway/test/services/user-model-synthesis.test.ts
+++ b/services/gateway/test/services/user-model-synthesis.test.ts
@@ -1,0 +1,173 @@
+/**
+ * user-model-synthesis — unit tests (BOOTSTRAP-MEMORY-DAILY-LEARNING)
+ *
+ * Contract under test:
+ *   - computeInputsHash is stable for identical inputs, order-independent
+ *     for facts/routines
+ *   - synthesizeUserModel skips users below MIN_FACTS_FOR_NARRATIVE
+ *   - synthesizeUserModel skips when the inputs hash is unchanged
+ *   - DeepSeek is called as the PRIMARY provider (staging verification
+ *     showed Vertex returning nothing at runtime); falls to Vertex/Gemini
+ *     on DeepSeek failure
+ *   - a successful narrative is upserted with the inputs hash stamped
+ */
+
+process.env.DEEPSEEK_API_KEY = 'test-deepseek-key';
+delete process.env.GOOGLE_GEMINI_API_KEY;
+
+jest.mock('@google-cloud/vertexai', () => ({
+  VertexAI: jest.fn().mockImplementation(() => ({
+    getGenerativeModel: jest.fn().mockReturnValue({
+      generateContent: jest.fn().mockResolvedValue({
+        response: { candidates: [{ content: { parts: [{ text: '' }] } }] },
+      }),
+    }),
+  })),
+}));
+
+const fetchCalls: Array<{ url: string; body: any }> = [];
+let deepseekNarrative = 'Dragan is planning his wedding to Sarah in September and has been focusing on evening walks, which seem to correlate with his improving sleep pillar.';
+let deepseekOk = true;
+
+global.fetch = jest.fn(async (url: any, opts: any) => {
+  const body = opts?.body ? JSON.parse(opts.body) : undefined;
+  fetchCalls.push({ url: String(url), body });
+  if (String(url).includes('api.deepseek.com')) {
+    if (!deepseekOk) return { ok: false, status: 500, text: async () => 'down' } as any;
+    return { ok: true, json: async () => ({ choices: [{ message: { content: deepseekNarrative } }] }) } as any;
+  }
+  return { ok: false, status: 404, text: async () => 'not found' } as any;
+}) as any;
+
+import {
+  computeInputsHash,
+  synthesizeUserModel,
+  gatherSynthesisInputs,
+  MIN_FACTS_FOR_NARRATIVE,
+  SIGNAL_PROFILE_NARRATIVE,
+} from '../../src/services/user-model-synthesis';
+
+function makeInputs(overrides: Partial<Parameters<typeof computeInputsHash>[0]> = {}) {
+  return {
+    facts: [{ fact_key: 'user_name', fact_value: 'Dragan', provenance_source: 'user_stated' }],
+    routines: [],
+    goal: null,
+    index: null,
+    ...overrides,
+  };
+}
+
+function makeSupabaseStub(opts: {
+  factCount: number;
+  existingNarrativeHash?: string;
+}) {
+  const facts = Array.from({ length: opts.factCount }, (_, i) => ({
+    fact_key: `fact_${i}`,
+    fact_value: `value_${i}`,
+    provenance_source: 'user_stated',
+  }));
+  const upserts: any[] = [];
+  const client: any = {
+    from: (table: string) => {
+      const chain: any = {};
+      for (const m of ['select', 'eq', 'is', 'order', 'limit']) chain[m] = () => chain;
+      if (table === 'memory_facts') {
+        chain.then = (res: any) => Promise.resolve({ data: facts, error: null }).then(res);
+      } else if (table === 'user_routines' || table === 'life_compass' || table === 'vitana_index_scores') {
+        chain.then = (res: any) => Promise.resolve({ data: [], error: null }).then(res);
+      } else if (table === 'user_assistant_state') {
+        chain.maybeSingle = () =>
+          Promise.resolve({
+            data: opts.existingNarrativeHash
+              ? { value: { narrative: 'old', inputs_hash: opts.existingNarrativeHash } }
+              : null,
+            error: null,
+          });
+        chain.upsert = (row: any) => {
+          upserts.push(row);
+          return Promise.resolve({ error: null });
+        };
+      }
+      return chain;
+    },
+  };
+  return { client, upserts };
+}
+
+describe('computeInputsHash', () => {
+  it('is stable for identical inputs', () => {
+    const a = makeInputs();
+    const b = makeInputs();
+    expect(computeInputsHash(a)).toBe(computeInputsHash(b));
+  });
+
+  it('is order-independent for facts and routines', () => {
+    const a = makeInputs({
+      facts: [
+        { fact_key: 'x', fact_value: '1', provenance_source: 'user_stated' },
+        { fact_key: 'y', fact_value: '2', provenance_source: 'user_stated' },
+      ],
+    });
+    const b = makeInputs({
+      facts: [
+        { fact_key: 'y', fact_value: '2', provenance_source: 'user_stated' },
+        { fact_key: 'x', fact_value: '1', provenance_source: 'user_stated' },
+      ],
+    });
+    expect(computeInputsHash(a)).toBe(computeInputsHash(b));
+  });
+
+  it('changes when a fact value changes', () => {
+    const a = makeInputs();
+    const b = makeInputs({ facts: [{ fact_key: 'user_name', fact_value: 'Someone Else', provenance_source: 'user_stated' }] });
+    expect(computeInputsHash(a)).not.toBe(computeInputsHash(b));
+  });
+});
+
+describe('synthesizeUserModel', () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    deepseekOk = true;
+    deepseekNarrative =
+      'Dragan is planning his wedding to Sarah in September and has been focusing on evening walks, which seem to correlate with his improving sleep pillar.';
+  });
+
+  it(`skips users below MIN_FACTS_FOR_NARRATIVE (${MIN_FACTS_FOR_NARRATIVE})`, async () => {
+    const { client } = makeSupabaseStub({ factCount: MIN_FACTS_FOR_NARRATIVE - 1 });
+    const result = await synthesizeUserModel(client, 't1', 'u1');
+    expect(result).toEqual({ ok: true, written: false, reason: 'too_few_facts' });
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it('calls DeepSeek as the primary provider and writes the narrative with its inputs hash', async () => {
+    const { client, upserts } = makeSupabaseStub({ factCount: 5 });
+    const result = await synthesizeUserModel(client, 't1', 'u1');
+    expect(result).toEqual({ ok: true, written: true });
+
+    const dsCall = fetchCalls.find((c) => c.url.includes('api.deepseek.com'));
+    expect(dsCall).toBeDefined();
+    expect(dsCall!.body.model).toBe('deepseek-chat');
+
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0].signal_name).toBe(SIGNAL_PROFILE_NARRATIVE);
+    expect(upserts[0].value.narrative).toBe(deepseekNarrative);
+    expect(typeof upserts[0].value.inputs_hash).toBe('string');
+  });
+
+  it('skips re-synthesis when the inputs hash matches the stored one', async () => {
+    const inputs = await gatherSynthesisInputs(makeSupabaseStub({ factCount: 5 }).client, 't1', 'u1');
+    const hash = computeInputsHash(inputs);
+    const { client } = makeSupabaseStub({ factCount: 5, existingNarrativeHash: hash });
+    const result = await synthesizeUserModel(client, 't1', 'u1');
+    expect(result).toEqual({ ok: true, written: false, reason: 'inputs_unchanged' });
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it('reports model_failed when DeepSeek errors and no Vertex/Gemini narrative is produced', async () => {
+    deepseekOk = false;
+    const { client } = makeSupabaseStub({ factCount: 5 });
+    const result = await synthesizeUserModel(client, 't1', 'u1');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('model_failed');
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-MEMORY-DAILY-LEARNING` (follow-up to #2845, #2848)

**Layer:** APIL / CICDL | **Priority:** P1

## 📋 Summary

Staging verification of the memory-learning feature found the entire LLM-based capture pipeline producing zero output on `gateway-staging`: a live conversation test extracted 0 facts from a message with clearly stated facts, and AP-0911 wrote 0 narratives across two separate runs. Root cause: `/api/v1/llm/providers/health` reports Vertex "available" by checking only env-var presence, not actual call success — the real Vertex invocations were failing silently. Per instruction, this switches the primary provider to DeepSeek and fixes the actual staging deploy gap that was blocking any provider from working.

## ✅ Changes

- **`inline-fact-extractor.ts`** — DeepSeek (`deepseek-chat`, matching the existing `llm-router.ts` adapter shape) is now the first attempt, ahead of Vertex and the Gemini API key (both retained as fallback).
- **`user-model-synthesis.ts` (AP-0911)** — same DeepSeek-first ladder.
- **`.github/workflows/STAGE-DEPLOY.yml`** ⚠️ **workflow file change** — `gateway-staging` never had `OPENAI_API_KEY` or `DEEPSEEK_API_KEY` bound at all (only `GOOGLE_GEMINI_API_KEY` was). Both are now forwarded from GitHub Actions secrets as plain env vars, mirroring exactly how `EXEC-DEPLOY.yml` already does it for prod. Without this, no code change to the provider ladder could ever take effect on staging.

## 🧪 Testing

- [x] New dedicated test files (env-var-gated modules require a separate file from the existing Vertex/Gemini-only suite, since `DEEPSEEK_API_KEY` is read once at module-import time): DeepSeek-primary success, DeepSeek-failure→Vertex-fallback, inputs-hash stability/skip conditions for AP-0911
- [x] Full gateway suite: **6580 passing**; only the pre-existing, unrelated `nav-manifest-sync` gate fails (compares files this PR doesn't touch)
- [ ] Staging verification — pending merge + you adding the `DEEPSEEK_API_KEY` / `OPENAI_API_KEY` GitHub repo secrets (Settings → Secrets and variables → Actions on `exafyltd/vitana-platform`)

## 🚨 Breaking Changes

None to runtime behavior. The workflow change is additive (new env vars, no existing ones removed/reordered).

## 📌 Additional Notes

This PR alone won't light up the pipeline on staging — it also requires the `DEEPSEEK_API_KEY` and `OPENAI_API_KEY` GitHub repo secrets to actually exist (I cannot see or set secret values, only that the workflow now references them correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nXnLyojrW5m8L9SegctxH

---
_Generated by [Claude Code](https://claude.ai/code/session_014nXnLyojrW5m8L9SegctxH)_