### PR TITLE
feat(voice): Wave 1 of Voice Tools Expansion Plan v2 — 69 community P0 tools (commerce, wallet, messaging, events, health)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -2826,6 +2826,744 @@ async def dev_list_agents(context: RunContext, tier: str | None = None) -> str:
 
 
 # ---------------------------------------------------------------------------
+# BOOTSTRAP-VOICE-TOOLS-CATALOG-WAVE1 — 69 new voice tools built out from six
+# gateway handler modules (services/gateway/src/services/orb-tools/*.ts),
+# reached through the shared dispatcher exactly like the tools above. All use
+# _dispatch_with_directive since several of these (navigation redirects to
+# cart/checkout/product/event screens) can carry a `directive` payload.
+# ---------------------------------------------------------------------------
+
+
+# --- A1 Marketplace & Discovery (16) ---------------------------------------
+
+
+@function_tool
+async def search_marketplace(context: RunContext, q: str | None = None, category: str | None = None, price_min_cents: float | None = None, price_max_cents: float | None = None, limit: float | None = None) -> str:
+    """Search the Maxina marketplace for products by free-text query, category, or price range."""
+    body = await _dispatch_with_directive(context, "search_marketplace", {
+            "q": q,
+            "category": category,
+            "price_min_cents": price_min_cents,
+            "price_max_cents": price_max_cents,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_product_details(context: RunContext, product_id: str | None = None, query: str | None = None) -> str:
+    """Get details for one marketplace product by id or by spoken name."""
+    body = await _dispatch_with_directive(context, "get_product_details", {
+            "product_id": product_id,
+            "query": query,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def browse_supplements(context: RunContext, limit: float | None = None) -> str:
+    """Browse the marketplace supplements shop (not the personal supplement tracker)."""
+    body = await _dispatch_with_directive(context, "browse_supplements", {
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def add_supplement_to_regimen(context: RunContext, name: str | None = None) -> str:
+    """NOT CURRENTLY AVAILABLE via voice — the personal supplement tracker has no gateway-side backing yet."""
+    body = await _dispatch_with_directive(context, "add_supplement_to_regimen", {
+            "name": name,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_my_supplements(context: RunContext) -> str:
+    """NOT CURRENTLY AVAILABLE via voice — always returns an error."""
+    body = await _dispatch_with_directive(context, "list_my_supplements")
+    return summarize(body)
+
+
+@function_tool
+async def remove_supplement_from_regimen(context: RunContext, name: str | None = None) -> str:
+    """NOT CURRENTLY AVAILABLE via voice — always returns an error."""
+    body = await _dispatch_with_directive(context, "remove_supplement_from_regimen", {
+            "name": name,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def browse_wellness_services(context: RunContext, limit: float | None = None) -> str:
+    """Browse wellness/nutrition/fitness/therapy/lab services listed in the marketplace."""
+    body = await _dispatch_with_directive(context, "browse_wellness_services", {
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_provider_profile(context: RunContext, provider_id: str | None = None, query: str | None = None) -> str:
+    """Get one service/provider listing by id or spoken name (doctor, coach, wellness provider, etc)."""
+    body = await _dispatch_with_directive(context, "get_provider_profile", {
+            "provider_id": provider_id,
+            "query": query,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def browse_doctors_coaches(context: RunContext, limit: float | None = None) -> str:
+    """Browse doctors and coaches listed in the marketplace."""
+    body = await _dispatch_with_directive(context, "browse_doctors_coaches", {
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_coach_compatibility(context: RunContext, provider_id: str | None = None) -> str:
+    """NOT CURRENTLY AVAILABLE via voice — no compatibility-scoring system exists yet."""
+    body = await _dispatch_with_directive(context, "get_coach_compatibility", {
+            "provider_id": provider_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def browse_deals_offers(context: RunContext, limit: float | None = None) -> str:
+    """Browse marketplace products currently on sale (discounted vs. their reference price)."""
+    body = await _dispatch_with_directive(context, "browse_deals_offers", {
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def apply_discount_code(context: RunContext, code: str | None = None) -> str:
+    """NOT CURRENTLY AVAILABLE via voice — the discount-code system has no gateway-side backing yet."""
+    body = await _dispatch_with_directive(context, "apply_discount_code", {
+            "code": code,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_ai_product_picks(context: RunContext, prompt: str, max_items: float | None = None) -> str:
+    """Have the Vitana shopping agent propose marketplace products for a goal or need and stage them in the cart."""
+    body = await _dispatch_with_directive(context, "get_ai_product_picks", {
+            "prompt": prompt,
+            "max_items": max_items,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_my_orders(context: RunContext, limit: float | None = None) -> str:
+    """List the user's recent marketplace orders with status and amount."""
+    body = await _dispatch_with_directive(context, "list_my_orders", {
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_order_status(context: RunContext, order_id: str | None = None) -> str:
+    """Check the status of one order by id, or the most recent order if no id is given."""
+    body = await _dispatch_with_directive(context, "get_order_status", {
+            "order_id": order_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def reorder_last_order(context: RunContext, confirm: bool | None = None) -> str:
+    """Add the user's most recent (still-available) purchase back to the cart. Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "reorder_last_order", {
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+# --- A2 Cart & Checkout (8) -------------------------------------------------
+
+
+@function_tool
+async def add_to_cart(context: RunContext, product_id: str | None = None, query: str | None = None, quantity: float | None = None) -> str:
+    """Add a marketplace product to the user's cart, by product_id or fuzzy product name."""
+    body = await _dispatch_with_directive(context, "add_to_cart", {
+            "product_id": product_id,
+            "query": query,
+            "quantity": quantity,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def view_cart(context: RunContext) -> str:
+    """Read the contents of the user's cart: items, quantities, prices, and the total."""
+    body = await _dispatch_with_directive(context, "view_cart")
+    return summarize(body)
+
+
+@function_tool
+async def update_cart_item(context: RunContext, quantity: float, item_id: str | None = None, query: str | None = None) -> str:
+    """Change the quantity of an item already in the cart, by item_id or fuzzy product name."""
+    body = await _dispatch_with_directive(context, "update_cart_item", {
+            "item_id": item_id,
+            "query": query,
+            "quantity": quantity,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def remove_from_cart(context: RunContext, item_id: str | None = None, query: str | None = None) -> str:
+    """Remove a single item from the cart, by item_id or fuzzy product name."""
+    body = await _dispatch_with_directive(context, "remove_from_cart", {
+            "item_id": item_id,
+            "query": query,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def clear_cart(context: RunContext, confirm: bool | None = None) -> str:
+    """Remove ALL items from the cart. Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "clear_cart", {
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def set_shopping_budget(context: RunContext, monthly_cap_amount: float | None = None, clear: bool | None = None) -> str:
+    """Set or clear the user's monthly shopping budget cap (advisory only, never blocks purchases)."""
+    body = await _dispatch_with_directive(context, "set_shopping_budget", {
+            "monthly_cap_amount": monthly_cap_amount,
+            "clear": clear,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def review_agent_purchase_proposals(context: RunContext) -> str:
+    """List the items the shopping agent (autopilot) has proposed and placed into the user's cart for review."""
+    body = await _dispatch_with_directive(context, "review_agent_purchase_proposals")
+    return summarize(body)
+
+
+@function_tool
+async def start_checkout(context: RunContext, confirm: bool | None = None) -> str:
+    """Begin checkout for the user's cart. Call once without confirm first; never charges anything by voice."""
+    body = await _dispatch_with_directive(context, "start_checkout", {
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+# --- A3 Wallet & Payments (11) ----------------------------------------------
+
+
+@function_tool
+async def get_wallet_summary(context: RunContext) -> str:
+    """READ-ONLY wallet snapshot: balance per currency, active subscription, and referral rewards."""
+    body = await _dispatch_with_directive(context, "get_wallet_summary")
+    return summarize(body)
+
+
+@function_tool
+async def list_wallet_transactions(context: RunContext, limit: float | None = None, currency: str | None = None, cursor: str | None = None) -> str:
+    """READ-ONLY: list the user's recent wallet transactions, newest first."""
+    body = await _dispatch_with_directive(context, "list_wallet_transactions", {
+            "limit": limit,
+            "currency": currency,
+            "cursor": cursor,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def send_funds(context: RunContext, recipient_name: str | None = None, recipient_user_id: str | None = None, amount: float | None = None, currency: str | None = None, confirm: bool | None = None) -> str:
+    """Send money from the user's wallet to another Vitana member (internal transfer only, never a card charge)."""
+    body = await _dispatch_with_directive(context, "send_funds", {
+            "recipient_name": recipient_name,
+            "recipient_user_id": recipient_user_id,
+            "amount": amount,
+            "currency": currency,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def request_payment(context: RunContext, recipient_name: str | None = None, amount: float | None = None, currency: str | None = None, description: str | None = None) -> str:
+    """NOT YET AVAILABLE — always returns an error explaining there is no backing endpoint for payment requests."""
+    body = await _dispatch_with_directive(context, "request_payment", {
+            "recipient_name": recipient_name,
+            "amount": amount,
+            "currency": currency,
+            "description": description,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def exchange_currency(context: RunContext, amount: float | None = None, from_currency: str | None = None, to_currency: str | None = None, confirm: bool | None = None) -> str:
+    """NOT YET AVAILABLE — always returns an error: the wallet has no cross-currency conversion RPC."""
+    body = await _dispatch_with_directive(context, "exchange_currency", {
+            "amount": amount,
+            "from_currency": from_currency,
+            "to_currency": to_currency,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_exchange_rate(context: RunContext, from_currency: str | None = None, to_currency: str | None = None) -> str:
+    """NOT YET AVAILABLE — always returns an error: no exchange-rate table/RPC is wired into the gateway."""
+    body = await _dispatch_with_directive(context, "get_exchange_rate", {
+            "from_currency": from_currency,
+            "to_currency": to_currency,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def set_display_currency(context: RunContext, currency: str | None = None) -> str:
+    """NOT YET AVAILABLE — always returns an error: the display-currency toggle is stored only in the browser."""
+    body = await _dispatch_with_directive(context, "set_display_currency", {
+            "currency": currency,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_referral_earnings(context: RunContext) -> str:
+    """READ-ONLY: total referral rewards earned (confirmed) and pending, from the user's reward ledger."""
+    body = await _dispatch_with_directive(context, "get_referral_earnings")
+    return summarize(body)
+
+
+@function_tool
+async def get_commissions_summary(context: RunContext) -> str:
+    """READ-ONLY: commissions earned this calendar month — total, confirmed, and still-pending amounts."""
+    body = await _dispatch_with_directive(context, "get_commissions_summary")
+    return summarize(body)
+
+
+@function_tool
+async def get_pending_rewards(context: RunContext) -> str:
+    """READ-ONLY: rewards awaiting merchant confirmation (not yet payable)."""
+    body = await _dispatch_with_directive(context, "get_pending_rewards")
+    return summarize(body)
+
+
+@function_tool
+async def list_payment_requests(context: RunContext, direction: str | None = None) -> str:
+    """NOT YET AVAILABLE — always returns an error: payment requests have no structured table to list from."""
+    body = await _dispatch_with_directive(context, "list_payment_requests", {
+            "direction": direction,
+        })
+    return summarize(body)
+
+
+# --- A8 Messaging Depth (9) --------------------------------------------------
+
+
+@function_tool
+async def send_group_chat_message(context: RunContext, message: str, group: str | None = None, group_id: str | None = None, confirmed: bool | None = None) -> str:
+    """Send a text message to a group chat the user is a member of (not a 1-to-1 DM). Call once without confirmed first."""
+    body = await _dispatch_with_directive(context, "send_group_chat_message", {
+            "group": group,
+            "group_id": group_id,
+            "message": message,
+            "confirmed": confirmed,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def reply_to_message(context: RunContext, message_id: str | None = None, message: str | None = None) -> str:
+    """NOT AVAILABLE YET — Vitana chat has no reply/quote-thread feature; always answers that it is unavailable."""
+    body = await _dispatch_with_directive(context, "reply_to_message", {
+            "message_id": message_id,
+            "message": message,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def react_to_message(context: RunContext, message_id: str, emoji: str, remove: bool | None = None) -> str:
+    """Add (or remove) an emoji reaction on a chat message — one of the six supported emoji only."""
+    body = await _dispatch_with_directive(context, "react_to_message", {
+            "message_id": message_id,
+            "emoji": emoji,
+            "remove": remove,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def create_group_chat(context: RunContext, name: str, description: str | None = None, members: list[str] | None = None, confirm: bool | None = None) -> str:
+    """Create a new group chat, optionally adding named members immediately. Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "create_group_chat", {
+            "name": name,
+            "description": description,
+            "members": members,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def add_group_chat_member(context: RunContext, group: str | None = None, group_id: str | None = None, member: str | None = None, member_user_id: str | None = None) -> str:
+    """Add a community member to a group chat the user already belongs to."""
+    body = await _dispatch_with_directive(context, "add_group_chat_member", {
+            "group": group,
+            "group_id": group_id,
+            "member": member,
+            "member_user_id": member_user_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def leave_group_chat(context: RunContext, group: str | None = None, group_id: str | None = None, confirm: bool | None = None) -> str:
+    """Leave a group chat. Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "leave_group_chat", {
+            "group": group,
+            "group_id": group_id,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def send_calendar_invite_in_chat(context: RunContext, member: str | None = None, member_user_id: str | None = None, event: str | None = None, event_id: str | None = None, confirmed: bool | None = None) -> str:
+    """Share one of the user's own upcoming calendar events with a community member via direct message."""
+    body = await _dispatch_with_directive(context, "send_calendar_invite_in_chat", {
+            "member": member,
+            "member_user_id": member_user_id,
+            "event": event,
+            "event_id": event_id,
+            "confirmed": confirmed,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def start_voice_call(context: RunContext, member: str | None = None, member_user_id: str | None = None, confirmed: bool | None = None) -> str:
+    """Send another community member a request to start a voice call — Vitana cannot place a live call from voice."""
+    body = await _dispatch_with_directive(context, "start_voice_call", {
+            "member": member,
+            "member_user_id": member_user_id,
+            "confirmed": confirmed,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def start_video_call(context: RunContext, member: str | None = None, member_user_id: str | None = None, confirmed: bool | None = None) -> str:
+    """Send another community member a request to start a video call — Vitana cannot place a live call from voice."""
+    body = await _dispatch_with_directive(context, "start_video_call", {
+            "member": member,
+            "member_user_id": member_user_id,
+            "confirmed": confirmed,
+        })
+    return summarize(body)
+
+
+# --- A10 Events & Tickets (10) -----------------------------------------------
+
+
+@function_tool
+async def create_event(context: RunContext, title: str, start_time: str, description: str | None = None, location: str | None = None, virtual_link: str | None = None, end_time: str | None = None, max_participants: float | None = None, image_url: str | None = None, confirm: bool | None = None) -> str:
+    """Create a new ticketed/community event. Requires a title and start_time. Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "create_event", {
+            "title": title,
+            "description": description,
+            "location": location,
+            "virtual_link": virtual_link,
+            "start_time": start_time,
+            "end_time": end_time,
+            "max_participants": max_participants,
+            "image_url": image_url,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def update_my_event(context: RunContext, query: str | None = None, event_id: str | None = None, title: str | None = None, description: str | None = None, location: str | None = None, virtual_link: str | None = None, start_time: str | None = None, end_time: str | None = None, max_participants: float | None = None, image_url: str | None = None) -> str:
+    """Edit one of the user's own upcoming events. Only the creator can edit, and only before it starts."""
+    body = await _dispatch_with_directive(context, "update_my_event", {
+            "query": query,
+            "event_id": event_id,
+            "title": title,
+            "description": description,
+            "location": location,
+            "virtual_link": virtual_link,
+            "start_time": start_time,
+            "end_time": end_time,
+            "max_participants": max_participants,
+            "image_url": image_url,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def cancel_my_event(context: RunContext, query: str | None = None, event_id: str | None = None, confirm: bool | None = None) -> str:
+    """Cancel (delete) one of the user's own upcoming events. Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "cancel_my_event", {
+            "query": query,
+            "event_id": event_id,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def create_meetup(context: RunContext, title: str, start_time: str, description: str | None = None, location: str | None = None, virtual_link: str | None = None, end_time: str | None = None, max_participants: float | None = None, image_url: str | None = None, confirm: bool | None = None) -> str:
+    """Create a new casual community meetup. Requires a title and start_time. Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "create_meetup", {
+            "title": title,
+            "description": description,
+            "location": location,
+            "virtual_link": virtual_link,
+            "start_time": start_time,
+            "end_time": end_time,
+            "max_participants": max_participants,
+            "image_url": image_url,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def update_my_meetup(context: RunContext, query: str | None = None, event_id: str | None = None, title: str | None = None, description: str | None = None, location: str | None = None, virtual_link: str | None = None, start_time: str | None = None, end_time: str | None = None, max_participants: float | None = None, image_url: str | None = None) -> str:
+    """Edit one of the user's own upcoming meetups. Only the creator can edit, and only before it starts."""
+    body = await _dispatch_with_directive(context, "update_my_meetup", {
+            "query": query,
+            "event_id": event_id,
+            "title": title,
+            "description": description,
+            "location": location,
+            "virtual_link": virtual_link,
+            "start_time": start_time,
+            "end_time": end_time,
+            "max_participants": max_participants,
+            "image_url": image_url,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def invite_to_event(context: RunContext, event: str | None = None, event_id: str | None = None, member_name: str | None = None, member_user_id: str | None = None) -> str:
+    """Invite a community member to an event or meetup by spoken name."""
+    body = await _dispatch_with_directive(context, "invite_to_event", {
+            "event": event,
+            "event_id": event_id,
+            "member_name": member_name,
+            "member_user_id": member_user_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def buy_event_ticket(context: RunContext, event: str | None = None, event_id: str | None = None, ticket_name: str | None = None, ticket_type_id: str | None = None, quantity: float | None = None, confirm: bool | None = None) -> str:
+    """Buy a ticket for an event. Checks availability/price, then call once without confirm first."""
+    body = await _dispatch_with_directive(context, "buy_event_ticket", {
+            "event": event,
+            "event_id": event_id,
+            "ticket_name": ticket_name,
+            "ticket_type_id": ticket_type_id,
+            "quantity": quantity,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_my_event_tickets(context: RunContext) -> str:
+    """List the user's own purchased (completed) event tickets."""
+    body = await _dispatch_with_directive(context, "list_my_event_tickets")
+    return summarize(body)
+
+
+@function_tool
+async def share_event(context: RunContext, query: str | None = None, event_id: str | None = None) -> str:
+    """Get a shareable public link for an event or meetup."""
+    body = await _dispatch_with_directive(context, "share_event", {
+            "query": query,
+            "event_id": event_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_event_attendees(context: RunContext, query: str | None = None, event_id: str | None = None) -> str:
+    """List who has RSVP'd to one of the user's OWN events (organizer view only)."""
+    body = await _dispatch_with_directive(context, "get_event_attendees", {
+            "query": query,
+            "event_id": event_id,
+        })
+    return summarize(body)
+
+
+# --- A11 Health Depth (15) ---------------------------------------------------
+
+
+@function_tool
+async def log_meal(context: RunContext, description: str | None = None, meal_type: str | None = None, calories: float | None = None, date: str | None = None) -> str:
+    """Log a meal (breakfast/lunch/dinner/snack) toward the nutrition pillar."""
+    body = await _dispatch_with_directive(context, "log_meal", {
+            "description": description,
+            "meal_type": meal_type,
+            "calories": calories,
+            "date": date,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def log_vitals(context: RunContext, heart_rate: float | None = None, weight_kg: float | None = None, systolic: float | None = None, diastolic: float | None = None, date: str | None = None) -> str:
+    """Log vitals: heart rate, weight, and/or blood pressure. Pass any subset."""
+    body = await _dispatch_with_directive(context, "log_vitals", {
+            "heart_rate": heart_rate,
+            "weight_kg": weight_kg,
+            "systolic": systolic,
+            "diastolic": diastolic,
+            "date": date,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def log_mood(context: RunContext, mood_score: float | None = None, mood_label: str | None = None, notes: str | None = None, date: str | None = None) -> str:
+    """Log a mental-health / mood check-in (1-5 scale, or a mood word)."""
+    body = await _dispatch_with_directive(context, "log_mood", {
+            "mood_score": mood_score,
+            "mood_label": mood_label,
+            "notes": notes,
+            "date": date,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def log_biomarker(context: RunContext, name: str, value: float, unit: str | None = None, biomarker_code: str | None = None, ref_range_low: float | None = None, ref_range_high: float | None = None, status: str | None = None, measured_at: str | None = None) -> str:
+    """Record a single lab/biomarker value the user reports out loud, creating a lab report entry."""
+    body = await _dispatch_with_directive(context, "log_biomarker", {
+            "name": name,
+            "value": value,
+            "unit": unit,
+            "biomarker_code": biomarker_code,
+            "ref_range_low": ref_range_low,
+            "ref_range_high": ref_range_high,
+            "status": status,
+            "measured_at": measured_at,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_health_trends(context: RunContext, days: float | None = None) -> str:
+    """Get the Vitana Index trend (total + per-pillar) over a recent window."""
+    body = await _dispatch_with_directive(context, "get_health_trends", {
+            "days": days,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_health_streaks(context: RunContext) -> str:
+    """Get the user's diary streak and per-pillar Vitana Index streaks."""
+    body = await _dispatch_with_directive(context, "get_health_streaks")
+    return summarize(body)
+
+
+@function_tool
+async def order_lab_test(context: RunContext, test_name: str | None = None) -> str:
+    """Order a lab test. NOT AVAILABLE YET — always returns an error explaining there is no ordering backend."""
+    body = await _dispatch_with_directive(context, "order_lab_test", {
+            "test_name": test_name,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_lab_results(context: RunContext, biomarker: str | None = None, limit: float | None = None) -> str:
+    """Read the user's recorded lab/biomarker results, most recent first."""
+    body = await _dispatch_with_directive(context, "get_lab_results", {
+            "biomarker": biomarker,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def generate_health_plan(context: RunContext, plan_type: str | None = None, confirm: bool | None = None) -> str:
+    """Create a starter health plan (template-based, not AI-personalized) for a pillar. Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "generate_health_plan", {
+            "plan_type": plan_type,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_my_health_plans(context: RunContext) -> str:
+    """List the user's active health plans with adherence scores."""
+    body = await _dispatch_with_directive(context, "list_my_health_plans")
+    return summarize(body)
+
+
+@function_tool
+async def get_health_plan_progress(context: RunContext, plan_type: str | None = None, plan_id: str | None = None) -> str:
+    """Get adherence/progress for a specific active health plan."""
+    body = await _dispatch_with_directive(context, "get_health_plan_progress", {
+            "plan_type": plan_type,
+            "plan_id": plan_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def list_my_conditions(context: RunContext) -> str:
+    """List the user's recorded health conditions, allergies, medications, and dietary restrictions."""
+    body = await _dispatch_with_directive(context, "list_my_conditions")
+    return summarize(body)
+
+
+@function_tool
+async def get_health_education(context: RunContext, topic: str) -> str:
+    """Get grounded educational content on a health/longevity topic from the knowledge hub."""
+    body = await _dispatch_with_directive(context, "get_health_education", {
+            "topic": topic,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_next_best_action(context: RunContext) -> str:
+    """Get today's single highest-priority recommended health action."""
+    body = await _dispatch_with_directive(context, "get_next_best_action")
+    return summarize(body)
+
+
+@function_tool
+async def connect_health_device(context: RunContext, device_name: str | None = None) -> str:
+    """Start pairing a wearable/health device. Opens the health tracker screen where device connections are managed."""
+    body = await _dispatch_with_directive(context, "connect_health_device", {
+            "device_name": device_name,
+        })
+    return summarize(body)
+
+
+# ---------------------------------------------------------------------------
 # Catalogue export — used by tests + libcst smoke
 # ---------------------------------------------------------------------------
 
@@ -2953,6 +3691,40 @@ def all_tool_names() -> list[str]:
         "follow_member", "unfollow_member", "get_notifications",
         "mark_notifications_read", "get_wallet_balance", "update_profile",
         "play_podcast", "like_post", "comment_on_post",
+        # BOOTSTRAP-VOICE-TOOLS-CATALOG-WAVE1 — 69 tools from six new gateway
+        # handler modules (services/gateway/src/services/orb-tools/*.ts).
+        # A1 Marketplace & Discovery (16)
+        "search_marketplace", "get_product_details", "browse_supplements",
+        "add_supplement_to_regimen", "list_my_supplements",
+        "remove_supplement_from_regimen", "browse_wellness_services",
+        "get_provider_profile", "browse_doctors_coaches",
+        "get_coach_compatibility", "browse_deals_offers", "apply_discount_code",
+        "get_ai_product_picks", "list_my_orders", "get_order_status",
+        "reorder_last_order",
+        # A2 Cart & Checkout (8)
+        "add_to_cart", "view_cart", "update_cart_item", "remove_from_cart",
+        "clear_cart", "set_shopping_budget", "review_agent_purchase_proposals",
+        "start_checkout",
+        # A3 Wallet & Payments (11)
+        "get_wallet_summary", "list_wallet_transactions", "send_funds",
+        "request_payment", "exchange_currency", "get_exchange_rate",
+        "set_display_currency", "get_referral_earnings",
+        "get_commissions_summary", "get_pending_rewards",
+        "list_payment_requests",
+        # A8 Messaging Depth (9)
+        "send_group_chat_message", "reply_to_message", "react_to_message",
+        "create_group_chat", "add_group_chat_member", "leave_group_chat",
+        "send_calendar_invite_in_chat", "start_voice_call", "start_video_call",
+        # A10 Events & Tickets (10)
+        "create_event", "update_my_event", "cancel_my_event", "create_meetup",
+        "update_my_meetup", "invite_to_event", "buy_event_ticket",
+        "list_my_event_tickets", "share_event", "get_event_attendees",
+        # A11 Health Depth (15)
+        "log_meal", "log_vitals", "log_mood", "log_biomarker",
+        "get_health_trends", "get_health_streaks", "order_lab_test",
+        "get_lab_results", "generate_health_plan", "list_my_health_plans",
+        "get_health_plan_progress", "list_my_conditions",
+        "get_health_education", "get_next_best_action", "connect_health_device",
     ]
 
 

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -47,6 +47,16 @@ import { DISCOVERY_TOOL_HANDLERS, DISCOVERY_TOOL_DECLARATIONS } from './orb-tool
 import { AWARENESS_TOOL_HANDLERS, AWARENESS_TOOL_DECLARATIONS } from './orb-tools/awareness-tools';
 import { DEVELOPER_TOOL_HANDLERS, DEVELOPER_TOOL_DECLARATIONS } from './orb-tools/developer-tools';
 import { P0_GAP_TOOL_HANDLERS, P0_GAP_TOOL_DECLARATIONS } from './orb-tools/p0-gap-tools';
+// WAVE-1-VOICE-CATALOG-V2 — first wave of the approved 425-tool expansion
+// (docs/VOICE_TOOLS_EXPANSION_PLAN.md): community P0 domains covering
+// commerce/marketplace, cart/checkout, wallet transfers, messaging depth,
+// events/tickets, and health depth.
+import { MARKETPLACE_DISCOVERY_TOOL_HANDLERS, MARKETPLACE_DISCOVERY_TOOL_DECLARATIONS } from './orb-tools/marketplace-discovery-tools';
+import { CART_CHECKOUT_TOOL_HANDLERS, CART_CHECKOUT_TOOL_DECLARATIONS } from './orb-tools/cart-checkout-tools';
+import { WALLET_PAYMENTS_TOOL_HANDLERS, WALLET_PAYMENTS_TOOL_DECLARATIONS } from './orb-tools/wallet-payments-tools';
+import { MESSAGING_DEPTH_TOOL_HANDLERS, MESSAGING_DEPTH_TOOL_DECLARATIONS } from './orb-tools/messaging-depth-tools';
+import { EVENTS_TICKETS_TOOL_HANDLERS, EVENTS_TICKETS_TOOL_DECLARATIONS } from './orb-tools/events-tickets-tools';
+import { HEALTH_DEPTH_TOOL_HANDLERS, HEALTH_DEPTH_TOOL_DECLARATIONS } from './orb-tools/health-depth-tools';
 import {
   lookupScreen,
   lookupByAlias,
@@ -5142,6 +5152,13 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   ...AWARENESS_TOOL_HANDLERS,
   ...DEVELOPER_TOOL_HANDLERS,
   ...P0_GAP_TOOL_HANDLERS,
+  // WAVE-1-VOICE-CATALOG-V2
+  ...MARKETPLACE_DISCOVERY_TOOL_HANDLERS,
+  ...CART_CHECKOUT_TOOL_HANDLERS,
+  ...WALLET_PAYMENTS_TOOL_HANDLERS,
+  ...MESSAGING_DEPTH_TOOL_HANDLERS,
+  ...EVENTS_TICKETS_TOOL_HANDLERS,
+  ...HEALTH_DEPTH_TOOL_HANDLERS,
 };
 
 // BOOTSTRAP-VOICE-CATALOG-COMPLETE — combined Vertex/Gemini function
@@ -5160,6 +5177,13 @@ export const NEW_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
   ...DISCOVERY_TOOL_DECLARATIONS,
   ...AWARENESS_TOOL_DECLARATIONS,
   ...P0_GAP_TOOL_DECLARATIONS,
+  // WAVE-1-VOICE-CATALOG-V2
+  ...MARKETPLACE_DISCOVERY_TOOL_DECLARATIONS,
+  ...CART_CHECKOUT_TOOL_DECLARATIONS,
+  ...WALLET_PAYMENTS_TOOL_DECLARATIONS,
+  ...MESSAGING_DEPTH_TOOL_DECLARATIONS,
+  ...EVENTS_TICKETS_TOOL_DECLARATIONS,
+  ...HEALTH_DEPTH_TOOL_DECLARATIONS,
 ];
 
 // Developer tools are role-gated the same way ADMIN_TOOL_SCHEMAS is —

--- a/services/gateway/src/services/orb-tools/cart-checkout-tools.ts
+++ b/services/gateway/src/services/orb-tools/cart-checkout-tools.ts
@@ -1,0 +1,974 @@
+/**
+ * A2 Cart & Checkout voice tools (community role).
+ *
+ * Real backing: the Universal Cart gateway slice (VTID-03213,
+ * routes/universal-cart.ts) — reads/writes ONLY `universal_carts`,
+ * `universal_cart_items`, `universal_cart_events`, exactly like that route
+ * file's own handlers. Agent-proposed items (review_agent_purchase_proposals)
+ * read the same `universal_cart_items` rows the Propose-then-approve shopping
+ * agent (VTID-03260, routes/shopping-agent.ts POST /propose + /reorder) writes
+ * — those rows are tagged `source_surface='autopilot'` and carry a
+ * `metadata.rationale/safety_flags/confidence/proposed_at` blob; there is no
+ * separate "proposals" table, the cart items themselves ARE the proposals
+ * until the user checks out or removes them.
+ *
+ * The `sb` passed into every handler here is the gateway's service-role
+ * admin client (see routes/orb-tool.ts: `adminClient() || getSupabase()`),
+ * NOT an RLS-scoped user client — so every query below explicitly filters by
+ * `user_id` / cart ownership itself, the same defensive pattern
+ * groups-events-tools.ts uses for global_community_group_members etc.
+ *
+ * PAYMENT POLICY (see wave1-shared-brief.md): start_checkout must NEVER call
+ * checkoutUniversalCart() / debit a wallet / charge a card by voice. It only
+ * validates cart preconditions and returns an orb_directive that navigates the
+ * user to the cart/checkout screen to confirm payment themselves.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { emitCartEvent } from '../../routes/universal-cart';
+import { deriveItemType } from '../shopping-agent/agent-core';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+const VTID_CART = 'VTID-03213';
+const VTID_SHOPPING_AGENT = 'VTID-03260';
+
+/** Kept in sync with routes/universal-cart.ts DEFAULT_CURRENCY. */
+const DEFAULT_CURRENCY = 'EUR';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** ok:false when there is no authenticated user — every one of these tools touches commerce data. */
+function authGate(tool: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+function navDirective(
+  screen_id: string,
+  route: string,
+  title: string,
+  reason: string,
+  vtid: string,
+): Record<string, unknown> {
+  return { type: 'orb_directive', directive: 'navigate', screen_id, route, title, reason, vtid };
+}
+
+function fmtMoney(cents: number | null | undefined, currency: string | null | undefined): string {
+  if (cents === null || cents === undefined || !Number.isFinite(cents)) return 'price unavailable';
+  return `${(cents / 100).toFixed(2)} ${currency || DEFAULT_CURRENCY}`;
+}
+
+function isNoRowsError(error: unknown): boolean {
+  return (error as { code?: string } | null)?.code === 'PGRST116';
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (error as { code?: string } | null)?.code === '23505';
+}
+
+interface CartRow {
+  id: string;
+  user_id: string;
+  tenant_id: string | null;
+  status: string;
+}
+
+interface CartItemRow {
+  id: string;
+  cart_id: string;
+  product_id: string;
+  item_type: string;
+  quantity: number;
+  status: string;
+  source_surface: string | null;
+  unit_price_cents_snapshot: number | null;
+  currency_snapshot: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+interface ProductLite {
+  id: string;
+  title: string;
+  category: string | null;
+  price_cents: number | null;
+  currency: string | null;
+  is_active: boolean;
+  availability: string;
+}
+
+const CART_ITEM_COLS =
+  'id, cart_id, product_id, item_type, quantity, status, source_surface, unit_price_cents_snapshot, currency_snapshot, metadata';
+const PRODUCT_COLS = 'id, title, category, price_cents, currency, is_active, availability';
+
+/** Find the caller's active cart (no autocreate). Always scoped to id.user_id explicitly (sb is service-role). */
+async function findActiveCart(sb: SupabaseClient, userId: string): Promise<{ ok: true; cart: CartRow | null } | { ok: false; error: string }> {
+  const { data, error } = await sb
+    .from('universal_carts')
+    .select('id, user_id, tenant_id, status')
+    .eq('user_id', userId)
+    .eq('status', 'active')
+    .maybeSingle();
+  if (error && !isNoRowsError(error)) return { ok: false, error: error.message };
+  return { ok: true, cart: (data as CartRow | null) ?? null };
+}
+
+/** Get-or-create the caller's ONE active cart. Mirrors universal-cart.ts POST /items cart resolution. */
+async function resolveOrCreateActiveCart(
+  sb: SupabaseClient,
+  userId: string,
+  tenantId: string | null,
+): Promise<{ ok: true; cartId: string; created: boolean } | { ok: false; error: string }> {
+  const existing = await findActiveCart(sb, userId);
+  if (!existing.ok) return existing;
+  if (existing.cart) return { ok: true, cartId: existing.cart.id, created: false };
+
+  const inserted = await sb
+    .from('universal_carts')
+    .insert({ user_id: userId, tenant_id: tenantId, status: 'active', metadata: {} })
+    .select('id')
+    .single();
+
+  if (inserted.error && isUniqueViolation(inserted.error)) {
+    const raced = await findActiveCart(sb, userId);
+    if (raced.ok && raced.cart) return { ok: true, cartId: raced.cart.id, created: false };
+    return { ok: false, error: raced.ok ? 'cart_create_failed' : raced.error };
+  }
+  if (inserted.error || !inserted.data) {
+    return { ok: false, error: inserted.error?.message ?? 'cart_create_failed' };
+  }
+  const cartId = inserted.data.id as string;
+  await emitCartEvent({ cart_id: cartId, user_id: userId, event_type: 'cart.created', event_payload: {} });
+  return { ok: true, cartId, created: true };
+}
+
+/** Active items for a cart + the products they reference, hydrated in one pass. */
+async function fetchActiveItemsWithProducts(
+  sb: SupabaseClient,
+  cartId: string,
+): Promise<{ ok: true; items: CartItemRow[]; productsById: Map<string, ProductLite> } | { ok: false; error: string }> {
+  const itemsRes = await sb
+    .from('universal_cart_items')
+    .select(CART_ITEM_COLS)
+    .eq('cart_id', cartId)
+    .eq('status', 'active')
+    .order('created_at', { ascending: true });
+  if (itemsRes.error) return { ok: false, error: itemsRes.error.message };
+  const items = (itemsRes.data as CartItemRow[]) ?? [];
+  const productsById = new Map<string, ProductLite>();
+  if (items.length > 0) {
+    const productIds = [...new Set(items.map((i) => i.product_id))];
+    const productsRes = await sb.from('products').select(PRODUCT_COLS).in('id', productIds);
+    if (productsRes.error) return { ok: false, error: productsRes.error.message };
+    for (const p of (productsRes.data as ProductLite[]) ?? []) productsById.set(p.id, p);
+  }
+  return { ok: true, items, productsById };
+}
+
+type ProductResolution =
+  | { kind: 'one'; product: ProductLite }
+  | { kind: 'many'; products: ProductLite[] }
+  | { kind: 'none'; query: string }
+  | { kind: 'error'; message: string };
+
+/** Resolve a product by UUID or fuzzy title against the real marketplace `products` table. */
+async function resolveProduct(sb: SupabaseClient, rawId: unknown, rawQuery: unknown): Promise<ProductResolution> {
+  const productId = String(rawId ?? '').trim();
+  const query = String(rawQuery ?? '').trim();
+
+  if (UUID_RE.test(productId)) {
+    const { data, error } = await sb.from('products').select(PRODUCT_COLS).eq('id', productId).maybeSingle();
+    if (error) return { kind: 'error', message: error.message };
+    if (!data) return { kind: 'none', query: productId };
+    return { kind: 'one', product: data as ProductLite };
+  }
+
+  if (!query) return { kind: 'none', query: '' };
+
+  const { data, error } = await sb
+    .from('products')
+    .select(PRODUCT_COLS)
+    .eq('is_active', true)
+    .ilike('title', `%${query}%`)
+    .order('title', { ascending: true })
+    .limit(5);
+  if (error) return { kind: 'error', message: error.message };
+  const products = (data as ProductLite[]) ?? [];
+  if (products.length === 0) return { kind: 'none', query };
+  if (products.length === 1) return { kind: 'one', product: products[0] };
+  const exact = products.find((p) => p.title.toLowerCase() === query.toLowerCase());
+  if (exact) return { kind: 'one', product: exact };
+  return { kind: 'many', products };
+}
+
+/** Match active cart items against an item_id (exact) or a fuzzy product-name query. */
+function matchCartItems(
+  items: CartItemRow[],
+  productsById: Map<string, ProductLite>,
+  itemIdArg: string,
+  queryArg: string,
+): CartItemRow[] {
+  if (UUID_RE.test(itemIdArg)) {
+    const hit = items.find((i) => i.id === itemIdArg);
+    return hit ? [hit] : [];
+  }
+  if (!queryArg) return items;
+  const q = queryArg.toLowerCase();
+  return items.filter((i) => {
+    const p = productsById.get(i.product_id);
+    return !!p && p.title.toLowerCase().includes(q);
+  });
+}
+
+function speakItem(item: CartItemRow, productsById: Map<string, ProductLite>): string {
+  const p = productsById.get(item.product_id);
+  const title = p?.title ?? 'an item';
+  const unit = item.unit_price_cents_snapshot ?? p?.price_cents ?? null;
+  const currency = item.currency_snapshot ?? p?.currency ?? DEFAULT_CURRENCY;
+  return `${item.quantity}x ${title} (${fmtMoney(unit, currency)} each)`;
+}
+
+/** Subtotal over active items, same formula as universal-cart.ts GET /budget (unit_price_cents_snapshot only). */
+function computeSubtotalCents(items: CartItemRow[]): number {
+  let total = 0;
+  for (const i of items) {
+    const unit = Number(i.unit_price_cents_snapshot ?? 0);
+    const qty = Number(i.quantity ?? 0);
+    if (Number.isFinite(unit) && Number.isFinite(qty)) total += unit * qty;
+  }
+  return total;
+}
+
+function cartCurrency(items: CartItemRow[], productsById: Map<string, ProductLite>): string {
+  const currencies = new Set(
+    items.map((i) => i.currency_snapshot ?? productsById.get(i.product_id)?.currency ?? DEFAULT_CURRENCY),
+  );
+  if (currencies.size === 1) return [...currencies][0];
+  return DEFAULT_CURRENCY;
+}
+
+// ---------------------------------------------------------------------------
+// add_to_cart
+// ---------------------------------------------------------------------------
+
+export async function tool_add_to_cart(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('add_to_cart', id);
+  if (gate) return gate;
+
+  const rawQuantity = Number(args.quantity ?? 1);
+  const quantity = Number.isFinite(rawQuantity) && rawQuantity > 0 ? rawQuantity : 1;
+  const productQuery = String(args.query ?? args.product_name ?? '').trim();
+
+  try {
+    const resolved = await resolveProduct(sb, args.product_id, productQuery);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { added: false },
+        text: productQuery
+          ? `I couldn't find a product matching "${productQuery}". Want me to search the marketplace for you?`
+          : 'Which product would you like to add to your cart?',
+      };
+    }
+    if (resolved.kind === 'many') {
+      const names = resolved.products.map((p) => `${p.title} (${fmtMoney(p.price_cents, p.currency)})`).join(', ');
+      return {
+        ok: true,
+        result: { added: false, candidates: resolved.products.map((p) => ({ product_id: p.id, title: p.title })) },
+        text: `I found ${resolved.products.length} products matching that: ${names}. Which one do you mean?`,
+      };
+    }
+
+    const product = resolved.product;
+    if (product.is_active !== true || product.availability !== 'in_stock') {
+      return {
+        ok: true,
+        result: { added: false, product_id: product.id, unavailable: true },
+        text: `"${product.title}" isn't available to purchase right now.`,
+      };
+    }
+
+    const cartResolution = await resolveOrCreateActiveCart(sb, id.user_id, id.tenant_id);
+    if (!cartResolution.ok) return { ok: false, error: cartResolution.error };
+    const cartId = cartResolution.cartId;
+
+    const existingItem = await sb
+      .from('universal_cart_items')
+      .select('id, quantity, metadata')
+      .eq('cart_id', cartId)
+      .eq('product_id', product.id)
+      .eq('status', 'active')
+      .maybeSingle();
+    if (existingItem.error && !isNoRowsError(existingItem.error)) {
+      return { ok: false, error: existingItem.error.message };
+    }
+
+    if (existingItem.data) {
+      const before = Number(existingItem.data.quantity ?? 0);
+      const after = before + quantity;
+      const updated = await sb
+        .from('universal_cart_items')
+        .update({ quantity: after })
+        .eq('id', existingItem.data.id)
+        .select('id')
+        .single();
+      if (updated.error) return { ok: false, error: updated.error.message };
+      await emitCartEvent({
+        cart_id: cartId,
+        user_id: id.user_id,
+        event_type: 'item.added',
+        event_payload: {
+          cart_item_id: existingItem.data.id,
+          product_id: product.id,
+          quantity_before: before,
+          quantity_after: after,
+          source_surface: 'voice',
+        },
+      });
+      return {
+        ok: true,
+        result: { added: true, item_id: existingItem.data.id, product_id: product.id, quantity: after, action: 'quantity_bumped' },
+        text: `You already had "${product.title}" in your cart — I bumped it to ${after}.`,
+      };
+    }
+
+    const inserted = await sb
+      .from('universal_cart_items')
+      .insert({
+        cart_id: cartId,
+        item_type: deriveItemType(product.category),
+        product_id: product.id,
+        quantity,
+        status: 'active',
+        source_surface: 'voice',
+        unit_price_cents_snapshot: product.price_cents,
+        currency_snapshot: product.currency,
+        metadata: {},
+      })
+      .select('id')
+      .single();
+    if (inserted.error || !inserted.data) {
+      return { ok: false, error: inserted.error?.message ?? 'item_insert_failed' };
+    }
+    await emitCartEvent({
+      cart_id: cartId,
+      user_id: id.user_id,
+      event_type: 'item.added',
+      event_payload: {
+        cart_item_id: inserted.data.id,
+        product_id: product.id,
+        quantity_before: 0,
+        quantity_after: quantity,
+        source_surface: 'voice',
+      },
+    });
+
+    return {
+      ok: true,
+      result: { added: true, item_id: inserted.data.id, product_id: product.id, quantity, action: 'created' },
+      text: `Added ${quantity}x "${product.title}" to your cart (${fmtMoney(product.price_cents, product.currency)} each).`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'add_to_cart failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// view_cart
+// ---------------------------------------------------------------------------
+
+export async function tool_view_cart(_args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('view_cart', id);
+  if (gate) return gate;
+  try {
+    const cartRes = await findActiveCart(sb, id.user_id);
+    if (!cartRes.ok) return { ok: false, error: cartRes.error };
+    if (!cartRes.cart) {
+      return { ok: true, result: { items: [], subtotal_cents: 0 }, text: 'Your cart is empty.' };
+    }
+    const fetched = await fetchActiveItemsWithProducts(sb, cartRes.cart.id);
+    if (!fetched.ok) return { ok: false, error: fetched.error };
+    const { items, productsById } = fetched;
+    if (items.length === 0) {
+      return { ok: true, result: { items: [], subtotal_cents: 0 }, text: 'Your cart is empty.' };
+    }
+    const subtotal = computeSubtotalCents(items);
+    const currency = cartCurrency(items, productsById);
+    const lines = items.map((i) => speakItem(i, productsById)).join('; ');
+    return {
+      ok: true,
+      result: {
+        items: items.map((i) => ({
+          item_id: i.id,
+          product_id: i.product_id,
+          title: productsById.get(i.product_id)?.title ?? null,
+          quantity: i.quantity,
+          unit_price_cents: i.unit_price_cents_snapshot ?? productsById.get(i.product_id)?.price_cents ?? null,
+          source_surface: i.source_surface,
+        })),
+        subtotal_cents: subtotal,
+        currency,
+      },
+      text: `Your cart has ${items.length} item${items.length === 1 ? '' : 's'}: ${lines}. Total: ${fmtMoney(subtotal, currency)}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'view_cart failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// update_cart_item
+// ---------------------------------------------------------------------------
+
+export async function tool_update_cart_item(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('update_cart_item', id);
+  if (gate) return gate;
+  const rawQuantity = Number(args.quantity);
+  if (!Number.isFinite(rawQuantity) || rawQuantity <= 0) {
+    return { ok: false, error: 'update_cart_item requires a positive "quantity". Use remove_from_cart to remove an item.' };
+  }
+  const itemIdArg = String(args.item_id ?? '').trim();
+  const queryArg = String(args.query ?? args.product_name ?? '').trim();
+  try {
+    const cartRes = await findActiveCart(sb, id.user_id);
+    if (!cartRes.ok) return { ok: false, error: cartRes.error };
+    if (!cartRes.cart) {
+      return { ok: true, result: { updated: false }, text: 'Your cart is empty — there is nothing to update.' };
+    }
+    const fetched = await fetchActiveItemsWithProducts(sb, cartRes.cart.id);
+    if (!fetched.ok) return { ok: false, error: fetched.error };
+    const { items, productsById } = fetched;
+
+    const matches = matchCartItems(items, productsById, itemIdArg, queryArg);
+    if (matches.length === 0) {
+      return {
+        ok: true,
+        result: { updated: false },
+        text: queryArg
+          ? `I couldn't find "${queryArg}" in your cart.`
+          : 'Which item in your cart should I update the quantity for?',
+      };
+    }
+    if (matches.length > 1) {
+      const lines = matches.map((m) => speakItem(m, productsById)).join('; ');
+      return {
+        ok: true,
+        result: { updated: false, candidates: matches.map((m) => ({ item_id: m.id, product_id: m.product_id })) },
+        text: `You have ${matches.length} matching items: ${lines}. Which one should I update?`,
+      };
+    }
+
+    const target = matches[0];
+    const before = Number(target.quantity);
+    const updated = await sb
+      .from('universal_cart_items')
+      .update({ quantity: rawQuantity })
+      .eq('id', target.id)
+      .eq('status', 'active')
+      .select('id')
+      .single();
+    if (updated.error) return { ok: false, error: updated.error.message };
+
+    if (rawQuantity !== before) {
+      await emitCartEvent({
+        cart_id: cartRes.cart.id,
+        user_id: id.user_id,
+        event_type: 'item.quantity_changed',
+        event_payload: { cart_item_id: target.id, quantity_before: before, quantity_after: rawQuantity },
+      });
+    }
+
+    const title = productsById.get(target.product_id)?.title ?? 'that item';
+    return {
+      ok: true,
+      result: { updated: true, item_id: target.id, quantity: rawQuantity },
+      text: `Updated "${title}" to ${rawQuantity}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'update_cart_item failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// remove_from_cart
+// ---------------------------------------------------------------------------
+
+export async function tool_remove_from_cart(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('remove_from_cart', id);
+  if (gate) return gate;
+  const itemIdArg = String(args.item_id ?? '').trim();
+  const queryArg = String(args.query ?? args.product_name ?? '').trim();
+  try {
+    const cartRes = await findActiveCart(sb, id.user_id);
+    if (!cartRes.ok) return { ok: false, error: cartRes.error };
+    if (!cartRes.cart) {
+      return { ok: true, result: { removed: false }, text: 'Your cart is already empty.' };
+    }
+    const fetched = await fetchActiveItemsWithProducts(sb, cartRes.cart.id);
+    if (!fetched.ok) return { ok: false, error: fetched.error };
+    const { items, productsById } = fetched;
+
+    const matches = matchCartItems(items, productsById, itemIdArg, queryArg);
+    if (matches.length === 0) {
+      return {
+        ok: true,
+        result: { removed: false },
+        text: queryArg
+          ? `I couldn't find "${queryArg}" in your cart.`
+          : 'Which item should I remove from your cart?',
+      };
+    }
+    if (matches.length > 1) {
+      const lines = matches.map((m) => speakItem(m, productsById)).join('; ');
+      return {
+        ok: true,
+        result: { removed: false, candidates: matches.map((m) => ({ item_id: m.id, product_id: m.product_id })) },
+        text: `You have ${matches.length} matching items: ${lines}. Which one should I remove?`,
+      };
+    }
+
+    const target = matches[0];
+    const title = productsById.get(target.product_id)?.title ?? 'that item';
+    const updated = await sb
+      .from('universal_cart_items')
+      .update({ status: 'removed' })
+      .eq('id', target.id)
+      .eq('status', 'active')
+      .select('id')
+      .single();
+    if (updated.error) return { ok: false, error: updated.error.message };
+
+    await emitCartEvent({
+      cart_id: cartRes.cart.id,
+      user_id: id.user_id,
+      event_type: 'item.removed',
+      event_payload: { cart_item_id: target.id, removal_reason: 'voice_remove' },
+    });
+
+    return { ok: true, result: { removed: true, item_id: target.id }, text: `Removed "${title}" from your cart.` };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'remove_from_cart failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// clear_cart (⚠️ confirm)
+// ---------------------------------------------------------------------------
+
+export async function tool_clear_cart(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('clear_cart', id);
+  if (gate) return gate;
+  try {
+    const cartRes = await findActiveCart(sb, id.user_id);
+    if (!cartRes.ok) return { ok: false, error: cartRes.error };
+    if (!cartRes.cart) {
+      return { ok: true, result: { cleared: false }, text: 'Your cart is already empty.' };
+    }
+    const fetched = await fetchActiveItemsWithProducts(sb, cartRes.cart.id);
+    if (!fetched.ok) return { ok: false, error: fetched.error };
+    const { items, productsById } = fetched;
+    if (items.length === 0) {
+      return { ok: true, result: { cleared: false }, text: 'Your cart is already empty.' };
+    }
+
+    if (args.confirm !== true) {
+      const lines = items.map((i) => speakItem(i, productsById)).join('; ');
+      return {
+        ok: true,
+        result: { needs_confirmation: true, item_count: items.length },
+        text: `Confirm with the user: remove all ${items.length} items from the cart (${lines})? When they say yes, call clear_cart again with confirm:true.`,
+      };
+    }
+
+    const cleared = await sb
+      .from('universal_cart_items')
+      .update({ status: 'removed' })
+      .eq('cart_id', cartRes.cart.id)
+      .eq('status', 'active')
+      .select('id');
+    if (cleared.error) return { ok: false, error: cleared.error.message };
+
+    const clearedIds = ((cleared.data as Array<{ id: string }>) ?? []).map((r) => r.id);
+    await Promise.all(
+      clearedIds.map((itemId) =>
+        emitCartEvent({
+          cart_id: cartRes.cart!.id,
+          user_id: id.user_id,
+          event_type: 'item.removed',
+          event_payload: { cart_item_id: itemId, removal_reason: 'clear_cart' },
+        }),
+      ),
+    );
+
+    return {
+      ok: true,
+      result: { cleared: true, item_count: clearedIds.length },
+      text: `Done — I cleared your cart (${clearedIds.length} item${clearedIds.length === 1 ? '' : 's'} removed).`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'clear_cart failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// set_shopping_budget
+// ---------------------------------------------------------------------------
+
+/** tenant backfill from app_users when the voice session carries a null tenant (needed: user_limitations.tenant_id is NOT NULL). */
+async function resolveTenantId(id: OrbToolIdentity, sb: SupabaseClient): Promise<string | null> {
+  if (id.tenant_id) return id.tenant_id;
+  try {
+    const { data } = await sb.from('app_users').select('tenant_id').eq('user_id', id.user_id).maybeSingle();
+    return (data as { tenant_id?: string | null } | null)?.tenant_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function tool_set_shopping_budget(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('set_shopping_budget', id);
+  if (gate) return gate;
+  const clear = args.clear === true;
+
+  try {
+    const { data: userRow } = await sb
+      .from('app_users')
+      .select('currency_preference')
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    const currency = (userRow as { currency_preference?: string | null } | null)?.currency_preference || DEFAULT_CURRENCY;
+
+    if (clear) {
+      const { data: existing } = await sb
+        .from('user_limitations')
+        .select('user_id')
+        .eq('user_id', id.user_id)
+        .maybeSingle();
+      if (!existing) {
+        return { ok: true, result: { cleared: false }, text: "You don't have a monthly shopping budget set." };
+      }
+      const { error } = await sb
+        .from('user_limitations')
+        .update({ budget_monthly_cap_cents: null })
+        .eq('user_id', id.user_id);
+      if (error) return { ok: false, error: error.message };
+      return { ok: true, result: { cleared: true }, text: 'Done — I removed your monthly shopping budget cap.' };
+    }
+
+    let capCents: number | null = null;
+    if (args.monthly_cap_cents !== undefined) {
+      const n = Number(args.monthly_cap_cents);
+      if (Number.isFinite(n) && n >= 0) capCents = Math.round(n);
+    } else if (args.monthly_cap_amount !== undefined || args.amount !== undefined) {
+      const n = Number(args.monthly_cap_amount ?? args.amount);
+      if (Number.isFinite(n) && n >= 0) capCents = Math.round(n * 100);
+    }
+    if (capCents === null) {
+      return { ok: false, error: 'set_shopping_budget requires a monthly_cap_amount (e.g. 200 for 200 EUR) or clear:true.' };
+    }
+
+    const tenantId = await resolveTenantId(id, sb);
+    if (!tenantId) {
+      return { ok: false, error: 'set_shopping_budget requires a resolvable tenant for this user; none found.' };
+    }
+
+    const { error } = await sb
+      .from('user_limitations')
+      .upsert(
+        { user_id: id.user_id, tenant_id: tenantId, budget_monthly_cap_cents: capCents },
+        { onConflict: 'user_id' },
+      );
+    if (error) return { ok: false, error: error.message };
+
+    return {
+      ok: true,
+      result: { saved: true, monthly_cap_cents: capCents, currency },
+      text: `Got it — I've set your monthly shopping budget to ${fmtMoney(capCents, currency)}. I'll flag it if your cart plus this month's spending gets close.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'set_shopping_budget failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// review_agent_purchase_proposals
+// ---------------------------------------------------------------------------
+
+export async function tool_review_agent_purchase_proposals(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('review_agent_purchase_proposals', id);
+  if (gate) return gate;
+  try {
+    const cartRes = await findActiveCart(sb, id.user_id);
+    if (!cartRes.ok) return { ok: false, error: cartRes.error };
+    if (!cartRes.cart) {
+      return { ok: true, result: { proposals: [] }, text: 'There are no pending shopping-agent proposals right now.' };
+    }
+    const fetched = await fetchActiveItemsWithProducts(sb, cartRes.cart.id);
+    if (!fetched.ok) return { ok: false, error: fetched.error };
+    const { items, productsById } = fetched;
+
+    // Agent-proposed items are the active cart items the propose/reorder
+    // endpoints wrote — tagged source_surface='autopilot' (see agent-core.ts
+    // insertPick / shopping-agent.ts POST /propose + /reorder). They sit in
+    // the cart, unreviewed, until the user checks out or removes them.
+    const proposals = items.filter((i) => i.source_surface === 'autopilot');
+    if (proposals.length === 0) {
+      return { ok: true, result: { proposals: [] }, text: 'There are no pending shopping-agent proposals right now.' };
+    }
+
+    const spoken = proposals
+      .map((i) => {
+        const p = productsById.get(i.product_id);
+        const meta = (i.metadata ?? {}) as { rationale?: string; origin?: string };
+        const title = p?.title ?? 'an item';
+        const price = fmtMoney(i.unit_price_cents_snapshot ?? p?.price_cents ?? null, i.currency_snapshot ?? p?.currency ?? null);
+        return `${title} (${price})${meta.rationale ? ` — ${meta.rationale}` : ''}`;
+      })
+      .join('; ');
+
+    return {
+      ok: true,
+      result: {
+        proposals: proposals.map((i) => {
+          const meta = (i.metadata ?? {}) as {
+            rationale?: string;
+            safety_flags?: string[];
+            confidence?: number;
+            origin?: string;
+            proposed_at?: string;
+          };
+          return {
+            item_id: i.id,
+            product_id: i.product_id,
+            title: productsById.get(i.product_id)?.title ?? null,
+            quantity: i.quantity,
+            rationale: meta.rationale ?? null,
+            safety_flags: meta.safety_flags ?? [],
+            confidence: meta.confidence ?? null,
+            origin: meta.origin ?? null,
+            proposed_at: meta.proposed_at ?? null,
+          };
+        }),
+      },
+      text: `The shopping agent proposed ${proposals.length} item${proposals.length === 1 ? '' : 's'} for your cart: ${spoken}. Want me to remove any, or shall I take you to checkout?`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'review_agent_purchase_proposals failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// start_checkout (⚠️ confirm, PAYMENT POLICY APPLIES)
+// ---------------------------------------------------------------------------
+
+export async function tool_start_checkout(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('start_checkout', id);
+  if (gate) return gate;
+  try {
+    const cartRes = await findActiveCart(sb, id.user_id);
+    if (!cartRes.ok) return { ok: false, error: cartRes.error };
+    if (!cartRes.cart) {
+      return { ok: true, result: { started: false, reason: 'cart_empty' }, text: 'Your cart is empty — add something first.' };
+    }
+    const fetched = await fetchActiveItemsWithProducts(sb, cartRes.cart.id);
+    if (!fetched.ok) return { ok: false, error: fetched.error };
+    const { items, productsById } = fetched;
+    if (items.length === 0) {
+      return { ok: true, result: { started: false, reason: 'cart_empty' }, text: 'Your cart is empty — add something first.' };
+    }
+
+    const subtotal = computeSubtotalCents(items);
+    const currency = cartCurrency(items, productsById);
+
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { needs_confirmation: true, item_count: items.length, subtotal_cents: subtotal, currency },
+        text: `Confirm with the user: your cart has ${items.length} item${items.length === 1 ? '' : 's'} totaling ${fmtMoney(subtotal, currency)} — ready to go to checkout? When they say yes, call start_checkout again with confirm:true. I will NOT charge anything by voice — the user always confirms payment on their screen.`,
+      };
+    }
+
+    // PAYMENT POLICY: never call checkoutUniversalCart() / debit a wallet here.
+    // Only validate preconditions (done above) and hand off to the screen
+    // where the user taps the existing Approve & Pay control.
+    const route = '/cart';
+    return {
+      ok: true,
+      result: {
+        started: true,
+        item_count: items.length,
+        subtotal_cents: subtotal,
+        currency,
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.CART', route, 'Shopping Cart', 'start_checkout handoff', VTID_CART),
+        redirect: { route },
+      },
+      text: `Your cart is ready — ${items.length} item${items.length === 1 ? '' : 's'}, ${fmtMoney(subtotal, currency)} total. Go ahead and confirm payment on your screen.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'start_checkout failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const CART_CHECKOUT_TOOL_HANDLERS: Record<string, Handler> = {
+  add_to_cart: tool_add_to_cart,
+  view_cart: tool_view_cart,
+  update_cart_item: tool_update_cart_item,
+  remove_from_cart: tool_remove_from_cart,
+  clear_cart: tool_clear_cart,
+  set_shopping_budget: tool_set_shopping_budget,
+  review_agent_purchase_proposals: tool_review_agent_purchase_proposals,
+  start_checkout: tool_start_checkout,
+};
+
+export const CART_CHECKOUT_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'add_to_cart',
+    description: [
+      'Add a marketplace product to the user\'s cart, by product_id or fuzzy',
+      'product name. Bumps quantity if the product is already in the cart.',
+      'CALL WHEN the user says: "add ... to my cart", "I want to buy ...",',
+      '"lege ... in den Warenkorb", "ich möchte ... kaufen".',
+      'If several products match, read the candidates and ask which one.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Exact product UUID when already known from a previous tool result.' },
+        query: { type: 'string', description: 'Spoken product name (fuzzy matched against the marketplace catalog).' },
+        quantity: { type: 'number', description: 'How many to add. Defaults to 1.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'view_cart',
+    description: [
+      'Read the contents of the user\'s cart: items, quantities, prices, and',
+      'the total. CALL WHEN the user asks: "what\'s in my cart?", "show my',
+      'cart", "was ist in meinem Warenkorb?", "zeig mir meinen Warenkorb".',
+      'Read the items and total aloud.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'update_cart_item',
+    description: [
+      'Change the quantity of an item already in the cart, by item_id or',
+      'fuzzy product name. CALL WHEN the user says: "make it 2 of those",',
+      '"change the quantity to ...", "ändere die Menge auf ...".',
+      'If several items match, read the candidates and ask which one. Use',
+      'remove_from_cart instead if the user wants to remove the item entirely.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        item_id: { type: 'string', description: 'Exact cart item UUID when known from a previous tool result.' },
+        query: { type: 'string', description: 'Spoken product name to find the cart line (fuzzy matched).' },
+        quantity: { type: 'number', description: 'The new quantity (must be positive).' },
+      },
+      required: ['quantity'],
+    },
+  },
+  {
+    name: 'remove_from_cart',
+    description: [
+      'Remove a single item from the cart, by item_id or fuzzy product name.',
+      'CALL WHEN the user says: "remove ... from my cart", "take that out of',
+      'my cart", "entferne ... aus dem Warenkorb".',
+      'If several items match, read the candidates and ask which one.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        item_id: { type: 'string', description: 'Exact cart item UUID when known.' },
+        query: { type: 'string', description: 'Spoken product name to find the cart line (fuzzy matched).' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'clear_cart',
+    description: [
+      'Remove ALL items from the cart. ALWAYS call once WITHOUT confirm',
+      'first — the tool returns a confirmation question listing what will be',
+      'removed; after the user says yes, call again with confirm:true.',
+      'CALL WHEN the user says: "clear my cart", "empty my cart", "remove',
+      'everything", "leere meinen Warenkorb".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed clearing the cart.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'set_shopping_budget',
+    description: [
+      'Set or clear the user\'s monthly shopping budget cap, used as an',
+      'advisory warning (never blocks purchases) when the cart plus this',
+      'month\'s spending gets close to or exceeds it.',
+      'CALL WHEN the user says: "set my monthly budget to ...", "limit my',
+      'shopping to ... a month", "remove my budget", "setze mein monatliches',
+      'Budget auf ...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        monthly_cap_amount: { type: 'number', description: 'Monthly cap in the user\'s major currency unit (e.g. 200 for 200 EUR).' },
+        clear: { type: 'boolean', description: 'Pass true to remove the existing budget cap instead of setting one.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'review_agent_purchase_proposals',
+    description: [
+      'List the items the shopping agent (autopilot) has proposed and placed',
+      'into the user\'s cart for review — each with its rationale, safety',
+      'flags, and confidence. These are NOT yet purchased; the user can',
+      'remove any with remove_from_cart or proceed with start_checkout.',
+      'CALL WHEN the user asks: "what did the shopping agent pick for me?",',
+      '"show my pending proposals", "was hat der Einkaufsassistent',
+      'vorgeschlagen?".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'start_checkout',
+    description: [
+      'Begin checkout for the user\'s cart. ALWAYS call once WITHOUT confirm',
+      'first — the tool returns the cart total and asks for confirmation;',
+      'after the user says yes, call again with confirm:true. This tool',
+      'NEVER charges a card or completes payment by voice — it only',
+      'validates the cart and navigates the user to the cart/checkout screen',
+      'where THEY confirm payment themselves.',
+      'CALL WHEN the user says: "check out", "let\'s pay for this", "go to',
+      'checkout", "zur Kasse gehen", "ich möchte bezahlen".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed proceeding to checkout.' },
+      },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/events-tickets-tools.ts
+++ b/services/gateway/src/services/orb-tools/events-tickets-tools.ts
@@ -1,0 +1,1176 @@
+/**
+ * Events & Tickets voice tools (plan_domain "A10 Events & Tickets",
+ * VTID-03300 — used only as a local traceability tag on nav directives,
+ * same convention groups-events-tools.ts uses for VTID_GROUPS/VTID_EVENTS).
+ *
+ * Real tables backing these tools (grepped from vitana-v1's
+ * useCommunityEvents / useEventTickets / useEventInvites hooks and the
+ * matching supabase/migrations there — this domain's schema lives in the
+ * vitana-v1 repo, not vitana-platform):
+ *
+ *  - global_community_events — the SAME table groups-events-tools.ts's
+ *    rsvp_event/cancel_rsvp/list_upcoming_meetups already read. Columns:
+ *    id, title, description, event_type ('event' | 'meetup' | 'community' |
+ *    'personal'), location, virtual_link, start_time, end_time,
+ *    max_participants, participant_count, created_by, image_url, metadata,
+ *    resellable, resale_scope. "Meetups" are NOT a separate table — they
+ *    are rows with event_type='meetup' (confirmed via CreateMeetupPopup.tsx
+ *    vs CreateEventPopup.tsx, both calling the same useCommunityEvents
+ *    createEvent()). Editing/cancelling checks created_by === caller,
+ *    mirroring EventKebabMenu.tsx's isCreator/canEdit/canDelete gates
+ *    (canEdit additionally requires start_time still in the future).
+ *  - event_ticket_types / event_ticket_purchases — real tables (migration
+ *    20251204115920_97af8073…sql). Ticket purchase in the app goes through
+ *    the `stripe-create-ticket-checkout` Supabase edge function (Stripe
+ *    Checkout redirect) — there is no gateway route or RPC that completes a
+ *    purchase, and this domain's payment policy forbids voice tools from
+ *    charging a card anyway. So buy_event_ticket only *validates* against
+ *    the real event_ticket_types row (availability, sale window) and then
+ *    returns a navigate directive to the event's ticket selector — it does
+ *    NOT insert an event_ticket_purchases row itself (a purchase row with no
+ *    real qr_code_token/stripe_session_id would just be dead data; only the
+ *    edge function can mint those correctly).
+ *  - event_attendees / invite_analytics — real tables (migration
+ *    20251006190211_a4029964…sql), the ones useEventInvites.ts writes on
+ *    "invite contacts to this event" (NOT the same as
+ *    global_event_participants, which is the RSVP/"I'm attending" table
+ *    groups-events-tools.ts's rsvp_event uses).
+ *
+ * get_event_attendees reads global_event_participants (status='attending')
+ * joined against app_users for display names — the same
+ * resolve-then-join-app_users shape groups-events-tools.ts uses for group
+ * members — restricted to events the caller created (organizer view).
+ *
+ * None of these tables carry a tenant_id column (confirmed by grepping both
+ * the CommunityEvent hook interface and the migrations' RLS policies), so
+ * unlike groups-events-tools.ts there is no resolveTenantId() tenant
+ * backfill needed here.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+const VTID_EVENTS_TICKETS = 'VTID-03300';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** ok:false when there is no authenticated user — these tools touch user data. */
+function authGate(tool: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+/** "Tue, Jul 8, 6:00 PM" — English; the LLM translates when speaking DE. */
+function fmtWhen(iso: string | null | undefined): string {
+  if (!iso) return 'time to be announced';
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return 'time to be announced';
+  return d.toLocaleString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * The event drawer overlay for a specific event/meetup — matches
+ * navigation-catalog.ts's OVERLAY.EVENT_DRAWER entry (route
+ * '/comm/events-meetups', overlay query_marker 'event', needs_param
+ * 'event_id'), which the frontend's EventsAndMeetups.tsx page reads via
+ * useSearchParams().get('event') to open MeetupDetailsDrawer.
+ */
+function eventDrawerRoute(eventId: string): string {
+  return `/comm/events-meetups?event=${encodeURIComponent(eventId)}`;
+}
+
+function navDirective(route: string, title: string, reason: string): Record<string, unknown> {
+  return {
+    type: 'orb_directive',
+    directive: 'navigate',
+    screen_id: 'OVERLAY.EVENT_DRAWER',
+    route,
+    title,
+    reason,
+    vtid: VTID_EVENTS_TICKETS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event resolution — owner-scoped (create_event/update/cancel/attendees) and
+// any-event (invite/buy/share, which don't require the caller to own it).
+// ---------------------------------------------------------------------------
+
+interface MyEventRow {
+  id: string;
+  title: string;
+  description: string | null;
+  event_type: string;
+  location: string | null;
+  virtual_link: string | null;
+  start_time: string;
+  end_time: string | null;
+  max_participants: number | null;
+  image_url: string | null;
+  created_by: string;
+}
+
+const MY_EVENT_COLS =
+  'id, title, description, event_type, location, virtual_link, start_time, end_time, max_participants, image_url, created_by';
+
+type MyEventResolution =
+  | { kind: 'one'; event: MyEventRow }
+  | { kind: 'many'; events: MyEventRow[] }
+  | { kind: 'none'; query: string }
+  | { kind: 'error'; message: string };
+
+/** Resolve one of MY OWN events/meetups by id or fuzzy title. */
+async function resolveMyEvent(
+  sb: SupabaseClient,
+  userId: string,
+  rawId: unknown,
+  rawQuery: unknown,
+  eventTypeFilter?: string,
+): Promise<MyEventResolution> {
+  const eventId = String(rawId ?? '').trim();
+  const query = String(rawQuery ?? '').trim();
+
+  if (UUID_RE.test(eventId)) {
+    let q = sb.from('global_community_events').select(MY_EVENT_COLS).eq('id', eventId).eq('created_by', userId);
+    if (eventTypeFilter) q = q.eq('event_type', eventTypeFilter);
+    const { data, error } = await q.maybeSingle();
+    if (error) return { kind: 'error', message: error.message };
+    if (!data) return { kind: 'none', query: eventId };
+    return { kind: 'one', event: data as MyEventRow };
+  }
+
+  let q = sb
+    .from('global_community_events')
+    .select(MY_EVENT_COLS)
+    .eq('created_by', userId)
+    .gte('start_time', new Date().toISOString())
+    .order('start_time', { ascending: true })
+    .limit(10);
+  if (eventTypeFilter) q = q.eq('event_type', eventTypeFilter);
+  if (query) q = q.ilike('title', `%${query}%`);
+  const { data, error } = await q;
+  if (error) return { kind: 'error', message: error.message };
+  const events = (data as MyEventRow[]) ?? [];
+  if (events.length === 0) return { kind: 'none', query };
+  if (events.length === 1) return { kind: 'one', event: events[0] };
+  const exact = events.find((e) => e.title.toLowerCase() === query.toLowerCase());
+  if (exact) return { kind: 'one', event: exact };
+  return { kind: 'many', events };
+}
+
+interface AnyEventRow {
+  id: string;
+  title: string;
+  start_time: string;
+  location: string | null;
+}
+
+const ANY_EVENT_COLS = 'id, title, start_time, location';
+
+type AnyEventResolution =
+  | { kind: 'one'; event: AnyEventRow }
+  | { kind: 'many'; events: AnyEventRow[] }
+  | { kind: 'none'; query: string }
+  | { kind: 'error'; message: string };
+
+/** Resolve any upcoming event/meetup (not restricted to the caller's own). */
+async function resolveAnyUpcomingEvent(sb: SupabaseClient, rawId: unknown, rawQuery: unknown): Promise<AnyEventResolution> {
+  const eventId = String(rawId ?? '').trim();
+  const query = String(rawQuery ?? '').trim();
+
+  if (UUID_RE.test(eventId)) {
+    const { data, error } = await sb.from('global_community_events').select(ANY_EVENT_COLS).eq('id', eventId).maybeSingle();
+    if (error) return { kind: 'error', message: error.message };
+    if (!data) return { kind: 'none', query: eventId };
+    return { kind: 'one', event: data as AnyEventRow };
+  }
+
+  if (!query) return { kind: 'none', query: '' };
+
+  const { data, error } = await sb
+    .from('global_community_events')
+    .select(ANY_EVENT_COLS)
+    .gte('start_time', new Date().toISOString())
+    .ilike('title', `%${query}%`)
+    .order('start_time', { ascending: true })
+    .limit(5);
+  if (error) return { kind: 'error', message: error.message };
+  const events = (data as AnyEventRow[]) ?? [];
+  if (events.length === 0) return { kind: 'none', query };
+  if (events.length === 1) return { kind: 'one', event: events[0] };
+  const exact = events.find((e) => e.title.toLowerCase() === query.toLowerCase());
+  if (exact) return { kind: 'one', event: exact };
+  return { kind: 'many', events };
+}
+
+function speakEventLine(e: { title: string; start_time: string; location?: string | null }): string {
+  return `"${e.title}" on ${fmtWhen(e.start_time)}${e.location ? ` at ${e.location}` : ''}`;
+}
+
+/**
+ * Resolve a spoken member name to a user_id via the platform's canonical
+ * resolver RPC (same as groups-events-tools.ts's resolveMember /
+ * tool_send_chat_message / tool_resolve_recipient).
+ */
+async function resolveMember(
+  sb: SupabaseClient,
+  actorUserId: string,
+  spoken: string,
+): Promise<
+  | { kind: 'one'; user_id: string; display_name: string }
+  | { kind: 'ambiguous'; names: string[] }
+  | { kind: 'none' }
+  | { kind: 'error'; message: string }
+> {
+  const { data, error } = await sb.rpc('resolve_recipient_candidates', {
+    p_actor: actorUserId,
+    p_token: spoken,
+    p_limit: 3,
+    p_global: true,
+  });
+  if (error) return { kind: 'error', message: error.message };
+  const candidates = (data || []) as Array<{
+    user_id: string;
+    vitana_id: string | null;
+    display_name: string | null;
+    score: number;
+  }>;
+  if (candidates.length === 0) return { kind: 'none' };
+  const top = candidates[0];
+  const topScore = Number(top.score) || 0;
+  const second = candidates[1] ? Number(candidates[1].score) || 0 : 0;
+  const ambiguous = topScore < 0.85 || (candidates.length > 1 && second / Math.max(topScore, 0.0001) > 0.85);
+  if (ambiguous) {
+    return {
+      kind: 'ambiguous',
+      names: candidates.slice(0, 3).map((c) => c.display_name || c.vitana_id || c.user_id),
+    };
+  }
+  return { kind: 'one', user_id: top.user_id, display_name: top.display_name || top.vitana_id || 'that member' };
+}
+
+// ---------------------------------------------------------------------------
+// create_event / create_meetup — same underlying insert, different event_type
+// ---------------------------------------------------------------------------
+
+async function createOwnedEvent(
+  toolName: string,
+  eventType: string,
+  kindLabel: string,
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate(toolName, id);
+  if (gate) return gate;
+
+  const title = String(args.title ?? '').trim();
+  const description = String(args.description ?? '').trim();
+  const location = String(args.location ?? '').trim();
+  const virtualLink = String(args.virtual_link ?? '').trim();
+  const startTime = String(args.start_time ?? '').trim();
+  const endTime = String(args.end_time ?? '').trim();
+  const imageUrl = String(args.image_url ?? '').trim();
+  const maxParticipantsRaw = args.max_participants;
+  const maxParticipants =
+    maxParticipantsRaw != null && Number.isFinite(Number(maxParticipantsRaw)) ? Number(maxParticipantsRaw) : null;
+
+  if (!title) {
+    return { ok: false, error: `${toolName} requires a title. Ask the user what to call the ${kindLabel}.` };
+  }
+  if (!startTime || !Number.isFinite(new Date(startTime).getTime())) {
+    return { ok: false, error: `${toolName} requires a valid start_time (date/time). Ask the user when the ${kindLabel} starts.` };
+  }
+  if (endTime && !Number.isFinite(new Date(endTime).getTime())) {
+    return { ok: false, error: `${toolName} was given an end_time that isn't a valid date/time.` };
+  }
+
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { needs_confirmation: true, title, start_time: startTime, location: location || null },
+      text: `Confirm with the user: create the ${kindLabel} "${title}" on ${fmtWhen(startTime)}${location ? ` at ${location}` : ''}? When they say yes, call ${toolName} again with confirm:true.`,
+    };
+  }
+
+  try {
+    const { data: event, error } = await sb
+      .from('global_community_events')
+      .insert({
+        title,
+        description: description || null,
+        event_type: eventType,
+        location: location || null,
+        virtual_link: virtualLink || null,
+        start_time: startTime,
+        end_time: endTime || null,
+        max_participants: maxParticipants,
+        image_url: imageUrl || null,
+        metadata: {},
+        created_by: id.user_id,
+        participant_count: 0,
+      })
+      .select('id, title, start_time')
+      .single();
+    if (error || !event) {
+      return { ok: false, error: error?.message ?? `${kindLabel} insert failed` };
+    }
+    const e = event as { id: string; title: string; start_time: string };
+    const route = eventDrawerRoute(e.id);
+    return {
+      ok: true,
+      result: {
+        event_id: e.id,
+        title: e.title,
+        start_time: e.start_time,
+        decision: 'auto_nav',
+        directive: navDirective(route, e.title, `${toolName} created`),
+        redirect: { route },
+      },
+      text: `Done — I created the ${kindLabel} "${e.title}" for ${fmtWhen(e.start_time)}. Opening it now.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : `${toolName} failed` };
+  }
+}
+
+export async function tool_create_event(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  return createOwnedEvent('create_event', 'event', 'event', args, id, sb);
+}
+
+export async function tool_create_meetup(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  return createOwnedEvent('create_meetup', 'meetup', 'meetup', args, id, sb);
+}
+
+// ---------------------------------------------------------------------------
+// update_my_event / update_my_meetup — same underlying update, event_type
+// filter distinguishes which of the caller's rows a fuzzy title can match.
+// ---------------------------------------------------------------------------
+
+async function updateOwnedEvent(
+  toolName: string,
+  kindLabel: string,
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+  eventTypeFilter?: string,
+): Promise<OrbToolResult> {
+  const gate = authGate(toolName, id);
+  if (gate) return gate;
+  const queryLabel = String(args.query ?? args.title ?? '').trim();
+  try {
+    const resolved = await resolveMyEvent(sb, id.user_id, args.event_id, queryLabel, eventTypeFilter);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { updated: false },
+        text: queryLabel
+          ? `I couldn't find an upcoming ${kindLabel} of yours matching "${queryLabel}".`
+          : `Which ${kindLabel} would you like to update? Tell me its name.`,
+      };
+    }
+    if (resolved.kind === 'many') {
+      const names = resolved.events.map((e) => e.title).join(', ');
+      return {
+        ok: true,
+        result: { updated: false, candidates: resolved.events.map((e) => ({ event_id: e.id, title: e.title })) },
+        text: `You have ${resolved.events.length} upcoming ${kindLabel}s matching that: ${names}. Which one should I update?`,
+      };
+    }
+
+    const event = resolved.event;
+    if (new Date(event.start_time).getTime() <= Date.now()) {
+      return {
+        ok: true,
+        result: { updated: false, event_id: event.id, title: event.title },
+        text: `"${event.title}" has already started or passed, so it can't be edited anymore.`,
+      };
+    }
+
+    const patch: Record<string, unknown> = {};
+    if (typeof args.title === 'string' && args.title.trim()) patch.title = args.title.trim();
+    if (typeof args.description === 'string') patch.description = args.description.trim() || null;
+    if (typeof args.location === 'string') patch.location = args.location.trim() || null;
+    if (typeof args.virtual_link === 'string') patch.virtual_link = args.virtual_link.trim() || null;
+    if (typeof args.start_time === 'string' && args.start_time.trim()) {
+      const d = new Date(args.start_time);
+      if (!Number.isFinite(d.getTime())) {
+        return { ok: false, error: `${toolName} was given a start_time that isn't a valid date/time.` };
+      }
+      patch.start_time = args.start_time.trim();
+    }
+    if (typeof args.end_time === 'string') {
+      if (args.end_time.trim() && !Number.isFinite(new Date(args.end_time).getTime())) {
+        return { ok: false, error: `${toolName} was given an end_time that isn't a valid date/time.` };
+      }
+      patch.end_time = args.end_time.trim() || null;
+    }
+    if (args.max_participants != null && Number.isFinite(Number(args.max_participants))) {
+      patch.max_participants = Number(args.max_participants);
+    }
+    if (typeof args.image_url === 'string') patch.image_url = args.image_url.trim() || null;
+
+    if (Object.keys(patch).length === 0) {
+      return {
+        ok: true,
+        result: { updated: false, event_id: event.id, title: event.title },
+        text: `What would you like to change about "${event.title}"?`,
+      };
+    }
+
+    const { error: updErr } = await sb
+      .from('global_community_events')
+      .update(patch)
+      .eq('id', event.id)
+      .eq('created_by', id.user_id);
+    if (updErr) return { ok: false, error: updErr.message };
+
+    const newTitle = (patch.title as string | undefined) ?? event.title;
+    const route = eventDrawerRoute(event.id);
+    return {
+      ok: true,
+      result: {
+        updated: true,
+        event_id: event.id,
+        title: newTitle,
+        decision: 'auto_nav',
+        directive: navDirective(route, newTitle, `${toolName} updated`),
+        redirect: { route },
+      },
+      text: `Done — I've updated "${newTitle}".`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : `${toolName} failed` };
+  }
+}
+
+export async function tool_update_my_event(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  return updateOwnedEvent('update_my_event', 'event', args, id, sb);
+}
+
+export async function tool_update_my_meetup(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  return updateOwnedEvent('update_my_meetup', 'meetup', args, id, sb, 'meetup');
+}
+
+// ---------------------------------------------------------------------------
+// cancel_my_event — creator-only DELETE, same action EventKebabMenu.tsx's
+// "Delete Event" performs (there is no separate cancelled/status flag).
+// ---------------------------------------------------------------------------
+
+export async function tool_cancel_my_event(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('cancel_my_event', id);
+  if (gate) return gate;
+  const queryLabel = String(args.query ?? args.title ?? '').trim();
+  try {
+    const resolved = await resolveMyEvent(sb, id.user_id, args.event_id, queryLabel);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { cancelled: false },
+        text: queryLabel
+          ? `I couldn't find an upcoming event of yours matching "${queryLabel}".`
+          : 'Which event would you like to cancel? Tell me its name.',
+      };
+    }
+    if (resolved.kind === 'many') {
+      const lines = resolved.events.map(speakEventLine).join('; ');
+      return {
+        ok: true,
+        result: { cancelled: false, candidates: resolved.events.map((e) => ({ event_id: e.id, title: e.title })) },
+        text: `You have ${resolved.events.length} upcoming events matching that: ${lines}. Which one should I cancel?`,
+      };
+    }
+
+    const event = resolved.event;
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { needs_confirmation: true, event_id: event.id, title: event.title },
+        text: `Confirm with the user: cancel "${event.title}" (${fmtWhen(event.start_time)})? This removes it for everyone who RSVP'd. When they say yes, call cancel_my_event again with this event_id and confirm:true.`,
+      };
+    }
+
+    const { error: delErr } = await sb
+      .from('global_community_events')
+      .delete()
+      .eq('id', event.id)
+      .eq('created_by', id.user_id);
+    if (delErr) return { ok: false, error: delErr.message };
+
+    return {
+      ok: true,
+      result: { cancelled: true, event_id: event.id, title: event.title },
+      text: `Done — I've cancelled "${event.title}".`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'cancel_my_event failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// invite_to_event — event_attendees (response='pending') + invite_analytics
+// bump, mirroring vitana-v1's useEventInvites.sendInvites() exactly (it
+// upserts the same two tables for its "messenger"/"email" channels; voice
+// records channel:'voice').
+// ---------------------------------------------------------------------------
+
+export async function tool_invite_to_event(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('invite_to_event', id);
+  if (gate) return gate;
+  const memberName = String(args.member_name ?? args.member ?? '').trim();
+  const memberUserIdArg = String(args.member_user_id ?? '').trim();
+  if (!memberName && !UUID_RE.test(memberUserIdArg)) {
+    return { ok: false, error: 'invite_to_event requires the name of the person to invite.' };
+  }
+  try {
+    const resolved = await resolveAnyUpcomingEvent(sb, args.event_id, String(args.event ?? args.query ?? '').trim());
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { invited: false },
+        text: "I couldn't find an upcoming event matching that. Which event did you want to invite them to?",
+      };
+    }
+    if (resolved.kind === 'many') {
+      const lines = resolved.events.map(speakEventLine).join('; ');
+      return {
+        ok: true,
+        result: { invited: false, candidates: resolved.events.map((e) => ({ event_id: e.id, title: e.title })) },
+        text: `I found several matching events: ${lines}. Which one should I send the invitation for?`,
+      };
+    }
+    const event = resolved.event;
+
+    let inviteeId = memberUserIdArg;
+    let inviteeName = memberName || 'that member';
+    if (!UUID_RE.test(inviteeId)) {
+      const member = await resolveMember(sb, id.user_id, memberName);
+      if (member.kind === 'error') return { ok: false, error: member.message };
+      if (member.kind === 'none') {
+        return {
+          ok: true,
+          result: { invited: false },
+          text: `I couldn't find anyone named "${memberName}" in the community — they may not have a Vitana account yet.`,
+        };
+      }
+      if (member.kind === 'ambiguous') {
+        return {
+          ok: true,
+          result: { invited: false, candidates: member.names },
+          text: `I found a few possible matches: ${member.names.join(', ')}. Which one did you mean?`,
+        };
+      }
+      inviteeId = member.user_id;
+      inviteeName = member.display_name;
+    }
+    if (inviteeId === id.user_id) {
+      return { ok: false, error: 'You cannot invite yourself to an event.' };
+    }
+
+    const { error: upErr } = await sb.from('event_attendees').upsert(
+      {
+        event_id: event.id,
+        user_id: inviteeId,
+        response: 'pending',
+        invited_by: id.user_id,
+        metadata: { channel: 'voice' },
+      },
+      { onConflict: 'event_id,user_id', ignoreDuplicates: false },
+    );
+    if (upErr) return { ok: false, error: upErr.message };
+
+    // Best-effort invite_analytics bump — cosmetic engagement counter, mirrors
+    // useEventInvites.ts; never fails the invite itself.
+    try {
+      const { data: existing } = await sb
+        .from('invite_analytics')
+        .select('sent_count')
+        .eq('event_id', event.id)
+        .eq('channel', 'voice')
+        .maybeSingle();
+      const newCount = (Number((existing as { sent_count?: number } | null)?.sent_count) || 0) + 1;
+      await sb
+        .from('invite_analytics')
+        .upsert({ event_id: event.id, channel: 'voice', sent_count: newCount }, { onConflict: 'event_id,channel' });
+    } catch {
+      /* analytics is best-effort */
+    }
+
+    return {
+      ok: true,
+      result: { invited: true, event_id: event.id, invited_user_id: inviteeId },
+      text: `Invitation sent — ${inviteeName} will see "${event.title}" among their pending invites.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'invite_to_event failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// buy_event_ticket — PAYMENT POLICY: validates against the real
+// event_ticket_types row, then hands off to the screen for the actual
+// Stripe checkout. Never writes event_ticket_purchases (only the
+// stripe-create-ticket-checkout edge function can mint a real
+// qr_code_token/stripe_session_id pair) and never charges anything by voice.
+// ---------------------------------------------------------------------------
+
+interface TicketTypeRow {
+  id: string;
+  event_id: string;
+  name: string;
+  price: number | string;
+  currency: string;
+  quantity_available: number;
+  quantity_sold: number;
+  is_active: boolean;
+  sale_start_date: string | null;
+  sale_end_date: string | null;
+}
+
+export async function tool_buy_event_ticket(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('buy_event_ticket', id);
+  if (gate) return gate;
+  const quantity = Math.max(1, Math.floor(Number(args.quantity) || 1));
+  try {
+    const resolved = await resolveAnyUpcomingEvent(sb, args.event_id, String(args.event ?? args.query ?? '').trim());
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { available: false },
+        text: "I couldn't find an upcoming event matching that. Which event's tickets did you want?",
+      };
+    }
+    if (resolved.kind === 'many') {
+      const lines = resolved.events.map(speakEventLine).join('; ');
+      return {
+        ok: true,
+        result: { available: false, candidates: resolved.events.map((e) => ({ event_id: e.id, title: e.title })) },
+        text: `I found several matching events: ${lines}. Which one's tickets do you want?`,
+      };
+    }
+    const event = resolved.event;
+
+    const { data: types, error: tErr } = await sb
+      .from('event_ticket_types')
+      .select('id, event_id, name, price, currency, quantity_available, quantity_sold, is_active, sale_start_date, sale_end_date')
+      .eq('event_id', event.id)
+      .eq('is_active', true)
+      .order('sort_order', { ascending: true });
+    if (tErr) return { ok: false, error: tErr.message };
+    const ticketTypes = (types as TicketTypeRow[]) ?? [];
+    if (ticketTypes.length === 0) {
+      return {
+        ok: true,
+        result: { available: false },
+        text: `"${event.title}" doesn't have any tickets for sale.`,
+      };
+    }
+
+    const wantedName = String(args.ticket_name ?? args.ticket_type ?? '').trim().toLowerCase();
+    const ticketTypeIdArg = String(args.ticket_type_id ?? '').trim();
+    let chosen: TicketTypeRow | undefined;
+    if (UUID_RE.test(ticketTypeIdArg)) {
+      chosen = ticketTypes.find((t) => t.id === ticketTypeIdArg);
+    } else if (wantedName) {
+      chosen = ticketTypes.find((t) => t.name.toLowerCase().includes(wantedName));
+    } else if (ticketTypes.length === 1) {
+      chosen = ticketTypes[0];
+    }
+
+    if (!chosen) {
+      const names = ticketTypes.map((t) => `${t.name} (${t.currency} ${Number(t.price).toFixed(2)})`).join(', ');
+      return {
+        ok: true,
+        result: {
+          available: true,
+          event_id: event.id,
+          ticket_types: ticketTypes.map((t) => ({ ticket_type_id: t.id, name: t.name, price: Number(t.price), currency: t.currency })),
+        },
+        text: `"${event.title}" has these ticket types: ${names}. Which one would you like?`,
+      };
+    }
+
+    const now = new Date();
+    if (chosen.sale_start_date && new Date(chosen.sale_start_date) > now) {
+      return { ok: true, result: { available: false }, text: `Sales for "${chosen.name}" haven't opened yet.` };
+    }
+    if (chosen.sale_end_date && new Date(chosen.sale_end_date) < now) {
+      return { ok: true, result: { available: false }, text: `Sales for "${chosen.name}" have closed.` };
+    }
+    const remaining = Number(chosen.quantity_available) - Number(chosen.quantity_sold);
+    if (remaining < quantity) {
+      return {
+        ok: true,
+        result: { available: false, remaining },
+        text:
+          remaining <= 0
+            ? `"${chosen.name}" tickets for "${event.title}" are sold out.`
+            : `Only ${remaining} "${chosen.name}" ticket${remaining === 1 ? '' : 's'} left for "${event.title}" — you asked for ${quantity}.`,
+      };
+    }
+
+    const totalAmount = Number(chosen.price) * quantity;
+
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: {
+          needs_confirmation: true,
+          event_id: event.id,
+          ticket_type_id: chosen.id,
+          quantity,
+          total_amount: totalAmount,
+          currency: chosen.currency,
+        },
+        text: `${quantity} × "${chosen.name}" for "${event.title}" comes to ${chosen.currency} ${totalAmount.toFixed(2)}. Confirm with the user, then call buy_event_ticket again with confirm:true — payment happens on their screen, never by voice.`,
+      };
+    }
+
+    const route = eventDrawerRoute(event.id);
+    return {
+      ok: true,
+      result: {
+        prepared: true,
+        event_id: event.id,
+        ticket_type_id: chosen.id,
+        quantity,
+        total_amount: totalAmount,
+        currency: chosen.currency,
+        decision: 'auto_nav',
+        directive: navDirective(route, event.title, 'buy_event_ticket prepared'),
+        redirect: { route },
+      },
+      text: `I've got ${quantity} "${chosen.name}" ticket${quantity === 1 ? '' : 's'} for "${event.title}" ready — confirm payment on your screen to finish.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'buy_event_ticket failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// list_my_event_tickets — completed event_ticket_purchases for the caller,
+// same query shape as vitana-v1's useMyTickets() hook.
+// ---------------------------------------------------------------------------
+
+interface MyTicketRow {
+  id: string;
+  event_id: string;
+  quantity: number;
+  total_amount: number | string;
+  currency: string;
+  status: string;
+  ticket_number: string;
+  checked_in_at: string | null;
+  ticket_type: { name: string } | null;
+  event: { title: string; start_time: string; location: string | null } | null;
+}
+
+export async function tool_list_my_event_tickets(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('list_my_event_tickets', id);
+  if (gate) return gate;
+  try {
+    const { data, error } = await sb
+      .from('event_ticket_purchases')
+      .select(
+        'id, event_id, quantity, total_amount, currency, status, ticket_number, checked_in_at, ticket_type:event_ticket_types(name), event:global_community_events(title, start_time, location)',
+      )
+      .eq('buyer_id', id.user_id)
+      .eq('status', 'completed')
+      .order('created_at', { ascending: false })
+      .limit(10);
+    if (error) return { ok: false, error: error.message };
+    const rows = (data as unknown as MyTicketRow[]) ?? [];
+    if (rows.length === 0) {
+      return { ok: true, result: { tickets: [] }, text: "You don't have any event tickets yet." };
+    }
+    const lines = rows
+      .slice(0, 5)
+      .map(
+        (r) =>
+          `${r.quantity} × ${r.ticket_type?.name ?? 'ticket'} for "${r.event?.title ?? 'an event'}"${
+            r.event?.start_time ? ` on ${fmtWhen(r.event.start_time)}` : ''
+          }`,
+      )
+      .join('; ');
+    return {
+      ok: true,
+      result: {
+        tickets: rows.map((r) => ({
+          ticket_id: r.id,
+          event_id: r.event_id,
+          event_title: r.event?.title ?? null,
+          quantity: r.quantity,
+          total_amount: Number(r.total_amount),
+          currency: r.currency,
+          ticket_number: r.ticket_number,
+          checked_in: !!r.checked_in_at,
+        })),
+      },
+      text: `You have ${rows.length} event ticket${rows.length === 1 ? '' : 's'}: ${lines}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'list_my_event_tickets failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// share_event — no DB write; returns the public event landing link (the
+// same /pub/events/:id route PublicEventLanding.tsx serves, which works for
+// recipients who aren't logged in yet, unlike the in-app drawer route).
+// ---------------------------------------------------------------------------
+
+export async function tool_share_event(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('share_event', id);
+  if (gate) return gate;
+  try {
+    const resolved = await resolveAnyUpcomingEvent(sb, args.event_id, String(args.query ?? args.title ?? '').trim());
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { shared: false },
+        text: "I couldn't find that event to share. Which event did you mean?",
+      };
+    }
+    if (resolved.kind === 'many') {
+      const lines = resolved.events.map(speakEventLine).join('; ');
+      return {
+        ok: true,
+        result: { shared: false, candidates: resolved.events.map((e) => ({ event_id: e.id, title: e.title })) },
+        text: `I found several matching events: ${lines}. Which one should I get the share link for?`,
+      };
+    }
+    const event = resolved.event;
+    const base = process.env.FRONTEND_PUBLIC_URL || 'https://vitanaland.com';
+    const shareUrl = `${base}/pub/events/${encodeURIComponent(event.id)}`;
+    return {
+      ok: true,
+      result: { event_id: event.id, title: event.title, share_url: shareUrl },
+      text: `Here's the link to share "${event.title}": ${shareUrl}`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'share_event failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_event_attendees — organizer-only. Reads global_event_participants
+// (status='attending', the RSVP table) joined with app_users, the same
+// resolve-then-join-app_users shape groups-events-tools.ts's group-member
+// lookups use.
+// ---------------------------------------------------------------------------
+
+export async function tool_get_event_attendees(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('get_event_attendees', id);
+  if (gate) return gate;
+  const queryLabel = String(args.query ?? args.title ?? '').trim();
+  try {
+    const resolved = await resolveMyEvent(sb, id.user_id, args.event_id, queryLabel);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') {
+      return {
+        ok: true,
+        result: { attendees: [] },
+        text: queryLabel
+          ? `I couldn't find an upcoming event of yours matching "${queryLabel}" — only the organizer can see attendees.`
+          : 'Which of your events do you want the attendee list for?',
+      };
+    }
+    if (resolved.kind === 'many') {
+      const names = resolved.events.map((e) => e.title).join(', ');
+      return {
+        ok: true,
+        result: { attendees: [], candidates: resolved.events.map((e) => ({ event_id: e.id, title: e.title })) },
+        text: `You have ${resolved.events.length} upcoming events matching that: ${names}. Which one?`,
+      };
+    }
+    const event = resolved.event;
+
+    const { data: parts, error: pErr } = await sb
+      .from('global_event_participants')
+      .select('user_id')
+      .eq('event_id', event.id)
+      .eq('status', 'attending');
+    if (pErr) return { ok: false, error: pErr.message };
+    const userIds = ((parts as Array<{ user_id: string }>) ?? []).map((p) => p.user_id);
+    if (userIds.length === 0) {
+      return {
+        ok: true,
+        result: { event_id: event.id, title: event.title, attendee_count: 0, attendees: [] },
+        text: `No one has signed up for "${event.title}" yet.`,
+      };
+    }
+
+    const { data: users, error: uErr } = await sb
+      .from('app_users')
+      .select('user_id, display_name, vitana_id')
+      .in('user_id', userIds);
+    if (uErr) return { ok: false, error: uErr.message };
+    const names = ((users as Array<{ user_id: string; display_name: string | null; vitana_id: string | null }>) ?? []).map(
+      (u) => u.display_name || u.vitana_id || 'a member',
+    );
+    const shown = names.slice(0, 8).join(', ');
+    return {
+      ok: true,
+      result: { event_id: event.id, title: event.title, attendee_count: userIds.length, attendees: names },
+      text: `${userIds.length} ${userIds.length === 1 ? 'person is' : 'people are'} signed up for "${event.title}": ${shown}${
+        names.length > 8 ? ', and more' : ''
+      }.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_event_attendees failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const EVENTS_TICKETS_TOOL_HANDLERS: Record<string, Handler> = {
+  create_event: tool_create_event,
+  update_my_event: tool_update_my_event,
+  cancel_my_event: tool_cancel_my_event,
+  create_meetup: tool_create_meetup,
+  update_my_meetup: tool_update_my_meetup,
+  invite_to_event: tool_invite_to_event,
+  buy_event_ticket: tool_buy_event_ticket,
+  list_my_event_tickets: tool_list_my_event_tickets,
+  share_event: tool_share_event,
+  get_event_attendees: tool_get_event_attendees,
+};
+
+export const EVENTS_TICKETS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'create_event',
+    description: [
+      'Create a new ticketed/community event. Requires a title and start_time.',
+      'ALWAYS call once WITHOUT confirm first — the tool returns a',
+      'confirmation question; after the user says yes, call again with',
+      'confirm:true.',
+      'CALL WHEN the user says: "create an event called ...", "schedule a new',
+      'event", "erstelle ein Event ...", "plane eine neue Veranstaltung".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'The event title.' },
+        description: { type: 'string', description: 'Optional short event description.' },
+        location: { type: 'string', description: 'Optional physical location.' },
+        virtual_link: { type: 'string', description: 'Optional virtual/streaming link.' },
+        start_time: { type: 'string', description: 'ISO date/time the event starts. Required.' },
+        end_time: { type: 'string', description: 'Optional ISO date/time the event ends.' },
+        max_participants: { type: 'number', description: 'Optional capacity cap.' },
+        image_url: { type: 'string', description: 'Optional cover image URL.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the creation.' },
+      },
+      required: ['title', 'start_time'],
+    },
+  },
+  {
+    name: 'update_my_event',
+    description: [
+      "Edit one of the user's own upcoming events (title, description,",
+      'location, virtual_link, start_time, end_time, max_participants,',
+      'image_url). Only the creator can edit, and only before it starts.',
+      'CALL WHEN the user says: "change the time of my event ...", "update my',
+      'event description", "ändere mein Event ...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: "Spoken title of the user's event (fuzzy matched)." },
+        event_id: { type: 'string', description: 'Exact event UUID when known from a previous tool result.' },
+        title: { type: 'string', description: 'New title, if changing it.' },
+        description: { type: 'string', description: 'New description, if changing it.' },
+        location: { type: 'string', description: 'New location, if changing it.' },
+        virtual_link: { type: 'string', description: 'New virtual link, if changing it.' },
+        start_time: { type: 'string', description: 'New ISO start_time, if changing it.' },
+        end_time: { type: 'string', description: 'New ISO end_time, if changing it.' },
+        max_participants: { type: 'number', description: 'New capacity cap, if changing it.' },
+        image_url: { type: 'string', description: 'New cover image URL, if changing it.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'cancel_my_event',
+    description: [
+      "Cancel (delete) one of the user's own upcoming events. ALWAYS call",
+      'once WITHOUT confirm first — the tool returns a confirmation question;',
+      'after the user says yes, call again with the event_id and confirm:true.',
+      'CALL WHEN the user says: "cancel my event", "delete the ... event",',
+      '"sage mein Event ... ab".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: "Spoken title of the user's event (fuzzy matched)." },
+        event_id: { type: 'string', description: 'Exact event UUID when known.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the cancellation.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'create_meetup',
+    description: [
+      'Create a new casual community meetup (lighter-weight than a ticketed',
+      'event). Requires a title and start_time. ALWAYS call once WITHOUT',
+      'confirm first — the tool returns a confirmation question; after the',
+      'user says yes, call again with confirm:true.',
+      'CALL WHEN the user says: "create a meetup for ...", "start a walking',
+      'meetup", "erstelle ein Meetup für ...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'The meetup title.' },
+        description: { type: 'string', description: 'Optional short meetup description.' },
+        location: { type: 'string', description: 'Optional physical location.' },
+        virtual_link: { type: 'string', description: 'Optional virtual/streaming link.' },
+        start_time: { type: 'string', description: 'ISO date/time the meetup starts. Required.' },
+        end_time: { type: 'string', description: 'Optional ISO date/time the meetup ends.' },
+        max_participants: { type: 'number', description: 'Optional capacity cap.' },
+        image_url: { type: 'string', description: 'Optional cover image URL.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the creation.' },
+      },
+      required: ['title', 'start_time'],
+    },
+  },
+  {
+    name: 'update_my_meetup',
+    description: [
+      "Edit one of the user's own upcoming meetups (title, description,",
+      'location, virtual_link, start_time, end_time, max_participants,',
+      'image_url). Only the creator can edit, and only before it starts.',
+      'CALL WHEN the user says: "change my meetup time", "update the hiking',
+      'meetup details", "ändere mein Meetup ...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: "Spoken title of the user's meetup (fuzzy matched)." },
+        event_id: { type: 'string', description: 'Exact meetup UUID when known from a previous tool result.' },
+        title: { type: 'string', description: 'New title, if changing it.' },
+        description: { type: 'string', description: 'New description, if changing it.' },
+        location: { type: 'string', description: 'New location, if changing it.' },
+        virtual_link: { type: 'string', description: 'New virtual link, if changing it.' },
+        start_time: { type: 'string', description: 'New ISO start_time, if changing it.' },
+        end_time: { type: 'string', description: 'New ISO end_time, if changing it.' },
+        max_participants: { type: 'number', description: 'New capacity cap, if changing it.' },
+        image_url: { type: 'string', description: 'New cover image URL, if changing it.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'invite_to_event',
+    description: [
+      'Invite a community member to an event or meetup by spoken name. The',
+      'member gets a pending invite on the event.',
+      'CALL WHEN the user says: "invite Anna to my yoga meetup", "ask Ben to',
+      'come to the event", "lade Anna zu meinem Event ... ein".',
+      'If the tool lists several event or member candidates, ask which one.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        event: { type: 'string', description: 'Spoken event/meetup title (fuzzy matched against upcoming events).' },
+        event_id: { type: 'string', description: 'Exact event UUID when known.' },
+        member_name: { type: 'string', description: 'Spoken name of the member to invite.' },
+        member_user_id: { type: 'string', description: 'Exact user UUID when known from a previous tool result.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'buy_event_ticket',
+    description: [
+      'Buy a ticket for an event. Checks ticket availability and price, then',
+      'ALWAYS call once WITHOUT confirm first — the tool returns a price',
+      'confirmation question; after the user says yes, call again with',
+      'confirm:true. Even after confirming, payment is completed on the',
+      "user's screen — this tool never charges a card by voice; it prepares",
+      'the purchase and opens the ticket screen.',
+      'CALL WHEN the user says: "buy a ticket for ...", "I want two tickets to',
+      'the gala", "kauf mir ein Ticket für ...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        event: { type: 'string', description: 'Spoken event title (fuzzy matched against upcoming events).' },
+        event_id: { type: 'string', description: 'Exact event UUID when known.' },
+        ticket_name: { type: 'string', description: 'Spoken ticket tier name (e.g. "VIP", "General Admission").' },
+        ticket_type_id: { type: 'string', description: 'Exact ticket type UUID when known.' },
+        quantity: { type: 'number', description: 'How many tickets to buy. Defaults to 1.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the price and purchase.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'list_my_event_tickets',
+    description: [
+      "List the user's own purchased (completed) event tickets.",
+      'CALL WHEN the user asks: "what tickets do I have?", "show my event',
+      'tickets", "welche Tickets habe ich?".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'share_event',
+    description: [
+      'Get a shareable public link for an event or meetup (works even for',
+      "people who aren't logged in). Does not send anything itself — just",
+      'returns the link for the user to share however they like.',
+      'CALL WHEN the user says: "share the yoga meetup", "get me a link for',
+      'that event", "gib mir einen Link für das Event ...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Spoken event/meetup title (fuzzy matched).' },
+        event_id: { type: 'string', description: 'Exact event UUID when known.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_event_attendees',
+    description: [
+      "List who has RSVP'd to one of the user's OWN events (organizer view",
+      'only — the user must be the creator).',
+      'CALL WHEN the user asks: "who\'s coming to my event?", "how many people',
+      'signed up for my meetup?", "wer kommt zu meinem Event?".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: "Spoken title of the user's event (fuzzy matched)." },
+        event_id: { type: 'string', description: 'Exact event UUID when known.' },
+      },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/health-depth-tools.ts
+++ b/services/gateway/src/services/orb-tools/health-depth-tools.ts
@@ -1,0 +1,1222 @@
+/**
+ * A11 Health depth (community role) — 15 voice tools extending the existing
+ * VTID-02753 structured health-logging chokepoint (services/gateway/src/
+ * services/voice-tools/health-log.ts) and the Vitana Index compute stack
+ * to cover meals, vitals, mood, biomarkers, trends, streaks, health plans,
+ * conditions, education and "next best action".
+ *
+ * REUSE, not reinvention — every write/read below targets a table or RPC
+ * that already exists and is already used by production code:
+ *
+ *   - health_features_daily   — the exact table tool_log_health()
+ *     (voice-tools/health-log.ts) upserts to for log_water/log_sleep/
+ *     log_exercise/log_meditation. Its allowed feature_key catalog per
+ *     pillar (routes/integrations.ts PILLAR_FEATURE_KEYS) already includes
+ *     'meal_log' (nutrition), 'mood_entry' (mental) and 'wearable_heart_rate'
+ *     (exercise) — log_meal / log_mood / the heart-rate leg of log_vitals
+ *     write here, then call health_compute_vitana_index_for_user() for the
+ *     same delta math save_diary_entry/tool_log_health already do.
+ *   - wearable_samples        — the free-metric raw-signal table backing
+ *     POST /api/v1/health/wearables/ingest (health_ingest_wearable_samples
+ *     RPC, routes/health.ts). No feature_key exists for weight or blood
+ *     pressure in the Index scoring catalog, so those legs of log_vitals
+ *     land here instead — honest: they're recorded, but don't move the
+ *     Index (matches what a real BP cuff/scale sync would do today).
+ *   - lab_reports + biomarker_results — the exact tables
+ *     health_ingest_lab_report() (routes/health.ts POST /lab-reports/ingest)
+ *     writes to. That RPC is SECURITY DEFINER keyed off auth.uid()/
+ *     current_tenant_id() from a user-JWT Supabase client, which the shared
+ *     `sb` handed to orb tools (service-role admin client, see
+ *     routes/orb-tool.ts adminClient()) cannot satisfy — so log_biomarker /
+ *     get_lab_results write and read the SAME two tables directly with
+ *     explicit tenant_id/user_id, matching the RPC's column-for-column shape.
+ *   - vitana_index_scores      — get_health_trends reads the same table
+ *     useVitanaIndexHistory.ts (vitana-v1) and fetchVitanaIndexForProfiler
+ *     read, so trend math matches the My Journey trajectory card exactly.
+ *   - user_diary_streak (view) + vitana_pillar_streak_days() RPC —
+ *     get_health_streaks combines the real diary-streak view
+ *     (20260427090000_user_diary_streak_view.sql) with the per-pillar
+ *     streak RPC the v3 Index compute function already calls for the
+ *     streak sub-score, instead of the client-only localStorage streak in
+ *     vitana-v1's useVitanaStreaks.ts (not a server concept).
+ *   - user_health_plans + plan_adherence_logs — REAL tables (their
+ *     migration lives in the vitana-v1 repo:
+ *     supabase/migrations/20251031134344_...sql — same physical Supabase
+ *     project the gateway's service-role client talks to) backing
+ *     useHealthPlans.ts. generate_health_plan writes here; the frontend's
+ *     LLM-authored version (supabase/functions/generate-personalized-plan)
+ *     calls a Lovable-AI-gateway edge function with a LOVABLE_API_KEY the
+ *     gateway does not hold and no gateway code today invokes Supabase Edge
+ *     Functions server-side — so generate_health_plan here builds
+ *     plan_data from the same PILLAR_ACTION_TEMPLATES library
+ *     tool_create_index_improvement_plan already uses for its template
+ *     fallback, and marks ai_generated:false. This is a REAL row in the
+ *     real table, just not the LLM-personalized copy — documented honestly
+ *     in the tool's spoken text.
+ *   - autopilot_recommendations — get_next_best_action ranks the same
+ *     table tool_create_index_improvement_plan and tool_activate_recommendation
+ *     already read/write, so its result id can be hop straight into
+ *     activate_recommendation.
+ *   - getUserHealthContext() (services/user-health-context.ts) — the exact
+ *     primitive already assembling active_conditions/allergies/medications
+ *     from user_limitations + memory_facts for the marketplace/discover
+ *     tools. list_my_conditions calls it instead of inventing a new
+ *     "conditions" table (none exists).
+ *   - computeRetrievalRouterDecision + buildContextPack — the same
+ *     knowledge-hub retrieval stack orb-tools-shared.ts's private
+ *     _runRetrievalSearch('search_knowledge', ...) uses (that helper isn't
+ *     exported, so get_health_education calls the same two underlying
+ *     modules directly rather than duplicating a table).
+ *
+ * Two tools are honest stubs (no backing table/RPC found anywhere in
+ * supabase/migrations or the frontend's own migrations):
+ *   - order_lab_test        — no lab_test_orders (or equivalent) table.
+ *   - connect_health_device  is NOT a stub — it's a real navigate-only
+ *     orb_directive (no DB write required), per the brief.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { fetchVitanaIndexForProfiler } from '../user-context-profiler';
+import { getUserHealthContext } from '../user-health-context';
+import {
+  resolvePillarKey,
+  PILLAR_ACTION_TEMPLATES,
+  PILLAR_KEYS,
+  type PillarKey,
+} from '../../lib/vitana-pillars';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+const DEFAULT_TENANT_ID = '00000000-0000-0000-0000-000000000000';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function authGate(tool: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function parseDateArg(raw: unknown): string {
+  const s = typeof raw === 'string' ? raw : '';
+  return /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : todayIso();
+}
+
+/** Tenant resolution mirrors voice-tools/health-log.ts (user_tenants, zero-UUID fallback). */
+async function resolveHealthTenantId(id: OrbToolIdentity, sb: SupabaseClient): Promise<string> {
+  if (id.tenant_id) return id.tenant_id;
+  try {
+    const { data } = await sb
+      .from('user_tenants')
+      .select('tenant_id')
+      .eq('user_id', id.user_id)
+      .limit(1)
+      .maybeSingle();
+    return (data as { tenant_id?: string } | null)?.tenant_id ?? DEFAULT_TENANT_ID;
+  } catch {
+    return DEFAULT_TENANT_ID;
+  }
+}
+
+const PILLAR_SCORE_COLUMN: Record<PillarKey, string> = {
+  nutrition: 'score_nutrition',
+  hydration: 'score_hydration',
+  exercise: 'score_exercise',
+  sleep: 'score_sleep',
+  mental: 'score_mental',
+};
+
+/**
+ * Upsert one health_features_daily row (same shape as
+ * voice-tools/health-log.ts's logHealthSignal) and recompute the Vitana
+ * Index so the caller gets pillar_score_after / index_delta. Used by
+ * log_meal, log_mood, and the heart-rate leg of log_vitals — the three new
+ * verbs that map onto a real PILLAR_FEATURE_KEYS entry
+ * (routes/integrations.ts) but aren't in tool_log_health's fixed
+ * log_water/log_sleep/log_exercise/log_meditation union.
+ */
+async function upsertHealthFeatureAndRecompute(
+  sb: SupabaseClient,
+  id: OrbToolIdentity,
+  opts: {
+    date: string;
+    featureKey: string;
+    pillar: PillarKey;
+    value: number;
+    unit: string;
+    metadata: Record<string, unknown>;
+  },
+): Promise<{ ok: true; pillarScoreAfter: number | null; totalAfter: number | null; indexDelta: number | null } | { ok: false; error: string }> {
+  const tenantId = await resolveHealthTenantId(id, sb);
+
+  const { data: prevRow } = await sb
+    .from('vitana_index_scores')
+    .select('score_total')
+    .eq('user_id', id.user_id)
+    .eq('date', opts.date)
+    .maybeSingle();
+  const prevTotal = (prevRow as { score_total?: number } | null)?.score_total ?? null;
+
+  const { error: featErr } = await sb.from('health_features_daily').upsert(
+    {
+      tenant_id: tenantId,
+      user_id: id.user_id,
+      date: opts.date,
+      feature_key: opts.featureKey,
+      feature_value: opts.value,
+      feature_unit: opts.unit,
+      sample_count: 1,
+      confidence: 0.85,
+      metadata: opts.metadata,
+    },
+    { onConflict: 'tenant_id,user_id,date,feature_key' },
+  );
+  if (featErr) return { ok: false, error: `feature_write_failed: ${featErr.message}` };
+
+  // Mark manual-entry integration connected (mirrors logHealthSignal / manual/log).
+  try {
+    await sb.from('user_integrations').upsert(
+      {
+        user_id: id.user_id,
+        integration_id: 'manual-entry',
+        status: 'connected',
+        connected_at: new Date().toISOString(),
+        last_sync_at: new Date().toISOString(),
+        metadata: { source: 'voice_tool' },
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,integration_id' },
+    );
+  } catch {
+    /* non-fatal — mirrors health-log.ts */
+  }
+
+  const { data: newRow } = await sb.rpc('health_compute_vitana_index_for_user', {
+    p_user_id: id.user_id,
+    p_date: opts.date,
+  });
+  const r = newRow as Record<string, unknown> | null;
+  const newTotal = typeof r?.score_total === 'number' ? r.score_total : null;
+  const pillarCol = PILLAR_SCORE_COLUMN[opts.pillar];
+  const pillarScoreAfter = typeof r?.[pillarCol] === 'number' ? (r[pillarCol] as number) : null;
+
+  return {
+    ok: true,
+    pillarScoreAfter,
+    totalAfter: newTotal,
+    indexDelta: newTotal !== null && prevTotal !== null ? newTotal - prevTotal : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. log_meal
+// ---------------------------------------------------------------------------
+
+export async function tool_log_meal(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('log_meal', id);
+  if (gate) return gate;
+  const description = String(args.description ?? args.meal ?? '').trim();
+  const mealType = String(args.meal_type ?? '').trim().toLowerCase() || null;
+  const calories = typeof args.calories === 'number' ? args.calories : null;
+  const date = parseDateArg(args.date);
+
+  try {
+    // meal_log is a COUNT feature (routes/integrations.ts PILLAR_FEATURE_KEYS.nutrition
+    // includes 'meal_log'; diary-health-extractor.ts documents it the same way) —
+    // read-modify-write so multiple meals in a day accumulate rather than overwrite.
+    const tenantId = await resolveHealthTenantId(id, sb);
+    const { data: existing } = await sb
+      .from('health_features_daily')
+      .select('feature_value')
+      .eq('tenant_id', tenantId)
+      .eq('user_id', id.user_id)
+      .eq('date', date)
+      .eq('feature_key', 'meal_log')
+      .maybeSingle();
+    const newCount = (Number((existing as { feature_value?: number } | null)?.feature_value) || 0) + 1;
+
+    const out = await upsertHealthFeatureAndRecompute(sb, id, {
+      date,
+      featureKey: 'meal_log',
+      pillar: 'nutrition',
+      value: newCount,
+      unit: 'meal',
+      metadata: { description: description || null, meal_type: mealType, calories, source: 'voice_tool' },
+    });
+    if (!out.ok) return { ok: false, error: out.error };
+
+    const deltaText = out.indexDelta !== null && out.indexDelta > 0 ? ` Vitana Index up ${out.indexDelta}.` : '';
+    return {
+      ok: true,
+      result: { date, meal_count_today: newCount, meal_type: mealType, description, pillar_score_after: out.pillarScoreAfter, index_delta: out.indexDelta },
+      text: `Logged ${mealType ? `your ${mealType}` : 'that meal'}${description ? ` (${description.slice(0, 80)})` : ''} — meal ${newCount} today.${deltaText}`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'log_meal failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. log_vitals
+// ---------------------------------------------------------------------------
+
+export async function tool_log_vitals(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('log_vitals', id);
+  if (gate) return gate;
+  const date = parseDateArg(args.date);
+  const heartRate = typeof args.heart_rate === 'number' ? args.heart_rate : null;
+  const weightKg = typeof args.weight_kg === 'number' ? args.weight_kg : null;
+  const systolic = typeof args.systolic === 'number' ? args.systolic : null;
+  const diastolic = typeof args.diastolic === 'number' ? args.diastolic : null;
+
+  if (heartRate === null && weightKg === null && systolic === null && diastolic === null) {
+    return { ok: false, error: 'log_vitals requires at least one of heart_rate, weight_kg, systolic/diastolic.' };
+  }
+
+  const logged: string[] = [];
+  let indexDelta: number | null = null;
+
+  try {
+    const tenantId = await resolveHealthTenantId(id, sb);
+    const nowIso = new Date().toISOString();
+
+    // Heart rate maps onto a REAL Index feature_key (exercise pillar's
+    // 'wearable_heart_rate', per routes/integrations.ts PILLAR_FEATURE_KEYS) —
+    // so it lands in health_features_daily and moves the Index, exactly like
+    // a wearable sync would.
+    if (heartRate !== null) {
+      const out = await upsertHealthFeatureAndRecompute(sb, id, {
+        date,
+        featureKey: 'wearable_heart_rate',
+        pillar: 'exercise',
+        value: heartRate,
+        unit: 'bpm',
+        metadata: { source: 'voice_tool_vitals' },
+      });
+      if (!out.ok) return { ok: false, error: out.error };
+      indexDelta = out.indexDelta;
+      logged.push(`heart rate ${heartRate} bpm`);
+    }
+
+    // Weight and blood pressure have no Index feature_key today (only
+    // biomarker_glucose/hba1c, meal_log, macro_balance exist for nutrition;
+    // no weight/BP slot exists anywhere in the pillar catalog) — they go to
+    // wearable_samples, the same free-metric raw-signal table
+    // health_ingest_wearable_samples (routes/health.ts) writes to. Honest:
+    // recorded, but does not move the Vitana Index (same as a real scale
+    // sync with no matching feature_key would behave).
+    const wearableRows: Array<{ tenant_id: string; user_id: string; provider: string; metric: string; ts: string; value: number; unit: string }> = [];
+    if (weightKg !== null) {
+      wearableRows.push({ tenant_id: tenantId, user_id: id.user_id, provider: 'manual_voice', metric: 'weight_kg', ts: nowIso, value: weightKg, unit: 'kg' });
+      logged.push(`weight ${weightKg} kg`);
+    }
+    if (systolic !== null) {
+      wearableRows.push({ tenant_id: tenantId, user_id: id.user_id, provider: 'manual_voice', metric: 'blood_pressure_systolic', ts: nowIso, value: systolic, unit: 'mmHg' });
+      logged.push(`systolic ${systolic}`);
+    }
+    if (diastolic !== null) {
+      wearableRows.push({ tenant_id: tenantId, user_id: id.user_id, provider: 'manual_voice', metric: 'blood_pressure_diastolic', ts: nowIso, value: diastolic, unit: 'mmHg' });
+      logged.push(`diastolic ${diastolic}`);
+    }
+    if (wearableRows.length > 0) {
+      const { error: wErr } = await sb.from('wearable_samples').insert(wearableRows);
+      if (wErr) return { ok: false, error: `wearable_write_failed: ${wErr.message}` };
+    }
+
+    const deltaText = indexDelta !== null && indexDelta > 0 ? ` Vitana Index up ${indexDelta}.` : '';
+    return {
+      ok: true,
+      result: { date, heart_rate: heartRate, weight_kg: weightKg, systolic, diastolic, index_delta: indexDelta },
+      text: `Logged ${logged.join(', ')}.${deltaText}`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'log_vitals failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. log_mood
+// ---------------------------------------------------------------------------
+
+const MOOD_LABEL_SCORE: Record<string, number> = {
+  terrible: 1, bad: 2, down: 2, okay: 3, neutral: 3, fine: 3, good: 4, great: 5, fantastic: 5,
+};
+
+export async function tool_log_mood(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('log_mood', id);
+  if (gate) return gate;
+  const date = parseDateArg(args.date);
+  const label = String(args.mood_label ?? '').trim().toLowerCase();
+  let score = typeof args.mood_score === 'number' ? args.mood_score : null;
+  if (score === null && label && MOOD_LABEL_SCORE[label] !== undefined) score = MOOD_LABEL_SCORE[label];
+  if (score === null) {
+    return { ok: false, error: 'log_mood requires mood_score (1-5) or a recognizable mood_label.' };
+  }
+  score = Math.max(1, Math.min(5, Math.round(score)));
+  const notes = String(args.notes ?? '').trim();
+
+  try {
+    // 'mood_entry' is a real mental-pillar feature_key (routes/integrations.ts
+    // PILLAR_FEATURE_KEYS.mental) — same chokepoint as log_meditation.
+    const out = await upsertHealthFeatureAndRecompute(sb, id, {
+      date,
+      featureKey: 'mood_entry',
+      pillar: 'mental',
+      value: score,
+      unit: 'score_1_5',
+      metadata: { mood_label: label || null, notes: notes || null, source: 'voice_tool' },
+    });
+    if (!out.ok) return { ok: false, error: out.error };
+    const deltaText = out.indexDelta !== null && out.indexDelta > 0 ? ` Vitana Index up ${out.indexDelta}.` : '';
+    return {
+      ok: true,
+      result: { date, mood_score: score, mood_label: label || null, pillar_score_after: out.pillarScoreAfter, index_delta: out.indexDelta },
+      text: `Logged your mood at ${score} out of 5${label ? ` (${label})` : ''}.${deltaText}`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'log_mood failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. log_biomarker
+// ---------------------------------------------------------------------------
+
+export async function tool_log_biomarker(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('log_biomarker', id);
+  if (gate) return gate;
+  const name = String(args.name ?? '').trim();
+  const value = typeof args.value === 'number' ? args.value : Number(args.value);
+  if (!name || !Number.isFinite(value)) {
+    return { ok: false, error: 'log_biomarker requires a biomarker name and a numeric value.' };
+  }
+  const unit = String(args.unit ?? '').trim() || null;
+  const biomarkerCode = String(args.biomarker_code ?? '').trim() || null;
+  const refLow = typeof args.ref_range_low === 'number' ? args.ref_range_low : null;
+  const refHigh = typeof args.ref_range_high === 'number' ? args.ref_range_high : null;
+  const measuredAt = typeof args.measured_at === 'string' && args.measured_at ? args.measured_at : new Date().toISOString();
+  let status = String(args.status ?? '').trim().toLowerCase() || null;
+  if (!status && refLow !== null && refHigh !== null) {
+    status = value < refLow ? 'low' : value > refHigh ? 'high' : 'normal';
+  }
+
+  try {
+    // Same two tables health_ingest_lab_report() (routes/health.ts) writes
+    // to — that RPC needs a user-JWT client (current_user_id()/
+    // current_tenant_id()), so we insert directly with the service-role `sb`
+    // using the identical column shape (lab_reports -> biomarker_results).
+    const tenantId = await resolveHealthTenantId(id, sb);
+    const { data: labReport, error: labErr } = await sb
+      .from('lab_reports')
+      .insert({
+        tenant_id: tenantId,
+        user_id: id.user_id,
+        source: 'voice',
+        report_date: todayIso(),
+      })
+      .select('id')
+      .single();
+    if (labErr || !labReport) return { ok: false, error: labErr?.message ?? 'lab_reports insert failed' };
+
+    const { error: bmErr } = await sb.from('biomarker_results').insert({
+      tenant_id: tenantId,
+      user_id: id.user_id,
+      lab_report_id: (labReport as { id: string }).id,
+      biomarker_code: biomarkerCode,
+      name,
+      value,
+      unit,
+      ref_range_low: refLow,
+      ref_range_high: refHigh,
+      status,
+      measured_at: measuredAt,
+    });
+    if (bmErr) return { ok: false, error: bmErr.message };
+
+    const statusPhrase = status ? ` — ${status}` : '';
+    return {
+      ok: true,
+      result: { name, value, unit, status, measured_at: measuredAt },
+      text: `Recorded ${name}: ${value}${unit ? ` ${unit}` : ''}${statusPhrase}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'log_biomarker failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. get_health_trends
+// ---------------------------------------------------------------------------
+
+export async function tool_get_health_trends(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('get_health_trends', id);
+  if (gate) return gate;
+  const days = typeof args.days === 'number' ? Math.min(90, Math.max(3, Math.round(args.days))) : 14;
+  const from = new Date();
+  from.setDate(from.getDate() - days);
+  const fromDate = from.toISOString().slice(0, 10);
+
+  try {
+    // Same table + shape as vitana-v1's useVitanaIndexHistory.ts / useVitanaIndex.ts
+    // and user-context-profiler.ts's fetchVitanaIndex — trend math matches the
+    // My Journey trajectory card exactly.
+    const { data, error } = await sb
+      .from('vitana_index_scores')
+      .select('date, score_total, score_nutrition, score_hydration, score_exercise, score_sleep, score_mental')
+      .eq('user_id', id.user_id)
+      .gte('date', fromDate)
+      .order('date', { ascending: true });
+    if (error) return { ok: false, error: error.message };
+    const rows = (data as Array<Record<string, number | string>>) ?? [];
+    if (rows.length === 0) {
+      return { ok: true, result: { history: [] }, text: `No Vitana Index history in the last ${days} days yet.` };
+    }
+
+    const first = rows[0];
+    const last = rows[rows.length - 1];
+    const trendFor = (col: string): 'up' | 'down' | 'stable' => {
+      const a = Number(first[col]) || 0;
+      const b = Number(last[col]) || 0;
+      if (b > a + 5) return 'up';
+      if (b < a - 5) return 'down';
+      return 'stable';
+    };
+    const pillarTrends: Record<PillarKey, 'up' | 'down' | 'stable'> = {
+      nutrition: trendFor('score_nutrition'),
+      hydration: trendFor('score_hydration'),
+      exercise: trendFor('score_exercise'),
+      sleep: trendFor('score_sleep'),
+      mental: trendFor('score_mental'),
+    };
+    const totalTrend = trendFor('score_total');
+    const rising = PILLAR_KEYS.filter((p) => pillarTrends[p] === 'up');
+    const falling = PILLAR_KEYS.filter((p) => pillarTrends[p] === 'down');
+
+    let text = `Over the last ${days} days your Vitana Index total is ${totalTrend === 'up' ? 'trending up' : totalTrend === 'down' ? 'trending down' : 'holding steady'} (${first.score_total} → ${last.score_total}).`;
+    if (rising.length) text += ` ${rising.join(', ')} improving.`;
+    if (falling.length) text += ` ${falling.join(', ')} declining.`;
+
+    return {
+      ok: true,
+      result: {
+        days,
+        history: rows.map((r) => ({ date: r.date, score_total: r.score_total })),
+        total_trend: totalTrend,
+        pillar_trends: pillarTrends,
+        first: { date: first.date, score_total: first.score_total },
+        last: { date: last.date, score_total: last.score_total },
+      },
+      text,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_health_trends failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6. get_health_streaks
+// ---------------------------------------------------------------------------
+
+export async function tool_get_health_streaks(_args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('get_health_streaks', id);
+  if (gate) return gate;
+  try {
+    // Diary streak: real view (20260427090000_user_diary_streak_view.sql).
+    let diaryStreak = 0;
+    try {
+      const { data } = await sb
+        .from('user_diary_streak')
+        .select('current_streak_days')
+        .eq('user_id', id.user_id)
+        .maybeSingle();
+      diaryStreak = Number((data as { current_streak_days?: number } | null)?.current_streak_days) || 0;
+    } catch {
+      /* view may be absent in some envs — non-fatal */
+    }
+
+    // Per-pillar streaks: same RPC the v3 Index compute function calls for
+    // the streak sub-score (vitana_pillar_streak_days).
+    const pillarStreaks: Partial<Record<PillarKey, number>> = {};
+    for (const pillar of PILLAR_KEYS) {
+      try {
+        const { data } = await sb.rpc('vitana_pillar_streak_days', { p_user_id: id.user_id, p_pillar_key: pillar });
+        pillarStreaks[pillar] = Number(data) || 0;
+      } catch {
+        pillarStreaks[pillar] = 0;
+      }
+    }
+
+    const bestPillarEntry = (Object.entries(pillarStreaks) as Array<[PillarKey, number]>).sort((a, b) => b[1] - a[1])[0];
+    const bestPillar = bestPillarEntry?.[0];
+    const bestPillarDays = bestPillarEntry?.[1] ?? 0;
+
+    let text = '';
+    if (diaryStreak > 0) text += `Your diary streak is ${diaryStreak} day${diaryStreak === 1 ? '' : 's'}. `;
+    if (bestPillar && bestPillarDays > 0) {
+      text += `Your longest active pillar streak is ${bestPillar} at ${bestPillarDays} day${bestPillarDays === 1 ? '' : 's'}.`;
+    } else if (!text) {
+      text = "No active streaks yet — log something today to start one.";
+    }
+
+    return {
+      ok: true,
+      result: { diary_streak_days: diaryStreak, pillar_streaks: pillarStreaks },
+      text: text.trim(),
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_health_streaks failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 7. order_lab_test — STUB. No lab_test_orders (or equivalent) table/RPC
+// exists anywhere in supabase/migrations or the frontend's own migrations.
+// Fabricating an ordering flow with no backend would silently lie to the
+// user about a lab test actually being placed, so this returns ok:false
+// per the hard rule against inventing tables.
+// ---------------------------------------------------------------------------
+
+export async function tool_order_lab_test(_args: OrbToolArgs, id: OrbToolIdentity, _sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('order_lab_test', id);
+  if (gate) return gate;
+  return { ok: false, error: 'order_lab_test is not available yet — no backing endpoint (no lab_test_orders table or ordering RPC exists).' };
+}
+
+// ---------------------------------------------------------------------------
+// 8. get_lab_results
+// ---------------------------------------------------------------------------
+
+export async function tool_get_lab_results(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('get_lab_results', id);
+  if (gate) return gate;
+  const query = String(args.biomarker ?? args.query ?? '').trim();
+  const limit = typeof args.limit === 'number' ? Math.min(25, Math.max(1, Math.round(args.limit))) : 10;
+
+  try {
+    let q = sb
+      .from('biomarker_results')
+      .select('name, biomarker_code, value, unit, ref_range_low, ref_range_high, status, measured_at')
+      .eq('user_id', id.user_id)
+      .order('measured_at', { ascending: false })
+      .limit(limit);
+    if (query) q = q.or(`name.ilike.%${query}%,biomarker_code.ilike.%${query}%`);
+    const { data, error } = await q;
+    if (error) return { ok: false, error: error.message };
+    const rows = (data as Array<Record<string, unknown>>) ?? [];
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { results: [] },
+        text: query ? `No lab results found matching "${query}".` : 'No lab results on file yet.',
+      };
+    }
+    const lines = rows
+      .slice(0, 8)
+      .map((r) => `${r.name}: ${r.value}${r.unit ? ` ${r.unit}` : ''}${r.status ? ` (${r.status})` : ''}`)
+      .join('; ');
+    return {
+      ok: true,
+      result: { results: rows },
+      text: `Latest lab results: ${lines}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_lab_results failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 9. generate_health_plan (⚠️ two-step confirm; template-based — see file
+// header for why this isn't the LLM-authored version the app UI produces)
+// ---------------------------------------------------------------------------
+
+export async function tool_generate_health_plan(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('generate_health_plan', id);
+  if (gate) return gate;
+  try {
+    let pillar = resolvePillarKey(args.plan_type as string | undefined);
+    if (!pillar) {
+      const snap = await fetchVitanaIndexForProfiler(sb, id.user_id);
+      pillar = snap?.weakest_pillar?.name;
+    }
+    if (!pillar) {
+      return {
+        ok: true,
+        result: { ok: false, reason: 'no_index_data' },
+        text: "I don't have Index data for you yet, so I can't target a plan. Complete the baseline survey first, or tell me which area to focus on.",
+      };
+    }
+
+    const templates = PILLAR_ACTION_TEMPLATES[pillar];
+    const planData = {
+      planName: `${pillar[0].toUpperCase()}${pillar.slice(1)} starter plan`,
+      duration: '14 days',
+      goals: templates.map((t) => t.title),
+      dailyPlan: { focus: pillar, actions: templates.map((t) => ({ title: t.title, description: t.description })) },
+      recommendations: templates.map((t) => t.description),
+    };
+
+    const confirm = args.confirm === true || args.confirm === 'true';
+    if (!confirm) {
+      return {
+        ok: true,
+        result: { needs_confirmation: true, plan_type: pillar, preview: planData },
+        text: `Confirm with the user: create a ${pillar} health plan with ${templates.length} template actions (this is a starter template, not an AI-personalized plan — say yes to save it)? When they agree, call generate_health_plan again with plan_type:"${pillar}" and confirm:true.`,
+      };
+    }
+
+    // Same table useHealthPlans.ts reads (supabase.from('user_health_plans')),
+    // upserted the same way the generate-personalized-plan edge function does
+    // (onConflict user_id,plan_type) — but ai_generated:false since the
+    // gateway cannot reach the Lovable-AI-backed edge function (see file header).
+    const { data: saved, error } = await sb
+      .from('user_health_plans')
+      .upsert(
+        {
+          user_id: id.user_id,
+          plan_type: pillar,
+          plan_data: planData,
+          ai_generated: false,
+          generated_at: new Date().toISOString(),
+          active: true,
+          adherence_score: 0,
+          last_updated: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,plan_type' },
+      )
+      .select('id, plan_type')
+      .single();
+    if (error || !saved) return { ok: false, error: error?.message ?? 'user_health_plans upsert failed' };
+
+    return {
+      ok: true,
+      result: { plan_id: (saved as { id: string }).id, plan_type: pillar, plan_data: planData },
+      text: `Saved a ${pillar} starter plan with ${templates.length} actions. You can track adherence with "how's my plan going".`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'generate_health_plan failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 10. list_my_health_plans
+// ---------------------------------------------------------------------------
+
+export async function tool_list_my_health_plans(_args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('list_my_health_plans', id);
+  if (gate) return gate;
+  try {
+    const { data, error } = await sb
+      .from('user_health_plans')
+      .select('id, plan_type, ai_generated, adherence_score, active, created_at')
+      .eq('user_id', id.user_id)
+      .eq('active', true)
+      .order('created_at', { ascending: false });
+    if (error) return { ok: false, error: error.message };
+    const rows = (data as Array<Record<string, unknown>>) ?? [];
+    if (rows.length === 0) {
+      return { ok: true, result: { plans: [] }, text: "You don't have any active health plans yet. Want me to create one?" };
+    }
+    const lines = rows.map((r) => `${r.plan_type} (${r.adherence_score ?? 0}% adherence)`).join(', ');
+    return {
+      ok: true,
+      result: { plans: rows },
+      text: `Your active health plans: ${lines}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'list_my_health_plans failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 11. get_health_plan_progress
+// ---------------------------------------------------------------------------
+
+export async function tool_get_health_plan_progress(args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('get_health_plan_progress', id);
+  if (gate) return gate;
+  const planType = resolvePillarKey(args.plan_type as string | undefined);
+  const planId = String(args.plan_id ?? '').trim();
+
+  try {
+    let planQuery = sb
+      .from('user_health_plans')
+      .select('id, plan_type, adherence_score, created_at')
+      .eq('user_id', id.user_id)
+      .eq('active', true);
+    if (planId) planQuery = planQuery.eq('id', planId);
+    else if (planType) planQuery = planQuery.eq('plan_type', planType);
+    const { data: plans, error: planErr } = await planQuery.order('created_at', { ascending: false }).limit(5);
+    if (planErr) return { ok: false, error: planErr.message };
+    const candidates = (plans as Array<Record<string, unknown>>) ?? [];
+    if (candidates.length === 0) {
+      return { ok: true, result: { found: false }, text: "I couldn't find an active plan matching that. Say 'list my health plans' to see what's active." };
+    }
+    if (candidates.length > 1) {
+      return {
+        ok: true,
+        result: { candidates: candidates.map((p) => ({ plan_id: p.id, plan_type: p.plan_type })) },
+        text: `You have ${candidates.length} active plans: ${candidates.map((p) => p.plan_type).join(', ')}. Which one?`,
+      };
+    }
+    const plan = candidates[0] as { id: string; plan_type: string; adherence_score: number | null };
+
+    // plan_adherence_logs — same table useHealthPlans.ts's logAdherence writes to.
+    const { data: logs, error: logErr } = await sb
+      .from('plan_adherence_logs')
+      .select('completed, logged_at')
+      .eq('plan_id', plan.id)
+      .eq('user_id', id.user_id)
+      .order('logged_at', { ascending: false })
+      .limit(30);
+    if (logErr) return { ok: false, error: logErr.message };
+    const logRows = (logs as Array<{ completed: boolean; logged_at: string }>) ?? [];
+    const completedCount = logRows.filter((l) => l.completed).length;
+    const rate = logRows.length > 0 ? Math.round((completedCount / logRows.length) * 100) : null;
+
+    return {
+      ok: true,
+      result: {
+        plan_id: plan.id,
+        plan_type: plan.plan_type,
+        adherence_score: plan.adherence_score,
+        recent_log_count: logRows.length,
+        recent_completed: completedCount,
+        recent_completion_rate_pct: rate,
+      },
+      text:
+        logRows.length > 0
+          ? `Your ${plan.plan_type} plan: ${completedCount} of ${logRows.length} recent check-ins completed (${rate}%). Stored adherence score is ${plan.adherence_score ?? 0}%.`
+          : `Your ${plan.plan_type} plan has an adherence score of ${plan.adherence_score ?? 0}% but no logged check-ins yet.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_health_plan_progress failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 12. list_my_conditions
+// ---------------------------------------------------------------------------
+
+export async function tool_list_my_conditions(_args: OrbToolArgs, id: OrbToolIdentity, _sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('list_my_conditions', id);
+  if (gate) return gate;
+  try {
+    // Same primitive search_marketplace_products / open_discover_feed already
+    // use (services/user-health-context.ts) — assembles active_conditions
+    // from user_limitations.contraindications + memory_facts, instead of a
+    // dedicated (nonexistent) "conditions" table.
+    const ctx = await getUserHealthContext(id.user_id, { include_wearable: false, include_calendar: false, include_past_purchases: false });
+    const conditions = ctx.active_conditions.map((c) => c.key);
+    if (conditions.length === 0 && ctx.allergies.length === 0 && ctx.current_medications.length === 0) {
+      return {
+        ok: true,
+        result: { conditions: [], allergies: [], medications: [] },
+        text: "You don't have any conditions, allergies, or medications on file yet. You can add them in Preferences.",
+      };
+    }
+    const parts: string[] = [];
+    if (conditions.length) parts.push(`conditions: ${conditions.join(', ')}`);
+    if (ctx.allergies.length) parts.push(`allergies: ${ctx.allergies.join(', ')}`);
+    if (ctx.current_medications.length) parts.push(`medications: ${ctx.current_medications.join(', ')}`);
+    if (ctx.dietary_restrictions.length) parts.push(`dietary restrictions: ${ctx.dietary_restrictions.join(', ')}`);
+
+    return {
+      ok: true,
+      result: {
+        conditions,
+        allergies: ctx.allergies,
+        medications: ctx.current_medications,
+        dietary_restrictions: ctx.dietary_restrictions,
+      },
+      text: `On file for you — ${parts.join('; ')}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'list_my_conditions failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 13. get_health_education
+// ---------------------------------------------------------------------------
+
+export async function tool_get_health_education(args: OrbToolArgs, id: OrbToolIdentity, _sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('get_health_education', id);
+  if (gate) return gate;
+  const topic = String(args.topic ?? args.query ?? '').trim();
+  if (!topic) return { ok: false, error: 'get_health_education requires a topic.' };
+  if (!id.tenant_id) return { ok: false, error: 'get_health_education requires a tenant_id on the session.' };
+
+  try {
+    // Same knowledge-hub retrieval stack orb-tools-shared.ts's private
+    // _runRetrievalSearch('search_knowledge', ...) uses — that helper isn't
+    // exported, so we call the two underlying modules directly (forcing
+    // knowledge_hub) rather than duplicating a table.
+    const { computeRetrievalRouterDecision } = await import('../retrieval-router');
+    const { buildContextPack } = await import('../context-pack-builder');
+    const { createContextLens } = await import('../../types/context-lens');
+
+    const query = `health education: ${topic}`;
+    const routerDecision = computeRetrievalRouterDecision(query, {
+      channel: 'orb',
+      force_sources: ['knowledge_hub'],
+      limit_overrides: { memory_garden: 0, knowledge_hub: 5, web_search: 0 },
+    });
+    const lens = createContextLens(id.tenant_id, id.user_id, { workspace_scope: 'product', active_role: id.role || undefined });
+    const threadId = id.thread_id || id.session_id || `${id.user_id}:get_health_education`;
+    const contextPack = await buildContextPack({
+      lens,
+      query,
+      channel: 'orb',
+      thread_id: threadId,
+      turn_number: typeof id.turn_number === 'number' ? id.turn_number : 0,
+      conversation_start: id.session_started_iso || new Date().toISOString(),
+      role: id.role || 'user',
+      router_decision: routerDecision,
+    });
+
+    const hits = (contextPack.knowledge_hits || []) as Array<{ title?: string; excerpt?: string; content?: string; citation?: string }>;
+    if (hits.length === 0) {
+      return { ok: true, result: { items: [] }, text: `I don't have grounded knowledge-base content on "${topic}" yet.` };
+    }
+    const MAX = 4000;
+    let formatted = hits
+      .slice(0, 4)
+      .map((h) => `**${h.title || 'KB'}**\n${h.excerpt || h.content || ''}`)
+      .join('\n\n');
+    if (formatted.length > MAX) formatted = formatted.substring(0, MAX) + '\n... (truncated)';
+    return {
+      ok: true,
+      result: { items: hits.slice(0, 4) },
+      text: `Here's what I found on ${topic}:\n${formatted}`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_health_education failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 14. get_next_best_action
+// ---------------------------------------------------------------------------
+
+export async function tool_get_next_best_action(_args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('get_next_best_action', id);
+  if (gate) return gate;
+  try {
+    // Same table + ranking approach tool_create_index_improvement_plan and
+    // tool_activate_recommendation already use — so the returned id can be
+    // handed straight to activate_recommendation.
+    const { data } = await sb
+      .from('autopilot_recommendations')
+      .select('id, title, summary, action_description, contribution_vector, priority')
+      .eq('user_id', id.user_id)
+      .in('status', ['pending', 'new', 'snoozed'])
+      .not('contribution_vector', 'is', null)
+      .order('priority', { ascending: false })
+      .limit(50);
+
+    const ranked = ((data as Array<Record<string, unknown>>) ?? [])
+      .map((r) => {
+        const cv = (r.contribution_vector as Record<string, number> | null) ?? {};
+        const bestPillar = (PILLAR_KEYS as readonly string[])
+          .map((p) => ({ pillar: p, lift: typeof cv[p] === 'number' ? cv[p] : 0 }))
+          .sort((a, b) => b.lift - a.lift)[0];
+        return { ...r, _lift: bestPillar?.lift ?? 0, _pillar: bestPillar?.pillar };
+      })
+      .filter((r) => r._lift > 0)
+      .sort((a, b) => b._lift - a._lift);
+
+    if (ranked.length > 0) {
+      const top = ranked[0] as unknown as { id: string; title: string | null; summary: string | null; action_description: string | null; _pillar?: string };
+      return {
+        ok: true,
+        result: { source: 'autopilot', id: top.id, title: top.title, pillar: top._pillar },
+        text: `Today's next best health action: ${top.title ?? 'an autopilot suggestion'}${top.summary ? ` — ${top.summary}` : ''}. Want me to activate it?`,
+      };
+    }
+
+    // Fallback: no queued autopilot recommendation with a pillar lift —
+    // suggest the top template action for the weakest Vitana Index pillar
+    // (same PILLAR_ACTION_TEMPLATES library the plan tool uses). This has
+    // no autopilot_recommendations id, so it can't be handed to
+    // activate_recommendation — it's a spoken suggestion only, and the
+    // result says so explicitly (no fabricated id).
+    const snap = await fetchVitanaIndexForProfiler(sb, id.user_id);
+    if (!snap) {
+      return { ok: true, result: { source: 'none' }, text: "I don't have a specific next action for you yet — log something today to get started." };
+    }
+    const pillar = snap.weakest_pillar.name;
+    const template = PILLAR_ACTION_TEMPLATES[pillar][0];
+    return {
+      ok: true,
+      result: { source: 'template_fallback', pillar, title: template.title, description: template.description },
+      text: `No queued suggestions right now, but your weakest pillar is ${pillar} — try: ${template.title}. ${template.description}`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_next_best_action failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 15. connect_health_device — navigate-only orb_directive, no DB write
+// (device pairing is inherently a client-side/native flow).
+// ---------------------------------------------------------------------------
+
+export async function tool_connect_health_device(args: OrbToolArgs, id: OrbToolIdentity, _sb: SupabaseClient): Promise<OrbToolResult> {
+  const gate = authGate('connect_health_device', id);
+  if (gate) return gate;
+  const deviceName = String(args.device_name ?? '').trim();
+  // /health-tracker/devices and /health/my-health-tracker both redirect to
+  // /health (vitana-v1/src/App.tsx) — that's where device connections live.
+  const route = '/health';
+  return {
+    ok: true,
+    result: {
+      directive: { type: 'orb_directive', directive: 'navigate', screen_id: 'HEALTH.TRACKER', route, title: 'Health', reason: 'connect_health_device', vtid: 'A11-HEALTH-DEPTH' },
+      redirect: { route },
+    },
+    text: `Opening your health tracker so you can pair${deviceName ? ` ${deviceName}` : ' your device'} — device connections are set up there.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const HEALTH_DEPTH_TOOL_HANDLERS: Record<string, Handler> = {
+  log_meal: tool_log_meal,
+  log_vitals: tool_log_vitals,
+  log_mood: tool_log_mood,
+  log_biomarker: tool_log_biomarker,
+  get_health_trends: tool_get_health_trends,
+  get_health_streaks: tool_get_health_streaks,
+  order_lab_test: tool_order_lab_test,
+  get_lab_results: tool_get_lab_results,
+  generate_health_plan: tool_generate_health_plan,
+  list_my_health_plans: tool_list_my_health_plans,
+  get_health_plan_progress: tool_get_health_plan_progress,
+  list_my_conditions: tool_list_my_conditions,
+  get_health_education: tool_get_health_education,
+  get_next_best_action: tool_get_next_best_action,
+  connect_health_device: tool_connect_health_device,
+};
+
+export const HEALTH_DEPTH_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'log_meal',
+    description: [
+      'Log a meal (breakfast/lunch/dinner/snack) toward the nutrition pillar.',
+      'CALL WHEN the user says: "I just had breakfast", "log my lunch",',
+      '"ich habe gerade gegessen", "trage mein Mittagessen ein".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        description: { type: 'string', description: 'What was eaten, e.g. "oatmeal with berries".' },
+        meal_type: { type: 'string', description: "One of breakfast, lunch, dinner, snack." },
+        calories: { type: 'number', description: 'Optional estimated calories.' },
+        date: { type: 'string', description: 'YYYY-MM-DD, defaults to today.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'log_vitals',
+    description: [
+      'Log vitals: heart rate, weight, and/or blood pressure. Pass any subset.',
+      'Heart rate contributes to the Vitana Index exercise pillar; weight and',
+      'blood pressure are recorded but do not currently move the Index.',
+      'CALL WHEN the user says: "my heart rate is 68", "I weigh 74 kilos",',
+      '"my blood pressure is 120 over 80", "meine Herzfrequenz ist ...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        heart_rate: { type: 'number', description: 'Heart rate in bpm.' },
+        weight_kg: { type: 'number', description: 'Body weight in kilograms.' },
+        systolic: { type: 'number', description: 'Systolic blood pressure (mmHg).' },
+        diastolic: { type: 'number', description: 'Diastolic blood pressure (mmHg).' },
+        date: { type: 'string', description: 'YYYY-MM-DD, defaults to today.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'log_mood',
+    description: [
+      'Log a mental-health / mood check-in (1-5 scale, or a mood word).',
+      'CALL WHEN the user says: "I feel great today", "log my mood as okay",',
+      '"ich fühle mich heute gut".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        mood_score: { type: 'number', description: '1 (terrible) to 5 (fantastic).' },
+        mood_label: { type: 'string', description: "A word like 'great', 'okay', 'down' — used if mood_score is omitted." },
+        notes: { type: 'string', description: 'Optional short note about why.' },
+        date: { type: 'string', description: 'YYYY-MM-DD, defaults to today.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'log_biomarker',
+    description: [
+      'Record a single lab/biomarker value the user reports out loud (e.g. from',
+      'a home test or a doctor visit), creating a lab report entry.',
+      'CALL WHEN the user says: "my glucose was 95", "my cholesterol came back',
+      'at 180", "mein Blutzucker war 95".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: "Biomarker name, e.g. 'glucose', 'LDL cholesterol'." },
+        value: { type: 'number', description: 'The measured value.' },
+        unit: { type: 'string', description: "Unit, e.g. 'mg/dL'." },
+        biomarker_code: { type: 'string', description: "Optional code, e.g. 'HBA1C'." },
+        ref_range_low: { type: 'number', description: 'Optional reference range low.' },
+        ref_range_high: { type: 'number', description: 'Optional reference range high.' },
+        status: { type: 'string', description: "Optional: 'low'|'normal'|'high'|'critical' — inferred from range if omitted." },
+        measured_at: { type: 'string', description: 'Optional ISO timestamp; defaults to now.' },
+      },
+      required: ['name', 'value'],
+    },
+  },
+  {
+    name: 'get_health_trends',
+    description: [
+      'Get the Vitana Index trend (total + per-pillar) over a recent window.',
+      'CALL WHEN the user asks: "how have I been trending?", "am I improving?",',
+      '"wie hat sich mein Index entwickelt?".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { days: { type: 'number', description: 'Window size in days, default 14, max 90.' } },
+      required: [],
+    },
+  },
+  {
+    name: 'get_health_streaks',
+    description: [
+      'Get the user\'s diary streak and per-pillar Vitana Index streaks.',
+      'CALL WHEN the user asks: "what\'s my streak?", "am I on a streak?",',
+      '"wie lange ist meine Serie schon?".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'order_lab_test',
+    description: 'Order a lab test. NOT AVAILABLE YET — always returns an error explaining there is no ordering backend; tell the user this feature is not live yet.',
+    parameters: { type: 'object', properties: { test_name: { type: 'string', description: 'Name of the test requested.' } }, required: [] },
+  },
+  {
+    name: 'get_lab_results',
+    description: [
+      'Read the user\'s recorded lab/biomarker results, most recent first.',
+      'CALL WHEN the user asks: "what were my last lab results?", "what\'s my',
+      'cholesterol?", "wie waren meine letzten Laborwerte?".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        biomarker: { type: 'string', description: 'Optional biomarker name/code to filter by.' },
+        limit: { type: 'number', description: 'Max results, default 10.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'generate_health_plan',
+    description: [
+      'Create a starter health plan (template-based, not AI-personalized) for a',
+      'pillar. ALWAYS call once WITHOUT confirm first — the tool returns a',
+      'preview; after the user agrees, call again with confirm:true.',
+      'CALL WHEN the user says: "make me a nutrition plan", "erstelle einen',
+      'Ernährungsplan für mich".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        plan_type: { type: 'string', description: 'One of nutrition, hydration, exercise, sleep, mental. Defaults to the weakest pillar.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed creating the plan.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'list_my_health_plans',
+    description: 'List the user\'s active health plans with adherence scores. CALL WHEN the user asks: "what plans do I have?", "welche Pläne habe ich?".',
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_health_plan_progress',
+    description: [
+      'Get adherence/progress for a specific active health plan.',
+      'CALL WHEN the user asks: "how\'s my plan going?", "am I keeping up with',
+      'my sleep plan?", "wie läuft mein Plan?".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        plan_type: { type: 'string', description: 'One of nutrition, hydration, exercise, sleep, mental.' },
+        plan_id: { type: 'string', description: 'Exact plan UUID if known.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'list_my_conditions',
+    description: [
+      'List the user\'s recorded health conditions, allergies, medications, and',
+      'dietary restrictions.',
+      'CALL WHEN the user asks: "what conditions do I have on file?", "what',
+      'are my allergies?", "welche Erkrankungen habe ich hinterlegt?".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_health_education',
+    description: [
+      'Get grounded educational content on a health/longevity topic from the',
+      'knowledge hub.',
+      'CALL WHEN the user asks: "tell me about HRV", "what is VO2 max?",',
+      '"erkläre mir was Schlafqualität bedeutet".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { topic: { type: 'string', description: 'The health topic to explain.' } },
+      required: ['topic'],
+    },
+  },
+  {
+    name: 'get_next_best_action',
+    description: [
+      'Get today\'s single highest-priority recommended health action.',
+      'CALL WHEN the user asks: "what should I do today?", "what\'s my next',
+      'step?", "was soll ich heute für meine Gesundheit tun?".',
+      'If the result has an autopilot id, offer to call activate_recommendation.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'connect_health_device',
+    description: [
+      'Start pairing a wearable/health device. Opens the health tracker screen',
+      'where device connections are managed (pairing itself is a native/client flow).',
+      'CALL WHEN the user says: "connect my Oura ring", "pair my device",',
+      '"verbinde mein Gerät".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { device_name: { type: 'string', description: 'Optional device name, e.g. "Oura Ring".' } },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/marketplace-discovery-tools.ts
+++ b/services/gateway/src/services/orb-tools/marketplace-discovery-tools.ts
@@ -1,0 +1,1286 @@
+/**
+ * A1 Commerce & Marketplace Discovery voice tools.
+ *
+ * Real backings verified by grepping the actual gateway routes/services/
+ * migrations before writing any handler (per the wave-1 shared brief):
+ *
+ *   - search_marketplace / get_product_details / browse_supplements /
+ *     browse_deals_offers → the SAME `public.products` table
+ *     routes/discover-search.ts (GET /search, GET /product/:id) and
+ *     routes/discover-feed.ts query. This is the live, populated VTID-02000
+ *     marketplace catalog (images, price_cents, affiliate_url, rating,
+ *     availability, compare_at_price_cents, etc.) — NOT the sparse
+ *     VTID-01092 `products_catalog` memory table some older tools
+ *     (discovery-tools.ts's global_search) use for a different purpose.
+ *     "Deals" are derived honestly from the real
+ *     compare_at_price_cents > price_cents columns; there is no separate
+ *     deals/promotions table.
+ *   - browse_wellness_services / browse_doctors_coaches / get_provider_profile
+ *     → `public.services_catalog` (VTID-01092 migration
+ *     20251231100000_vtid_01092_services_products_memory.sql), columns
+ *     verified as (id, tenant_id, name, service_type, topic_keys,
+ *     provider_name, metadata, created_at). service_type CHECK includes
+ *     'coach' | 'doctor' | 'lab' | 'wellness' | 'nutrition' | 'fitness' |
+ *     'therapy' | 'other'. Same columns discovery-tools.ts's global_search
+ *     already reads from this table.
+ *   - get_ai_product_picks → reuses runPropose() from
+ *     services/shopping-agent/agent-core.ts verbatim (the exact planning +
+ *     limitations-filtered search + annotation logic
+ *     routes/shopping-agent.ts POST /propose calls) with a local insertPick
+ *     writer that inserts into universal_cart_items directly via the
+ *     service-role `sb` this dispatcher always passes (see
+ *     routes/orb-tool.ts's `adminClient() || getSupabase()` — every sibling
+ *     tool file in this directory does explicit user_id/tenant_id scoping
+ *     rather than an RLS-scoped user client, and this file follows the same
+ *     convention). NEVER re-implements the AI planning logic itself.
+ *   - reorder_last_order → reuses buildReorderPicks() from
+ *     services/shopping-agent/reorder-core.ts verbatim (the exact
+ *     dedupe → hydrate → drop-out-of-stock → re-snapshot logic
+ *     routes/shopping-agent.ts POST /reorder calls), with maxItems=1 so
+ *     "last order" resolves to the single most-recently-purchased,
+ *     still-purchasable product. Two-step confirm per the shared brief.
+ *   - list_my_orders / get_order_status → `public.product_orders`
+ *     (supabase/migrations/20260416180000_vtid_02000_fix_products_v2.sql),
+ *     columns verified as (id, user_id, tenant_id, product_id, merchant_id,
+ *     state, amount_cents, currency, purchased_at, created_at, ...).
+ *   - Cart writes (get_ai_product_picks, reorder_last_order confirm step)
+ *     reuse emitCartEvent()/sanitizeEventPayload() imported directly from
+ *     routes/universal-cart.ts (already an established cross-module import —
+ *     routes/shopping-agent.ts imports the same two functions from the same
+ *     file) instead of re-deriving the audit-payload whitelist rules.
+ *
+ * Explicitly STUBBED (no real backing found — see each handler's comment):
+ *   - add_supplement_to_regimen / list_my_supplements /
+ *     remove_supplement_from_regimen: the frontend's personal supplement
+ *     tracker (useUserSupplements.ts) reads/writes `user_supplements`
+ *     directly against Supabase. That table is explicitly named as an
+ *     OUT-OF-SCOPE "Lovable-side ghost table" the gateway must never read
+ *     or write in
+ *     supabase/migrations/20260605000000_VTID_03186_universal_cart_schema.sql
+ *     (see the VTID-03186 NOTICE block), tracked for convergence under
+ *     VTID-03176 / issue #2371. Inventing a gateway-side read/write path to
+ *     it would violate that explicit architectural decision.
+ *   - apply_discount_code: same story — `user_discount_codes`
+ *     (useDiscountCode.ts) is in the SAME out-of-scope ghost-table list.
+ *   - get_coach_compatibility: no compatibility-scoring table, RPC, or
+ *     service function exists anywhere in the codebase. Fabricating a
+ *     scoring algorithm would violate the "never hallucinate" hard rule.
+ *
+ * Payment policy: get_ai_product_picks and reorder_last_order only ever
+ * stage `universal_cart_items` (exactly like the real /propose and /reorder
+ * HTTP routes) and return a `navigate` directive at the cart screen for the
+ * user to review + pay. Neither tool ever calls checkout/Stripe/wallet debit.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { emitCartEvent } from '../../routes/universal-cart';
+import { getUserHealthContext } from '../user-health-context';
+import { getMonthlySpend } from '../budget/spend-service';
+import { runPropose, type AnnotatedPick, type InsertPickFn } from '../shopping-agent/agent-core';
+import { buildReorderPicks } from '../shopping-agent/reorder-core';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DEFAULT_CURRENCY = 'EUR';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function authGate(tool: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+async function resolveTenantId(id: OrbToolIdentity, sb: SupabaseClient): Promise<string | null> {
+  if (id.tenant_id) return id.tenant_id;
+  try {
+    const { data } = await sb
+      .from('app_users')
+      .select('tenant_id')
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    return (data as { tenant_id?: string | null } | null)?.tenant_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function navDirective(
+  screen_id: string,
+  route: string,
+  title: string,
+  reason: string,
+): Record<string, unknown> {
+  return { type: 'orb_directive', directive: 'navigate', screen_id, route, title, reason, vtid: 'A1-MARKETPLACE-DISCOVERY' };
+}
+
+function clampInt(raw: unknown, min: number, max: number, fallback: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(n)));
+}
+
+function fmtPrice(cents: number | null | undefined, currency: string | null | undefined): string {
+  if (cents == null) return 'price unavailable';
+  const amount = (cents / 100).toFixed(2);
+  return `${amount} ${currency ?? DEFAULT_CURRENCY}`;
+}
+
+interface ProductRow {
+  id: string;
+  title: string;
+  description: string | null;
+  brand: string | null;
+  category: string | null;
+  subcategory: string | null;
+  price_cents: number | null;
+  currency: string | null;
+  compare_at_price_cents: number | null;
+  rating: number | null;
+  review_count: number | null;
+  availability: string;
+  affiliate_url?: string | null;
+  dosage?: string | null;
+  serving_size?: string | null;
+  safety_notes?: string | null;
+}
+
+const PRODUCT_COLS =
+  'id, title, description, brand, category, subcategory, price_cents, currency, compare_at_price_cents, rating, review_count, availability, affiliate_url, dosage, serving_size, safety_notes';
+
+function speakProduct(p: ProductRow): string {
+  return `"${p.title}"${p.brand ? ` by ${p.brand}` : ''} — ${fmtPrice(p.price_cents, p.currency)}${
+    p.rating != null ? `, rated ${p.rating.toFixed(1)}/5` : ''
+  }`;
+}
+
+// ---------------------------------------------------------------------------
+// 1. search_marketplace
+// ---------------------------------------------------------------------------
+
+export async function tool_search_marketplace(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('search_marketplace', id);
+  if (gate) return gate;
+  const q = String(args.q ?? args.query ?? '').trim();
+  const category = String(args.category ?? '').trim();
+  const priceMin = args.price_min_cents != null ? Number(args.price_min_cents) : null;
+  const priceMax = args.price_max_cents != null ? Number(args.price_max_cents) : null;
+  const limit = clampInt(args.limit, 1, 10, 5);
+
+  try {
+    let query = sb.from('products').select(PRODUCT_COLS).eq('is_active', true);
+    if (q) {
+      const sanitized = q.replace(/[&|!<>()]/g, ' ').trim();
+      if (sanitized) query = query.textSearch('search_text', sanitized, { config: 'simple', type: 'websearch' });
+    }
+    if (category) query = query.eq('category', category);
+    if (priceMin != null && Number.isFinite(priceMin)) query = query.gte('price_cents', priceMin);
+    if (priceMax != null && Number.isFinite(priceMax)) query = query.lte('price_cents', priceMax);
+    query = query.order('rating', { ascending: false, nullsFirst: false }).limit(limit);
+
+    const { data, error } = await query;
+    if (error) return { ok: false, error: error.message };
+    const items = (data as ProductRow[]) ?? [];
+
+    const route = `/discover/marketplace${q ? `?q=${encodeURIComponent(q)}` : ''}`;
+    if (items.length === 0) {
+      return {
+        ok: true,
+        result: { items: [], decision: 'list_only', directive: navDirective('DISCOVER.MARKETPLACE', route, 'Marketplace', 'search_marketplace empty') },
+        text: q
+          ? `I couldn't find anything in the marketplace matching "${q}". Want me to widen the search?`
+          : "What are you looking for in the marketplace?",
+      };
+    }
+
+    return {
+      ok: true,
+      result: {
+        items: items.map((p) => ({
+          product_id: p.id,
+          title: p.title,
+          price_cents: p.price_cents,
+          currency: p.currency,
+          rating: p.rating,
+          availability: p.availability,
+        })),
+        decision: 'list_only',
+        directive: navDirective('DISCOVER.MARKETPLACE', route, 'Marketplace', 'search_marketplace results'),
+      },
+      text: `I found ${items.length} item${items.length === 1 ? '' : 's'}: ${items.map(speakProduct).join('; ')}. Opening the marketplace.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'search_marketplace failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. get_product_details
+// ---------------------------------------------------------------------------
+
+export async function tool_get_product_details(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_product_details', id);
+  if (gate) return gate;
+  const productId = String(args.product_id ?? '').trim();
+  const query = String(args.query ?? args.title ?? '').trim();
+
+  try {
+    let product: ProductRow | null = null;
+
+    if (UUID_RE.test(productId)) {
+      const { data, error } = await sb
+        .from('products')
+        .select(PRODUCT_COLS)
+        .eq('id', productId)
+        .eq('is_active', true)
+        .maybeSingle();
+      if (error) return { ok: false, error: error.message };
+      product = (data as ProductRow | null) ?? null;
+    } else if (query) {
+      const { data, error } = await sb
+        .from('products')
+        .select(PRODUCT_COLS)
+        .eq('is_active', true)
+        .ilike('title', `%${query}%`)
+        .order('rating', { ascending: false, nullsFirst: false })
+        .limit(1)
+        .maybeSingle();
+      if (error) return { ok: false, error: error.message };
+      product = (data as ProductRow | null) ?? null;
+    } else {
+      return { ok: false, error: 'get_product_details requires a product_id or a product name to look up.' };
+    }
+
+    if (!product) {
+      return {
+        ok: true,
+        result: { found: false },
+        text: `I couldn't find that product${query ? ` ("${query}")` : ''} in the marketplace.`,
+      };
+    }
+
+    const route = `/discover/product/${encodeURIComponent(product.id)}`;
+    return {
+      ok: true,
+      result: {
+        product_id: product.id,
+        title: product.title,
+        description: product.description,
+        brand: product.brand,
+        price_cents: product.price_cents,
+        currency: product.currency,
+        rating: product.rating,
+        review_count: product.review_count,
+        availability: product.availability,
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.PRODUCT_DETAIL', route, product.title, 'get_product_details resolved'),
+        redirect: { route },
+      },
+      text: `${speakProduct(product)}.${product.description ? ` ${product.description.slice(0, 200)}` : ''} Opening the product page.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_product_details failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. browse_supplements
+// ---------------------------------------------------------------------------
+
+export async function tool_browse_supplements(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('browse_supplements', id);
+  if (gate) return gate;
+  const limit = clampInt(args.limit, 1, 10, 8);
+  try {
+    const { data, error } = await sb
+      .from('products')
+      .select(PRODUCT_COLS)
+      .eq('is_active', true)
+      .eq('category', 'supplements')
+      .order('rating', { ascending: false, nullsFirst: false })
+      .limit(limit);
+    if (error) return { ok: false, error: error.message };
+    const items = (data as ProductRow[]) ?? [];
+    const route = '/discover/supplements';
+    if (items.length === 0) {
+      return {
+        ok: true,
+        result: { items: [], directive: navDirective('DISCOVER.SUPPLEMENTS', route, 'Supplements', 'browse_supplements empty') },
+        text: 'There are no supplements in the marketplace catalog right now.',
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        items: items.map((p) => ({ product_id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency, rating: p.rating })),
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.SUPPLEMENTS', route, 'Supplements', 'browse_supplements'),
+        redirect: { route },
+      },
+      text: `Here are ${items.length} supplements: ${items.map(speakProduct).join('; ')}. Opening the supplements shop.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'browse_supplements failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4-6. Personal supplement regimen — STUBBED (see file header).
+// ---------------------------------------------------------------------------
+
+const REGIMEN_UNAVAILABLE =
+  'The personal supplement regimen tracker (user_supplements) is an explicit ' +
+  'out-of-scope "Lovable-side ghost table" the gateway is documented to never ' +
+  'read or write (VTID-03186 migration NOTICE; tracked under VTID-03176 / ' +
+  'issue #2371). This tool has no real backing yet.';
+
+export async function tool_add_supplement_to_regimen(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('add_supplement_to_regimen', id);
+  if (gate) return gate;
+  return { ok: false, error: `add_supplement_to_regimen is not available yet — ${REGIMEN_UNAVAILABLE}` };
+}
+
+export async function tool_list_my_supplements(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('list_my_supplements', id);
+  if (gate) return gate;
+  return { ok: false, error: `list_my_supplements is not available yet — ${REGIMEN_UNAVAILABLE}` };
+}
+
+export async function tool_remove_supplement_from_regimen(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('remove_supplement_from_regimen', id);
+  if (gate) return gate;
+  return { ok: false, error: `remove_supplement_from_regimen is not available yet — ${REGIMEN_UNAVAILABLE}` };
+}
+
+// ---------------------------------------------------------------------------
+// 7. browse_wellness_services
+// ---------------------------------------------------------------------------
+
+interface ServiceRow {
+  id: string;
+  name: string;
+  service_type: string;
+  provider_name: string | null;
+  topic_keys: string[] | null;
+  metadata: Record<string, unknown> | null;
+}
+const SERVICE_COLS = 'id, name, service_type, provider_name, topic_keys, metadata';
+const WELLNESS_TYPES = ['wellness', 'nutrition', 'fitness', 'therapy', 'lab', 'other'];
+const PRACTITIONER_TYPES = ['doctor', 'coach'];
+
+export async function tool_browse_wellness_services(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('browse_wellness_services', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'browse_wellness_services requires a known tenant context.' };
+  const limit = clampInt(args.limit, 1, 10, 8);
+  try {
+    const { data, error } = await sb
+      .from('services_catalog')
+      .select(SERVICE_COLS)
+      .eq('tenant_id', tenantId)
+      .in('service_type', WELLNESS_TYPES)
+      .limit(limit);
+    if (error) return { ok: false, error: error.message };
+    const items = (data as ServiceRow[]) ?? [];
+    const route = '/discover/wellness-services';
+    if (items.length === 0) {
+      return {
+        ok: true,
+        result: { items: [], directive: navDirective('DISCOVER.WELLNESS_SERVICES', route, 'Wellness Services', 'browse_wellness_services empty') },
+        text: "There aren't any wellness services listed yet.",
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        items: items.map((s) => ({ service_id: s.id, name: s.name, service_type: s.service_type, provider_name: s.provider_name })),
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.WELLNESS_SERVICES', route, 'Wellness Services', 'browse_wellness_services'),
+        redirect: { route },
+      },
+      text: `Wellness services: ${items.map((s) => `"${s.name}"${s.provider_name ? ` with ${s.provider_name}` : ''}`).join('; ')}. Opening wellness services.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'browse_wellness_services failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 8. get_provider_profile
+// ---------------------------------------------------------------------------
+
+export async function tool_get_provider_profile(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_provider_profile', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'get_provider_profile requires a known tenant context.' };
+  const serviceId = String(args.provider_id ?? args.service_id ?? '').trim();
+  const query = String(args.query ?? args.name ?? '').trim();
+  try {
+    let row: ServiceRow | null = null;
+    if (UUID_RE.test(serviceId)) {
+      const { data, error } = await sb
+        .from('services_catalog')
+        .select(SERVICE_COLS)
+        .eq('tenant_id', tenantId)
+        .eq('id', serviceId)
+        .maybeSingle();
+      if (error) return { ok: false, error: error.message };
+      row = (data as ServiceRow | null) ?? null;
+    } else if (query) {
+      const { data, error } = await sb
+        .from('services_catalog')
+        .select(SERVICE_COLS)
+        .eq('tenant_id', tenantId)
+        .or(`name.ilike.%${query}%,provider_name.ilike.%${query}%`)
+        .limit(1)
+        .maybeSingle();
+      if (error) return { ok: false, error: error.message };
+      row = (data as ServiceRow | null) ?? null;
+    } else {
+      return { ok: false, error: 'get_provider_profile requires a provider_id or a name to look up.' };
+    }
+
+    if (!row) {
+      return { ok: true, result: { found: false }, text: `I couldn't find a provider matching ${query ? `"${query}"` : 'that'}.` };
+    }
+
+    const route = `/discover/provider/${encodeURIComponent(row.id)}`;
+    return {
+      ok: true,
+      result: {
+        service_id: row.id,
+        name: row.name,
+        service_type: row.service_type,
+        provider_name: row.provider_name,
+        topic_keys: row.topic_keys ?? [],
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.PROVIDER_PROFILE', route, row.name, 'get_provider_profile resolved'),
+        redirect: { route },
+      },
+      text: `"${row.name}"${row.provider_name ? ` (${row.provider_name})` : ''} — ${row.service_type}. Opening the provider profile.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_provider_profile failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 9. browse_doctors_coaches
+// ---------------------------------------------------------------------------
+
+export async function tool_browse_doctors_coaches(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('browse_doctors_coaches', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'browse_doctors_coaches requires a known tenant context.' };
+  const limit = clampInt(args.limit, 1, 10, 8);
+  try {
+    const { data, error } = await sb
+      .from('services_catalog')
+      .select(SERVICE_COLS)
+      .eq('tenant_id', tenantId)
+      .in('service_type', PRACTITIONER_TYPES)
+      .limit(limit);
+    if (error) return { ok: false, error: error.message };
+    const items = (data as ServiceRow[]) ?? [];
+    const route = '/discover/doctors-coaches';
+    if (items.length === 0) {
+      return {
+        ok: true,
+        result: { items: [], directive: navDirective('DISCOVER.DOCTORS_COACHES', route, 'Doctors & Coaches', 'browse_doctors_coaches empty') },
+        text: "There aren't any doctors or coaches listed yet.",
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        items: items.map((s) => ({ service_id: s.id, name: s.name, service_type: s.service_type, provider_name: s.provider_name })),
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.DOCTORS_COACHES', route, 'Doctors & Coaches', 'browse_doctors_coaches'),
+        redirect: { route },
+      },
+      text: `Doctors & coaches: ${items.map((s) => `"${s.name}" (${s.service_type})`).join('; ')}. Opening doctors & coaches.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'browse_doctors_coaches failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 10. get_coach_compatibility — STUBBED (see file header).
+// ---------------------------------------------------------------------------
+
+export async function tool_get_coach_compatibility(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_coach_compatibility', id);
+  if (gate) return gate;
+  return {
+    ok: false,
+    error:
+      'get_coach_compatibility is not available yet — no compatibility-scoring table, RPC, or service exists in this ' +
+      'codebase. Fabricating a score here would be inventing data, which is not allowed.',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 11. browse_deals_offers
+// ---------------------------------------------------------------------------
+
+export async function tool_browse_deals_offers(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('browse_deals_offers', id);
+  if (gate) return gate;
+  const limit = clampInt(args.limit, 1, 10, 8);
+  try {
+    // "Deals" are derived honestly from the real products.compare_at_price_cents
+    // column (no dedicated deals/promotions table exists) — a product is "on
+    // sale" when its compare_at_price_cents (the pre-discount reference price)
+    // is present and greater than its current price_cents.
+    const { data, error } = await sb
+      .from('products')
+      .select(PRODUCT_COLS)
+      .eq('is_active', true)
+      .eq('availability', 'in_stock')
+      .not('compare_at_price_cents', 'is', null)
+      .order('rating', { ascending: false, nullsFirst: false })
+      .limit(50);
+    if (error) return { ok: false, error: error.message };
+    const onSale = ((data as ProductRow[]) ?? []).filter(
+      (p) => p.compare_at_price_cents != null && p.price_cents != null && p.compare_at_price_cents > p.price_cents,
+    );
+    onSale.sort((a, b) => {
+      const discA = (a.compare_at_price_cents! - a.price_cents!) / a.compare_at_price_cents!;
+      const discB = (b.compare_at_price_cents! - b.price_cents!) / b.compare_at_price_cents!;
+      return discB - discA;
+    });
+    const items = onSale.slice(0, limit);
+    const route = '/discover/deals-offers';
+
+    if (items.length === 0) {
+      return {
+        ok: true,
+        result: { items: [], directive: navDirective('DISCOVER.DEALS', route, 'Deals & Offers', 'browse_deals_offers empty') },
+        text: "There aren't any active deals in the marketplace right now.",
+      };
+    }
+    const speak = (p: ProductRow) => {
+      const pct = Math.round(((p.compare_at_price_cents! - p.price_cents!) / p.compare_at_price_cents!) * 100);
+      return `"${p.title}" — ${fmtPrice(p.price_cents, p.currency)} (${pct}% off ${fmtPrice(p.compare_at_price_cents, p.currency)})`;
+    };
+    return {
+      ok: true,
+      result: {
+        items: items.map((p) => ({
+          product_id: p.id,
+          title: p.title,
+          price_cents: p.price_cents,
+          compare_at_price_cents: p.compare_at_price_cents,
+          currency: p.currency,
+        })),
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.DEALS', route, 'Deals & Offers', 'browse_deals_offers'),
+        redirect: { route },
+      },
+      text: `Current deals: ${items.map(speak).join('; ')}. Opening deals & offers.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'browse_deals_offers failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 12. apply_discount_code — STUBBED (see file header).
+// ---------------------------------------------------------------------------
+
+export async function tool_apply_discount_code(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('apply_discount_code', id);
+  if (gate) return gate;
+  return {
+    ok: false,
+    error:
+      'apply_discount_code is not available yet — the discount-code table (user_discount_codes) used by the ' +
+      "frontend's useDiscountCode.ts is an explicit out-of-scope \"Lovable-side ghost table\" the gateway is " +
+      'documented to never read or write (VTID-03186 migration NOTICE; tracked under VTID-03176 / issue #2371).',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cart helpers shared by get_ai_product_picks + reorder_last_order.
+// ---------------------------------------------------------------------------
+
+function isNoRowsError(error: unknown): boolean {
+  return (error as { code?: string } | null)?.code === 'PGRST116';
+}
+function isUniqueViolation(error: unknown): boolean {
+  return (error as { code?: string } | null)?.code === '23505';
+}
+
+/**
+ * Get-or-create the caller's ONE active universal cart. Mirrors the
+ * resolution block in routes/shopping-agent.ts's resolveActiveCartId, using
+ * the service-role `sb` this dispatcher passes (explicit user_id/tenant_id
+ * scoping instead of an RLS-scoped user client, matching every other handler
+ * in this tool-file family — see routes/orb-tool.ts).
+ */
+async function getOrCreateActiveCart(
+  sb: SupabaseClient,
+  userId: string,
+  tenantId: string | null,
+): Promise<{ ok: true; cartId: string } | { ok: false; error: string }> {
+  const lookup = await sb.from('universal_carts').select('id').eq('user_id', userId).eq('status', 'active').maybeSingle();
+  if (lookup.error && !isNoRowsError(lookup.error)) return { ok: false, error: lookup.error.message };
+  if (lookup.data?.id) return { ok: true, cartId: lookup.data.id as string };
+
+  const created = await sb
+    .from('universal_carts')
+    .insert({ user_id: userId, tenant_id: tenantId, status: 'active', metadata: {} })
+    .select('id')
+    .single();
+  if (created.error && isUniqueViolation(created.error)) {
+    const raced = await sb.from('universal_carts').select('id').eq('user_id', userId).eq('status', 'active').maybeSingle();
+    if (raced.data?.id) return { ok: true, cartId: raced.data.id as string };
+    return { ok: false, error: 'cart_create_failed' };
+  }
+  if (created.error || !created.data?.id) return { ok: false, error: created.error?.message ?? 'cart_create_failed' };
+
+  await emitCartEvent({ cart_id: created.data.id as string, user_id: userId, event_type: 'cart.created', event_payload: {} });
+  return { ok: true, cartId: created.data.id as string };
+}
+
+// ---------------------------------------------------------------------------
+// 13. get_ai_product_picks
+// ---------------------------------------------------------------------------
+
+export async function tool_get_ai_product_picks(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_ai_product_picks', id);
+  if (gate) return gate;
+  const prompt = String(args.prompt ?? args.query ?? '').trim();
+  if (!prompt) {
+    return { ok: false, error: 'get_ai_product_picks requires a description of what the user is looking for.' };
+  }
+  const maxItems = clampInt(args.max_items, 1, 6, 4);
+
+  try {
+    const ctx = await getUserHealthContext(id.user_id);
+    const cartRes = await getOrCreateActiveCart(sb, id.user_id, id.tenant_id);
+    if (!cartRes.ok) return { ok: false, error: cartRes.error };
+    const cartId = cartRes.cartId;
+    const monthlySpendCents = await getMonthlySpend(sb, id.user_id, ctx.currency ?? DEFAULT_CURRENCY);
+    const runId = randomUUID();
+
+    const insertPick: InsertPickFn = async (pick: AnnotatedPick, rid: string, proposedAt: string) => {
+      const insertPayload: Record<string, unknown> = {
+        cart_id: cartId,
+        item_type: pick.item_type,
+        product_id: pick.product_id,
+        quantity: 1,
+        status: 'active',
+        source_surface: 'voice',
+        metadata: {
+          origin: 'agent',
+          rationale: pick.rationale,
+          safety_flags: pick.safety_flags,
+          confidence: pick.confidence,
+          run_id: rid,
+          proposed_at: proposedAt,
+        },
+      };
+      if (pick.unit_price_cents_snapshot !== null) insertPayload.unit_price_cents_snapshot = pick.unit_price_cents_snapshot;
+      if (pick.currency_snapshot !== null) insertPayload.currency_snapshot = pick.currency_snapshot;
+
+      const inserted = await sb.from('universal_cart_items').insert(insertPayload).select('id').single();
+      if (inserted.error || !inserted.data) return { ok: false, error: inserted.error?.message ?? 'item_insert_failed' };
+      const itemId = inserted.data.id as string;
+      await emitCartEvent({
+        cart_id: cartId,
+        user_id: id.user_id,
+        event_type: 'item.added',
+        event_payload: { cart_item_id: itemId, product_id: pick.product_id, quantity_before: 0, quantity_after: 1, source_surface: 'voice' },
+      });
+      return { ok: true, item_id: itemId };
+    };
+
+    const result = await runPropose({ prompt, maxItems, ctx, supabase: sb, insertPick, runId, monthly_spend_cents: monthlySpendCents });
+
+    if (!result.ok) {
+      if (result.error === 'llm_unavailable') {
+        return { ok: false, error: 'get_ai_product_picks is temporarily unavailable — no AI provider is reachable right now.' };
+      }
+      return { ok: false, error: result.error ?? 'get_ai_product_picks failed' };
+    }
+
+    const proposed = result.proposed ?? [];
+    const route = '/cart';
+    if (proposed.length === 0) {
+      return {
+        ok: true,
+        result: { proposed: [], advisory: result.advisory ?? [] },
+        text: "I couldn't find anything in the marketplace matching that request right now.",
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        run_id: result.run_id,
+        proposed,
+        advisory: result.advisory ?? [],
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.CART', route, 'Shopping Cart', 'get_ai_product_picks proposed'),
+        redirect: { route },
+      },
+      text: `I've added ${proposed.length} pick${proposed.length === 1 ? '' : 's'} to your cart: ${proposed
+        .map((p) => `"${p.title}" (${p.rationale})`)
+        .join('; ')}. Review and confirm payment on your screen.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_ai_product_picks failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 14. list_my_orders
+// ---------------------------------------------------------------------------
+
+interface OrderRow {
+  id: string;
+  product_id: string | null;
+  state: string;
+  amount_cents: number | null;
+  currency: string | null;
+  purchased_at: string | null;
+  created_at: string;
+}
+const ORDER_COLS = 'id, product_id, state, amount_cents, currency, purchased_at, created_at';
+
+export async function tool_list_my_orders(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('list_my_orders', id);
+  if (gate) return gate;
+  const limit = clampInt(args.limit, 1, 20, 10);
+  try {
+    const { data, error } = await sb
+      .from('product_orders')
+      .select(ORDER_COLS)
+      .eq('user_id', id.user_id)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (error) return { ok: false, error: error.message };
+    const orders = (data as OrderRow[]) ?? [];
+    const route = '/discover/orders';
+    if (orders.length === 0) {
+      return {
+        ok: true,
+        result: { orders: [], directive: navDirective('DISCOVER.ORDERS', route, 'Orders', 'list_my_orders empty') },
+        text: "You don't have any orders yet.",
+      };
+    }
+    // Resolve product titles for a readable summary (best-effort).
+    const productIds = orders.map((o) => o.product_id).filter((v): v is string => !!v);
+    const titleById = new Map<string, string>();
+    if (productIds.length > 0) {
+      const { data: products } = await sb.from('products').select('id, title').in('id', productIds);
+      for (const p of (products as Array<{ id: string; title: string }>) ?? []) titleById.set(p.id, p.title);
+    }
+    const speak = (o: OrderRow) =>
+      `${o.product_id ? titleById.get(o.product_id) ?? 'an item' : 'an item'} — ${o.state}${
+        o.amount_cents != null ? ` (${fmtPrice(o.amount_cents, o.currency)})` : ''
+      }`;
+    return {
+      ok: true,
+      result: {
+        orders: orders.map((o) => ({
+          order_id: o.id,
+          product_id: o.product_id,
+          title: o.product_id ? titleById.get(o.product_id) ?? null : null,
+          state: o.state,
+          amount_cents: o.amount_cents,
+          currency: o.currency,
+          purchased_at: o.purchased_at,
+        })),
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.ORDERS', route, 'Orders', 'list_my_orders'),
+        redirect: { route },
+      },
+      text: `Your recent orders: ${orders.map(speak).join('; ')}. Opening your orders.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'list_my_orders failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 15. get_order_status
+// ---------------------------------------------------------------------------
+
+export async function tool_get_order_status(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_order_status', id);
+  if (gate) return gate;
+  const orderId = String(args.order_id ?? '').trim();
+  try {
+    let order: OrderRow | null = null;
+    if (UUID_RE.test(orderId)) {
+      const { data, error } = await sb
+        .from('product_orders')
+        .select(ORDER_COLS)
+        .eq('id', orderId)
+        .eq('user_id', id.user_id)
+        .maybeSingle();
+      if (error) return { ok: false, error: error.message };
+      order = (data as OrderRow | null) ?? null;
+    } else {
+      // No order_id given → track the most recent order (a reasonable
+      // default for "where's my order?").
+      const { data, error } = await sb
+        .from('product_orders')
+        .select(ORDER_COLS)
+        .eq('user_id', id.user_id)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (error) return { ok: false, error: error.message };
+      order = (data as OrderRow | null) ?? null;
+    }
+
+    if (!order) {
+      return { ok: true, result: { found: false }, text: "I couldn't find that order." };
+    }
+    let title: string | null = null;
+    if (order.product_id) {
+      const { data: product } = await sb.from('products').select('title').eq('id', order.product_id).maybeSingle();
+      title = (product as { title?: string } | null)?.title ?? null;
+    }
+    const route = '/discover/orders';
+    return {
+      ok: true,
+      result: {
+        order_id: order.id,
+        title,
+        state: order.state,
+        amount_cents: order.amount_cents,
+        currency: order.currency,
+        purchased_at: order.purchased_at,
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.ORDERS', route, 'Orders', 'get_order_status resolved'),
+        redirect: { route },
+      },
+      text: `Your order${title ? ` for "${title}"` : ''} is ${order.state}${
+        order.amount_cents != null ? ` (${fmtPrice(order.amount_cents, order.currency)})` : ''
+      }.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_order_status failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 16. reorder_last_order (⚠️ two-step confirm)
+// ---------------------------------------------------------------------------
+
+export async function tool_reorder_last_order(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('reorder_last_order', id);
+  if (gate) return gate;
+  try {
+    const ctx = await getUserHealthContext(id.user_id);
+    // maxItems=1: buildReorderPicks returns picks most-recently-purchased-first,
+    // so 1 resolves to exactly "the last order" (still purchasable today).
+    const picks = await buildReorderPicks(sb, ctx, 1);
+
+    if (picks.length === 0) {
+      return {
+        ok: true,
+        result: { reordered: false },
+        text: "I couldn't find a previous order of yours that's still available to reorder.",
+      };
+    }
+    const pick = picks[0];
+
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: {
+          needs_confirmation: true,
+          product_id: pick.product_id,
+          title: pick.title,
+          price_cents: pick.unit_price_cents_snapshot,
+          currency: pick.currency_snapshot,
+        },
+        text: `Confirm with the user: add "${pick.title}" (${fmtPrice(pick.unit_price_cents_snapshot, pick.currency_snapshot)}) — your last order — back to the cart? When they say yes, call reorder_last_order again with confirm:true.`,
+      };
+    }
+
+    const cartRes = await getOrCreateActiveCart(sb, id.user_id, id.tenant_id);
+    if (!cartRes.ok) return { ok: false, error: cartRes.error };
+    const cartId = cartRes.cartId;
+    const runId = randomUUID();
+    const proposedAt = new Date().toISOString();
+
+    const insertPayload: Record<string, unknown> = {
+      cart_id: cartId,
+      item_type: pick.item_type,
+      product_id: pick.product_id,
+      quantity: 1,
+      status: 'active',
+      source_surface: 'voice',
+      metadata: {
+        origin: 'reorder',
+        rationale: pick.rationale,
+        safety_flags: pick.safety_flags,
+        confidence: pick.confidence,
+        run_id: runId,
+        proposed_at: proposedAt,
+        previously_purchased_at: pick.previously_purchased_at,
+      },
+    };
+    if (pick.unit_price_cents_snapshot !== null) insertPayload.unit_price_cents_snapshot = pick.unit_price_cents_snapshot;
+    if (pick.currency_snapshot !== null) insertPayload.currency_snapshot = pick.currency_snapshot;
+
+    const inserted = await sb.from('universal_cart_items').insert(insertPayload).select('id').single();
+    if (inserted.error || !inserted.data) {
+      return { ok: false, error: inserted.error?.message ?? 'reorder_insert_failed' };
+    }
+    const itemId = inserted.data.id as string;
+    await emitCartEvent({
+      cart_id: cartId,
+      user_id: id.user_id,
+      event_type: 'item.added',
+      event_payload: { cart_item_id: itemId, product_id: pick.product_id, quantity_before: 0, quantity_after: 1, source_surface: 'voice' },
+    });
+
+    const route = '/cart';
+    return {
+      ok: true,
+      result: {
+        reordered: true,
+        item_id: itemId,
+        product_id: pick.product_id,
+        title: pick.title,
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.CART', route, 'Shopping Cart', 'reorder_last_order added'),
+        redirect: { route },
+      },
+      text: `Done — I've added "${pick.title}" back to your cart. Confirm payment on your screen.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'reorder_last_order failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const MARKETPLACE_DISCOVERY_TOOL_HANDLERS: Record<string, Handler> = {
+  search_marketplace: tool_search_marketplace,
+  get_product_details: tool_get_product_details,
+  browse_supplements: tool_browse_supplements,
+  add_supplement_to_regimen: tool_add_supplement_to_regimen,
+  list_my_supplements: tool_list_my_supplements,
+  remove_supplement_from_regimen: tool_remove_supplement_from_regimen,
+  browse_wellness_services: tool_browse_wellness_services,
+  get_provider_profile: tool_get_provider_profile,
+  browse_doctors_coaches: tool_browse_doctors_coaches,
+  get_coach_compatibility: tool_get_coach_compatibility,
+  browse_deals_offers: tool_browse_deals_offers,
+  apply_discount_code: tool_apply_discount_code,
+  get_ai_product_picks: tool_get_ai_product_picks,
+  list_my_orders: tool_list_my_orders,
+  get_order_status: tool_get_order_status,
+  reorder_last_order: tool_reorder_last_order,
+};
+
+export const MARKETPLACE_DISCOVERY_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'search_marketplace',
+    description: [
+      'Search the Maxina marketplace for products by free-text query, category,',
+      'or price range. CALL WHEN the user says: "search the marketplace for ...",',
+      '"find me some ...", "durchsuche den Marktplatz nach ...".',
+      'Read the top results (name, price, rating) aloud.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        q: { type: 'string', description: 'Free-text search query.' },
+        category: { type: 'string', description: 'Exact product category (e.g. "supplements").' },
+        price_min_cents: { type: 'number', description: 'Minimum price in cents.' },
+        price_max_cents: { type: 'number', description: 'Maximum price in cents.' },
+        limit: { type: 'number', description: 'Max results to return (default 5, max 10).' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_product_details',
+    description: [
+      'Get details for one marketplace product by id or by spoken name.',
+      'CALL WHEN the user asks: "tell me about ...", "what is ... exactly",',
+      '"erzähl mir mehr über ...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Exact product UUID when known from a previous tool result.' },
+        query: { type: 'string', description: 'Spoken product name (fuzzy matched).' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'browse_supplements',
+    description: [
+      'Browse the marketplace supplements shop (NOT the personal supplement',
+      'tracker — that is unavailable via voice today).',
+      'CALL WHEN the user says: "show me supplements", "what supplements do you',
+      'have", "zeig mir Nahrungsergänzungsmittel".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { limit: { type: 'number', description: 'Max results (default 8, max 10).' } },
+      required: [],
+    },
+  },
+  {
+    name: 'add_supplement_to_regimen',
+    description:
+      'NOT CURRENTLY AVAILABLE via voice — always returns an error explaining ' +
+      'the personal supplement tracker has no gateway-side backing yet. Do not ' +
+      'call unless the user explicitly asks to add a supplement to their ' +
+      'personal regimen/tracker, then relay the unavailability honestly.',
+    parameters: {
+      type: 'object',
+      properties: { name: { type: 'string', description: 'Supplement name.' } },
+      required: [],
+    },
+  },
+  {
+    name: 'list_my_supplements',
+    description:
+      'NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call ' +
+      'unless the user explicitly asks to hear their personal supplement list, ' +
+      'then relay the unavailability honestly.',
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'remove_supplement_from_regimen',
+    description:
+      'NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call ' +
+      'unless the user explicitly asks to remove a supplement from their ' +
+      'personal regimen, then relay the unavailability honestly.',
+    parameters: {
+      type: 'object',
+      properties: { name: { type: 'string', description: 'Supplement name.' } },
+      required: [],
+    },
+  },
+  {
+    name: 'browse_wellness_services',
+    description: [
+      'Browse wellness/nutrition/fitness/therapy/lab services listed in the',
+      'Maxina marketplace. CALL WHEN the user asks about wellness services,',
+      'massage, spa, recovery, or treatments — "Wellness-Services".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { limit: { type: 'number', description: 'Max results (default 8, max 10).' } },
+      required: [],
+    },
+  },
+  {
+    name: 'get_provider_profile',
+    description: [
+      'Get one service/provider listing by id or spoken name (doctor, coach,',
+      'wellness provider, etc). CALL WHEN the user asks about a specific',
+      'provider or practitioner by name.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        provider_id: { type: 'string', description: 'Exact service/provider UUID when known.' },
+        query: { type: 'string', description: 'Spoken provider or service name (fuzzy matched).' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'browse_doctors_coaches',
+    description: [
+      'Browse doctors and coaches listed in the marketplace. CALL WHEN the user',
+      'asks to find a doctor, coach, practitioner, or specialist — "Ärzte &',
+      'Coaches".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { limit: { type: 'number', description: 'Max results (default 8, max 10).' } },
+      required: [],
+    },
+  },
+  {
+    name: 'get_coach_compatibility',
+    description:
+      'NOT CURRENTLY AVAILABLE via voice — always returns an error, since no ' +
+      'compatibility-scoring system exists yet. Do not fabricate a score; relay ' +
+      'the unavailability honestly if asked.',
+    parameters: {
+      type: 'object',
+      properties: { provider_id: { type: 'string', description: 'Coach/provider UUID.' } },
+      required: [],
+    },
+  },
+  {
+    name: 'browse_deals_offers',
+    description: [
+      'Browse marketplace products currently on sale (discounted vs. their',
+      'reference price). CALL WHEN the user asks about deals, discounts,',
+      'offers, promotions, or "what is on sale" — "Angebote & Deals".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { limit: { type: 'number', description: 'Max results (default 8, max 10).' } },
+      required: [],
+    },
+  },
+  {
+    name: 'apply_discount_code',
+    description:
+      'NOT CURRENTLY AVAILABLE via voice — always returns an error, since the ' +
+      'discount-code system has no gateway-side backing yet. Do not call unless ' +
+      'the user explicitly asks to apply a promo code, then relay the ' +
+      'unavailability honestly.',
+    parameters: {
+      type: 'object',
+      properties: { code: { type: 'string', description: 'The discount/promo code.' } },
+      required: [],
+    },
+  },
+  {
+    name: 'get_ai_product_picks',
+    description: [
+      'Have the Vitana shopping agent propose marketplace products for a goal',
+      'or need, filtered against the user\'s health/dietary/budget profile, and',
+      'add them to the cart for review (NEVER charges anything).',
+      'CALL WHEN the user says: "find me something for ...", "what should I take',
+      'for ...", "shop for ... for me", "kauf mir etwas gegen ...".',
+      'After the tool runs, read the picks + rationale aloud and tell the user',
+      'to confirm payment on screen — never say payment completed.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        prompt: { type: 'string', description: 'What the user wants help finding/shopping for.' },
+        max_items: { type: 'number', description: 'Max picks to propose (default 4, max 6).' },
+      },
+      required: ['prompt'],
+    },
+  },
+  {
+    name: 'list_my_orders',
+    description: [
+      'List the user\'s recent marketplace orders with status and amount.',
+      'CALL WHEN the user asks: "what have I ordered", "show my orders",',
+      '"zeig mir meine Bestellungen".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { limit: { type: 'number', description: 'Max orders to return (default 10, max 20).' } },
+      required: [],
+    },
+  },
+  {
+    name: 'get_order_status',
+    description: [
+      'Check the status of one order by id, or the most recent order if no id',
+      'is given. CALL WHEN the user asks: "where is my order", "track my order",',
+      '"wo ist meine Bestellung".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { order_id: { type: 'string', description: 'Exact order UUID when known.' } },
+      required: [],
+    },
+  },
+  {
+    name: 'reorder_last_order',
+    description: [
+      'Add the user\'s most recent (still-available) purchase back to the cart.',
+      'ALWAYS call once WITHOUT confirm first — the tool returns a confirmation',
+      'question; after the user says yes, call again with confirm:true. NEVER',
+      'charges anything — only stages the cart.',
+      'CALL WHEN the user says: "reorder my last order", "get me the same thing',
+      'again", "bestelle das Gleiche nochmal".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the reorder.' } },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/messaging-depth-tools.ts
+++ b/services/gateway/src/services/orb-tools/messaging-depth-tools.ts
@@ -1,0 +1,1244 @@
+/**
+ * Messaging depth (A8) voice tools — group chat, reactions, and call invites.
+ *
+ * Tables used (all verified against real migrations, no invented schema):
+ *
+ *  - chat_groups / chat_group_members (supabase/migrations/
+ *    20260525000000_VTID_03089_chat_groups.sql) — many-to-many group chat on
+ *    top of the 1-to-1 chat_messages model. chat_group_members has no
+ *    dedicated HTTP add/leave route (routes/chat-groups.ts only exposes
+ *    list/get/messages/send/read/edit/delete) — this file writes to it
+ *    directly, exactly the same pattern create_group / join_group in
+ *    groups-events-tools.ts already use for the sibling
+ *    global_community_group_members table.
+ *
+ *  - chat_messages.group_id (same migration) — a chat_messages row is either
+ *    a DM (receiver_id set, group_id null) or a group message (group_id set,
+ *    receiver_id null); enforced by chat_messages_target_xor. Group sends
+ *    here mirror routes/chat-groups.ts POST /:id/send (membership required,
+ *    message_type default 'text', metadata jsonb, best-effort push fanout).
+ *
+ *  - message_reactions (vitana-v1 migration 20250918121049 — polymorphic on
+ *    chat_messages.id / global_messages.id / messages.id; message_id UUID,
+ *    user_id UUID, emoji TEXT CHECK IN ('👍','❤️','😂','😮','🙏','🎉'),
+ *    PRIMARY KEY (message_id, user_id, emoji)). notify_on_reaction() already
+ *    fires a push on insert (supabase/migrations/
+ *    20260710120000_fix_reaction_notification_deeplink.sql), so this file
+ *    only needs to insert/delete the row.
+ *
+ *  - calendar_events (services/calendar-service.ts; user_id-scoped) — reused
+ *    read-only to resolve which event to share; the message itself goes
+ *    through the same chat_messages insert tool_share_link in
+ *    orb-tools-shared.ts uses for link shares (custom message_type value,
+ *    structured metadata), since resolveAndValidateRecipient /
+ *    emitChatSendFailure in that file are module-private and not exported.
+ *
+ * NOT backed by any real table/route (verified, not invented):
+ *
+ *  - reply_to_message: chat_messages (and global_messages / messages) have
+ *    no reply-to / parent-message / thread column anywhere in the schema
+ *    (grepped supabase/migrations for reply_to|parent_message|in_reply_to|
+ *    quoted_message — zero hits). Stubbed as unavailable rather than
+ *    inventing a fake thread.
+ *
+ *  - start_voice_call / start_video_call: vitana-v1's useWebRTC.ts /
+ *    useCallState.ts / CallContext.tsx show calling is 100% client-side —
+ *    raw WebRTC peer connections signaled over ad-hoc Supabase Realtime
+ *    broadcast channels (`user:<id>:calls`, `room:<roomId>`), with no
+ *    server-side call/session table or gateway route anywhere. The gateway
+ *    cannot place or ring a call (no media capability, no persisted call
+ *    state to join). Per the wave-1 brief, these two tools instead send a
+ *    real chat_messages "call invite" row + push notification asking the
+ *    other person to open the app — they do not connect a call.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { notifyUserAsync } from '../notification-service';
+import { checkVoiceSendQuota } from '../voice-message-guard';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const ALLOWED_REACTION_EMOJIS = new Set(['👍', '❤️', '😂', '😮', '🙏', '🎉']);
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** ok:false when there is no authenticated user — every tool here touches user data. */
+function authGate(tool: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+/** First non-empty string among the given arg keys. */
+function argString(args: OrbToolArgs, ...keys: string[]): string {
+  for (const k of keys) {
+    const v = args[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return '';
+}
+
+/** tenant backfill from app_users when the voice session carries a null tenant. */
+async function resolveTenantId(id: OrbToolIdentity, sb: SupabaseClient): Promise<string | null> {
+  if (id.tenant_id) return id.tenant_id;
+  try {
+    const { data } = await sb
+      .from('app_users')
+      .select('tenant_id')
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    return (data as { tenant_id?: string | null } | null)?.tenant_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface ResolvedMember {
+  user_id: string;
+  display_name: string | null;
+  vitana_id: string | null;
+}
+
+function memberDisplay(m: ResolvedMember): string {
+  return m.display_name || m.vitana_id || 'that member';
+}
+
+/**
+ * Resolve a spoken name / Vitana ID / UUID to a single confident member —
+ * same canonical RPC + thresholds as tool_resolve_recipient /
+ * tool_send_chat_message in orb-tools-shared.ts and resolveMember in
+ * chat-privacy-tools.ts / groups-events-tools.ts.
+ */
+async function resolveMember(
+  raw: string,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<{ ok: true; member: ResolvedMember } | { ok: false; error: string }> {
+  const token = raw.trim();
+  if (!token) {
+    return { ok: false, error: 'Who do you mean? Please say their name or Vitana ID.' };
+  }
+
+  if (UUID_RE.test(token)) {
+    const { data, error } = await sb
+      .from('app_users')
+      .select('user_id, display_name, vitana_id')
+      .eq('user_id', token)
+      .maybeSingle();
+    if (error) {
+      return { ok: false, error: 'I had a problem looking that member up — want me to try again?' };
+    }
+    if (!data) {
+      return { ok: false, error: "I couldn't find that member — they may have left the community." };
+    }
+    return { ok: true, member: data as ResolvedMember };
+  }
+
+  const { data, error } = await sb.rpc('resolve_recipient_candidates', {
+    p_actor: id.user_id,
+    p_token: token,
+    p_limit: 5,
+    p_global: true,
+  });
+  if (error) {
+    return { ok: false, error: `I had a problem looking up ${token} — want me to try again?` };
+  }
+  const candidates = (data || []) as Array<{
+    user_id: string;
+    vitana_id: string | null;
+    display_name: string | null;
+    score: number;
+  }>;
+  if (candidates.length === 0) {
+    return { ok: false, error: `I couldn't find anyone named "${token}" in the community.` };
+  }
+  const topScore = Number(candidates[0].score);
+  const secondScore = candidates[1] ? Number(candidates[1].score) : 0;
+  const ambiguous = topScore < 0.85 || secondScore / Math.max(topScore, 0.0001) > 0.85;
+  if (ambiguous) {
+    const names = candidates
+      .slice(0, 3)
+      .map((c) => c.display_name || c.vitana_id || c.user_id)
+      .join(', ');
+    return {
+      ok: false,
+      error: `I found several possible matches for "${token}": ${names}. Which one did you mean?`,
+    };
+  }
+  const top = candidates[0];
+  return {
+    ok: true,
+    member: {
+      user_id: top.user_id,
+      display_name: top.display_name ?? null,
+      vitana_id: top.vitana_id ?? null,
+    },
+  };
+}
+
+/** Best-effort sender display name for fanout notification bodies. */
+async function senderDisplayName(sb: SupabaseClient, userId: string): Promise<string> {
+  try {
+    const [{ data: profile }, { data: appUser }] = await Promise.all([
+      sb.from('profiles').select('display_name, full_name').eq('user_id', userId).maybeSingle(),
+      sb.from('app_users').select('display_name, email').eq('user_id', userId).maybeSingle(),
+    ]);
+    const p = profile as { display_name?: string | null; full_name?: string | null } | null;
+    const au = appUser as { display_name?: string | null; email?: string | null } | null;
+    return (
+      p?.display_name ||
+      p?.full_name ||
+      au?.display_name ||
+      (au?.email ? au.email.split('@')[0] : null) ||
+      'Someone'
+    );
+  } catch {
+    return 'Someone';
+  }
+}
+
+/** "Tue, Jul 8, 6:00 PM" — English; the LLM translates when speaking DE. */
+function fmtWhen(iso: string | null | undefined): string {
+  if (!iso) return 'time to be announced';
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return 'time to be announced';
+  return d.toLocaleString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Chat-group resolution (chat_groups / chat_group_members)
+// ---------------------------------------------------------------------------
+
+interface ChatGroupRow {
+  id: string;
+  name: string;
+  description: string | null;
+  is_system: boolean | null;
+  tenant_id: string;
+}
+
+type ChatGroupResolution =
+  | { kind: 'one'; group: ChatGroupRow }
+  | { kind: 'many'; groups: ChatGroupRow[] }
+  | { kind: 'none' }
+  | { kind: 'error'; message: string };
+
+/**
+ * Resolve a group chat the CALLER already belongs to, by id or fuzzy name.
+ * Scoping to the caller's own chat_group_members rows doubles as the
+ * membership check every group-chat tool below needs (you cannot send to,
+ * add members to, or leave a group you are not in) — same security shape as
+ * invite_to_group's caller-membership check in groups-events-tools.ts.
+ */
+async function resolveMyChatGroup(
+  sb: SupabaseClient,
+  userId: string,
+  rawGroupId: unknown,
+  rawQuery: unknown,
+): Promise<ChatGroupResolution> {
+  const groupIdArg = String(rawGroupId ?? '').trim();
+  const query = String(rawQuery ?? '').trim();
+
+  const { data: memberships, error: mErr } = await sb
+    .from('chat_group_members')
+    .select('group_id')
+    .eq('user_id', userId);
+  if (mErr) return { kind: 'error', message: mErr.message };
+  const groupIds = ((memberships as Array<{ group_id: string }>) ?? []).map((m) => m.group_id);
+  if (groupIds.length === 0) return { kind: 'none' };
+
+  const { data: groups, error: gErr } = await sb
+    .from('chat_groups')
+    .select('id, name, description, is_system, tenant_id')
+    .in('id', groupIds);
+  if (gErr) return { kind: 'error', message: gErr.message };
+  const myGroups = (groups as ChatGroupRow[]) ?? [];
+  if (myGroups.length === 0) return { kind: 'none' };
+
+  if (UUID_RE.test(groupIdArg)) {
+    const hit = myGroups.find((g) => g.id === groupIdArg);
+    return hit ? { kind: 'one', group: hit } : { kind: 'none' };
+  }
+
+  if (query) {
+    const matches = myGroups.filter((g) => g.name.toLowerCase().includes(query.toLowerCase()));
+    if (matches.length === 0) return { kind: 'none' };
+    if (matches.length === 1) return { kind: 'one', group: matches[0] };
+    const exact = matches.find((g) => g.name.toLowerCase() === query.toLowerCase());
+    if (exact) return { kind: 'one', group: exact };
+    return { kind: 'many', groups: matches };
+  }
+
+  // No id/query given — auto-resolve only when the caller is in exactly one
+  // group chat; otherwise the model must ask which one.
+  if (myGroups.length === 1) return { kind: 'one', group: myGroups[0] };
+  return { kind: 'many', groups: myGroups };
+}
+
+function groupNotFoundText(query: string): string {
+  return query
+    ? `I couldn't find a group chat of yours matching "${query}". Which group chat did you mean?`
+    : "I couldn't find that group chat, or you're not a member of it.";
+}
+
+function groupAmbiguousResult(groups: ChatGroupRow[]) {
+  const names = groups.map((g) => g.name).join(', ');
+  return {
+    ok: true as const,
+    result: { resolved: false, candidates: groups.map((g) => ({ group_id: g.id, name: g.name })) },
+    text: `You're in ${groups.length} group chats matching that: ${names}. Which one did you mean?`,
+  };
+}
+
+function groupNoneResult(query: string) {
+  return { ok: true as const, result: { resolved: false }, text: groupNotFoundText(query) };
+}
+
+// ---------------------------------------------------------------------------
+// 1. send_group_chat_message
+// ---------------------------------------------------------------------------
+
+export const tool_send_group_chat_message: Handler = async (args, id, sb) => {
+  const gate = authGate('send_group_chat_message', id);
+  if (gate) return gate;
+  try {
+    const body = argString(args, 'message', 'body', 'text');
+    if (!body) {
+      return { ok: false, error: "I didn't catch the message — what would you like me to say?" };
+    }
+    const queryLabel = argString(args, 'group', 'group_name', 'query');
+    const resolved = await resolveMyChatGroup(sb, id.user_id, args.group_id, queryLabel);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') return groupNoneResult(queryLabel);
+    if (resolved.kind === 'many') return groupAmbiguousResult(resolved.groups);
+    const group = resolved.group;
+
+    if (args.confirmed !== true) {
+      return {
+        ok: true,
+        result: {
+          stage: 'awaiting_confirmation',
+          group_id: group.id,
+          group_name: group.name,
+          message_preview: body,
+        },
+        text: `Ready to send to "${group.name}": "${body}". Read this back and only call send_group_chat_message again with confirmed=true after explicit confirmation.`,
+      };
+    }
+
+    const quota = await checkVoiceSendQuota({
+      // No single recipient exists for a group send; the group id stands in
+      // so the same per-session voice-send cap (VTID-01967) still applies to
+      // group chats, not just DMs.
+      session_id: `${id.user_id}:send_group_chat_message`,
+      actor_id: id.user_id,
+      vitana_id: id.vitana_id ?? null,
+      recipient_user_id: group.id,
+      recipient_vitana_id: null,
+      kind: 'message',
+      body_length: body.length,
+    });
+    if (!quota.allowed) {
+      return {
+        ok: true,
+        result: { rate_limited: true, reason: quota.reason },
+        text: `Couldn't send (${quota.reason ?? 'rate-limited'}). Try again in a bit.`,
+      };
+    }
+
+    const { data: inserted, error: insErr } = await sb
+      .from('chat_messages')
+      .insert({
+        tenant_id: group.tenant_id,
+        sender_id: id.user_id,
+        receiver_id: null,
+        group_id: group.id,
+        content: body,
+        message_type: 'text',
+        metadata: { source: 'voice', kind: 'group_message' },
+      })
+      .select('id')
+      .single();
+    if (insErr) {
+      return { ok: false, error: "I couldn't send that just now — want me to try again?" };
+    }
+    const messageId = (inserted as { id: string }).id;
+
+    // Best-effort push fanout — same shape as routes/chat-groups.ts's
+    // fanoutGroupNotifications, minus @vitana-mention handling (that is a
+    // whole conversation-brain flow out of scope for this voice tool).
+    try {
+      const { data: members } = await sb
+        .from('chat_group_members')
+        .select('user_id')
+        .eq('group_id', group.id);
+      const senderName = await senderDisplayName(sb, id.user_id);
+      const preview = body.length > 100 ? `${body.slice(0, 97)}...` : body;
+      for (const m of (members as Array<{ user_id: string }>) ?? []) {
+        if (m.user_id === id.user_id) continue;
+        notifyUserAsync(
+          m.user_id,
+          group.tenant_id,
+          'new_chat_message',
+          {
+            title: group.name,
+            body: `${senderName}: ${preview}`,
+            data: {
+              type: 'new_group_message',
+              group_id: group.id,
+              sender_id: id.user_id,
+              message_id: messageId,
+              url: `/inbox/g/${group.id}`,
+            },
+          },
+          sb,
+        );
+      }
+    } catch {
+      /* fanout is best-effort; never fail the send because of it */
+    }
+
+    return {
+      ok: true,
+      result: { sent: true, group_id: group.id, message_id: messageId },
+      text: `Sent to "${group.name}".`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'send_group_chat_message error';
+    return { ok: false, error: `I hit a snag sending that (${msg}).` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 2. reply_to_message — stub (no backing column)
+// ---------------------------------------------------------------------------
+
+/**
+ * chat_messages (and global_messages / messages) have no reply-to / parent /
+ * thread column anywhere in the schema — grepped every migration for
+ * reply_to|parent_message|in_reply_to|quoted_message with zero hits.
+ * There is nowhere to persist "this message replies to that one", so per the
+ * wave-1 hard rule this is an honest stub rather than a fabricated thread.
+ */
+export const tool_reply_to_message: Handler = async (_args, _id, _sb) => {
+  return {
+    ok: false,
+    error:
+      'reply_to_message is not available yet — no backing endpoint. Vitana chat has no reply/quote-thread ' +
+      'column, so a reply cannot be linked to the original message. Offer to send_chat_message or ' +
+      'send_group_chat_message with the quoted context typed into the new message instead, and say plainly ' +
+      'that threaded replies are not supported yet.',
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 3. react_to_message
+// ---------------------------------------------------------------------------
+
+export const tool_react_to_message: Handler = async (args, id, sb) => {
+  const gate = authGate('react_to_message', id);
+  if (gate) return gate;
+  try {
+    const messageId = argString(args, 'message_id', 'message');
+    if (!UUID_RE.test(messageId)) {
+      return { ok: false, error: 'react_to_message needs a message_id (UUID) from a previous tool result.' };
+    }
+    const emoji = argString(args, 'emoji', 'reaction');
+    if (!emoji || !ALLOWED_REACTION_EMOJIS.has(emoji)) {
+      return {
+        ok: false,
+        error: `Reactions must be one of 👍 ❤️ 😂 😮 🙏 🎉 — "${emoji || 'none given'}" isn't supported.`,
+      };
+    }
+
+    // Access check: the message must be a DM the caller sent/received, or a
+    // group message in a group the caller belongs to — same predicate the
+    // message_reactions RLS SELECT policy and get_message_reactions_text RPC
+    // use (supabase/migrations/20260522000000_vtid_03089_chat_group_reactions_rls.sql).
+    const { data: msgRow, error: msgErr } = await sb
+      .from('chat_messages')
+      .select('id, sender_id, receiver_id, group_id')
+      .eq('id', messageId)
+      .maybeSingle();
+    if (msgErr) return { ok: false, error: "I had a problem finding that message — want me to try again?" };
+    if (!msgRow) return { ok: false, error: "I couldn't find that message." };
+    const msg = msgRow as { sender_id: string; receiver_id: string | null; group_id: string | null };
+
+    let allowed = msg.sender_id === id.user_id || msg.receiver_id === id.user_id;
+    if (!allowed && msg.group_id) {
+      const { data: membership } = await sb
+        .from('chat_group_members')
+        .select('user_id')
+        .eq('group_id', msg.group_id)
+        .eq('user_id', id.user_id)
+        .maybeSingle();
+      allowed = Boolean(membership);
+    }
+    if (!allowed) {
+      return { ok: false, error: "You don't have access to that message." };
+    }
+
+    if (args.remove === true) {
+      const { error: delErr } = await sb
+        .from('message_reactions')
+        .delete()
+        .eq('message_id', messageId)
+        .eq('user_id', id.user_id)
+        .eq('emoji', emoji);
+      if (delErr) return { ok: false, error: "I couldn't remove that reaction just now — want me to try again?" };
+      return { ok: true, result: { removed: true, message_id: messageId, emoji }, text: `Removed your ${emoji} reaction.` };
+    }
+
+    const { error: insErr } = await sb
+      .from('message_reactions')
+      .insert({ message_id: messageId, user_id: id.user_id, emoji });
+    if (insErr) {
+      if ((insErr as { code?: string }).code === '23505') {
+        return {
+          ok: true,
+          result: { already_reacted: true, message_id: messageId, emoji },
+          text: `You already reacted ${emoji} to that message.`,
+        };
+      }
+      return { ok: false, error: "I couldn't add that reaction just now — want me to try again?" };
+    }
+    return {
+      ok: true,
+      result: { reacted: true, message_id: messageId, emoji },
+      text: `Reacted ${emoji} to that message.`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'react_to_message error';
+    return { ok: false, error: `I hit a snag with that reaction (${msg}).` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 4. create_group_chat
+// ---------------------------------------------------------------------------
+
+function parseMemberList(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.map((v) => String(v ?? '').trim()).filter(Boolean);
+  }
+  if (typeof raw === 'string') {
+    return raw
+      .split(/,| and | und /i)
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+export const tool_create_group_chat: Handler = async (args, id, sb) => {
+  const gate = authGate('create_group_chat', id);
+  if (gate) return gate;
+  const name = argString(args, 'name', 'group_name');
+  const description = argString(args, 'description');
+  if (!name) {
+    return { ok: false, error: 'create_group_chat requires a name for the group. What should it be called?' };
+  }
+  const memberNames = parseMemberList(args.members ?? args.member_names);
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: {
+        needs_confirmation: true,
+        name,
+        description: description || null,
+        members: memberNames,
+      },
+      text:
+        `Confirm with the user: create a group chat called "${name}"` +
+        `${memberNames.length ? ` with ${memberNames.join(', ')}` : ''}? ` +
+        'When they say yes, call create_group_chat again with confirm:true.',
+    };
+  }
+  try {
+    const tenantId = await resolveTenantId(id, sb);
+    if (!tenantId) {
+      return {
+        ok: false,
+        error: "I can't create that right now — I'm missing some account context. Try once more in a moment.",
+      };
+    }
+    const { data: group, error: insErr } = await sb
+      .from('chat_groups')
+      .insert({
+        tenant_id: tenantId,
+        name,
+        description: description || null,
+        created_by: id.user_id,
+        is_system: false,
+        metadata: { source: 'voice' },
+      })
+      .select('id, name')
+      .single();
+    if (insErr || !group) {
+      return { ok: false, error: insErr?.message ?? 'group chat creation failed' };
+    }
+    const g = group as { id: string; name: string };
+
+    const { error: memErr } = await sb
+      .from('chat_group_members')
+      .insert({ group_id: g.id, user_id: id.user_id, tenant_id: tenantId, role: 'admin' });
+    if (memErr && (memErr as { code?: string }).code !== '23505') {
+      return { ok: false, error: memErr.message };
+    }
+
+    const added: string[] = [];
+    const failed: string[] = [];
+    for (const nameArg of memberNames) {
+      const resolved = await resolveMember(nameArg, id, sb);
+      if (!resolved.ok) {
+        failed.push(nameArg);
+        continue;
+      }
+      const target = resolved.member;
+      if (target.user_id === id.user_id) continue;
+      const { error: addErr } = await sb
+        .from('chat_group_members')
+        .insert({ group_id: g.id, user_id: target.user_id, tenant_id: tenantId, role: 'member' });
+      if (addErr && (addErr as { code?: string }).code !== '23505') {
+        failed.push(nameArg);
+        continue;
+      }
+      added.push(memberDisplay(target));
+    }
+
+    const parts = [`Created the group chat "${g.name}".`];
+    if (added.length) parts.push(`Added: ${added.join(', ')}.`);
+    if (failed.length) parts.push(`Couldn't find/add: ${failed.join(', ')}.`);
+
+    return {
+      ok: true,
+      result: { group_id: g.id, name: g.name, added_members: added, failed_members: failed },
+      text: parts.join(' '),
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'create_group_chat error';
+    return { ok: false, error: `I hit a snag creating that group chat (${msg}).` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 5. add_group_chat_member
+// ---------------------------------------------------------------------------
+
+export const tool_add_group_chat_member: Handler = async (args, id, sb) => {
+  const gate = authGate('add_group_chat_member', id);
+  if (gate) return gate;
+  try {
+    const queryLabel = argString(args, 'group', 'group_name', 'query');
+    const resolved = await resolveMyChatGroup(sb, id.user_id, args.group_id, queryLabel);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') return groupNoneResult(queryLabel);
+    if (resolved.kind === 'many') return groupAmbiguousResult(resolved.groups);
+    const group = resolved.group;
+
+    const memberArg = argString(args, 'member', 'member_name', 'name');
+    const memberIdArg = argString(args, 'member_user_id');
+    if (!memberArg && !memberIdArg) {
+      return { ok: false, error: 'Who would you like to add to the group?' };
+    }
+    const resolvedMember = await resolveMember(memberIdArg || memberArg, id, sb);
+    if (!resolvedMember.ok) return resolvedMember;
+    const target = resolvedMember.member;
+    if (target.user_id === id.user_id) {
+      return { ok: false, error: "You're already in this group." };
+    }
+
+    const { error: insErr } = await sb
+      .from('chat_group_members')
+      .insert({ group_id: group.id, user_id: target.user_id, tenant_id: group.tenant_id, role: 'member' });
+    const name = memberDisplay(target);
+    if (insErr) {
+      if ((insErr as { code?: string }).code === '23505') {
+        return {
+          ok: true,
+          result: { added: false, already_member: true, group_id: group.id },
+          text: `${name} is already in "${group.name}".`,
+        };
+      }
+      return { ok: false, error: `I couldn't add ${name} just now — want me to try again?` };
+    }
+    return {
+      ok: true,
+      result: { added: true, group_id: group.id, member_user_id: target.user_id },
+      text: `Added ${name} to "${group.name}".`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'add_group_chat_member error';
+    return { ok: false, error: `I hit a snag adding that member (${msg}).` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 6. leave_group_chat
+// ---------------------------------------------------------------------------
+
+export const tool_leave_group_chat: Handler = async (args, id, sb) => {
+  const gate = authGate('leave_group_chat', id);
+  if (gate) return gate;
+  try {
+    const queryLabel = argString(args, 'group', 'group_name', 'query');
+    const resolved = await resolveMyChatGroup(sb, id.user_id, args.group_id, queryLabel);
+    if (resolved.kind === 'error') return { ok: false, error: resolved.message };
+    if (resolved.kind === 'none') return groupNoneResult(queryLabel);
+    if (resolved.kind === 'many') return groupAmbiguousResult(resolved.groups);
+    const group = resolved.group;
+
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { needs_confirmation: true, group_id: group.id, group_name: group.name },
+        text: `Confirm with the user: leave the group chat "${group.name}"? When they say yes, call leave_group_chat again with this group_id and confirm:true.`,
+      };
+    }
+
+    const { error: delErr } = await sb
+      .from('chat_group_members')
+      .delete()
+      .eq('group_id', group.id)
+      .eq('user_id', id.user_id);
+    if (delErr) return { ok: false, error: `I couldn't leave "${group.name}" just now — want me to try again?` };
+
+    return {
+      ok: true,
+      result: { left: true, group_id: group.id, group_name: group.name },
+      text: `You've left "${group.name}".`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'leave_group_chat error';
+    return { ok: false, error: `I hit a snag leaving that group (${msg}).` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 7. send_calendar_invite_in_chat
+// ---------------------------------------------------------------------------
+
+interface CalendarEventRow {
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string | null;
+  location: string | null;
+}
+
+type CalendarEventResolution =
+  | { kind: 'one'; event: CalendarEventRow }
+  | { kind: 'many'; events: CalendarEventRow[] }
+  | { kind: 'none' }
+  | { kind: 'error'; message: string };
+
+/** Resolve one of the CALLER's own (non-cancelled) calendar_events rows. */
+async function resolveMyCalendarEvent(
+  sb: SupabaseClient,
+  userId: string,
+  rawEventId: unknown,
+  rawQuery: unknown,
+): Promise<CalendarEventResolution> {
+  const eventIdArg = String(rawEventId ?? '').trim();
+  const query = String(rawQuery ?? '').trim();
+  const cols = 'id, title, start_time, end_time, location';
+
+  if (UUID_RE.test(eventIdArg)) {
+    const { data, error } = await sb
+      .from('calendar_events')
+      .select(cols)
+      .eq('id', eventIdArg)
+      .eq('user_id', userId)
+      .neq('status', 'cancelled')
+      .maybeSingle();
+    if (error) return { kind: 'error', message: error.message };
+    if (!data) return { kind: 'none' };
+    return { kind: 'one', event: data as CalendarEventRow };
+  }
+
+  if (!query) return { kind: 'none' };
+  const { data, error } = await sb
+    .from('calendar_events')
+    .select(cols)
+    .eq('user_id', userId)
+    .neq('status', 'cancelled')
+    .gte('start_time', new Date().toISOString())
+    .ilike('title', `%${query}%`)
+    .order('start_time', { ascending: true })
+    .limit(5);
+  if (error) return { kind: 'error', message: error.message };
+  const events = (data as CalendarEventRow[]) ?? [];
+  if (events.length === 0) return { kind: 'none' };
+  if (events.length === 1) return { kind: 'one', event: events[0] };
+  const exact = events.find((e) => e.title.toLowerCase() === query.toLowerCase());
+  if (exact) return { kind: 'one', event: exact };
+  return { kind: 'many', events };
+}
+
+function speakEvent(e: CalendarEventRow): string {
+  return `"${e.title}" on ${fmtWhen(e.start_time)}${e.location ? ` at ${e.location}` : ''}`;
+}
+
+export const tool_send_calendar_invite_in_chat: Handler = async (args, id, sb) => {
+  const gate = authGate('send_calendar_invite_in_chat', id);
+  if (gate) return gate;
+  try {
+    const memberArg = argString(args, 'member', 'member_name', 'name');
+    const memberIdArg = argString(args, 'member_user_id', 'recipient_user_id');
+    if (!memberArg && !memberIdArg) {
+      return { ok: false, error: 'Who would you like to send the calendar invite to?' };
+    }
+    const queryLabel = argString(args, 'event', 'query', 'title');
+    const resolvedEvent = await resolveMyCalendarEvent(sb, id.user_id, args.event_id, queryLabel);
+    if (resolvedEvent.kind === 'error') return { ok: false, error: resolvedEvent.message };
+    if (resolvedEvent.kind === 'none') {
+      return {
+        ok: true,
+        result: { sent: false },
+        text: queryLabel
+          ? `I couldn't find an event of yours matching "${queryLabel}". Which event did you mean?`
+          : 'Which event would you like to share? Tell me its title.',
+      };
+    }
+    if (resolvedEvent.kind === 'many') {
+      const lines = resolvedEvent.events.map(speakEvent).join('; ');
+      return {
+        ok: true,
+        result: {
+          sent: false,
+          candidates: resolvedEvent.events.map((e) => ({ event_id: e.id, title: e.title, start_time: e.start_time })),
+        },
+        text: `I found ${resolvedEvent.events.length} matching events: ${lines}. Which one do you mean?`,
+      };
+    }
+    const event = resolvedEvent.event;
+
+    const resolvedMember = await resolveMember(memberIdArg || memberArg, id, sb);
+    if (!resolvedMember.ok) return resolvedMember;
+    const target = resolvedMember.member;
+    if (target.user_id === id.user_id) {
+      return { ok: false, error: "You can't send a calendar invite to yourself." };
+    }
+    const name = memberDisplay(target);
+
+    if (args.confirmed !== true) {
+      return {
+        ok: true,
+        result: {
+          stage: 'awaiting_confirmation',
+          recipient_user_id: target.user_id,
+          recipient_label: name,
+          event_id: event.id,
+        },
+        text: `Ready to send ${name} the invite for ${speakEvent(event)}. Read this back and only call send_calendar_invite_in_chat again with confirmed=true after explicit confirmation.`,
+      };
+    }
+
+    const tenantId = await resolveTenantId(id, sb);
+    if (!tenantId) {
+      return {
+        ok: false,
+        error: "I can't send right now — I'm missing some account context. Try once more in a moment.",
+      };
+    }
+
+    const quota = await checkVoiceSendQuota({
+      session_id: `${id.user_id}:send_calendar_invite_in_chat`,
+      actor_id: id.user_id,
+      vitana_id: id.vitana_id ?? null,
+      recipient_user_id: target.user_id,
+      recipient_vitana_id: target.vitana_id,
+      kind: 'message',
+    });
+    if (!quota.allowed) {
+      return {
+        ok: true,
+        result: { rate_limited: true, reason: quota.reason },
+        text: `Couldn't send (${quota.reason ?? 'rate-limited'}). Try again in a bit.`,
+      };
+    }
+
+    const content = `📅 ${event.title} — ${fmtWhen(event.start_time)}${event.location ? ` at ${event.location}` : ''}`;
+    const { error: insErr } = await sb.from('chat_messages').insert({
+      tenant_id: tenantId,
+      sender_id: id.user_id,
+      receiver_id: target.user_id,
+      content,
+      // Custom message_type value — same convention tool_share_link in
+      // orb-tools-shared.ts uses ('link_share'); message_type has no DB
+      // CHECK constraint, so a descriptive kind is safe and matches
+      // established precedent rather than inventing a new column.
+      message_type: 'calendar_invite',
+      metadata: {
+        source: 'voice',
+        kind: 'calendar_invite',
+        event_id: event.id,
+        title: event.title,
+        start_time: event.start_time,
+        end_time: event.end_time,
+        location: event.location,
+      },
+    });
+    if (insErr) {
+      return { ok: false, error: "I couldn't send that invite just now — want me to try again?" };
+    }
+
+    try {
+      if (!/^00000000-0000-0000-0000-000000000001$/i.test(target.user_id)) {
+        const senderName = await senderDisplayName(sb, id.user_id);
+        notifyUserAsync(
+          target.user_id,
+          tenantId,
+          'new_chat_message',
+          {
+            title: senderName,
+            body: content,
+            data: { type: 'new_chat_message', sender_id: id.user_id, url: `/inbox?peer=${id.user_id}` },
+          },
+          sb,
+        );
+      }
+    } catch {
+      /* push is best-effort */
+    }
+
+    return {
+      ok: true,
+      result: { sent: true, recipient_user_id: target.user_id, event_id: event.id },
+      text: `Sent ${name} the invite for ${speakEvent(event)}.`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'send_calendar_invite_in_chat error';
+    return { ok: false, error: `I hit a snag sending that invite (${msg}).` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 8 & 9. start_voice_call / start_video_call — call INVITE only, not a real
+// connection (see header comment: calling is client-only WebRTC with no
+// server-side call table or route to drive from the gateway).
+// ---------------------------------------------------------------------------
+
+async function sendCallInvite(
+  isVideo: boolean,
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const tool = isVideo ? 'start_video_call' : 'start_voice_call';
+  const gate = authGate(tool, id);
+  if (gate) return gate;
+  try {
+    const memberArg = argString(args, 'member', 'member_name', 'name');
+    const memberIdArg = argString(args, 'member_user_id', 'recipient_user_id');
+    if (!memberArg && !memberIdArg) {
+      return { ok: false, error: `Who would you like to ${isVideo ? 'video' : 'voice'} call?` };
+    }
+    const resolvedMember = await resolveMember(memberIdArg || memberArg, id, sb);
+    if (!resolvedMember.ok) return resolvedMember;
+    const target = resolvedMember.member;
+    if (target.user_id === id.user_id) {
+      return { ok: false, error: "You can't call yourself." };
+    }
+    const name = memberDisplay(target);
+    const kindWord = isVideo ? 'video call' : 'voice call';
+
+    if (args.confirmed !== true) {
+      return {
+        ok: true,
+        result: { stage: 'awaiting_confirmation', recipient_user_id: target.user_id, recipient_label: name },
+        text:
+          `Vitana can't place a live ${kindWord} for you — calls only work between two people who both have ` +
+          `the app open. I can send ${name} a ${kindWord} request instead. Confirm with the user, then call ` +
+          `${tool} again with confirmed=true.`,
+      };
+    }
+
+    const tenantId = await resolveTenantId(id, sb);
+    if (!tenantId) {
+      return {
+        ok: false,
+        error: "I can't send that right now — I'm missing some account context. Try once more in a moment.",
+      };
+    }
+
+    const quota = await checkVoiceSendQuota({
+      session_id: `${id.user_id}:${tool}`,
+      actor_id: id.user_id,
+      vitana_id: id.vitana_id ?? null,
+      recipient_user_id: target.user_id,
+      recipient_vitana_id: target.vitana_id,
+      kind: 'message',
+    });
+    if (!quota.allowed) {
+      return {
+        ok: true,
+        result: { rate_limited: true, reason: quota.reason },
+        text: `Couldn't send (${quota.reason ?? 'rate-limited'}). Try again in a bit.`,
+      };
+    }
+
+    const senderName = await senderDisplayName(sb, id.user_id);
+    const content = `${isVideo ? '🎥' : '📞'} ${senderName} would like to start a ${kindWord} with you — open Vitana to connect.`;
+    const { error: insErr } = await sb.from('chat_messages').insert({
+      tenant_id: tenantId,
+      sender_id: id.user_id,
+      receiver_id: target.user_id,
+      content,
+      message_type: 'call_invite',
+      metadata: { source: 'voice', kind: 'call_invite', call_type: isVideo ? 'video' : 'voice' },
+    });
+    if (insErr) {
+      return { ok: false, error: "I couldn't send that request just now — want me to try again?" };
+    }
+
+    try {
+      notifyUserAsync(
+        target.user_id,
+        tenantId,
+        'new_chat_message',
+        {
+          title: senderName,
+          body: content,
+          data: { type: 'new_chat_message', sender_id: id.user_id, url: `/inbox?peer=${id.user_id}` },
+        },
+        sb,
+      );
+    } catch {
+      /* push is best-effort */
+    }
+
+    return {
+      ok: true,
+      result: { sent: true, recipient_user_id: target.user_id, call_type: isVideo ? 'video' : 'voice' },
+      text:
+        `I've sent ${name} a ${kindWord} request — real-time calls need both of you in the app, so ask them ` +
+        `to open Vitana, or open it yourself to start the call.`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : `${tool} error`;
+    return { ok: false, error: `I hit a snag with that call request (${msg}).` };
+  }
+}
+
+export const tool_start_voice_call: Handler = (args, id, sb) => sendCallInvite(false, args, id, sb);
+export const tool_start_video_call: Handler = (args, id, sb) => sendCallInvite(true, args, id, sb);
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const MESSAGING_DEPTH_TOOL_HANDLERS: Record<string, Handler> = {
+  send_group_chat_message: tool_send_group_chat_message,
+  reply_to_message: tool_reply_to_message,
+  react_to_message: tool_react_to_message,
+  create_group_chat: tool_create_group_chat,
+  add_group_chat_member: tool_add_group_chat_member,
+  leave_group_chat: tool_leave_group_chat,
+  send_calendar_invite_in_chat: tool_send_calendar_invite_in_chat,
+  start_voice_call: tool_start_voice_call,
+  start_video_call: tool_start_video_call,
+};
+
+export const MESSAGING_DEPTH_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'send_group_chat_message',
+    description: [
+      "Send a text message to a group chat the user is a member of (not a 1-to-1 DM —",
+      'use send_chat_message for that). ALWAYS call once WITHOUT confirmed first — the',
+      'tool returns a preview; read it back and only call again with confirmed:true after',
+      'explicit confirmation.',
+      'CALL WHEN the user says: "message the running group", "tell everyone in Alle',
+      'Beisammen ...", "schreib in die Gruppe ...".',
+      'If several of the user\'s groups match, read the candidates and ask which one.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        group: { type: 'string', description: 'Spoken group chat name (fuzzy matched among the user\'s own groups).' },
+        group_id: { type: 'string', description: 'Exact group UUID when already known.' },
+        message: { type: 'string', description: 'The message to send.' },
+        confirmed: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the exact wording.' },
+      },
+      required: ['message'],
+    },
+  },
+  {
+    name: 'reply_to_message',
+    description: [
+      'Reply to a specific earlier message. NOTE: Vitana chat has no reply/quote-thread',
+      'feature yet — this tool always answers that it is unavailable. Relay that plainly',
+      'and offer send_chat_message or send_group_chat_message instead, optionally quoting',
+      'the original text inline in the new message.',
+      'CALL WHEN the user says: "reply to that message", "antworte auf die Nachricht".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        message_id: { type: 'string', description: 'UUID of the message being replied to, if known.' },
+        message: { type: 'string', description: 'The reply text the user wants to send.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'react_to_message',
+    description: [
+      'Add (or remove) an emoji reaction on a chat message — one of 👍 ❤️ 😂 😮 🙏 🎉 only.',
+      'Requires message_id from a previous tool result (e.g. from list_conversations or a',
+      'group message read-back).',
+      'CALL WHEN the user says: "react with a heart to that", "give that a thumbs up",',
+      '"reagiere mit einem Herz darauf".',
+      'Set remove:true to take the reaction back off.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        message_id: { type: 'string', description: 'UUID of the message to react to.' },
+        emoji: { type: 'string', description: 'One of: 👍 ❤️ 😂 😮 🙏 🎉' },
+        remove: { type: 'boolean', description: 'Pass true to remove a reaction the user previously added.' },
+      },
+      required: ['message_id', 'emoji'],
+    },
+  },
+  {
+    name: 'create_group_chat',
+    description: [
+      'Create a new group chat, optionally adding named members immediately. ALWAYS call',
+      'once WITHOUT confirm first — the tool returns a confirmation question; after the',
+      'user says yes, call again with confirm:true.',
+      'CALL WHEN the user says: "create a group chat called ...", "start a new chat with',
+      'me, Anna and Ben", "erstelle einen Gruppenchat ...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'The group chat name.' },
+        description: { type: 'string', description: 'Optional short description.' },
+        members: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Spoken names of members to add immediately (fuzzy resolved).',
+        },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the creation.' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'add_group_chat_member',
+    description: [
+      'Add a community member to a group chat the user already belongs to.',
+      'CALL WHEN the user says: "add Anna to the running group chat", "füge Anna dem',
+      'Gruppenchat hinzu".',
+      'If several of the user\'s groups or several matching members are found, ask which one.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        group: { type: 'string', description: 'Spoken group chat name (fuzzy matched among the user\'s own groups).' },
+        group_id: { type: 'string', description: 'Exact group UUID when already known.' },
+        member: { type: 'string', description: 'Spoken name or Vitana ID of the member to add.' },
+        member_user_id: { type: 'string', description: 'UUID of the member if already resolved.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'leave_group_chat',
+    description: [
+      'Leave a group chat. ALWAYS call once WITHOUT confirm first — the tool returns a',
+      'confirmation question; after the user says yes, call again with the group_id and',
+      'confirm:true.',
+      'CALL WHEN the user says: "leave the running group chat", "verlasse den Gruppenchat',
+      '...".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        group: { type: 'string', description: 'Spoken group chat name (fuzzy matched among the user\'s own groups).' },
+        group_id: { type: 'string', description: 'Exact group UUID when already known.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed leaving.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'send_calendar_invite_in_chat',
+    description: [
+      'Share one of the user\'s own upcoming calendar events with a community member via',
+      'direct message. ALWAYS call once WITHOUT confirmed first — the tool returns a',
+      'preview; after explicit confirmation call again with confirmed:true.',
+      'CALL WHEN the user says: "send Anna the invite for my yoga session", "share my',
+      'appointment with Ben", "schick Anna die Einladung zu meinem Termin".',
+      'If several events or member matches are found, ask which one.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        member: { type: 'string', description: 'Spoken name or Vitana ID of the recipient.' },
+        member_user_id: { type: 'string', description: 'UUID of the recipient if already resolved.' },
+        event: { type: 'string', description: 'Spoken event title (fuzzy matched against the user\'s own upcoming events).' },
+        event_id: { type: 'string', description: 'Exact calendar_events UUID when already known.' },
+        confirmed: { type: 'boolean', description: 'Pass true ONLY after the user explicitly confirmed sending.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'start_voice_call',
+    description: [
+      'Send another community member a request to start a voice call. IMPORTANT: Vitana',
+      'cannot place a live call from voice — calling only works client-side between two',
+      'open apps. This tool sends a chat message + notification asking them to open the',
+      'app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again',
+      'with confirmed:true after explicit confirmation.',
+      'CALL WHEN the user says: "call Anna", "start a voice call with Ben", "ruf Anna an".',
+      'Afterwards, tell the user the request was sent and real-time calling needs both',
+      'people in the app.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        member: { type: 'string', description: 'Spoken name or Vitana ID of the person to call.' },
+        member_user_id: { type: 'string', description: 'UUID of the member if already resolved.' },
+        confirmed: { type: 'boolean', description: 'Pass true ONLY after the user explicitly confirmed sending the request.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'start_video_call',
+    description: [
+      'Send another community member a request to start a video call. IMPORTANT: Vitana',
+      'cannot place a live call from voice — calling only works client-side between two',
+      'open apps. This tool sends a chat message + notification asking them to open the',
+      'app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again',
+      'with confirmed:true after explicit confirmation.',
+      'CALL WHEN the user says: "video call Anna", "start a video chat with Ben", "starte',
+      'einen Videoanruf mit Anna".',
+      'Afterwards, tell the user the request was sent and real-time calling needs both',
+      'people in the app.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        member: { type: 'string', description: 'Spoken name or Vitana ID of the person to video call.' },
+        member_user_id: { type: 'string', description: 'UUID of the member if already resolved.' },
+        confirmed: { type: 'boolean', description: 'Pass true ONLY after the user explicitly confirmed sending the request.' },
+      },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/wallet-payments-tools.ts
+++ b/services/gateway/src/services/orb-tools/wallet-payments-tools.ts
@@ -1,0 +1,958 @@
+/**
+ * Wallet & Payments (A3) voice tools — community role.
+ *
+ * REAL backings used (never fabricated — see per-tool notes below):
+ *   - wallet_accounts / wallet_ledger_entries via services/wallet/balance-service.ts
+ *     (getAccountsForUser / getTransactionsForUser) — same source tool_get_wallet_balance
+ *     in p0-gap-tools.ts already reads.
+ *   - debit_wallet_for_spend / credit_wallet_for_earning RPCs via
+ *     services/wallet/spend-earning-service.ts — the only sanctioned way to move
+ *     wallet money; both own SELECT FOR UPDATE + ledger insert + idempotency via
+ *     reference_type/reference_id. send_funds composes these two primitives with
+ *     a shared reference_id to build a real internal transfer — there is no
+ *     dedicated "transfer" RPC/table (verified: vitana-v1's CreditTransferPopup.tsx
+ *     is UI-only, no backend call).
+ *   - commission_event / rewards_ledger (VCAOP schema, prisma/migrations/
+ *     20260604_vcaop_ctrl_schema_0002/migration.sql) — the real, currently-wired
+ *     referral/commission/reward tables. Confirmed live via routes/vcaop.ts:
+ *     GET /api/v1/vcaop/wallet reads rewards_ledger for the caller, GET
+ *     /api/v1/vcaop/commissions reads commission_event. This module queries the
+ *     same tables directly (service-role sb, same pattern every other orb-tools
+ *     module uses) rather than duplicating the ⚠️ admin-gated HTTP routes.
+ *     States: rewards_ledger.state ∈ {pending, confirmed, redeemable, reversed};
+ *     commission_event.status ∈ {pending, confirmed, reversed} (see
+ *     services/gateway/src/services/awin-conversions.ts mapAwinTxStatus).
+ *
+ * STUBBED (no real backing found — hard rule: never fabricate a table/RPC):
+ *   - request_payment / list_payment_requests: "payment requests" in this app are
+ *     NOT a table. vitana-v1's GlobalPaymentRequest.tsx sends a normal chat
+ *     message with message_type='payment_request' + JSON metadata via a direct
+ *     Supabase client insert. The gateway's OWN canonical send route
+ *     (routes/chat.ts POST /send) explicitly rejects that: its allowedTypes set
+ *     is `{'text','attachment','voice','voice_transcript'}` — 'payment_request'
+ *     is not in it. Recreating the frontend's bypass in a new voice tool would
+ *     mean inventing a server contract the gateway's own validation forbids, so
+ *     both tools return ok:false rather than fabricate one.
+ *   - exchange_currency / get_exchange_rate: the canonical wallet
+ *     (types/wallet.ts) only knows WalletCurrency = 'EUR' | 'USD', and
+ *     debit_wallet_for_spend / credit_wallet_for_earning only move money within
+ *     ONE currency — there is no cross-currency conversion RPC anywhere in the
+ *     gateway. The only `exchange_rates` table in the schema is a legacy
+ *     Lovable-era ghost table (USD/VTNA/CREDITS tokens) explicitly called out as
+ *     "OUT OF SCOPE ... no DDL, no reads, no writes" in
+ *     supabase/migrations/20260605000000_VTID_03186_universal_cart_schema.sql,
+ *     pending a convergence decision (issue #2371 / VTID-03176). Building new
+ *     voice tools against a table the codebase itself flags for decommission
+ *     would be reintroducing exactly the debt that migration is unwinding.
+ *   - set_display_currency: verified NOT server-side at all. vitana-v1's
+ *     src/hooks/useDisplayCurrency.ts stores the USD/EUR display toggle in
+ *     `window.localStorage['vitana.wallet.displayCurrency']` only — there is no
+ *     app_users column or user_preferences table for it, so there is nothing a
+ *     gateway voice tool could write to.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { isWalletCurrency, type WalletCurrency } from '../../types/wallet';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function authGate(tool: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+function strArg(args: OrbToolArgs, ...keys: string[]): string {
+  for (const key of keys) {
+    const v = args[key];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return '';
+}
+
+function isConfirmed(args: OrbToolArgs): boolean {
+  return args.confirm === true || args.confirmed === true;
+}
+
+function errText(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+function fmtMinor(minor: number, currency: string): string {
+  return `${(minor / 100).toFixed(2)} ${currency}`;
+}
+
+// ---------------------------------------------------------------------------
+// get_wallet_summary — wallet_accounts + wallet_ledger_entries (balance-service)
+// + user_subscriptions (benefits) + rewards_ledger (VCAOP: lifetime earnings /
+// pending rewards — real numbers, not a stub, since the VCAOP reward ledger is
+// a genuine gateway-owned table).
+// ---------------------------------------------------------------------------
+
+export async function tool_get_wallet_summary(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_wallet_summary', id);
+  if (gate) return gate;
+  try {
+    const { getAccountsForUser, getTransactionsForUser } = await import('../wallet/balance-service');
+    const [accounts, page] = await Promise.all([
+      getAccountsForUser(id.user_id),
+      getTransactionsForUser({ user_id: id.user_id, limit: 5 }),
+    ]);
+
+    interface SubscriptionRow {
+      plan_key: string;
+      status: string;
+      current_period_end: string | null;
+    }
+    let subscription: SubscriptionRow | null = null;
+    try {
+      let subQuery = sb
+        .from('user_subscriptions')
+        .select('plan_key, status, current_period_end')
+        .eq('user_id', id.user_id);
+      if (id.tenant_id) subQuery = subQuery.eq('tenant_id', id.tenant_id);
+      const { data: subRow } = await subQuery.maybeSingle();
+      subscription = (subRow as SubscriptionRow | null) ?? null;
+    } catch {
+      /* subscription read is optional */
+    }
+
+    // Referral rewards (VCAOP rewards_ledger — same table GET /api/v1/vcaop/wallet reads).
+    let lifetimeEarnings = 0;
+    let pendingRewards = 0;
+    let rewardsCurrency: string = accounts[0]?.currency ?? 'EUR';
+    let hasRewards = false;
+    try {
+      const { data: rewardRows } = await sb
+        .from('rewards_ledger')
+        .select('amount, state, currency')
+        .eq('user_id', id.user_id);
+      const rows = (rewardRows ?? []) as Array<{ amount: number; state: string; currency: string }>;
+      hasRewards = rows.length > 0;
+      if (hasRewards) rewardsCurrency = rows[0].currency || rewardsCurrency;
+      for (const r of rows) {
+        const amt = Number(r.amount) || 0;
+        if (r.state === 'confirmed' || r.state === 'redeemable') lifetimeEarnings += amt;
+        else if (r.state === 'pending') pendingRewards += amt;
+      }
+    } catch {
+      /* rewards read is best-effort */
+    }
+
+    const balanceLine =
+      accounts.length > 0
+        ? `Your wallet balance is ${accounts.map((a) => fmtMinor(a.balance_minor, a.currency)).join(' and ')}.`
+        : 'Your wallet has no accounts yet — the balance is zero.';
+
+    const subLine =
+      subscription && subscription.status !== 'free' && subscription.status !== 'canceled'
+        ? ` Your ${subscription.plan_key} subscription is ${subscription.status}${
+            subscription.current_period_end
+              ? ` until ${new Date(subscription.current_period_end).toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}`
+              : ''
+          }.`
+        : '';
+
+    const rewardsLine = hasRewards
+      ? ` You've earned ${lifetimeEarnings.toFixed(2)} ${rewardsCurrency} in referral rewards${
+          pendingRewards > 0 ? `, with ${pendingRewards.toFixed(2)} ${rewardsCurrency} still pending` : ''
+        }.`
+      : '';
+
+    const txLine =
+      page.entries.length > 0
+        ? ` Latest activity: ${page.entries
+            .map((e) => `${e.description || e.entry_type} ${e.direction === 'credit' ? '+' : '-'}${fmtMinor(e.amount_minor, e.currency)}`)
+            .join('; ')}.`
+        : '';
+
+    return {
+      ok: true,
+      result: {
+        accounts: accounts.map((a) => ({ currency: a.currency, balance_minor: a.balance_minor, status: a.status })),
+        subscription,
+        referral_rewards: hasRewards
+          ? { lifetime_earned: +lifetimeEarnings.toFixed(2), pending: +pendingRewards.toFixed(2), currency: rewardsCurrency }
+          : null,
+        recent_transactions: page.entries.map((e) => ({
+          entry_type: e.entry_type,
+          direction: e.direction,
+          amount_minor: e.amount_minor,
+          currency: e.currency,
+          description: e.description,
+          created_at: e.created_at,
+        })),
+      },
+      text: `${balanceLine}${subLine}${rewardsLine}${txLine}`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'get_wallet_summary failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// list_wallet_transactions — wallet_ledger_entries via balance-service, with
+// pagination (cursor is the last row's created_at, same contract
+// getTransactionsForUser already returns as next_cursor).
+// ---------------------------------------------------------------------------
+
+export async function tool_list_wallet_transactions(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('list_wallet_transactions', id);
+  if (gate) return gate;
+  const limitRaw = Number(args.limit);
+  const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.floor(limitRaw), 50) : 15;
+  const currencyArg = String(args.currency ?? '').trim().toUpperCase();
+  const currency = isWalletCurrency(currencyArg) ? (currencyArg as WalletCurrency) : undefined;
+  const cursor = typeof args.cursor === 'string' && args.cursor.trim() ? args.cursor.trim() : null;
+  try {
+    const { getTransactionsForUser } = await import('../wallet/balance-service');
+    const page = await getTransactionsForUser({ user_id: id.user_id, currency, limit, cursor });
+    if (page.entries.length === 0) {
+      return {
+        ok: true,
+        result: { transactions: [], next_cursor: null },
+        text: cursor ? 'No more transactions.' : "You don't have any wallet transactions yet.",
+      };
+    }
+    const lines = page.entries.map(
+      (e) =>
+        `${e.description || e.entry_type} ${e.direction === 'credit' ? '+' : '-'}${fmtMinor(e.amount_minor, e.currency)}` +
+        ` (${new Date(e.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })})`,
+    );
+    return {
+      ok: true,
+      result: {
+        transactions: page.entries.map((e) => ({
+          id: e.id,
+          entry_type: e.entry_type,
+          direction: e.direction,
+          amount_minor: e.amount_minor,
+          currency: e.currency,
+          description: e.description,
+          created_at: e.created_at,
+        })),
+        next_cursor: page.next_cursor,
+      },
+      text: `Here are your ${cursor ? 'next' : 'latest'} ${page.entries.length} transaction${page.entries.length === 1 ? '' : 's'}: ${lines.join('; ')}.${
+        page.next_cursor ? ' Want me to read more, further back?' : ''
+      }`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'list_wallet_transactions failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// send_funds (⚠️ confirm) — REAL internal user-to-user wallet transfer.
+//
+// No dedicated transfer RPC/table exists, so this composes the two safe,
+// transactional primitives with a shared reference_id: debit the sender
+// (reference_type:'manual'), then credit the recipient with the SAME
+// reference_id (also 'manual' — the SpendEarningReferenceType union has no
+// dedicated transfer value and the brief forbids inventing one). If the debit
+// fails, nothing moves. If the debit succeeds but the credit leg fails for any
+// reason (recipient account can't be found/provisioned, RPC error), this
+// compensates by crediting the sender back rather than letting money vanish —
+// each individual RPC call is atomic (SELECT FOR UPDATE) but the two-call
+// composition is not, so the compensation step is the best available
+// consistency guarantee without a dedicated two-leg transfer RPC.
+//
+// This is the ONLY tool in this file allowed to fully execute money movement
+// by voice, per the approved payment policy — everything else here that would
+// move or convert money either has no backing (stubbed) or is a read.
+// ---------------------------------------------------------------------------
+
+export async function tool_send_funds(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('send_funds', id);
+  if (gate) return gate;
+
+  let amountMinor: number;
+  if (typeof args.amount_minor === 'number' && Number.isFinite(args.amount_minor)) {
+    amountMinor = Math.round(args.amount_minor);
+  } else if (typeof args.amount === 'number' && Number.isFinite(args.amount)) {
+    amountMinor = Math.round(args.amount * 100);
+  } else {
+    return { ok: false, error: 'send_funds requires an `amount` (e.g. 25.00) — ask the user how much to send.' };
+  }
+  if (amountMinor <= 0) {
+    return { ok: false, error: 'send_funds requires a positive amount.' };
+  }
+
+  try {
+    const { getAccountsForUser } = await import('../wallet/balance-service');
+    const { debitWalletForSpend, creditWalletForEarning } = await import('../wallet/spend-earning-service');
+
+    const senderAccounts = await getAccountsForUser(id.user_id);
+    if (senderAccounts.length === 0) {
+      return {
+        ok: true,
+        result: { sent: false, reason: 'no_wallet' },
+        text: "You don't have a wallet account yet — add funds in the Wallet screen first.",
+      };
+    }
+
+    const currencyArg = String(args.currency ?? '').trim().toUpperCase();
+    let senderAccount = senderAccounts[0];
+    if (isWalletCurrency(currencyArg)) {
+      const match = senderAccounts.find((a) => a.currency === currencyArg);
+      if (!match) {
+        return {
+          ok: true,
+          result: { sent: false, reason: 'currency_not_found' },
+          text: `You don't have a ${currencyArg} wallet account.`,
+        };
+      }
+      senderAccount = match;
+    } else if (senderAccounts.length > 1) {
+      return {
+        ok: true,
+        result: { sent: false, needs_currency: true, currencies: senderAccounts.map((a) => a.currency) },
+        text: `You have wallets in ${senderAccounts.map((a) => a.currency).join(' and ')}. Which currency should I send from?`,
+      };
+    }
+    const currency = senderAccount.currency;
+
+    // Resolve recipient — same resolve_recipient_candidates RPC every other
+    // resolver in this codebase uses (tool_resolve_recipient, groups-events'
+    // resolveMember, send_chat_message).
+    let recipientUserId = String(args.recipient_user_id ?? '').trim();
+    let recipientName = strArg(args, 'recipient_name', 'name', 'spoken_name');
+    if (!UUID_RE.test(recipientUserId)) {
+      if (!recipientName) {
+        return { ok: false, error: 'send_funds requires the recipient\'s name — ask the user who to send to.' };
+      }
+      const { data, error } = await sb.rpc('resolve_recipient_candidates', {
+        p_actor: id.user_id,
+        p_token: recipientName,
+        p_limit: 3,
+        p_global: true,
+      });
+      if (error) return { ok: false, error: error.message };
+      const candidates = (data || []) as Array<{
+        user_id: string;
+        vitana_id: string | null;
+        display_name: string | null;
+        score: number;
+      }>;
+      if (candidates.length === 0) {
+        return {
+          ok: true,
+          result: { sent: false, reason: 'recipient_not_found' },
+          text: `I couldn't find anyone named "${recipientName}" — they may not have a Vitana account yet.`,
+        };
+      }
+      const top = candidates[0];
+      const topScore = Number(top.score) || 0;
+      const secondScore = candidates[1] ? Number(candidates[1].score) || 0 : 0;
+      const ambiguous = topScore < 0.85 || (candidates.length > 1 && secondScore / Math.max(topScore, 0.0001) > 0.85);
+      if (ambiguous) {
+        const names = candidates.slice(0, 3).map((c) => c.display_name || c.vitana_id || c.user_id);
+        return {
+          ok: true,
+          result: { sent: false, candidates: candidates.slice(0, 3).map((c) => ({ user_id: c.user_id, display_name: names })) },
+          text: `I found a few possible matches: ${names.join(', ')}. Which one did you mean?`,
+        };
+      }
+      recipientUserId = top.user_id;
+      recipientName = top.display_name || top.vitana_id || recipientName;
+    }
+
+    if (recipientUserId === id.user_id) {
+      return { ok: false, error: 'You cannot send funds to yourself.' };
+    }
+
+    // Verify the recipient actually exists (mirrors send_chat_message's guard).
+    const { data: recipRow, error: recipErr } = await sb
+      .from('app_users')
+      .select('user_id, display_name, vitana_id')
+      .eq('user_id', recipientUserId)
+      .maybeSingle();
+    if (recipErr) return { ok: false, error: recipErr.message };
+    if (!recipRow) {
+      return {
+        ok: true,
+        result: { sent: false, reason: 'recipient_not_found' },
+        text: `I couldn't find that person — they may have left the community.`,
+      };
+    }
+    const recipient = recipRow as { user_id: string; display_name: string | null; vitana_id: string | null };
+    const recipientDisplay = recipient.display_name || recipient.vitana_id || recipientName || 'that person';
+
+    if (!isConfirmed(args)) {
+      return {
+        ok: true,
+        result: {
+          requires_confirmation: true,
+          recipient_user_id: recipientUserId,
+          recipient_name: recipientDisplay,
+          amount_minor: amountMinor,
+          currency,
+        },
+        text: `Ready to send ${fmtMinor(amountMinor, currency)} to ${recipientDisplay}. Say yes to confirm, then call send_funds again with this recipient_user_id, amount, currency, and confirm:true.`,
+      };
+    }
+
+    // ---- Execute: debit sender, then credit recipient, same reference_id ----
+    const transferId = randomUUID();
+    const debit = await debitWalletForSpend({
+      account_id: senderAccount.id,
+      amount_minor: amountMinor,
+      currency,
+      reference_type: 'manual',
+      reference_id: transferId,
+      description: `Wallet transfer to ${recipientDisplay}`,
+      metadata: { kind: 'p2p_transfer', recipient_user_id: recipientUserId, transfer_id: transferId },
+    });
+    if (!debit.ok) {
+      const text =
+        debit.error === 'INSUFFICIENT_BALANCE'
+          ? `You don't have enough balance to send that — your ${currency} balance is${
+              debit.balance_minor != null ? ` ${fmtMinor(debit.balance_minor, currency)}` : ' too low'
+            }.`
+          : `I couldn't complete the transfer (${debit.error}).`;
+      return { ok: true, result: { sent: false, error_code: debit.error }, text };
+    }
+
+    // Find (or lazily provision, same defensive pattern as deposit-service) the
+    // recipient's account in the same currency.
+    const recipientAccounts = await getAccountsForUser(recipientUserId);
+    let recipientAccount = recipientAccounts.find((a) => a.currency === currency && a.status === 'active');
+    if (!recipientAccount) {
+      const { data: created, error: createErr } = await sb
+        .from('wallet_accounts')
+        .insert({ user_id: recipientUserId, currency })
+        .select('id, user_id, currency, balance_minor, status, created_at, updated_at')
+        .single();
+      if (createErr || !created) {
+        // Compensate: the debit succeeded but we can't deliver — refund the sender.
+        await creditWalletForEarning({
+          account_id: senderAccount.id,
+          amount_minor: amountMinor,
+          currency,
+          reference_type: 'manual',
+          reference_id: `${transferId}-refund`,
+          description: `Refund: could not create ${recipientDisplay}'s wallet account`,
+        });
+        return {
+          ok: true,
+          result: { sent: false, error_code: 'RECIPIENT_ACCOUNT_FAILED', refunded: true },
+          text: `I couldn't set up ${recipientDisplay}'s wallet account, so I've refunded your ${fmtMinor(amountMinor, currency)} back.`,
+        };
+      }
+      recipientAccount = created as typeof senderAccount;
+    }
+
+    const credit = await creditWalletForEarning({
+      account_id: recipientAccount.id,
+      amount_minor: amountMinor,
+      currency,
+      reference_type: 'manual',
+      reference_id: transferId,
+      description: `Wallet transfer received`,
+      metadata: { kind: 'p2p_transfer', sender_user_id: id.user_id, transfer_id: transferId },
+    });
+    if (!credit.ok) {
+      const refund = await creditWalletForEarning({
+        account_id: senderAccount.id,
+        amount_minor: amountMinor,
+        currency,
+        reference_type: 'manual',
+        reference_id: `${transferId}-refund`,
+        description: `Refund: transfer to ${recipientDisplay} failed (${credit.error})`,
+      });
+      if (refund.ok) {
+        return {
+          ok: true,
+          result: { sent: false, error_code: credit.error, refunded: true },
+          text: `The transfer to ${recipientDisplay} didn't go through, so I've refunded your ${fmtMinor(amountMinor, currency)}.`,
+        };
+      }
+      // Debit succeeded, credit failed, AND the compensating refund failed.
+      // This needs human reconciliation — never hide it as a soft "ok" outcome.
+      return {
+        ok: false,
+        error: `Transfer to ${recipientDisplay} failed after debit (${credit.error}), and the automatic refund also failed (${refund.error}). This needs manual reconciliation — reference ${transferId}.`,
+      };
+    }
+
+    return {
+      ok: true,
+      result: {
+        sent: true,
+        recipient_user_id: recipientUserId,
+        recipient_name: recipientDisplay,
+        amount_minor: amountMinor,
+        currency,
+        transfer_id: transferId,
+        new_balance_minor: debit.balance_minor,
+      },
+      text: `Done — sent ${fmtMinor(amountMinor, currency)} to ${recipientDisplay}. Your new balance is ${
+        debit.balance_minor != null ? fmtMinor(debit.balance_minor, currency) : 'updated'
+      }.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'send_funds failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// request_payment — STUBBED. See file header: no payment_requests table; the
+// only precedent (message_type='payment_request' chat message) is rejected by
+// the gateway's own POST /api/v1/chat/send allowedTypes set.
+// ---------------------------------------------------------------------------
+
+export async function tool_request_payment(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('request_payment', id);
+  if (gate) return gate;
+  return {
+    ok: false,
+    error:
+      "request_payment is not available yet — no backing endpoint. Payment requests exist only as a message_type='payment_request' chat-message convention the community frontend inserts directly (bypassing the gateway's own POST /api/v1/chat/send, whose allowedTypes explicitly excludes 'payment_request'). There is no payment_requests table and no gateway-owned way to create one. Tell the user to send the request from the Wallet or Messages screen.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// exchange_currency (⚠️ confirm) — STUBBED. See file header: no cross-currency
+// RPC exists; the only exchange_rates table is a legacy ghost table explicitly
+// marked out-of-scope in the VTID-03186 migration.
+// ---------------------------------------------------------------------------
+
+export async function tool_exchange_currency(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('exchange_currency', id);
+  if (gate) return gate;
+  return {
+    ok: false,
+    error:
+      "exchange_currency is not available yet — no backing RPC. debit_wallet_for_spend / credit_wallet_for_earning only move money within a single currency (EUR or USD); there is no cross-currency conversion RPC in the gateway. The only exchange_rates table in the schema is a legacy Lovable-era ghost table (VTNA/CREDITS tokens) explicitly marked OUT OF SCOPE pending a convergence decision (see supabase/migrations/20260605000000_VTID_03186_universal_cart_schema.sql).",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// get_exchange_rate — STUBBED. Same rationale as exchange_currency.
+// ---------------------------------------------------------------------------
+
+export async function tool_get_exchange_rate(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_exchange_rate', id);
+  if (gate) return gate;
+  return {
+    ok: false,
+    error:
+      "get_exchange_rate is not available yet — no backing table/RPC. The canonical wallet only has EUR and USD accounts with no conversion concept; the only exchange_rates table found is the legacy ghost table called out as out-of-scope in the VTID-03186 migration, and it is not wired to any gateway service.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// set_display_currency — STUBBED. Verified client-only (localStorage), no
+// server-side column exists at all.
+// ---------------------------------------------------------------------------
+
+export async function tool_set_display_currency(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('set_display_currency', id);
+  if (gate) return gate;
+  return {
+    ok: false,
+    error:
+      "set_display_currency is not available yet — no backing column. The USD/EUR display toggle is stored only in the browser's localStorage (vitana.wallet.displayCurrency); there is no app_users column or user_preferences table for the gateway to write.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// get_referral_earnings — REAL: rewards_ledger (VCAOP), same table
+// GET /api/v1/vcaop/wallet reads for the caller.
+// ---------------------------------------------------------------------------
+
+export async function tool_get_referral_earnings(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_referral_earnings', id);
+  if (gate) return gate;
+  try {
+    const { data, error } = await sb
+      .from('rewards_ledger')
+      .select('amount, state, currency, created_at')
+      .eq('user_id', id.user_id)
+      .order('created_at', { ascending: false });
+    if (error) return { ok: false, error: error.message };
+    const rows = (data ?? []) as Array<{ amount: number; state: string; currency: string; created_at: string }>;
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { total_earned: 0, pending: 0, currency: 'EUR', entry_count: 0 },
+        text: "You haven't earned any referral rewards yet. Share your referral links from Business Hub → Sell & Earn → Referrals to start.",
+      };
+    }
+    const currency = rows[0].currency || 'EUR';
+    let earned = 0;
+    let pending = 0;
+    let reversed = 0;
+    for (const r of rows) {
+      const amt = Number(r.amount) || 0;
+      if (r.state === 'confirmed' || r.state === 'redeemable') earned += amt;
+      else if (r.state === 'pending') pending += amt;
+      else if (r.state === 'reversed') reversed += amt;
+    }
+    return {
+      ok: true,
+      result: {
+        total_earned: +earned.toFixed(2),
+        pending: +pending.toFixed(2),
+        reversed: +reversed.toFixed(2),
+        currency,
+        entry_count: rows.length,
+      },
+      text: `You've earned ${earned.toFixed(2)} ${currency} in referral rewards${
+        pending > 0 ? `, with ${pending.toFixed(2)} ${currency} still pending confirmation` : ''
+      }.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'get_referral_earnings failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_commissions_summary — REAL: commission_event (VCAOP), scoped to the
+// current calendar month, same source GET /api/v1/vcaop/commissions reads
+// (that route is admin-only; this queries the same table directly, scoped to
+// the caller's own user_id, same pattern every other read-only tool here uses).
+// ---------------------------------------------------------------------------
+
+export async function tool_get_commissions_summary(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_commissions_summary', id);
+  if (gate) return gate;
+  try {
+    const now = new Date();
+    const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+    const { data, error } = await sb
+      .from('commission_event')
+      .select('gross_commission, currency, status, merchant, created_at')
+      .eq('user_id', id.user_id)
+      .gte('created_at', monthStart)
+      .order('created_at', { ascending: false });
+    if (error) return { ok: false, error: error.message };
+    const rows = (data ?? []) as Array<{
+      gross_commission: number;
+      currency: string;
+      status: string;
+      merchant: string;
+      created_at: string;
+    }>;
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { total: 0, confirmed: 0, pending: 0, currency: 'EUR', count: 0 },
+        text: "You don't have any commissions this month yet.",
+      };
+    }
+    const currency = rows[0].currency || 'EUR';
+    let confirmed = 0;
+    let pending = 0;
+    let reversed = 0;
+    for (const r of rows) {
+      const amt = Number(r.gross_commission) || 0;
+      if (r.status === 'confirmed') confirmed += amt;
+      else if (r.status === 'pending') pending += amt;
+      else if (r.status === 'reversed') reversed += amt;
+    }
+    const total = confirmed + pending;
+    return {
+      ok: true,
+      result: {
+        total: +total.toFixed(2),
+        confirmed: +confirmed.toFixed(2),
+        pending: +pending.toFixed(2),
+        reversed: +reversed.toFixed(2),
+        currency,
+        count: rows.length,
+      },
+      text: `This month you've made ${total.toFixed(2)} ${currency} in commissions across ${rows.length} order${
+        rows.length === 1 ? '' : 's'
+      } — ${confirmed.toFixed(2)} ${currency} confirmed and ${pending.toFixed(2)} ${currency} still pending.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'get_commissions_summary failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_pending_rewards — REAL: rewards_ledger where state='pending' (VCAOP).
+// ---------------------------------------------------------------------------
+
+export async function tool_get_pending_rewards(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_pending_rewards', id);
+  if (gate) return gate;
+  try {
+    const { data, error } = await sb
+      .from('rewards_ledger')
+      .select('amount, currency, created_at')
+      .eq('user_id', id.user_id)
+      .eq('state', 'pending')
+      .order('created_at', { ascending: false })
+      .limit(10);
+    if (error) return { ok: false, error: error.message };
+    const rows = (data ?? []) as Array<{ amount: number; currency: string; created_at: string }>;
+    if (rows.length === 0) {
+      return {
+        ok: true,
+        result: { pending_total: 0, currency: 'EUR', count: 0 },
+        text: "You don't have any pending rewards right now.",
+      };
+    }
+    const currency = rows[0].currency || 'EUR';
+    const total = rows.reduce((s, r) => s + (Number(r.amount) || 0), 0);
+    return {
+      ok: true,
+      result: { pending_total: +total.toFixed(2), currency, count: rows.length },
+      text: `You have ${total.toFixed(2)} ${currency} in pending rewards across ${rows.length} entr${
+        rows.length === 1 ? 'y' : 'ies'
+      } — they'll confirm once the merchant validates the order.`,
+    };
+  } catch (err) {
+    return { ok: false, error: errText(err, 'get_pending_rewards failed') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// list_payment_requests — STUBBED. Same rationale as request_payment: no
+// structured table to list, and the frontend's chat-message convention isn't
+// reachable through the gateway's own send validation either.
+// ---------------------------------------------------------------------------
+
+export async function tool_list_payment_requests(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('list_payment_requests', id);
+  if (gate) return gate;
+  return {
+    ok: false,
+    error:
+      "list_payment_requests is not available yet — no backing endpoint. Payment requests are only free-text chat messages (message_type='payment_request', set by the frontend directly, outside the gateway's own send validation), so there is no structured table or list/read endpoint to query them from.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const WALLET_PAYMENTS_TOOL_HANDLERS: Record<string, Handler> = {
+  get_wallet_summary: tool_get_wallet_summary,
+  list_wallet_transactions: tool_list_wallet_transactions,
+  send_funds: tool_send_funds,
+  request_payment: tool_request_payment,
+  exchange_currency: tool_exchange_currency,
+  get_exchange_rate: tool_get_exchange_rate,
+  set_display_currency: tool_set_display_currency,
+  get_referral_earnings: tool_get_referral_earnings,
+  get_commissions_summary: tool_get_commissions_summary,
+  get_pending_rewards: tool_get_pending_rewards,
+  list_payment_requests: tool_list_payment_requests,
+};
+
+export const WALLET_PAYMENTS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'get_wallet_summary',
+    description: [
+      'READ-ONLY wallet snapshot: balance per currency, active subscription,',
+      'lifetime + pending referral rewards, and recent activity.',
+      'CALL WHEN the user asks: "give me my wallet summary", "how much do I have',
+      'and how much have I earned", "wie steht es um mein Wallet".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'list_wallet_transactions',
+    description: [
+      "READ-ONLY: list the user's recent wallet transactions, newest first.",
+      'Supports pagination via cursor (from a previous call\'s next_cursor).',
+      'CALL WHEN the user asks: "show my transactions", "what did I spend',
+      'recently", "zeig mir meine letzten Transaktionen".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'How many to read out, 1-50. Uses 15 when omitted.' },
+        currency: { type: 'string', description: "Optional: 'EUR' or 'USD' to filter to one currency." },
+        cursor: { type: 'string', description: 'Pass the previous next_cursor to page further back.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'send_funds',
+    description: [
+      'Send money from the user\'s wallet to another Vitana member (internal',
+      'transfer only — never a card charge). ALWAYS call once WITHOUT confirm',
+      'first — it resolves the recipient and previews the amount; after the user',
+      'says yes, call again with confirm:true, recipient_user_id, amount and',
+      'currency from the preview result.',
+      'CALL WHEN the user says: "send Anna 20 euros", "transfer money to Peter",',
+      '"schicke Anna 20 Euro".',
+      'This is the ONLY tool that fully executes money movement by voice.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        recipient_name: { type: 'string', description: 'Spoken name of who to send money to.' },
+        recipient_user_id: { type: 'string', description: 'Exact recipient UUID once resolved from a previous call.' },
+        amount: { type: 'number', description: 'Amount in major currency units, e.g. 20 for 20.00.' },
+        currency: { type: 'string', description: "'EUR' or 'USD'. Omit if the user has only one wallet currency." },
+        confirm: { type: 'boolean', description: 'true ONLY after the user explicitly confirmed the preview.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'request_payment',
+    description: [
+      'NOT YET AVAILABLE — always returns an error explaining there is no',
+      'backing endpoint for payment requests. Do not imply this worked; tell',
+      'the user to send a payment request from the Wallet or Messages screen.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        recipient_name: { type: 'string', description: 'Spoken name of who the request would go to.' },
+        amount: { type: 'number', description: 'Amount requested, major currency units.' },
+        currency: { type: 'string', description: "'EUR' or 'USD'." },
+        description: { type: 'string', description: 'What the request is for.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'exchange_currency',
+    description: [
+      'NOT YET AVAILABLE — always returns an error: the wallet has no',
+      'cross-currency conversion RPC. Do not imply this worked.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        amount: { type: 'number', description: 'Amount to exchange.' },
+        from_currency: { type: 'string', description: "Source currency, e.g. 'EUR'." },
+        to_currency: { type: 'string', description: "Target currency, e.g. 'USD'." },
+        confirm: { type: 'boolean', description: 'Not used — the tool is unavailable.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_exchange_rate',
+    description: [
+      'NOT YET AVAILABLE — always returns an error: no exchange-rate',
+      'table/RPC is wired into the gateway.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        from_currency: { type: 'string', description: "e.g. 'EUR'." },
+        to_currency: { type: 'string', description: "e.g. 'USD'." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'set_display_currency',
+    description: [
+      'NOT YET AVAILABLE — always returns an error: the display-currency toggle',
+      'is stored only in the browser, not on any server-side record.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        currency: { type: 'string', description: "'EUR' or 'USD'." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_referral_earnings',
+    description: [
+      'READ-ONLY: total referral rewards earned (confirmed) and pending, from',
+      "the user's reward ledger.",
+      'CALL WHEN the user asks: "how much have I earned from referrals",',
+      '"was habe ich mit Empfehlungen verdient".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_commissions_summary',
+    description: [
+      'READ-ONLY: commissions earned this calendar month — total, confirmed,',
+      'and still-pending amounts.',
+      'CALL WHEN the user asks: "what are my commissions this month",',
+      '"wie viel Provision habe ich diesen Monat gemacht".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_pending_rewards',
+    description: [
+      'READ-ONLY: rewards awaiting merchant confirmation (not yet payable).',
+      'CALL WHEN the user asks: "do I have any pending rewards",',
+      '"was ist noch ausstehend bei meinen Prämien".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'list_payment_requests',
+    description: [
+      'NOT YET AVAILABLE — always returns an error: payment requests have no',
+      'structured table to list from.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        direction: { type: 'string', description: "'incoming' or 'outgoing' — not used, tool is unavailable." },
+      },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-12T18:17:25.959Z",
-  "source": "reconciled+plan-seed",
+  "generated_at": "2026-07-12T19:38:52.054Z",
+  "source": "reconciled",
   "total": 594,
   "tools": [
     {
@@ -2653,9 +2653,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Search products with filters (scope, category, price)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2668,9 +2671,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Read out one product (price, rating, description)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2683,9 +2689,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Supplements catalog",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2698,9 +2707,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Add supplement to personal regimen",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2713,9 +2725,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Current regimen",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2728,9 +2743,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Remove from regimen",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2743,9 +2761,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Wellness services directory",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2758,9 +2779,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Provider/practitioner detail",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2773,9 +2797,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Doctors & coaches directory",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2788,9 +2815,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Compatibility score with a coach",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2803,9 +2833,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Current deals & offers",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2818,9 +2851,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Apply promo code",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2833,9 +2869,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Shopping-agent recommendations",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2848,9 +2887,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Order history",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2863,9 +2905,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Track one order",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2878,9 +2923,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Repeat a previous order",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A1 Commerce & Marketplace Discovery",
@@ -2893,9 +2941,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Add product to universal cart",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A2 Cart & Checkout",
@@ -2908,9 +2959,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Read cart contents + total",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A2 Cart & Checkout",
@@ -2923,9 +2977,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Change quantity",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A2 Cart & Checkout",
@@ -2938,9 +2995,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Remove item",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A2 Cart & Checkout",
@@ -2953,9 +3013,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Empty the cart",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A2 Cart & Checkout",
@@ -2968,9 +3031,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Set/track budget meter",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A2 Cart & Checkout",
@@ -2983,9 +3049,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Read pending AI purchase proposals",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A2 Cart & Checkout",
@@ -2998,9 +3067,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Begin Stripe checkout (hands off to screen for payment)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A2 Cart & Checkout",
@@ -3013,9 +3085,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Balance + lifetime earnings + pending rewards + benefits",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A3 Wallet & Payments",
@@ -3028,9 +3103,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Recent transactions",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A3 Wallet & Payments",
@@ -3043,9 +3121,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Transfer credits to a member (resolve recipient → confirm)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A3 Wallet & Payments",
@@ -3058,9 +3139,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Send a payment request",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A3 Wallet & Payments",
@@ -3073,9 +3157,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Exchange between currencies/credits",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A3 Wallet & Payments",
@@ -3088,9 +3175,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Current EUR/USD/token rate",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A3 Wallet & Payments",
@@ -3103,9 +3193,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Toggle display currency",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A3 Wallet & Payments",
@@ -3118,9 +3211,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Referral earnings snapshot",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A3 Wallet & Payments",
@@ -3133,9 +3229,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Commissions this month",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A3 Wallet & Payments",
@@ -3148,9 +3247,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Pending rewards",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A3 Wallet & Payments",
@@ -3163,9 +3265,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Incoming/outgoing requests",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A3 Wallet & Payments",
@@ -3718,9 +3823,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Message a group thread",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A8 Messaging depth",
@@ -3733,9 +3841,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Quote-reply to a specific message",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A8 Messaging depth",
@@ -3748,9 +3859,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Emoji-react",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A8 Messaging depth",
@@ -3763,9 +3877,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "New group conversation",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A8 Messaging depth",
@@ -3778,9 +3895,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Add member to group chat",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A8 Messaging depth",
@@ -3793,9 +3913,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Leave a group thread",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A8 Messaging depth",
@@ -3808,9 +3931,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Share a calendar invite in a DM",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A8 Messaging depth",
@@ -3823,9 +3949,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Call a member (WebRTC)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A8 Messaging depth",
@@ -3838,9 +3967,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Video-call a member",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A8 Messaging depth",
@@ -4018,9 +4150,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Create a community event",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A10 Events & Tickets",
@@ -4033,9 +4168,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Edit my event",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A10 Events & Tickets",
@@ -4048,9 +4186,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Cancel my event",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A10 Events & Tickets",
@@ -4063,9 +4204,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Create a meetup",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A10 Events & Tickets",
@@ -4078,9 +4222,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Edit my meetup",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A10 Events & Tickets",
@@ -4093,9 +4240,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Invite contacts/members",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A10 Events & Tickets",
@@ -4108,9 +4258,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Purchase a ticket",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A10 Events & Tickets",
@@ -4123,9 +4276,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "My event tickets",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A10 Events & Tickets",
@@ -4138,9 +4294,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Share event link",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A10 Events & Tickets",
@@ -4153,9 +4312,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Who's coming (organizer view)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A10 Events & Tickets",
@@ -4168,9 +4330,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Log nutrition/meal",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A11 Health depth",
@@ -4183,9 +4348,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Log BP/HR/weight etc.",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A11 Health depth",
@@ -4198,9 +4366,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Log mental-health check-in",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A11 Health depth",
@@ -4213,9 +4384,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Record a lab value",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "A11 Health depth",
@@ -4228,9 +4402,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Trends across trackers",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A11 Health depth",
@@ -4243,9 +4420,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Vitana streaks",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A11 Health depth",
@@ -4258,9 +4438,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Order a lab test",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A11 Health depth",
@@ -4273,9 +4456,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Read biomarker/lab results",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A11 Health depth",
@@ -4288,9 +4474,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Run plan-generator wizard",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A11 Health depth",
@@ -4303,9 +4492,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Active plans",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A11 Health depth",
@@ -4318,9 +4510,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Plan adherence",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A11 Health depth",
@@ -4333,9 +4528,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Conditions & risks",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A11 Health depth",
@@ -4348,9 +4546,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Education resources on a topic",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A11 Health depth",
@@ -4363,9 +4564,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Today's next best health action",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "A11 Health depth",
@@ -4378,9 +4582,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Start device pairing (navigates)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "A11 Health depth",

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -2384,7 +2384,431 @@ COMMENT on a community feed post (public text). Two-step confirm:
 first call returns the comment for verbatim read-back — speak it, then call
 again with confirmed=true after the user says post/yes.
 CALL THIS for: "Comment on Anna's post: great work" /
-"Kommentiere Peters Beitrag mit …"."
+"Kommentiere Peters Beitrag mit …".
+
+### search_marketplace
+Search the Maxina marketplace for products by free-text query, category,
+or price range. CALL WHEN the user says: "search the marketplace for ...",
+"find me some ...", "durchsuche den Marktplatz nach ...".
+Read the top results (name, price, rating) aloud.
+
+### get_product_details
+Get details for one marketplace product by id or by spoken name.
+CALL WHEN the user asks: "tell me about ...", "what is ... exactly",
+"erzähl mir mehr über ...".
+
+### browse_supplements
+Browse the marketplace supplements shop (NOT the personal supplement
+tracker — that is unavailable via voice today).
+CALL WHEN the user says: "show me supplements", "what supplements do you
+have", "zeig mir Nahrungsergänzungsmittel".
+
+### add_supplement_to_regimen
+NOT CURRENTLY AVAILABLE via voice — always returns an error explaining the personal supplement tracker has no gateway-side backing yet. Do not call unless the user explicitly asks to add a supplement to their personal regimen/tracker, then relay the unavailability honestly.
+
+### list_my_supplements
+NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call unless the user explicitly asks to hear their personal supplement list, then relay the unavailability honestly.
+
+### remove_supplement_from_regimen
+NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call unless the user explicitly asks to remove a supplement from their personal regimen, then relay the unavailability honestly.
+
+### browse_wellness_services
+Browse wellness/nutrition/fitness/therapy/lab services listed in the
+Maxina marketplace. CALL WHEN the user asks about wellness services,
+massage, spa, recovery, or treatments — "Wellness-Services".
+
+### get_provider_profile
+Get one service/provider listing by id or spoken name (doctor, coach,
+wellness provider, etc). CALL WHEN the user asks about a specific
+provider or practitioner by name.
+
+### browse_doctors_coaches
+Browse doctors and coaches listed in the marketplace. CALL WHEN the user
+asks to find a doctor, coach, practitioner, or specialist — "Ärzte &
+Coaches".
+
+### get_coach_compatibility
+NOT CURRENTLY AVAILABLE via voice — always returns an error, since no compatibility-scoring system exists yet. Do not fabricate a score; relay the unavailability honestly if asked.
+
+### browse_deals_offers
+Browse marketplace products currently on sale (discounted vs. their
+reference price). CALL WHEN the user asks about deals, discounts,
+offers, promotions, or "what is on sale" — "Angebote & Deals".
+
+### apply_discount_code
+NOT CURRENTLY AVAILABLE via voice — always returns an error, since the discount-code system has no gateway-side backing yet. Do not call unless the user explicitly asks to apply a promo code, then relay the unavailability honestly.
+
+### get_ai_product_picks
+Have the Vitana shopping agent propose marketplace products for a goal
+or need, filtered against the user's health/dietary/budget profile, and
+add them to the cart for review (NEVER charges anything).
+CALL WHEN the user says: "find me something for ...", "what should I take
+for ...", "shop for ... for me", "kauf mir etwas gegen ...".
+After the tool runs, read the picks + rationale aloud and tell the user
+to confirm payment on screen — never say payment completed.
+
+### list_my_orders
+List the user's recent marketplace orders with status and amount.
+CALL WHEN the user asks: "what have I ordered", "show my orders",
+"zeig mir meine Bestellungen".
+
+### get_order_status
+Check the status of one order by id, or the most recent order if no id
+is given. CALL WHEN the user asks: "where is my order", "track my order",
+"wo ist meine Bestellung".
+
+### reorder_last_order
+Add the user's most recent (still-available) purchase back to the cart.
+ALWAYS call once WITHOUT confirm first — the tool returns a confirmation
+question; after the user says yes, call again with confirm:true. NEVER
+charges anything — only stages the cart.
+CALL WHEN the user says: "reorder my last order", "get me the same thing
+again", "bestelle das Gleiche nochmal".
+
+### add_to_cart
+Add a marketplace product to the user's cart, by product_id or fuzzy
+product name. Bumps quantity if the product is already in the cart.
+CALL WHEN the user says: "add ... to my cart", "I want to buy ...",
+"lege ... in den Warenkorb", "ich möchte ... kaufen".
+If several products match, read the candidates and ask which one.
+
+### view_cart
+Read the contents of the user's cart: items, quantities, prices, and
+the total. CALL WHEN the user asks: "what's in my cart?", "show my
+cart", "was ist in meinem Warenkorb?", "zeig mir meinen Warenkorb".
+Read the items and total aloud.
+
+### update_cart_item
+Change the quantity of an item already in the cart, by item_id or
+fuzzy product name. CALL WHEN the user says: "make it 2 of those",
+"change the quantity to ...", "ändere die Menge auf ...".
+If several items match, read the candidates and ask which one. Use
+remove_from_cart instead if the user wants to remove the item entirely.
+
+### remove_from_cart
+Remove a single item from the cart, by item_id or fuzzy product name.
+CALL WHEN the user says: "remove ... from my cart", "take that out of
+my cart", "entferne ... aus dem Warenkorb".
+If several items match, read the candidates and ask which one.
+
+### clear_cart
+Remove ALL items from the cart. ALWAYS call once WITHOUT confirm
+first — the tool returns a confirmation question listing what will be
+removed; after the user says yes, call again with confirm:true.
+CALL WHEN the user says: "clear my cart", "empty my cart", "remove
+everything", "leere meinen Warenkorb".
+
+### set_shopping_budget
+Set or clear the user's monthly shopping budget cap, used as an
+advisory warning (never blocks purchases) when the cart plus this
+month's spending gets close to or exceeds it.
+CALL WHEN the user says: "set my monthly budget to ...", "limit my
+shopping to ... a month", "remove my budget", "setze mein monatliches
+Budget auf ...".
+
+### review_agent_purchase_proposals
+List the items the shopping agent (autopilot) has proposed and placed
+into the user's cart for review — each with its rationale, safety
+flags, and confidence. These are NOT yet purchased; the user can
+remove any with remove_from_cart or proceed with start_checkout.
+CALL WHEN the user asks: "what did the shopping agent pick for me?",
+"show my pending proposals", "was hat der Einkaufsassistent
+vorgeschlagen?".
+
+### start_checkout
+Begin checkout for the user's cart. ALWAYS call once WITHOUT confirm
+first — the tool returns the cart total and asks for confirmation;
+after the user says yes, call again with confirm:true. This tool
+NEVER charges a card or completes payment by voice — it only
+validates the cart and navigates the user to the cart/checkout screen
+where THEY confirm payment themselves.
+CALL WHEN the user says: "check out", "let's pay for this", "go to
+checkout", "zur Kasse gehen", "ich möchte bezahlen".
+
+### get_wallet_summary
+READ-ONLY wallet snapshot: balance per currency, active subscription,
+lifetime + pending referral rewards, and recent activity.
+CALL WHEN the user asks: "give me my wallet summary", "how much do I have
+and how much have I earned", "wie steht es um mein Wallet".
+
+### list_wallet_transactions
+READ-ONLY: list the user's recent wallet transactions, newest first.
+Supports pagination via cursor (from a previous call's next_cursor).
+CALL WHEN the user asks: "show my transactions", "what did I spend
+recently", "zeig mir meine letzten Transaktionen".
+
+### send_funds
+Send money from the user's wallet to another Vitana member (internal
+transfer only — never a card charge). ALWAYS call once WITHOUT confirm
+first — it resolves the recipient and previews the amount; after the user
+says yes, call again with confirm:true, recipient_user_id, amount and
+currency from the preview result.
+CALL WHEN the user says: "send Anna 20 euros", "transfer money to Peter",
+"schicke Anna 20 Euro".
+This is the ONLY tool that fully executes money movement by voice.
+
+### request_payment
+NOT YET AVAILABLE — always returns an error explaining there is no
+backing endpoint for payment requests. Do not imply this worked; tell
+the user to send a payment request from the Wallet or Messages screen.
+
+### exchange_currency
+NOT YET AVAILABLE — always returns an error: the wallet has no
+cross-currency conversion RPC. Do not imply this worked.
+
+### get_exchange_rate
+NOT YET AVAILABLE — always returns an error: no exchange-rate
+table/RPC is wired into the gateway.
+
+### set_display_currency
+NOT YET AVAILABLE — always returns an error: the display-currency toggle
+is stored only in the browser, not on any server-side record.
+
+### get_referral_earnings
+READ-ONLY: total referral rewards earned (confirmed) and pending, from
+the user's reward ledger.
+CALL WHEN the user asks: "how much have I earned from referrals",
+"was habe ich mit Empfehlungen verdient".
+
+### get_commissions_summary
+READ-ONLY: commissions earned this calendar month — total, confirmed,
+and still-pending amounts.
+CALL WHEN the user asks: "what are my commissions this month",
+"wie viel Provision habe ich diesen Monat gemacht".
+
+### get_pending_rewards
+READ-ONLY: rewards awaiting merchant confirmation (not yet payable).
+CALL WHEN the user asks: "do I have any pending rewards",
+"was ist noch ausstehend bei meinen Prämien".
+
+### list_payment_requests
+NOT YET AVAILABLE — always returns an error: payment requests have no
+structured table to list from.
+
+### send_group_chat_message
+Send a text message to a group chat the user is a member of (not a 1-to-1 DM —
+use send_chat_message for that). ALWAYS call once WITHOUT confirmed first — the
+tool returns a preview; read it back and only call again with confirmed:true after
+explicit confirmation.
+CALL WHEN the user says: "message the running group", "tell everyone in Alle
+Beisammen ...", "schreib in die Gruppe ...".
+If several of the user's groups match, read the candidates and ask which one.
+
+### reply_to_message
+Reply to a specific earlier message. NOTE: Vitana chat has no reply/quote-thread
+feature yet — this tool always answers that it is unavailable. Relay that plainly
+and offer send_chat_message or send_group_chat_message instead, optionally quoting
+the original text inline in the new message.
+CALL WHEN the user says: "reply to that message", "antworte auf die Nachricht".
+
+### react_to_message
+Add (or remove) an emoji reaction on a chat message — one of 👍 ❤️ 😂 😮 🙏 🎉 only.
+Requires message_id from a previous tool result (e.g. from list_conversations or a
+group message read-back).
+CALL WHEN the user says: "react with a heart to that", "give that a thumbs up",
+"reagiere mit einem Herz darauf".
+Set remove:true to take the reaction back off.
+
+### create_group_chat
+Create a new group chat, optionally adding named members immediately. ALWAYS call
+once WITHOUT confirm first — the tool returns a confirmation question; after the
+user says yes, call again with confirm:true.
+CALL WHEN the user says: "create a group chat called ...", "start a new chat with
+me, Anna and Ben", "erstelle einen Gruppenchat ...".
+
+### add_group_chat_member
+Add a community member to a group chat the user already belongs to.
+CALL WHEN the user says: "add Anna to the running group chat", "füge Anna dem
+Gruppenchat hinzu".
+If several of the user's groups or several matching members are found, ask which one.
+
+### leave_group_chat
+Leave a group chat. ALWAYS call once WITHOUT confirm first — the tool returns a
+confirmation question; after the user says yes, call again with the group_id and
+confirm:true.
+CALL WHEN the user says: "leave the running group chat", "verlasse den Gruppenchat
+...".
+
+### send_calendar_invite_in_chat
+Share one of the user's own upcoming calendar events with a community member via
+direct message. ALWAYS call once WITHOUT confirmed first — the tool returns a
+preview; after explicit confirmation call again with confirmed:true.
+CALL WHEN the user says: "send Anna the invite for my yoga session", "share my
+appointment with Ben", "schick Anna die Einladung zu meinem Termin".
+If several events or member matches are found, ask which one.
+
+### start_voice_call
+Send another community member a request to start a voice call. IMPORTANT: Vitana
+cannot place a live call from voice — calling only works client-side between two
+open apps. This tool sends a chat message + notification asking them to open the
+app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again
+with confirmed:true after explicit confirmation.
+CALL WHEN the user says: "call Anna", "start a voice call with Ben", "ruf Anna an".
+Afterwards, tell the user the request was sent and real-time calling needs both
+people in the app.
+
+### start_video_call
+Send another community member a request to start a video call. IMPORTANT: Vitana
+cannot place a live call from voice — calling only works client-side between two
+open apps. This tool sends a chat message + notification asking them to open the
+app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again
+with confirmed:true after explicit confirmation.
+CALL WHEN the user says: "video call Anna", "start a video chat with Ben", "starte
+einen Videoanruf mit Anna".
+Afterwards, tell the user the request was sent and real-time calling needs both
+people in the app.
+
+### create_event
+Create a new ticketed/community event. Requires a title and start_time.
+ALWAYS call once WITHOUT confirm first — the tool returns a
+confirmation question; after the user says yes, call again with
+confirm:true.
+CALL WHEN the user says: "create an event called ...", "schedule a new
+event", "erstelle ein Event ...", "plane eine neue Veranstaltung".
+
+### update_my_event
+Edit one of the user's own upcoming events (title, description,
+location, virtual_link, start_time, end_time, max_participants,
+image_url). Only the creator can edit, and only before it starts.
+CALL WHEN the user says: "change the time of my event ...", "update my
+event description", "ändere mein Event ...".
+
+### cancel_my_event
+Cancel (delete) one of the user's own upcoming events. ALWAYS call
+once WITHOUT confirm first — the tool returns a confirmation question;
+after the user says yes, call again with the event_id and confirm:true.
+CALL WHEN the user says: "cancel my event", "delete the ... event",
+"sage mein Event ... ab".
+
+### create_meetup
+Create a new casual community meetup (lighter-weight than a ticketed
+event). Requires a title and start_time. ALWAYS call once WITHOUT
+confirm first — the tool returns a confirmation question; after the
+user says yes, call again with confirm:true.
+CALL WHEN the user says: "create a meetup for ...", "start a walking
+meetup", "erstelle ein Meetup für ...".
+
+### update_my_meetup
+Edit one of the user's own upcoming meetups (title, description,
+location, virtual_link, start_time, end_time, max_participants,
+image_url). Only the creator can edit, and only before it starts.
+CALL WHEN the user says: "change my meetup time", "update the hiking
+meetup details", "ändere mein Meetup ...".
+
+### invite_to_event
+Invite a community member to an event or meetup by spoken name. The
+member gets a pending invite on the event.
+CALL WHEN the user says: "invite Anna to my yoga meetup", "ask Ben to
+come to the event", "lade Anna zu meinem Event ... ein".
+If the tool lists several event or member candidates, ask which one.
+
+### buy_event_ticket
+Buy a ticket for an event. Checks ticket availability and price, then
+ALWAYS call once WITHOUT confirm first — the tool returns a price
+confirmation question; after the user says yes, call again with
+confirm:true. Even after confirming, payment is completed on the
+user's screen — this tool never charges a card by voice; it prepares
+the purchase and opens the ticket screen.
+CALL WHEN the user says: "buy a ticket for ...", "I want two tickets to
+the gala", "kauf mir ein Ticket für ...".
+
+### list_my_event_tickets
+List the user's own purchased (completed) event tickets.
+CALL WHEN the user asks: "what tickets do I have?", "show my event
+tickets", "welche Tickets habe ich?".
+
+### share_event
+Get a shareable public link for an event or meetup (works even for
+people who aren't logged in). Does not send anything itself — just
+returns the link for the user to share however they like.
+CALL WHEN the user says: "share the yoga meetup", "get me a link for
+that event", "gib mir einen Link für das Event ...".
+
+### get_event_attendees
+List who has RSVP'd to one of the user's OWN events (organizer view
+only — the user must be the creator).
+CALL WHEN the user asks: "who's coming to my event?", "how many people
+signed up for my meetup?", "wer kommt zu meinem Event?".
+
+### log_meal
+Log a meal (breakfast/lunch/dinner/snack) toward the nutrition pillar.
+CALL WHEN the user says: "I just had breakfast", "log my lunch",
+"ich habe gerade gegessen", "trage mein Mittagessen ein".
+
+### log_vitals
+Log vitals: heart rate, weight, and/or blood pressure. Pass any subset.
+Heart rate contributes to the Vitana Index exercise pillar; weight and
+blood pressure are recorded but do not currently move the Index.
+CALL WHEN the user says: "my heart rate is 68", "I weigh 74 kilos",
+"my blood pressure is 120 over 80", "meine Herzfrequenz ist ...".
+
+### log_mood
+Log a mental-health / mood check-in (1-5 scale, or a mood word).
+CALL WHEN the user says: "I feel great today", "log my mood as okay",
+"ich fühle mich heute gut".
+
+### log_biomarker
+Record a single lab/biomarker value the user reports out loud (e.g. from
+a home test or a doctor visit), creating a lab report entry.
+CALL WHEN the user says: "my glucose was 95", "my cholesterol came back
+at 180", "mein Blutzucker war 95".
+
+### get_health_trends
+Get the Vitana Index trend (total + per-pillar) over a recent window.
+CALL WHEN the user asks: "how have I been trending?", "am I improving?",
+"wie hat sich mein Index entwickelt?".
+
+### get_health_streaks
+Get the user's diary streak and per-pillar Vitana Index streaks.
+CALL WHEN the user asks: "what's my streak?", "am I on a streak?",
+"wie lange ist meine Serie schon?".
+
+### order_lab_test
+Order a lab test. NOT AVAILABLE YET — always returns an error explaining there is no ordering backend; tell the user this feature is not live yet.
+
+### get_lab_results
+Read the user's recorded lab/biomarker results, most recent first.
+CALL WHEN the user asks: "what were my last lab results?", "what's my
+cholesterol?", "wie waren meine letzten Laborwerte?".
+
+### generate_health_plan
+Create a starter health plan (template-based, not AI-personalized) for a
+pillar. ALWAYS call once WITHOUT confirm first — the tool returns a
+preview; after the user agrees, call again with confirm:true.
+CALL WHEN the user says: "make me a nutrition plan", "erstelle einen
+Ernährungsplan für mich".
+
+### list_my_health_plans
+List the user's active health plans with adherence scores. CALL WHEN the user asks: "what plans do I have?", "welche Pläne habe ich?".
+
+### get_health_plan_progress
+Get adherence/progress for a specific active health plan.
+CALL WHEN the user asks: "how's my plan going?", "am I keeping up with
+my sleep plan?", "wie läuft mein Plan?".
+
+### list_my_conditions
+List the user's recorded health conditions, allergies, medications, and
+dietary restrictions.
+CALL WHEN the user asks: "what conditions do I have on file?", "what
+are my allergies?", "welche Erkrankungen habe ich hinterlegt?".
+
+### get_health_education
+Get grounded educational content on a health/longevity topic from the
+knowledge hub.
+CALL WHEN the user asks: "tell me about HRV", "what is VO2 max?",
+"erkläre mir was Schlafqualität bedeutet".
+
+### get_next_best_action
+Get today's single highest-priority recommended health action.
+CALL WHEN the user asks: "what should I do today?", "what's my next
+step?", "was soll ich heute für meine Gesundheit tun?".
+If the result has an autopilot id, offer to call activate_recommendation.
+
+### connect_health_device
+Start pairing a wearable/health device. Opens the health tracker screen
+where device connections are managed (pairing itself is a native/client flow).
+CALL WHEN the user says: "connect my Oura ring", "pair my device",
+"verbinde mein Gerät"."
 `;
 
 exports[`A0.1 characterization: buildLiveSystemInstruction renders a stable system instruction for persona "day-180-veteran-reconnect": persona:day-180-veteran-reconnect 1`] = `
@@ -4513,5 +4937,429 @@ COMMENT on a community feed post (public text). Two-step confirm:
 first call returns the comment for verbatim read-back — speak it, then call
 again with confirmed=true after the user says post/yes.
 CALL THIS for: "Comment on Anna's post: great work" /
-"Kommentiere Peters Beitrag mit …"."
+"Kommentiere Peters Beitrag mit …".
+
+### search_marketplace
+Search the Maxina marketplace for products by free-text query, category,
+or price range. CALL WHEN the user says: "search the marketplace for ...",
+"find me some ...", "durchsuche den Marktplatz nach ...".
+Read the top results (name, price, rating) aloud.
+
+### get_product_details
+Get details for one marketplace product by id or by spoken name.
+CALL WHEN the user asks: "tell me about ...", "what is ... exactly",
+"erzähl mir mehr über ...".
+
+### browse_supplements
+Browse the marketplace supplements shop (NOT the personal supplement
+tracker — that is unavailable via voice today).
+CALL WHEN the user says: "show me supplements", "what supplements do you
+have", "zeig mir Nahrungsergänzungsmittel".
+
+### add_supplement_to_regimen
+NOT CURRENTLY AVAILABLE via voice — always returns an error explaining the personal supplement tracker has no gateway-side backing yet. Do not call unless the user explicitly asks to add a supplement to their personal regimen/tracker, then relay the unavailability honestly.
+
+### list_my_supplements
+NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call unless the user explicitly asks to hear their personal supplement list, then relay the unavailability honestly.
+
+### remove_supplement_from_regimen
+NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call unless the user explicitly asks to remove a supplement from their personal regimen, then relay the unavailability honestly.
+
+### browse_wellness_services
+Browse wellness/nutrition/fitness/therapy/lab services listed in the
+Maxina marketplace. CALL WHEN the user asks about wellness services,
+massage, spa, recovery, or treatments — "Wellness-Services".
+
+### get_provider_profile
+Get one service/provider listing by id or spoken name (doctor, coach,
+wellness provider, etc). CALL WHEN the user asks about a specific
+provider or practitioner by name.
+
+### browse_doctors_coaches
+Browse doctors and coaches listed in the marketplace. CALL WHEN the user
+asks to find a doctor, coach, practitioner, or specialist — "Ärzte &
+Coaches".
+
+### get_coach_compatibility
+NOT CURRENTLY AVAILABLE via voice — always returns an error, since no compatibility-scoring system exists yet. Do not fabricate a score; relay the unavailability honestly if asked.
+
+### browse_deals_offers
+Browse marketplace products currently on sale (discounted vs. their
+reference price). CALL WHEN the user asks about deals, discounts,
+offers, promotions, or "what is on sale" — "Angebote & Deals".
+
+### apply_discount_code
+NOT CURRENTLY AVAILABLE via voice — always returns an error, since the discount-code system has no gateway-side backing yet. Do not call unless the user explicitly asks to apply a promo code, then relay the unavailability honestly.
+
+### get_ai_product_picks
+Have the Vitana shopping agent propose marketplace products for a goal
+or need, filtered against the user's health/dietary/budget profile, and
+add them to the cart for review (NEVER charges anything).
+CALL WHEN the user says: "find me something for ...", "what should I take
+for ...", "shop for ... for me", "kauf mir etwas gegen ...".
+After the tool runs, read the picks + rationale aloud and tell the user
+to confirm payment on screen — never say payment completed.
+
+### list_my_orders
+List the user's recent marketplace orders with status and amount.
+CALL WHEN the user asks: "what have I ordered", "show my orders",
+"zeig mir meine Bestellungen".
+
+### get_order_status
+Check the status of one order by id, or the most recent order if no id
+is given. CALL WHEN the user asks: "where is my order", "track my order",
+"wo ist meine Bestellung".
+
+### reorder_last_order
+Add the user's most recent (still-available) purchase back to the cart.
+ALWAYS call once WITHOUT confirm first — the tool returns a confirmation
+question; after the user says yes, call again with confirm:true. NEVER
+charges anything — only stages the cart.
+CALL WHEN the user says: "reorder my last order", "get me the same thing
+again", "bestelle das Gleiche nochmal".
+
+### add_to_cart
+Add a marketplace product to the user's cart, by product_id or fuzzy
+product name. Bumps quantity if the product is already in the cart.
+CALL WHEN the user says: "add ... to my cart", "I want to buy ...",
+"lege ... in den Warenkorb", "ich möchte ... kaufen".
+If several products match, read the candidates and ask which one.
+
+### view_cart
+Read the contents of the user's cart: items, quantities, prices, and
+the total. CALL WHEN the user asks: "what's in my cart?", "show my
+cart", "was ist in meinem Warenkorb?", "zeig mir meinen Warenkorb".
+Read the items and total aloud.
+
+### update_cart_item
+Change the quantity of an item already in the cart, by item_id or
+fuzzy product name. CALL WHEN the user says: "make it 2 of those",
+"change the quantity to ...", "ändere die Menge auf ...".
+If several items match, read the candidates and ask which one. Use
+remove_from_cart instead if the user wants to remove the item entirely.
+
+### remove_from_cart
+Remove a single item from the cart, by item_id or fuzzy product name.
+CALL WHEN the user says: "remove ... from my cart", "take that out of
+my cart", "entferne ... aus dem Warenkorb".
+If several items match, read the candidates and ask which one.
+
+### clear_cart
+Remove ALL items from the cart. ALWAYS call once WITHOUT confirm
+first — the tool returns a confirmation question listing what will be
+removed; after the user says yes, call again with confirm:true.
+CALL WHEN the user says: "clear my cart", "empty my cart", "remove
+everything", "leere meinen Warenkorb".
+
+### set_shopping_budget
+Set or clear the user's monthly shopping budget cap, used as an
+advisory warning (never blocks purchases) when the cart plus this
+month's spending gets close to or exceeds it.
+CALL WHEN the user says: "set my monthly budget to ...", "limit my
+shopping to ... a month", "remove my budget", "setze mein monatliches
+Budget auf ...".
+
+### review_agent_purchase_proposals
+List the items the shopping agent (autopilot) has proposed and placed
+into the user's cart for review — each with its rationale, safety
+flags, and confidence. These are NOT yet purchased; the user can
+remove any with remove_from_cart or proceed with start_checkout.
+CALL WHEN the user asks: "what did the shopping agent pick for me?",
+"show my pending proposals", "was hat der Einkaufsassistent
+vorgeschlagen?".
+
+### start_checkout
+Begin checkout for the user's cart. ALWAYS call once WITHOUT confirm
+first — the tool returns the cart total and asks for confirmation;
+after the user says yes, call again with confirm:true. This tool
+NEVER charges a card or completes payment by voice — it only
+validates the cart and navigates the user to the cart/checkout screen
+where THEY confirm payment themselves.
+CALL WHEN the user says: "check out", "let's pay for this", "go to
+checkout", "zur Kasse gehen", "ich möchte bezahlen".
+
+### get_wallet_summary
+READ-ONLY wallet snapshot: balance per currency, active subscription,
+lifetime + pending referral rewards, and recent activity.
+CALL WHEN the user asks: "give me my wallet summary", "how much do I have
+and how much have I earned", "wie steht es um mein Wallet".
+
+### list_wallet_transactions
+READ-ONLY: list the user's recent wallet transactions, newest first.
+Supports pagination via cursor (from a previous call's next_cursor).
+CALL WHEN the user asks: "show my transactions", "what did I spend
+recently", "zeig mir meine letzten Transaktionen".
+
+### send_funds
+Send money from the user's wallet to another Vitana member (internal
+transfer only — never a card charge). ALWAYS call once WITHOUT confirm
+first — it resolves the recipient and previews the amount; after the user
+says yes, call again with confirm:true, recipient_user_id, amount and
+currency from the preview result.
+CALL WHEN the user says: "send Anna 20 euros", "transfer money to Peter",
+"schicke Anna 20 Euro".
+This is the ONLY tool that fully executes money movement by voice.
+
+### request_payment
+NOT YET AVAILABLE — always returns an error explaining there is no
+backing endpoint for payment requests. Do not imply this worked; tell
+the user to send a payment request from the Wallet or Messages screen.
+
+### exchange_currency
+NOT YET AVAILABLE — always returns an error: the wallet has no
+cross-currency conversion RPC. Do not imply this worked.
+
+### get_exchange_rate
+NOT YET AVAILABLE — always returns an error: no exchange-rate
+table/RPC is wired into the gateway.
+
+### set_display_currency
+NOT YET AVAILABLE — always returns an error: the display-currency toggle
+is stored only in the browser, not on any server-side record.
+
+### get_referral_earnings
+READ-ONLY: total referral rewards earned (confirmed) and pending, from
+the user's reward ledger.
+CALL WHEN the user asks: "how much have I earned from referrals",
+"was habe ich mit Empfehlungen verdient".
+
+### get_commissions_summary
+READ-ONLY: commissions earned this calendar month — total, confirmed,
+and still-pending amounts.
+CALL WHEN the user asks: "what are my commissions this month",
+"wie viel Provision habe ich diesen Monat gemacht".
+
+### get_pending_rewards
+READ-ONLY: rewards awaiting merchant confirmation (not yet payable).
+CALL WHEN the user asks: "do I have any pending rewards",
+"was ist noch ausstehend bei meinen Prämien".
+
+### list_payment_requests
+NOT YET AVAILABLE — always returns an error: payment requests have no
+structured table to list from.
+
+### send_group_chat_message
+Send a text message to a group chat the user is a member of (not a 1-to-1 DM —
+use send_chat_message for that). ALWAYS call once WITHOUT confirmed first — the
+tool returns a preview; read it back and only call again with confirmed:true after
+explicit confirmation.
+CALL WHEN the user says: "message the running group", "tell everyone in Alle
+Beisammen ...", "schreib in die Gruppe ...".
+If several of the user's groups match, read the candidates and ask which one.
+
+### reply_to_message
+Reply to a specific earlier message. NOTE: Vitana chat has no reply/quote-thread
+feature yet — this tool always answers that it is unavailable. Relay that plainly
+and offer send_chat_message or send_group_chat_message instead, optionally quoting
+the original text inline in the new message.
+CALL WHEN the user says: "reply to that message", "antworte auf die Nachricht".
+
+### react_to_message
+Add (or remove) an emoji reaction on a chat message — one of 👍 ❤️ 😂 😮 🙏 🎉 only.
+Requires message_id from a previous tool result (e.g. from list_conversations or a
+group message read-back).
+CALL WHEN the user says: "react with a heart to that", "give that a thumbs up",
+"reagiere mit einem Herz darauf".
+Set remove:true to take the reaction back off.
+
+### create_group_chat
+Create a new group chat, optionally adding named members immediately. ALWAYS call
+once WITHOUT confirm first — the tool returns a confirmation question; after the
+user says yes, call again with confirm:true.
+CALL WHEN the user says: "create a group chat called ...", "start a new chat with
+me, Anna and Ben", "erstelle einen Gruppenchat ...".
+
+### add_group_chat_member
+Add a community member to a group chat the user already belongs to.
+CALL WHEN the user says: "add Anna to the running group chat", "füge Anna dem
+Gruppenchat hinzu".
+If several of the user's groups or several matching members are found, ask which one.
+
+### leave_group_chat
+Leave a group chat. ALWAYS call once WITHOUT confirm first — the tool returns a
+confirmation question; after the user says yes, call again with the group_id and
+confirm:true.
+CALL WHEN the user says: "leave the running group chat", "verlasse den Gruppenchat
+...".
+
+### send_calendar_invite_in_chat
+Share one of the user's own upcoming calendar events with a community member via
+direct message. ALWAYS call once WITHOUT confirmed first — the tool returns a
+preview; after explicit confirmation call again with confirmed:true.
+CALL WHEN the user says: "send Anna the invite for my yoga session", "share my
+appointment with Ben", "schick Anna die Einladung zu meinem Termin".
+If several events or member matches are found, ask which one.
+
+### start_voice_call
+Send another community member a request to start a voice call. IMPORTANT: Vitana
+cannot place a live call from voice — calling only works client-side between two
+open apps. This tool sends a chat message + notification asking them to open the
+app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again
+with confirmed:true after explicit confirmation.
+CALL WHEN the user says: "call Anna", "start a voice call with Ben", "ruf Anna an".
+Afterwards, tell the user the request was sent and real-time calling needs both
+people in the app.
+
+### start_video_call
+Send another community member a request to start a video call. IMPORTANT: Vitana
+cannot place a live call from voice — calling only works client-side between two
+open apps. This tool sends a chat message + notification asking them to open the
+app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again
+with confirmed:true after explicit confirmation.
+CALL WHEN the user says: "video call Anna", "start a video chat with Ben", "starte
+einen Videoanruf mit Anna".
+Afterwards, tell the user the request was sent and real-time calling needs both
+people in the app.
+
+### create_event
+Create a new ticketed/community event. Requires a title and start_time.
+ALWAYS call once WITHOUT confirm first — the tool returns a
+confirmation question; after the user says yes, call again with
+confirm:true.
+CALL WHEN the user says: "create an event called ...", "schedule a new
+event", "erstelle ein Event ...", "plane eine neue Veranstaltung".
+
+### update_my_event
+Edit one of the user's own upcoming events (title, description,
+location, virtual_link, start_time, end_time, max_participants,
+image_url). Only the creator can edit, and only before it starts.
+CALL WHEN the user says: "change the time of my event ...", "update my
+event description", "ändere mein Event ...".
+
+### cancel_my_event
+Cancel (delete) one of the user's own upcoming events. ALWAYS call
+once WITHOUT confirm first — the tool returns a confirmation question;
+after the user says yes, call again with the event_id and confirm:true.
+CALL WHEN the user says: "cancel my event", "delete the ... event",
+"sage mein Event ... ab".
+
+### create_meetup
+Create a new casual community meetup (lighter-weight than a ticketed
+event). Requires a title and start_time. ALWAYS call once WITHOUT
+confirm first — the tool returns a confirmation question; after the
+user says yes, call again with confirm:true.
+CALL WHEN the user says: "create a meetup for ...", "start a walking
+meetup", "erstelle ein Meetup für ...".
+
+### update_my_meetup
+Edit one of the user's own upcoming meetups (title, description,
+location, virtual_link, start_time, end_time, max_participants,
+image_url). Only the creator can edit, and only before it starts.
+CALL WHEN the user says: "change my meetup time", "update the hiking
+meetup details", "ändere mein Meetup ...".
+
+### invite_to_event
+Invite a community member to an event or meetup by spoken name. The
+member gets a pending invite on the event.
+CALL WHEN the user says: "invite Anna to my yoga meetup", "ask Ben to
+come to the event", "lade Anna zu meinem Event ... ein".
+If the tool lists several event or member candidates, ask which one.
+
+### buy_event_ticket
+Buy a ticket for an event. Checks ticket availability and price, then
+ALWAYS call once WITHOUT confirm first — the tool returns a price
+confirmation question; after the user says yes, call again with
+confirm:true. Even after confirming, payment is completed on the
+user's screen — this tool never charges a card by voice; it prepares
+the purchase and opens the ticket screen.
+CALL WHEN the user says: "buy a ticket for ...", "I want two tickets to
+the gala", "kauf mir ein Ticket für ...".
+
+### list_my_event_tickets
+List the user's own purchased (completed) event tickets.
+CALL WHEN the user asks: "what tickets do I have?", "show my event
+tickets", "welche Tickets habe ich?".
+
+### share_event
+Get a shareable public link for an event or meetup (works even for
+people who aren't logged in). Does not send anything itself — just
+returns the link for the user to share however they like.
+CALL WHEN the user says: "share the yoga meetup", "get me a link for
+that event", "gib mir einen Link für das Event ...".
+
+### get_event_attendees
+List who has RSVP'd to one of the user's OWN events (organizer view
+only — the user must be the creator).
+CALL WHEN the user asks: "who's coming to my event?", "how many people
+signed up for my meetup?", "wer kommt zu meinem Event?".
+
+### log_meal
+Log a meal (breakfast/lunch/dinner/snack) toward the nutrition pillar.
+CALL WHEN the user says: "I just had breakfast", "log my lunch",
+"ich habe gerade gegessen", "trage mein Mittagessen ein".
+
+### log_vitals
+Log vitals: heart rate, weight, and/or blood pressure. Pass any subset.
+Heart rate contributes to the Vitana Index exercise pillar; weight and
+blood pressure are recorded but do not currently move the Index.
+CALL WHEN the user says: "my heart rate is 68", "I weigh 74 kilos",
+"my blood pressure is 120 over 80", "meine Herzfrequenz ist ...".
+
+### log_mood
+Log a mental-health / mood check-in (1-5 scale, or a mood word).
+CALL WHEN the user says: "I feel great today", "log my mood as okay",
+"ich fühle mich heute gut".
+
+### log_biomarker
+Record a single lab/biomarker value the user reports out loud (e.g. from
+a home test or a doctor visit), creating a lab report entry.
+CALL WHEN the user says: "my glucose was 95", "my cholesterol came back
+at 180", "mein Blutzucker war 95".
+
+### get_health_trends
+Get the Vitana Index trend (total + per-pillar) over a recent window.
+CALL WHEN the user asks: "how have I been trending?", "am I improving?",
+"wie hat sich mein Index entwickelt?".
+
+### get_health_streaks
+Get the user's diary streak and per-pillar Vitana Index streaks.
+CALL WHEN the user asks: "what's my streak?", "am I on a streak?",
+"wie lange ist meine Serie schon?".
+
+### order_lab_test
+Order a lab test. NOT AVAILABLE YET — always returns an error explaining there is no ordering backend; tell the user this feature is not live yet.
+
+### get_lab_results
+Read the user's recorded lab/biomarker results, most recent first.
+CALL WHEN the user asks: "what were my last lab results?", "what's my
+cholesterol?", "wie waren meine letzten Laborwerte?".
+
+### generate_health_plan
+Create a starter health plan (template-based, not AI-personalized) for a
+pillar. ALWAYS call once WITHOUT confirm first — the tool returns a
+preview; after the user agrees, call again with confirm:true.
+CALL WHEN the user says: "make me a nutrition plan", "erstelle einen
+Ernährungsplan für mich".
+
+### list_my_health_plans
+List the user's active health plans with adherence scores. CALL WHEN the user asks: "what plans do I have?", "welche Pläne habe ich?".
+
+### get_health_plan_progress
+Get adherence/progress for a specific active health plan.
+CALL WHEN the user asks: "how's my plan going?", "am I keeping up with
+my sleep plan?", "wie läuft mein Plan?".
+
+### list_my_conditions
+List the user's recorded health conditions, allergies, medications, and
+dietary restrictions.
+CALL WHEN the user asks: "what conditions do I have on file?", "what
+are my allergies?", "welche Erkrankungen habe ich hinterlegt?".
+
+### get_health_education
+Get grounded educational content on a health/longevity topic from the
+knowledge hub.
+CALL WHEN the user asks: "tell me about HRV", "what is VO2 max?",
+"erkläre mir was Schlafqualität bedeutet".
+
+### get_next_best_action
+Get today's single highest-priority recommended health action.
+CALL WHEN the user asks: "what should I do today?", "what's my next
+step?", "was soll ich heute für meine Gesundheit tun?".
+If the result has an autopilot id, offer to call activate_recommendation.
+
+### connect_health_device
+Start pairing a wearable/health device. Opens the health tracker screen
+where device connections are managed (pairing itself is a native/client flow).
+CALL WHEN the user says: "connect my Oura ring", "pair my device",
+"verbinde mein Gerät"."
 `;

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -4525,6 +4525,1610 @@ CALL THIS for: "Comment on Anna's post: great work" /
         },
       },
       {
+        "description": "Search the Maxina marketplace for products by free-text query, category,
+or price range. CALL WHEN the user says: "search the marketplace for ...",
+"find me some ...", "durchsuche den Marktplatz nach ...".
+Read the top results (name, price, rating) aloud.",
+        "name": "search_marketplace",
+        "parameters": {
+          "properties": {
+            "category": {
+              "description": "Exact product category (e.g. "supplements").",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max results to return (default 5, max 10).",
+              "type": "number",
+            },
+            "price_max_cents": {
+              "description": "Maximum price in cents.",
+              "type": "number",
+            },
+            "price_min_cents": {
+              "description": "Minimum price in cents.",
+              "type": "number",
+            },
+            "q": {
+              "description": "Free-text search query.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get details for one marketplace product by id or by spoken name.
+CALL WHEN the user asks: "tell me about ...", "what is ... exactly",
+"erzähl mir mehr über ...".",
+        "name": "get_product_details",
+        "parameters": {
+          "properties": {
+            "product_id": {
+              "description": "Exact product UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken product name (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse the marketplace supplements shop (NOT the personal supplement
+tracker — that is unavailable via voice today).
+CALL WHEN the user says: "show me supplements", "what supplements do you
+have", "zeig mir Nahrungsergänzungsmittel".",
+        "name": "browse_supplements",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 8, max 10).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error explaining the personal supplement tracker has no gateway-side backing yet. Do not call unless the user explicitly asks to add a supplement to their personal regimen/tracker, then relay the unavailability honestly.",
+        "name": "add_supplement_to_regimen",
+        "parameters": {
+          "properties": {
+            "name": {
+              "description": "Supplement name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call unless the user explicitly asks to hear their personal supplement list, then relay the unavailability honestly.",
+        "name": "list_my_supplements",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call unless the user explicitly asks to remove a supplement from their personal regimen, then relay the unavailability honestly.",
+        "name": "remove_supplement_from_regimen",
+        "parameters": {
+          "properties": {
+            "name": {
+              "description": "Supplement name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse wellness/nutrition/fitness/therapy/lab services listed in the
+Maxina marketplace. CALL WHEN the user asks about wellness services,
+massage, spa, recovery, or treatments — "Wellness-Services".",
+        "name": "browse_wellness_services",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 8, max 10).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get one service/provider listing by id or spoken name (doctor, coach,
+wellness provider, etc). CALL WHEN the user asks about a specific
+provider or practitioner by name.",
+        "name": "get_provider_profile",
+        "parameters": {
+          "properties": {
+            "provider_id": {
+              "description": "Exact service/provider UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken provider or service name (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse doctors and coaches listed in the marketplace. CALL WHEN the user
+asks to find a doctor, coach, practitioner, or specialist — "Ärzte &
+Coaches".",
+        "name": "browse_doctors_coaches",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 8, max 10).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error, since no compatibility-scoring system exists yet. Do not fabricate a score; relay the unavailability honestly if asked.",
+        "name": "get_coach_compatibility",
+        "parameters": {
+          "properties": {
+            "provider_id": {
+              "description": "Coach/provider UUID.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse marketplace products currently on sale (discounted vs. their
+reference price). CALL WHEN the user asks about deals, discounts,
+offers, promotions, or "what is on sale" — "Angebote & Deals".",
+        "name": "browse_deals_offers",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 8, max 10).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error, since the discount-code system has no gateway-side backing yet. Do not call unless the user explicitly asks to apply a promo code, then relay the unavailability honestly.",
+        "name": "apply_discount_code",
+        "parameters": {
+          "properties": {
+            "code": {
+              "description": "The discount/promo code.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Have the Vitana shopping agent propose marketplace products for a goal
+or need, filtered against the user's health/dietary/budget profile, and
+add them to the cart for review (NEVER charges anything).
+CALL WHEN the user says: "find me something for ...", "what should I take
+for ...", "shop for ... for me", "kauf mir etwas gegen ...".
+After the tool runs, read the picks + rationale aloud and tell the user
+to confirm payment on screen — never say payment completed.",
+        "name": "get_ai_product_picks",
+        "parameters": {
+          "properties": {
+            "max_items": {
+              "description": "Max picks to propose (default 4, max 6).",
+              "type": "number",
+            },
+            "prompt": {
+              "description": "What the user wants help finding/shopping for.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "prompt",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's recent marketplace orders with status and amount.
+CALL WHEN the user asks: "what have I ordered", "show my orders",
+"zeig mir meine Bestellungen".",
+        "name": "list_my_orders",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max orders to return (default 10, max 20).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check the status of one order by id, or the most recent order if no id
+is given. CALL WHEN the user asks: "where is my order", "track my order",
+"wo ist meine Bestellung".",
+        "name": "get_order_status",
+        "parameters": {
+          "properties": {
+            "order_id": {
+              "description": "Exact order UUID when known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Add the user's most recent (still-available) purchase back to the cart.
+ALWAYS call once WITHOUT confirm first — the tool returns a confirmation
+question; after the user says yes, call again with confirm:true. NEVER
+charges anything — only stages the cart.
+CALL WHEN the user says: "reorder my last order", "get me the same thing
+again", "bestelle das Gleiche nochmal".",
+        "name": "reorder_last_order",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the reorder.",
+              "type": "boolean",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Add a marketplace product to the user's cart, by product_id or fuzzy
+product name. Bumps quantity if the product is already in the cart.
+CALL WHEN the user says: "add ... to my cart", "I want to buy ...",
+"lege ... in den Warenkorb", "ich möchte ... kaufen".
+If several products match, read the candidates and ask which one.",
+        "name": "add_to_cart",
+        "parameters": {
+          "properties": {
+            "product_id": {
+              "description": "Exact product UUID when already known from a previous tool result.",
+              "type": "string",
+            },
+            "quantity": {
+              "description": "How many to add. Defaults to 1.",
+              "type": "number",
+            },
+            "query": {
+              "description": "Spoken product name (fuzzy matched against the marketplace catalog).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the contents of the user's cart: items, quantities, prices, and
+the total. CALL WHEN the user asks: "what's in my cart?", "show my
+cart", "was ist in meinem Warenkorb?", "zeig mir meinen Warenkorb".
+Read the items and total aloud.",
+        "name": "view_cart",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Change the quantity of an item already in the cart, by item_id or
+fuzzy product name. CALL WHEN the user says: "make it 2 of those",
+"change the quantity to ...", "ändere die Menge auf ...".
+If several items match, read the candidates and ask which one. Use
+remove_from_cart instead if the user wants to remove the item entirely.",
+        "name": "update_cart_item",
+        "parameters": {
+          "properties": {
+            "item_id": {
+              "description": "Exact cart item UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "quantity": {
+              "description": "The new quantity (must be positive).",
+              "type": "number",
+            },
+            "query": {
+              "description": "Spoken product name to find the cart line (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "quantity",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Remove a single item from the cart, by item_id or fuzzy product name.
+CALL WHEN the user says: "remove ... from my cart", "take that out of
+my cart", "entferne ... aus dem Warenkorb".
+If several items match, read the candidates and ask which one.",
+        "name": "remove_from_cart",
+        "parameters": {
+          "properties": {
+            "item_id": {
+              "description": "Exact cart item UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken product name to find the cart line (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Remove ALL items from the cart. ALWAYS call once WITHOUT confirm
+first — the tool returns a confirmation question listing what will be
+removed; after the user says yes, call again with confirm:true.
+CALL WHEN the user says: "clear my cart", "empty my cart", "remove
+everything", "leere meinen Warenkorb".",
+        "name": "clear_cart",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed clearing the cart.",
+              "type": "boolean",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set or clear the user's monthly shopping budget cap, used as an
+advisory warning (never blocks purchases) when the cart plus this
+month's spending gets close to or exceeds it.
+CALL WHEN the user says: "set my monthly budget to ...", "limit my
+shopping to ... a month", "remove my budget", "setze mein monatliches
+Budget auf ...".",
+        "name": "set_shopping_budget",
+        "parameters": {
+          "properties": {
+            "clear": {
+              "description": "Pass true to remove the existing budget cap instead of setting one.",
+              "type": "boolean",
+            },
+            "monthly_cap_amount": {
+              "description": "Monthly cap in the user's major currency unit (e.g. 200 for 200 EUR).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the items the shopping agent (autopilot) has proposed and placed
+into the user's cart for review — each with its rationale, safety
+flags, and confidence. These are NOT yet purchased; the user can
+remove any with remove_from_cart or proceed with start_checkout.
+CALL WHEN the user asks: "what did the shopping agent pick for me?",
+"show my pending proposals", "was hat der Einkaufsassistent
+vorgeschlagen?".",
+        "name": "review_agent_purchase_proposals",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Begin checkout for the user's cart. ALWAYS call once WITHOUT confirm
+first — the tool returns the cart total and asks for confirmation;
+after the user says yes, call again with confirm:true. This tool
+NEVER charges a card or completes payment by voice — it only
+validates the cart and navigates the user to the cart/checkout screen
+where THEY confirm payment themselves.
+CALL WHEN the user says: "check out", "let's pay for this", "go to
+checkout", "zur Kasse gehen", "ich möchte bezahlen".",
+        "name": "start_checkout",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed proceeding to checkout.",
+              "type": "boolean",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY wallet snapshot: balance per currency, active subscription,
+lifetime + pending referral rewards, and recent activity.
+CALL WHEN the user asks: "give me my wallet summary", "how much do I have
+and how much have I earned", "wie steht es um mein Wallet".",
+        "name": "get_wallet_summary",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY: list the user's recent wallet transactions, newest first.
+Supports pagination via cursor (from a previous call's next_cursor).
+CALL WHEN the user asks: "show my transactions", "what did I spend
+recently", "zeig mir meine letzten Transaktionen".",
+        "name": "list_wallet_transactions",
+        "parameters": {
+          "properties": {
+            "currency": {
+              "description": "Optional: 'EUR' or 'USD' to filter to one currency.",
+              "type": "string",
+            },
+            "cursor": {
+              "description": "Pass the previous next_cursor to page further back.",
+              "type": "string",
+            },
+            "limit": {
+              "description": "How many to read out, 1-50. Uses 15 when omitted.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Send money from the user's wallet to another Vitana member (internal
+transfer only — never a card charge). ALWAYS call once WITHOUT confirm
+first — it resolves the recipient and previews the amount; after the user
+says yes, call again with confirm:true, recipient_user_id, amount and
+currency from the preview result.
+CALL WHEN the user says: "send Anna 20 euros", "transfer money to Peter",
+"schicke Anna 20 Euro".
+This is the ONLY tool that fully executes money movement by voice.",
+        "name": "send_funds",
+        "parameters": {
+          "properties": {
+            "amount": {
+              "description": "Amount in major currency units, e.g. 20 for 20.00.",
+              "type": "number",
+            },
+            "confirm": {
+              "description": "true ONLY after the user explicitly confirmed the preview.",
+              "type": "boolean",
+            },
+            "currency": {
+              "description": "'EUR' or 'USD'. Omit if the user has only one wallet currency.",
+              "type": "string",
+            },
+            "recipient_name": {
+              "description": "Spoken name of who to send money to.",
+              "type": "string",
+            },
+            "recipient_user_id": {
+              "description": "Exact recipient UUID once resolved from a previous call.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error explaining there is no
+backing endpoint for payment requests. Do not imply this worked; tell
+the user to send a payment request from the Wallet or Messages screen.",
+        "name": "request_payment",
+        "parameters": {
+          "properties": {
+            "amount": {
+              "description": "Amount requested, major currency units.",
+              "type": "number",
+            },
+            "currency": {
+              "description": "'EUR' or 'USD'.",
+              "type": "string",
+            },
+            "description": {
+              "description": "What the request is for.",
+              "type": "string",
+            },
+            "recipient_name": {
+              "description": "Spoken name of who the request would go to.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error: the wallet has no
+cross-currency conversion RPC. Do not imply this worked.",
+        "name": "exchange_currency",
+        "parameters": {
+          "properties": {
+            "amount": {
+              "description": "Amount to exchange.",
+              "type": "number",
+            },
+            "confirm": {
+              "description": "Not used — the tool is unavailable.",
+              "type": "boolean",
+            },
+            "from_currency": {
+              "description": "Source currency, e.g. 'EUR'.",
+              "type": "string",
+            },
+            "to_currency": {
+              "description": "Target currency, e.g. 'USD'.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error: no exchange-rate
+table/RPC is wired into the gateway.",
+        "name": "get_exchange_rate",
+        "parameters": {
+          "properties": {
+            "from_currency": {
+              "description": "e.g. 'EUR'.",
+              "type": "string",
+            },
+            "to_currency": {
+              "description": "e.g. 'USD'.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error: the display-currency toggle
+is stored only in the browser, not on any server-side record.",
+        "name": "set_display_currency",
+        "parameters": {
+          "properties": {
+            "currency": {
+              "description": "'EUR' or 'USD'.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY: total referral rewards earned (confirmed) and pending, from
+the user's reward ledger.
+CALL WHEN the user asks: "how much have I earned from referrals",
+"was habe ich mit Empfehlungen verdient".",
+        "name": "get_referral_earnings",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY: commissions earned this calendar month — total, confirmed,
+and still-pending amounts.
+CALL WHEN the user asks: "what are my commissions this month",
+"wie viel Provision habe ich diesen Monat gemacht".",
+        "name": "get_commissions_summary",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY: rewards awaiting merchant confirmation (not yet payable).
+CALL WHEN the user asks: "do I have any pending rewards",
+"was ist noch ausstehend bei meinen Prämien".",
+        "name": "get_pending_rewards",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error: payment requests have no
+structured table to list from.",
+        "name": "list_payment_requests",
+        "parameters": {
+          "properties": {
+            "direction": {
+              "description": "'incoming' or 'outgoing' — not used, tool is unavailable.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Send a text message to a group chat the user is a member of (not a 1-to-1 DM —
+use send_chat_message for that). ALWAYS call once WITHOUT confirmed first — the
+tool returns a preview; read it back and only call again with confirmed:true after
+explicit confirmation.
+CALL WHEN the user says: "message the running group", "tell everyone in Alle
+Beisammen ...", "schreib in die Gruppe ...".
+If several of the user's groups match, read the candidates and ask which one.",
+        "name": "send_group_chat_message",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY after the user confirmed the exact wording.",
+              "type": "boolean",
+            },
+            "group": {
+              "description": "Spoken group chat name (fuzzy matched among the user's own groups).",
+              "type": "string",
+            },
+            "group_id": {
+              "description": "Exact group UUID when already known.",
+              "type": "string",
+            },
+            "message": {
+              "description": "The message to send.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "message",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Reply to a specific earlier message. NOTE: Vitana chat has no reply/quote-thread
+feature yet — this tool always answers that it is unavailable. Relay that plainly
+and offer send_chat_message or send_group_chat_message instead, optionally quoting
+the original text inline in the new message.
+CALL WHEN the user says: "reply to that message", "antworte auf die Nachricht".",
+        "name": "reply_to_message",
+        "parameters": {
+          "properties": {
+            "message": {
+              "description": "The reply text the user wants to send.",
+              "type": "string",
+            },
+            "message_id": {
+              "description": "UUID of the message being replied to, if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Add (or remove) an emoji reaction on a chat message — one of 👍 ❤️ 😂 😮 🙏 🎉 only.
+Requires message_id from a previous tool result (e.g. from list_conversations or a
+group message read-back).
+CALL WHEN the user says: "react with a heart to that", "give that a thumbs up",
+"reagiere mit einem Herz darauf".
+Set remove:true to take the reaction back off.",
+        "name": "react_to_message",
+        "parameters": {
+          "properties": {
+            "emoji": {
+              "description": "One of: 👍 ❤️ 😂 😮 🙏 🎉",
+              "type": "string",
+            },
+            "message_id": {
+              "description": "UUID of the message to react to.",
+              "type": "string",
+            },
+            "remove": {
+              "description": "Pass true to remove a reaction the user previously added.",
+              "type": "boolean",
+            },
+          },
+          "required": [
+            "message_id",
+            "emoji",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a new group chat, optionally adding named members immediately. ALWAYS call
+once WITHOUT confirm first — the tool returns a confirmation question; after the
+user says yes, call again with confirm:true.
+CALL WHEN the user says: "create a group chat called ...", "start a new chat with
+me, Anna and Ben", "erstelle einen Gruppenchat ...".",
+        "name": "create_group_chat",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the creation.",
+              "type": "boolean",
+            },
+            "description": {
+              "description": "Optional short description.",
+              "type": "string",
+            },
+            "members": {
+              "description": "Spoken names of members to add immediately (fuzzy resolved).",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "name": {
+              "description": "The group chat name.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Add a community member to a group chat the user already belongs to.
+CALL WHEN the user says: "add Anna to the running group chat", "füge Anna dem
+Gruppenchat hinzu".
+If several of the user's groups or several matching members are found, ask which one.",
+        "name": "add_group_chat_member",
+        "parameters": {
+          "properties": {
+            "group": {
+              "description": "Spoken group chat name (fuzzy matched among the user's own groups).",
+              "type": "string",
+            },
+            "group_id": {
+              "description": "Exact group UUID when already known.",
+              "type": "string",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the member to add.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Leave a group chat. ALWAYS call once WITHOUT confirm first — the tool returns a
+confirmation question; after the user says yes, call again with the group_id and
+confirm:true.
+CALL WHEN the user says: "leave the running group chat", "verlasse den Gruppenchat
+...".",
+        "name": "leave_group_chat",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed leaving.",
+              "type": "boolean",
+            },
+            "group": {
+              "description": "Spoken group chat name (fuzzy matched among the user's own groups).",
+              "type": "string",
+            },
+            "group_id": {
+              "description": "Exact group UUID when already known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Share one of the user's own upcoming calendar events with a community member via
+direct message. ALWAYS call once WITHOUT confirmed first — the tool returns a
+preview; after explicit confirmation call again with confirmed:true.
+CALL WHEN the user says: "send Anna the invite for my yoga session", "share my
+appointment with Ben", "schick Anna die Einladung zu meinem Termin".
+If several events or member matches are found, ask which one.",
+        "name": "send_calendar_invite_in_chat",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY after the user explicitly confirmed sending.",
+              "type": "boolean",
+            },
+            "event": {
+              "description": "Spoken event title (fuzzy matched against the user's own upcoming events).",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact calendar_events UUID when already known.",
+              "type": "string",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the recipient.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the recipient if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Send another community member a request to start a voice call. IMPORTANT: Vitana
+cannot place a live call from voice — calling only works client-side between two
+open apps. This tool sends a chat message + notification asking them to open the
+app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again
+with confirmed:true after explicit confirmation.
+CALL WHEN the user says: "call Anna", "start a voice call with Ben", "ruf Anna an".
+Afterwards, tell the user the request was sent and real-time calling needs both
+people in the app.",
+        "name": "start_voice_call",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY after the user explicitly confirmed sending the request.",
+              "type": "boolean",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the person to call.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Send another community member a request to start a video call. IMPORTANT: Vitana
+cannot place a live call from voice — calling only works client-side between two
+open apps. This tool sends a chat message + notification asking them to open the
+app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again
+with confirmed:true after explicit confirmation.
+CALL WHEN the user says: "video call Anna", "start a video chat with Ben", "starte
+einen Videoanruf mit Anna".
+Afterwards, tell the user the request was sent and real-time calling needs both
+people in the app.",
+        "name": "start_video_call",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY after the user explicitly confirmed sending the request.",
+              "type": "boolean",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the person to video call.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a new ticketed/community event. Requires a title and start_time.
+ALWAYS call once WITHOUT confirm first — the tool returns a
+confirmation question; after the user says yes, call again with
+confirm:true.
+CALL WHEN the user says: "create an event called ...", "schedule a new
+event", "erstelle ein Event ...", "plane eine neue Veranstaltung".",
+        "name": "create_event",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the creation.",
+              "type": "boolean",
+            },
+            "description": {
+              "description": "Optional short event description.",
+              "type": "string",
+            },
+            "end_time": {
+              "description": "Optional ISO date/time the event ends.",
+              "type": "string",
+            },
+            "image_url": {
+              "description": "Optional cover image URL.",
+              "type": "string",
+            },
+            "location": {
+              "description": "Optional physical location.",
+              "type": "string",
+            },
+            "max_participants": {
+              "description": "Optional capacity cap.",
+              "type": "number",
+            },
+            "start_time": {
+              "description": "ISO date/time the event starts. Required.",
+              "type": "string",
+            },
+            "title": {
+              "description": "The event title.",
+              "type": "string",
+            },
+            "virtual_link": {
+              "description": "Optional virtual/streaming link.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "title",
+            "start_time",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Edit one of the user's own upcoming events (title, description,
+location, virtual_link, start_time, end_time, max_participants,
+image_url). Only the creator can edit, and only before it starts.
+CALL WHEN the user says: "change the time of my event ...", "update my
+event description", "ändere mein Event ...".",
+        "name": "update_my_event",
+        "parameters": {
+          "properties": {
+            "description": {
+              "description": "New description, if changing it.",
+              "type": "string",
+            },
+            "end_time": {
+              "description": "New ISO end_time, if changing it.",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "image_url": {
+              "description": "New cover image URL, if changing it.",
+              "type": "string",
+            },
+            "location": {
+              "description": "New location, if changing it.",
+              "type": "string",
+            },
+            "max_participants": {
+              "description": "New capacity cap, if changing it.",
+              "type": "number",
+            },
+            "query": {
+              "description": "Spoken title of the user's event (fuzzy matched).",
+              "type": "string",
+            },
+            "start_time": {
+              "description": "New ISO start_time, if changing it.",
+              "type": "string",
+            },
+            "title": {
+              "description": "New title, if changing it.",
+              "type": "string",
+            },
+            "virtual_link": {
+              "description": "New virtual link, if changing it.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Cancel (delete) one of the user's own upcoming events. ALWAYS call
+once WITHOUT confirm first — the tool returns a confirmation question;
+after the user says yes, call again with the event_id and confirm:true.
+CALL WHEN the user says: "cancel my event", "delete the ... event",
+"sage mein Event ... ab".",
+        "name": "cancel_my_event",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the cancellation.",
+              "type": "boolean",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken title of the user's event (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a new casual community meetup (lighter-weight than a ticketed
+event). Requires a title and start_time. ALWAYS call once WITHOUT
+confirm first — the tool returns a confirmation question; after the
+user says yes, call again with confirm:true.
+CALL WHEN the user says: "create a meetup for ...", "start a walking
+meetup", "erstelle ein Meetup für ...".",
+        "name": "create_meetup",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the creation.",
+              "type": "boolean",
+            },
+            "description": {
+              "description": "Optional short meetup description.",
+              "type": "string",
+            },
+            "end_time": {
+              "description": "Optional ISO date/time the meetup ends.",
+              "type": "string",
+            },
+            "image_url": {
+              "description": "Optional cover image URL.",
+              "type": "string",
+            },
+            "location": {
+              "description": "Optional physical location.",
+              "type": "string",
+            },
+            "max_participants": {
+              "description": "Optional capacity cap.",
+              "type": "number",
+            },
+            "start_time": {
+              "description": "ISO date/time the meetup starts. Required.",
+              "type": "string",
+            },
+            "title": {
+              "description": "The meetup title.",
+              "type": "string",
+            },
+            "virtual_link": {
+              "description": "Optional virtual/streaming link.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "title",
+            "start_time",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Edit one of the user's own upcoming meetups (title, description,
+location, virtual_link, start_time, end_time, max_participants,
+image_url). Only the creator can edit, and only before it starts.
+CALL WHEN the user says: "change my meetup time", "update the hiking
+meetup details", "ändere mein Meetup ...".",
+        "name": "update_my_meetup",
+        "parameters": {
+          "properties": {
+            "description": {
+              "description": "New description, if changing it.",
+              "type": "string",
+            },
+            "end_time": {
+              "description": "New ISO end_time, if changing it.",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact meetup UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "image_url": {
+              "description": "New cover image URL, if changing it.",
+              "type": "string",
+            },
+            "location": {
+              "description": "New location, if changing it.",
+              "type": "string",
+            },
+            "max_participants": {
+              "description": "New capacity cap, if changing it.",
+              "type": "number",
+            },
+            "query": {
+              "description": "Spoken title of the user's meetup (fuzzy matched).",
+              "type": "string",
+            },
+            "start_time": {
+              "description": "New ISO start_time, if changing it.",
+              "type": "string",
+            },
+            "title": {
+              "description": "New title, if changing it.",
+              "type": "string",
+            },
+            "virtual_link": {
+              "description": "New virtual link, if changing it.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Invite a community member to an event or meetup by spoken name. The
+member gets a pending invite on the event.
+CALL WHEN the user says: "invite Anna to my yoga meetup", "ask Ben to
+come to the event", "lade Anna zu meinem Event ... ein".
+If the tool lists several event or member candidates, ask which one.",
+        "name": "invite_to_event",
+        "parameters": {
+          "properties": {
+            "event": {
+              "description": "Spoken event/meetup title (fuzzy matched against upcoming events).",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "member_name": {
+              "description": "Spoken name of the member to invite.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "Exact user UUID when known from a previous tool result.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Buy a ticket for an event. Checks ticket availability and price, then
+ALWAYS call once WITHOUT confirm first — the tool returns a price
+confirmation question; after the user says yes, call again with
+confirm:true. Even after confirming, payment is completed on the
+user's screen — this tool never charges a card by voice; it prepares
+the purchase and opens the ticket screen.
+CALL WHEN the user says: "buy a ticket for ...", "I want two tickets to
+the gala", "kauf mir ein Ticket für ...".",
+        "name": "buy_event_ticket",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the price and purchase.",
+              "type": "boolean",
+            },
+            "event": {
+              "description": "Spoken event title (fuzzy matched against upcoming events).",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "quantity": {
+              "description": "How many tickets to buy. Defaults to 1.",
+              "type": "number",
+            },
+            "ticket_name": {
+              "description": "Spoken ticket tier name (e.g. "VIP", "General Admission").",
+              "type": "string",
+            },
+            "ticket_type_id": {
+              "description": "Exact ticket type UUID when known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's own purchased (completed) event tickets.
+CALL WHEN the user asks: "what tickets do I have?", "show my event
+tickets", "welche Tickets habe ich?".",
+        "name": "list_my_event_tickets",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get a shareable public link for an event or meetup (works even for
+people who aren't logged in). Does not send anything itself — just
+returns the link for the user to share however they like.
+CALL WHEN the user says: "share the yoga meetup", "get me a link for
+that event", "gib mir einen Link für das Event ...".",
+        "name": "share_event",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken event/meetup title (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List who has RSVP'd to one of the user's OWN events (organizer view
+only — the user must be the creator).
+CALL WHEN the user asks: "who's coming to my event?", "how many people
+signed up for my meetup?", "wer kommt zu meinem Event?".",
+        "name": "get_event_attendees",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken title of the user's event (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Log a meal (breakfast/lunch/dinner/snack) toward the nutrition pillar.
+CALL WHEN the user says: "I just had breakfast", "log my lunch",
+"ich habe gerade gegessen", "trage mein Mittagessen ein".",
+        "name": "log_meal",
+        "parameters": {
+          "properties": {
+            "calories": {
+              "description": "Optional estimated calories.",
+              "type": "number",
+            },
+            "date": {
+              "description": "YYYY-MM-DD, defaults to today.",
+              "type": "string",
+            },
+            "description": {
+              "description": "What was eaten, e.g. "oatmeal with berries".",
+              "type": "string",
+            },
+            "meal_type": {
+              "description": "One of breakfast, lunch, dinner, snack.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Log vitals: heart rate, weight, and/or blood pressure. Pass any subset.
+Heart rate contributes to the Vitana Index exercise pillar; weight and
+blood pressure are recorded but do not currently move the Index.
+CALL WHEN the user says: "my heart rate is 68", "I weigh 74 kilos",
+"my blood pressure is 120 over 80", "meine Herzfrequenz ist ...".",
+        "name": "log_vitals",
+        "parameters": {
+          "properties": {
+            "date": {
+              "description": "YYYY-MM-DD, defaults to today.",
+              "type": "string",
+            },
+            "diastolic": {
+              "description": "Diastolic blood pressure (mmHg).",
+              "type": "number",
+            },
+            "heart_rate": {
+              "description": "Heart rate in bpm.",
+              "type": "number",
+            },
+            "systolic": {
+              "description": "Systolic blood pressure (mmHg).",
+              "type": "number",
+            },
+            "weight_kg": {
+              "description": "Body weight in kilograms.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Log a mental-health / mood check-in (1-5 scale, or a mood word).
+CALL WHEN the user says: "I feel great today", "log my mood as okay",
+"ich fühle mich heute gut".",
+        "name": "log_mood",
+        "parameters": {
+          "properties": {
+            "date": {
+              "description": "YYYY-MM-DD, defaults to today.",
+              "type": "string",
+            },
+            "mood_label": {
+              "description": "A word like 'great', 'okay', 'down' — used if mood_score is omitted.",
+              "type": "string",
+            },
+            "mood_score": {
+              "description": "1 (terrible) to 5 (fantastic).",
+              "type": "number",
+            },
+            "notes": {
+              "description": "Optional short note about why.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Record a single lab/biomarker value the user reports out loud (e.g. from
+a home test or a doctor visit), creating a lab report entry.
+CALL WHEN the user says: "my glucose was 95", "my cholesterol came back
+at 180", "mein Blutzucker war 95".",
+        "name": "log_biomarker",
+        "parameters": {
+          "properties": {
+            "biomarker_code": {
+              "description": "Optional code, e.g. 'HBA1C'.",
+              "type": "string",
+            },
+            "measured_at": {
+              "description": "Optional ISO timestamp; defaults to now.",
+              "type": "string",
+            },
+            "name": {
+              "description": "Biomarker name, e.g. 'glucose', 'LDL cholesterol'.",
+              "type": "string",
+            },
+            "ref_range_high": {
+              "description": "Optional reference range high.",
+              "type": "number",
+            },
+            "ref_range_low": {
+              "description": "Optional reference range low.",
+              "type": "number",
+            },
+            "status": {
+              "description": "Optional: 'low'|'normal'|'high'|'critical' — inferred from range if omitted.",
+              "type": "string",
+            },
+            "unit": {
+              "description": "Unit, e.g. 'mg/dL'.",
+              "type": "string",
+            },
+            "value": {
+              "description": "The measured value.",
+              "type": "number",
+            },
+          },
+          "required": [
+            "name",
+            "value",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the Vitana Index trend (total + per-pillar) over a recent window.
+CALL WHEN the user asks: "how have I been trending?", "am I improving?",
+"wie hat sich mein Index entwickelt?".",
+        "name": "get_health_trends",
+        "parameters": {
+          "properties": {
+            "days": {
+              "description": "Window size in days, default 14, max 90.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the user's diary streak and per-pillar Vitana Index streaks.
+CALL WHEN the user asks: "what's my streak?", "am I on a streak?",
+"wie lange ist meine Serie schon?".",
+        "name": "get_health_streaks",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Order a lab test. NOT AVAILABLE YET — always returns an error explaining there is no ordering backend; tell the user this feature is not live yet.",
+        "name": "order_lab_test",
+        "parameters": {
+          "properties": {
+            "test_name": {
+              "description": "Name of the test requested.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's recorded lab/biomarker results, most recent first.
+CALL WHEN the user asks: "what were my last lab results?", "what's my
+cholesterol?", "wie waren meine letzten Laborwerte?".",
+        "name": "get_lab_results",
+        "parameters": {
+          "properties": {
+            "biomarker": {
+              "description": "Optional biomarker name/code to filter by.",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max results, default 10.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a starter health plan (template-based, not AI-personalized) for a
+pillar. ALWAYS call once WITHOUT confirm first — the tool returns a
+preview; after the user agrees, call again with confirm:true.
+CALL WHEN the user says: "make me a nutrition plan", "erstelle einen
+Ernährungsplan für mich".",
+        "name": "generate_health_plan",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed creating the plan.",
+              "type": "boolean",
+            },
+            "plan_type": {
+              "description": "One of nutrition, hydration, exercise, sleep, mental. Defaults to the weakest pillar.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's active health plans with adherence scores. CALL WHEN the user asks: "what plans do I have?", "welche Pläne habe ich?".",
+        "name": "list_my_health_plans",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get adherence/progress for a specific active health plan.
+CALL WHEN the user asks: "how's my plan going?", "am I keeping up with
+my sleep plan?", "wie läuft mein Plan?".",
+        "name": "get_health_plan_progress",
+        "parameters": {
+          "properties": {
+            "plan_id": {
+              "description": "Exact plan UUID if known.",
+              "type": "string",
+            },
+            "plan_type": {
+              "description": "One of nutrition, hydration, exercise, sleep, mental.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's recorded health conditions, allergies, medications, and
+dietary restrictions.
+CALL WHEN the user asks: "what conditions do I have on file?", "what
+are my allergies?", "welche Erkrankungen habe ich hinterlegt?".",
+        "name": "list_my_conditions",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get grounded educational content on a health/longevity topic from the
+knowledge hub.
+CALL WHEN the user asks: "tell me about HRV", "what is VO2 max?",
+"erkläre mir was Schlafqualität bedeutet".",
+        "name": "get_health_education",
+        "parameters": {
+          "properties": {
+            "topic": {
+              "description": "The health topic to explain.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "topic",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get today's single highest-priority recommended health action.
+CALL WHEN the user asks: "what should I do today?", "what's my next
+step?", "was soll ich heute für meine Gesundheit tun?".
+If the result has an autopilot id, offer to call activate_recommendation.",
+        "name": "get_next_best_action",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Start pairing a wearable/health device. Opens the health tracker screen
+where device connections are managed (pairing itself is a native/client flow).
+CALL WHEN the user says: "connect my Oura ring", "pair my device",
+"verbinde mein Gerät".",
+        "name": "connect_health_device",
+        "parameters": {
+          "properties": {
+            "device_name": {
+              "description": "Optional device name, e.g. "Oura Ring".",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
         "description": "Return the top open admin_insights for this tenant, ranked by severity × confidence. Call this AT THE START of every admin orb session to know what needs attention. The bootstrap context already includes the briefing on session-open; only call again if the admin asks "what else?", "anything new?", or "give me the briefing again".",
         "name": "admin_briefing",
         "parameters": {
@@ -9303,6 +10907,1610 @@ CALL THIS for: "Comment on Anna's post: great work" /
             "author_name",
             "text",
           ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Search the Maxina marketplace for products by free-text query, category,
+or price range. CALL WHEN the user says: "search the marketplace for ...",
+"find me some ...", "durchsuche den Marktplatz nach ...".
+Read the top results (name, price, rating) aloud.",
+        "name": "search_marketplace",
+        "parameters": {
+          "properties": {
+            "category": {
+              "description": "Exact product category (e.g. "supplements").",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max results to return (default 5, max 10).",
+              "type": "number",
+            },
+            "price_max_cents": {
+              "description": "Maximum price in cents.",
+              "type": "number",
+            },
+            "price_min_cents": {
+              "description": "Minimum price in cents.",
+              "type": "number",
+            },
+            "q": {
+              "description": "Free-text search query.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get details for one marketplace product by id or by spoken name.
+CALL WHEN the user asks: "tell me about ...", "what is ... exactly",
+"erzähl mir mehr über ...".",
+        "name": "get_product_details",
+        "parameters": {
+          "properties": {
+            "product_id": {
+              "description": "Exact product UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken product name (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse the marketplace supplements shop (NOT the personal supplement
+tracker — that is unavailable via voice today).
+CALL WHEN the user says: "show me supplements", "what supplements do you
+have", "zeig mir Nahrungsergänzungsmittel".",
+        "name": "browse_supplements",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 8, max 10).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error explaining the personal supplement tracker has no gateway-side backing yet. Do not call unless the user explicitly asks to add a supplement to their personal regimen/tracker, then relay the unavailability honestly.",
+        "name": "add_supplement_to_regimen",
+        "parameters": {
+          "properties": {
+            "name": {
+              "description": "Supplement name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call unless the user explicitly asks to hear their personal supplement list, then relay the unavailability honestly.",
+        "name": "list_my_supplements",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error. Do not call unless the user explicitly asks to remove a supplement from their personal regimen, then relay the unavailability honestly.",
+        "name": "remove_supplement_from_regimen",
+        "parameters": {
+          "properties": {
+            "name": {
+              "description": "Supplement name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse wellness/nutrition/fitness/therapy/lab services listed in the
+Maxina marketplace. CALL WHEN the user asks about wellness services,
+massage, spa, recovery, or treatments — "Wellness-Services".",
+        "name": "browse_wellness_services",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 8, max 10).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get one service/provider listing by id or spoken name (doctor, coach,
+wellness provider, etc). CALL WHEN the user asks about a specific
+provider or practitioner by name.",
+        "name": "get_provider_profile",
+        "parameters": {
+          "properties": {
+            "provider_id": {
+              "description": "Exact service/provider UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken provider or service name (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse doctors and coaches listed in the marketplace. CALL WHEN the user
+asks to find a doctor, coach, practitioner, or specialist — "Ärzte &
+Coaches".",
+        "name": "browse_doctors_coaches",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 8, max 10).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error, since no compatibility-scoring system exists yet. Do not fabricate a score; relay the unavailability honestly if asked.",
+        "name": "get_coach_compatibility",
+        "parameters": {
+          "properties": {
+            "provider_id": {
+              "description": "Coach/provider UUID.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Browse marketplace products currently on sale (discounted vs. their
+reference price). CALL WHEN the user asks about deals, discounts,
+offers, promotions, or "what is on sale" — "Angebote & Deals".",
+        "name": "browse_deals_offers",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 8, max 10).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT CURRENTLY AVAILABLE via voice — always returns an error, since the discount-code system has no gateway-side backing yet. Do not call unless the user explicitly asks to apply a promo code, then relay the unavailability honestly.",
+        "name": "apply_discount_code",
+        "parameters": {
+          "properties": {
+            "code": {
+              "description": "The discount/promo code.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Have the Vitana shopping agent propose marketplace products for a goal
+or need, filtered against the user's health/dietary/budget profile, and
+add them to the cart for review (NEVER charges anything).
+CALL WHEN the user says: "find me something for ...", "what should I take
+for ...", "shop for ... for me", "kauf mir etwas gegen ...".
+After the tool runs, read the picks + rationale aloud and tell the user
+to confirm payment on screen — never say payment completed.",
+        "name": "get_ai_product_picks",
+        "parameters": {
+          "properties": {
+            "max_items": {
+              "description": "Max picks to propose (default 4, max 6).",
+              "type": "number",
+            },
+            "prompt": {
+              "description": "What the user wants help finding/shopping for.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "prompt",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's recent marketplace orders with status and amount.
+CALL WHEN the user asks: "what have I ordered", "show my orders",
+"zeig mir meine Bestellungen".",
+        "name": "list_my_orders",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max orders to return (default 10, max 20).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check the status of one order by id, or the most recent order if no id
+is given. CALL WHEN the user asks: "where is my order", "track my order",
+"wo ist meine Bestellung".",
+        "name": "get_order_status",
+        "parameters": {
+          "properties": {
+            "order_id": {
+              "description": "Exact order UUID when known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Add the user's most recent (still-available) purchase back to the cart.
+ALWAYS call once WITHOUT confirm first — the tool returns a confirmation
+question; after the user says yes, call again with confirm:true. NEVER
+charges anything — only stages the cart.
+CALL WHEN the user says: "reorder my last order", "get me the same thing
+again", "bestelle das Gleiche nochmal".",
+        "name": "reorder_last_order",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the reorder.",
+              "type": "boolean",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Add a marketplace product to the user's cart, by product_id or fuzzy
+product name. Bumps quantity if the product is already in the cart.
+CALL WHEN the user says: "add ... to my cart", "I want to buy ...",
+"lege ... in den Warenkorb", "ich möchte ... kaufen".
+If several products match, read the candidates and ask which one.",
+        "name": "add_to_cart",
+        "parameters": {
+          "properties": {
+            "product_id": {
+              "description": "Exact product UUID when already known from a previous tool result.",
+              "type": "string",
+            },
+            "quantity": {
+              "description": "How many to add. Defaults to 1.",
+              "type": "number",
+            },
+            "query": {
+              "description": "Spoken product name (fuzzy matched against the marketplace catalog).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the contents of the user's cart: items, quantities, prices, and
+the total. CALL WHEN the user asks: "what's in my cart?", "show my
+cart", "was ist in meinem Warenkorb?", "zeig mir meinen Warenkorb".
+Read the items and total aloud.",
+        "name": "view_cart",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Change the quantity of an item already in the cart, by item_id or
+fuzzy product name. CALL WHEN the user says: "make it 2 of those",
+"change the quantity to ...", "ändere die Menge auf ...".
+If several items match, read the candidates and ask which one. Use
+remove_from_cart instead if the user wants to remove the item entirely.",
+        "name": "update_cart_item",
+        "parameters": {
+          "properties": {
+            "item_id": {
+              "description": "Exact cart item UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "quantity": {
+              "description": "The new quantity (must be positive).",
+              "type": "number",
+            },
+            "query": {
+              "description": "Spoken product name to find the cart line (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [
+            "quantity",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Remove a single item from the cart, by item_id or fuzzy product name.
+CALL WHEN the user says: "remove ... from my cart", "take that out of
+my cart", "entferne ... aus dem Warenkorb".
+If several items match, read the candidates and ask which one.",
+        "name": "remove_from_cart",
+        "parameters": {
+          "properties": {
+            "item_id": {
+              "description": "Exact cart item UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken product name to find the cart line (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Remove ALL items from the cart. ALWAYS call once WITHOUT confirm
+first — the tool returns a confirmation question listing what will be
+removed; after the user says yes, call again with confirm:true.
+CALL WHEN the user says: "clear my cart", "empty my cart", "remove
+everything", "leere meinen Warenkorb".",
+        "name": "clear_cart",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed clearing the cart.",
+              "type": "boolean",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set or clear the user's monthly shopping budget cap, used as an
+advisory warning (never blocks purchases) when the cart plus this
+month's spending gets close to or exceeds it.
+CALL WHEN the user says: "set my monthly budget to ...", "limit my
+shopping to ... a month", "remove my budget", "setze mein monatliches
+Budget auf ...".",
+        "name": "set_shopping_budget",
+        "parameters": {
+          "properties": {
+            "clear": {
+              "description": "Pass true to remove the existing budget cap instead of setting one.",
+              "type": "boolean",
+            },
+            "monthly_cap_amount": {
+              "description": "Monthly cap in the user's major currency unit (e.g. 200 for 200 EUR).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the items the shopping agent (autopilot) has proposed and placed
+into the user's cart for review — each with its rationale, safety
+flags, and confidence. These are NOT yet purchased; the user can
+remove any with remove_from_cart or proceed with start_checkout.
+CALL WHEN the user asks: "what did the shopping agent pick for me?",
+"show my pending proposals", "was hat der Einkaufsassistent
+vorgeschlagen?".",
+        "name": "review_agent_purchase_proposals",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Begin checkout for the user's cart. ALWAYS call once WITHOUT confirm
+first — the tool returns the cart total and asks for confirmation;
+after the user says yes, call again with confirm:true. This tool
+NEVER charges a card or completes payment by voice — it only
+validates the cart and navigates the user to the cart/checkout screen
+where THEY confirm payment themselves.
+CALL WHEN the user says: "check out", "let's pay for this", "go to
+checkout", "zur Kasse gehen", "ich möchte bezahlen".",
+        "name": "start_checkout",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed proceeding to checkout.",
+              "type": "boolean",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY wallet snapshot: balance per currency, active subscription,
+lifetime + pending referral rewards, and recent activity.
+CALL WHEN the user asks: "give me my wallet summary", "how much do I have
+and how much have I earned", "wie steht es um mein Wallet".",
+        "name": "get_wallet_summary",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY: list the user's recent wallet transactions, newest first.
+Supports pagination via cursor (from a previous call's next_cursor).
+CALL WHEN the user asks: "show my transactions", "what did I spend
+recently", "zeig mir meine letzten Transaktionen".",
+        "name": "list_wallet_transactions",
+        "parameters": {
+          "properties": {
+            "currency": {
+              "description": "Optional: 'EUR' or 'USD' to filter to one currency.",
+              "type": "string",
+            },
+            "cursor": {
+              "description": "Pass the previous next_cursor to page further back.",
+              "type": "string",
+            },
+            "limit": {
+              "description": "How many to read out, 1-50. Uses 15 when omitted.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Send money from the user's wallet to another Vitana member (internal
+transfer only — never a card charge). ALWAYS call once WITHOUT confirm
+first — it resolves the recipient and previews the amount; after the user
+says yes, call again with confirm:true, recipient_user_id, amount and
+currency from the preview result.
+CALL WHEN the user says: "send Anna 20 euros", "transfer money to Peter",
+"schicke Anna 20 Euro".
+This is the ONLY tool that fully executes money movement by voice.",
+        "name": "send_funds",
+        "parameters": {
+          "properties": {
+            "amount": {
+              "description": "Amount in major currency units, e.g. 20 for 20.00.",
+              "type": "number",
+            },
+            "confirm": {
+              "description": "true ONLY after the user explicitly confirmed the preview.",
+              "type": "boolean",
+            },
+            "currency": {
+              "description": "'EUR' or 'USD'. Omit if the user has only one wallet currency.",
+              "type": "string",
+            },
+            "recipient_name": {
+              "description": "Spoken name of who to send money to.",
+              "type": "string",
+            },
+            "recipient_user_id": {
+              "description": "Exact recipient UUID once resolved from a previous call.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error explaining there is no
+backing endpoint for payment requests. Do not imply this worked; tell
+the user to send a payment request from the Wallet or Messages screen.",
+        "name": "request_payment",
+        "parameters": {
+          "properties": {
+            "amount": {
+              "description": "Amount requested, major currency units.",
+              "type": "number",
+            },
+            "currency": {
+              "description": "'EUR' or 'USD'.",
+              "type": "string",
+            },
+            "description": {
+              "description": "What the request is for.",
+              "type": "string",
+            },
+            "recipient_name": {
+              "description": "Spoken name of who the request would go to.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error: the wallet has no
+cross-currency conversion RPC. Do not imply this worked.",
+        "name": "exchange_currency",
+        "parameters": {
+          "properties": {
+            "amount": {
+              "description": "Amount to exchange.",
+              "type": "number",
+            },
+            "confirm": {
+              "description": "Not used — the tool is unavailable.",
+              "type": "boolean",
+            },
+            "from_currency": {
+              "description": "Source currency, e.g. 'EUR'.",
+              "type": "string",
+            },
+            "to_currency": {
+              "description": "Target currency, e.g. 'USD'.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error: no exchange-rate
+table/RPC is wired into the gateway.",
+        "name": "get_exchange_rate",
+        "parameters": {
+          "properties": {
+            "from_currency": {
+              "description": "e.g. 'EUR'.",
+              "type": "string",
+            },
+            "to_currency": {
+              "description": "e.g. 'USD'.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error: the display-currency toggle
+is stored only in the browser, not on any server-side record.",
+        "name": "set_display_currency",
+        "parameters": {
+          "properties": {
+            "currency": {
+              "description": "'EUR' or 'USD'.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY: total referral rewards earned (confirmed) and pending, from
+the user's reward ledger.
+CALL WHEN the user asks: "how much have I earned from referrals",
+"was habe ich mit Empfehlungen verdient".",
+        "name": "get_referral_earnings",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY: commissions earned this calendar month — total, confirmed,
+and still-pending amounts.
+CALL WHEN the user asks: "what are my commissions this month",
+"wie viel Provision habe ich diesen Monat gemacht".",
+        "name": "get_commissions_summary",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "READ-ONLY: rewards awaiting merchant confirmation (not yet payable).
+CALL WHEN the user asks: "do I have any pending rewards",
+"was ist noch ausstehend bei meinen Prämien".",
+        "name": "get_pending_rewards",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "NOT YET AVAILABLE — always returns an error: payment requests have no
+structured table to list from.",
+        "name": "list_payment_requests",
+        "parameters": {
+          "properties": {
+            "direction": {
+              "description": "'incoming' or 'outgoing' — not used, tool is unavailable.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Send a text message to a group chat the user is a member of (not a 1-to-1 DM —
+use send_chat_message for that). ALWAYS call once WITHOUT confirmed first — the
+tool returns a preview; read it back and only call again with confirmed:true after
+explicit confirmation.
+CALL WHEN the user says: "message the running group", "tell everyone in Alle
+Beisammen ...", "schreib in die Gruppe ...".
+If several of the user's groups match, read the candidates and ask which one.",
+        "name": "send_group_chat_message",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY after the user confirmed the exact wording.",
+              "type": "boolean",
+            },
+            "group": {
+              "description": "Spoken group chat name (fuzzy matched among the user's own groups).",
+              "type": "string",
+            },
+            "group_id": {
+              "description": "Exact group UUID when already known.",
+              "type": "string",
+            },
+            "message": {
+              "description": "The message to send.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "message",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Reply to a specific earlier message. NOTE: Vitana chat has no reply/quote-thread
+feature yet — this tool always answers that it is unavailable. Relay that plainly
+and offer send_chat_message or send_group_chat_message instead, optionally quoting
+the original text inline in the new message.
+CALL WHEN the user says: "reply to that message", "antworte auf die Nachricht".",
+        "name": "reply_to_message",
+        "parameters": {
+          "properties": {
+            "message": {
+              "description": "The reply text the user wants to send.",
+              "type": "string",
+            },
+            "message_id": {
+              "description": "UUID of the message being replied to, if known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Add (or remove) an emoji reaction on a chat message — one of 👍 ❤️ 😂 😮 🙏 🎉 only.
+Requires message_id from a previous tool result (e.g. from list_conversations or a
+group message read-back).
+CALL WHEN the user says: "react with a heart to that", "give that a thumbs up",
+"reagiere mit einem Herz darauf".
+Set remove:true to take the reaction back off.",
+        "name": "react_to_message",
+        "parameters": {
+          "properties": {
+            "emoji": {
+              "description": "One of: 👍 ❤️ 😂 😮 🙏 🎉",
+              "type": "string",
+            },
+            "message_id": {
+              "description": "UUID of the message to react to.",
+              "type": "string",
+            },
+            "remove": {
+              "description": "Pass true to remove a reaction the user previously added.",
+              "type": "boolean",
+            },
+          },
+          "required": [
+            "message_id",
+            "emoji",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a new group chat, optionally adding named members immediately. ALWAYS call
+once WITHOUT confirm first — the tool returns a confirmation question; after the
+user says yes, call again with confirm:true.
+CALL WHEN the user says: "create a group chat called ...", "start a new chat with
+me, Anna and Ben", "erstelle einen Gruppenchat ...".",
+        "name": "create_group_chat",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the creation.",
+              "type": "boolean",
+            },
+            "description": {
+              "description": "Optional short description.",
+              "type": "string",
+            },
+            "members": {
+              "description": "Spoken names of members to add immediately (fuzzy resolved).",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "name": {
+              "description": "The group chat name.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Add a community member to a group chat the user already belongs to.
+CALL WHEN the user says: "add Anna to the running group chat", "füge Anna dem
+Gruppenchat hinzu".
+If several of the user's groups or several matching members are found, ask which one.",
+        "name": "add_group_chat_member",
+        "parameters": {
+          "properties": {
+            "group": {
+              "description": "Spoken group chat name (fuzzy matched among the user's own groups).",
+              "type": "string",
+            },
+            "group_id": {
+              "description": "Exact group UUID when already known.",
+              "type": "string",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the member to add.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Leave a group chat. ALWAYS call once WITHOUT confirm first — the tool returns a
+confirmation question; after the user says yes, call again with the group_id and
+confirm:true.
+CALL WHEN the user says: "leave the running group chat", "verlasse den Gruppenchat
+...".",
+        "name": "leave_group_chat",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed leaving.",
+              "type": "boolean",
+            },
+            "group": {
+              "description": "Spoken group chat name (fuzzy matched among the user's own groups).",
+              "type": "string",
+            },
+            "group_id": {
+              "description": "Exact group UUID when already known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Share one of the user's own upcoming calendar events with a community member via
+direct message. ALWAYS call once WITHOUT confirmed first — the tool returns a
+preview; after explicit confirmation call again with confirmed:true.
+CALL WHEN the user says: "send Anna the invite for my yoga session", "share my
+appointment with Ben", "schick Anna die Einladung zu meinem Termin".
+If several events or member matches are found, ask which one.",
+        "name": "send_calendar_invite_in_chat",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY after the user explicitly confirmed sending.",
+              "type": "boolean",
+            },
+            "event": {
+              "description": "Spoken event title (fuzzy matched against the user's own upcoming events).",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact calendar_events UUID when already known.",
+              "type": "string",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the recipient.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the recipient if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Send another community member a request to start a voice call. IMPORTANT: Vitana
+cannot place a live call from voice — calling only works client-side between two
+open apps. This tool sends a chat message + notification asking them to open the
+app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again
+with confirmed:true after explicit confirmation.
+CALL WHEN the user says: "call Anna", "start a voice call with Ben", "ruf Anna an".
+Afterwards, tell the user the request was sent and real-time calling needs both
+people in the app.",
+        "name": "start_voice_call",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY after the user explicitly confirmed sending the request.",
+              "type": "boolean",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the person to call.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Send another community member a request to start a video call. IMPORTANT: Vitana
+cannot place a live call from voice — calling only works client-side between two
+open apps. This tool sends a chat message + notification asking them to open the
+app; it never connects a call. ALWAYS call once WITHOUT confirmed first, then again
+with confirmed:true after explicit confirmation.
+CALL WHEN the user says: "video call Anna", "start a video chat with Ben", "starte
+einen Videoanruf mit Anna".
+Afterwards, tell the user the request was sent and real-time calling needs both
+people in the app.",
+        "name": "start_video_call",
+        "parameters": {
+          "properties": {
+            "confirmed": {
+              "description": "Pass true ONLY after the user explicitly confirmed sending the request.",
+              "type": "boolean",
+            },
+            "member": {
+              "description": "Spoken name or Vitana ID of the person to video call.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "UUID of the member if already resolved.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a new ticketed/community event. Requires a title and start_time.
+ALWAYS call once WITHOUT confirm first — the tool returns a
+confirmation question; after the user says yes, call again with
+confirm:true.
+CALL WHEN the user says: "create an event called ...", "schedule a new
+event", "erstelle ein Event ...", "plane eine neue Veranstaltung".",
+        "name": "create_event",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the creation.",
+              "type": "boolean",
+            },
+            "description": {
+              "description": "Optional short event description.",
+              "type": "string",
+            },
+            "end_time": {
+              "description": "Optional ISO date/time the event ends.",
+              "type": "string",
+            },
+            "image_url": {
+              "description": "Optional cover image URL.",
+              "type": "string",
+            },
+            "location": {
+              "description": "Optional physical location.",
+              "type": "string",
+            },
+            "max_participants": {
+              "description": "Optional capacity cap.",
+              "type": "number",
+            },
+            "start_time": {
+              "description": "ISO date/time the event starts. Required.",
+              "type": "string",
+            },
+            "title": {
+              "description": "The event title.",
+              "type": "string",
+            },
+            "virtual_link": {
+              "description": "Optional virtual/streaming link.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "title",
+            "start_time",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Edit one of the user's own upcoming events (title, description,
+location, virtual_link, start_time, end_time, max_participants,
+image_url). Only the creator can edit, and only before it starts.
+CALL WHEN the user says: "change the time of my event ...", "update my
+event description", "ändere mein Event ...".",
+        "name": "update_my_event",
+        "parameters": {
+          "properties": {
+            "description": {
+              "description": "New description, if changing it.",
+              "type": "string",
+            },
+            "end_time": {
+              "description": "New ISO end_time, if changing it.",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "image_url": {
+              "description": "New cover image URL, if changing it.",
+              "type": "string",
+            },
+            "location": {
+              "description": "New location, if changing it.",
+              "type": "string",
+            },
+            "max_participants": {
+              "description": "New capacity cap, if changing it.",
+              "type": "number",
+            },
+            "query": {
+              "description": "Spoken title of the user's event (fuzzy matched).",
+              "type": "string",
+            },
+            "start_time": {
+              "description": "New ISO start_time, if changing it.",
+              "type": "string",
+            },
+            "title": {
+              "description": "New title, if changing it.",
+              "type": "string",
+            },
+            "virtual_link": {
+              "description": "New virtual link, if changing it.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Cancel (delete) one of the user's own upcoming events. ALWAYS call
+once WITHOUT confirm first — the tool returns a confirmation question;
+after the user says yes, call again with the event_id and confirm:true.
+CALL WHEN the user says: "cancel my event", "delete the ... event",
+"sage mein Event ... ab".",
+        "name": "cancel_my_event",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the cancellation.",
+              "type": "boolean",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken title of the user's event (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a new casual community meetup (lighter-weight than a ticketed
+event). Requires a title and start_time. ALWAYS call once WITHOUT
+confirm first — the tool returns a confirmation question; after the
+user says yes, call again with confirm:true.
+CALL WHEN the user says: "create a meetup for ...", "start a walking
+meetup", "erstelle ein Meetup für ...".",
+        "name": "create_meetup",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the creation.",
+              "type": "boolean",
+            },
+            "description": {
+              "description": "Optional short meetup description.",
+              "type": "string",
+            },
+            "end_time": {
+              "description": "Optional ISO date/time the meetup ends.",
+              "type": "string",
+            },
+            "image_url": {
+              "description": "Optional cover image URL.",
+              "type": "string",
+            },
+            "location": {
+              "description": "Optional physical location.",
+              "type": "string",
+            },
+            "max_participants": {
+              "description": "Optional capacity cap.",
+              "type": "number",
+            },
+            "start_time": {
+              "description": "ISO date/time the meetup starts. Required.",
+              "type": "string",
+            },
+            "title": {
+              "description": "The meetup title.",
+              "type": "string",
+            },
+            "virtual_link": {
+              "description": "Optional virtual/streaming link.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "title",
+            "start_time",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Edit one of the user's own upcoming meetups (title, description,
+location, virtual_link, start_time, end_time, max_participants,
+image_url). Only the creator can edit, and only before it starts.
+CALL WHEN the user says: "change my meetup time", "update the hiking
+meetup details", "ändere mein Meetup ...".",
+        "name": "update_my_meetup",
+        "parameters": {
+          "properties": {
+            "description": {
+              "description": "New description, if changing it.",
+              "type": "string",
+            },
+            "end_time": {
+              "description": "New ISO end_time, if changing it.",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact meetup UUID when known from a previous tool result.",
+              "type": "string",
+            },
+            "image_url": {
+              "description": "New cover image URL, if changing it.",
+              "type": "string",
+            },
+            "location": {
+              "description": "New location, if changing it.",
+              "type": "string",
+            },
+            "max_participants": {
+              "description": "New capacity cap, if changing it.",
+              "type": "number",
+            },
+            "query": {
+              "description": "Spoken title of the user's meetup (fuzzy matched).",
+              "type": "string",
+            },
+            "start_time": {
+              "description": "New ISO start_time, if changing it.",
+              "type": "string",
+            },
+            "title": {
+              "description": "New title, if changing it.",
+              "type": "string",
+            },
+            "virtual_link": {
+              "description": "New virtual link, if changing it.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Invite a community member to an event or meetup by spoken name. The
+member gets a pending invite on the event.
+CALL WHEN the user says: "invite Anna to my yoga meetup", "ask Ben to
+come to the event", "lade Anna zu meinem Event ... ein".
+If the tool lists several event or member candidates, ask which one.",
+        "name": "invite_to_event",
+        "parameters": {
+          "properties": {
+            "event": {
+              "description": "Spoken event/meetup title (fuzzy matched against upcoming events).",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "member_name": {
+              "description": "Spoken name of the member to invite.",
+              "type": "string",
+            },
+            "member_user_id": {
+              "description": "Exact user UUID when known from a previous tool result.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Buy a ticket for an event. Checks ticket availability and price, then
+ALWAYS call once WITHOUT confirm first — the tool returns a price
+confirmation question; after the user says yes, call again with
+confirm:true. Even after confirming, payment is completed on the
+user's screen — this tool never charges a card by voice; it prepares
+the purchase and opens the ticket screen.
+CALL WHEN the user says: "buy a ticket for ...", "I want two tickets to
+the gala", "kauf mir ein Ticket für ...".",
+        "name": "buy_event_ticket",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the price and purchase.",
+              "type": "boolean",
+            },
+            "event": {
+              "description": "Spoken event title (fuzzy matched against upcoming events).",
+              "type": "string",
+            },
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "quantity": {
+              "description": "How many tickets to buy. Defaults to 1.",
+              "type": "number",
+            },
+            "ticket_name": {
+              "description": "Spoken ticket tier name (e.g. "VIP", "General Admission").",
+              "type": "string",
+            },
+            "ticket_type_id": {
+              "description": "Exact ticket type UUID when known.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's own purchased (completed) event tickets.
+CALL WHEN the user asks: "what tickets do I have?", "show my event
+tickets", "welche Tickets habe ich?".",
+        "name": "list_my_event_tickets",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get a shareable public link for an event or meetup (works even for
+people who aren't logged in). Does not send anything itself — just
+returns the link for the user to share however they like.
+CALL WHEN the user says: "share the yoga meetup", "get me a link for
+that event", "gib mir einen Link für das Event ...".",
+        "name": "share_event",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken event/meetup title (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List who has RSVP'd to one of the user's OWN events (organizer view
+only — the user must be the creator).
+CALL WHEN the user asks: "who's coming to my event?", "how many people
+signed up for my meetup?", "wer kommt zu meinem Event?".",
+        "name": "get_event_attendees",
+        "parameters": {
+          "properties": {
+            "event_id": {
+              "description": "Exact event UUID when known.",
+              "type": "string",
+            },
+            "query": {
+              "description": "Spoken title of the user's event (fuzzy matched).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Log a meal (breakfast/lunch/dinner/snack) toward the nutrition pillar.
+CALL WHEN the user says: "I just had breakfast", "log my lunch",
+"ich habe gerade gegessen", "trage mein Mittagessen ein".",
+        "name": "log_meal",
+        "parameters": {
+          "properties": {
+            "calories": {
+              "description": "Optional estimated calories.",
+              "type": "number",
+            },
+            "date": {
+              "description": "YYYY-MM-DD, defaults to today.",
+              "type": "string",
+            },
+            "description": {
+              "description": "What was eaten, e.g. "oatmeal with berries".",
+              "type": "string",
+            },
+            "meal_type": {
+              "description": "One of breakfast, lunch, dinner, snack.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Log vitals: heart rate, weight, and/or blood pressure. Pass any subset.
+Heart rate contributes to the Vitana Index exercise pillar; weight and
+blood pressure are recorded but do not currently move the Index.
+CALL WHEN the user says: "my heart rate is 68", "I weigh 74 kilos",
+"my blood pressure is 120 over 80", "meine Herzfrequenz ist ...".",
+        "name": "log_vitals",
+        "parameters": {
+          "properties": {
+            "date": {
+              "description": "YYYY-MM-DD, defaults to today.",
+              "type": "string",
+            },
+            "diastolic": {
+              "description": "Diastolic blood pressure (mmHg).",
+              "type": "number",
+            },
+            "heart_rate": {
+              "description": "Heart rate in bpm.",
+              "type": "number",
+            },
+            "systolic": {
+              "description": "Systolic blood pressure (mmHg).",
+              "type": "number",
+            },
+            "weight_kg": {
+              "description": "Body weight in kilograms.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Log a mental-health / mood check-in (1-5 scale, or a mood word).
+CALL WHEN the user says: "I feel great today", "log my mood as okay",
+"ich fühle mich heute gut".",
+        "name": "log_mood",
+        "parameters": {
+          "properties": {
+            "date": {
+              "description": "YYYY-MM-DD, defaults to today.",
+              "type": "string",
+            },
+            "mood_label": {
+              "description": "A word like 'great', 'okay', 'down' — used if mood_score is omitted.",
+              "type": "string",
+            },
+            "mood_score": {
+              "description": "1 (terrible) to 5 (fantastic).",
+              "type": "number",
+            },
+            "notes": {
+              "description": "Optional short note about why.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Record a single lab/biomarker value the user reports out loud (e.g. from
+a home test or a doctor visit), creating a lab report entry.
+CALL WHEN the user says: "my glucose was 95", "my cholesterol came back
+at 180", "mein Blutzucker war 95".",
+        "name": "log_biomarker",
+        "parameters": {
+          "properties": {
+            "biomarker_code": {
+              "description": "Optional code, e.g. 'HBA1C'.",
+              "type": "string",
+            },
+            "measured_at": {
+              "description": "Optional ISO timestamp; defaults to now.",
+              "type": "string",
+            },
+            "name": {
+              "description": "Biomarker name, e.g. 'glucose', 'LDL cholesterol'.",
+              "type": "string",
+            },
+            "ref_range_high": {
+              "description": "Optional reference range high.",
+              "type": "number",
+            },
+            "ref_range_low": {
+              "description": "Optional reference range low.",
+              "type": "number",
+            },
+            "status": {
+              "description": "Optional: 'low'|'normal'|'high'|'critical' — inferred from range if omitted.",
+              "type": "string",
+            },
+            "unit": {
+              "description": "Unit, e.g. 'mg/dL'.",
+              "type": "string",
+            },
+            "value": {
+              "description": "The measured value.",
+              "type": "number",
+            },
+          },
+          "required": [
+            "name",
+            "value",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the Vitana Index trend (total + per-pillar) over a recent window.
+CALL WHEN the user asks: "how have I been trending?", "am I improving?",
+"wie hat sich mein Index entwickelt?".",
+        "name": "get_health_trends",
+        "parameters": {
+          "properties": {
+            "days": {
+              "description": "Window size in days, default 14, max 90.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the user's diary streak and per-pillar Vitana Index streaks.
+CALL WHEN the user asks: "what's my streak?", "am I on a streak?",
+"wie lange ist meine Serie schon?".",
+        "name": "get_health_streaks",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Order a lab test. NOT AVAILABLE YET — always returns an error explaining there is no ordering backend; tell the user this feature is not live yet.",
+        "name": "order_lab_test",
+        "parameters": {
+          "properties": {
+            "test_name": {
+              "description": "Name of the test requested.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's recorded lab/biomarker results, most recent first.
+CALL WHEN the user asks: "what were my last lab results?", "what's my
+cholesterol?", "wie waren meine letzten Laborwerte?".",
+        "name": "get_lab_results",
+        "parameters": {
+          "properties": {
+            "biomarker": {
+              "description": "Optional biomarker name/code to filter by.",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max results, default 10.",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Create a starter health plan (template-based, not AI-personalized) for a
+pillar. ALWAYS call once WITHOUT confirm first — the tool returns a
+preview; after the user agrees, call again with confirm:true.
+CALL WHEN the user says: "make me a nutrition plan", "erstelle einen
+Ernährungsplan für mich".",
+        "name": "generate_health_plan",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed creating the plan.",
+              "type": "boolean",
+            },
+            "plan_type": {
+              "description": "One of nutrition, hydration, exercise, sleep, mental. Defaults to the weakest pillar.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's active health plans with adherence scores. CALL WHEN the user asks: "what plans do I have?", "welche Pläne habe ich?".",
+        "name": "list_my_health_plans",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get adherence/progress for a specific active health plan.
+CALL WHEN the user asks: "how's my plan going?", "am I keeping up with
+my sleep plan?", "wie läuft mein Plan?".",
+        "name": "get_health_plan_progress",
+        "parameters": {
+          "properties": {
+            "plan_id": {
+              "description": "Exact plan UUID if known.",
+              "type": "string",
+            },
+            "plan_type": {
+              "description": "One of nutrition, hydration, exercise, sleep, mental.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "List the user's recorded health conditions, allergies, medications, and
+dietary restrictions.
+CALL WHEN the user asks: "what conditions do I have on file?", "what
+are my allergies?", "welche Erkrankungen habe ich hinterlegt?".",
+        "name": "list_my_conditions",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get grounded educational content on a health/longevity topic from the
+knowledge hub.
+CALL WHEN the user asks: "tell me about HRV", "what is VO2 max?",
+"erkläre mir was Schlafqualität bedeutet".",
+        "name": "get_health_education",
+        "parameters": {
+          "properties": {
+            "topic": {
+              "description": "The health topic to explain.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "topic",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get today's single highest-priority recommended health action.
+CALL WHEN the user asks: "what should I do today?", "what's my next
+step?", "was soll ich heute für meine Gesundheit tun?".
+If the result has an autopilot id, offer to call activate_recommendation.",
+        "name": "get_next_best_action",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Start pairing a wearable/health device. Opens the health tracker screen
+where device connections are managed (pairing itself is a native/client flow).
+CALL WHEN the user says: "connect my Oura ring", "pair my device",
+"verbinde mein Gerät".",
+        "name": "connect_health_device",
+        "parameters": {
+          "properties": {
+            "device_name": {
+              "description": "Optional device name, e.g. "Oura Ring".",
+              "type": "string",
+            },
+          },
+          "required": [],
           "type": "object",
         },
       },

--- a/services/gateway/test/wave1-voice-tools-flow.test.ts
+++ b/services/gateway/test/wave1-voice-tools-flow.test.ts
@@ -1,0 +1,197 @@
+/**
+ * VOICE-CATALOG-WAVE-1 — conversation-flow tests for the 6 new domain modules
+ * wired into orb-tools-shared.ts (marketplace, cart/checkout, wallet/payments,
+ * messaging depth, events/tickets, health depth). Pins the invariants that
+ * matter most for a voice assistant that can move money and charge cards:
+ *
+ *  1. Every one of the 69 Wave 1 tools is reachable via the shared dispatcher.
+ *  2. send_funds — the only tool allowed to execute real money movement by
+ *     voice — requires an explicit confirm:true turn before it moves a cent,
+ *     and never credits the recipient if the debit leg fails.
+ *  3. start_checkout never calls a wallet/payment primitive — it only
+ *     validates and hands off to the screen (payment policy).
+ *  4. A tool with no real backing returns an honest ok:false rather than a
+ *     fabricated success.
+ */
+import {
+  dispatchOrbTool,
+  ORB_TOOL_NAMES,
+  type OrbToolIdentity,
+} from '../src/services/orb-tools-shared';
+
+const ID: OrbToolIdentity = { user_id: 'u-sender', tenant_id: 't-1', role: 'community' };
+
+const WAVE1_TOOL_NAMES = [
+  'search_marketplace', 'get_product_details', 'browse_supplements', 'add_supplement_to_regimen',
+  'list_my_supplements', 'remove_supplement_from_regimen', 'browse_wellness_services', 'get_provider_profile',
+  'browse_doctors_coaches', 'get_coach_compatibility', 'browse_deals_offers', 'apply_discount_code',
+  'get_ai_product_picks', 'list_my_orders', 'get_order_status', 'reorder_last_order',
+  'add_to_cart', 'view_cart', 'update_cart_item', 'remove_from_cart', 'clear_cart',
+  'set_shopping_budget', 'review_agent_purchase_proposals', 'start_checkout',
+  'get_wallet_summary', 'list_wallet_transactions', 'send_funds', 'request_payment',
+  'exchange_currency', 'get_exchange_rate', 'set_display_currency', 'get_referral_earnings',
+  'get_commissions_summary', 'get_pending_rewards', 'list_payment_requests',
+  'send_group_chat_message', 'reply_to_message', 'react_to_message', 'create_group_chat',
+  'add_group_chat_member', 'leave_group_chat', 'send_calendar_invite_in_chat', 'start_voice_call',
+  'start_video_call', 'create_event', 'update_my_event', 'cancel_my_event', 'create_meetup',
+  'update_my_meetup', 'invite_to_event', 'buy_event_ticket', 'list_my_event_tickets', 'share_event',
+  'get_event_attendees', 'log_meal', 'log_vitals', 'log_mood', 'log_biomarker', 'get_health_trends',
+  'get_health_streaks', 'order_lab_test', 'get_lab_results', 'generate_health_plan',
+  'list_my_health_plans', 'get_health_plan_progress', 'list_my_conditions', 'get_health_education',
+  'get_next_best_action', 'connect_health_device',
+];
+
+test('all 69 Wave 1 tools are registered in the shared dispatcher', () => {
+  expect(WAVE1_TOOL_NAMES).toHaveLength(69);
+  for (const name of WAVE1_TOOL_NAMES) {
+    expect(ORB_TOOL_NAMES).toContain(name);
+  }
+});
+
+test('an unbacked tool (apply_discount_code) is honest, not fabricated', async () => {
+  const sb: any = {};
+  const r: any = await dispatchOrbTool('apply_discount_code', { code: 'SAVE10' }, ID, sb);
+  expect(r.ok).toBe(false);
+  expect(typeof r.error).toBe('string');
+  expect(r.error.length).toBeGreaterThan(0);
+});
+
+const RECIPIENT_UUID = '11111111-1111-1111-1111-111111111111';
+
+describe('send_funds — the only voice tool allowed to move real money', () => {
+  const senderAccount = { id: 'acct-sender', user_id: 'u-sender', currency: 'EUR', balance_minor: 5000, status: 'active' };
+  const recipientRow = { user_id: RECIPIENT_UUID, display_name: 'Alex', vitana_id: 'alex1' };
+
+  function makeSb(overrides: { debitOk: boolean; creditOk?: boolean }) {
+    const from = jest.fn((table: string) => {
+      if (table === 'app_users') {
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: recipientRow, error: null }) }) }),
+        };
+      }
+      throw new Error(`unexpected table in this test: ${table}`);
+    });
+    const rpc = jest.fn((fn: string) => {
+      if (fn === 'resolve_recipient_candidates') {
+        return Promise.resolve({
+          data: [{ user_id: RECIPIENT_UUID, vitana_id: 'alex1', display_name: 'Alex', score: 0.97 }],
+          error: null,
+        });
+      }
+      throw new Error(`unexpected rpc in this test: ${fn}`);
+    });
+    return { from, rpc } as any;
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('first call (no confirm) previews and moves nothing', async () => {
+    jest.doMock('../src/services/wallet/balance-service', () => ({
+      getAccountsForUser: jest.fn().mockResolvedValue([senderAccount]),
+    }));
+    const debitWalletForSpend = jest.fn();
+    const creditWalletForEarning = jest.fn();
+    jest.doMock('../src/services/wallet/spend-earning-service', () => ({ debitWalletForSpend, creditWalletForEarning }));
+
+    const { dispatchOrbTool: dispatch } = require('../src/services/orb-tools-shared');
+    const sb = makeSb({ debitOk: true });
+    const r: any = await dispatch('send_funds', { amount: 25, recipient_name: 'Alex' }, ID, sb);
+
+    expect(r.ok).toBe(true);
+    expect(r.result.requires_confirmation).toBe(true);
+    expect(r.result.recipient_user_id).toBe(RECIPIENT_UUID);
+    expect(debitWalletForSpend).not.toHaveBeenCalled();
+    expect(creditWalletForEarning).not.toHaveBeenCalled();
+  });
+
+  test('confirm:true executes debit then credit with a shared reference_id', async () => {
+    jest.doMock('../src/services/wallet/balance-service', () => ({
+      getAccountsForUser: jest.fn()
+        .mockResolvedValueOnce([senderAccount]) // sender
+        .mockResolvedValueOnce([{ id: 'acct-recipient', user_id: RECIPIENT_UUID, currency: 'EUR', balance_minor: 0, status: 'active' }]), // recipient
+    }));
+    const debitWalletForSpend = jest.fn().mockResolvedValue({ ok: true, duplicate: false, balance_minor: 2500, currency: 'EUR' });
+    const creditWalletForEarning = jest.fn().mockResolvedValue({ ok: true, duplicate: false, balance_minor: 2500, currency: 'EUR' });
+    jest.doMock('../src/services/wallet/spend-earning-service', () => ({ debitWalletForSpend, creditWalletForEarning }));
+
+    const { dispatchOrbTool: dispatch } = require('../src/services/orb-tools-shared');
+    const sb = makeSb({ debitOk: true, creditOk: true });
+    const r: any = await dispatch(
+      'send_funds',
+      { amount: 25, recipient_user_id: RECIPIENT_UUID, currency: 'EUR', confirm: true },
+      ID,
+      sb,
+    );
+
+    expect(r.ok).toBe(true);
+    expect(debitWalletForSpend).toHaveBeenCalledTimes(1);
+    expect(creditWalletForEarning).toHaveBeenCalledTimes(1);
+    const debitArgs = debitWalletForSpend.mock.calls[0][0];
+    const creditArgs = creditWalletForEarning.mock.calls[0][0];
+    expect(debitArgs.reference_id).toBe(creditArgs.reference_id);
+    expect(debitArgs.account_id).toBe('acct-sender');
+    expect(creditArgs.account_id).toBe('acct-recipient');
+  });
+
+  test('debit failure (insufficient balance) never calls credit — no money vanishes', async () => {
+    jest.doMock('../src/services/wallet/balance-service', () => ({
+      getAccountsForUser: jest.fn().mockResolvedValue([senderAccount]),
+    }));
+    const debitWalletForSpend = jest.fn().mockResolvedValue({ ok: false, error: 'INSUFFICIENT_BALANCE', balance_minor: 500 });
+    const creditWalletForEarning = jest.fn();
+    jest.doMock('../src/services/wallet/spend-earning-service', () => ({ debitWalletForSpend, creditWalletForEarning }));
+
+    const { dispatchOrbTool: dispatch } = require('../src/services/orb-tools-shared');
+    const sb = makeSb({ debitOk: false });
+    const r: any = await dispatch(
+      'send_funds',
+      { amount: 25, recipient_user_id: RECIPIENT_UUID, currency: 'EUR', confirm: true },
+      ID,
+      sb,
+    );
+
+    expect(r.ok).toBe(true);
+    expect(r.result.sent).toBe(false);
+    expect(r.result.error_code).toBe('INSUFFICIENT_BALANCE');
+    expect(creditWalletForEarning).not.toHaveBeenCalled();
+  });
+});
+
+describe('start_checkout — payment policy: never charges by voice', () => {
+  function chainable(result: any) {
+    const obj: any = {
+      select: () => obj,
+      eq: () => obj,
+      order: () => obj,
+      in: () => obj,
+      maybeSingle: () => Promise.resolve(result),
+      then: (resolve: any) => resolve(result),
+    };
+    return obj;
+  }
+
+  test('confirm:true returns a navigate directive, never a debit/checkout call', async () => {
+    const cart = { id: 'cart-1', user_id: ID.user_id, tenant_id: 't-1', status: 'active' };
+    const items = [{ id: 'item-1', cart_id: 'cart-1', product_id: 'p-1', quantity: 1, unit_price_cents: 1999, status: 'active' }];
+    const products = [{ id: 'p-1', title: 'Omega-3', price_cents: 1999, currency: 'EUR' }];
+
+    const sb: any = {
+      from: (table: string) => {
+        if (table === 'universal_carts') return chainable({ data: cart, error: null });
+        if (table === 'universal_cart_items') return chainable({ data: items, error: null });
+        if (table === 'products') return chainable({ data: products, error: null });
+        throw new Error(`unexpected table: ${table}`);
+      },
+    };
+
+    const r: any = await dispatchOrbTool('start_checkout', { confirm: true }, ID, sb);
+    expect(r.ok).toBe(true);
+    expect(r.result.started).toBe(true);
+    expect(r.result.directive).toBeDefined();
+    expect(r.result.directive.directive).toBe('navigate');
+    // No wallet/payment field anywhere in the response — confirms nothing was charged.
+    expect(JSON.stringify(r.result)).not.toMatch(/debit|charge|stripe/i);
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VOICE-CATALOG-WAVE-1`

**Layer:** Voice tools (Vertex + LiveKit shared registry)

**Priority:** P0

---

## 📋 Summary

Wave 1 of the approved **Voice Tools Expansion Plan v2** (`docs/VOICE_TOOLS_EXPANSION_PLAN.md`, merged in #2870): the 69 community P0 tools — the domains users ask for daily: buy, pay, send, book, log. All 69 flip from `status: planned` to `status: live` in `tool-manifest.json` (169 → 238 live tools).

| Domain | Tools | Real | Stubbed |
|---|---|---|---|
| Marketplace & Discovery | 16 | 11 | 5 |
| Cart & Checkout | 8 | 8 | 0 |
| Wallet & Payments | 11 | 7 | 4 |
| Messaging depth | 9 | 8 (2 partial) | 1 |
| Events & Tickets | 10 | 10 | 0 |
| Health depth | 15 | 14 (1 navigate-only) | 1 |
| **Total** | **69** | **57 real** | **12 stubbed** |

**Every handler was built against a verified, real backing table/route/service — never a guessed schema.** Where no real backing exists anywhere in the codebase (12 verbs — e.g. the personal supplement regimen and discount-code tables are explicitly out-of-scope "ghost tables" per VTID-03176; no reply-to-message parent column; no lab-test-ordering table), the handler returns an honest `{ ok: false, error: '... not available yet' }` instead of fabricating data, each documented in-file.

### Highlights
- **`send_funds`** — the only tool allowed to execute real money movement by voice (internal user-to-user transfers only, per approved policy). Composes the existing RPC-backed `debitWalletForSpend` + `creditWalletForEarning` primitives with a shared reference id, and auto-compensates with a refund credit if the debit succeeds but the credit leg fails.
- **Payment policy enforced**: every card/Stripe-charging tool (`start_checkout`, `buy_event_ticket`) validates and prepares, then hands off to the screen via an `orb_directive: navigate` — never completes a card charge by voice.
- **`start_voice_call`/`start_video_call`** — verified calling is 100% client-side WebRTC with no backend call/session table, so these send a real call-invite chat message rather than pretending to place a call.
- **`buy_event_ticket`** deliberately does not insert a ticket-purchase row itself — that table's `qr_code_token`/`stripe_session_id` can only be correctly minted by the real Stripe ticket-checkout edge function.

## ✅ Changes

- 6 new handler modules in `services/gateway/src/services/orb-tools/`: `marketplace-discovery-tools.ts`, `cart-checkout-tools.ts`, `wallet-payments-tools.ts`, `messaging-depth-tools.ts`, `events-tickets-tools.ts`, `health-depth-tools.ts`
- `orb-tools-shared.ts` — wired into `ORB_TOOL_REGISTRY` / `NEW_DOMAIN_TOOL_DECLARATIONS` (both pipelines dispatch through the same handlers)
- `tools.py` — 69 new `@function_tool` LiveKit wrappers, parameter names verified character-for-character against each TS declaration via a brace-depth-aware cross-checker (guards against the VTID-01983 pillar/target_pillar bug class)
- `tool-manifest.json` — reconciled via `scripts/voice-tools-manifest-reconcile.mjs --apply`
- Updated 2 characterization snapshots (pure additions, 0 removed — no existing tool's schema/instructions changed)

## 🧪 Testing

- [x] `npx tsc --noEmit` (gateway) — clean
- [x] `python3 -m py_compile tools.py` — clean; `all_tool_names()` returns 216 (147 + 69 new), zero duplicates
- [x] `node scripts/voice-tools-manifest-reconcile.mjs --check` — ✅ zero drift
- [x] `ORB_TOOLS_PARITY_GATE=1 node scripts/orb-tools-lift-scanner.mjs` — exit 0, no drift (the hard CI gate)
- [x] Gateway jest: 429/430 suites green — the 1 failure (`nav-manifest-sync`) confirmed **pre-existing** via git-stash baseline comparison, unrelated to this PR
- [x] orb-agent pytest: 134 passed / 25 failed — byte-identical failure set to the stashed baseline (confirmed via git stash), zero new regressions

## 🚨 Breaking Changes

None. Purely additive — no existing tool's handler, schema, or dispatch path changed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX)_