### PR TITLE
data(bodylab24) + fix(awin): real product photos + Awin Darwin feed rewrite

### DIFF
--- a/services/gateway/src/services/marketplace-sync/awin-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/awin-sync.ts
@@ -1,28 +1,68 @@
 /**
- * VTID-01938: Awin product data feed sync.
+ * VTID-01938 (rewrite): Awin "Darwin" product data feed sync.
  *
- * https://wiki.awin.com/index.php/Product_Feeds — Awin distributes catalogs
- * via per-advertiser "product data feeds" that can be downloaded in JSON
- * with selectable columns. We pull one feed per advertiser we're joined to.
+ * The classic Awin API this file used to target
+ * (`productdata.awin.com/datafeed/download/apikey/...`) is dead — verified
+ * live: `format/json` returns "json is not supported. Please use CSV
+ * format", and the classic feed-discovery endpoint
+ * (`productdata.awin.com/datafeed/list/apikey/...`) redirects to
+ * `legacydatafeeds.awin.com` and 500s regardless of format.
  *
- * EU-strongest network (~25k advertisers), useful when Vitana expands to
- * European retailers that aren't on CJ/Rakuten.
+ * The real, working mechanism is the "Darwin" download system exposed in the
+ * publisher UI (Toolbox → Create a Feed → Feed List Download):
+ *   - Feed list (CSV):
+ *       https://ui.awin.com/productdata-darwin-download/publisher/{publisher_id}/{download_token}/1/feedList
+ *   - Per-feed catalog (gzip CSV, Google-Shopping/Content-API column set):
+ *       https://ui.awin.com/productdata-darwin-download/publisher/{publisher_id}/{download_token}/1/feed/{FeedID}.csv.gz
+ *
+ * Both URLs embed the download_token directly — no separate Authorization
+ * header/api_key needed at fetch time (mirrors admitad-sync.ts's feed_url
+ * pattern, where the export credential is baked into the URL itself).
+ *
+ * Verified real feed columns (MISSHA US, Feed ID F3660 — Google Shopping /
+ * Content API for Shopping export):
+ *   advertiser_id,advertiser_name,id,title,description,link,image_link,
+ *   additional_image_link,mobile_link,virtual_model_link,aw_deep_link,
+ *   aw_mobile_link,google_product_category,product_type,gtin,mpn,brand,
+ *   identifier_exists,availability,availability_date,expiration_date,price,
+ *   sale_price,sale_price_effective_date,unit_pricing_measure,
+ *   unit_pricing_base_measure,installment,subscription_cost,loyalty_program,
+ *   condition,adult,multipack,is_bundle,energy_efficiency_class,
+ *   min_energy_efficiency_class,max_energy_efficiency_class,age_group,color,
+ *   gender,material,pattern,size,size_type,size_system,item_group_id,
+ *   product_weight,product_height,product_width,product_length,
+ *   product_detail,product_highlight,certification,lifestyle_image_link,
+ *   shipping,shipping_weight,shipping_height,shipping_width,shipping_length,
+ *   min_handling_time,max_handling_time,ships_from_country,tax
+ *
+ * `price`/`sale_price` are a single combined string ("11.50 USD"), unlike
+ * Admitad's separate price/currencyId columns — parsed by parsePriceString().
+ * `aw_deep_link` already carries `awinmid`/`awinaffid` query params — use it
+ * as-is, do not rebuild the affiliate URL.
  *
  * Config shape (JSON in marketplace_sources_config.config):
  *   {
- *     "api_key": "...",                       // Publisher API key
- *     "publisher_id": "123456",               // Publisher SID
  *     "feeds": [
- *       { "feed_id": "1234", "advertiser_id": "5678", "advertiser_name": "Acme Vitamins" }
+ *       { "feed_url": "https://ui.awin.com/productdata-darwin-download/publisher/2938137/<token>/1/feed/F3660.csv.gz",
+ *         "advertiser_name": "MISSHA US" }
  *     ],
- *     "merchant_country": "GB",
- *     "max_products_per_feed": 500
+ *     "category": "skincare",
+ *     "max_products_per_feed": 500,
+ *     "max_rows_scanned": 50000,
+ *     "merchant_country": "US",
+ *     "ships_to_countries": ["US"],
+ *     "ships_to_regions": ["US"]
  *   }
  *
- * Auth: the api_key is stamped into the feed URL path
- *   https://productdata.awin.com/datafeed/download/apikey/{key}/...
+ * The download_token in each feed_url is a personal export credential tied
+ * to the publisher account — treat it as sensitive (same handling as every
+ * other provider's secrets in this file: stored only in this JSON config
+ * column, never in git/code, never returned to the client).
  */
 
