### PR TITLE
fix(ops): stop surfacing self-heal escalations for recovered endpoints (VTID-02031d)

### DIFF
--- a/services/gateway/src/routes/ops-action-required.ts
+++ b/services/gateway/src/routes/ops-action-required.ts
@@ -19,6 +19,7 @@
  */
 
 import { Router, Request, Response } from 'express';
+import { probeEndpoint, isJsonHealthy, resolveProbeTarget } from '../services/self-healing-probe';
 
 const router = Router();
 
@@ -166,11 +167,27 @@ async function fetchSelfHealEscalations(
       created_at: string;
       diagnosis: any;
     }>;
-    return rows
-      .filter((row) => {
-        const ep = row.endpoint || '';
-        return !SELF_HEAL_ENDPOINT_BLOCKLIST.some((prefix) => ep.startsWith(prefix));
-      })
+    const candidates = rows.filter((row) => {
+      const ep = row.endpoint || '';
+      return !SELF_HEAL_ENDPOINT_BLOCKLIST.some((prefix) => ep.startsWith(prefix));
+    });
+
+    // VTID-02031d: the reconciler only re-probes rows still outcome='pending'.
+    // Once a row is tombstoned 'escalated'/'rolled_back' nothing re-checks it,
+    // so an endpoint that recovered minutes after tombstoning still shows as
+    // an open action item for the rest of the 24h lookback window. Re-probe
+    // live here (same probe the pre-probe gate and reconciler use) and drop
+    // rows whose endpoint is healthy right now — they don't need a human.
+    const stillDown = await Promise.all(
+      candidates.map(async (row) => {
+        const target = resolveProbeTarget(row.endpoint);
+        if (!target) return true; // not an HTTP target (e.g. voice-error://) — can't re-probe, keep it
+        const probe = await probeEndpoint(target, { timeoutMs: 4000 });
+        return !isJsonHealthy(probe);
+      }),
+    );
+    return candidates
+      .filter((_, i) => stillDown[i])
       .map((row) => {
         const reason =
           row.diagnosis?.reason ??

--- a/services/gateway/test/ops-action-required.test.ts
+++ b/services/gateway/test/ops-action-required.test.ts
@@ -1,0 +1,102 @@
+/**
+ * VTID-02031d: ops "Action Required" panel must not keep surfacing
+ * self-healing escalations whose endpoint has already recovered.
+ *
+ * Bug: fetchSelfHealEscalations only filtered on outcome + a 24h lookback —
+ * it never re-checked whether the endpoint is healthy *now*. A row
+ * tombstoned 'escalated' minutes before the endpoint self-recovered (or
+ * recovered via an unrelated deploy) sat in the panel demanding manual
+ * investigation for up to 24h with nothing left to investigate.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function freshRouter(): any {
+  jest.resetModules();
+  return require('../src/routes/ops-action-required').default;
+}
+
+function buildApp(router: any) {
+  const app = express();
+  app.use('/api/v1/ops/action-required', router);
+  return app;
+}
+
+const SELF_HEAL_ROW = {
+  vtid: 'SH-FALLBACK-1',
+  endpoint: '/api/v1/vtid/health',
+  failure_class: 'dependency_timeout',
+  outcome: 'escalated',
+  created_at: new Date().toISOString(),
+  diagnosis: {},
+};
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE;
+});
+
+describe('GET /api/v1/ops/action-required — self-heal live re-probe', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://supabase.test';
+    process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+  });
+
+  it('drops a self-heal escalation whose endpoint now probes healthy', async () => {
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url.includes('/rest/v1/voice_healing_quarantine')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url.includes('/rest/v1/voice_architecture_reports')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url.includes('/rest/v1/self_healing_log')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([SELF_HEAL_ROW]) });
+      }
+      // Live re-probe of the endpoint itself — healthy JSON response.
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: (k: string) => (k === 'content-type' ? 'application/json' : null) },
+      });
+    }) as unknown as typeof fetch;
+
+    const app = buildApp(freshRouter());
+    const res = await request(app).get('/api/v1/ops/action-required');
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.count_total).toBe(0);
+  });
+
+  it('keeps a self-heal escalation whose endpoint is still down', async () => {
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url.includes('/rest/v1/voice_healing_quarantine')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url.includes('/rest/v1/voice_architecture_reports')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url.includes('/rest/v1/self_healing_log')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([SELF_HEAL_ROW]) });
+      }
+      // Live re-probe — still failing.
+      return Promise.resolve({
+        ok: false,
+        status: 503,
+        headers: { get: () => 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const app = buildApp(freshRouter());
+    const res = await request(app).get('/api/v1/ops/action-required');
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].source_id).toBe('SH-FALLBACK-1');
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-02031d`

**Layer:** APIL (Gateway ops API)

**Priority:** P2

---

## 📋 Summary

The Command Hub "Action Required" panel (`GET /api/v1/ops/action-required`) was showing self-healing escalations for endpoints that had already recovered. `fetchSelfHealEscalations` only filtered `self_healing_log` rows by `outcome IN (escalated, rolled_back)` and a 24h lookback — it never re-checked the endpoint's *current* health. The reconciler only re-probes rows still `outcome='pending'`; once a row is tombstoned nothing re-checks it, so a recovered endpoint stayed listed as an open action item for up to 24h.

Verified live against `gateway.vitanaland.com`: `/api/v1/vtid/health`, `/api/v1/autopilot/health`, and `/api/v1/orb/health` were all returning healthy JSON (`ok:true`) while still listed in the panel as `escalated` with "Endpoint still requires manual investigation."

Out of scope: the critical `voice.model_under_responds` quarantine (open since 2026-04-30) and the `voice.low_turn_progression` architectural recommendation are separate, legitimately-still-open items requiring an operator/product decision (release the quarantine or act on the redesign recommendation) — not a code bug, so left untouched.

---

## ✅ Changes

- [x] `fetchSelfHealEscalations` re-probes each candidate endpoint (reusing the existing `probeEndpoint`/`isJsonHealthy`/`resolveProbeTarget` helpers from `self-healing-probe.ts`, the same ones the pre-probe gate and reconciler already use) and drops rows whose endpoint is healthy right now
- [x] Added `test/ops-action-required.test.ts` covering both the drop (recovered) and keep (still down) cases

---

## 🧪 Testing

- [x] Automated tests added/updated — `npx jest test/ops-action-required.test.ts` (2/2 passing)
- [x] Full `self-healing*` suite re-run to confirm no regressions (86/86 passing)
- [ ] Verified in staging/dev environment — this is a read-only GET route change; no manual staging verification performed

---

## 🚨 Breaking Changes

None.

---

## 📌 Additional Notes

Read-only route, no schema/migration changes. Confirmed via direct `curl` against the production gateway that the three previously-stuck escalations are healthy, which is what surfaced this bug.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6VsnhUqYodSe3oazPffZ4)_