### PR TITLE
fix(orb): recommendation follow-ups and diary nudges lose context

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -1285,6 +1285,17 @@ M. DIARY LOGGING IS A TOOL CALL, NOT A NAVIGATION. (VTID-01983)
    screen and stop. Do NOT say "I'll open the diary for you" — actually
    save the entry.
 
+   EXCEPTION — bare consent is NOT content. If you (Vitana) just offered
+   to help with a diary entry (e.g. "haven't logged in a week, want help
+   today?") and the user's reply is ONLY an acceptance — "yes" / "ja" /
+   "help me" / "hilf mir" / "okay" / "sure" / "gerne" — with no actual
+   report of what happened, do NOT call save_diary_entry yet. There is
+   nothing to log. Ask one short follow-up question first (e.g. "What
+   would you like to log for today?" / "Was möchtest du eintragen — wie
+   war dein Tag?"), then call save_diary_entry once the user answers with
+   real content. Never fabricate content on the user's behalf and never
+   claim an entry was created before it actually contains their words.
+
    IMPORTANT: pass the user's VERBATIM words as raw_text. The pattern
    extractor needs the original phrasing ("1 L of water", "two glasses",
    "Frühstück und Mittagessen") to catch every signal. Do NOT summarise.

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -4084,6 +4084,15 @@ async function tool_get_pillar_subscores(
 //   5) compute per-pillar delta
 //   6) celebrate diary streak (non-blocking)
 // ---------------------------------------------------------------------------
+
+// Bare acceptance of a "want help logging?" nudge, in the languages the
+// diary nudge/CTA is rendered in — DE and EN. Matches the WHOLE trimmed
+// string (optionally followed by punctuation) so real diary content that
+// happens to start with "yes" or "ja" ("Ja, ich habe heute 2L Wasser
+// getrunken") is never caught by this — only a standalone consent phrase.
+const BARE_CONSENT_RX =
+  /^(ja|okay?|klar|gerne|sicher|yes|sure|help me|hilf mir|ja,? hilf mir|yes,? help me|ja bitte|yes please)[.!,]*$/i;
+
 export async function tool_save_diary_entry(
   args: OrbToolArgs,
   identity: OrbToolIdentity,
@@ -4095,6 +4104,19 @@ export async function tool_save_diary_entry(
   }
   if (!identity.user_id) {
     return { ok: false, error: 'user_id is required' };
+  }
+  // DEV-COMHU-0505-follow-up: a bare acceptance of a diary nudge ("ja",
+  // "hilf mir", "yes", "okay") is not diary content — it's consent to be
+  // asked what to log. Without this the model could (and did) pass the
+  // user's own "yes, help me" straight through as raw_text, fabricating a
+  // persisted diary entry with no real content. Reject it here as a
+  // backstop regardless of what the live prompt does upstream.
+  if (BARE_CONSENT_RX.test(rawText)) {
+    return {
+      ok: true,
+      result: { needs_content: true },
+      text: 'That was just an acceptance, not diary content. Ask the user what they would like to log for today, then call save_diary_entry again with their actual words.',
+    };
   }
 
   const argDate = typeof args.entry_date === 'string' ? args.entry_date : undefined;

--- a/services/gateway/src/services/orb-tools/discovery-tools.ts
+++ b/services/gateway/src/services/orb-tools/discovery-tools.ts
@@ -487,6 +487,47 @@ async function resolveRecommendation(
   statuses: string[] | null,
   toolName: string,
 ): Promise<RecResolution> {
+  // No spoken reference — the user is likely reacting to the recommendation
+  // Vitana just offered (e.g. declined "activate?" but asked to hear more,
+  // or said "snooze/dismiss it" without naming it). That offer's id is the
+  // pending CTA persisted by wake-brief-wiring into orb_session_state (same
+  // fallback tool_activate_recommendation already uses below — see
+  // orb-tools-shared.ts). Without this, every such follow-up fell through to
+  // the broad "several recommendations match" ambiguity branch further down,
+  // even when there was only ever one specific recommendation on the table.
+  if (!ref && id.user_id) {
+    try {
+      const { readOrbSessionState } = await import('../orb/orb-session-state');
+      const pending = await readOrbSessionState<{ tool?: string; payload?: { id?: string } }>(
+        sb,
+        id.user_id,
+        'pending_cta',
+      );
+      const pendingId =
+        pending &&
+        pending.value &&
+        pending.value.tool === 'activate_recommendation' &&
+        typeof pending.value.payload?.id === 'string'
+          ? pending.value.payload.id.trim()
+          : '';
+      if (pendingId) {
+        const { data, error } = await sb
+          .from('autopilot_recommendations')
+          .select('*')
+          .eq('id', pendingId)
+          .maybeSingle();
+        const rec = !error ? (data as RecRow | null) : null;
+        if (rec && (!rec.user_id || rec.user_id === id.user_id)) {
+          return { ok: true, rec };
+        }
+        // Pending CTA is stale/inaccessible — fall through to the normal
+        // resolution below rather than failing outright.
+      }
+    } catch {
+      // Best-effort fallback only; fall through to normal resolution.
+    }
+  }
+
   if (UUID_RX.test(ref)) {
     const { data, error } = await sb
       .from('autopilot_recommendations')

--- a/services/gateway/test/orb-tools/discovery-tools.test.ts
+++ b/services/gateway/test/orb-tools/discovery-tools.test.ts
@@ -452,6 +452,49 @@ describe('explain_recommendation', () => {
     const res = await tool_explain_recommendation({ recommendation: UUID }, ANON, sb);
     expect(res.ok).toBe(false);
   });
+
+  // REGRESSION: "describe what you mean" / "show me" after declining the
+  // spoken "should I activate it?" offer used to fall through to the broad
+  // "several recommendations match" search (no name to filter by) and ask
+  // the user to disambiguate among unrelated rows — even though there was
+  // only ever ONE specific recommendation on the table. It should instead
+  // resolve straight to the pending CTA's id, same fallback
+  // tool_activate_recommendation already uses for a bare "yes".
+  it('falls back to the pending CTA id when asked about "it" with no name given', async () => {
+    const { sb } = makeSb({
+      orb_session_state: [
+        {
+          data: {
+            value: { tool: 'activate_recommendation', payload: { id: UUID } },
+            expires_at: '2999-01-01T00:00:00Z',
+          },
+          error: null,
+        },
+      ],
+      autopilot_recommendations: [{ data: REC, error: null }],
+    });
+    const res = await tool_explain_recommendation({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('Implement Sleep Quality Tracking');
+  });
+
+  it('ignores an expired pending CTA and falls through to normal resolution', async () => {
+    const { sb } = makeSb({
+      orb_session_state: [
+        {
+          data: {
+            value: { tool: 'activate_recommendation', payload: { id: UUID } },
+            expires_at: '2020-01-01T00:00:00Z', // expired
+          },
+          error: null,
+        },
+      ],
+      autopilot_recommendations: [{ data: [], error: null }],
+    });
+    const res = await tool_explain_recommendation({}, IDENT, sb);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.text).toContain('no open recommendations');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/services/gateway/test/save-diary-entry-shared.test.ts
+++ b/services/gateway/test/save-diary-entry-shared.test.ts
@@ -179,6 +179,37 @@ describe('VTID-03042 — save_diary_entry lifted to shared dispatcher', () => {
     expect(sb._calls).toHaveLength(0);
   });
 
+  // REGRESSION: a bare "yes/help me" reply to Vitana's own "want help
+  // logging today?" nudge is consent, not diary content. It must never be
+  // persisted as a fabricated entry (see live-system-instruction.ts Section
+  // M "bare consent" exception for the prompt-side half of this fix).
+  test('10. bare consent phrases ("ja", "hilf mir", "yes", "help me") are rejected, DB untouched', async () => {
+    const phrases = ['ja', 'Ja.', 'hilf mir', 'Ja, hilf mir!', 'yes', 'help me', 'okay', 'sure'];
+    for (const raw_text of phrases) {
+      const sb = makeStubSupabase({});
+      const result = await tool_save_diary_entry({ raw_text }, identity, sb as never);
+      expect(result.ok).toBe(true); // ok:true — it's a "needs content" signal, not a hard error
+      if (result.ok !== true) continue;
+      expect((result.result as { needs_content?: boolean }).needs_content).toBe(true);
+      expect(sb._calls).toHaveLength(0); // never touched diary_entries / RPC
+    }
+  });
+
+  test('11. real content that happens to start with "ja"/"yes" is NOT treated as bare consent', async () => {
+    const sb = makeStubSupabase({
+      preIndexRow: null,
+      rpcReturn: { data: { ok: true, score_total: 50 } },
+    });
+    const result = await tool_save_diary_entry(
+      { raw_text: 'Ja, ich habe heute zwei Liter Wasser getrunken und bin joggen gewesen.' },
+      identity,
+      sb as never,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok !== true) return;
+    expect(sb._calls.some((c) => c.table === 'diary_entries' && c.op === 'insert')).toBe(true);
+  });
+
   test('5. text is voice-friendly and mentions the entry_date', async () => {
     const sb = makeStubSupabase({
       preIndexRow: null,


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-ORB-NUDGE-CONTEXT-FIX` _(user-reported conversational bug, no OASIS VTID pre-allocated)_

**Layer:** AGTL (ORB / assistant-continuation)

**Priority:** P1

---

## 📋 Summary

Two related bugs where Vitana forgets what it just offered mid-conversation, both reported live from a real transcript:

1. **Recommendation follow-ups lose the specific item.** Vitana recommends one specific autopilot recommendation ("soll ich ihn aktivieren?"). The user declines activation but asks for an explanation ("zeig mir, worum es geht"). Instead of explaining the one thing just offered, Vitana replies "I see several recommendations — which one do you mean?" — because `explain_recommendation` (and `snooze`/`dismiss`) had no way to recover the specific id once the user's reply wasn't a clean "yes".
2. **Diary nudge fabricates an entry.** Vitana nudges "you haven't journaled in a week, want help?". The user says "yes, help me" — no actual diary content. Vitana replies "I've created an entry for today", even though the user never provided anything to log.

## ✅ Changes

- [x] `services/gateway/src/services/orb-tools/discovery-tools.ts`: `resolveRecommendation()` now falls back to the `pending_cta` persisted by `wake-brief-wiring.ts` when no reference is spoken — the same fallback `tool_activate_recommendation` already used (DEV-COMHU-0505) — so `explain_recommendation`/`snooze_recommendation`/`dismiss_recommendation` resolve deterministically to the just-offered recommendation instead of a broad, potentially ambiguous search.
- [x] `services/gateway/src/services/orb-tools-shared.ts`: `tool_save_diary_entry` now rejects bare-consent phrases ("ja", "hilf mir", "yes", "help me", "okay", …) as `raw_text` — a server-side backstop so a plain acceptance can never be persisted as a fabricated diary entry, regardless of what the model does upstream.
- [x] `services/gateway/src/orb/live/instruction/live-system-instruction.ts`: Section M ("diary logging is a tool call") now has an explicit exception — if the user's reply to Vitana's own diary nudge is only acceptance with no real content, ask a follow-up question first instead of calling `save_diary_entry`.

## 🧪 Testing

- [x] Automated tests added/updated (`test/orb-tools/discovery-tools.test.ts`, `test/save-diary-entry-shared.test.ts`)
- [x] `npm run typecheck` clean
- [x] Full gateway Jest suite: 7167 passed / 1 pre-existing unrelated failure (`nav-manifest-sync.test.ts`, a cross-repo drift check against the `vitana-v1` checkout state in this environment, untouched by this diff)
- [ ] Not verified against a live ORB voice session (no live Gemini Live session available in this environment) — the fix is scoped to the deterministic tool-resolution layer and a server-side content guard, both covered by unit tests; the system-instruction wording change is a prompt-level change that can't be unit-tested and should be spot-checked in a live conversation before/after promotion to staging.

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] N/A — no workflow files touched

### File Names
- [x] All new/changed files already followed kebab-case; no renames

### Code Standards
- [x] No new VTID constants introduced (see VTID Reference note above)
- [x] No new event types/kinds

### Cloud Run Deployments
- [x] N/A — no deploy/label changes

### Documentation
- [x] No schema changes requiring `DATABASE_SCHEMA.md` updates

---

## 🚨 Breaking Changes

None.

## 📌 Additional Notes

Both bugs are instances of a broader pattern noted during investigation: there are currently three separate, inconsistent "proactive suggestion" subsystems in the gateway (`assistant-continuation/next-action` + `wake-brief-wiring.ts`, `guide/initiative-registry.ts` + `vitana-brain.ts`, and `guide/conversation-focus.ts`), each with different levels of state-tracking sophistication. This PR fixes the two reported symptoms with targeted, low-risk changes; unifying the three systems behind one "pending proactive action" contract (entity id + content-gathering gate) would be a larger follow-up worth its own VTID.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Ry56RG6eGP3pzPuQpU5fd)_