+import { Readable } from 'stream';
+import { createInterface } from 'readline';
+import { createGunzip } from 'zlib';
 import {
   startSyncRun,
   finishSyncRun,
@@ -30,22 +70,28 @@ import {
   upsertProducts,
   type ProductUpsert,
 } from './shared';
-import { inferSupplementAttributes } from './supplement-inference';
 import { getSupabase } from '../../lib/supabase';
 
 interface AwinFeedRef {
-  feed_id: string;
-  advertiser_id: string;
+  feed_url: string;
   advertiser_name?: string;
 }
 
 interface AwinSourceConfig {
-  api_key: string;
-  publisher_id: string;
   feeds: AwinFeedRef[];
-  merchant_country?: string;
+  /** Top-level products.category value for every row from this source (default 'skincare'). */
+  category?: string;
   max_products_per_feed?: number;
+  /** Safety bound on CSV rows scanned per feed (default 50000 — these are single-advertiser feeds, not whole-network dumps). */
+  max_rows_scanned?: number;
+  merchant_country?: string;
+  ships_to_countries?: string[];
+  ships_to_regions?: string[];
 }
+
+const DEFAULT_CATEGORY = 'skincare';
+const DEFAULT_SHIPS_TO_COUNTRIES = ['US'];
+const DEFAULT_SHIPS_TO_REGIONS = ['US'];
 
 async function loadSourceConfigs(): Promise<AwinSourceConfig[]> {
   const supabase = getSupabase();
@@ -58,171 +104,206 @@ async function loadSourceConfigs(): Promise<AwinSourceConfig[]> {
   if (!data?.length) return [];
   return data
     .map((r) => r.config as AwinSourceConfig)
-    .filter((c) => c && c.api_key && c.publisher_id && Array.isArray(c.feeds) && c.feeds.length > 0);
+    .filter((c) => c && Array.isArray(c.feeds) && c.feeds.length > 0);
 }
 
-// ==================== Feed fetch ====================
+// ==================== CSV parsing (comma-delimited, RFC4180 quoting) ====================
 
-// Column list we care about — Awin supports >100 columns but we only need these.
-const FEED_COLUMNS = [
-  'aw_deep_link',
-  'aw_product_id',
-  'merchant_product_id',
-  'product_name',
-  'description',
-  'product_short_description',
-  'merchant_name',
-  'merchant_id',
-  'merchant_category',
-  'category_name',
-  'brand_name',
-  'merchant_image_url',
-  'aw_image_url',
-  'search_price',
-  'rrp_price',
-  'currency',
-  'ean',
-  'upc',
-  'product_gtin',
-  'in_stock',
-  'stock_status',
-  'language',
-  'keywords',
-  'specifications',
-  'condition',
-  'delivery_restrictions',
-].join(',');
-
-interface AwinFeedItem {
-  aw_deep_link?: string;
-  aw_product_id?: string;
-  merchant_product_id?: string;
-  product_name?: string;
-  description?: string;
-  product_short_description?: string;
-  merchant_name?: string;
-  merchant_id?: string;
-  merchant_category?: string;
-  category_name?: string;
-  brand_name?: string;
-  merchant_image_url?: string;
-  aw_image_url?: string;
-  search_price?: string;
-  rrp_price?: string;
-  currency?: string;
-  ean?: string;
-  upc?: string;
-  product_gtin?: string;
-  in_stock?: string;
-  stock_status?: string;
-  keywords?: string;
-  specifications?: string;
-  delivery_restrictions?: string;
-}
-
-async function fetchAwinFeed(
-  cfg: AwinSourceConfig,
-  feed: AwinFeedRef
-): Promise<AwinFeedItem[]> {
-  const url =
-    `https://productdata.awin.com/datafeed/download/apikey/${encodeURIComponent(cfg.api_key)}` +
-    `/language/any/fid/${encodeURIComponent(feed.feed_id)}/bandwidth/low` +
-    `/sid/${encodeURIComponent(cfg.publisher_id)}/mid/${encodeURIComponent(feed.advertiser_id)}` +
-    `/columns/${FEED_COLUMNS}/format/json`;
-
-  const resp = await fetch(url, { headers: { Accept: 'application/json' } });
-  if (!resp.ok) {
-    const text = await resp.text().catch(() => '(no body)');
-    throw new Error(`Awin feed ${feed.feed_id} HTTP ${resp.status} ${text.slice(0, 300)}`);
+/** Parses one already-quote-balanced logical record into fields. */
+function parseDelimitedRecord(line: string, delim: string): string[] {
+  const fields: string[] = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (line[i + 1] === '"') { cur += '"'; i++; }
+        else inQuotes = false;
+      } else {
+        cur += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === delim) {
+      fields.push(cur);
+      cur = '';
+    } else {
+      cur += c;
+    }
   }
-  const data = (await resp.json()) as AwinFeedItem[] | { products?: AwinFeedItem[] };
-  if (Array.isArray(data)) return data;
-  return data.products ?? [];
+  fields.push(cur);
+  return fields;
+}
+
+function hasUnbalancedQuotes(line: string): boolean {
+  let count = 0;
+  for (const ch of line) if (ch === '"') count++;
+  return count % 2 !== 0;
+}
+
+interface AwinRow {
+  advertiser_id?: string;
+  advertiser_name?: string;
+  id?: string;
+  title?: string;
+  description?: string;
+  link?: string;
+  image_link?: string;
+  additional_image_link?: string;
+  aw_deep_link?: string;
+  google_product_category?: string;
+  product_type?: string;
+  gtin?: string;
+  mpn?: string;
+  brand?: string;
+  availability?: string;
+  price?: string;
+  sale_price?: string;
+  ships_from_country?: string;
+  [key: string]: string | undefined;
+}
+
+/**
+ * Fetches + gunzips the feed and streams normalized row objects, keyed by
+ * the header row's own column names.
+ */
+async function* streamAwinRows(
+  feedUrl: string,
+  maxRowsScanned: number
+): AsyncGenerator<AwinRow> {
+  const resp = await fetch(feedUrl, { headers: { Accept: 'application/gzip,application/octet-stream,text/csv,*/*' } });
+  if (!resp.ok || !resp.body) {
+    const text = await resp.text().catch(() => '(no body)');
+    throw new Error(`Awin feed HTTP ${resp.status} ${text.slice(0, 300)}`);
+  }
+
+  const nodeStream = Readable.fromWeb(resp.body as import('stream/web').ReadableStream);
+  const gunzip = createGunzip();
+  let streamError: Error | null = null;
+  nodeStream.on('error', (e) => { streamError = e; });
+  gunzip.on('error', (e) => { streamError = e; });
+  nodeStream.pipe(gunzip);
+
+  const rl = createInterface({ input: gunzip, crlfDelay: Infinity });
+
+  let header: string[] | null = null;
+  let buffered = '';
+  let rowsScanned = 0;
+
+  for await (const rawLine of rl) {
+    if (rowsScanned >= maxRowsScanned) break;
+    buffered = buffered ? `${buffered}\n${rawLine}` : rawLine;
+    if (hasUnbalancedQuotes(buffered)) continue; // multi-line quoted field — keep buffering
+
+    const record = buffered;
+    buffered = '';
+    if (!record.trim()) continue;
+
+    const fields = parseDelimitedRecord(record, ',');
+    if (!header) {
+      header = fields.map((h) => h.trim());
+      continue;
+    }
+    rowsScanned++;
+    const row: AwinRow = {};
+    for (let i = 0; i < header.length; i++) row[header[i]] = fields[i];
+    yield row;
+  }
+
+  if (streamError) throw streamError;
 }
 
 // ==================== Normalization ====================
 
-function parseCents(amountStr: string | undefined): number | null {
-  if (!amountStr) return null;
-  const n = parseFloat(amountStr.replace(/[^0-9.]/g, ''));
-  return Number.isNaN(n) ? null : Math.round(n * 100);
+/** Parses a combined "11.50 USD" price string into cents + currency. */
+function parsePriceString(raw: string | undefined): { cents: number; currency: string } | null {
+  if (!raw) return null;
+  const m = raw.trim().match(/^([0-9]+(?:\.[0-9]+)?)\s*([A-Za-z]{3})?$/);
+  if (!m) return null;
+  const n = parseFloat(m[1]);
+  if (Number.isNaN(n)) return null;
+  return { cents: Math.round(n * 100), currency: (m[2] ?? 'USD').toUpperCase() };
 }
 
-function parseStock(item: AwinFeedItem): ProductUpsert['availability'] {
-  const s = (item.stock_status ?? item.in_stock ?? '').toLowerCase();
-  if (s.includes('out')) return 'out_of_stock';
-  if (s.includes('preorder') || s.includes('pre-order')) return 'preorder';
-  if (s.includes('discontinued')) return 'discontinued';
-  if (item.in_stock === '1' || s === 'in stock' || s === 'yes' || s === 'true') return 'in_stock';
+function parseAvailability(raw: string | undefined): ProductUpsert['availability'] {
+  const s = (raw ?? '').toLowerCase().trim();
+  if (s === 'in_stock' || s === 'in stock') return 'in_stock';
+  if (s === 'out_of_stock' || s === 'out of stock') return 'out_of_stock';
+  if (s === 'preorder' || s === 'pre-order' || s === 'backorder') return 'preorder';
   return 'unknown';
 }
 
-function normalizeAwinItem(
-  item: AwinFeedItem,
-  feed: AwinFeedRef,
+// Google's `google_product_category` taxonomy branch determines the
+// subcategory bucket. Order matters — e.g. "...Cosmetics > Make-Up > Eye
+// Make-Up..." contains "eye" but must classify as makeup, not a hypothetical
+// eye-care bucket, so the make-up check runs before any looser skin/eye rule.
+const SUBCATEGORY_RULES: Array<{ key: string; patterns: RegExp[] }> = [
+  { key: 'makeup', patterns: [/make-?up/] },
+  { key: 'hair-care', patterns: [/hair\s*care/, /shampoo/, /conditioner/] },
+  { key: 'fragrance', patterns: [/fragrance/, /perfume/, /cologne/] },
+  { key: 'sun-care', patterns: [/sun\s*care/, /sunscreen/, /tanning/] },
+  { key: 'body-care', patterns: [/bath\s*&\s*body/, /body\s*wash/, /deodorant/, /body\s*care/] },
+  { key: 'face-care', patterns: [/skin\s*care/, /facial/, /\bface\b/] },
+];
+
+function guessSubcategory(googleProductCategory: string | undefined, productType: string | undefined): string | undefined {
+  const hay = `${googleProductCategory ?? ''} ${productType ?? ''}`.toLowerCase();
+  if (!hay.trim()) return undefined;
+  for (const rule of SUBCATEGORY_RULES) {
+    if (rule.patterns.some((p) => p.test(hay))) return rule.key;
+  }
+  return undefined;
+}
+
+function normalizeAwinRow(
+  row: AwinRow,
   merchantId: string,
-  country?: string
+  cfg: AwinSourceConfig
 ): ProductUpsert | null {
-  const id = item.aw_product_id ?? item.merchant_product_id;
-  if (!id) return null;
-  const title = item.product_name;
-  if (!title) return null;
+  const id = row.id;
+  const title = row.title;
+  if (!id || !title) return null;
 
-  const priceCents = parseCents(item.search_price);
-  if (priceCents === null) return null;
-  const currency = (item.currency ?? 'EUR').toUpperCase();
-  const rrp = parseCents(item.rrp_price);
-  const compareCents = rrp && rrp > priceCents ? rrp : undefined;
+  const priceParsed = parsePriceString(row.price);
+  if (!priceParsed) return null;
+  const saleParsed = parsePriceString(row.sale_price);
 
-  const gtin = item.product_gtin ?? item.ean ?? item.upc;
-  const description = item.product_short_description ?? item.description;
-  const images: string[] = [];
-  if (item.aw_image_url) images.push(item.aw_image_url);
-  if (item.merchant_image_url && item.merchant_image_url !== item.aw_image_url) {
-    images.push(item.merchant_image_url);
-  }
+  // sale_price is the current selling price when present (Google Shopping
+  // convention); price becomes the "compare at" strike-through.
+  const priceCents = saleParsed ? saleParsed.cents : priceParsed.cents;
+  const currency = saleParsed ? saleParsed.currency : priceParsed.currency;
+  const compareCents = saleParsed && priceParsed.cents > saleParsed.cents ? priceParsed.cents : undefined;
 
-  const topic_keys: string[] = [];
-  if (item.keywords) {
-    for (const k of item.keywords.split(/[,;]/)) {
-      const s = k.trim().toLowerCase();
-      if (s) topic_keys.push(s);
-    }
-  }
+  const images = [row.image_link, ...(row.additional_image_link ? row.additional_image_link.split(',') : [])]
+    .map((s) => s?.trim())
+    .filter((s): s is string => !!s);
 
-  const inferText = [title, description, item.merchant_category, item.category_name, item.specifications, item.keywords]
-    .filter(Boolean).join(' ');
-  const inferred = inferSupplementAttributes(inferText);
-
-  // delivery_restrictions contains ISO country codes the merchant WILL NOT ship to — invert for ships_to_countries if needed.
-  // For now we skip this (requires global country list); leave null.
+  const affiliateUrl = row.aw_deep_link || row.link;
+  if (!affiliateUrl) return null;
 
   return {
     merchant_id: merchantId,
     source_network: 'awin',
     source_product_id: String(id),
-    gtin,
-    sku: item.merchant_product_id,
+    gtin: row.gtin || undefined,
+    sku: row.mpn || undefined,
     title,
-    description,
-    description_long: item.description,
-    brand: item.brand_name,
-    category: item.merchant_category ?? item.category_name,
-    subcategory: item.category_name,
-    topic_keys: topic_keys.slice(0, 20),
+    description: row.description,
+    description_long: row.description,
+    brand: row.brand,
+    category: cfg.category ?? DEFAULT_CATEGORY,
+    subcategory: guessSubcategory(row.google_product_category, row.product_type),
     price_cents: priceCents,
     currency,
     compare_at_price_cents: compareCents,
-    images,
-    affiliate_url: item.aw_deep_link ?? '',
-    availability: parseStock(item),
-    origin_country: country,
-    health_goals: inferred.health_goals,
-    dietary_tags: inferred.dietary_tags,
-    ingredients_primary: inferred.ingredients_primary,
-    form: inferred.form,
-    certifications: inferred.certifications,
-    raw: item as unknown as Record<string, unknown>,
+    images: [...new Set(images)],
+    affiliate_url: affiliateUrl,
+    availability: parseAvailability(row.availability),
+    origin_country: row.ships_from_country || cfg.merchant_country,
+    ships_to_countries: cfg.ships_to_countries ?? DEFAULT_SHIPS_TO_COUNTRIES,
+    ships_to_regions: cfg.ships_to_regions ?? DEFAULT_SHIPS_TO_REGIONS,
+    raw: row as unknown as Record<string, unknown>,
   };
 }
 
@@ -231,47 +312,59 @@ function normalizeAwinItem(
 async function syncOneFeed(
   cfg: AwinSourceConfig,
   feed: AwinFeedRef
-): Promise<{ inserted: number; updated: number; skipped: number; errors: number; fetched: number; error_sample: unknown[] }> {
+): Promise<{ inserted: number; updated: number; skipped: number; errors: number; scanned: number; matched: number; error_sample: unknown[] }> {
+  const advertiserName = feed.advertiser_name ?? 'Awin Advertiser';
+  const advertiserSlug = advertiserName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'awin';
+
   const merchantId = await upsertMerchant({
     source_network: 'awin',
-    source_merchant_id: feed.advertiser_id,
-    name: feed.advertiser_name ?? `Awin Advertiser ${feed.advertiser_id}`,
+    source_merchant_id: advertiserSlug,
+    name: advertiserName,
     affiliate_network: 'awin',
     merchant_country: cfg.merchant_country,
+    ships_to_countries: cfg.ships_to_countries ?? DEFAULT_SHIPS_TO_COUNTRIES,
+    ships_to_regions: cfg.ships_to_regions ?? DEFAULT_SHIPS_TO_REGIONS,
     quality_score: 65,
     customs_risk: 'unknown',
   });
   if (!merchantId) {
-    return { inserted: 0, updated: 0, skipped: 0, errors: 1, fetched: 0, error_sample: [{ feed_id: feed.feed_id, error: 'merchant upsert failed' }] };
+    return { inserted: 0, updated: 0, skipped: 0, errors: 1, scanned: 0, matched: 0, error_sample: [{ feed: advertiserName, error: 'merchant upsert failed' }] };
   }
 
-  let items: AwinFeedItem[];
+  const maxProducts = cfg.max_products_per_feed ?? 500;
+  const maxRowsScanned = cfg.max_rows_scanned ?? 50_000;
+
+  const matched: ProductUpsert[] = [];
+  let scanned = 0;
+  let errors = 0;
+  const errorSample: unknown[] = [];
+
   try {
-    items = await fetchAwinFeed(cfg, feed);
+    for await (const row of streamAwinRows(feed.feed_url, maxRowsScanned)) {
+      scanned++;
+      const p = normalizeAwinRow(row, merchantId, cfg);
+      if (p) matched.push(p);
+      if (matched.length >= maxProducts) break;
+    }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    return { inserted: 0, updated: 0, skipped: 0, errors: 1, fetched: 0, error_sample: [{ feed_id: feed.feed_id, error: message }] };
+    errors++;
+    errorSample.push({ feed: advertiserName, error: message });
   }
 
-  const max = cfg.max_products_per_feed ?? 500;
-  const limited = items.slice(0, max);
-
-  const normalized = limited
-    .map((i) => normalizeAwinItem(i, feed, merchantId, cfg.merchant_country))
-    .filter((p): p is ProductUpsert => p !== null);
-
-  if (normalized.length === 0) {
-    return { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: items.length, error_sample: [] };
+  if (matched.length === 0) {
+    return { inserted: 0, updated: 0, skipped: 0, errors, scanned, matched: 0, error_sample: errorSample };
   }
 
-  const r = await upsertProducts(normalized, 'awin');
+  const r = await upsertProducts(matched, 'awin');
   return {
     inserted: r.inserted,
     updated: r.updated,
     skipped: r.skipped_unchanged,
-    errors: r.errors.length,
-    fetched: items.length,
-    error_sample: r.errors.slice(0, 5),
+    errors: errors + r.errors.length,
+    scanned,
+    matched: matched.length,
+    error_sample: [...errorSample, ...r.errors.slice(0, 5)],
   };
 }
 
@@ -311,8 +404,8 @@ export async function runAwinSync(triggered_by = 'scheduler'): Promise<AwinSyncR
       feedCount++;
       const stats = await syncOneFeed(cfg, feed);
       per_feed.push({
-        feed_id: feed.feed_id,
-        advertiser_id: feed.advertiser_id,
+        feed_id: feed.feed_url,
+        advertiser_id: feed.advertiser_name ?? 'unknown',
         inserted: stats.inserted,
         updated: stats.updated,
         skipped: stats.skipped,
@@ -322,7 +415,7 @@ export async function runAwinSync(triggered_by = 'scheduler'): Promise<AwinSyncR
       totals.updated += stats.updated;
       totals.skipped += stats.skipped;
       totals.errors += stats.errors;
-      totals.fetched += stats.fetched;
+      totals.fetched += stats.scanned;
       if (stats.error_sample.length) errorSample.push(...stats.error_sample);
     }
     if (run) await finishSyncRun(run, { ...totals, error_sample: errorSample.slice(0, 10) });

--- a/services/gateway/src/services/marketplace-sync/providers/awin.ts
+++ b/services/gateway/src/services/marketplace-sync/providers/awin.ts
@@ -1,9 +1,11 @@
 /**
- * VTID-01938: Awin provider registration.
+ * VTID-01938 (rewrite): Awin provider registration.
  *
- * EU-strongest affiliate network (~25k advertisers). Catalog is distributed
- * as per-advertiser product data feeds — we configure one "feed entry" per
- * advertiser we've joined.
+ * Catalog is distributed via the "Darwin" download system (see ../awin-sync.ts
+ * for the full URL scheme + verified column set) — each feed_url is a stable,
+ * directly-fetchable gzip CSV with the download token already embedded, so
+ * (unlike the old classic-API shape) there is no separate api_key/publisher_id
+ * needed at fetch time.
  *
  * Sync logic: ../awin-sync.ts.
  */
@@ -15,29 +17,23 @@ export const awinProvider: MarketplaceProvider = {
   key: 'awin',
   displayName: 'Awin',
   description:
-    'Awin product data feeds. Configure one publisher account + a list of advertiser feeds you have access to. Strongest in the EU market; use in addition to CJ/Rakuten for broader retailer coverage.',
+    'Awin "Darwin" product data feeds — per-advertiser gzip CSV catalogs (Toolbox → Create a Feed → Feed List Download ' +
+    'in the Awin publisher dashboard). Each feed_url already carries the download token; no separate API key needed.',
   configSchema: [
-    {
-      key: 'api_key',
-      label: 'Awin publisher API key',
-      type: 'password',
-      required: true,
-      help: 'Publisher API key from My Account → API Credentials on awin.com.',
-    },
-    {
-      key: 'publisher_id',
-      label: 'Publisher ID (SID)',
-      type: 'text',
-      placeholder: '123456',
-      required: true,
-    },
     {
       key: 'feeds',
       label: 'Feed refs (JSON array)',
       type: 'textarea',
-      placeholder: '[{"feed_id":"1234","advertiser_id":"5678","advertiser_name":"Acme Vitamins"}]',
+      placeholder: '[{"feed_url":"https://ui.awin.com/productdata-darwin-download/publisher/2938137/<token>/1/feed/F3660.csv.gz","advertiser_name":"MISSHA US"}]',
       required: true,
-      help: 'JSON array of {feed_id, advertiser_id, advertiser_name?} objects — one per advertiser you have product-feed access to.',
+      help: 'JSON array of {feed_url, advertiser_name?} — one per advertiser feed. Get the feed_url from Awin → Toolbox → Create a Feed, or from the Feed List Download CSV.',
+    },
+    {
+      key: 'category',
+      label: 'Products category (default "skincare")',
+      type: 'text',
+      placeholder: 'skincare',
+      help: 'Top-level products.category value applied to every row from this source.',
     },
     {
       key: 'max_products_per_feed',
@@ -46,18 +42,33 @@ export const awinProvider: MarketplaceProvider = {
       placeholder: '500',
     },
     {
+      key: 'max_rows_scanned',
+      label: 'Max CSV rows scanned per feed (default 50000)',
+      type: 'number',
+      placeholder: '50000',
+    },
+    {
       key: 'merchant_country',
       label: 'Fallback merchant country (ISO-2, optional)',
       type: 'text',
-      placeholder: 'GB',
+      placeholder: 'US',
+    },
+    {
+      key: 'ships_to_countries',
+      label: 'Ships-to countries (JSON array, optional — default ["US"])',
+      type: 'textarea',
+      placeholder: '["US","CA"]',
+    },
+    {
+      key: 'ships_to_regions',
+      label: 'Ships-to regions (JSON array, optional — default ["US"])',
+      type: 'textarea',
+      placeholder: '["US"]',
     },
   ],
   validateConfig(cfg) {
     if (!cfg || typeof cfg !== 'object') return { ok: false, error: 'config must be an object' };
-    if (!cfg.api_key || typeof cfg.api_key !== 'string') return { ok: false, error: 'api_key is required' };
-    if (!cfg.publisher_id) return { ok: false, error: 'publisher_id is required' };
 
-    // feeds may come in as an array (direct JSON) or as a JSON-encoded string from the textarea.
     let feeds = cfg.feeds;
     if (typeof feeds === 'string') {
       try {
@@ -71,17 +82,42 @@ export const awinProvider: MarketplaceProvider = {
     }
     for (const f of feeds as Array<Record<string, unknown>>) {
       if (!f || typeof f !== 'object') return { ok: false, error: 'each feed must be an object' };
-      if (!f.feed_id || !f.advertiser_id) {
-        return { ok: false, error: 'each feed requires feed_id and advertiser_id' };
+      if (!f.feed_url || typeof f.feed_url !== 'string') {
+        return { ok: false, error: 'each feed requires feed_url' };
+      }
+      try {
+        new URL(f.feed_url);
+      } catch {
+        return { ok: false, error: `invalid feed_url: ${String(f.feed_url).slice(0, 80)}` };
       }
     }
-    // Normalize back — the admin route will persist this.
     cfg.feeds = feeds;
+
+    for (const key of ['ships_to_countries', 'ships_to_regions'] as const) {
+      let v = cfg[key];
+      if (typeof v === 'string' && v.trim()) {
+        try {
+          v = JSON.parse(v);
+        } catch {
+          return { ok: false, error: `${key} must be a JSON array` };
+        }
+      }
+      if (v !== undefined && !Array.isArray(v)) {
+        return { ok: false, error: `${key} must be a JSON array` };
+      }
+      if (Array.isArray(v)) cfg[key] = v;
+    }
 
     if (cfg.max_products_per_feed !== undefined) {
       const n = Number(cfg.max_products_per_feed);
       if (!Number.isFinite(n) || n < 1 || n > 10000) {
         return { ok: false, error: 'max_products_per_feed must be between 1 and 10000' };
+      }
+    }
+    if (cfg.max_rows_scanned !== undefined) {
+      const n = Number(cfg.max_rows_scanned);
+      if (!Number.isFinite(n) || n < 100) {
+        return { ok: false, error: 'max_rows_scanned must be at least 100' };
       }
     }
     return { ok: true };

--- a/supabase/migrations/20260709150000_vtid_02000_bodylab24_real_photos.sql
+++ b/supabase/migrations/20260709150000_vtid_02000_bodylab24_real_photos.sql
@@ -1,0 +1,29 @@
+-- VTID-02000 (Discover marketplace) — real Bodylab24 product photos.
+--
+-- Context: the 4 Bodylab24 products already got real per-product deeplinks
+-- in the earlier migration (20260709120000), but still used generic, reused
+-- Unsplash stock photos for images. Bodylab24 has no bulk Admitad product
+-- feed (single-merchant, deeplink-only program) and this sandbox's WebFetch
+-- is blocked by bot protection on bodylab24.de, so there is no automated
+-- path to real photos. The operator manually copied each product's real
+-- main-image URL directly from its bodylab24.de page (Shopify CDN, publicly
+-- hotlinkable) and provided them for this migration.
+--
+-- impact-allow-solo-migration: data-only migration, no code path changes
+-- required — ProductImage.tsx already renders whatever URL is in
+-- products.images[0].
+
+BEGIN;
+
+UPDATE products SET images = ARRAY['https://www.bodylab24.de/cdn/shop/files/1-bodylab-omega-3-120kapseln-int.png?v=1768464407&width=720']::text[], updated_at = now() WHERE id = 'd15c0000-0000-4000-8000-000000000009';
+UPDATE products SET images = ARRAY['https://www.bodylab24.de/cdn/shop/files/1-bodylab-magnesium-bis-120c-iml0.5-2025_1.png?v=1767794723&width=720']::text[], updated_at = now() WHERE id = 'd15c0000-0000-4000-8000-00000000000a';
+UPDATE products SET images = ARRAY['https://www.bodylab24.de/cdn/shop/files/2-box-bodylab-premium-health-vitamin-d3_k2-oil.png?v=1775059318&width=720']::text[], updated_at = now() WHERE id = 'd15c0000-0000-4000-8000-00000000000b';
+UPDATE products SET images = ARRAY['https://www.bodylab24.de/cdn/shop/files/1-bodylab-vitamine-b-complex-120t-iml0.5-2025.png?v=1767794717&width=720']::text[], updated_at = now() WHERE id = 'd15c0000-0000-4000-8000-00000000000c';
+
+COMMIT;
+
+-- =====================================================================================
+-- DOWN (rollback) — not meaningful to restore the old Unsplash placeholders;
+-- if ever needed, re-run the original seed migration
+-- 20260629120000_vtid_02000_discover_admitad_real_catalog.sql's images arrays.
+-- =====================================================================================


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-02000`

**Layer:** Data (marketplace catalog) + Backend (marketplace-sync)

**Priority:** P3

---

## 📋 Summary

Two independent fixes landed on this branch:

**1. Bodylab24 real photos.** The 4 Bodylab24 products already had real per-product deeplinks, but `images` still pointed at generic, reused Unsplash stock. Bodylab24 has no bulk Admitad product feed and this sandbox's `WebFetch` is blocked by bot protection on bodylab24.de, so the operator manually sourced each product's real main-image URL from its bodylab24.de listing (Shopify CDN) for this migration.

**2. Awin sync rewrite (real "Darwin" feed mechanism).** `awin-sync.ts` targeted a dead classic Awin API (`productdata.awin.com/datafeed/download/...` — confirmed via live testing: `format/json` returns "Please use CSV format", and the classic feed-discovery endpoint redirects to `legacydatafeeds.awin.com` and 500s regardless of format). Rewrote to the real, working "Darwin" download system (`ui.awin.com/productdata-darwin-download/...`), which serves stable gzip CSV feed URLs with the download token already embedded. Verified the real column set and price format against MISSHA US's actual feed (Feed ID F3660) and adapted the parsing accordingly.

This is the backend half of onboarding **MISSHA US (K-Beauty skincare)** as a real, separate **Skincare & Cosmetics** Discover category — not folded into Supplements > Beauty, since these are topical skincare/makeup products, not ingestible supplements. The frontend half (generalizing Discover's category components + a new "Skincare & Cosmetics" section) is in a companion `vitana-v1` PR.

---

## ✅ Changes

- [x] Data migration replacing `images[0]` on all 4 Bodylab24 products with the real product photo
- [x] Rewrite `awin-sync.ts`: gzip CSV fetch + RFC4180 parsing of the real Google-Shopping/Content-API column set, combined `"11.50 USD"`-style price string parsing, `google_product_category`-based subcategory inference (face-care, makeup, hair-care, body-care, fragrance, sun-care), `products.category` defaulting to `'skincare'`
- [x] Simplify `providers/awin.ts` config schema to match (`feeds: [{feed_url, advertiser_name?}]` — no more `api_key`/`publisher_id`/`feed_id`/`advertiser_id`, since the download token is embedded in the feed URL itself)

---

## 🧪 Testing

- [x] Bodylab24 migration applied directly to the live DB; verified via SQL that all 4 rows reference the correct photo
- [x] `npm run build` (tsc) passes clean for the gateway service after the Awin rewrite
- [ ] Awin end-to-end sync (real MISSHA feed → `marketplace_sources_config` row → Command Hub "Sync now" → verify real photos/deeplinks/category) — pending; will verify once merged and deployed

---

## 🚨 Breaking Changes

None. The Awin `source_network='awin'` config shape changed, but no live `marketplace_sources_config` row for `awin` exists yet (this is the first real onboarding), so nothing currently configured breaks.

---

## 📌 Additional Notes

Photo-authenticity fix completes across all current Discover marketplace sources: AliExpress, Amazon.ae, and Bodylab24. The Awin rewrite is a prerequisite for the MISSHA US onboarding — the actual `marketplace_sources_config` row (with the real feed URL + API token) will be inserted directly in Supabase after this merges, not committed to git.

---
_Generated by [Claude Code](https://claude.ai/code/session_011JdP3fAJvzaKsd5FF2xHB1)_