### PR TITLE
DEV-COMHU-03401: Add screen-load-time basic test to Command Hub Overview

### DIFF
--- a/.github/workflows/SCREEN-LOAD-TIMING.yml
+++ b/.github/workflows/SCREEN-LOAD-TIMING.yml
@@ -1,0 +1,60 @@
+name: Screen Load Timing (Basic Test)
+
+# VTID-SCREEN-LOAD-01 — standard basic test for Command Hub Overview.
+#
+# Runs the mobile screen-load-timing spec against production on a schedule
+# and reports every result to the gateway, which turns it into the
+# "Screen Load Time" entry in Command Hub's Overview service-health grid
+# (see fetchServiceHealth in services/gateway/src/frontend/command-hub/app.js).
+#
+# This is deliberately independent of the RUM beacon pipe (vitana-v1
+# src/lib/rum.ts), which is still staging-only — this gives Command Hub a
+# real, always-fresh signal on production screen load times without waiting
+# on that flag to graduate.
+
+on:
+  schedule:
+    # Every 30 minutes.
+    - cron: '7,37 * * * *'
+  workflow_dispatch:
+    inputs:
+      community_url:
+        description: 'Community app URL to test against'
+        required: false
+        type: string
+        default: 'https://vitanaland.com'
+
+concurrency:
+  group: screen-load-timing
+  cancel-in-progress: false
+
+jobs:
+  screen-load-timing:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install E2E dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e
+        run: npx playwright install chromium --with-deps
+
+      - name: Run screen load timing
+        working-directory: e2e
+        run: npx playwright test --project=mobile-shared screen-load-timing.spec.ts
+        env:
+          COMMUNITY_URL: ${{ inputs.community_url || 'https://vitanaland.com' }}
+          GATEWAY_URL: https://gateway-q74ibpv6ia-uc.a.run.app
+          SCREEN_LOAD_ENV: production
+          SCREEN_LOAD_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+          SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE }}

--- a/.github/workflows/SCREEN-LOAD-TIMING.yml
+++ b/.github/workflows/SCREEN-LOAD-TIMING.yml
@@ -1,4 +1,5 @@
 name: Screen Load Timing (Basic Test)
+run-name: VTID-SCREEN-LOAD-01 — Screen Load Timing
 
 # VTID-SCREEN-LOAD-01 — standard basic test for Command Hub Overview.
 #

--- a/.github/workflows/SCREEN-LOAD-TIMING.yml
+++ b/.github/workflows/SCREEN-LOAD-TIMING.yml
@@ -59,3 +59,4 @@ jobs:
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE }}
+          GATEWAY_SERVICE_TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}

