### PR TITLE
fix(admitad): real Bodylab24 deeplinks + keyword-filter false positives

### DIFF
--- a/services/gateway/src/services/marketplace-sync/admitad-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/admitad-sync.ts
@@ -190,9 +190,72 @@ function parseCents(amountStr: string | undefined): number | null {
   return Number.isNaN(n) ? null : Math.round(n * 100);
 }
 
+// Whole-catalog "WW Basic" feeds are dominated by unrelated categories
+// (kitchenware, power tools, toys, electronics, ...) whose product names
+// incidentally contain a bare keyword substring — e.g. "Zinc Alloy Ice Cream
+// Scoop" (zinc = alloy metal, not the mineral), "Protein Powder Measuring
+// Spoon" (a tool FOR protein powder, not protein powder), "Infant
+// Supplementary Food Scale" ("supplement" as a substring of "supplementary").
+// Excluding these categories outright is far more reliable than trying to
+// perfect keyword phrasing — confirmed against a real sync run where 100% of
+// 200 "matched" rows were false positives from exactly these categories.
+const EXCLUDED_CATEGORY_SUBSTRINGS = [
+  'kitchen', 'dining', 'tool', 'toy', 'action & toy', 'networking',
+  'pay on your order', 'electrical equipment', 'storage device', 'apparel',
+  'travel', 'computer', 'baby stroller', 'automotive', 'car ', 'furniture',
+  'jewelry', 'jewellery', 'watch', 'shoe', 'luggage', 'lighting', 'security',
+  'phone', 'cellphone', 'electronics', 'home improvement', 'hardware',
+];
+
+function isExcludedCategory(category: string | undefined): boolean {
+  if (!category) return false;
+  const c = category.toLowerCase();
+  return EXCLUDED_CATEGORY_SUBSTRINGS.some((s) => c.includes(s));
+}
+
 function matchesKeywords(row: AdmitadRow, keywords: string[]): boolean {
+  if (isExcludedCategory(row.category)) return false;
   const hay = `${row.name ?? ''} ${row.category ?? ''}`.toLowerCase();
-  return keywords.some((k) => hay.includes(k));
+  // Word-boundary match — a raw substring match let "supplement" match
+  // inside "supplementary" (baby-food tools), etc.
+  return keywords.some((k) => new RegExp(`\\b${escapeRegExp(k)}\\b`).test(hay));
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Feed-native category strings (AliExpress's own taxonomy, e.g. "Health &
+// Beauty") never match our fixed category enum, so a genuinely-matched
+// wellness row would otherwise be invisible to discover-search.ts's
+// `category = 'supplements'` filter. Every row that survives the keyword +
+// category-denylist gate above is, by construction, a supplement/wellness
+// product — so it always gets our canonical category.
+const SUPPLEMENTS_CATEGORY = 'supplements';
+
+// Best-effort subcategory guess so matched rows slot into the existing
+// Discover thematic collections (CategoryShopSections' SECTION_ORDER) —
+// first matching bucket wins. Falls back to no subcategory (still visible
+// via category='supplements', just outside the themed rows).
+const SUBCATEGORY_RULES: Array<{ key: string; ingredients?: string[]; healthGoals?: string[] }> = [
+  { key: 'essential-fatty-acids', ingredients: ['omega-3', 'epa', 'dha', 'fish-oil', 'krill-oil', 'algae-oil'] },
+  { key: 'adaptogens', ingredients: ['ashwagandha', 'rhodiola', 'holy-basil', 'ginseng', 'panax-ginseng', 'cordyceps', 'reishi', 'chaga'], healthGoals: ['adrenal-support'] },
+  { key: 'nootropics', ingredients: ['l-theanine', 'ginkgo', 'bacopa', 'lions-mane', 'caffeine'], healthGoals: ['focus'] },
+  { key: 'performance', ingredients: ['creatine', 'taurine', 'carnitine'], healthGoals: ['muscle-recovery', 'weight-management'] },
+  { key: 'beauty', ingredients: ['collagen', 'hyaluronic-acid'], healthGoals: ['skin-hair-nails'] },
+  { key: 'longevity', ingredients: ['resveratrol', 'nad', 'coq10'], healthGoals: ['longevity'] },
+  { key: 'antioxidants', ingredients: ['quercetin', 'curcumin'] },
+  { key: 'minerals', ingredients: ['magnesium', 'magnesium-glycinate', 'magnesium-citrate', 'magnesium-threonate', 'zinc', 'iron', 'iron-bisglycinate', 'calcium', 'selenium', 'iodine'] },
+  { key: 'vitamins', ingredients: ['vitamin-c', 'vitamin-d3', 'vitamin-d2', 'vitamin-k2', 'vitamin-b12', 'vitamin-b6', 'folate', 'vitamin-a', 'vitamin-e', 'biotin'] },
+  { key: 'immunity', healthGoals: ['immune-support'] },
+];
+
+function guessSubcategory(ingredients: string[], healthGoals: string[]): string | undefined {
+  for (const rule of SUBCATEGORY_RULES) {
+    if (rule.ingredients?.some((i) => ingredients.includes(i))) return rule.key;
+    if (rule.healthGoals?.some((g) => healthGoals.includes(g))) return rule.key;
+  }
+  return undefined;
 }
 
 // The feed carries no shipping-destination data per row. Downstream geo
@@ -227,13 +290,15 @@ function normalizeAdmitadRow(
 
   const inferText = [title, row.category ?? ''].filter(Boolean).join(' ');
   const inferred = inferSupplementAttributes(inferText);
+  const subcategory = guessSubcategory(inferred.ingredients_primary, inferred.health_goals);
 
   return {
     merchant_id: merchantId,
     source_network: 'admitad_feed',
     source_product_id: `${advertiserSlug}-${id}`,
     title,
-    category: row.category,
+    category: SUPPLEMENTS_CATEGORY,
+    subcategory,
     price_cents: priceCents,
     currency,
     compare_at_price_cents: compareCents,

--- a/supabase/migrations/20260709120000_vtid_02000_bodylab24_real_deeplinks_admitad_cleanup.sql
+++ b/supabase/migrations/20260709120000_vtid_02000_bodylab24_real_deeplinks_admitad_cleanup.sql
@@ -1,0 +1,71 @@
+-- VTID-02000 (Discover marketplace) — Bodylab24 real per-product deeplinks +
+-- admitad_feed junk cleanup.
+--
+-- Context: the 4 hand-seeded Bodylab24 products all pointed their
+-- affiliate_url at the bare bodylab24.de homepage (not a specific product).
+-- Bodylab24 does not offer a bulk Admitad Product Feed (verified in the
+-- publisher dashboard — Program search returns no results), only the
+-- single-link "Get link" deeplink tool, so these were hand-built there
+-- against the real matching product page for each seeded item.
+--
+-- Also deactivates the 200 'admitad_feed' rows imported by an earlier
+-- keyword-filter bug in admitad-sync.ts (bare terms like "zinc" and
+-- "protein powder" matched unrelated kitchenware/tool/toy listings — see
+-- the fix in that file). None of these rows were category='supplements' so
+-- they never surfaced on Discover, but they're garbage and should not
+-- linger as is_active=true.
+--
+-- impact-allow-solo-migration: data-only migration, no code path changes
+-- required — /r/:product_id already 302s any non-demo_seed product to its
+-- affiliate_url, and discover-search/feed already filter on is_active.
+
+BEGIN;
+
+UPDATE products SET
+  affiliate_url = 'https://ad.admitad.com/g/q51r4zfcu52fafe74eabfad1369401/?ulp=https%3A%2F%2Fwww.bodylab24.de%2Fomega-3-1000mg-tg-120-kapseln.html',
+  updated_at = now()
+WHERE id = 'd15c0000-0000-4000-8000-000000000009';
+
+UPDATE products SET
+  title = 'Magnesium Bisglycinate 300mg — Muscle & Sleep',
+  description = 'Bodylab24 Magnesium Bisglycinate, 300mg elemental magnesium per daily dose (2 capsules) — supports muscle function, recovery and restful sleep.',
+  description_long = 'Magnesium contributes to normal muscle function and a reduction in tiredness. Bisglycinate is bound to an amino acid for excellent tolerability and bioavailability. A staple for active people and anyone with poor sleep. Take in the evening.',
+  affiliate_url = 'https://ad.admitad.com/g/q51r4zfcu52fafe74eabfad1369401/?ulp=https%3A%2F%2Fwww.bodylab24.de%2Fmagnesium-bisglycinate-120-kapseln.html',
+  updated_at = now()
+WHERE id = 'd15c0000-0000-4000-8000-00000000000a';
+
+UPDATE products SET
+  affiliate_url = 'https://ad.admitad.com/g/q51r4zfcu52fafe74eabfad1369401/?ulp=https%3A%2F%2Fwww.bodylab24.de%2Fproducts%2Fvitamin-d3-k2-oel-tropfen-50ml',
+  updated_at = now()
+WHERE id = 'd15c0000-0000-4000-8000-00000000000b';
+
+UPDATE products SET
+  affiliate_url = 'https://ad.admitad.com/g/q51r4zfcu52fafe74eabfad1369401/?ulp=https%3A%2F%2Fwww.bodylab24.de%2Fproducts%2Fvitamin-b-complex-120-tabletten',
+  updated_at = now()
+WHERE id = 'd15c0000-0000-4000-8000-00000000000c';
+
+-- Retire the junk rows from the buggy admitad_feed sync run (all 200 were
+-- false-positive matches — kitchenware, power-tool parts, toy figures, etc.)
+UPDATE products SET is_active = false, updated_at = now()
+WHERE source_network = 'admitad_feed';
+
+COMMIT;
+
+-- =====================================================================================
+-- DOWN (rollback) — run manually or as a reverting migration if needed:
+--
+-- BEGIN;
+-- UPDATE products SET
+--   affiliate_url = 'https://ad.admitad.com/g/q51r4zfcu52fafe74eabfad1369401/?subid=discover&ulp=https%3A%2F%2Fwww.bodylab24.de%2F',
+--   updated_at = now()
+-- WHERE id IN (
+--   'd15c0000-0000-4000-8000-000000000009', 'd15c0000-0000-4000-8000-00000000000a',
+--   'd15c0000-0000-4000-8000-00000000000b', 'd15c0000-0000-4000-8000-00000000000c');
+-- UPDATE products SET
+--   title = 'Magnesium Capsules 400mg — Muscle & Sleep',
+--   description = 'Bodylab24 magnesium, 400mg elemental per serving — supports muscle function, recovery and restful sleep.',
+--   description_long = 'Magnesium contributes to normal muscle function and a reduction in tiredness. A staple for active people and anyone with poor sleep. Take in the evening.'
+-- WHERE id = 'd15c0000-0000-4000-8000-00000000000a';
+-- -- (admitad_feed junk rows are not worth restoring; leave is_active=false)
+-- COMMIT;
+-- =====================================================================================


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-02000`

**Layer:** APIL (marketplace-sync)

**Priority:** P2

---

## 📋 Summary

Discover's Bodylab24 products all linked to the bare bodylab24.de homepage instead of the specific product; AliExpress's real live product-feed sync had a keyword-filter bug that let 200 unrelated rows (kitchenware, power-tool parts, toys) through as "matches" while zero genuine supplements got in.

---

## ✅ Changes

- [x] Replaced the 4 Bodylab24 products' `affiliate_url` with real per-product deeplinks (Bodylab24 has no bulk Admitad product feed — single-merchant, deeplink-only program — so these were generated via Admitad's single-link tool against the real matching product page for each item)
- [x] Corrected the magnesium listing's dosage claim (400mg → 300mg/day) to match the real product now linked
- [x] Fixed `admitad-sync.ts`'s keyword matcher: word-boundary matching instead of raw substring (`"supplement"` was matching inside `"supplementary"`)
- [x] Added a category denylist for confirmed-irrelevant feed categories (kitchenware, power tools, toys, electronics, etc.) — bare terms like `"zinc"` and `"protein powder"` were matching things like "Zinc Alloy Ice Cream Scoop" and "Protein Powder Measuring Spoon"
- [x] Normalized matched rows to `category='supplements'` (the feed's native AliExpress category strings never matched `discover-search.ts`'s fixed category filter, so even a correct keyword match would have stayed invisible on Discover) plus a best-effort subcategory guess so matches slot into the existing thematic collections
- [x] Data migration deactivating the 200 junk `admitad_feed` rows produced by the buggy filter

---

## 🧪 Testing

- [x] `npx tsc --noEmit` passes clean on `services/gateway`
- [x] Verified via direct SQL against the live DB: all 200 `admitad_feed` rows from the broken run were 100% false positives (kitchen/tool/toy categories), now deactivated
- [x] Migration applied directly to the live DB (Bodylab24 links + cleanup); code fix not yet re-run against the live AliExpress feed — planned as a follow-up sync trigger once this merges
- [ ] Automated tests added/updated (none exist for this sync module yet)

---

## 🚨 Breaking Changes

None.

---

## 📌 Additional Notes

Follow-up: re-run the AliExpress `admitad_feed` sync now that the filter is fixed, to replace the 8 hand-seeded fake-link AliExpress rows with real matched products (real photos + real per-product deeplinks).


---
_Generated by [Claude Code](https://claude.ai/code/session_011JdP3fAJvzaKsd5FF2xHB1)_