### PR TITLE
feat(voice): Voice Tools Expansion Plan v2 — seed 425 planned tools into the catalog (BOOTSTRAP-VOICE-CATALOG-V2-PLAN)

### DIFF
--- a/docs/VOICE_TOOLS_EXPANSION_PLAN.md
+++ b/docs/VOICE_TOOLS_EXPANSION_PLAN.md
@@ -1,0 +1,773 @@
+# Voice Tools Catalog — Expansion Plan v2 (425 new tools)
+
+**Status: APPROVED 2026-07-12 — catalog seeded as `planned` in `tool-manifest.json`; implementation in 6 waves.**
+Prepared 2026-07-12 · Based on full codebase analysis of `vitana-platform` (gateway routes, Command Hub, orb-tools registry) and `vitana-v1` (551+ screens, App.tsx routes, hooks).
+
+## Approved decisions (owner review, 2026-07-12)
+
+1. **Scope: keep all 425 tools** (150 community / 125 admin / 150 developer).
+2. **Payment policy:** voice may *complete* only **internal user-to-user credit transfers** (`send_funds`, after 2-step confirm). Every card/Stripe charge (`start_checkout`, `buy_event_ticket`, `purchase_room_access`, `upgrade_subscription`, `add_voice_minutes`) is voice-*initiated* but hands off to the screen for final payment confirmation.
+3. **`dev_publish_to_prod` is IN Wave 2**, with double-confirm + spoken reason recorded to OASIS.
+4. **No Professional/Staff catalog** — out of scope, not planned.
+
+This document is the source of truth the seed script (`scripts/voice-tools-plan-seed.mjs`) parses to generate the 425 `status: planned` manifest entries.
+
+---
+
+## 1. Where we are today (169 live tools)
+
+| Role | Tools today | Coverage quality |
+|---|---|---|
+| Community | ~148 | Good on calendar, reminders, chat, intents, memory, health logging basics, groups/social basics. **Near-zero** on commerce, wallet actions, business hub, live rooms, tickets, subscriptions, campaigns, goals, content creation depth. |
+| Admin | 9 | Insights/KPI readouts only. No user management, moderation, broadcast, marketplace, KB, governance, tenant ops. |
+| Developer | 12 | Read-mostly (VTIDs, approvals, agents, routines). No deploy, CI/CD, governance, autopilot control, self-healing actions, testing, migrations. |
+
+## 2. Proposed split (this plan)
+
+| Role | New tools | New total |
+|---|---|---|
+| Community | **+150** | ~298 |
+| Admin | **+125** | ~134 |
+| Developer | **+150** | ~162 |
+| **Total** | **+425** | **~594** |
+
+*(You asked for ~350 split as 150 / 100–150 / 150 — the split itself sums to 400–450; this plan lands at 425. Easy to trim: each domain table below is independently cuttable.)*
+
+## 3. Build principles (same architecture as the 169)
+
+1. **One registry, two pipelines.** Every handler goes into `ORB_TOOL_REGISTRY` (`orb-tools-shared.ts`) → Vertex picks it up via the generic dispatch fallback in `orb-live.ts`; LiveKit gets a `@function_tool` wrapper in `tools.py`. Both wired from day one (no more Vertex-only stragglers).
+2. **Role gating at the dispatcher.** Community tools: default. Admin tools: `admin | exafy_admin` via the resolved effective role. Developer tools: existing `developerGate()` (`developer | admin | exafy_admin`).
+3. **Two-step confirm for every mutating/risky verb** (marked ⚠️ below) — same pattern as `dev_approve_pr`: first call returns a summary + confirmation token, second call with the token executes. Mandatory for: payments, purchases, deploys, publishes, merges, deletes, broadcasts, kill-switches, role grants.
+4. **Backed by existing endpoints only.** Every tool below maps to a route/service that already exists (verified in this analysis). No new backend features are invented — voice tools are a thin dispatch layer.
+5. **Manifest-first.** All 425 land in `tool-manifest.json` as `status: planned` when this plan is approved; flip to `live` per wave. The reconcile scanner + parity gate CI keep the catalog honest.
+6. **i18n**: all user-facing response strings via the `tt()` catalog (DE/EN/ES/SR), per CLAUDE.md hard rule.
+
+Priorities: **P0** = urgent, ships first (daily-use or unblocks role's core job) · **P1** = second wave · **P2** = completeness.
+
+---
+
+# PART A — COMMUNITY (+150)
+
+The biggest gaps are the **money and creation surfaces**: users can talk to Vitana about their health, but can't buy, sell, pay, host, or publish by voice.
+
+## A1. Commerce & Marketplace Discovery (16) — P0
+Backed by `useMarketplace`, `useShopFeed`, `useShoppingAgent`, `useOrderManagement`, discover routes.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `search_marketplace` | Search products with filters (scope, category, price) | R |
+| 2 | `get_product_details` | Read out one product (price, rating, description) | R |
+| 3 | `browse_supplements` | Supplements catalog | R |
+| 4 | `add_supplement_to_regimen` | Add supplement to personal regimen | W |
+| 5 | `list_my_supplements` | Current regimen | R |
+| 6 | `remove_supplement_from_regimen` | Remove from regimen | W |
+| 7 | `browse_wellness_services` | Wellness services directory | R |
+| 8 | `get_provider_profile` | Provider/practitioner detail | R |
+| 9 | `browse_doctors_coaches` | Doctors & coaches directory | R |
+| 10 | `get_coach_compatibility` | Compatibility score with a coach | R |
+| 11 | `browse_deals_offers` | Current deals & offers | R |
+| 12 | `apply_discount_code` | Apply promo code | W |
+| 13 | `get_ai_product_picks` | Shopping-agent recommendations | R |
+| 14 | `list_my_orders` | Order history | R |
+| 15 | `get_order_status` | Track one order | R |
+| 16 | `reorder_last_order` ⚠️ | Repeat a previous order | W |
+
+## A2. Cart & Checkout (8) — P0
+Backed by `useCart`, `useUniversalCart`, `useStripePayment`, BudgetMeter.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 17 | `add_to_cart` | Add product to universal cart | W |
+| 18 | `view_cart` | Read cart contents + total | R |
+| 19 | `update_cart_item` | Change quantity | W |
+| 20 | `remove_from_cart` | Remove item | W |
+| 21 | `clear_cart` ⚠️ | Empty the cart | W |
+| 22 | `set_shopping_budget` | Set/track budget meter | W |
+| 23 | `review_agent_purchase_proposals` | Read pending AI purchase proposals | R |
+| 24 | `start_checkout` ⚠️ | Begin Stripe checkout (hands off to screen for payment) | W |
+
+## A3. Wallet & Payments (11) — P0
+Backed by `useWallet`, `useWalletGateway`, send/request/exchange popups. Complements existing `get_wallet_balance`.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 25 | `get_wallet_summary` | Balance + lifetime earnings + pending rewards + benefits | R |
+| 26 | `list_wallet_transactions` | Recent transactions | R |
+| 27 | `send_funds` ⚠️ | Transfer credits to a member (resolve recipient → confirm) | W |
+| 28 | `request_payment` | Send a payment request | W |
+| 29 | `exchange_currency` ⚠️ | Exchange between currencies/credits | W |
+| 30 | `get_exchange_rate` | Current EUR/USD/token rate | R |
+| 31 | `set_display_currency` | Toggle display currency | W |
+| 32 | `get_referral_earnings` | Referral earnings snapshot | R |
+| 33 | `get_commissions_summary` | Commissions this month | R |
+| 34 | `get_pending_rewards` | Pending rewards | R |
+| 35 | `list_payment_requests` | Incoming/outgoing requests | R |
+
+## A4. Subscriptions & Billing (7) — P1
+Backed by `useBilling`, `useMemberships`, billing routes.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 36 | `get_my_subscription` | Current plan, renewal date, minutes left | R |
+| 37 | `compare_subscription_plans` | Plans + prices readout | R |
+| 38 | `upgrade_subscription` ⚠️ | Upgrade plan | W |
+| 39 | `cancel_subscription` ⚠️ | Cancel plan | W |
+| 40 | `add_voice_minutes` ⚠️ | Buy extra minutes | W |
+| 41 | `redeem_subscription_code` | Redeem sub code | W |
+| 42 | `get_billing_history` | Invoices/preview | R |
+
+## A5. Vouchers & Referrals (6) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 43 | `redeem_voucher` | Redeem gift/voucher code | W |
+| 44 | `send_gift_voucher` ⚠️ | Gift a voucher to someone | W |
+| 45 | `get_referral_link` | Read/share referral link | R |
+| 46 | `invite_friend` ⚠️ | Send an invite | W |
+| 47 | `get_referral_status` | Who joined via my link | R |
+| 48 | `activate_reseller` ⚠️ | Activate reseller status | W |
+
+## A6. Business Hub — seller/creator side (14) — P0
+Backed by `useBusinessPackages`, `useCreator`, BusinessHub tabs. This is the "responsibility to execute work" surface for earning members.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 49 | `list_my_services` | My service listings | R |
+| 50 | `create_service` ⚠️ | Create a service listing | W |
+| 51 | `update_service` | Edit price/description/availability | W |
+| 52 | `archive_service` ⚠️ | Take a service offline | W |
+| 53 | `list_my_packages` | My packages | R |
+| 54 | `create_package` ⚠️ | Create package/bundle | W |
+| 55 | `list_my_clients` | Client list | R |
+| 56 | `get_client_overview` | One client's history | R |
+| 57 | `list_business_orders` | Incoming orders | R |
+| 58 | `get_business_order_detail` | One order | R |
+| 59 | `get_business_kpis` | Revenue/booking KPIs | R |
+| 60 | `get_earnings_breakdown` | Earnings by source + ledger | R |
+| 61 | `list_business_opportunities` | Missions/opportunities | R |
+| 62 | `get_reseller_payouts` | Reseller sales & payouts | R |
+
+## A7. Live Rooms / Go Live (9) — P1
+Backed by `useLiveRoom*`, `useDailyRoom`, GoLivePopup, stream lifecycle hooks.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 63 | `list_live_rooms_now` | What's live right now | R |
+| 64 | `get_live_room_details` | Room info, host, access price | R |
+| 65 | `go_live` ⚠️ | Start hosting (opens room) | W |
+| 66 | `create_live_room` ⚠️ | Create a room | W |
+| 67 | `schedule_live_session` | Schedule future session | W |
+| 68 | `purchase_room_access` ⚠️ | Buy access to a paid room | W |
+| 69 | `extend_live_session` | Extend timer | W |
+| 70 | `end_live_session` ⚠️ | End my stream | W |
+| 71 | `play_room_recording` | Watch a past recording | R |
+
+## A8. Messaging depth (9) — P0
+Extends existing chat suite. Backed by `useHybridMessages`, `useMessageReactions`, `useWebRTC`, group chat pages.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 72 | `send_group_chat_message` | Message a group thread | W |
+| 73 | `reply_to_message` | Quote-reply to a specific message | W |
+| 74 | `react_to_message` | Emoji-react | W |
+| 75 | `create_group_chat` | New group conversation | W |
+| 76 | `add_group_chat_member` | Add member to group chat | W |
+| 77 | `leave_group_chat` ⚠️ | Leave a group thread | W |
+| 78 | `send_calendar_invite_in_chat` | Share a calendar invite in a DM | W |
+| 79 | `start_voice_call` ⚠️ | Call a member (WebRTC) | W |
+| 80 | `start_video_call` ⚠️ | Video-call a member | W |
+
+## A9. Feed, Content, Shorts, Asks & Challenges (11) — P1
+Extends existing post tools. Backed by feed/shorts/open-asks hooks.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 81 | `share_post` | Share/repost content | W |
+| 82 | `bookmark_post` | Save content | W |
+| 83 | `list_my_bookmarks` | Read saved items | R |
+| 84 | `edit_my_post` | Edit own post | W |
+| 85 | `delete_my_post` ⚠️ | Delete own post | W |
+| 86 | `comment_on_short` | Comment on a short video | W |
+| 87 | `post_open_ask` | Publish an Open Ask | W |
+| 88 | `answer_open_ask` | Answer someone's ask | W |
+| 89 | `list_open_asks` | Browse open asks | R |
+| 90 | `join_challenge` | Join a community challenge | W |
+| 91 | `get_challenge_progress` | My challenge standing | R |
+
+## A10. Events & Tickets (10) — P0
+Extends existing RSVP tools with the creation + ticketing side.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 92 | `create_event` ⚠️ | Create a community event | W |
+| 93 | `update_my_event` | Edit my event | W |
+| 94 | `cancel_my_event` ⚠️ | Cancel my event | W |
+| 95 | `create_meetup` ⚠️ | Create a meetup | W |
+| 96 | `update_my_meetup` | Edit my meetup | W |
+| 97 | `invite_to_event` | Invite contacts/members | W |
+| 98 | `buy_event_ticket` ⚠️ | Purchase a ticket | W |
+| 99 | `list_my_event_tickets` | My event tickets | R |
+| 100 | `share_event` | Share event link | W |
+| 101 | `get_event_attendees` | Who's coming (organizer view) | R |
+
+## A11. Health depth (15) — P0
+Extends the 4 existing loggers + Index tools. Backed by `useHealthLogger`, `useHealthPlans`, `useVitanaIndex*`, lab/biomarker components.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 102 | `log_meal` | Log nutrition/meal | W |
+| 103 | `log_vitals` | Log BP/HR/weight etc. | W |
+| 104 | `log_mood` | Log mental-health check-in | W |
+| 105 | `log_biomarker` | Record a lab value | W |
+| 106 | `get_health_trends` | Trends across trackers | R |
+| 107 | `get_health_streaks` | Vitana streaks | R |
+| 108 | `order_lab_test` ⚠️ | Order a lab test | W |
+| 109 | `get_lab_results` | Read biomarker/lab results | R |
+| 110 | `generate_health_plan` ⚠️ | Run plan-generator wizard | W |
+| 111 | `list_my_health_plans` | Active plans | R |
+| 112 | `get_health_plan_progress` | Plan adherence | R |
+| 113 | `list_my_conditions` | Conditions & risks | R |
+| 114 | `get_health_education` | Education resources on a topic | R |
+| 115 | `get_next_best_action` | Today's next best health action | R |
+| 116 | `connect_health_device` ⚠️ | Start device pairing (navigates) | W |
+
+## A12. Goals & Journey (6) — P1
+Backed by `useGoalPlan`, `useMyJourney`, `useDailyPriority`.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 117 | `set_goal` | Set a goal / north star | W |
+| 118 | `list_my_goals` | Active goals | R |
+| 119 | `update_goal` | Adjust a goal | W |
+| 120 | `get_goal_progress` | Progress readout | R |
+| 121 | `get_journey_checkpoints` | Journey checkpoints | R |
+| 122 | `get_daily_priority` | Today's priority | R |
+
+## A13. Memory & Diary extras (7) — P2
+Extends existing 6 memory + 3 diary tools.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 123 | `edit_memory` | Correct a stored memory | W |
+| 124 | `archive_memory` | Archive (soft-hide) memory | W |
+| 125 | `reinforce_memory` | Mark memory as important | W |
+| 126 | `promote_memory_to_knowledge` | Promote to knowledge base | W |
+| 127 | `set_memory_permissions` | Memory privacy controls | W |
+| 128 | `get_what_vitana_knows` | "What do you know about me" summary | R |
+| 129 | `add_diary_photo` | Attach photo to diary (navigates to picker) | W |
+
+## A14. Profile & Social depth (8) — P2
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 130 | `set_profile_theme` | Change profile theme | W |
+| 131 | `get_profile_completeness` | Completeness % + missing items | R |
+| 132 | `add_gallery_photo` | Add to gallery (navigates to picker) | W |
+| 133 | `share_my_profile` | Share profile link/QR | R |
+| 134 | `get_my_milestones` | Achievements & milestones | R |
+| 135 | `view_member_profile` | Spoken summary of a member | R |
+| 136 | `list_member_posts` | A member's recent posts | R |
+| 137 | `update_service_offerings` | Edit services shown on profile | W |
+
+## A15. Contacts, Campaigns & Social Sharing (10) — P1
+Backed by `useContacts`, `useCampaigns`, `useScheduledPosts`, `useSocialPlatforms`. The growth engine.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 138 | `list_contacts` | My contacts | R |
+| 139 | `add_contact` | Add a contact | W |
+| 140 | `sync_contacts` ⚠️ | Trigger contact import/sync | W |
+| 141 | `create_campaign` ⚠️ | Create sharing campaign | W |
+| 142 | `activate_campaign` ⚠️ | Activate a campaign | W |
+| 143 | `get_campaign_stats` | Campaign performance | R |
+| 144 | `schedule_social_post` ⚠️ | Schedule post to socials | W |
+| 145 | `list_scheduled_posts` | Scheduled queue | R |
+| 146 | `cancel_scheduled_post` | Remove from queue | W |
+| 147 | `share_to_social` ⚠️ | Share now to connected platform | W |
+
+## A16. Notifications & Settings depth (3) — P2
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 148 | `set_notification_preferences` | Per-category notif prefs | W |
+| 149 | `enable_do_not_disturb` | DND / quiet hours | W |
+| 150 | `connect_google_account` ⚠️ | Start Google connect flow | W |
+
+**Community total: 150** · P0: 69 · P1: 49 · P2: 32
+
+---
+
+# PART B — ADMIN (+125)
+
+Today an admin can only *hear about* insights/KPIs. This catalog makes the whole Command Hub admin surface voice-operable: users, moderation, marketplace, broadcast, governance. All tools `admin_` prefixed, gated `admin | exafy_admin`, tenant-scoped. Every endpoint below already exists in `routes/tenant-admin/*` and `routes/admin-*.ts`.
+
+## B1. Users & RBAC (8) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `admin_lookup_user` | Find user by name/email/vitana_id | R |
+| 2 | `admin_list_users` | List/filter users | R |
+| 3 | `admin_get_user_detail` | Full user record | R |
+| 4 | `admin_roles_summary` | Role distribution | R |
+| 5 | `admin_grant_role` ⚠️ | Grant a role | W |
+| 6 | `admin_revoke_role` ⚠️ | Revoke a role | W |
+| 7 | `admin_set_trust_tier` ⚠️ | Change trust tier | W |
+| 8 | `admin_get_at_risk_members` | At-risk members (overview) | R |
+
+## B2. Tenants & Settings (7) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 9 | `admin_list_tenants` | Tenants list | R |
+| 10 | `admin_get_tenant` | Tenant detail | R |
+| 11 | `admin_update_tenant_profile` ⚠️ | Edit tenant profile | W |
+| 12 | `admin_get_feature_flags` | Read flags | R |
+| 13 | `admin_set_feature_flag` ⚠️ | Flip a flag | W |
+| 14 | `admin_update_branding` ⚠️ | Branding settings | W |
+| 15 | `admin_list_tenant_integrations` | Integrations status | R |
+
+## B3. Signups & Invitations (7) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 16 | `admin_list_signups` | Recent signups | R |
+| 17 | `admin_get_signup_stats` | Signup funnel stats | R |
+| 18 | `admin_list_signup_attempts` | Failed/pending attempts | R |
+| 19 | `admin_repair_signup` ⚠️ | Repair a broken signup | W |
+| 20 | `admin_create_invitation` ⚠️ | Invite someone | W |
+| 21 | `admin_list_invitations` | Open invitations | R |
+| 22 | `admin_revoke_invitation` ⚠️ | Revoke invitation | W |
+
+## B4. Content Moderation (8) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 23 | `admin_list_moderation_queue` | Pending items | R |
+| 24 | `admin_get_moderation_item` | One item detail | R |
+| 25 | `admin_moderation_stats` | Queue stats | R |
+| 26 | `admin_approve_content` ⚠️ | Approve item | W |
+| 27 | `admin_reject_content` ⚠️ | Reject/remove item | W |
+| 28 | `admin_flag_content` | Flag for review | W |
+| 29 | `admin_list_reports` | User reports | R |
+| 30 | `admin_get_report` | One report | R |
+
+## B5. Community Oversight (8) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 31 | `admin_list_meetups` | All meetups | R |
+| 32 | `admin_delete_meetup` ⚠️ | Remove a meetup | W |
+| 33 | `admin_list_groups` | All groups | R |
+| 34 | `admin_list_live_rooms` | All live rooms (supervision) | R |
+| 35 | `admin_list_creators` | Creators list | R |
+| 36 | `admin_list_memberships` | Memberships | R |
+| 37 | `admin_community_stats` | Community-wide stats | R |
+| 38 | `admin_activity_feed` | Tenant activity feed + alerts | R |
+
+## B6. Marketplace Admin (12) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 39 | `admin_marketplace_overview` | Marketplace KPIs | R |
+| 40 | `admin_list_merchants` | Merchants | R |
+| 41 | `admin_update_merchant` ⚠️ | Edit merchant status | W |
+| 42 | `admin_list_products` | Products (admin view) | R |
+| 43 | `admin_update_product` ⚠️ | Edit/approve product | W |
+| 44 | `admin_bulk_product_action` ⚠️ | Bulk enable/disable | W |
+| 45 | `admin_get_feed_curation` | Curation rules | R |
+| 46 | `admin_update_feed_curation` ⚠️ | Change curation | W |
+| 47 | `admin_list_geo_policies` | Geo policies | R |
+| 48 | `admin_update_geo_policy` ⚠️ | Edit geo policy | W |
+| 49 | `admin_trigger_source_sync` ⚠️ | Sync a product network | W |
+| 50 | `admin_get_ingestion_coverage` | Ingestion runs & coverage | R |
+
+## B7. Billing & Wallet Admin (6) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 51 | `admin_credit_wallet` ⚠️ | Credit a user's wallet | W |
+| 52 | `admin_debit_wallet` ⚠️ | Debit adjustment | W |
+| 53 | `admin_get_founding_status` | Founding-member status | R |
+| 54 | `admin_get_monetization_config` | Monetization config | R |
+| 55 | `admin_update_monetization_config` ⚠️ | Update config | W |
+| 56 | `admin_run_monetization_detect` | Run detection | W |
+
+## B8. Knowledge Base Admin (8) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 57 | `admin_kb_search` | Search tenant KB | R |
+| 58 | `admin_kb_list_docs` | List docs | R |
+| 59 | `admin_kb_create_doc` ⚠️ | Create doc | W |
+| 60 | `admin_kb_update_doc` ⚠️ | Update doc | W |
+| 61 | `admin_kb_delete_doc` ⚠️ | Delete doc | W |
+| 62 | `admin_kb_reindex` ⚠️ | Reindex KB | W |
+| 63 | `admin_kb_baseline_optout` ⚠️ | Opt out of a baseline doc | W |
+| 64 | `admin_system_kb_update` ⚠️ | Update system KB doc (exafy_admin) | W |
+
+## B9. Assistant & Voice Config (7) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 65 | `admin_get_assistant_config` | Config per surface | R |
+| 66 | `admin_set_assistant_config` ⚠️ | Update config | W |
+| 67 | `admin_list_assistant_speeches` | Canned speeches | R |
+| 68 | `admin_set_assistant_speech` ⚠️ | Edit a speech | W |
+| 69 | `admin_get_awareness_config` | Awareness registry | R |
+| 70 | `admin_set_awareness_config` ⚠️ | Set awareness signal config | W |
+| 71 | `admin_bulk_set_awareness` ⚠️ | Bulk update | W |
+
+## B10. Specialists / Personas (10) — P2
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 72 | `admin_list_specialists` | Personas | R |
+| 73 | `admin_get_specialist` | One persona + versions | R |
+| 74 | `admin_create_specialist` ⚠️ | New persona | W |
+| 75 | `admin_update_specialist` ⚠️ | Edit persona | W |
+| 76 | `admin_rollback_specialist` ⚠️ | Roll back version | W |
+| 77 | `admin_set_specialist_tools` ⚠️ | Bind tools | W |
+| 78 | `admin_set_specialist_kb` ⚠️ | Bind KB | W |
+| 79 | `admin_set_specialist_status` ⚠️ | Enable/disable | W |
+| 80 | `admin_test_specialist_connection` | Test connection | R |
+| 81 | `admin_approve_specialist_ticket` ⚠️ | Approve lifecycle ticket | W |
+
+## B11. Notifications & Broadcast (7) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 82 | `admin_compose_broadcast` | Draft a broadcast (returns preview) | W |
+| 83 | `admin_send_broadcast` ⚠️ | Send to audience | W |
+| 84 | `admin_list_broadcasts` | Sent history | R |
+| 85 | `admin_notification_pref_stats` | Opt-in/out stats | R |
+| 86 | `admin_create_notification_category` ⚠️ | New category | W |
+| 87 | `admin_update_notification_category` ⚠️ | Edit category | W |
+| 88 | `admin_test_notification_category` | Send test | W |
+
+## B12. Governance & Controls (8) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 89 | `admin_governance_status` | Governance status | R |
+| 90 | `admin_list_governance_rules` | Rules | R |
+| 91 | `admin_list_violations` | Violations feed | R |
+| 92 | `admin_list_proposals` | Proposals | R |
+| 93 | `admin_create_proposal` ⚠️ | New proposal | W |
+| 94 | `admin_update_proposal_status` ⚠️ | Approve/reject proposal | W |
+| 95 | `admin_get_control_key` | Read a control (kill switches) | R |
+| 96 | `admin_set_control_key` ⚠️ | Flip a control key | W |
+
+## B13. Autopilot Admin (8) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 97 | `admin_get_autopilot_settings` | Settings | R |
+| 98 | `admin_update_autopilot_settings` ⚠️ | Patch settings | W |
+| 99 | `admin_list_autopilot_bindings` | Bindings | R |
+| 100 | `admin_create_autopilot_binding` ⚠️ | New binding | W |
+| 101 | `admin_delete_autopilot_binding` ⚠️ | Remove binding | W |
+| 102 | `admin_list_autopilot_runs` | Runs | R |
+| 103 | `admin_autopilot_run_stats` | Run stats | R |
+| 104 | `admin_update_autopilot_wave` ⚠️ | Edit wave | W |
+
+## B14. Analytics & Intent Engine (10) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 105 | `admin_analytics_summary` | Product analytics summary | R |
+| 106 | `admin_assistant_analytics` | Assistant usage | R |
+| 107 | `admin_journey_analytics` | Journeys | R |
+| 108 | `admin_feature_analytics` | Feature usage | R |
+| 109 | `admin_interest_analytics` | Interests | R |
+| 110 | `admin_intent_engine_stats` | Intent/match KPIs | R |
+| 111 | `admin_close_intent` ⚠️ | Force-close an intent | W |
+| 112 | `admin_recompute_intent` ⚠️ | Recompute matches | W |
+| 113 | `admin_resolve_dispute` ⚠️ | Resolve match dispute | W |
+| 114 | `admin_archive_intent` ⚠️ | Archive intent | W |
+
+## B15. Feedback & Support Admin (5) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 115 | `admin_list_feedback_tickets` | Support tickets | R |
+| 116 | `admin_get_feedback_ticket` | One ticket | R |
+| 117 | `admin_feedback_kpis` | Support KPIs | R |
+| 118 | `admin_list_handoffs` | Recent handoffs | R |
+| 119 | `admin_act_on_ticket` ⚠️ | Resolve/assign/respond | W |
+
+## B16. Audit, i18n & Memory Ops (6) — P2
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 120 | `admin_audit_actions_log` | Admin actions audit | R |
+| 121 | `admin_audit_access_log` | Access audit | R |
+| 122 | `admin_i18n_translate` ⚠️ | Run translation job | W |
+| 123 | `admin_i18n_audit` ⚠️ | Run LLM locale audit | W |
+| 124 | `admin_run_memory_consolidator` ⚠️ | Run memory consolidation | W |
+| 125 | `admin_run_embeddings_backfill` ⚠️ | Run embeddings backfill | W |
+
+**Admin total: 125** · P0: 37 · P1: 55 · P2: 33
+
+---
+
+# PART C — DEVELOPER (+150)
+
+Goal: a developer can run the platform's whole operational loop by voice — VTID lifecycle, governance, PRs, deploys, autopilot, healing, tests, migrations — with hard confirms on anything that mutates prod. All `dev_` prefixed, gated by `developerGate()`. Every endpoint verified to exist (routes listed per domain).
+
+## C1. VTID / OASIS Lifecycle (15) — P0
+`routes/vtid.ts`, `oasis-tasks.ts`, `execute.ts`.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `dev_allocate_vtid` ⚠️ | Allocate a new VTID | W |
+| 2 | `dev_create_task` ⚠️ | Create OASIS task | W |
+| 3 | `dev_update_task` ⚠️ | Patch task fields | W |
+| 4 | `dev_cancel_task` ⚠️ | Cancel task | W |
+| 5 | `dev_complete_task` ⚠️ | Mark complete | W |
+| 6 | `dev_terminalize_vtid` ⚠️ | Set is_terminal + outcome | W |
+| 7 | `dev_discover_tasks` | Discover eligible tasks | R |
+| 8 | `dev_get_vtid_projection` | VTID projection | R |
+| 9 | `dev_get_allocator_status` | Allocator on/off + health | R |
+| 10 | `dev_query_oasis_events` | Query events by vtid/type/time | R |
+| 11 | `dev_execute_vtid` ⚠️ | Trigger execution | W |
+| 12 | `dev_run_exec_workflow` ⚠️ | Run a workflow | W |
+| 13 | `dev_submit_evidence` | Submit evidence for a VTID | W |
+| 14 | `dev_list_work_orders` | Work orders | R |
+| 15 | `dev_get_work_order` | One work order | R |
+
+## C2. Governance (13) — P0
+`routes/governance.ts`, `governance-controls.ts`.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 16 | `dev_evaluate_governance` | Evaluate action against rules | R |
+| 17 | `dev_governance_status` | Status snapshot | R |
+| 18 | `dev_list_governance_rules` | Rules | R |
+| 19 | `dev_get_governance_rule` | One rule by code | R |
+| 20 | `dev_list_violations` | Violations | R |
+| 21 | `dev_list_enforcements` | Enforcements | R |
+| 22 | `dev_governance_feed` | Live feed | R |
+| 23 | `dev_list_proposals` | Proposals | R |
+| 24 | `dev_create_proposal` ⚠️ | New proposal | W |
+| 25 | `dev_update_proposal` ⚠️ | Update status | W |
+| 26 | `dev_get_control` | Read control key (EXECUTION_DISARMED etc.) | R |
+| 27 | `dev_set_control` ⚠️ | Flip control key | W |
+| 28 | `dev_get_control_history` | Key history | R |
+
+## C3. CI/CD & Pull Requests (14) — P0
+`routes/cicd.ts`, `services/github-service.ts`, `approvals.ts`.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 29 | `dev_create_pr` ⚠️ | Create PR from branch | W |
+| 30 | `dev_get_pr_status` | PR state + mergeability | R |
+| 31 | `dev_get_pr_checks` | Check runs for a PR | R |
+| 32 | `dev_list_open_prs` | Open PRs w/ status | R |
+| 33 | `dev_merge_pr` ⚠️ | Merge via governed pipeline | W |
+| 34 | `dev_safe_merge` ⚠️ | Safe-merge flow | W |
+| 35 | `dev_revert_pr` ⚠️ | Create revert PR | W |
+| 36 | `dev_trigger_workflow` ⚠️ | Dispatch a GH workflow | W |
+| 37 | `dev_list_workflow_runs` | Runs for a workflow | R |
+| 38 | `dev_get_run_jobs` | Jobs + failures for a run | R |
+| 39 | `dev_get_merge_lock` | Merge lock status | R |
+| 40 | `dev_release_merge_lock` ⚠️ | Release stuck lock | W |
+| 41 | `dev_cicd_health` | CI/CD pipeline health | R |
+| 42 | `dev_approvals_feed` | Approvals activity feed | R |
+
+## C4. Deployment & Release (13) — P0
+`routes/operator.ts` (PUBLISH lives here), `canary-target.ts`, staging-first model.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 43 | `dev_deploy_service` ⚠️ | Deploy a service (staging path) | W |
+| 44 | `dev_publish_to_prod` ⚠️⚠️ | The PUBLISH button by voice (double confirm + reason) | W |
+| 45 | `dev_list_revisions` | Cloud Run revisions | R |
+| 46 | `dev_list_deployments` | Deployment history | R |
+| 47 | `dev_deployment_health` | Deploy health | R |
+| 48 | `dev_promote_canary` ⚠️ | Promote canary | W |
+| 49 | `dev_abort_canary` ⚠️ | Abort canary | W |
+| 50 | `dev_revert_deploy` ⚠️ | Revert gateway | W |
+| 51 | `dev_revert_both` ⚠️ | Revert gateway + frontend | W |
+| 52 | `dev_canary_status` | Canary target status | R |
+| 53 | `dev_staging_status` | What's on staging (env, build) | R |
+| 54 | `dev_compare_staging_prod` | Diff staging vs prod builds | R |
+| 55 | `dev_release_feed` | Recent releases | R |
+
+## C5. Worker Orchestrator (10) — P1
+`routes/worker-orchestrator.ts`.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 56 | `dev_list_workers` | Registered workers | R |
+| 57 | `dev_orchestrator_stats` | Stats | R |
+| 58 | `dev_list_pending_worker_tasks` | Pending queue | R |
+| 59 | `dev_get_task_progress` | Progress of claimed task | R |
+| 60 | `dev_release_claim` ⚠️ | Release a stuck claim | W |
+| 61 | `dev_list_subagents` | Subagents | R |
+| 62 | `dev_list_worker_skills` | Skills | R |
+| 63 | `dev_cleanup_stale_claims` ⚠️ | Cleanup stale claims | W |
+| 64 | `dev_orchestrator_health` | Health | R |
+| 65 | `dev_route_to_subagent` ⚠️ | Route task to subagent | W |
+
+## C6. Autopilot Controller & Loop (15) — P1
+`routes/autopilot.ts`.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 66 | `dev_autopilot_loop_status` | Loop status | R |
+| 67 | `dev_start_autopilot_loop` ⚠️ | Start loop | W |
+| 68 | `dev_stop_autopilot_loop` ⚠️ | Stop loop | W |
+| 69 | `dev_autopilot_loop_history` | Loop history | R |
+| 70 | `dev_reset_loop_cursor` ⚠️ | Reset cursor | W |
+| 71 | `dev_controller_status` | Controller status | R |
+| 72 | `dev_list_controller_runs` | Runs | R |
+| 73 | `dev_get_controller_run` | One run | R |
+| 74 | `dev_plan_task` ⚠️ | Plan a VTID | W |
+| 75 | `dev_start_task_work` ⚠️ | Start work | W |
+| 76 | `dev_complete_task_work` ⚠️ | Complete work | W |
+| 77 | `dev_validate_task` | Validate | R |
+| 78 | `dev_list_pending_plans` | Pending plans | R |
+| 79 | `dev_get_task_spec` | Spec for VTID | R |
+| 80 | `dev_autopilot_pipeline_health` | Pipeline health + summary | R |
+
+## C7. Dev-Autopilot Scanners & Findings (15) — P1
+`routes/dev-autopilot.ts`.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 81 | `dev_trigger_scan` ⚠️ | Run a scanner | W |
+| 82 | `dev_list_scanners` | Scanners | R |
+| 83 | `dev_list_impact_rules` | Impact rules | R |
+| 84 | `dev_get_auto_approve_config` | Auto-approve config | R |
+| 85 | `dev_list_scan_runs` | Scan runs | R |
+| 86 | `dev_get_scan_run` | One run | R |
+| 87 | `dev_findings_queue` | Findings queue | R |
+| 88 | `dev_get_finding` | One finding | R |
+| 89 | `dev_generate_finding_plan` ⚠️ | Generate fix plan | W |
+| 90 | `dev_reject_finding` ⚠️ | Reject finding | W |
+| 91 | `dev_snooze_finding` | Snooze | W |
+| 92 | `dev_approve_auto_execute` ⚠️ | Approve auto-execution | W |
+| 93 | `dev_cancel_execution` ⚠️ | Cancel execution | W |
+| 94 | `dev_list_executions` | Executions | R |
+| 95 | `dev_get_execution_lineage` | Lineage | R |
+
+## C8. Self-Healing (13) — P1
+`routes/self-healing.ts`, voice-lab healing subset.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 96 | `dev_report_incident` ⚠️ | File an incident | W |
+| 97 | `dev_healing_config` | Config | R |
+| 98 | `dev_set_healing_mode` ⚠️ | Change mode | W |
+| 99 | `dev_healing_kill_switch` ⚠️ | Flip kill switch | W |
+| 100 | `dev_healing_history` | Heal history | R |
+| 101 | `dev_healing_metrics` | Metrics summary | R |
+| 102 | `dev_approve_heal` ⚠️ | Approve pending heal | W |
+| 103 | `dev_reject_heal` ⚠️ | Reject heal | W |
+| 104 | `dev_verify_heal` | Verify a heal | R |
+| 105 | `dev_rollback_heal` ⚠️ | Roll back a heal | W |
+| 106 | `dev_list_quarantine` | Quarantined items | R |
+| 107 | `dev_release_quarantine` ⚠️ | Release from quarantine | W |
+| 108 | `dev_shadow_comparison` | Staging shadow-comparison report | R |
+
+## C9. Observability (15) — P0
+`admin-health.ts`, `telemetry.ts`, `voice-lab.ts`, `orb-agent-trace.ts`, `conversation-hub.ts`, `supervisor-summary.ts`.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 109 | `dev_build_info` | Running revision/build per service | R |
+| 110 | `dev_service_health` | /alive + health across services | R |
+| 111 | `dev_error_rate` | Recent error rates | R |
+| 112 | `dev_latency_summary` | Latency percentiles | R |
+| 113 | `dev_telemetry_snapshot` | Telemetry snapshot | R |
+| 114 | `dev_recent_events` | Recent OASIS/system events | R |
+| 115 | `dev_agent_trace` | ORB agent trace | R |
+| 116 | `dev_supervisor_summary` | Supervisor summary | R |
+| 117 | `dev_get_session_turns` | Voice session turns | R |
+| 118 | `dev_get_session_diagnostics` | Session diagnostics | R |
+| 119 | `dev_conversation_decisions` | Greeting/NBA decisions | R |
+| 120 | `dev_tool_failures` | Recent tool failures | R |
+| 121 | `dev_tool_health` | Tool health dashboard | R |
+| 122 | `dev_greeting_decisions` | Greeting monitor | R |
+| 123 | `dev_get_agent_detail` | One registered agent detail | R |
+
+## C10. Testing & QA (10) — P1
+`routes/testing.ts`, `test-contracts.ts`, orb-monitor.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 124 | `dev_run_test_suite` ⚠️ | Run a suite | W |
+| 125 | `dev_list_test_suites` | Suites | R |
+| 126 | `dev_list_test_runs` | Runs | R |
+| 127 | `dev_get_test_run` | One run + failures | R |
+| 128 | `dev_run_e2e` ⚠️ | Trigger E2E workflow | W |
+| 129 | `dev_orb_monitor_status` | ORB monitor status | R |
+| 130 | `dev_trigger_orb_monitor` ⚠️ | Trigger ORB monitor | W |
+| 131 | `dev_list_test_contracts` | Test contracts | R |
+| 132 | `dev_run_orb_selfcheck` ⚠️ | ORB tools selfcheck | W |
+| 133 | `dev_voice_lab_probe` | Voice-lab probe | R |
+
+## C11. Database & Migrations (6) — P2 (all dispatch-guarded)
+`RUN-STAGING-MIGRATION.yml`, `RUN-MIGRATION.yml`, backfill scripts.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 134 | `dev_list_pending_migrations` | Unapplied migration files | R |
+| 135 | `dev_run_staging_migration` ⚠️ | Dispatch staging migration | W |
+| 136 | `dev_run_prod_migration` ⚠️⚠️ | Dispatch prod migration (double confirm + reason) | W |
+| 137 | `dev_migration_status` | Last migration run status | R |
+| 138 | `dev_run_backfill` ⚠️ | Run a named backfill | W |
+| 139 | `dev_schema_info` | Table/schema summary from DATABASE_SCHEMA.md | R |
+
+## C12. Dev Access, Simulator & Meta (11) — P2
+`dev-access.ts`, `dev-auth.ts`, Command Hub Simulator/catalog.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 140 | `dev_list_dev_users` | Dev-access users | R |
+| 141 | `dev_grant_access` ⚠️ | Grant dev access | W |
+| 142 | `dev_revoke_access` ⚠️ | Revoke dev access | W |
+| 143 | `dev_mint_token` ⚠️ | Mint a dev token | W |
+| 144 | `dev_open_hub_panel` | Navigate Command Hub to module/tab | R |
+| 145 | `dev_run_simulator` | Dry-run conversation decision for a user | R |
+| 146 | `dev_journey_context` | Journey context readout | R |
+| 147 | `dev_voice_catalog_stats` | Catalog stats (live/planned/parity) | R |
+| 148 | `dev_get_voice_tool_detail` | One tool's manifest entry | R |
+| 149 | `dev_run_routine_now` ⚠️ | Fire a routine immediately | W |
+| 150 | `dev_system_briefing` | Composite morning briefing: health + deploys + approvals + violations + failing checks | R |
+
+**Developer total: 150** · P0: 57 · P1: 63 · P2: 30
+
+---
+
+# PART D — Delivery plan
+
+## Phasing (each wave = one PR, independently shippable)
+
+| Wave | Content | Tools | Why first |
+|---|---|---|---|
+| **1** | Community P0: Commerce+Cart+Wallet+Messaging depth+Events/Tickets+Health depth | ~69 | Users' most-asked verbs: buy, pay, send, book, log |
+| **2** | Developer P0: VTID lifecycle, Governance, CI/CD, Deploy, Observability | ~57 | Makes the ops loop voice-drivable; devs dogfood daily |
+| **3** | Admin P0: Users/RBAC, Moderation, Marketplace, Broadcast, Governance, Feedback | ~37 | Admin daily-drivers |
+| **4** | Community P1 + Admin P1 | ~104 | Business hub depth, live rooms, campaigns; tenant/KB/autopilot admin |
+| **5** | Developer P1: autopilot control, scanners, healing, orchestrator, testing | ~63 | Autonomy operations |
+| **6** | All P2: memory extras, profile depth, specialists, migrations, dev access | ~95 | Completeness |
+
+## Safety tiers
+
+- **Read (R)** — no confirm, rate-limited.
+- **Write (W)** — executes with spoken confirmation of the result.
+- **⚠️ Confirm** — 2-step confirm token (existing `dev_approve_pr` pattern).
+- **⚠️⚠️ Double confirm** — `dev_publish_to_prod`, `dev_run_prod_migration`: 2-step confirm **plus** a spoken reason recorded to OASIS, mirroring the escape-hatch script's `--reason` requirement.
+
+## Per-wave engineering checklist (matches how the first 169 shipped)
+
+1. Handlers in new `services/gateway/src/services/orb-tools/<domain>-tools.ts` modules, spread into `ORB_TOOL_REGISTRY`.
+2. Declarations added to Vertex catalog (role-gated) + LiveKit `tools.py` wrappers — **key names verified against handler `args.*` reads** (the pillar-bug lesson: a regression test per param contract).
+3. `tool-manifest.json` entries (planned → live per wave); reconcile scanner + parity gate green.
+4. Jest tests per module + `spec.json` parity entries.
+5. Staging deploy → live voice smoke test per wave (with test-artifact cleanup, per standing rule).
+
+## Review outcome
+
+The four open questions were resolved on 2026-07-12 — see "Approved decisions" at the top of this document.

--- a/scripts/voice-tools-plan-seed.mjs
+++ b/scripts/voice-tools-plan-seed.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * BOOTSTRAP-VOICE-CATALOG-V2-PLAN — seed the approved expansion catalog.
+ *
+ * Parses docs/VOICE_TOOLS_EXPANSION_PLAN.md (the approved 425-tool plan)
+ * and merges every tool into services/gateway/src/services/tool-manifest.json
+ * as `status: "planned"`, `wired_in: []`, so the Command Hub Tool Catalog
+ * shows the full roadmap. The plan document is the source of truth: re-run
+ * this script after editing the plan tables and commit the regenerated
+ * manifest.
+ *
+ * Idempotent: entries whose name already exists in the manifest are left
+ * untouched (never downgrades a live tool back to planned). Hard-fails on
+ * duplicate names inside the plan or a per-section count mismatch, so a
+ * mis-edited table cannot silently corrupt the catalog.
+ *
+ * Usage: node scripts/voice-tools-plan-seed.mjs [--dry-run]
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PLAN = resolve(ROOT, 'docs/VOICE_TOOLS_EXPANSION_PLAN.md');
+const MANIFEST = resolve(ROOT, 'services/gateway/src/services/tool-manifest.json');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// Section id → catalog metadata. Roles follow the plan's parts:
+// A* community, B* admin, C* developer (same gating as the existing 169).
+const PART_META = {
+  A: { roles: ['community'], surfaceDefault: 'Community' },
+  B: { roles: ['admin', 'exafy_admin'], surfaceDefault: 'Admin' },
+  C: { roles: ['developer', 'admin', 'exafy_admin'], surfaceDefault: 'Developer' },
+};
+
+// Community sections get real surfaces so the catalog filter stays useful;
+// admin/developer keep their part-wide surface (matches the existing 9/12).
+const SECTION_SURFACE = {
+  A1: 'Marketplace', A2: 'Marketplace', A3: 'Wallet', A4: 'Billing',
+  A5: 'Referrals', A6: 'Business', A7: 'LiveRooms', A8: 'Chat',
+  A9: 'Community', A10: 'Events', A11: 'Health', A12: 'Goals',
+  A13: 'Memory', A14: 'Profile', A15: 'Campaigns', A16: 'Settings',
+};
+
+const SECTION_RE = /^## ([ABC]\d+)\.\s+(.+?)\s+\((\d+)\)\s+—\s+(P\d)/;
+const ROW_RE = /^\|\s*\d+\s*\|\s*`([a-z0-9_]+)`\s*(⚠️⚠️|⚠️)?\s*\|\s*(.+?)\s*\|\s*(R|W)\s*\|/;
+
+function parsePlan(md) {
+  const tools = [];
+  let section = null;
+  let sectionCount = 0;
+  const counts = [];
+
+  const flush = () => {
+    if (section) counts.push({ id: section.id, expected: section.expected, got: sectionCount });
+  };
+
+  for (const line of md.split('\n')) {
+    const h = line.match(SECTION_RE);
+    if (h) {
+      flush();
+      section = { id: h[1], title: h[2], expected: Number(h[3]), priority: h[4] };
+      sectionCount = 0;
+      continue;
+    }
+    if (!section) continue;
+    const r = line.match(ROW_RE);
+    if (!r) continue;
+    const [, name, warn, description, rw] = r;
+    const risk =
+      warn === '⚠️⚠️' ? 'double_confirm'
+      : warn === '⚠️' ? 'confirm'
+      : rw === 'W' ? 'write'
+      : 'read';
+    const part = section.id[0];
+    const meta = PART_META[part];
+    tools.push({
+      name,
+      surface: SECTION_SURFACE[section.id] ?? meta.surfaceDefault,
+      category: part === 'A' ? 'community' : part === 'B' ? 'admin' : 'developer',
+      role: meta.roles,
+      status: 'planned',
+      description,
+      wired_in: [],
+      priority: section.priority,
+      risk,
+      plan_domain: `${section.id} ${section.title}`,
+      plan: 'expansion-v2',
+    });
+    sectionCount++;
+  }
+  flush();
+
+  const bad = counts.filter((c) => c.expected !== c.got);
+  if (bad.length) {
+    for (const b of bad) console.error(`[seed] section ${b.id}: header says ${b.expected}, parsed ${b.got}`);
+    throw new Error('section count mismatch — fix the plan tables or headers');
+  }
+
+  const seen = new Set();
+  for (const t of tools) {
+    if (seen.has(t.name)) throw new Error(`duplicate tool in plan: ${t.name}`);
+    seen.add(t.name);
+  }
+  return tools;
+}
+
+function main() {
+  const planned = parsePlan(readFileSync(PLAN, 'utf8'));
+  const manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'));
+  const existing = new Set(manifest.tools.map((t) => t.name));
+
+  const collisions = planned.filter((t) => existing.has(t.name));
+  if (collisions.length) {
+    for (const c of collisions) console.error(`[seed] name already in manifest: ${c.name}`);
+    throw new Error('plan tool names collide with existing manifest entries — rename in the plan');
+  }
+
+  const byPart = { A: 0, B: 0, C: 0 };
+  for (const t of planned) byPart[t.plan_domain[0]]++;
+  console.log(`[seed] parsed ${planned.length} planned tools (community=${byPart.A}, admin=${byPart.B}, developer=${byPart.C})`);
+
+  if (DRY_RUN) {
+    console.log('[seed] dry-run: manifest not written');
+    return;
+  }
+
+  const tools = [...manifest.tools, ...planned];
+  writeFileSync(
+    MANIFEST,
+    JSON.stringify(
+      { ...manifest, generated_at: new Date().toISOString(), source: 'reconciled+plan-seed', total: tools.length, tools },
+      null,
+      2,
+    ) + '\n',
+  );
+  console.log(`[seed] wrote ${tools.length} tools to tool-manifest.json (+${planned.length} planned)`);
+}
+
+main();

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-07-06T14:48:07.618Z",
-  "source": "reconciled",
-  "total": 169,
+  "generated_at": "2026-07-12T18:17:25.959Z",
+  "source": "reconciled+plan-seed",
+  "total": 594,
   "tools": [
     {
       "name": "search_knowledge",
@@ -2645,6 +2645,6806 @@
       "wired_in": [
         "vertex"
       ]
+    },
+    {
+      "name": "search_marketplace",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Search products with filters (scope, category, price)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_product_details",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Read out one product (price, rating, description)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "browse_supplements",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Supplements catalog",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "add_supplement_to_regimen",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Add supplement to personal regimen",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_supplements",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Current regimen",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "remove_supplement_from_regimen",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Remove from regimen",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "browse_wellness_services",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Wellness services directory",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_provider_profile",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Provider/practitioner detail",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "browse_doctors_coaches",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Doctors & coaches directory",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_coach_compatibility",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Compatibility score with a coach",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "browse_deals_offers",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Current deals & offers",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "apply_discount_code",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Apply promo code",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_ai_product_picks",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Shopping-agent recommendations",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_orders",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Order history",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_order_status",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Track one order",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "reorder_last_order",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Repeat a previous order",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A1 Commerce & Marketplace Discovery",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "add_to_cart",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Add product to universal cart",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A2 Cart & Checkout",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "view_cart",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Read cart contents + total",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A2 Cart & Checkout",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "update_cart_item",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Change quantity",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A2 Cart & Checkout",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "remove_from_cart",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Remove item",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A2 Cart & Checkout",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "clear_cart",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Empty the cart",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A2 Cart & Checkout",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "set_shopping_budget",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Set/track budget meter",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A2 Cart & Checkout",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "review_agent_purchase_proposals",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Read pending AI purchase proposals",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A2 Cart & Checkout",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "start_checkout",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Begin Stripe checkout (hands off to screen for payment)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A2 Cart & Checkout",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_wallet_summary",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Balance + lifetime earnings + pending rewards + benefits",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_wallet_transactions",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Recent transactions",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "send_funds",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Transfer credits to a member (resolve recipient → confirm)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "request_payment",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Send a payment request",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "exchange_currency",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Exchange between currencies/credits",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_exchange_rate",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Current EUR/USD/token rate",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "set_display_currency",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Toggle display currency",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_referral_earnings",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Referral earnings snapshot",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_commissions_summary",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Commissions this month",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_pending_rewards",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Pending rewards",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_payment_requests",
+      "surface": "Wallet",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Incoming/outgoing requests",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A3 Wallet & Payments",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_my_subscription",
+      "surface": "Billing",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Current plan, renewal date, minutes left",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A4 Subscriptions & Billing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "compare_subscription_plans",
+      "surface": "Billing",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Plans + prices readout",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A4 Subscriptions & Billing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "upgrade_subscription",
+      "surface": "Billing",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Upgrade plan",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A4 Subscriptions & Billing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "cancel_subscription",
+      "surface": "Billing",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Cancel plan",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A4 Subscriptions & Billing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "add_voice_minutes",
+      "surface": "Billing",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Buy extra minutes",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A4 Subscriptions & Billing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "redeem_subscription_code",
+      "surface": "Billing",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Redeem sub code",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A4 Subscriptions & Billing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_billing_history",
+      "surface": "Billing",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Invoices/preview",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A4 Subscriptions & Billing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "redeem_voucher",
+      "surface": "Referrals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Redeem gift/voucher code",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A5 Vouchers & Referrals",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "send_gift_voucher",
+      "surface": "Referrals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Gift a voucher to someone",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A5 Vouchers & Referrals",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_referral_link",
+      "surface": "Referrals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Read/share referral link",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A5 Vouchers & Referrals",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "invite_friend",
+      "surface": "Referrals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Send an invite",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A5 Vouchers & Referrals",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_referral_status",
+      "surface": "Referrals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Who joined via my link",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A5 Vouchers & Referrals",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "activate_reseller",
+      "surface": "Referrals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Activate reseller status",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A5 Vouchers & Referrals",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_services",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "My service listings",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "create_service",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Create a service listing",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "update_service",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Edit price/description/availability",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "archive_service",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Take a service offline",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_packages",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "My packages",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "create_package",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Create package/bundle",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_clients",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Client list",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_client_overview",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "One client's history",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_business_orders",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Incoming orders",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_business_order_detail",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "One order",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_business_kpis",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Revenue/booking KPIs",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_earnings_breakdown",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Earnings by source + ledger",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_business_opportunities",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Missions/opportunities",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_reseller_payouts",
+      "surface": "Business",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Reseller sales & payouts",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A6 Business Hub — seller/creator side",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_live_rooms_now",
+      "surface": "LiveRooms",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "What's live right now",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A7 Live Rooms / Go Live",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_live_room_details",
+      "surface": "LiveRooms",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Room info, host, access price",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A7 Live Rooms / Go Live",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "go_live",
+      "surface": "LiveRooms",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Start hosting (opens room)",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A7 Live Rooms / Go Live",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "create_live_room",
+      "surface": "LiveRooms",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Create a room",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A7 Live Rooms / Go Live",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "schedule_live_session",
+      "surface": "LiveRooms",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Schedule future session",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A7 Live Rooms / Go Live",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "purchase_room_access",
+      "surface": "LiveRooms",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Buy access to a paid room",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A7 Live Rooms / Go Live",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "extend_live_session",
+      "surface": "LiveRooms",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Extend timer",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A7 Live Rooms / Go Live",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "end_live_session",
+      "surface": "LiveRooms",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "End my stream",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A7 Live Rooms / Go Live",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "play_room_recording",
+      "surface": "LiveRooms",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Watch a past recording",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A7 Live Rooms / Go Live",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "send_group_chat_message",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Message a group thread",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A8 Messaging depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "reply_to_message",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Quote-reply to a specific message",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A8 Messaging depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "react_to_message",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Emoji-react",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A8 Messaging depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "create_group_chat",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "New group conversation",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A8 Messaging depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "add_group_chat_member",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Add member to group chat",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A8 Messaging depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "leave_group_chat",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Leave a group thread",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A8 Messaging depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "send_calendar_invite_in_chat",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Share a calendar invite in a DM",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A8 Messaging depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "start_voice_call",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Call a member (WebRTC)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A8 Messaging depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "start_video_call",
+      "surface": "Chat",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Video-call a member",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A8 Messaging depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "share_post",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Share/repost content",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "bookmark_post",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Save content",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_bookmarks",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Read saved items",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "edit_my_post",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Edit own post",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "delete_my_post",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Delete own post",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "comment_on_short",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Comment on a short video",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "post_open_ask",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Publish an Open Ask",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "answer_open_ask",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Answer someone's ask",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_open_asks",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Browse open asks",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "join_challenge",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Join a community challenge",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_challenge_progress",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "My challenge standing",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A9 Feed, Content, Shorts, Asks & Challenges",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "create_event",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Create a community event",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "update_my_event",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Edit my event",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "cancel_my_event",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Cancel my event",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "create_meetup",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Create a meetup",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "update_my_meetup",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Edit my meetup",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "invite_to_event",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Invite contacts/members",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "buy_event_ticket",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Purchase a ticket",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_event_tickets",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "My event tickets",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "share_event",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Share event link",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_event_attendees",
+      "surface": "Events",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Who's coming (organizer view)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A10 Events & Tickets",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "log_meal",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Log nutrition/meal",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "log_vitals",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Log BP/HR/weight etc.",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "log_mood",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Log mental-health check-in",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "log_biomarker",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Record a lab value",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_health_trends",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Trends across trackers",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_health_streaks",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Vitana streaks",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "order_lab_test",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Order a lab test",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_lab_results",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Read biomarker/lab results",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "generate_health_plan",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Run plan-generator wizard",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_health_plans",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Active plans",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_health_plan_progress",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Plan adherence",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_conditions",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Conditions & risks",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_health_education",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Education resources on a topic",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_next_best_action",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Today's next best health action",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "connect_health_device",
+      "surface": "Health",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Start device pairing (navigates)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A11 Health depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "set_goal",
+      "surface": "Goals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Set a goal / north star",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A12 Goals & Journey",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_my_goals",
+      "surface": "Goals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Active goals",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A12 Goals & Journey",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "update_goal",
+      "surface": "Goals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Adjust a goal",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A12 Goals & Journey",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_goal_progress",
+      "surface": "Goals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Progress readout",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A12 Goals & Journey",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_journey_checkpoints",
+      "surface": "Goals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Journey checkpoints",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A12 Goals & Journey",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_daily_priority",
+      "surface": "Goals",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Today's priority",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A12 Goals & Journey",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "edit_memory",
+      "surface": "Memory",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Correct a stored memory",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A13 Memory & Diary extras",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "archive_memory",
+      "surface": "Memory",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Archive (soft-hide) memory",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A13 Memory & Diary extras",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "reinforce_memory",
+      "surface": "Memory",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Mark memory as important",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A13 Memory & Diary extras",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "promote_memory_to_knowledge",
+      "surface": "Memory",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Promote to knowledge base",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A13 Memory & Diary extras",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "set_memory_permissions",
+      "surface": "Memory",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Memory privacy controls",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A13 Memory & Diary extras",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_what_vitana_knows",
+      "surface": "Memory",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "\"What do you know about me\" summary",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A13 Memory & Diary extras",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "add_diary_photo",
+      "surface": "Memory",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Attach photo to diary (navigates to picker)",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A13 Memory & Diary extras",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "set_profile_theme",
+      "surface": "Profile",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Change profile theme",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A14 Profile & Social depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_profile_completeness",
+      "surface": "Profile",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Completeness % + missing items",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A14 Profile & Social depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "add_gallery_photo",
+      "surface": "Profile",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Add to gallery (navigates to picker)",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A14 Profile & Social depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "share_my_profile",
+      "surface": "Profile",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Share profile link/QR",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A14 Profile & Social depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_my_milestones",
+      "surface": "Profile",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Achievements & milestones",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A14 Profile & Social depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "view_member_profile",
+      "surface": "Profile",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Spoken summary of a member",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A14 Profile & Social depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_member_posts",
+      "surface": "Profile",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "A member's recent posts",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A14 Profile & Social depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "update_service_offerings",
+      "surface": "Profile",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Edit services shown on profile",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A14 Profile & Social depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_contacts",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "My contacts",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "add_contact",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Add a contact",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "sync_contacts",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Trigger contact import/sync",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "create_campaign",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Create sharing campaign",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "activate_campaign",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Activate a campaign",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "get_campaign_stats",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Campaign performance",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "schedule_social_post",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Schedule post to socials",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "list_scheduled_posts",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Scheduled queue",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "cancel_scheduled_post",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Remove from queue",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "share_to_social",
+      "surface": "Campaigns",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Share now to connected platform",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A15 Contacts, Campaigns & Social Sharing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "set_notification_preferences",
+      "surface": "Settings",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Per-category notif prefs",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A16 Notifications & Settings depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "enable_do_not_disturb",
+      "surface": "Settings",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "DND / quiet hours",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A16 Notifications & Settings depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "connect_google_account",
+      "surface": "Settings",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Start Google connect flow",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "A16 Notifications & Settings depth",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_lookup_user",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Find user by name/email/vitana_id",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B1 Users & RBAC",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_users",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "List/filter users",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B1 Users & RBAC",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_user_detail",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Full user record",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B1 Users & RBAC",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_roles_summary",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Role distribution",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B1 Users & RBAC",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_grant_role",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Grant a role",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B1 Users & RBAC",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_revoke_role",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Revoke a role",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B1 Users & RBAC",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_set_trust_tier",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Change trust tier",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B1 Users & RBAC",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_at_risk_members",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "At-risk members (overview)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B1 Users & RBAC",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_tenants",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Tenants list",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B2 Tenants & Settings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_tenant",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Tenant detail",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B2 Tenants & Settings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_tenant_profile",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Edit tenant profile",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B2 Tenants & Settings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_feature_flags",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Read flags",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B2 Tenants & Settings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_set_feature_flag",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Flip a flag",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B2 Tenants & Settings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_branding",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Branding settings",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B2 Tenants & Settings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_tenant_integrations",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Integrations status",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B2 Tenants & Settings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_signups",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Recent signups",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B3 Signups & Invitations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_signup_stats",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Signup funnel stats",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B3 Signups & Invitations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_signup_attempts",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Failed/pending attempts",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B3 Signups & Invitations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_repair_signup",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Repair a broken signup",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B3 Signups & Invitations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_create_invitation",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Invite someone",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B3 Signups & Invitations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_invitations",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Open invitations",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B3 Signups & Invitations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_revoke_invitation",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Revoke invitation",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B3 Signups & Invitations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_moderation_queue",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Pending items",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B4 Content Moderation",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_moderation_item",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One item detail",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B4 Content Moderation",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_moderation_stats",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Queue stats",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B4 Content Moderation",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_approve_content",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Approve item",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B4 Content Moderation",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_reject_content",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Reject/remove item",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B4 Content Moderation",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_flag_content",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Flag for review",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "B4 Content Moderation",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_reports",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "User reports",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B4 Content Moderation",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_report",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One report",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B4 Content Moderation",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_meetups",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "All meetups",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B5 Community Oversight",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_delete_meetup",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Remove a meetup",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B5 Community Oversight",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_groups",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "All groups",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B5 Community Oversight",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_live_rooms",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "All live rooms (supervision)",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B5 Community Oversight",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_creators",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Creators list",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B5 Community Oversight",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_memberships",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Memberships",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B5 Community Oversight",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_community_stats",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Community-wide stats",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B5 Community Oversight",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_activity_feed",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Tenant activity feed + alerts",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B5 Community Oversight",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_marketplace_overview",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Marketplace KPIs",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_merchants",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Merchants",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_merchant",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Edit merchant status",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_products",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Products (admin view)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_product",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Edit/approve product",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_bulk_product_action",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Bulk enable/disable",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_feed_curation",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Curation rules",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_feed_curation",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Change curation",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_geo_policies",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Geo policies",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_geo_policy",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Edit geo policy",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_trigger_source_sync",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Sync a product network",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_ingestion_coverage",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Ingestion runs & coverage",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B6 Marketplace Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_credit_wallet",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Credit a user's wallet",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B7 Billing & Wallet Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_debit_wallet",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Debit adjustment",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B7 Billing & Wallet Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_founding_status",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Founding-member status",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B7 Billing & Wallet Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_monetization_config",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Monetization config",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B7 Billing & Wallet Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_monetization_config",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Update config",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B7 Billing & Wallet Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_run_monetization_detect",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run detection",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "B7 Billing & Wallet Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_kb_search",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Search tenant KB",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B8 Knowledge Base Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_kb_list_docs",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "List docs",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B8 Knowledge Base Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_kb_create_doc",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Create doc",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B8 Knowledge Base Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_kb_update_doc",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Update doc",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B8 Knowledge Base Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_kb_delete_doc",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Delete doc",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B8 Knowledge Base Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_kb_reindex",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Reindex KB",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B8 Knowledge Base Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_kb_baseline_optout",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Opt out of a baseline doc",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B8 Knowledge Base Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_system_kb_update",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Update system KB doc (exafy_admin)",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B8 Knowledge Base Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_assistant_config",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Config per surface",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B9 Assistant & Voice Config",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_set_assistant_config",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Update config",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B9 Assistant & Voice Config",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_assistant_speeches",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Canned speeches",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B9 Assistant & Voice Config",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_set_assistant_speech",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Edit a speech",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B9 Assistant & Voice Config",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_awareness_config",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Awareness registry",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B9 Assistant & Voice Config",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_set_awareness_config",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Set awareness signal config",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B9 Assistant & Voice Config",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_bulk_set_awareness",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Bulk update",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B9 Assistant & Voice Config",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_specialists",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Personas",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_specialist",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One persona + versions",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_create_specialist",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "New persona",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_specialist",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Edit persona",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_rollback_specialist",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Roll back version",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_set_specialist_tools",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Bind tools",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_set_specialist_kb",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Bind KB",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_set_specialist_status",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Enable/disable",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_test_specialist_connection",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Test connection",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_approve_specialist_ticket",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Approve lifecycle ticket",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B10 Specialists / Personas",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_compose_broadcast",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Draft a broadcast (returns preview)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "B11 Notifications & Broadcast",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_send_broadcast",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Send to audience",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B11 Notifications & Broadcast",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_broadcasts",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Sent history",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B11 Notifications & Broadcast",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_notification_pref_stats",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Opt-in/out stats",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B11 Notifications & Broadcast",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_create_notification_category",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "New category",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B11 Notifications & Broadcast",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_notification_category",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Edit category",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B11 Notifications & Broadcast",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_test_notification_category",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Send test",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "B11 Notifications & Broadcast",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_governance_status",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Governance status",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B12 Governance & Controls",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_governance_rules",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Rules",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B12 Governance & Controls",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_violations",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Violations feed",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B12 Governance & Controls",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_proposals",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Proposals",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B12 Governance & Controls",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_create_proposal",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "New proposal",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B12 Governance & Controls",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_proposal_status",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Approve/reject proposal",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B12 Governance & Controls",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_control_key",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Read a control (kill switches)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B12 Governance & Controls",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_set_control_key",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Flip a control key",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B12 Governance & Controls",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_autopilot_settings",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Settings",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B13 Autopilot Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_autopilot_settings",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Patch settings",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B13 Autopilot Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_autopilot_bindings",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Bindings",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B13 Autopilot Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_create_autopilot_binding",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "New binding",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B13 Autopilot Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_delete_autopilot_binding",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Remove binding",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B13 Autopilot Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_autopilot_runs",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Runs",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B13 Autopilot Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_autopilot_run_stats",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run stats",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B13 Autopilot Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_update_autopilot_wave",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Edit wave",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B13 Autopilot Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_analytics_summary",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Product analytics summary",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_assistant_analytics",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Assistant usage",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_journey_analytics",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Journeys",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_feature_analytics",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Feature usage",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_interest_analytics",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Interests",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_intent_engine_stats",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Intent/match KPIs",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_close_intent",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Force-close an intent",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_recompute_intent",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Recompute matches",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_resolve_dispute",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Resolve match dispute",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_archive_intent",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Archive intent",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "B14 Analytics & Intent Engine",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_feedback_tickets",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Support tickets",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B15 Feedback & Support Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_get_feedback_ticket",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One ticket",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B15 Feedback & Support Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_feedback_kpis",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Support KPIs",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B15 Feedback & Support Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_list_handoffs",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Recent handoffs",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "B15 Feedback & Support Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_act_on_ticket",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Resolve/assign/respond",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "B15 Feedback & Support Admin",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_audit_actions_log",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Admin actions audit",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "B16 Audit, i18n & Memory Ops",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_audit_access_log",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Access audit",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "B16 Audit, i18n & Memory Ops",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_i18n_translate",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run translation job",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B16 Audit, i18n & Memory Ops",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_i18n_audit",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run LLM locale audit",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B16 Audit, i18n & Memory Ops",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_run_memory_consolidator",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run memory consolidation",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B16 Audit, i18n & Memory Ops",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "admin_run_embeddings_backfill",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run embeddings backfill",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "B16 Audit, i18n & Memory Ops",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_allocate_vtid",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Allocate a new VTID",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_create_task",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Create OASIS task",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_update_task",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Patch task fields",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_cancel_task",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Cancel task",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_complete_task",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Mark complete",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_terminalize_vtid",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Set is_terminal + outcome",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_discover_tasks",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Discover eligible tasks",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_vtid_projection",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "VTID projection",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_allocator_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Allocator on/off + health",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_query_oasis_events",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Query events by vtid/type/time",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_execute_vtid",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Trigger execution",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_run_exec_workflow",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run a workflow",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_submit_evidence",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Submit evidence for a VTID",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_work_orders",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Work orders",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_work_order",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One work order",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C1 VTID / OASIS Lifecycle",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_evaluate_governance",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Evaluate action against rules",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_governance_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Status snapshot",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_governance_rules",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Rules",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_governance_rule",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One rule by code",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_violations",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Violations",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_enforcements",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Enforcements",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_governance_feed",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Live feed",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_proposals",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Proposals",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_create_proposal",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "New proposal",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_update_proposal",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Update status",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_control",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Read control key (EXECUTION_DISARMED etc.)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_set_control",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Flip control key",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_control_history",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Key history",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C2 Governance",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_create_pr",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Create PR from branch",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_pr_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "PR state + mergeability",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_pr_checks",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Check runs for a PR",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_open_prs",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Open PRs w/ status",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_merge_pr",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Merge via governed pipeline",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_safe_merge",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Safe-merge flow",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_revert_pr",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Create revert PR",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_trigger_workflow",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Dispatch a GH workflow",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_workflow_runs",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Runs for a workflow",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_run_jobs",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Jobs + failures for a run",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_merge_lock",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Merge lock status",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_release_merge_lock",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Release stuck lock",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_cicd_health",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "CI/CD pipeline health",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_approvals_feed",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Approvals activity feed",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C3 CI/CD & Pull Requests",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_deploy_service",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Deploy a service (staging path)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_publish_to_prod",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "The PUBLISH button by voice (double confirm + reason)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "double_confirm",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_revisions",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Cloud Run revisions",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_deployments",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Deployment history",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_deployment_health",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Deploy health",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_promote_canary",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Promote canary",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_abort_canary",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Abort canary",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_revert_deploy",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Revert gateway",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_revert_both",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Revert gateway + frontend",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_canary_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Canary target status",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_staging_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "What's on staging (env, build)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_compare_staging_prod",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Diff staging vs prod builds",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_release_feed",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Recent releases",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C4 Deployment & Release",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_workers",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Registered workers",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_orchestrator_stats",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Stats",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_pending_worker_tasks",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Pending queue",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_task_progress",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Progress of claimed task",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_release_claim",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Release a stuck claim",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_subagents",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Subagents",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_worker_skills",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Skills",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_cleanup_stale_claims",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Cleanup stale claims",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_orchestrator_health",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Health",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_route_to_subagent",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Route task to subagent",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C5 Worker Orchestrator",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_autopilot_loop_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Loop status",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_start_autopilot_loop",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Start loop",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_stop_autopilot_loop",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Stop loop",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_autopilot_loop_history",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Loop history",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_reset_loop_cursor",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Reset cursor",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_controller_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Controller status",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_controller_runs",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Runs",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_controller_run",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One run",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_plan_task",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Plan a VTID",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_start_task_work",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Start work",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_complete_task_work",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Complete work",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_validate_task",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Validate",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_pending_plans",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Pending plans",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_task_spec",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Spec for VTID",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_autopilot_pipeline_health",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Pipeline health + summary",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C6 Autopilot Controller & Loop",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_trigger_scan",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run a scanner",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_scanners",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Scanners",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_impact_rules",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Impact rules",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_auto_approve_config",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Auto-approve config",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_scan_runs",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Scan runs",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_scan_run",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One run",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_findings_queue",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Findings queue",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_finding",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One finding",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_generate_finding_plan",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Generate fix plan",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_reject_finding",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Reject finding",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_snooze_finding",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Snooze",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_approve_auto_execute",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Approve auto-execution",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_cancel_execution",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Cancel execution",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_executions",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Executions",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_execution_lineage",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Lineage",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_report_incident",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "File an incident",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_healing_config",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Config",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_set_healing_mode",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Change mode",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_healing_kill_switch",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Flip kill switch",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_healing_history",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Heal history",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_healing_metrics",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Metrics summary",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_approve_heal",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Approve pending heal",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_reject_heal",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Reject heal",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_verify_heal",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Verify a heal",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_rollback_heal",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Roll back a heal",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_quarantine",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Quarantined items",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_release_quarantine",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Release from quarantine",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_shadow_comparison",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Staging shadow-comparison report",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C8 Self-Healing",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_build_info",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Running revision/build per service",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_service_health",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "/alive + health across services",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_error_rate",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Recent error rates",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_latency_summary",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Latency percentiles",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_telemetry_snapshot",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Telemetry snapshot",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_recent_events",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Recent OASIS/system events",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_agent_trace",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "ORB agent trace",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_supervisor_summary",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Supervisor summary",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_session_turns",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Voice session turns",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_session_diagnostics",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Session diagnostics",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_conversation_decisions",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Greeting/NBA decisions",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_tool_failures",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Recent tool failures",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_tool_health",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Tool health dashboard",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_greeting_decisions",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Greeting monitor",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_agent_detail",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One registered agent detail",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "C9 Observability",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_run_test_suite",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run a suite",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_test_suites",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Suites",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_test_runs",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Runs",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_test_run",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One run + failures",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_run_e2e",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Trigger E2E workflow",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_orb_monitor_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "ORB monitor status",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_trigger_orb_monitor",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Trigger ORB monitor",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_test_contracts",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Test contracts",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_run_orb_selfcheck",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "ORB tools selfcheck",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_voice_lab_probe",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Voice-lab probe",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "C10 Testing & QA",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_pending_migrations",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Unapplied migration files",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C11 Database & Migrations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_run_staging_migration",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Dispatch staging migration",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "C11 Database & Migrations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_run_prod_migration",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Dispatch prod migration (double confirm + reason)",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "double_confirm",
+      "plan_domain": "C11 Database & Migrations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_migration_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Last migration run status",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C11 Database & Migrations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_run_backfill",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Run a named backfill",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "C11 Database & Migrations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_schema_info",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Table/schema summary from DATABASE_SCHEMA.md",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C11 Database & Migrations",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_list_dev_users",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Dev-access users",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_grant_access",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Grant dev access",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_revoke_access",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Revoke dev access",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_mint_token",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Mint a dev token",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_open_hub_panel",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Navigate Command Hub to module/tab",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_run_simulator",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Dry-run conversation decision for a user",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_journey_context",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Journey context readout",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_voice_catalog_stats",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Catalog stats (live/planned/parity)",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_get_voice_tool_detail",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "One tool's manifest entry",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_run_routine_now",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Fire a routine immediately",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
+    },
+    {
+      "name": "dev_system_briefing",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "description": "Composite morning briefing: health + deploys + approvals + violations + failing checks",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "C12 Dev Access, Simulator & Meta",
+      "plan": "expansion-v2"
     }
   ]
 }


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-VOICE-CATALOG-V2-PLAN`

**Layer:** Voice tools catalog (manifest + docs + tooling — no runtime behavior change)

**Priority:** P1 (roadmap/catalog seeding)

---

## 📋 Summary

Materializes the **approved Voice Tools Expansion Plan v2**: all **425 future voice tools** are seeded into `tool-manifest.json` as `status: planned` / `wired_in: []`, so the Command Hub Tool Catalog now shows the complete roadmap alongside the 169 live tools (594 total).

Split per the approved plan:
- **+150 community** — commerce/marketplace, cart & checkout, wallet transfers & payment requests, subscriptions, vouchers/referrals, Business Hub seller tools, live rooms, messaging depth, feed/content, events + tickets, health depth (labs, plans), goals, memory/profile depth, campaigns
- **+125 admin** — users/RBAC, tenants, signups/invitations, moderation, community oversight, marketplace admin, billing/wallet admin, KB, assistant/voice config, specialists, broadcast, governance controls, autopilot admin, analytics/intent engine, feedback, audit/i18n/memory ops
- **+150 developer** — VTID/OASIS lifecycle, governance, CI/CD & PRs, deployment incl. `dev_publish_to_prod`, worker orchestrator, autopilot controller/loop, scanners/findings, self-healing, observability, testing, migrations, dev access & meta

Approved decisions baked into the doc: keep 425; voice completes **internal user-to-user credit transfers only** (card/Stripe flows hand off to screen); `dev_publish_to_prod` ships in Wave 2 with double-confirm + spoken reason; no Professional/Staff catalog.

## ✅ Changes

- `docs/VOICE_TOOLS_EXPANSION_PLAN.md` — the approved plan; source of truth for planned entries (every tool named, risk-classified, mapped to an existing backend endpoint; 6-wave delivery)
- `scripts/voice-tools-plan-seed.mjs` — parses the plan tables → merges planned entries into the manifest; idempotent, hard-fails on duplicate names, existing-manifest collisions, or section count mismatches
- `services/gateway/src/services/tool-manifest.json` — 169 live + 425 planned = 594; new entries carry `priority` (P0/P1/P2), `risk` (read/write/confirm/double_confirm), `plan_domain` metadata

## 🧪 Testing

- [x] `node scripts/voice-tools-plan-seed.mjs --dry-run` — parses exactly 425 (150/125/150), zero collisions
- [x] `node scripts/voice-tools-manifest-reconcile.mjs --check` — ✅ manifest in sync, zero drift (planned entries are exactly what the reconciler normalizes to)
- [x] `npm run build` (gateway) — clean; catalog route already supports `planned` + empty `wired_in`
- [x] Verified `livekit-test-coverage` and voice-lab parity only compare against the manifest's **live** set — planned entries don't affect them

## 🚨 Breaking Changes

None — no handler, route, or pipeline changes. Catalog UI gains 425 "Planned" rows; live tool count is unchanged at 169.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX)_