--- a/e2e/community-mobile/shared/screen-load-timing.spec.ts
+++ b/e2e/community-mobile/shared/screen-load-timing.spec.ts
@@ -1,0 +1,124 @@
+import { test } from '@playwright/test';
+
+/**
+ * Screen Load Time — standard basic test (VTID-SCREEN-LOAD-01).
+ *
+ * Loads a handful of key, always-authenticated mobile screens against
+ * whichever `baseURL` the running project points at (production by default
+ * via COMMUNITY_URL, same as every other mobile-shared spec) and measures
+ * wall-clock time to the `load` event — the number a user actually feels
+ * when they tap into a screen.
+ *
+ * Every screen's result is POSTed to the gateway's
+ * `/api/v1/frontend/screen-load/report` endpoint regardless of pass/fail, so
+ * Command Hub's Overview always has a fresh number even when a screen is
+ * slow. Assertions stay generous (SLOW_THRESHOLD_MS) so a single network
+ * blip doesn't fail the whole CI run — the gateway's own `/health` endpoint
+ * applies the real p75 threshold that Command Hub displays.
+ *
+ * Runs on a schedule via .github/workflows/SCREEN-LOAD-TIMING.yml, and also
+ * picks up automatically in ad-hoc `mobile-shared` runs (Command Hub's
+ * "Cloud Run — Full Suite" button, `npm run test:mobile`, etc).
+ */
+
+const GATEWAY_URL = process.env.GATEWAY_URL || 'https://gateway-q74ibpv6ia-uc.a.run.app';
+const ENVIRONMENT = process.env.SCREEN_LOAD_ENV === 'staging' ? 'staging' : 'production';
+const RUN_ID = process.env.SCREEN_LOAD_RUN_ID || `local-${Date.now()}`;
+const SLOW_THRESHOLD_MS = 6000;
+
+// Small, deliberately curated set — the screens a session realistically
+// passes through in its first minute, not full route coverage (that's what
+// the 272-route E2E smoke suite is for).
+const SCREENS: { name: string; path: string }[] = [
+  { name: 'News Feed', path: '/home' },
+  { name: 'Discover', path: '/discover' },
+  { name: 'Community Events', path: '/comm/events-meetups' },
+  { name: 'Health', path: '/health' },
+  { name: 'Inbox', path: '/inbox' },
+  { name: 'My Profile', path: '/me/profile' },
+];
+
+type ScreenResult = {
+  screen: string;
+  duration_ms: number;
+  lcp_ms: number | null;
+  status: 'ok' | 'error';
+  error?: string;
+};
+
+async function reportResults(results: ScreenResult[]) {
+  try {
+    await fetch(`${GATEWAY_URL}/api/v1/frontend/screen-load/report`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ run_id: RUN_ID, environment: ENVIRONMENT, results }),
+    });
+  } catch (err) {
+    // The report call must never fail the test suite — a down gateway
+    // should surface as a "no recent runs" health check, not a CI red.
+    console.warn('[screen-load-timing] failed to report results:', err);
+  }
+}
+
+test.describe('Mobile — Screen Load Time', () => {
+  const collected: ScreenResult[] = [];
+
+  test.afterAll(async () => {
+    if (collected.length > 0) await reportResults(collected);
+  });
+
+  for (const { name, path } of SCREENS) {
+    test(`${name} (${path}) loads within budget`, async ({ page }) => {
+      const start = Date.now();
+      let result: ScreenResult;
+
+      try {
+        await page.goto(path, { waitUntil: 'load', timeout: 20_000 });
+        const duration_ms = Date.now() - start;
+
+        // Best-effort LCP — buffered PerformanceObserver, short settle window.
+        // Never blocks or fails the test if the browser can't report it.
+        let lcp_ms: number | null = null;
+        try {
+          lcp_ms = await page.evaluate(
+            () =>
+              new Promise<number | null>((resolve) => {
+                try {
+                  const po = new PerformanceObserver((list) => {
+                    const entries = list.getEntries();
+                    const last = entries[entries.length - 1] as (PerformanceEntry & { startTime: number }) | undefined;
+                    resolve(last ? last.startTime : null);
+                  });
+                  po.observe({ type: 'largest-contentful-paint', buffered: true });
+                  setTimeout(() => resolve(null), 1500);
+                } catch {
+                  resolve(null);
+                }
+              }),
+          );
+        } catch {
+          // ignore — LCP is a bonus metric
+        }
+
+        result = { screen: path, duration_ms, lcp_ms, status: 'ok' };
+      } catch (err) {
+        result = {
+          screen: path,
+          duration_ms: Date.now() - start,
+          lcp_ms: null,
+          status: 'error',
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      collected.push(result);
+
+      // Soft budget — logs a clear signal on the CI run without being flaky.
+      if (result.status === 'error') {
+        console.error(`[screen-load-timing] ${path} failed: ${result.error}`);
+      } else if (result.duration_ms > SLOW_THRESHOLD_MS) {
+        console.warn(`[screen-load-timing] ${path} slow: ${result.duration_ms}ms (budget ${SLOW_THRESHOLD_MS}ms)`);
+      }
+    });
+  }
+});

--- a/e2e/community-mobile/shared/screen-load-timing.spec.ts
+++ b/e2e/community-mobile/shared/screen-load-timing.spec.ts
@@ -48,9 +48,14 @@ type ScreenResult = {
 
 async function reportResults(results: ScreenResult[]) {
   try {
+    const serviceToken = process.env.GATEWAY_SERVICE_TOKEN;
+    if (!serviceToken) {
+      console.warn('[screen-load-timing] GATEWAY_SERVICE_TOKEN not set — skipping report POST');
+      return;
+    }
     await fetch(`${GATEWAY_URL}/api/v1/frontend/screen-load/report`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${serviceToken}` },
       body: JSON.stringify({ run_id: RUN_ID, environment: ENVIRONMENT, results }),
     });
   } catch (err) {

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -27951,11 +27951,12 @@ async function fetchServiceHealth(silentRefresh) {
         { name: 'Visual Interactive',   url: '/api/v1/visual/health',                    group: 'Visual & VTID' },
         { name: 'VTID Terminalize',     url: '/api/v1/oasis/vtid/terminalize/health',    group: 'Visual & VTID' },
         { name: 'VTID',                 url: '/api/v1/vtid/health',                      group: 'Visual & VTID' },
-        // VTID-SCREEN-LOAD-01: standard basic test — scheduled Playwright run
-        // (SCREEN-LOAD-TIMING.yml, every 30 min) measures mobile screen load
-        // time against production and reports here. 'down' means either a
-        // screen failed to load or the scheduled job itself hasn't reported
-        // in 3h+; 'degraded' means it's reporting but slow (p75 over budget).
+        // DEV-COMHU-03401 / VTID-SCREEN-LOAD-01: standard basic test —
+        // scheduled Playwright run (SCREEN-LOAD-TIMING.yml, every 30 min)
+        // measures mobile screen load time against production and reports
+        // here. 'down' means either a screen failed to load or the
+        // scheduled job itself hasn't reported in 3h+; 'degraded' means
+        // it's reporting but slow (p75 over budget).
         { name: 'Screen Load Time',     url: '/api/v1/frontend/screen-load/health',      group: 'Frontend & Performance' }
     ];
 

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -27950,7 +27950,13 @@ async function fetchServiceHealth(silentRefresh) {
         { name: 'Opportunities',        url: '/api/v1/opportunities/health',             group: 'Domain & Context' },
         { name: 'Visual Interactive',   url: '/api/v1/visual/health',                    group: 'Visual & VTID' },
         { name: 'VTID Terminalize',     url: '/api/v1/oasis/vtid/terminalize/health',    group: 'Visual & VTID' },
-        { name: 'VTID',                 url: '/api/v1/vtid/health',                      group: 'Visual & VTID' }
+        { name: 'VTID',                 url: '/api/v1/vtid/health',                      group: 'Visual & VTID' },
+        // VTID-SCREEN-LOAD-01: standard basic test — scheduled Playwright run
+        // (SCREEN-LOAD-TIMING.yml, every 30 min) measures mobile screen load
+        // time against production and reports here. 'down' means either a
+        // screen failed to load or the scheduled job itself hasn't reported
+        // in 3h+; 'degraded' means it's reporting but slow (p75 over budget).
+        { name: 'Screen Load Time',     url: '/api/v1/frontend/screen-load/health',      group: 'Frontend & Performance' }
     ];
 
     try {

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -68,6 +68,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const { vtidRouter } = require('./routes/vtid');
   // VTID-03177 (PROFILE): RUM beacon receiver from vitana-v1 frontend
   const { rumBeaconRouter } = require('./routes/rum-beacon');
+  // VTID-SCREEN-LOAD-01: synthetic screen-load-time basic test — ingest +
+  // Command Hub Overview health check (independent of the RUM feature flag).
+  const { screenLoadHealthRouter } = require('./routes/screen-load-health');
   // VTID-03204 (Phase 1 W2): one-off staging-only admin endpoint for the
   // tenant_settings.data_export_ok consent flip. Hard-gated on isStaging
   // inside the router; mounted unconditionally because route registration
@@ -647,6 +650,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/vtid', vtidRouter, { owner: 'vtid' });
   // VTID-03177 (PROFILE): RUM beacon — POST /api/v1/rum/beacon
   mountRouterSync(app, '/api/v1/rum', rumBeaconRouter, { owner: 'rum-beacon' });
+  // VTID-SCREEN-LOAD-01: POST /api/v1/frontend/screen-load/report, GET /api/v1/frontend/screen-load/health
+  mountRouterSync(app, '/api/v1/frontend/screen-load', screenLoadHealthRouter, { owner: 'screen-load-health' });
   // VTID-03204 (Phase 1 W2): POST /api/v1/admin/staging/tenant-consent/flip
   mountRouterSync(app, '/api/v1/admin/staging', adminStagingRouter, { owner: 'admin-staging' });
   // BOOTSTRAP-SUPERVISOR-SUMMARY: GET /api/v1/supervisor/summary — one read-only

--- a/services/gateway/src/routes/screen-load-health.ts
+++ b/services/gateway/src/routes/screen-load-health.ts
@@ -1,0 +1,193 @@
+/**
+ * Screen Load Time — synthetic basic test (VTID-SCREEN-LOAD-01).
+ *
+ * The frontend already ships a Real User Monitoring beacon (vitana-v1
+ * src/lib/rum.ts → POST /api/v1/rum/beacon → `screen.latency.measured` OASIS
+ * events), but that pipe is gated `staging-only` — production traffic never
+ * reaches it, so there is currently no way to answer "how long do screens
+ * take to load" from real data.
+ *
+ * This route is a second, independent signal: a scheduled Playwright job
+ * (e2e/community-mobile/shared/screen-load-timing.spec.ts, run on a cron via
+ * .github/workflows/SCREEN-LOAD-TIMING.yml) loads a handful of key mobile
+ * screens against production and POSTs each measured load time here. Each
+ * result becomes a `screen.load.synthetic_test` OASIS event — same event
+ * store, same table, different topic, so it survives independent of the RUM
+ * feature flag.
+ *
+ * GET /health aggregates the most recent run into the same
+ * `{ status: 'ok' | 'degraded' | 'down' }` shape every other Command Hub
+ * "basic test" health endpoint returns, so it slots into the existing
+ * Overview service-health grid (fetchServiceHealth in command-hub/app.js)
+ * with zero special-casing on the frontend.
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import { getSupabase } from '../lib/supabase';
+
+const VTID = 'VTID-SCREEN-LOAD-01';
+const TOPIC = 'screen.load.synthetic_test';
+
+// A screen counts "slow" past this many ms, and "healthy" requires the p75
+// across the last run to stay under it. Generous on purpose — this is a
+// full authenticated SPA route load (JS bundle + data fetch + render), not
+// a bare LCP paint, so it runs hotter than the RUM LCP thresholds in rum.ts.
+const SLOW_THRESHOLD_MS = 6000;
+// A run counts "stale" (→ down, not just degraded) if nothing has reported
+// in this long — catches the cron itself being broken, not just a slow app.
+const STALE_AFTER_MS = 3 * 60 * 60 * 1000; // 3h — covers a couple of missed 30-min runs
+
+const ReportSchema = z.object({
+  run_id: z.string().min(1).max(128),
+  environment: z.enum(['production', 'staging']).default('production'),
+  results: z
+    .array(
+      z.object({
+        screen: z.string().min(1).max(256),
+        duration_ms: z.number().finite().nonnegative(),
+        lcp_ms: z.number().finite().nonnegative().nullable().optional(),
+        status: z.enum(['ok', 'error']).default('ok'),
+        error: z.string().max(500).optional(),
+      }),
+    )
+    .min(1)
+    .max(50),
+});
+
+const router = Router();
+
+/**
+ * POST /report — called by the scheduled Playwright job after each run.
+ * Batches all screens from one run into one call; each screen still becomes
+ * its own OASIS event so per-screen history stays queryable.
+ */
+router.post('/report', async (req: Request, res: Response) => {
+  const parse = ReportSchema.safeParse(req.body);
+  if (!parse.success) {
+    return res.status(400).json({ ok: false, error: 'invalid_report', issues: parse.error.issues });
+  }
+  const { run_id, environment, results } = parse.data;
+
+  try {
+    await Promise.all(
+      results.map((r) =>
+        emitOasisEvent({
+          vtid: VTID,
+          type: TOPIC,
+          source: 'e2e/screen-load-timing',
+          status: r.status === 'error' ? 'error' : r.duration_ms > SLOW_THRESHOLD_MS ? 'warning' : 'success',
+          message:
+            r.status === 'error'
+              ? `${r.screen} failed to load: ${r.error ?? 'unknown error'}`
+              : `${r.screen} loaded in ${r.duration_ms}ms`,
+          payload: {
+            run_id,
+            environment,
+            screen: r.screen,
+            duration_ms: r.duration_ms,
+            lcp_ms: r.lcp_ms ?? null,
+            load_status: r.status,
+            error: r.error ?? null,
+          },
+        }),
+      ),
+    );
+    return res.status(204).end();
+  } catch (err) {
+    console.error('[screen-load-health] report ingest failed:', err);
+    return res.status(500).json({ ok: false, error: 'ingest_failed' });
+  }
+});
+
+/**
+ * GET /health — Command Hub Overview's "basic test" grid polls this like
+ * every other service. Reads the most recent run out of oasis_events rather
+ * than re-running anything live (the actual test runs on its own cron).
+ */
+router.get('/health', async (_req: Request, res: Response) => {
+  const sb = getSupabase();
+  if (!sb) {
+    return res.status(200).json({ status: 'down', reason: 'supabase_unconfigured' });
+  }
+
+  const since = new Date(Date.now() - STALE_AFTER_MS).toISOString();
+  const { data, error } = await sb
+    .from('oasis_events')
+    .select('created_at, metadata')
+    .eq('topic', TOPIC)
+    .gte('created_at', since)
+    .order('created_at', { ascending: false })
+    .limit(200);
+
+  if (error) {
+    return res.status(200).json({ status: 'down', reason: 'query_failed', detail: error.message });
+  }
+
+  if (!data || data.length === 0) {
+    return res.status(200).json({
+      status: 'down',
+      reason: 'no_recent_runs',
+      message: `No screen-load-timing results in the last ${Math.round(STALE_AFTER_MS / 3600000)}h — the scheduled job may be broken.`,
+    });
+  }
+
+  // Keep only the most recent run (results within 5 min of the newest event).
+  const latestAt = new Date(data[0].created_at).getTime();
+  const latestRun = data.filter((row) => latestAt - new Date(row.created_at).getTime() < 5 * 60 * 1000);
+
+  type Screen = { screen: string; duration_ms: number; lcp_ms: number | null; load_status: string };
+  const screens: Screen[] = latestRun
+    .map((row) => row.metadata as Record<string, unknown>)
+    .filter((m): m is Record<string, unknown> => !!m)
+    .map((m) => ({
+      screen: String(m.screen ?? 'unknown'),
+      duration_ms: Number(m.duration_ms ?? 0),
+      lcp_ms: m.lcp_ms == null ? null : Number(m.lcp_ms),
+      load_status: String(m.load_status ?? 'ok'),
+    }));
+
+  const failed = screens.filter((s) => s.load_status === 'error');
+  const durations = screens.filter((s) => s.load_status === 'ok').map((s) => s.duration_ms).sort((a, b) => a - b);
+  const p75Index = Math.min(durations.length - 1, Math.floor(durations.length * 0.75));
+  const p75Ms = durations.length ? durations[p75Index] : null;
+  const maxMs = durations.length ? durations[durations.length - 1] : null;
+
+  const status: 'ok' | 'degraded' | 'down' =
+    failed.length > 0 || p75Ms === null
+      ? 'down'
+      : p75Ms > SLOW_THRESHOLD_MS
+        ? 'degraded'
+        : 'ok';
+
+  return res.status(200).json({
+    status,
+    checked_at: new Date().toISOString(),
+    last_run_at: data[0].created_at,
+    threshold_ms: SLOW_THRESHOLD_MS,
+    p75_ms: p75Ms,
+    max_ms: maxMs,
+    screens_checked: screens.length,
+    screens_failed: failed.map((s) => s.screen),
+    screens,
+  });
+});
+
+/**
+ * GET / — router status, mirrors the convention other routers use.
+ */
+router.get('/', (_req: Request, res: Response) => {
+  return res.status(200).json({
+    ok: true,
+    service: 'screen-load-health',
+    vtid: VTID,
+    endpoints: [
+      'POST /api/v1/frontend/screen-load/report',
+      'GET /api/v1/frontend/screen-load/health',
+    ],
+    timestamp: new Date().toISOString(),
+  });
+});
+
+export { router as screenLoadHealthRouter };

--- a/services/gateway/src/routes/screen-load-health.ts
+++ b/services/gateway/src/routes/screen-load-health.ts
@@ -59,11 +59,32 @@ const ReportSchema = z.object({
 const router = Router();
 
 /**
+ * Service-token gate for /report, mirroring the orb-agent pattern in
+ * routes/oasis-emit.ts: only the SCREEN-LOAD-TIMING.yml runner (which holds
+ * GATEWAY_SERVICE_TOKEN as a repo secret) may write results, so nobody can
+ * forge a "healthy" or "down" reading by POSTing arbitrary timings.
+ */
+function requireServiceToken(req: Request, res: Response, next: () => void): void {
+  const authHeader = req.headers.authorization ?? '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  if (!token) {
+    res.status(401).json({ ok: false, error: 'missing_bearer_token' });
+    return;
+  }
+  const serviceToken = process.env.GATEWAY_SERVICE_TOKEN ?? '';
+  if (serviceToken.length === 0 || token !== serviceToken) {
+    res.status(401).json({ ok: false, error: 'invalid_service_token' });
+    return;
+  }
+  next();
+}
+
+/**
  * POST /report — called by the scheduled Playwright job after each run.
  * Batches all screens from one run into one call; each screen still becomes
  * its own OASIS event so per-screen history stays queryable.
  */
-router.post('/report', async (req: Request, res: Response) => {
+router.post('/report', requireServiceToken, async (req: Request, res: Response) => {
   const parse = ReportSchema.safeParse(req.body);
   if (!parse.success) {
     return res.status(400).json({ ok: false, error: 'invalid_report', issues: parse.error.issues });
@@ -101,6 +122,10 @@ router.post('/report', async (req: Request, res: Response) => {
   }
 });
 
+// public-route — read-only aggregate status, same as every other
+// `/api/v1/*/health` endpoint Command Hub's Overview grid polls
+// unauthenticated (see fetchServiceHealth in command-hub/app.js). Exposes
+// only timing numbers, nothing sensitive.
 /**
  * GET /health — Command Hub Overview's "basic test" grid polls this like
  * every other service. Reads the most recent run out of oasis_events rather
@@ -174,6 +199,7 @@ router.get('/health', async (_req: Request, res: Response) => {
   });
 });
 
+// public-route — router status/self-description only, no data.
 /**
  * GET / — router status, mirrors the convention other routers use.
  */

--- a/services/gateway/src/routes/screen-load-health.ts
+++ b/services/gateway/src/routes/screen-load-health.ts
@@ -64,7 +64,7 @@ const router = Router();
  * GATEWAY_SERVICE_TOKEN as a repo secret) may write results, so nobody can
  * forge a "healthy" or "down" reading by POSTing arbitrary timings.
  */
-function requireServiceToken(req: Request, res: Response, next: () => void): void {
+function requireApiKey(req: Request, res: Response, next: () => void): void {
   const authHeader = req.headers.authorization ?? '';
   const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
   if (!token) {
@@ -84,7 +84,7 @@ function requireServiceToken(req: Request, res: Response, next: () => void): voi
  * Batches all screens from one run into one call; each screen still becomes
  * its own OASIS event so per-screen history stays queryable.
  */
-router.post('/report', requireServiceToken, async (req: Request, res: Response) => {
+router.post('/report', requireApiKey, async (req: Request, res: Response) => {
   const parse = ReportSchema.safeParse(req.body);
   if (!parse.success) {
     return res.status(400).json({ ok: false, error: 'invalid_report', issues: parse.error.issues });
@@ -122,16 +122,15 @@ router.post('/report', requireServiceToken, async (req: Request, res: Response) 
   }
 });
 
-// public-route — read-only aggregate status, same as every other
-// `/api/v1/*/health` endpoint Command Hub's Overview grid polls
-// unauthenticated (see fetchServiceHealth in command-hub/app.js). Exposes
-// only timing numbers, nothing sensitive.
 /**
  * GET /health — Command Hub Overview's "basic test" grid polls this like
- * every other service. Reads the most recent run out of oasis_events rather
- * than re-running anything live (the actual test runs on its own cron).
+ * every other service, unauthenticated (see fetchServiceHealth in
+ * command-hub/app.js) — same convention as every other `/api/v1/*/health`
+ * endpoint. Exposes only aggregate timing numbers, nothing sensitive.
+ * Reads the most recent run out of oasis_events rather than re-running
+ * anything live (the actual test runs on its own cron).
  */
-router.get('/health', async (_req: Request, res: Response) => {
+router.get('/health', async (_req: Request, res: Response) => { // public-route
   const sb = getSupabase();
   if (!sb) {
     return res.status(200).json({ status: 'down', reason: 'supabase_unconfigured' });
@@ -199,11 +198,11 @@ router.get('/health', async (_req: Request, res: Response) => {
   });
 });
 
-// public-route — router status/self-description only, no data.
 /**
- * GET / — router status, mirrors the convention other routers use.
+ * GET / — router status/self-description only, no data. Mirrors the
+ * convention other routers use.
  */
-router.get('/', (_req: Request, res: Response) => {
+router.get('/', (_req: Request, res: Response) => { // public-route
   return res.status(200).json({
     ok: true,
     service: 'screen-load-health',

--- a/services/gateway/src/routes/screen-load-health.ts
+++ b/services/gateway/src/routes/screen-load-health.ts
@@ -125,7 +125,7 @@ router.post('/report', requireApiKey, async (req: Request, res: Response) => {
 /**
  * GET /health — Command Hub Overview's "basic test" grid polls this like
  * every other service, unauthenticated (see fetchServiceHealth in
- * command-hub/app.js) — same convention as every other `/api/v1/*/health`
+ * command-hub/app.js) — same convention as every other per-service health
  * endpoint. Exposes only aggregate timing numbers, nothing sensitive.
  * Reads the most recent run out of oasis_events rather than re-running
  * anything live (the actual test runs on its own cron).

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -923,6 +923,10 @@ export type CicdEventType =
   // Inert in prod until FEATURE_LATENCY_TELEMETRY_ENV is flipped on.
   | 'voice.latency.measured'        // per-turn phased latency: audio_in_first_byte..audio_out_first_chunk
   | 'screen.latency.measured'       // per-route TTFB / Server-Timing breakdown from gateway
+  // VTID-SCREEN-LOAD-01: scheduled Playwright job's per-screen load-time
+  // result — independent of FEATURE_LATENCY_TELEMETRY_ENV, always live so
+  // Command Hub Overview has a signal even while RUM stays staging-only.
+  | 'screen.load.synthetic_test'    // synthetic mobile screen-load-time basic test result
   | 'eval.shadow.compared'          // shadow harness compared primary vs candidate model on one eval input
   | 'eval.coverage.report'          // periodic golden-corpus coverage report (replay-runner output)
   | 'dataset.extraction.completed'  // dataset-extraction cron finished one slice; metadata.rows / .target

--- a/services/gateway/test/routes/screen-load-health.test.ts
+++ b/services/gateway/test/routes/screen-load-health.test.ts
@@ -1,0 +1,250 @@
+/**
+ * VTID-SCREEN-LOAD-01: tests for the `/api/v1/frontend/screen-load` router.
+ *
+ * Coverage matrix:
+ *   POST /report
+ *     1. Missing Authorization → 401, NOT emitted.
+ *     2. Wrong service token → 401, NOT emitted.
+ *     3. Correct service token + valid body → 204, emitOasisEvent called
+ *        once per screen.
+ *     4. Correct service token + invalid body (missing results) → 400.
+ *     5. A screen with status:'error' → emitted with status:'error'.
+ *     6. A screen over the slow threshold → emitted with status:'warning'.
+ *     7. emitOasisEvent throwing → 500.
+ *   GET /health
+ *     8. No recent events → 'down' (no_recent_runs).
+ *     9. Recent run, all fast, none failed → 'ok'.
+ *    10. Recent run, p75 over threshold → 'degraded'.
+ *    11. Recent run with a failed screen → 'down'.
+ *    12. Supabase unconfigured (getSupabase() → null) → 'down'.
+ *   GET /
+ *    13. Router self-description → 200.
+ */
+
+import request from 'supertest';
+import express from 'express';
+
+const mockEmit = jest.fn(async () => ({ ok: true, event_id: 'evt-test-1' }));
+jest.mock('../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: (...args: unknown[]) => (mockEmit as any)(...args),
+}));
+
+// Chainable Supabase query-builder mock: `.from().select().eq().gte().order().limit()`
+// resolves to whatever `mockQueryResult` is set to for that test.
+let mockQueryResult: { data: any[] | null; error: { message: string } | null } = { data: [], error: null };
+let mockGetSupabase: () => any = () => ({
+  from: () => ({
+    select: () => ({
+      eq: () => ({
+        gte: () => ({
+          order: () => ({
+            limit: () => Promise.resolve(mockQueryResult),
+          }),
+        }),
+      }),
+    }),
+  }),
+});
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: (...args: unknown[]) => mockGetSupabase(),
+}));
+
+import { screenLoadHealthRouter } from '../../src/routes/screen-load-health';
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/frontend/screen-load', screenLoadHealthRouter);
+  return app;
+}
+
+const VALID_BODY = {
+  run_id: 'run-1',
+  environment: 'production' as const,
+  results: [{ screen: '/home', duration_ms: 1200, lcp_ms: 900, status: 'ok' as const }],
+};
+
+beforeEach(() => {
+  mockEmit.mockClear();
+  mockEmit.mockResolvedValue({ ok: true, event_id: 'evt-test-1' });
+  mockQueryResult = { data: [], error: null };
+  mockGetSupabase = () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          gte: () => ({
+            order: () => ({
+              limit: () => Promise.resolve(mockQueryResult),
+            }),
+          }),
+        }),
+      }),
+    }),
+  });
+  process.env.GATEWAY_SERVICE_TOKEN = 'svc-secret-token-xyz';
+});
+
+afterAll(() => {
+  delete process.env.GATEWAY_SERVICE_TOKEN;
+});
+
+describe('POST /api/v1/frontend/screen-load/report — auth gate', () => {
+  it('1. missing Authorization → 401, NOT emitted', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/frontend/screen-load/report').send(VALID_BODY);
+    expect(res.status).toBe(401);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('2. wrong service token → 401, NOT emitted', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/frontend/screen-load/report')
+      .set('Authorization', 'Bearer wrong-token')
+      .send(VALID_BODY);
+    expect(res.status).toBe(401);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/v1/frontend/screen-load/report — happy path', () => {
+  it('3. correct token + valid body → 204, emitOasisEvent called once per screen', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/frontend/screen-load/report')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send(VALID_BODY);
+    expect(res.status).toBe(204);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    const call = mockEmit.mock.calls[0][0];
+    expect(call.type).toBe('screen.load.synthetic_test');
+    expect(call.status).toBe('success');
+    expect(call.payload).toMatchObject({ run_id: 'run-1', screen: '/home', duration_ms: 1200 });
+  });
+
+  it('5. screen with status:error → emitted with status:error', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/frontend/screen-load/report')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({
+        run_id: 'run-2',
+        results: [{ screen: '/discover', duration_ms: 20000, status: 'error', error: 'net::ERR_TIMED_OUT' }],
+      });
+    expect(res.status).toBe(204);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    expect(mockEmit.mock.calls[0][0].status).toBe('error');
+  });
+
+  it('6. screen over slow threshold → emitted with status:warning', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/frontend/screen-load/report')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({
+        run_id: 'run-3',
+        results: [{ screen: '/health', duration_ms: 7000, status: 'ok' }],
+      });
+    expect(res.status).toBe(204);
+    expect(mockEmit.mock.calls[0][0].status).toBe('warning');
+  });
+});
+
+describe('POST /api/v1/frontend/screen-load/report — body validation', () => {
+  it('4. missing results array → 400, NOT emitted', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/frontend/screen-load/report')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ run_id: 'run-4' });
+    expect(res.status).toBe(400);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/v1/frontend/screen-load/report — ingest failure', () => {
+  it('7. emitOasisEvent throwing → 500', async () => {
+    mockEmit.mockRejectedValueOnce(new Error('supabase exploded'));
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/frontend/screen-load/report')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send(VALID_BODY);
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+  });
+});
+
+describe('GET /api/v1/frontend/screen-load/health', () => {
+  it('8. no recent events → down (no_recent_runs)', async () => {
+    mockQueryResult = { data: [], error: null };
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/frontend/screen-load/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('down');
+    expect(res.body.reason).toBe('no_recent_runs');
+  });
+
+  it('9. recent run, all fast, none failed → ok', async () => {
+    const now = new Date().toISOString();
+    mockQueryResult = {
+      data: [
+        { created_at: now, metadata: { screen: '/home', duration_ms: 1000, load_status: 'ok' } },
+        { created_at: now, metadata: { screen: '/discover', duration_ms: 1500, load_status: 'ok' } },
+      ],
+      error: null,
+    };
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/frontend/screen-load/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.screens_checked).toBe(2);
+  });
+
+  it('10. recent run, p75 over threshold → degraded', async () => {
+    const now = new Date().toISOString();
+    mockQueryResult = {
+      data: [
+        { created_at: now, metadata: { screen: '/home', duration_ms: 8000, load_status: 'ok' } },
+        { created_at: now, metadata: { screen: '/discover', duration_ms: 7500, load_status: 'ok' } },
+      ],
+      error: null,
+    };
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/frontend/screen-load/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('degraded');
+  });
+
+  it('11. recent run with a failed screen → down', async () => {
+    const now = new Date().toISOString();
+    mockQueryResult = {
+      data: [{ created_at: now, metadata: { screen: '/inbox', duration_ms: 0, load_status: 'error' } }],
+      error: null,
+    };
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/frontend/screen-load/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('down');
+    expect(res.body.screens_failed).toContain('/inbox');
+  });
+
+  it('12. supabase unconfigured → down', async () => {
+    mockGetSupabase = () => null;
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/frontend/screen-load/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('down');
+    expect(res.body.reason).toBe('supabase_unconfigured');
+  });
+});
+
+describe('GET /api/v1/frontend/screen-load/', () => {
+  it('13. router self-description → 200', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/frontend/screen-load/');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.service).toBe('screen-load-health');
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-SCREEN-LOAD-01`

**Layer:** UIUX / CICDL (Command Hub Overview + scheduled test infra)

**Priority:** P2

---

## 📋 Summary

There was no standing signal for how long mobile screens actually take to load. The existing RUM beacon pipe (`vitana-v1` `src/lib/rum.ts` → `POST /api/v1/rum/beacon`) already captures LCP/TTFB/FCP/CLS/INP per screen, but `FEATURE_LATENCY_TELEMETRY_ENV` is `staging-only` — production traffic never reaches it, so there's currently zero real-world screen-load data.

This adds an independent, always-live signal: a scheduled Playwright job that loads 6 key mobile screens against production every 30 minutes and reports results into a new gateway health check, wired into Command Hub Overview's existing service-health grid alongside every other basic test (Auth, CI/CD, Assistant, etc.) — so a slow or broken screen shows up there automatically, without waiting on the RUM flag to graduate.

---

## ✅ Changes

- [x] New Playwright spec `e2e/community-mobile/shared/screen-load-timing.spec.ts` — loads News Feed, Discover, Community Events, Health, Inbox, and My Profile on mobile viewport, measures wall-clock load time (+ best-effort LCP), reports every result regardless of pass/fail
- [x] New gateway router `services/gateway/src/routes/screen-load-health.ts` — `POST /report` (ingest, emits `screen.load.synthetic_test` OASIS events) + `GET /health` (aggregates latest run into `ok`/`degraded`/`down`, p75 threshold 6000ms, stale-after 3h)
- [x] Registered new route at `/api/v1/frontend/screen-load` in `index.ts`
- [x] Added `screen.load.synthetic_test` to the `CicdEventType` union in `types/cicd.ts`
- [x] Added "Screen Load Time" entry (new "Frontend & Performance" group) to Command Hub Overview's `fetchServiceHealth` list in `app.js`
- [x] New scheduled workflow `.github/workflows/SCREEN-LOAD-TIMING.yml` — runs every 30 min against `https://vitanaland.com`, also dispatchable manually against any URL (e.g. a Cloud Run preview)

---

## 🧪 Testing

- [x] Automated tests added (this PR's whole purpose)
- [ ] Verified in staging/dev environment — **not yet**: needs the first scheduled run (or a manual `workflow_dispatch`) after merge to populate real data. Until then `GET /api/v1/frontend/screen-load/health` correctly reports `down` / `no_recent_runs`.
- [ ] Manual testing completed — local Playwright execution against production was blocked by this sandbox's network/proxy setup (works fine via `curl`, not via Chromium); relying on GitHub Actions' existing working Playwright CI (same runner used by `E2E-TEST-RUN.yml`) to validate on first run.

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] Workflow file uses UPPERCASE name (`SCREEN-LOAD-TIMING.yml`)
- [x] Workflow includes `run-name` with VTID
- [x] No lowercase workflow names present

### File Names
- [x] New files follow kebab-case (`screen-load-health.ts`, `screen-load-timing.spec.ts`)
- [x] No files violate naming canon

### Code Standards
- [x] VTID constant is UPPERCASE (`const VTID = 'VTID-SCREEN-LOAD-01'`)
- [x] Event type uses snake_case/dot convention matching existing `screen.latency.measured` (`screen.load.synthetic_test`)
- [x] Status values are lowercase (`ok`, `degraded`, `down`, `success`, `warning`, `error`)

### Cloud Run Deployments
- [x] N/A — no new Cloud Run service, reuses existing `gateway` deploy

### Documentation
- [x] VTID mentioned in commit messages

---

## 🚨 Breaking Changes

None. New route, new workflow, one new array entry in an existing health-check list, one new union member in `CicdEventType`. Nothing existing changes behavior.

---

## 📌 Additional Notes

- The 6 screens tested are a deliberately small, curated "first minute of a session" set — not full route coverage (that's what the existing 272-route E2E smoke suite is for).
- Threshold (6000ms p75) is intentionally more generous than the RUM LCP thresholds in `rum.ts`, since this measures full authenticated SPA route load (JS + data fetch + render), not bare paint timing.
- Once `FEATURE_LATENCY_TELEMETRY_ENV` graduates to `staging+prod`, this synthetic signal and real RUM data can be cross-checked against each other.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc8aLiwDpNyWg4owRJ32Du)_