### PR TITLE
feat(voice): Wave 2 of Voice Tools Expansion Plan v2 — 70 developer P0 tools

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -3564,6 +3564,575 @@ async def connect_health_device(context: RunContext, device_name: str | None = N
 
 
 # ---------------------------------------------------------------------------
+# WAVE-2-VOICE-CATALOG-V2 — Developer P0: VTID/OASIS lifecycle, governance,
+# CI/CD & PRs, deployment/release, observability (70 tools). All dispatch
+# through the shared gateway registry (services/gateway/src/services/
+# orb-tools/{vtid-lifecycle,governance,cicd-pr,deployment-release,
+# observability}-tools.ts) via _dispatch — same generic-fallback pattern the
+# existing 12 developer tools above already use.
+# ---------------------------------------------------------------------------
+
+# C1 VTID / OASIS Lifecycle (15)
+
+
+@function_tool
+async def dev_allocate_vtid(context: RunContext, source: str | None = None, layer: str | None = None, module: str | None = None, title: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Allocate a new VTID. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_allocate_vtid", {
+            "source": source, "layer": layer, "module": module, "title": title, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_create_task(context: RunContext, title: str, task_family: str | None = None, task_module: str | None = None, target_roles: list[str] | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Create a new OASIS task/VTID with a title. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_create_task", {
+            "title": title, "task_family": task_family, "task_module": task_module,
+            "target_roles": target_roles, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_update_task(context: RunContext, vtid: str, title: str | None = None, status: str | None = None, summary: str | None = None, assigned_to: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Patch a VTID task's title/status/summary/assigned_to. Refuses terminal tasks. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_update_task", {
+            "vtid": vtid, "title": title, "status": status, "summary": summary,
+            "assigned_to": assigned_to, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_cancel_task(context: RunContext, vtid: str, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Cancel a VTID task. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_cancel_task", {"vtid": vtid, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_complete_task(context: RunContext, vtid: str, terminal_outcome: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Mark a VTID task complete with an outcome. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_complete_task", {
+            "vtid": vtid, "terminal_outcome": terminal_outcome, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_terminalize_vtid(context: RunContext, vtid: str, outcome: str, run_id: str | None = None, commit_sha: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Set is_terminal + terminal_outcome on a VTID directly. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_terminalize_vtid", {
+            "vtid": vtid, "outcome": outcome, "run_id": run_id, "commit_sha": commit_sha, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_discover_tasks(context: RunContext, statuses: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. List VTIDs eligible for worker pickup."""
+    body = await _dispatch(context, "dev_discover_tasks", {"statuses": statuses, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_vtid_projection(context: RunContext, limit: int | None = None, offset: int | None = None) -> str:
+    """DEVELOPER ONLY. VTID projection view: stage, status, attention flags."""
+    body = await _dispatch(context, "dev_get_vtid_projection", {"limit": limit, "offset": offset})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_allocator_status(context: RunContext) -> str:
+    """DEVELOPER ONLY. Whether the VTID allocator kill-switch is on or off."""
+    body = await _dispatch(context, "dev_get_allocator_status", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_query_oasis_events(context: RunContext, vtid: str | None = None, type: str | None = None, source: str | None = None, status: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Query OASIS events by vtid/topic/source/status."""
+    body = await _dispatch(context, "dev_query_oasis_events", {
+            "vtid": vtid, "type": type, "source": source, "status": status, "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_execute_vtid(context: RunContext, vtid: str, title: str, task_family: str | None = None, task_domain: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Route a VTID to the worker orchestrator for execution. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_execute_vtid", {
+            "vtid": vtid, "title": title, "task_family": task_family, "task_domain": task_domain, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_run_exec_workflow(context: RunContext, vtid: str, action: str, params: dict[str, Any] | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Validate/log a workflow action for a VTID (validation-only endpoint, does not execute real work). TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_run_exec_workflow", {
+            "vtid": vtid, "action": action, "params": params, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_submit_evidence(context: RunContext, vtid: str, domain: str, run_id: str, result_ok: bool | None = None, files_changed: int | None = None) -> str:
+    """DEVELOPER ONLY. Submit subagent completion evidence for a VTID."""
+    body = await _dispatch(context, "dev_submit_evidence", {
+            "vtid": vtid, "domain": domain, "run_id": run_id, "result_ok": result_ok, "files_changed": files_changed,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_work_orders(context: RunContext, statuses: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. List pending work orders (maps to task discovery)."""
+    body = await _dispatch(context, "dev_list_work_orders", {"statuses": statuses, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_work_order(context: RunContext, vtid: str) -> str:
+    """DEVELOPER ONLY. Get one task/work-order by VTID."""
+    body = await _dispatch(context, "dev_get_work_order", {"vtid": vtid})
+    return summarize(body)
+
+
+# C2 Governance (13)
+
+
+@function_tool
+async def dev_evaluate_governance(context: RunContext, action: str, service: str, environment: str, vtid: str | None = None) -> str:
+    """DEVELOPER ONLY. Evaluate whether an action would be allowed by governance rules."""
+    body = await _dispatch(context, "dev_evaluate_governance", {
+            "action": action, "service": service, "environment": environment, "vtid": vtid,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_governance_status(context: RunContext) -> str:
+    """DEVELOPER ONLY. Governance control-plane snapshot."""
+    body = await _dispatch(context, "dev_governance_status", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_governance_rules(context: RunContext, category: str | None = None, status: str | None = None, level: str | None = None, search: str | None = None) -> str:
+    """DEVELOPER ONLY. List governance rules."""
+    body = await _dispatch(context, "dev_list_governance_rules", {
+            "category": category, "status": status, "level": level, "search": search,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_governance_rule(context: RunContext, rule_code: str) -> str:
+    """DEVELOPER ONLY. Get one governance rule by its code."""
+    body = await _dispatch(context, "dev_get_governance_rule", {"rule_code": rule_code})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_violations(context: RunContext) -> str:
+    """DEVELOPER ONLY. List open/recent governance violations."""
+    body = await _dispatch(context, "dev_list_violations", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_enforcements(context: RunContext) -> str:
+    """DEVELOPER ONLY. List recent governance enforcement actions."""
+    body = await _dispatch(context, "dev_list_enforcements", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_governance_feed(context: RunContext) -> str:
+    """DEVELOPER ONLY. Recent governance activity feed."""
+    body = await _dispatch(context, "dev_governance_feed", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_proposals(context: RunContext, status: str | None = None, ruleCode: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. List governance rule-change proposals."""
+    body = await _dispatch(context, "dev_list_proposals", {"status": status, "ruleCode": ruleCode, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_create_proposal(context: RunContext, type: str, proposed_rule: str, rule_code: str | None = None, rationale: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Create a governance rule-change proposal. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_create_proposal", {
+            "type": type, "proposed_rule": proposed_rule, "rule_code": rule_code,
+            "rationale": rationale, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_update_proposal(context: RunContext, proposal_id: str, status: str, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Change a proposal's status. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_update_proposal", {
+            "proposal_id": proposal_id, "status": status, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_control(context: RunContext, key: str) -> str:
+    """DEVELOPER ONLY. Read a governance control key (e.g. vtid_allocator_enabled)."""
+    body = await _dispatch(context, "dev_get_control", {"key": key})
+    return summarize(body)
+
+
+@function_tool
+async def dev_set_control(context: RunContext, key: str, enabled: bool, reason: str, duration_minutes: int | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Flip a governance control key on/off. Requires a reason. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_set_control", {
+            "key": key, "enabled": enabled, "reason": reason,
+            "duration_minutes": duration_minutes, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_control_history(context: RunContext, key: str, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Change history for a governance control key."""
+    body = await _dispatch(context, "dev_get_control_history", {"key": key, "limit": limit})
+    return summarize(body)
+
+
+# C3 CI/CD & Pull Requests (14)
+
+
+@function_tool
+async def dev_create_pr(context: RunContext, vtid: str, title: str, head: str, body: str | None = None, repo: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Create a PR from a branch into main. TWO-STEP confirm."""
+    result = await _dispatch(context, "dev_create_pr", {
+            "vtid": vtid, "title": title, "head": head, "body": body, "repo": repo, "confirm": confirm,
+        })
+    return summarize(result)
+
+
+@function_tool
+async def dev_get_pr_status(context: RunContext, pr_number: int, repo: str | None = None) -> str:
+    """DEVELOPER ONLY. PR state and mergeability."""
+    body = await _dispatch(context, "dev_get_pr_status", {"pr_number": pr_number, "repo": repo})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_pr_checks(context: RunContext, pr_number: int, repo: str | None = None) -> str:
+    """DEVELOPER ONLY. CI check runs for a PR."""
+    body = await _dispatch(context, "dev_get_pr_checks", {"pr_number": pr_number, "repo": repo})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_open_prs(context: RunContext, limit: int | None = None, repo: str | None = None) -> str:
+    """DEVELOPER ONLY. List open PRs with CI/mergeable status."""
+    body = await _dispatch(context, "dev_list_open_prs", {"limit": limit, "repo": repo})
+    return summarize(body)
+
+
+@function_tool
+async def dev_merge_pr(context: RunContext, vtid: str, pr_number: int, repo: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Merge a PR through the governed pipeline. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_merge_pr", {
+            "vtid": vtid, "pr_number": pr_number, "repo": repo, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_safe_merge(context: RunContext, vtid: str, pr_number: int, repo: str | None = None, require_checks: bool | None = None, merge_strategy: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Safe-merge a PR. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_safe_merge", {
+            "vtid": vtid, "pr_number": pr_number, "repo": repo, "require_checks": require_checks,
+            "merge_strategy": merge_strategy, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_revert_pr(context: RunContext, merge_sha: str, branch_name: str, title: str | None = None, body: str | None = None, repo: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Open a revert PR for a given merge commit. TWO-STEP confirm."""
+    result = await _dispatch(context, "dev_revert_pr", {
+            "merge_sha": merge_sha, "branch_name": branch_name, "title": title,
+            "body": body, "repo": repo, "confirm": confirm,
+        })
+    return summarize(result)
+
+
+@function_tool
+async def dev_trigger_workflow(context: RunContext, workflow_id: str, ref: str | None = None, inputs: dict[str, str] | None = None, repo: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Dispatch a GitHub Actions workflow file by name. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_trigger_workflow", {
+            "workflow_id": workflow_id, "ref": ref, "inputs": inputs, "repo": repo, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_workflow_runs(context: RunContext, workflow_id: str, repo: str | None = None) -> str:
+    """DEVELOPER ONLY. Recent runs for a GitHub Actions workflow."""
+    body = await _dispatch(context, "dev_list_workflow_runs", {"workflow_id": workflow_id, "repo": repo})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_run_jobs(context: RunContext, run_id: int, repo: str | None = None) -> str:
+    """DEVELOPER ONLY. Jobs and failures for a specific workflow run."""
+    body = await _dispatch(context, "dev_get_run_jobs", {"run_id": run_id, "repo": repo})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_merge_lock(context: RunContext) -> str:
+    """DEVELOPER ONLY. Current CI/CD merge lock status."""
+    body = await _dispatch(context, "dev_get_merge_lock", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_release_merge_lock(context: RunContext, vtid: str, reason: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Force-release a stuck merge lock for a VTID. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_release_merge_lock", {"vtid": vtid, "reason": reason, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_cicd_health(context: RunContext) -> str:
+    """DEVELOPER ONLY. CI/CD pipeline health."""
+    body = await _dispatch(context, "dev_cicd_health", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_approvals_feed(context: RunContext, limit: int | None = None, repo: str | None = None) -> str:
+    """DEVELOPER ONLY. GitHub-authoritative feed of open PRs and their approval-readiness."""
+    body = await _dispatch(context, "dev_approvals_feed", {"limit": limit, "repo": repo})
+    return summarize(body)
+
+
+# C4 Deployment & Release (13)
+
+
+@function_tool
+async def dev_deploy_service(context: RunContext, vtid: str, service: str, environment: str | None = None, branch: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Deploy a service to staging (never production). TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_deploy_service", {
+            "vtid": vtid, "service": service, "environment": environment, "branch": branch, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_publish_to_prod(context: RunContext, reason: str, mode: str | None = None, vtid: str | None = None, confirm_short_sha: str | None = None, confirm: bool | None = None, confirm_again: bool | None = None) -> str:
+    """DEVELOPER ONLY. The PUBLISH button by voice — promotes staging to production. DOUBLE-CONFIRM required, plus a reason."""
+    body = await _dispatch(context, "dev_publish_to_prod", {
+            "reason": reason, "mode": mode, "vtid": vtid, "confirm_short_sha": confirm_short_sha,
+            "confirm": confirm, "confirm_again": confirm_again,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_revisions(context: RunContext, service: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Cloud Run revisions for a service. Requires an admin session."""
+    body = await _dispatch(context, "dev_list_revisions", {"service": service, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_deployments(context: RunContext, service: str | None = None, environment: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Deployment history."""
+    body = await _dispatch(context, "dev_list_deployments", {"service": service, "environment": environment, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_deployment_health(context: RunContext) -> str:
+    """DEVELOPER ONLY. Deployment pipeline config health."""
+    body = await _dispatch(context, "dev_deployment_health", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_promote_canary(context: RunContext, service: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Promote the canary revision to 100% traffic. Requires an admin session. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_promote_canary", {"service": service, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_abort_canary(context: RunContext, service: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Abort the canary and restore the stable revision. Requires an admin session. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_abort_canary", {"service": service, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_revert_deploy(context: RunContext, service: str, target_revision: str, confirm_short_sha: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Revert a service to a prior revision. Requires an admin session. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_revert_deploy", {
+            "service": service, "target_revision": target_revision,
+            "confirm_short_sha": confirm_short_sha, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_revert_both(context: RunContext, service: str, target_revision: str, target_created_at: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Revert a service AND its paired counterpart together. Requires an admin session. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_revert_both", {
+            "service": service, "target_revision": target_revision,
+            "target_created_at": target_created_at, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_canary_status(context: RunContext, service: str | None = None) -> str:
+    """DEVELOPER ONLY. Whether a canary traffic split is active. Requires an admin session."""
+    body = await _dispatch(context, "dev_canary_status", {"service": service})
+    return summarize(body)
+
+
+@function_tool
+async def dev_staging_status(context: RunContext) -> str:
+    """DEVELOPER ONLY. What build/commit is currently on staging."""
+    body = await _dispatch(context, "dev_staging_status", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_compare_staging_prod(context: RunContext) -> str:
+    """DEVELOPER ONLY. Whether staging and production are on the same build."""
+    body = await _dispatch(context, "dev_compare_staging_prod", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_release_feed(context: RunContext, service: str | None = None, environment: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Recent releases across services."""
+    body = await _dispatch(context, "dev_release_feed", {"service": service, "environment": environment, "limit": limit})
+    return summarize(body)
+
+
+# C9 Observability (15)
+
+
+@function_tool
+async def dev_build_info(context: RunContext) -> str:
+    """DEVELOPER ONLY. Running revision/build info for this gateway instance."""
+    body = await _dispatch(context, "dev_build_info", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_service_health(context: RunContext) -> str:
+    """DEVELOPER ONLY. Health + /alive check for this gateway instance."""
+    body = await _dispatch(context, "dev_service_health", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_error_rate(context: RunContext, hours: int | None = None) -> str:
+    """DEVELOPER ONLY. Recent OASIS event error rate over a time window."""
+    body = await _dispatch(context, "dev_error_rate", {"hours": hours})
+    return summarize(body)
+
+
+@function_tool
+async def dev_latency_summary(context: RunContext, hours: int | None = None) -> str:
+    """DEVELOPER ONLY. Voice turn latency percentiles over a time window."""
+    body = await _dispatch(context, "dev_latency_summary", {"hours": hours})
+    return summarize(body)
+
+
+@function_tool
+async def dev_telemetry_snapshot(context: RunContext) -> str:
+    """DEVELOPER ONLY. Telemetry snapshot: recent events + pipeline stage counters."""
+    body = await _dispatch(context, "dev_telemetry_snapshot", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_recent_events(context: RunContext, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Recent OASIS/system events."""
+    body = await _dispatch(context, "dev_recent_events", {"limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_agent_trace(context: RunContext, phase: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Recent ORB agent trace(s)."""
+    body = await _dispatch(context, "dev_agent_trace", {"phase": phase, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_supervisor_summary(context: RunContext, window_hours: int | None = None) -> str:
+    """DEVELOPER ONLY. Supervisor summary: dataset/shadow/finetune/canary/backlog sections."""
+    body = await _dispatch(context, "dev_supervisor_summary", {"window_hours": window_hours})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_session_turns(context: RunContext, session_id: str) -> str:
+    """DEVELOPER ONLY. Per-turn timeline for a voice session."""
+    body = await _dispatch(context, "dev_get_session_turns", {"session_id": session_id})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_session_diagnostics(context: RunContext, session_id: str) -> str:
+    """DEVELOPER ONLY. Diagnostics analysis for a voice session."""
+    body = await _dispatch(context, "dev_get_session_diagnostics", {"session_id": session_id})
+    return summarize(body)
+
+
+@function_tool
+async def dev_conversation_decisions(context: RunContext, limit: int | None = None, window_hours: int | None = None) -> str:
+    """DEVELOPER ONLY. Recent greeting/next-best-action decisions. Requires exafy_admin session."""
+    body = await _dispatch(context, "dev_conversation_decisions", {"limit": limit, "window_hours": window_hours})
+    return summarize(body)
+
+
+@function_tool
+async def dev_tool_failures(context: RunContext, limit: int | None = None, window_hours: int | None = None) -> str:
+    """DEVELOPER ONLY. Recent voice-tool failures, grouped by tool. Requires exafy_admin session."""
+    body = await _dispatch(context, "dev_tool_failures", {"limit": limit, "window_hours": window_hours})
+    return summarize(body)
+
+
+@function_tool
+async def dev_tool_health(context: RunContext, window_hours: int | None = None) -> str:
+    """DEVELOPER ONLY. Tool health rollup derived from recent failures. Requires exafy_admin session."""
+    body = await _dispatch(context, "dev_tool_health", {"window_hours": window_hours})
+    return summarize(body)
+
+
+@function_tool
+async def dev_greeting_decisions(context: RunContext, limit: int | None = None, window_hours: int | None = None) -> str:
+    """DEVELOPER ONLY. Greeting-monitor view of recent conversation decisions. Requires exafy_admin session."""
+    body = await _dispatch(context, "dev_greeting_decisions", {"limit": limit, "window_hours": window_hours})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_agent_detail(context: RunContext, agent_id: str) -> str:
+    """DEVELOPER ONLY. Detail for one registered agent by id."""
+    body = await _dispatch(context, "dev_get_agent_detail", {"agent_id": agent_id})
+    return summarize(body)
+
+
+# ---------------------------------------------------------------------------
 # Catalogue export — used by tests + libcst smoke
 # ---------------------------------------------------------------------------
 
@@ -3725,6 +4294,37 @@ def all_tool_names() -> list[str]:
         "get_lab_results", "generate_health_plan", "list_my_health_plans",
         "get_health_plan_progress", "list_my_conditions",
         "get_health_education", "get_next_best_action", "connect_health_device",
+        # WAVE-2-VOICE-CATALOG-V2 — Developer P0 (70)
+        # C1 VTID / OASIS Lifecycle (15)
+        "dev_allocate_vtid", "dev_create_task", "dev_update_task", "dev_cancel_task",
+        "dev_complete_task", "dev_terminalize_vtid", "dev_discover_tasks",
+        "dev_get_vtid_projection", "dev_get_allocator_status", "dev_query_oasis_events",
+        "dev_execute_vtid", "dev_run_exec_workflow", "dev_submit_evidence",
+        "dev_list_work_orders", "dev_get_work_order",
+        # C2 Governance (13)
+        "dev_evaluate_governance", "dev_governance_status", "dev_list_governance_rules",
+        "dev_get_governance_rule", "dev_list_violations", "dev_list_enforcements",
+        "dev_governance_feed", "dev_list_proposals", "dev_create_proposal",
+        "dev_update_proposal", "dev_get_control", "dev_set_control",
+        "dev_get_control_history",
+        # C3 CI/CD & Pull Requests (14)
+        "dev_create_pr", "dev_get_pr_status", "dev_get_pr_checks", "dev_list_open_prs",
+        "dev_merge_pr", "dev_safe_merge", "dev_revert_pr", "dev_trigger_workflow",
+        "dev_list_workflow_runs", "dev_get_run_jobs", "dev_get_merge_lock",
+        "dev_release_merge_lock", "dev_cicd_health", "dev_approvals_feed",
+        # C4 Deployment & Release (13)
+        "dev_deploy_service", "dev_publish_to_prod", "dev_list_revisions",
+        "dev_list_deployments", "dev_deployment_health", "dev_promote_canary",
+        "dev_abort_canary", "dev_revert_deploy", "dev_revert_both",
+        "dev_canary_status", "dev_staging_status", "dev_compare_staging_prod",
+        "dev_release_feed",
+        # C9 Observability (15)
+        "dev_build_info", "dev_service_health", "dev_error_rate",
+        "dev_latency_summary", "dev_telemetry_snapshot", "dev_recent_events",
+        "dev_agent_trace", "dev_supervisor_summary", "dev_get_session_turns",
+        "dev_get_session_diagnostics", "dev_conversation_decisions",
+        "dev_tool_failures", "dev_tool_health", "dev_greeting_decisions",
+        "dev_get_agent_detail",
     ]
 
 

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -57,6 +57,14 @@ import { WALLET_PAYMENTS_TOOL_HANDLERS, WALLET_PAYMENTS_TOOL_DECLARATIONS } from
 import { MESSAGING_DEPTH_TOOL_HANDLERS, MESSAGING_DEPTH_TOOL_DECLARATIONS } from './orb-tools/messaging-depth-tools';
 import { EVENTS_TICKETS_TOOL_HANDLERS, EVENTS_TICKETS_TOOL_DECLARATIONS } from './orb-tools/events-tickets-tools';
 import { HEALTH_DEPTH_TOOL_HANDLERS, HEALTH_DEPTH_TOOL_DECLARATIONS } from './orb-tools/health-depth-tools';
+// WAVE-2-VOICE-CATALOG-V2 — second wave of the approved 425-tool expansion:
+// developer P0 domains covering VTID/OASIS lifecycle, governance, CI/CD &
+// PRs, deployment/release, and observability (docs/VOICE_TOOLS_EXPANSION_PLAN.md).
+import { VTID_LIFECYCLE_TOOL_HANDLERS, VTID_LIFECYCLE_TOOL_DECLARATIONS } from './orb-tools/vtid-lifecycle-tools';
+import { GOVERNANCE_TOOL_HANDLERS, GOVERNANCE_TOOL_DECLARATIONS } from './orb-tools/governance-tools';
+import { CICD_PR_TOOL_HANDLERS, CICD_PR_TOOL_DECLARATIONS } from './orb-tools/cicd-pr-tools';
+import { DEPLOYMENT_RELEASE_TOOL_HANDLERS, DEPLOYMENT_RELEASE_TOOL_DECLARATIONS } from './orb-tools/deployment-release-tools';
+import { OBSERVABILITY_TOOL_HANDLERS, OBSERVABILITY_TOOL_DECLARATIONS } from './orb-tools/observability-tools';
 import {
   lookupScreen,
   lookupByAlias,
@@ -5159,6 +5167,12 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   ...MESSAGING_DEPTH_TOOL_HANDLERS,
   ...EVENTS_TICKETS_TOOL_HANDLERS,
   ...HEALTH_DEPTH_TOOL_HANDLERS,
+  // WAVE-2-VOICE-CATALOG-V2
+  ...VTID_LIFECYCLE_TOOL_HANDLERS,
+  ...GOVERNANCE_TOOL_HANDLERS,
+  ...CICD_PR_TOOL_HANDLERS,
+  ...DEPLOYMENT_RELEASE_TOOL_HANDLERS,
+  ...OBSERVABILITY_TOOL_HANDLERS,
 };
 
 // BOOTSTRAP-VOICE-CATALOG-COMPLETE — combined Vertex/Gemini function
@@ -5190,7 +5204,15 @@ export const NEW_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
 // declared only for developer/admin/exafy_admin sessions. Kept separate so
 // live-tool-catalog.ts can apply the same activeRole check it already uses
 // for ADMIN_TOOL_SCHEMAS.
-export const DEVELOPER_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = DEVELOPER_TOOL_DECLARATIONS;
+export const DEVELOPER_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  ...DEVELOPER_TOOL_DECLARATIONS,
+  // WAVE-2-VOICE-CATALOG-V2
+  ...VTID_LIFECYCLE_TOOL_DECLARATIONS,
+  ...GOVERNANCE_TOOL_DECLARATIONS,
+  ...CICD_PR_TOOL_DECLARATIONS,
+  ...DEPLOYMENT_RELEASE_TOOL_DECLARATIONS,
+  ...OBSERVABILITY_TOOL_DECLARATIONS,
+];
 
 export const ORB_TOOL_NAMES = Object.keys(ORB_TOOL_REGISTRY);
 

--- a/services/gateway/src/services/orb-tools/cicd-pr-tools.ts
+++ b/services/gateway/src/services/orb-tools/cicd-pr-tools.ts
@@ -1,0 +1,505 @@
+/**
+ * Developer voice tools — CI/CD & Pull Requests (Wave 2, plan section C3).
+ *
+ * Some tools map to existing Express routes (self-called via gatewayApiCall);
+ * others have no dedicated route and call services/github-service.ts exports
+ * directly (getPullRequest/getPrStatus/createRevertPullRequest/
+ * triggerWorkflow/getWorkflowRuns/getWorkflowRunJobs), same functions the
+ * existing cicd.ts routes already call — no new backend behaviour.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { developerGate, clampLimit, relAge, gatewayApiCall } from './developer-tools';
+import githubService from '../github-service';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const DEFAULT_REPO = 'exafyltd/vitana-platform';
+
+function repoArg(args: OrbToolArgs): string {
+  return String(args.repo ?? DEFAULT_REPO);
+}
+
+// ---------------------------------------------------------------------------
+// 29. dev_create_pr — POST /api/v1/github/create-pr
+// ---------------------------------------------------------------------------
+
+export const dev_create_pr: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const vtid = String(args.vtid ?? '').trim();
+  const title = String(args.title ?? '').trim();
+  const head = String(args.head ?? '').trim();
+  if (!vtid || !title || !head) return { ok: false, error: 'dev_create_pr requires vtid, title and head branch.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid, title, head },
+      text: `About to open a PR "${title}" from ${head} into main for ${vtid}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/github/create-pr', {
+    method: 'POST',
+    body: { vtid, title, body: String(args.body ?? ''), head, base: 'main' },
+  });
+  if (!ok) return { ok: true, result: { created: false, status, detail: body }, text: `Could not create the PR: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { created: true, detail: body }, text: `PR opened for ${vtid}${body.pr_url ? `: ${String(body.pr_url)}` : ''}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 30. dev_get_pr_status — no route; githubService.getPrStatus() directly
+// ---------------------------------------------------------------------------
+
+export const dev_get_pr_status: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const prNumber = Number(args.pr_number);
+  if (!Number.isFinite(prNumber)) return { ok: false, error: 'dev_get_pr_status requires pr_number.' };
+  try {
+    const { pr, allPassed } = await githubService.getPrStatus(repoArg(args), prNumber);
+    return {
+      ok: true,
+      result: { pr, allPassed },
+      text: `PR #${prNumber} "${pr.title}" — ${pr.state}, mergeable: ${String(pr.mergeable)}, checks ${allPassed ? 'passing' : 'not all passing'}.`,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_get_pr_status failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 31. dev_get_pr_checks — no route; githubService.getPrStatus() .checks
+// ---------------------------------------------------------------------------
+
+export const dev_get_pr_checks: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const prNumber = Number(args.pr_number);
+  if (!Number.isFinite(prNumber)) return { ok: false, error: 'dev_get_pr_checks requires pr_number.' };
+  try {
+    const { checks, allPassed } = await githubService.getPrStatus(repoArg(args), prNumber);
+    if (checks.length === 0) return { ok: true, result: { checks: [] }, text: `PR #${prNumber} has no check runs yet.` };
+    const lines = checks.slice(0, 10).map((c: { name: string; status: string; conclusion?: string | null }) => `${c.name} — ${c.conclusion ?? c.status}`);
+    return { ok: true, result: { checks, allPassed }, text: `${checks.length} checks (${allPassed ? 'all passing' : 'not all passing'}): ${lines.join('. ')}` };
+  } catch (err) {
+    return { ok: false, error: `dev_get_pr_checks failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 32/42. dev_list_open_prs / dev_approvals_feed — GET /api/v1/approvals/feed
+// (identical backing route; kept as two tools per the plan, different framing)
+// ---------------------------------------------------------------------------
+
+async function fetchApprovalsFeed(args: OrbToolArgs): Promise<OrbToolResult> {
+  const limit = clampLimit(args.limit, 20, 100);
+  const repo = repoArg(args);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/approvals/feed?limit=${limit}&repo=${encodeURIComponent(repo)}`);
+  if (!ok || body.ok !== true) return { ok: false, error: `approvals feed unavailable (${status}): ${String(body.error ?? 'unknown')}` };
+  const items = (Array.isArray(body.items) ? body.items : []) as Array<{ vtid?: string; pr_number: number; branch: string; ci_state: string; mergeable?: boolean }>;
+  if (items.length === 0) return { ok: true, result: { items: [] }, text: 'No open PRs found.' };
+  const lines = items.slice(0, 10).map((it) => `PR #${it.pr_number}${it.vtid ? ` (${it.vtid})` : ''} — branch ${it.branch}, CI ${it.ci_state}`);
+  return { ok: true, result: { items }, text: `${items.length} open PR${items.length === 1 ? '' : 's'}: ${lines.join('. ')}` };
+}
+
+export const dev_list_open_prs: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  return fetchApprovalsFeed(args);
+};
+
+export const dev_approvals_feed: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  return fetchApprovalsFeed(args);
+};
+
+// ---------------------------------------------------------------------------
+// 33. dev_merge_pr — POST /api/v1/cicd/merge
+// ---------------------------------------------------------------------------
+
+export const dev_merge_pr: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const vtid = String(args.vtid ?? '').trim();
+  const prNumber = Number(args.pr_number);
+  if (!vtid || !Number.isFinite(prNumber)) return { ok: false, error: 'dev_merge_pr requires vtid and pr_number.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid, pr_number: prNumber },
+      text: `About to merge PR #${prNumber} for ${vtid} through the governed pipeline. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/cicd/merge', {
+    method: 'POST',
+    body: { vtid, pr_number: prNumber, repo: repoArg(args) },
+  });
+  if (!ok || body.ok !== true) {
+    return { ok: true, result: { merged: false, status, detail: body }, text: `Merge blocked: ${String(body.reason ?? body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { merged: true, detail: body }, text: `PR #${prNumber} merged for ${vtid}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 34. dev_safe_merge — POST /api/v1/github/safe-merge
+// ---------------------------------------------------------------------------
+
+export const dev_safe_merge: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const vtid = String(args.vtid ?? '').trim();
+  const prNumber = Number(args.pr_number);
+  if (!vtid || !Number.isFinite(prNumber)) return { ok: false, error: 'dev_safe_merge requires vtid and pr_number.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid, pr_number: prNumber },
+      text: `About to safe-merge PR #${prNumber} for ${vtid}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/github/safe-merge', {
+    method: 'POST',
+    body: {
+      vtid,
+      pr_number: prNumber,
+      repo: repoArg(args),
+      require_checks: args.require_checks !== false,
+      merge_strategy: String(args.merge_strategy ?? 'squash'),
+    },
+  });
+  if (!ok || body.ok !== true) {
+    return { ok: true, result: { merged: false, status, detail: body }, text: `Safe-merge blocked: ${String(body.reason ?? body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { merged: true, detail: body }, text: `PR #${prNumber} safe-merged for ${vtid}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 35. dev_revert_pr — no route; githubService.createRevertPullRequest() directly
+// ---------------------------------------------------------------------------
+
+export const dev_revert_pr: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const mergeSha = String(args.merge_sha ?? '').trim();
+  const branchName = String(args.branch_name ?? '').trim();
+  const title = String(args.title ?? `Revert ${mergeSha.slice(0, 7)}`);
+  if (!mergeSha || !branchName) return { ok: false, error: 'dev_revert_pr requires merge_sha and branch_name.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, merge_sha: mergeSha, branch_name: branchName },
+      text: `About to open a revert PR for merge ${mergeSha.slice(0, 7)} on branch ${branchName}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  try {
+    const pr = await githubService.createRevertPullRequest(
+      repoArg(args),
+      mergeSha,
+      branchName,
+      title,
+      String(args.body ?? `Automated revert of ${mergeSha}`),
+    );
+    return { ok: true, result: { created: true, pr }, text: `Revert PR #${pr.number} opened: ${pr.html_url}` };
+  } catch (err) {
+    return { ok: false, error: `dev_revert_pr failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 36. dev_trigger_workflow — no generic route; githubService.triggerWorkflow()
+// ---------------------------------------------------------------------------
+
+export const dev_trigger_workflow: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const workflowId = String(args.workflow_id ?? '').trim();
+  if (!workflowId.endsWith('.yml') && !workflowId.endsWith('.yaml')) {
+    return { ok: false, error: 'dev_trigger_workflow requires workflow_id, e.g. "STAGE-DEPLOY.yml".' };
+  }
+  const ref = String(args.ref ?? 'main');
+  const inputs = (args.inputs ?? {}) as Record<string, string>;
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, workflow_id: workflowId, ref, inputs },
+      text: `About to dispatch workflow ${workflowId} on ${ref}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  try {
+    await githubService.triggerWorkflow(repoArg(args), workflowId, ref, inputs);
+    return { ok: true, result: { triggered: true, workflow_id: workflowId, ref }, text: `Dispatched ${workflowId} on ${ref}.` };
+  } catch (err) {
+    return { ok: false, error: `dev_trigger_workflow failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 37. dev_list_workflow_runs — no route; githubService.getWorkflowRuns()
+// ---------------------------------------------------------------------------
+
+export const dev_list_workflow_runs: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const workflowId = String(args.workflow_id ?? '').trim();
+  if (!workflowId) return { ok: false, error: 'dev_list_workflow_runs requires workflow_id.' };
+  try {
+    const { workflow_runs } = await githubService.getWorkflowRuns(repoArg(args), workflowId);
+    if (workflow_runs.length === 0) return { ok: true, result: { runs: [] }, text: `No runs found for ${workflowId}.` };
+    const lines = workflow_runs.map((r) => `run ${r.id} — ${r.conclusion ?? r.status} (${relAge(r.created_at)})`);
+    return { ok: true, result: { runs: workflow_runs }, text: `Recent runs of ${workflowId}: ${lines.join('. ')}` };
+  } catch (err) {
+    return { ok: false, error: `dev_list_workflow_runs failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 38. dev_get_run_jobs — no route; githubService.getWorkflowRunJobs()
+// ---------------------------------------------------------------------------
+
+export const dev_get_run_jobs: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const runId = Number(args.run_id);
+  if (!Number.isFinite(runId)) return { ok: false, error: 'dev_get_run_jobs requires run_id.' };
+  try {
+    const { jobs } = await githubService.getWorkflowRunJobs(repoArg(args), runId);
+    if (jobs.length === 0) return { ok: true, result: { jobs: [] }, text: `No jobs found for run ${runId}.` };
+    const failed = jobs.filter((j) => j.conclusion === 'failure');
+    const lines = jobs.map((j) => `${j.name} — ${j.conclusion ?? j.status}`);
+    return {
+      ok: true,
+      result: { jobs, failed },
+      text: `${jobs.length} jobs (${failed.length} failed): ${lines.join('. ')}`,
+    };
+  } catch (err) {
+    return { ok: false, error: `dev_get_run_jobs failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 39. dev_get_merge_lock — GET /api/v1/cicd/lock-status
+// ---------------------------------------------------------------------------
+
+export const dev_get_merge_lock: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/cicd/lock-status');
+  if (!ok || body.ok !== true) return { ok: false, error: `dev_get_merge_lock failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const active = (Array.isArray(body.active_merges) ? body.active_merges : []) as string[];
+  return {
+    ok: true,
+    result: body,
+    text: active.length === 0 ? 'No merges are locked right now.' : `${active.length} active merge lock(s): ${active.join(', ')}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 40. dev_release_merge_lock — POST /api/v1/cicd/lock-release
+// ---------------------------------------------------------------------------
+
+export const dev_release_merge_lock: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const vtid = String(args.vtid ?? '').trim();
+  if (!vtid) return { ok: false, error: 'dev_release_merge_lock requires a vtid.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid },
+      text: `About to release the merge lock held by ${vtid}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/cicd/lock-release', {
+    method: 'POST',
+    body: { vtid, reason: typeof args.reason === 'string' ? args.reason : 'released via voice' },
+  });
+  if (!ok || body.ok !== true) return { ok: true, result: { released: false, status, detail: body }, text: `Could not release the lock: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { released: true, detail: body }, text: `Merge lock for ${vtid} released.` };
+};
+
+// ---------------------------------------------------------------------------
+// 41. dev_cicd_health — GET /api/v1/cicd/health
+// ---------------------------------------------------------------------------
+
+export const dev_cicd_health: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/cicd/health');
+  if (!ok || body.ok !== true) return { ok: false, error: `dev_cicd_health failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: `CI/CD pipeline is ${String(body.status ?? 'unknown')}.${body.notes ? ` ${String(body.notes)}` : ''}` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const CICD_PR_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_create_pr,
+  dev_get_pr_status,
+  dev_get_pr_checks,
+  dev_list_open_prs,
+  dev_merge_pr,
+  dev_safe_merge,
+  dev_revert_pr,
+  dev_trigger_workflow,
+  dev_list_workflow_runs,
+  dev_get_run_jobs,
+  dev_get_merge_lock,
+  dev_release_merge_lock,
+  dev_cicd_health,
+  dev_approvals_feed,
+};
+
+export const CICD_PR_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'dev_create_pr',
+    description: 'DEVELOPER ONLY. Create a PR from a branch into main. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'Required.' },
+        title: { type: 'string', description: 'Required.' },
+        body: { type: 'string' },
+        head: { type: 'string', description: 'Source branch. Required.' },
+        repo: { type: 'string', description: 'Default exafyltd/vitana-platform.' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid', 'title', 'head'],
+    },
+  },
+  {
+    name: 'dev_get_pr_status',
+    description: 'DEVELOPER ONLY. PR state and mergeability.',
+    parameters: {
+      type: 'object',
+      properties: { pr_number: { type: 'integer', description: 'Required.' }, repo: { type: 'string' } },
+      required: ['pr_number'],
+    },
+  },
+  {
+    name: 'dev_get_pr_checks',
+    description: 'DEVELOPER ONLY. CI check runs for a PR.',
+    parameters: {
+      type: 'object',
+      properties: { pr_number: { type: 'integer', description: 'Required.' }, repo: { type: 'string' } },
+      required: ['pr_number'],
+    },
+  },
+  {
+    name: 'dev_list_open_prs',
+    description: 'DEVELOPER ONLY. List open PRs with CI/mergeable status.',
+    parameters: { type: 'object', properties: { limit: { type: 'integer' }, repo: { type: 'string' } } },
+  },
+  {
+    name: 'dev_merge_pr',
+    description: 'DEVELOPER ONLY. Merge a PR through the governed pipeline (checks + governance + validator gate). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'Required.' },
+        pr_number: { type: 'integer', description: 'Required.' },
+        repo: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid', 'pr_number'],
+    },
+  },
+  {
+    name: 'dev_safe_merge',
+    description: 'DEVELOPER ONLY. Safe-merge a PR (checks + governance gate, no validator step). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'Required.' },
+        pr_number: { type: 'integer', description: 'Required.' },
+        repo: { type: 'string' },
+        require_checks: { type: 'boolean' },
+        merge_strategy: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid', 'pr_number'],
+    },
+  },
+  {
+    name: 'dev_revert_pr',
+    description: 'DEVELOPER ONLY. Open a revert PR for a given merge commit. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        merge_sha: { type: 'string', description: 'Required.' },
+        branch_name: { type: 'string', description: 'Required — new branch name for the revert.' },
+        title: { type: 'string' },
+        body: { type: 'string' },
+        repo: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['merge_sha', 'branch_name'],
+    },
+  },
+  {
+    name: 'dev_trigger_workflow',
+    description: 'DEVELOPER ONLY. Dispatch a GitHub Actions workflow file by name. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        workflow_id: { type: 'string', description: 'Workflow filename, e.g. "STAGE-DEPLOY.yml". Required.' },
+        ref: { type: 'string', description: 'Branch/ref. Default main.' },
+        inputs: { type: 'object', description: 'Workflow inputs.' },
+        repo: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['workflow_id'],
+    },
+  },
+  {
+    name: 'dev_list_workflow_runs',
+    description: 'DEVELOPER ONLY. Recent runs for a GitHub Actions workflow.',
+    parameters: {
+      type: 'object',
+      properties: { workflow_id: { type: 'string', description: 'Required.' }, repo: { type: 'string' } },
+      required: ['workflow_id'],
+    },
+  },
+  {
+    name: 'dev_get_run_jobs',
+    description: 'DEVELOPER ONLY. Jobs and failures for a specific workflow run.',
+    parameters: {
+      type: 'object',
+      properties: { run_id: { type: 'integer', description: 'Required.' }, repo: { type: 'string' } },
+      required: ['run_id'],
+    },
+  },
+  {
+    name: 'dev_get_merge_lock',
+    description: 'DEVELOPER ONLY. Current CI/CD merge lock status.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_release_merge_lock',
+    description: 'DEVELOPER ONLY. Force-release a stuck merge lock for a VTID. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'Required.' },
+        reason: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid'],
+    },
+  },
+  {
+    name: 'dev_cicd_health',
+    description: 'DEVELOPER ONLY. CI/CD pipeline health (env config, runtime deploy, governance, AI services).',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_approvals_feed',
+    description: 'DEVELOPER ONLY. GitHub-authoritative feed of open PRs and their approval-readiness.',
+    parameters: { type: 'object', properties: { limit: { type: 'integer' }, repo: { type: 'string' } } },
+  },
+];

--- a/services/gateway/src/services/orb-tools/deployment-release-tools.ts
+++ b/services/gateway/src/services/orb-tools/deployment-release-tools.ts
@@ -1,0 +1,513 @@
+/**
+ * Developer voice tools — Deployment & Release (Wave 2, plan section C4).
+ *
+ * Backed by services/gateway/src/routes/operator.ts. Several routes require
+ * a real admin JWT (requireAdminAuth: exafy_admin), not just header trust —
+ * those handlers forward the caller's own session JWT (identity.user_jwt)
+ * as a Bearer token and fail clearly if it isn't present, rather than
+ * fabricating credentials. `dev_canary_status`, `dev_staging_status` and
+ * `dev_compare_staging_prod` have no dedicated endpoint (per plan-gap
+ * analysis) — they compose the existing /revisions and /deployments reads.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { developerGate, clampLimit, relAge, gatewayApiCall } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const DEPLOYABLE_SERVICES = ['gateway', 'gateway-staging', 'community-app', 'community-app-staging'];
+
+function adminAuthHeaders(id: OrbToolIdentity): Record<string, string> | null {
+  if (!id.user_jwt) return null;
+  return { Authorization: `Bearer ${id.user_jwt}` };
+}
+
+const NO_ADMIN_JWT: OrbToolResult = {
+  ok: true,
+  result: { reason: 'no_admin_session' },
+  text: "This action needs a signed-in admin session — I don't have one for this voice session. Please use the Command Hub for this action, or sign in with an admin account first.",
+};
+
+// ---------------------------------------------------------------------------
+// 43. dev_deploy_service — POST /api/v1/operator/deploy (staging path only;
+// production goes through dev_publish_to_prod, per the staging-first cutover)
+// ---------------------------------------------------------------------------
+
+export const dev_deploy_service: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const service = String(args.service ?? '').trim();
+  if (!service) return { ok: false, error: 'dev_deploy_service requires a service name.' };
+  const environment = String(args.environment ?? 'staging');
+  if (environment === 'production') {
+    return { ok: false, error: 'dev_deploy_service only deploys to staging. Use dev_publish_to_prod for production.' };
+  }
+  const vtid = String(args.vtid ?? '').trim();
+  if (!vtid) return { ok: false, error: 'dev_deploy_service requires a vtid.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, service, environment, vtid },
+      text: `About to deploy ${service} to ${environment} for ${vtid}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/operator/deploy', {
+    method: 'POST',
+    body: { vtid, service, environment, branch: String(args.branch ?? 'main'), source: 'orb-voice' },
+  });
+  if (!ok || body.ok !== true) {
+    return { ok: true, result: { deployed: false, status, detail: body }, text: `Deploy was not started: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { deployed: true, detail: body }, text: `Deploy of ${service} to ${environment} started.` };
+};
+
+// ---------------------------------------------------------------------------
+// 44. dev_publish_to_prod — POST /api/v1/operator/publish
+// Double-confirm + spoken reason (recorded to OASIS — /publish itself has no
+// reason field, so the reason is emitted as its own OASIS event alongside
+// the call, per the plan-gap finding).
+// ---------------------------------------------------------------------------
+
+export const dev_publish_to_prod: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const reason = String(args.reason ?? '').trim();
+  if (!reason) return { ok: false, error: 'dev_publish_to_prod requires a spoken reason for this publish.' };
+  const mode = args.mode === 'canary' ? 'canary' : 'full';
+
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, step: 1, mode, reason },
+      text: `You're about to PUBLISH gateway to PRODUCTION (mode: ${mode}) — reason: "${reason}". This is a real production release. Ask the developer to confirm once, then call again with confirm=true.`,
+    };
+  }
+  if (args.confirm_again !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, step: 2, mode, reason },
+      text: `Second confirmation required: PUBLISH ${mode} to PRODUCTION for reason "${reason}". Ask the developer to confirm one more time, then call again with confirm=true and confirm_again=true.`,
+    };
+  }
+
+  const auth = adminAuthHeaders(id);
+  if (!auth) return NO_ADMIN_JWT;
+
+  try {
+    const { emitOasisEvent } = await import('../oasis-event-service');
+    await emitOasisEvent({
+      vtid: typeof args.vtid === 'string' ? args.vtid : 'VTID-PUBLISH',
+      type: 'production.publish.requested',
+      source: 'orb-voice-tools',
+      status: 'info',
+      message: `Voice-initiated production publish requested: ${reason}`,
+      payload: { reason, mode, confirm_short_sha: args.confirm_short_sha ?? null },
+      actor_id: id.user_id,
+      actor_role: 'admin',
+      surface: 'orb',
+    }).catch(() => {});
+  } catch {
+    /* best-effort audit event; publish proceeds regardless */
+  }
+
+  const { ok, status, body } = await gatewayApiCall('/api/v1/operator/publish', {
+    method: 'POST',
+    headers: auth,
+    body: { mode, confirm_short_sha: typeof args.confirm_short_sha === 'string' ? args.confirm_short_sha : undefined },
+  });
+  if (!ok || body.ok !== true) {
+    return { ok: true, result: { published: false, status, detail: body }, text: `Publish to production did not go through: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { published: true, detail: body }, text: `Published to production (${mode}). Reason recorded: "${reason}".` };
+};
+
+// ---------------------------------------------------------------------------
+// 45. dev_list_revisions — GET /api/v1/operator/revisions (requireAdminAuth)
+// ---------------------------------------------------------------------------
+
+export const dev_list_revisions: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const service = String(args.service ?? 'gateway');
+  if (!DEPLOYABLE_SERVICES.includes(service)) {
+    return { ok: false, error: `dev_list_revisions requires service to be one of ${DEPLOYABLE_SERVICES.join(', ')}.` };
+  }
+  const auth = adminAuthHeaders(id);
+  if (!auth) return NO_ADMIN_JWT;
+  const limit = clampLimit(args.limit, 5, 20);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/operator/revisions?service=${service}&limit=${limit}`, { headers: auth });
+  if (!ok || body.ok !== true) return { ok: false, error: `dev_list_revisions failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const revisions = (Array.isArray(body.revisions) ? body.revisions : []) as Array<{ name: string; created_at?: string; is_active?: boolean }>;
+  if (revisions.length === 0) return { ok: true, result: { revisions: [] }, text: `No revisions found for ${service}.` };
+  const lines = revisions.slice(0, 8).map((r) => `${r.name}${r.is_active ? ' (active)' : ''}`);
+  return { ok: true, result: { revisions }, text: `${revisions.length} revisions for ${service}: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 46/55. dev_list_deployments / dev_release_feed — GET /api/v1/operator/deployments
+// (identical backing route; kept as two tools per the plan)
+// ---------------------------------------------------------------------------
+
+async function fetchDeployments(args: OrbToolArgs): Promise<OrbToolResult> {
+  const limit = clampLimit(args.limit, 10, 100);
+  const qs = new URLSearchParams({ limit: String(limit) });
+  if (typeof args.service === 'string' && args.service) qs.set('service', args.service);
+  if (typeof args.environment === 'string' && args.environment) qs.set('environment', args.environment);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/operator/deployments?${qs.toString()}`);
+  if (!ok) return { ok: false, error: `deployments read failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rows = (Array.isArray(body.deployments) ? body.deployments : Array.isArray(body.data) ? body.data : []) as Array<{
+    service?: string; environment?: string; commit_sha?: string; created_at?: string; is_active?: boolean;
+  }>;
+  if (rows.length === 0) return { ok: true, result: { deployments: [] }, text: 'No deployments recorded.' };
+  const lines = rows.slice(0, 8).map((r) => `${r.service ?? '?'} (${r.environment ?? '?'}) — ${(r.commit_sha ?? '').slice(0, 7)}${r.is_active ? ' active' : ''}, ${relAge(r.created_at)}`);
+  return { ok: true, result: { deployments: rows }, text: `${rows.length} deployments: ${lines.join('. ')}` };
+}
+
+export const dev_list_deployments: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  return fetchDeployments(args);
+};
+
+export const dev_release_feed: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  return fetchDeployments(args);
+};
+
+// ---------------------------------------------------------------------------
+// 47. dev_deployment_health — GET /api/v1/operator/deployments/health
+// ---------------------------------------------------------------------------
+
+export const dev_deployment_health: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/operator/deployments/health');
+  if (!ok) return { ok: false, error: `dev_deployment_health failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: `Deployment config health: ${String(body.status ?? 'unknown')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 48. dev_promote_canary — POST /api/v1/operator/promote (requireAdminAuth)
+// ---------------------------------------------------------------------------
+
+export const dev_promote_canary: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const service = String(args.service ?? 'gateway');
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, service },
+      text: `About to promote the canary revision to 100% traffic for ${service}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const auth = adminAuthHeaders(id);
+  if (!auth) return NO_ADMIN_JWT;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/operator/promote', { method: 'POST', headers: auth, body: { service } });
+  if (!ok || body.ok !== true) return { ok: true, result: { promoted: false, status, detail: body }, text: `Could not promote the canary: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { promoted: true, detail: body }, text: `Canary promoted to 100% for ${service}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 49. dev_abort_canary — POST /api/v1/operator/abort-canary (requireAdminAuth)
+// ---------------------------------------------------------------------------
+
+export const dev_abort_canary: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const service = String(args.service ?? 'gateway');
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, service },
+      text: `About to abort the canary for ${service} and restore the stable revision to 100%. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const auth = adminAuthHeaders(id);
+  if (!auth) return NO_ADMIN_JWT;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/operator/abort-canary', { method: 'POST', headers: auth, body: { service } });
+  if (!ok || body.ok !== true) return { ok: true, result: { aborted: false, status, detail: body }, text: `Could not abort the canary: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { aborted: true, detail: body }, text: `Canary aborted for ${service} — stable revision restored.` };
+};
+
+// ---------------------------------------------------------------------------
+// 50. dev_revert_deploy — POST /api/v1/operator/revert (requireAdminAuth)
+// ---------------------------------------------------------------------------
+
+export const dev_revert_deploy: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const service = String(args.service ?? '').trim();
+  const targetRevision = String(args.target_revision ?? '').trim();
+  if (!service || !targetRevision) return { ok: false, error: 'dev_revert_deploy requires service and target_revision.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, service, target_revision: targetRevision },
+      text: `About to revert ${service} to revision ${targetRevision}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const auth = adminAuthHeaders(id);
+  if (!auth) return NO_ADMIN_JWT;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/operator/revert', {
+    method: 'POST',
+    headers: auth,
+    body: { service, target_revision: targetRevision, confirm_short_sha: typeof args.confirm_short_sha === 'string' ? args.confirm_short_sha : undefined },
+  });
+  if (!ok || body.ok !== true) return { ok: true, result: { reverted: false, status, detail: body }, text: `Could not revert ${service}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { reverted: true, detail: body }, text: `${service} reverted to ${targetRevision}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 51. dev_revert_both — POST /api/v1/operator/revert-both (requireAdminAuth)
+// ---------------------------------------------------------------------------
+
+export const dev_revert_both: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const service = String(args.service ?? '').trim();
+  const targetRevision = String(args.target_revision ?? '').trim();
+  if (!service || !targetRevision) return { ok: false, error: 'dev_revert_both requires service and target_revision.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, service, target_revision: targetRevision },
+      text: `About to revert ${service} AND its paired frontend/backend service to revision ${targetRevision}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const auth = adminAuthHeaders(id);
+  if (!auth) return NO_ADMIN_JWT;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/operator/revert-both', {
+    method: 'POST',
+    headers: auth,
+    body: {
+      service,
+      target_revision: targetRevision,
+      target_created_at: typeof args.target_created_at === 'string' ? args.target_created_at : undefined,
+    },
+  });
+  if (!ok || body.ok !== true) return { ok: true, result: { reverted: false, status, detail: body }, text: `Could not revert both services: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { reverted: true, detail: body }, text: `Both ${service} and its paired service reverted to ${targetRevision}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 52. dev_canary_status — no dedicated endpoint; composed from /revisions
+// ---------------------------------------------------------------------------
+
+export const dev_canary_status: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const service = String(args.service ?? 'gateway');
+  const auth = adminAuthHeaders(id);
+  if (!auth) return NO_ADMIN_JWT;
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/operator/revisions?service=${service}&limit=5`, { headers: auth });
+  if (!ok || body.ok !== true) return { ok: false, error: `dev_canary_status failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const revisions = (Array.isArray(body.revisions) ? body.revisions : []) as Array<{ name: string; percent?: number; is_active?: boolean }>;
+  const withTraffic = revisions.filter((r) => typeof r.percent === 'number' && r.percent > 0);
+  if (withTraffic.length >= 2) {
+    const lines = withTraffic.map((r) => `${r.name}: ${r.percent}%`);
+    return { ok: true, result: { canary_active: true, revisions: withTraffic }, text: `Canary is active on ${service}: ${lines.join(', ')}.` };
+  }
+  return {
+    ok: true,
+    result: { canary_active: false, revisions },
+    text: `No canary split detected on ${service} — one revision is serving 100%. (Traffic-percent detail isn't exposed on every environment; check the Command Hub Deployments tab for exact figures.)`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 53. dev_staging_status — no dedicated endpoint; composed
+// ---------------------------------------------------------------------------
+
+export const dev_staging_status: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const deployRes = await gatewayApiCall('/api/v1/operator/deployments?service=gateway-staging&environment=staging&limit=1');
+  const rows = (Array.isArray(deployRes.body.deployments) ? deployRes.body.deployments : Array.isArray(deployRes.body.data) ? deployRes.body.data : []) as Array<{
+    commit_sha?: string; created_at?: string;
+  }>;
+  const latest = rows[0];
+  if (!latest) return { ok: true, result: { found: false }, text: 'No staging deployment history found.' };
+  return {
+    ok: true,
+    result: { latest },
+    text: `Staging is on commit ${(latest.commit_sha ?? '').slice(0, 7) || 'unknown'}, deployed ${relAge(latest.created_at)}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 54. dev_compare_staging_prod — no dedicated endpoint; composed
+// ---------------------------------------------------------------------------
+
+export const dev_compare_staging_prod: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const [stagingRes, prodRes] = await Promise.all([
+    gatewayApiCall('/api/v1/operator/deployments?service=gateway-staging&limit=1'),
+    gatewayApiCall('/api/v1/operator/deployments?service=gateway&limit=1'),
+  ]);
+  const pick = (r: { body: Record<string, unknown> }) => {
+    const rows = (Array.isArray(r.body.deployments) ? r.body.deployments : Array.isArray(r.body.data) ? r.body.data : []) as Array<{ commit_sha?: string; created_at?: string }>;
+    return rows[0];
+  };
+  const staging = pick(stagingRes);
+  const prod = pick(prodRes);
+  if (!staging || !prod) {
+    return { ok: true, result: { staging, prod }, text: 'Could not find deployment history for both staging and production.' };
+  }
+  const same = staging.commit_sha && prod.commit_sha && staging.commit_sha === prod.commit_sha;
+  return {
+    ok: true,
+    result: { staging, prod, same_commit: Boolean(same) },
+    text: same
+      ? `Staging and production are on the same commit (${(staging.commit_sha ?? '').slice(0, 7)}).`
+      : `Staging is on ${(staging.commit_sha ?? '').slice(0, 7) || 'unknown'} (${relAge(staging.created_at)}); production is on ${(prod.commit_sha ?? '').slice(0, 7) || 'unknown'} (${relAge(prod.created_at)}). They differ.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const DEPLOYMENT_RELEASE_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_deploy_service,
+  dev_publish_to_prod,
+  dev_list_revisions,
+  dev_list_deployments,
+  dev_deployment_health,
+  dev_promote_canary,
+  dev_abort_canary,
+  dev_revert_deploy,
+  dev_revert_both,
+  dev_canary_status,
+  dev_staging_status,
+  dev_compare_staging_prod,
+  dev_release_feed,
+};
+
+export const DEPLOYMENT_RELEASE_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'dev_deploy_service',
+    description: 'DEVELOPER ONLY. Deploy a service to staging (never production — use dev_publish_to_prod for that). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'Required.' },
+        service: { type: 'string', description: 'Required.' },
+        environment: { type: 'string', description: 'staging or dev. Default staging.' },
+        branch: { type: 'string', description: 'Default main.' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid', 'service'],
+    },
+  },
+  {
+    name: 'dev_publish_to_prod',
+    description: 'DEVELOPER ONLY. The PUBLISH button by voice — promotes the tested staging build to production. DOUBLE-CONFIRM: requires a reason, then confirm=true, then confirm_again=true on a third call after re-confirming out loud. Requires a signed-in admin session.',
+    parameters: {
+      type: 'object',
+      properties: {
+        reason: { type: 'string', description: 'Required — why this publish is happening.' },
+        mode: { type: 'string', description: '"full" or "canary". Default full.' },
+        vtid: { type: 'string' },
+        confirm_short_sha: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true after the first explicit confirmation.' },
+        confirm_again: { type: 'boolean', description: 'Set true after the SECOND explicit confirmation.' },
+      },
+      required: ['reason'],
+    },
+  },
+  {
+    name: 'dev_list_revisions',
+    description: 'DEVELOPER ONLY. Cloud Run revisions for a service. Requires an admin session.',
+    parameters: {
+      type: 'object',
+      properties: {
+        service: { type: 'string', description: 'gateway, gateway-staging, community-app, or community-app-staging.' },
+        limit: { type: 'integer' },
+      },
+    },
+  },
+  {
+    name: 'dev_list_deployments',
+    description: 'DEVELOPER ONLY. Deployment history, optionally filtered by service/environment.',
+    parameters: {
+      type: 'object',
+      properties: { service: { type: 'string' }, environment: { type: 'string' }, limit: { type: 'integer' } },
+    },
+  },
+  {
+    name: 'dev_deployment_health',
+    description: 'DEVELOPER ONLY. Deployment pipeline config health.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_promote_canary',
+    description: 'DEVELOPER ONLY. Promote the canary revision to 100% traffic. Requires an admin session. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: { service: { type: 'string', description: 'Default gateway.' }, confirm: { type: 'boolean' } },
+    },
+  },
+  {
+    name: 'dev_abort_canary',
+    description: 'DEVELOPER ONLY. Abort the canary and restore the stable revision to 100%. Requires an admin session. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: { service: { type: 'string', description: 'Default gateway.' }, confirm: { type: 'boolean' } },
+    },
+  },
+  {
+    name: 'dev_revert_deploy',
+    description: 'DEVELOPER ONLY. Revert a service to a prior revision. Requires an admin session. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        service: { type: 'string', description: 'Required.' },
+        target_revision: { type: 'string', description: 'Required.' },
+        confirm_short_sha: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['service', 'target_revision'],
+    },
+  },
+  {
+    name: 'dev_revert_both',
+    description: 'DEVELOPER ONLY. Revert a service AND its paired frontend/backend counterpart together. Requires an admin session. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        service: { type: 'string', description: 'Required.' },
+        target_revision: { type: 'string', description: 'Required.' },
+        target_created_at: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['service', 'target_revision'],
+    },
+  },
+  {
+    name: 'dev_canary_status',
+    description: 'DEVELOPER ONLY. Whether a canary traffic split is currently active for a service. Requires an admin session.',
+    parameters: { type: 'object', properties: { service: { type: 'string', description: 'Default gateway.' } } },
+  },
+  {
+    name: 'dev_staging_status',
+    description: 'DEVELOPER ONLY. What build/commit is currently on staging.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_compare_staging_prod',
+    description: 'DEVELOPER ONLY. Whether staging and production are on the same build.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_release_feed',
+    description: 'DEVELOPER ONLY. Recent releases across services.',
+    parameters: { type: 'object', properties: { service: { type: 'string' }, environment: { type: 'string' }, limit: { type: 'integer' } } },
+  },
+];

--- a/services/gateway/src/services/orb-tools/developer-tools.ts
+++ b/services/gateway/src/services/orb-tools/developer-tools.ts
@@ -49,14 +49,14 @@ export function developerGate(id: OrbToolIdentity): OrbToolResult | null {
 // Small helpers
 // ---------------------------------------------------------------------------
 
-function clampLimit(raw: unknown, def: number, max: number): number {
+export function clampLimit(raw: unknown, def: number, max: number): number {
   const n = Number(raw);
   if (!Number.isFinite(n)) return def;
   return Math.max(1, Math.min(max, Math.round(n)));
 }
 
 /** Compact relative age for speech ("12 min ago", "3 h ago", "2 days ago"). */
-function relAge(iso: string | null | undefined): string {
+export function relAge(iso: string | null | undefined): string {
   if (!iso) return 'unknown time';
   const ms = Date.now() - new Date(iso).getTime();
   if (!Number.isFinite(ms)) return 'unknown time';
@@ -95,17 +95,23 @@ export function approvalIdForVtid(vtid: string): string {
 }
 
 /** Same gateway-self-call base the approvals route itself uses. */
-function gatewayBaseUrl(): string {
+export function gatewayBaseUrl(): string {
   return process.env.GATEWAY_URL || `http://localhost:${process.env.PORT || 8080}`;
 }
 
-async function approvalsApi(
+/**
+ * Generic gateway self-call, shared by every Wave 2 developer-tool domain
+ * module (VTID/OASIS lifecycle, governance, CI/CD, deployment, observability)
+ * so each one doesn't re-implement the same fetch-and-parse boilerplate.
+ * Mirrors the narrower approvalsApi() below, just not fixed to one prefix.
+ */
+export async function gatewayApiCall(
   path: string,
-  init?: { method?: string; body?: unknown },
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> },
 ): Promise<{ ok: boolean; status: number; body: Record<string, unknown> }> {
-  const res = await fetch(`${gatewayBaseUrl()}/api/v1/approvals${path}`, {
+  const res = await fetch(`${gatewayBaseUrl()}${path}`, {
     method: init?.method || 'GET',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
     body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
   });
   let body: Record<string, unknown> = {};
@@ -115,6 +121,13 @@ async function approvalsApi(
     /* non-JSON body — keep {} */
   }
   return { ok: res.ok, status: res.status, body };
+}
+
+async function approvalsApi(
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<{ ok: boolean; status: number; body: Record<string, unknown> }> {
+  return gatewayApiCall(`/api/v1/approvals${path}`, init);
 }
 
 // ---------------------------------------------------------------------------

--- a/services/gateway/src/services/orb-tools/governance-tools.ts
+++ b/services/gateway/src/services/orb-tools/governance-tools.ts
@@ -1,0 +1,463 @@
+/**
+ * Developer voice tools — Governance (Wave 2, plan section C2).
+ *
+ * Thin dispatch layer over routes/governance.ts and routes/governance-controls.ts.
+ * Those routes trust caller-supplied x-tenant-id / x-user-id / x-user-role
+ * headers rather than enforcing real per-request auth (see
+ * governance-controller.ts / governance-controls.ts) — handlers here forward
+ * an 'admin' role header for the internal self-call since developerGate()
+ * has already restricted the caller to developer/admin/exafy_admin.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { developerGate, clampLimit, relAge, gatewayApiCall } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+function adminHeaders(id: OrbToolIdentity): Record<string, string> {
+  return { 'x-user-id': id.user_id, 'x-user-role': 'admin' };
+}
+
+// ---------------------------------------------------------------------------
+// 16. dev_evaluate_governance — POST /api/v1/governance/evaluate
+// ---------------------------------------------------------------------------
+
+export const dev_evaluate_governance: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const action = String(args.action ?? '').trim();
+  const service = String(args.service ?? '').trim();
+  const environment = String(args.environment ?? '').trim();
+  if (!action || !service || !environment) {
+    return { ok: false, error: 'dev_evaluate_governance requires action, service and environment.' };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/governance/evaluate', {
+    method: 'POST',
+    body: { action, service, environment, vtid: typeof args.vtid === 'string' ? args.vtid : undefined },
+  });
+  if (!ok) return { ok: false, error: `dev_evaluate_governance failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const violations = (Array.isArray(body.violations) ? body.violations : []) as Array<{ message?: string }>;
+  return {
+    ok: true,
+    result: body,
+    text: body.allowed
+      ? `Allowed (level ${String(body.level ?? '?')}).`
+      : `Blocked (level ${String(body.level ?? '?')}): ${violations.map((v) => v.message).filter(Boolean).join('. ') || 'no details'}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 17. dev_governance_status — GET /api/v1/governance/controls (closest
+// existing snapshot — there is no dedicated /status route)
+// ---------------------------------------------------------------------------
+
+export const dev_governance_status: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/governance/controls', { headers: adminHeaders(id) });
+  if (!ok || body.ok !== true) return { ok: false, error: `dev_governance_status failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const controls = (Array.isArray(body.data) ? body.data : []) as Array<{ key: string; enabled: boolean }>;
+  const disabled = controls.filter((c) => !c.enabled);
+  return {
+    ok: true,
+    result: { controls },
+    text: `${controls.length} governance controls. ${disabled.length === 0 ? 'All enabled.' : `Disabled: ${disabled.map((c) => c.key).join(', ')}.`}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 18. dev_list_governance_rules — GET /api/v1/governance/rules
+// ---------------------------------------------------------------------------
+
+export const dev_list_governance_rules: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const qs = new URLSearchParams();
+  for (const k of ['category', 'status', 'level', 'search'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/rules?${qs.toString()}`);
+  if (!ok || body.ok !== true) return { ok: false, error: `dev_list_governance_rules failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rows = (Array.isArray(body.data) ? body.data : []) as Array<{ id: string; title: string; level: string; status: string }>;
+  if (rows.length === 0) return { ok: true, result: { data: [] }, text: 'No governance rules matched.' };
+  const lines = rows.slice(0, 8).map((r) => `${r.id} "${r.title}" — level ${r.level}, ${r.status}`);
+  return { ok: true, result: { data: rows }, text: `${rows.length} rules: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 19. dev_get_governance_rule — GET /api/v1/governance/rules/:ruleCode
+// ---------------------------------------------------------------------------
+
+export const dev_get_governance_rule: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const ruleCode = String(args.rule_code ?? args.ruleCode ?? '').trim();
+  if (!ruleCode) return { ok: false, error: 'dev_get_governance_rule requires a rule_code.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/rules/${encodeURIComponent(ruleCode)}`);
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No governance rule found for ${ruleCode}.` }
+      : { ok: false, error: `dev_get_governance_rule failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return {
+    ok: true,
+    result: { found: true, rule: body },
+    text: `${String(body.ruleCode)} "${String(body.name ?? '')}" — ${String(body.status ?? 'unknown')}. ${String(body.description ?? '')}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 20. dev_list_violations — GET /api/v1/governance/violations
+// ---------------------------------------------------------------------------
+
+export const dev_list_violations: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/governance/violations');
+  if (!ok) return { ok: false, error: `dev_list_violations failed (${status}).` };
+  const rows = (Array.isArray(body) ? body : []) as Array<{ ruleCode: string; severity: string; status: string; description: string }>;
+  if (rows.length === 0) return { ok: true, result: { violations: [] }, text: 'No open governance violations.' };
+  const open = rows.filter((r) => r.status === 'Open');
+  const lines = (open.length ? open : rows).slice(0, 8).map((r) => `${r.ruleCode} — ${r.severity}, ${r.status}: ${r.description}`);
+  return { ok: true, result: { violations: rows }, text: `${rows.length} violations (${open.length} open): ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 21. dev_list_enforcements — GET /api/v1/governance/enforcements
+// ---------------------------------------------------------------------------
+
+export const dev_list_enforcements: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/governance/enforcements');
+  if (!ok) return { ok: false, error: `dev_list_enforcements failed (${status}).` };
+  const rows = (Array.isArray(body) ? body : []) as Array<{ rule_id: string; action: string; status: string; executed_at: string }>;
+  if (rows.length === 0) return { ok: true, result: { enforcements: [] }, text: 'No enforcement actions recorded.' };
+  const lines = rows.slice(0, 8).map((r) => `${r.action} on rule ${r.rule_id} — ${r.status} (${relAge(r.executed_at)})`);
+  return { ok: true, result: { enforcements: rows }, text: `${rows.length} enforcement actions: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 22. dev_governance_feed — GET /api/v1/governance/feed
+// ---------------------------------------------------------------------------
+
+export const dev_governance_feed: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/governance/feed');
+  if (!ok) return { ok: false, error: `dev_governance_feed failed (${status}).` };
+  const rows = (Array.isArray(body) ? body : []) as Array<{ message: string; timestamp: string }>;
+  if (rows.length === 0) return { ok: true, result: { feed: [] }, text: 'No recent governance activity.' };
+  const lines = rows.slice(0, 8).map((r) => `${r.message} (${relAge(r.timestamp)})`);
+  return { ok: true, result: { feed: rows }, text: `${rows.length} recent governance events: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 23. dev_list_proposals — GET /api/v1/governance/proposals
+// ---------------------------------------------------------------------------
+
+export const dev_list_proposals: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const qs = new URLSearchParams();
+  for (const k of ['status', 'ruleCode'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  qs.set('limit', String(clampLimit(args.limit, 10, 100)));
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/proposals?${qs.toString()}`);
+  if (!ok) return { ok: false, error: `dev_list_proposals failed (${status}).` };
+  const rows = (Array.isArray(body) ? body : []) as Array<{ proposalId: string; type: string; status: string; ruleCode?: string }>;
+  if (rows.length === 0) return { ok: true, result: { proposals: [] }, text: 'No governance proposals found.' };
+  const lines = rows.slice(0, 8).map((r) => `${r.proposalId} — ${r.type}${r.ruleCode ? ` (${r.ruleCode})` : ''}, ${r.status}`);
+  return { ok: true, result: { proposals: rows }, text: `${rows.length} proposals: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 24. dev_create_proposal — POST /api/v1/governance/proposals
+// ---------------------------------------------------------------------------
+
+export const dev_create_proposal: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const type = String(args.type ?? '').trim();
+  if (!['New Rule', 'Change Rule', 'Deprecate Rule'].includes(type)) {
+    return { ok: false, error: 'dev_create_proposal requires type: "New Rule", "Change Rule", or "Deprecate Rule".' };
+  }
+  const proposedRule = String(args.proposed_rule ?? args.proposedRule ?? '').trim();
+  if (!proposedRule) return { ok: false, error: 'dev_create_proposal requires proposed_rule text.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, type, proposedRule },
+      text: `About to create a "${type}" governance proposal: "${proposedRule}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/governance/proposals', {
+    method: 'POST',
+    body: {
+      type,
+      ruleCode: typeof args.rule_code === 'string' ? args.rule_code : undefined,
+      proposedRule,
+      rationale: typeof args.rationale === 'string' ? args.rationale : undefined,
+      source: 'orb-voice',
+    },
+  });
+  if (!ok) return { ok: true, result: { created: false, status, detail: body }, text: `Could not create the proposal: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { created: true, proposal: body }, text: `Proposal ${String(body.proposalId ?? '')} created.` };
+};
+
+// ---------------------------------------------------------------------------
+// 25. dev_update_proposal — PATCH /api/v1/governance/proposals/:proposalId/status
+// ---------------------------------------------------------------------------
+
+export const dev_update_proposal: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const proposalId = String(args.proposal_id ?? args.proposalId ?? '').trim();
+  if (!proposalId) return { ok: false, error: 'dev_update_proposal requires proposal_id.' };
+  const newStatus = String(args.status ?? '').trim();
+  if (!['Draft', 'Under Review', 'Approved', 'Rejected', 'Implemented'].includes(newStatus)) {
+    return { ok: false, error: 'dev_update_proposal requires status: Draft, Under Review, Approved, Rejected, or Implemented.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, proposalId, status: newStatus },
+      text: `About to set ${proposalId} to "${newStatus}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/proposals/${encodeURIComponent(proposalId)}/status`, {
+    method: 'PATCH',
+    body: { status: newStatus },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update ${proposalId}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, proposal: body }, text: `${proposalId} is now "${newStatus}".` };
+};
+
+// ---------------------------------------------------------------------------
+// 26. dev_get_control — GET /api/v1/governance/controls/:key
+// ---------------------------------------------------------------------------
+
+export const dev_get_control: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const key = String(args.key ?? '').trim();
+  if (!key) return { ok: false, error: 'dev_get_control requires a control key, e.g. "vtid_allocator_enabled".' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/controls/${encodeURIComponent(key)}`, { headers: adminHeaders(id) });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No control key "${key}" found.` }
+      : { ok: false, error: `dev_get_control failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const data = (body.data ?? {}) as { enabled?: boolean; reason?: string };
+  return { ok: true, result: body, text: `${key} is ${data.enabled ? 'enabled' : 'disabled'}${data.reason ? ` (${data.reason})` : ''}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 27. dev_set_control — POST /api/v1/governance/controls/:key
+// ---------------------------------------------------------------------------
+
+export const dev_set_control: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const key = String(args.key ?? '').trim();
+  if (!key) return { ok: false, error: 'dev_set_control requires a control key.' };
+  const enabled = Boolean(args.enabled);
+  const reason = String(args.reason ?? '').trim();
+  if (!reason) return { ok: false, error: 'dev_set_control requires a reason.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, key, enabled, reason },
+      text: `About to set control "${key}" to ${enabled ? 'enabled' : 'disabled'} — reason: "${reason}". This can change platform-wide behavior. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/controls/${encodeURIComponent(key)}`, {
+    method: 'POST',
+    headers: adminHeaders(id),
+    body: {
+      enabled,
+      reason,
+      duration_minutes: typeof args.duration_minutes === 'number' ? args.duration_minutes : undefined,
+    },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update control "${key}": ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Control "${key}" is now ${enabled ? 'enabled' : 'disabled'}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 28. dev_get_control_history — GET /api/v1/governance/controls/:key/history
+// ---------------------------------------------------------------------------
+
+export const dev_get_control_history: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const key = String(args.key ?? '').trim();
+  if (!key) return { ok: false, error: 'dev_get_control_history requires a control key.' };
+  const limit = clampLimit(args.limit, 10, 200);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/controls/${encodeURIComponent(key)}/history?limit=${limit}`, { headers: adminHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_get_control_history failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rows = (Array.isArray(body.data) ? body.data : []) as Array<{ from_enabled: boolean; to_enabled: boolean; reason: string; created_at: string }>;
+  if (rows.length === 0) return { ok: true, result: { history: [] }, text: `No history for control "${key}".` };
+  const lines = rows.slice(0, 8).map((r) => `${r.from_enabled ? 'on' : 'off'} → ${r.to_enabled ? 'on' : 'off'}: ${r.reason} (${relAge(r.created_at)})`);
+  return { ok: true, result: { history: rows }, text: `${rows.length} changes to "${key}": ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const GOVERNANCE_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_evaluate_governance,
+  dev_governance_status,
+  dev_list_governance_rules,
+  dev_get_governance_rule,
+  dev_list_violations,
+  dev_list_enforcements,
+  dev_governance_feed,
+  dev_list_proposals,
+  dev_create_proposal,
+  dev_update_proposal,
+  dev_get_control,
+  dev_set_control,
+  dev_get_control_history,
+};
+
+export const GOVERNANCE_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'dev_evaluate_governance',
+    description: 'DEVELOPER ONLY. Evaluate whether an action would be allowed by governance rules for a service/environment.',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', description: 'Required.' },
+        service: { type: 'string', description: 'Required.' },
+        environment: { type: 'string', description: 'Required.' },
+        vtid: { type: 'string' },
+      },
+      required: ['action', 'service', 'environment'],
+    },
+  },
+  {
+    name: 'dev_governance_status',
+    description: 'DEVELOPER ONLY. Governance control-plane snapshot: which control keys are enabled/disabled.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_list_governance_rules',
+    description: 'DEVELOPER ONLY. List governance rules, optionally filtered by category/status/level/search.',
+    parameters: {
+      type: 'object',
+      properties: {
+        category: { type: 'string' },
+        status: { type: 'string' },
+        level: { type: 'string' },
+        search: { type: 'string' },
+      },
+    },
+  },
+  {
+    name: 'dev_get_governance_rule',
+    description: 'DEVELOPER ONLY. Get one governance rule by its code, with recent evaluations.',
+    parameters: {
+      type: 'object',
+      properties: { rule_code: { type: 'string', description: 'Required.' } },
+      required: ['rule_code'],
+    },
+  },
+  {
+    name: 'dev_list_violations',
+    description: 'DEVELOPER ONLY. List open/recent governance violations.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_list_enforcements',
+    description: 'DEVELOPER ONLY. List recent governance enforcement actions.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_governance_feed',
+    description: 'DEVELOPER ONLY. Recent governance activity feed.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_list_proposals',
+    description: 'DEVELOPER ONLY. List governance rule-change proposals, optionally filtered by status/rule_code.',
+    parameters: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', description: 'Draft, Under Review, Approved, Rejected, Implemented.' },
+        ruleCode: { type: 'string' },
+        limit: { type: 'integer' },
+      },
+    },
+  },
+  {
+    name: 'dev_create_proposal',
+    description: 'DEVELOPER ONLY. Create a governance rule-change proposal. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        type: { type: 'string', description: '"New Rule", "Change Rule", or "Deprecate Rule". Required.' },
+        rule_code: { type: 'string', description: 'Required for Change/Deprecate.' },
+        proposed_rule: { type: 'string', description: 'Required.' },
+        rationale: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['type', 'proposed_rule'],
+    },
+  },
+  {
+    name: 'dev_update_proposal',
+    description: 'DEVELOPER ONLY. Change a proposal\'s status (Draft/Under Review/Approved/Rejected/Implemented). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        proposal_id: { type: 'string', description: 'Required.' },
+        status: { type: 'string', description: 'Required.' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['proposal_id', 'status'],
+    },
+  },
+  {
+    name: 'dev_get_control',
+    description: 'DEVELOPER ONLY. Read a governance control key (e.g. vtid_allocator_enabled, autopilot_execution_enabled).',
+    parameters: {
+      type: 'object',
+      properties: { key: { type: 'string', description: 'Required.' } },
+      required: ['key'],
+    },
+  },
+  {
+    name: 'dev_set_control',
+    description: 'DEVELOPER ONLY. Flip a governance control key on/off — a real kill-switch, requires a reason. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        key: { type: 'string', description: 'Required.' },
+        enabled: { type: 'boolean', description: 'Required.' },
+        reason: { type: 'string', description: 'Required.' },
+        duration_minutes: { type: 'integer', description: 'Optional auto-expiry.' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['key', 'enabled', 'reason'],
+    },
+  },
+  {
+    name: 'dev_get_control_history',
+    description: 'DEVELOPER ONLY. Change history for a governance control key.',
+    parameters: {
+      type: 'object',
+      properties: {
+        key: { type: 'string', description: 'Required.' },
+        limit: { type: 'integer' },
+      },
+      required: ['key'],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/observability-tools.ts
+++ b/services/gateway/src/services/orb-tools/observability-tools.ts
@@ -1,0 +1,433 @@
+/**
+ * Developer voice tools — Observability (Wave 2, plan section C9).
+ *
+ * Backed by routes/admin-health.ts, telemetry.ts, events.ts, orb-agent-trace.ts,
+ * supervisor-summary.ts, voice-lab.ts, conversation-hub.ts, agents-registry.ts.
+ * Several routes require the caller's own session JWT (requireAuth /
+ * requireExafyAdmin) — forwarded from identity.user_jwt when present, with a
+ * clear fallback message when it isn't (never fabricated).
+ * dev_service_health / dev_build_info are scoped to this gateway instance —
+ * there is no cross-service health aggregator today (plan-gap, flagged).
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { developerGate, clampLimit, relAge, gatewayApiCall } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+function authHeaders(id: OrbToolIdentity): Record<string, string> {
+  return id.user_jwt ? { Authorization: `Bearer ${id.user_jwt}` } : {};
+}
+
+const NO_SESSION: OrbToolResult = {
+  ok: true,
+  result: { reason: 'no_session' },
+  text: "I need a signed-in session to read that — I don't have one for this voice session.",
+};
+
+// ---------------------------------------------------------------------------
+// 109. dev_build_info — GET /api/v1/admin/build-info (this gateway instance)
+// ---------------------------------------------------------------------------
+
+export const dev_build_info: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/build-info');
+  if (!ok) return { ok: false, error: `dev_build_info failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return {
+    ok: true,
+    result: body,
+    text: `Gateway is running ${String(body.git_commit ?? 'unknown commit')} (${String(body.cloud_run_revision ?? 'unknown revision')}) in ${String(body.env ?? 'unknown env')}. (Scoped to this gateway instance — no cross-service aggregator exists yet.)`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 110. dev_service_health — GET /api/v1/admin/health + /alive (this instance)
+// ---------------------------------------------------------------------------
+
+export const dev_service_health: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const [healthRes, aliveRes] = await Promise.all([
+    gatewayApiCall('/api/v1/admin/health'),
+    gatewayApiCall('/alive'),
+  ]);
+  return {
+    ok: true,
+    result: { health: healthRes.body, alive: aliveRes.ok },
+    text: `Gateway health: ${String(healthRes.body.status ?? (healthRes.ok ? 'ok' : 'unknown'))}, /alive is ${aliveRes.ok ? 'responding' : 'not responding'}. (No cross-service aggregator exists yet — this covers the gateway only.)`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 111. dev_error_rate — direct oasis_events read (no dedicated endpoint)
+// ---------------------------------------------------------------------------
+
+export const dev_error_rate: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const hours = Math.max(1, Math.min(168, Number(args.hours) || 24));
+  const since = new Date(Date.now() - hours * 3600_000).toISOString();
+  const { data, error } = await sb
+    .from('oasis_events')
+    .select('status')
+    .gte('created_at', since)
+    .limit(5000);
+  if (error) return { ok: false, error: `dev_error_rate failed: ${error.message}` };
+  const rows = (data ?? []) as Array<{ status: string | null }>;
+  const total = rows.length;
+  const errors = rows.filter((r) => r.status === 'error' || r.status === 'failure').length;
+  const rate = total > 0 ? (errors / total) * 100 : 0;
+  return {
+    ok: true,
+    result: { total, errors, rate_percent: Number(rate.toFixed(2)), window_hours: hours },
+    text: `Over the last ${hours}h: ${errors} of ${total} OASIS events were errors (${rate.toFixed(1)}%).`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 112. dev_latency_summary — direct oasis_events read of voice.latency.measured
+// ---------------------------------------------------------------------------
+
+export const dev_latency_summary: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const hours = Math.max(1, Math.min(168, Number(args.hours) || 24));
+  const since = new Date(Date.now() - hours * 3600_000).toISOString();
+  const { data, error } = await sb
+    .from('oasis_events')
+    .select('payload')
+    .eq('topic', 'voice.latency.measured')
+    .gte('created_at', since)
+    .limit(2000);
+  if (error) return { ok: false, error: `dev_latency_summary failed: ${error.message}` };
+  const values = ((data ?? []) as Array<{ payload: Record<string, unknown> | null }>)
+    .map((r) => Number(r.payload?.total_ms))
+    .filter((n) => Number.isFinite(n))
+    .sort((a, b) => a - b);
+  if (values.length === 0) {
+    return { ok: true, result: { count: 0 }, text: `No voice latency samples in the last ${hours}h.` };
+  }
+  const pct = (p: number) => values[Math.min(values.length - 1, Math.floor((p / 100) * values.length))];
+  const p50 = pct(50);
+  const p95 = pct(95);
+  return {
+    ok: true,
+    result: { count: values.length, p50_ms: p50, p95_ms: p95, window_hours: hours },
+    text: `Voice turn latency over the last ${hours}h (${values.length} samples): p50 ${p50}ms, p95 ${p95}ms.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 113. dev_telemetry_snapshot — GET /api/v1/telemetry/snapshot (requireAuth)
+// ---------------------------------------------------------------------------
+
+export const dev_telemetry_snapshot: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_SESSION;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/telemetry/snapshot', { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_telemetry_snapshot failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: 'Telemetry snapshot retrieved.' };
+};
+
+// ---------------------------------------------------------------------------
+// 114. dev_recent_events — GET /api/v1/oasis/events
+// ---------------------------------------------------------------------------
+
+export const dev_recent_events: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 10, 100);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/oasis/events?limit=${limit}`);
+  if (!ok) return { ok: false, error: `dev_recent_events failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rows = (Array.isArray(body.data) ? body.data : []) as Array<{ type?: string; topic?: string; message?: string; created_at?: string }>;
+  if (rows.length === 0) return { ok: true, result: { data: [] }, text: 'No recent events.' };
+  const lines = rows.slice(0, 8).map((r) => `${r.type || r.topic || 'event'}${r.message ? ` — ${r.message}` : ''} (${relAge(r.created_at)})`);
+  return { ok: true, result: { data: rows }, text: `${rows.length} recent events: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 115. dev_agent_trace — GET /api/v1/orb/agent-trace(/recent)
+// ---------------------------------------------------------------------------
+
+export const dev_agent_trace: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 5, 20);
+  const path = id.user_jwt
+    ? `/api/v1/orb/agent-trace?limit=${limit}${typeof args.phase === 'string' ? `&phase=${encodeURIComponent(args.phase)}` : ''}`
+    : `/api/v1/orb/agent-trace/recent`;
+  const { ok, status, body } = await gatewayApiCall(path, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_agent_trace failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const traces = (Array.isArray(body.traces) ? body.traces : Array.isArray(body.data) ? body.data : []) as Array<Record<string, unknown>>;
+  if (traces.length === 0) return { ok: true, result: { traces: [] }, text: 'No agent traces found.' };
+  return { ok: true, result: { traces }, text: `${traces.length} recent agent trace${traces.length === 1 ? '' : 's'} retrieved.` };
+};
+
+// ---------------------------------------------------------------------------
+// 116. dev_supervisor_summary — GET /api/v1/supervisor/summary
+// (requireServiceRole — needs the gateway's own service token, not a user JWT)
+// ---------------------------------------------------------------------------
+
+export const dev_supervisor_summary: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const serviceToken = process.env.GATEWAY_SERVICE_TOKEN;
+  if (!serviceToken) {
+    return { ok: true, result: { reason: 'no_service_token' }, text: 'Supervisor summary is unavailable — no gateway service token configured.' };
+  }
+  const windowHours = Math.max(1, Math.min(168, Number(args.window_hours) || 24));
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/supervisor/summary?window_hours=${windowHours}`, {
+    headers: { Authorization: `Bearer ${serviceToken}` },
+  });
+  if (!ok) return { ok: false, error: `dev_supervisor_summary failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: `Supervisor summary over the last ${windowHours}h retrieved.` };
+};
+
+// ---------------------------------------------------------------------------
+// 117. dev_get_session_turns — GET /api/v1/voice-lab/live/sessions/:id/turns
+// ---------------------------------------------------------------------------
+
+export const dev_get_session_turns: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const sessionId = String(args.session_id ?? '').trim();
+  if (!sessionId) return { ok: false, error: 'dev_get_session_turns requires session_id.' };
+  if (!id.user_jwt) return NO_SESSION;
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/voice-lab/live/sessions/${encodeURIComponent(sessionId)}/turns`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_get_session_turns failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const turns = (Array.isArray(body.turns) ? body.turns : []) as Array<{ turn_number: number; turn_ms?: number }>;
+  if (turns.length === 0) return { ok: true, result: { turns: [] }, text: `No turns recorded for session ${sessionId}.` };
+  return { ok: true, result: { turns }, text: `${turns.length} turns for session ${sessionId}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 118. dev_get_session_diagnostics — GET .../sessions/:id/diagnostics
+// ---------------------------------------------------------------------------
+
+export const dev_get_session_diagnostics: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const sessionId = String(args.session_id ?? '').trim();
+  if (!sessionId) return { ok: false, error: 'dev_get_session_diagnostics requires session_id.' };
+  if (!id.user_jwt) return NO_SESSION;
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/voice-lab/live/sessions/${encodeURIComponent(sessionId)}/diagnostics`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_get_session_diagnostics failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: `Diagnostics retrieved for session ${sessionId}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 119/122. dev_conversation_decisions / dev_greeting_decisions —
+// GET /api/v1/admin/conversation/decisions (requireAuth + requireExafyAdmin)
+// identical backing route, kept as two tools per the plan.
+// ---------------------------------------------------------------------------
+
+async function fetchConversationDecisions(args: OrbToolArgs, id: OrbToolIdentity): Promise<OrbToolResult> {
+  if (!id.user_jwt) return NO_SESSION;
+  const limit = clampLimit(args.limit, 10, 100);
+  const windowHours = Math.max(1, Math.min(168, Number(args.window_hours) || 24));
+  const { ok, status, body } = await gatewayApiCall(
+    `/api/v1/admin/conversation/decisions?limit=${limit}&window_hours=${windowHours}`,
+    { headers: authHeaders(id) },
+  );
+  if (!ok) return { ok: false, error: `conversation decisions failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rows = (Array.isArray(body.data) ? body.data : []) as Array<Record<string, unknown>>;
+  if (rows.length === 0) return { ok: true, result: { data: [] }, text: 'No greeting/NBA decisions in that window.' };
+  return { ok: true, result: { data: rows }, text: `${rows.length} decisions over the last ${windowHours}h.` };
+}
+
+export const dev_conversation_decisions: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  return fetchConversationDecisions(args, id);
+};
+
+export const dev_greeting_decisions: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  return fetchConversationDecisions(args, id);
+};
+
+// ---------------------------------------------------------------------------
+// 120. dev_tool_failures — GET /api/v1/admin/conversation/tool-failures
+// ---------------------------------------------------------------------------
+
+async function fetchToolFailures(args: OrbToolArgs, id: OrbToolIdentity) {
+  if (!id.user_jwt) return { rows: [] as Array<Record<string, unknown>>, error: NO_SESSION };
+  const limit = clampLimit(args.limit, 20, 200);
+  const windowHours = Math.max(1, Math.min(168, Number(args.window_hours) || 24));
+  const { ok, status, body } = await gatewayApiCall(
+    `/api/v1/admin/conversation/tool-failures?limit=${limit}&window_hours=${windowHours}`,
+    { headers: authHeaders(id) },
+  );
+  if (!ok) return { rows: [], error: { ok: false, error: `tool failures failed (${status}): ${String(body.error ?? 'unknown')}` } as OrbToolResult };
+  return { rows: (Array.isArray(body.data) ? body.data : []) as Array<Record<string, unknown>>, error: null };
+}
+
+export const dev_tool_failures: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { rows, error } = await fetchToolFailures(args, id);
+  if (error) return error;
+  if (rows.length === 0) return { ok: true, result: { data: [] }, text: 'No recent tool failures.' };
+  const byTool = new Map<string, number>();
+  for (const r of rows) {
+    const meta = (r.metadata ?? {}) as Record<string, unknown>;
+    const tool = String(meta.tool ?? 'unknown');
+    byTool.set(tool, (byTool.get(tool) ?? 0) + 1);
+  }
+  const lines = [...byTool.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8).map(([t, n]) => `${t}: ${n}`);
+  return { ok: true, result: { data: rows, by_tool: Object.fromEntries(byTool) }, text: `${rows.length} tool failures: ${lines.join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 121. dev_tool_health — built from the same tool-failures feed (no dedicated
+// health-dashboard endpoint exists per plan-gap analysis)
+// ---------------------------------------------------------------------------
+
+export const dev_tool_health: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { rows, error } = await fetchToolFailures(args, id);
+  if (error) return error;
+  if (rows.length === 0) return { ok: true, result: { healthy: true }, text: 'No tool failures recorded — tools look healthy.' };
+  const byTool = new Map<string, number>();
+  for (const r of rows) {
+    const meta = (r.metadata ?? {}) as Record<string, unknown>;
+    const tool = String(meta.tool ?? 'unknown');
+    byTool.set(tool, (byTool.get(tool) ?? 0) + 1);
+  }
+  const worst = [...byTool.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5);
+  return {
+    ok: true,
+    result: { healthy: false, failure_counts: Object.fromEntries(byTool) },
+    text: `Tool health rollup (from recent failures, no dedicated dashboard yet): worst offenders — ${worst.map(([t, n]) => `${t} (${n})`).join(', ')}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 123. dev_get_agent_detail — GET /api/v1/agents/registry/:agent_id
+// ---------------------------------------------------------------------------
+
+export const dev_get_agent_detail: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const agentId = String(args.agent_id ?? '').trim();
+  if (!agentId) return { ok: false, error: 'dev_get_agent_detail requires agent_id.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/agents/registry/${encodeURIComponent(agentId)}`);
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No agent found with id "${agentId}".` }
+      : { ok: false, error: `dev_get_agent_detail failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return {
+    ok: true,
+    result: { found: true, agent: body },
+    text: `${String(body.display_name ?? agentId)} (${String(body.tier ?? 'unknown tier')}) — ${String(body.derived_status ?? body.status ?? 'unknown status')}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const OBSERVABILITY_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_build_info,
+  dev_service_health,
+  dev_error_rate,
+  dev_latency_summary,
+  dev_telemetry_snapshot,
+  dev_recent_events,
+  dev_agent_trace,
+  dev_supervisor_summary,
+  dev_get_session_turns,
+  dev_get_session_diagnostics,
+  dev_conversation_decisions,
+  dev_tool_failures,
+  dev_tool_health,
+  dev_greeting_decisions,
+  dev_get_agent_detail,
+};
+
+export const OBSERVABILITY_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'dev_build_info',
+    description: 'DEVELOPER ONLY. Running revision/build info for this gateway instance.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_service_health',
+    description: 'DEVELOPER ONLY. Health + /alive check for this gateway instance.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_error_rate',
+    description: 'DEVELOPER ONLY. Recent OASIS event error rate over a time window.',
+    parameters: { type: 'object', properties: { hours: { type: 'integer', description: 'Window size, default 24.' } } },
+  },
+  {
+    name: 'dev_latency_summary',
+    description: 'DEVELOPER ONLY. Voice turn latency percentiles (p50/p95) over a time window.',
+    parameters: { type: 'object', properties: { hours: { type: 'integer', description: 'Window size, default 24.' } } },
+  },
+  {
+    name: 'dev_telemetry_snapshot',
+    description: 'DEVELOPER ONLY. Telemetry snapshot: recent events + pipeline stage counters.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_recent_events',
+    description: 'DEVELOPER ONLY. Recent OASIS/system events, most recent first.',
+    parameters: { type: 'object', properties: { limit: { type: 'integer' } } },
+  },
+  {
+    name: 'dev_agent_trace',
+    description: 'DEVELOPER ONLY. Recent ORB agent trace(s).',
+    parameters: { type: 'object', properties: { phase: { type: 'string' }, limit: { type: 'integer' } } },
+  },
+  {
+    name: 'dev_supervisor_summary',
+    description: 'DEVELOPER ONLY. Supervisor summary: dataset/shadow/finetune/canary/backlog sections.',
+    parameters: { type: 'object', properties: { window_hours: { type: 'integer' } } },
+  },
+  {
+    name: 'dev_get_session_turns',
+    description: 'DEVELOPER ONLY. Per-turn timeline for a voice session.',
+    parameters: { type: 'object', properties: { session_id: { type: 'string', description: 'Required.' } }, required: ['session_id'] },
+  },
+  {
+    name: 'dev_get_session_diagnostics',
+    description: 'DEVELOPER ONLY. Diagnostics analysis for a voice session.',
+    parameters: { type: 'object', properties: { session_id: { type: 'string', description: 'Required.' } }, required: ['session_id'] },
+  },
+  {
+    name: 'dev_conversation_decisions',
+    description: 'DEVELOPER ONLY. Recent greeting/next-best-action decisions. Requires exafy_admin session.',
+    parameters: { type: 'object', properties: { limit: { type: 'integer' }, window_hours: { type: 'integer' } } },
+  },
+  {
+    name: 'dev_tool_failures',
+    description: 'DEVELOPER ONLY. Recent voice-tool failures, grouped by tool. Requires exafy_admin session.',
+    parameters: { type: 'object', properties: { limit: { type: 'integer' }, window_hours: { type: 'integer' } } },
+  },
+  {
+    name: 'dev_tool_health',
+    description: 'DEVELOPER ONLY. Tool health rollup derived from recent failures (no dedicated dashboard exists). Requires exafy_admin session.',
+    parameters: { type: 'object', properties: { window_hours: { type: 'integer' } } },
+  },
+  {
+    name: 'dev_greeting_decisions',
+    description: 'DEVELOPER ONLY. Greeting-monitor view of recent conversation decisions (same source as dev_conversation_decisions). Requires exafy_admin session.',
+    parameters: { type: 'object', properties: { limit: { type: 'integer' }, window_hours: { type: 'integer' } } },
+  },
+  {
+    name: 'dev_get_agent_detail',
+    description: 'DEVELOPER ONLY. Detail for one registered agent by id.',
+    parameters: { type: 'object', properties: { agent_id: { type: 'string', description: 'Required.' } }, required: ['agent_id'] },
+  },
+];

--- a/services/gateway/src/services/orb-tools/vtid-lifecycle-tools.ts
+++ b/services/gateway/src/services/orb-tools/vtid-lifecycle-tools.ts
@@ -1,0 +1,678 @@
+/**
+ * Developer voice tools — VTID / OASIS Lifecycle (Wave 2, plan section C1).
+ *
+ * Thin dispatch layer over the existing routes/vtid.ts, routes/oasis-tasks.ts,
+ * routes/vtid-terminalize.ts and routes/worker-orchestrator.ts endpoints — no
+ * new backend behaviour is introduced here. Every handler re-checks the
+ * caller's role server-side via developerGate(), same as developer-tools.ts.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import {
+  developerGate,
+  normalizeVtidCandidates,
+  clampLimit,
+  relAge,
+  gatewayApiCall,
+} from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+async function resolveVtid(
+  args: OrbToolArgs,
+  sb: SupabaseClient,
+): Promise<{ vtid: string; status: string | null; is_terminal: boolean } | { error: string }> {
+  const candidates = normalizeVtidCandidates(args.vtid);
+  if (candidates.length === 0) {
+    return { error: 'A VTID is required, e.g. "VTID-01234" or "1234".' };
+  }
+  const { data, error } = await sb
+    .from('vtid_ledger')
+    .select('vtid, status, is_terminal')
+    .in('vtid', candidates)
+    .limit(1);
+  if (error) return { error: error.message };
+  const row = ((data ?? []) as Array<{ vtid: string; status: string | null; is_terminal: boolean | null }>)[0];
+  if (!row) return { error: `VTID ${candidates[0]} not found in the ledger.` };
+  return { vtid: row.vtid, status: row.status, is_terminal: Boolean(row.is_terminal) };
+}
+
+// ---------------------------------------------------------------------------
+// 1. dev_allocate_vtid — POST /api/v1/vtid/allocate
+// ---------------------------------------------------------------------------
+
+export const dev_allocate_vtid: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const source = String(args.source ?? 'orb-voice');
+  const layer = String(args.layer ?? 'DEV');
+  const module = String(args.module ?? 'TASK');
+  const title = typeof args.title === 'string' ? args.title : undefined;
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, layer, module, title },
+      text: `About to allocate a new ${layer}/${module} VTID${title ? ` for "${title}"` : ''}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/vtid/allocate', {
+    method: 'POST',
+    body: { source, layer, module, title },
+  });
+  if (!ok || body.ok !== true) {
+    return { ok: true, result: { allocated: false, status, detail: body }, text: `Could not allocate a VTID: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { allocated: true, vtid: body.vtid }, text: `Allocated ${String(body.vtid)}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. dev_create_task — POST /api/v1/vtid/create
+// ---------------------------------------------------------------------------
+
+export const dev_create_task: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const title = String(args.title ?? '').trim();
+  if (!title) return { ok: false, error: 'dev_create_task requires a title.' };
+  const task_family = String(args.task_family ?? 'DEV');
+  const task_module = String(args.task_module ?? 'TASK');
+  const target_roles = Array.isArray(args.target_roles) && args.target_roles.length > 0
+    ? args.target_roles
+    : ['DEV'];
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, title, task_family, task_module, target_roles },
+      text: `About to create a new OASIS task "${title}" (${task_family}/${task_module}). Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/vtid/create', {
+    method: 'POST',
+    body: { task_family, task_module, title, target_roles },
+  });
+  if (!ok || body.ok !== true) {
+    return { ok: true, result: { created: false, status, detail: body }, text: `Could not create the task: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { created: true, task: body }, text: `Created ${String(body.vtid ?? '(unknown vtid)')} — "${title}".` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. dev_update_task — PATCH /api/v1/oasis/tasks/:id
+// ---------------------------------------------------------------------------
+
+export const dev_update_task: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const target = await resolveVtid(args, sb);
+  if ('error' in target) return { ok: false, error: target.error };
+  if (target.is_terminal) {
+    return { ok: false, error: `${target.vtid} is terminal and may not be modified.` };
+  }
+  const patch: Record<string, unknown> = {};
+  if (typeof args.title === 'string') patch.title = args.title;
+  if (typeof args.status === 'string') patch.status = args.status;
+  if (typeof args.summary === 'string') patch.summary = args.summary;
+  if (typeof args.assigned_to === 'string') patch.assigned_to = args.assigned_to;
+  if (Object.keys(patch).length === 0) {
+    return { ok: false, error: 'dev_update_task requires at least one field to change (title, status, summary, assigned_to).' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid: target.vtid, patch },
+      text: `About to update ${target.vtid}: ${JSON.stringify(patch)}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/oasis/tasks/${encodeURIComponent(target.vtid)}`, {
+    method: 'PATCH',
+    body: patch,
+  });
+  if (!ok) {
+    return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update ${target.vtid}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { updated: true, task: body }, text: `${target.vtid} updated.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. dev_cancel_task — DELETE (pre-start) or complete(cancelled) (in-flight)
+// ---------------------------------------------------------------------------
+
+const PRE_START_STATUSES = new Set(['scheduled', 'allocated', 'pending']);
+
+export const dev_cancel_task: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const target = await resolveVtid(args, sb);
+  if ('error' in target) return { ok: false, error: target.error };
+  if (target.is_terminal) {
+    return { ok: true, result: { already_terminal: true }, text: `${target.vtid} is already terminal — nothing to cancel.` };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid: target.vtid, current_status: target.status },
+      text: `About to cancel ${target.vtid} (currently ${target.status}). Confirm, then call again with confirm=true.`,
+    };
+  }
+  const preStart = PRE_START_STATUSES.has(String(target.status ?? ''));
+  const { ok, status, body } = preStart
+    ? await gatewayApiCall(`/api/v1/oasis/tasks/${encodeURIComponent(target.vtid)}`, { method: 'DELETE' })
+    : await gatewayApiCall(`/api/v1/oasis/tasks/${encodeURIComponent(target.vtid)}/complete`, {
+        method: 'POST',
+        body: { terminal_outcome: 'cancelled' },
+      });
+  if (!ok) {
+    return { ok: true, result: { cancelled: false, status, detail: body }, text: `Could not cancel ${target.vtid}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { cancelled: true, vtid: target.vtid }, text: `${target.vtid} cancelled.` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. dev_complete_task — POST /api/v1/oasis/tasks/:vtid/complete
+// ---------------------------------------------------------------------------
+
+export const dev_complete_task: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const target = await resolveVtid(args, sb);
+  if ('error' in target) return { ok: false, error: target.error };
+  const outcome = String(args.terminal_outcome ?? 'success');
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid: target.vtid, terminal_outcome: outcome },
+      text: `About to complete ${target.vtid} with outcome "${outcome}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/oasis/tasks/${encodeURIComponent(target.vtid)}/complete`, {
+    method: 'POST',
+    body: { terminal_outcome: outcome },
+  });
+  if (!ok) {
+    return { ok: true, result: { completed: false, status, detail: body }, text: `Could not complete ${target.vtid}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  const retried = body.status === 'scheduled' && outcome === 'failed';
+  return {
+    ok: true,
+    result: { completed: true, detail: body },
+    text: retried
+      ? `${target.vtid} failed and was reset for retry (attempt ${String(body.failure_count ?? '?')}).`
+      : `${target.vtid} completed with outcome ${outcome}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 6. dev_terminalize_vtid — POST /api/v1/oasis/vtid/terminalize
+// ---------------------------------------------------------------------------
+
+export const dev_terminalize_vtid: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const target = await resolveVtid(args, sb);
+  if ('error' in target) return { ok: false, error: target.error };
+  const outcome = String(args.outcome ?? '').trim();
+  if (!['success', 'failed', 'cancelled'].includes(outcome)) {
+    return { ok: false, error: 'dev_terminalize_vtid requires outcome to be one of success, failed, cancelled.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid: target.vtid, outcome },
+      text: `About to terminalize ${target.vtid} with outcome "${outcome}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/oasis/vtid/terminalize', {
+    method: 'POST',
+    body: {
+      vtid: target.vtid,
+      outcome,
+      run_id: typeof args.run_id === 'string' ? args.run_id : undefined,
+      commit_sha: typeof args.commit_sha === 'string' ? args.commit_sha : undefined,
+      actor: 'manual',
+    },
+  });
+  if (!ok || body.ok !== true) {
+    return { ok: true, result: { terminalized: false, status, detail: body }, text: `Could not terminalize ${target.vtid}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return {
+    ok: true,
+    result: { terminalized: true, already_terminal: Boolean(body.already_terminal) },
+    text: body.already_terminal
+      ? `${target.vtid} was already terminal.`
+      : `${target.vtid} terminalized with outcome ${outcome}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 7. dev_discover_tasks — GET /api/v1/oasis/tasks/discover
+// ---------------------------------------------------------------------------
+
+export const dev_discover_tasks: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 20, 200);
+  const statuses = typeof args.statuses === 'string' ? args.statuses : undefined;
+  const qs = new URLSearchParams({ limit: String(limit) });
+  if (statuses) qs.set('statuses', statuses);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/oasis/tasks/discover?${qs.toString()}`);
+  if (!ok || body.ok !== true) {
+    return { ok: false, error: `dev_discover_tasks failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const pending = (Array.isArray(body.pending) ? body.pending : []) as Array<{ vtid: string; title?: string; status?: string }>;
+  if (pending.length === 0) {
+    return { ok: true, result: { pending: [] }, text: 'No eligible tasks discovered right now.' };
+  }
+  const lines = pending.slice(0, 8).map((t) => `${t.vtid} — ${t.title || '(untitled)'} (${t.status ?? 'unknown'})`);
+  return { ok: true, result: { pending }, text: `${pending.length} eligible task${pending.length === 1 ? '' : 's'}: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 8. dev_get_vtid_projection — GET /api/v1/vtid/projection
+// ---------------------------------------------------------------------------
+
+export const dev_get_vtid_projection: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 20, 200);
+  const offset = Math.max(0, Number(args.offset) || 0);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/vtid/projection?limit=${limit}&offset=${offset}`);
+  if (!ok || body.ok !== true) {
+    return { ok: false, error: `dev_get_vtid_projection failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const rows = (Array.isArray(body.data) ? body.data : []) as Array<{
+    vtid: string; title?: string; current_stage?: string; status?: string; attention_required?: boolean;
+  }>;
+  if (rows.length === 0) return { ok: true, result: { data: [] }, text: 'No VTIDs in the projection.' };
+  const attention = rows.filter((r) => r.attention_required);
+  const lines = rows.slice(0, 8).map((r) => `${r.vtid} — ${r.title || '(untitled)'} (${r.current_stage ?? r.status ?? 'unknown'})`);
+  return {
+    ok: true,
+    result: { data: rows },
+    text: `${rows.length} VTIDs${attention.length ? `, ${attention.length} need attention` : ''}: ${lines.join('. ')}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 9. dev_get_allocator_status — GET /api/v1/vtid/allocator/status
+// ---------------------------------------------------------------------------
+
+export const dev_get_allocator_status: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/vtid/allocator/status');
+  if (!ok || body.ok !== true) {
+    return { ok: false, error: `dev_get_allocator_status failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return {
+    ok: true,
+    result: body,
+    text: `VTID allocator is ${body.enabled ? 'enabled' : 'disabled'}.${body.message ? ` ${String(body.message)}` : ''}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 10. dev_query_oasis_events — GET /api/v1/oasis/events
+// ---------------------------------------------------------------------------
+
+export const dev_query_oasis_events: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 10, 200);
+  const qs = new URLSearchParams({ limit: String(limit) });
+  const vtid = normalizeVtidCandidates(args.vtid)[0];
+  if (vtid) qs.set('vtid', vtid);
+  // The events route has no "type" column filter — "topic" is the closest
+  // proxy (ilike substring), matching the actual oasis_events schema.
+  const topic = String(args.type ?? args.topic ?? '').trim();
+  if (topic) qs.set('topic', topic);
+  if (typeof args.source === 'string' && args.source) qs.set('source', args.source);
+  if (typeof args.status === 'string' && args.status) qs.set('status', args.status);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/oasis/events?${qs.toString()}`);
+  if (!ok) return { ok: false, error: `dev_query_oasis_events failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rows = (Array.isArray(body.data) ? body.data : []) as Array<{ type?: string; topic?: string; message?: string; created_at?: string }>;
+  if (rows.length === 0) return { ok: true, result: { data: [] }, text: 'No matching OASIS events found.' };
+  const lines = rows.slice(0, 8).map((r) => `${r.type || r.topic || 'event'} — ${r.message || ''} (${relAge(r.created_at)})`);
+  return { ok: true, result: { data: rows }, text: `${rows.length} events: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 11. dev_execute_vtid — POST /api/v1/worker/orchestrator/route
+// ---------------------------------------------------------------------------
+
+export const dev_execute_vtid: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const target = await resolveVtid(args, sb);
+  if ('error' in target) return { ok: false, error: target.error };
+  const title = String(args.title ?? '').trim();
+  if (!title) return { ok: false, error: 'dev_execute_vtid requires a title describing the work order.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid: target.vtid, title },
+      text: `About to route ${target.vtid} ("${title}") to the worker orchestrator for execution. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/worker/orchestrator/route', {
+    method: 'POST',
+    body: {
+      vtid: target.vtid,
+      title,
+      task_family: typeof args.task_family === 'string' ? args.task_family : 'DEV',
+      task_domain: typeof args.task_domain === 'string' ? args.task_domain : undefined,
+    },
+  });
+  if (!ok || body.ok !== true) {
+    return { ok: true, result: { routed: false, status, detail: body }, text: `Execution was not started for ${target.vtid}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { routed: true, detail: body }, text: `${target.vtid} routed to execution.` };
+};
+
+// ---------------------------------------------------------------------------
+// 12. dev_run_exec_workflow — POST /api/v1/execute/workflow
+// ---------------------------------------------------------------------------
+
+export const dev_run_exec_workflow: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const target = await resolveVtid(args, sb);
+  if ('error' in target) return { ok: false, error: target.error };
+  const action = String(args.action ?? '').trim();
+  if (!action.includes('.')) {
+    return { ok: false, error: 'dev_run_exec_workflow requires an action like "domain.step".' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid: target.vtid, action },
+      text: `About to validate workflow action "${action}" for ${target.vtid}. Note: this endpoint validates and logs only — it does not execute real work yet. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/execute/workflow', {
+    method: 'POST',
+    body: { vtid: target.vtid, action, params: (args.params as Record<string, unknown>) ?? {} },
+  });
+  if (!ok || body.ok !== true) {
+    return { ok: true, result: { validated: false, status, detail: body }, text: `Workflow validation failed: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return {
+    ok: true,
+    result: { validated: true, detail: body },
+    text: `Validated "${action}" for ${target.vtid} — this endpoint is validation-only today and does not execute real work.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 13. dev_submit_evidence — POST /api/v1/worker/subagent/complete
+// ---------------------------------------------------------------------------
+
+export const dev_submit_evidence: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const target = await resolveVtid(args, sb);
+  if ('error' in target) return { ok: false, error: target.error };
+  const domain = String(args.domain ?? '').trim();
+  if (!['frontend', 'backend', 'memory', 'infra', 'ai', 'mixed'].includes(domain)) {
+    return { ok: false, error: 'dev_submit_evidence requires domain: frontend, backend, memory, infra, ai, or mixed.' };
+  }
+  const runId = String(args.run_id ?? '').trim();
+  if (!runId) return { ok: false, error: 'dev_submit_evidence requires a run_id.' };
+  const { ok, status, body } = await gatewayApiCall('/api/v1/worker/subagent/complete', {
+    method: 'POST',
+    body: {
+      vtid: target.vtid,
+      domain,
+      run_id: runId,
+      result: { ok: args.result_ok !== false, files_changed: typeof args.files_changed === 'number' ? args.files_changed : undefined },
+    },
+  });
+  if (!ok) return { ok: true, result: { submitted: false, status, detail: body }, text: `Could not submit evidence for ${target.vtid}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { submitted: true, detail: body }, text: `Evidence submitted for ${target.vtid}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 14/15. dev_list_work_orders / dev_get_work_order
+// "Work orders" have no dedicated table — the closest live concept is task
+// discovery (list) and the task ledger row itself (get), per plan gap notes.
+// ---------------------------------------------------------------------------
+
+export const dev_list_work_orders: Handler = async (args, id) => {
+  const result = await dev_discover_tasks(args, id, undefined as unknown as SupabaseClient);
+  if (!result.ok) return result;
+  return { ...result, text: `(Work orders map to task discovery today.) ${result.text ?? ''}` };
+};
+
+export const dev_get_work_order: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const target = await resolveVtid(args, sb);
+  if ('error' in target) return { ok: false, error: target.error };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/oasis/tasks/${encodeURIComponent(target.vtid)}`);
+  if (!ok) return { ok: false, error: `dev_get_work_order failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return {
+    ok: true,
+    result: body,
+    text: `${target.vtid} — ${String(body.title ?? '(untitled)')}, status ${String(body.status ?? 'unknown')}${body.is_terminal ? `, terminal (${String(body.terminal_outcome ?? 'unknown')})` : ''}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const VTID_LIFECYCLE_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_allocate_vtid,
+  dev_create_task,
+  dev_update_task,
+  dev_cancel_task,
+  dev_complete_task,
+  dev_terminalize_vtid,
+  dev_discover_tasks,
+  dev_get_vtid_projection,
+  dev_get_allocator_status,
+  dev_query_oasis_events,
+  dev_execute_vtid,
+  dev_run_exec_workflow,
+  dev_submit_evidence,
+  dev_list_work_orders,
+  dev_get_work_order,
+};
+
+export const VTID_LIFECYCLE_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'dev_allocate_vtid',
+    description: 'DEVELOPER ONLY. Allocate a new VTID. TWO-STEP: call without confirm first, then again with confirm=true after the developer agrees.',
+    parameters: {
+      type: 'object',
+      properties: {
+        source: { type: 'string', description: 'Origin tag, e.g. "orb-voice".' },
+        layer: { type: 'string', description: 'Layer, e.g. DEV, ADM. Default DEV.' },
+        module: { type: 'string', description: 'Module tag. Default TASK.' },
+        title: { type: 'string', description: 'Optional title for the new VTID.' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+    },
+  },
+  {
+    name: 'dev_create_task',
+    description: 'DEVELOPER ONLY. Create a new OASIS task/VTID with a title. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'Task title. Required.' },
+        task_family: { type: 'string', description: 'Task family, e.g. DEV, ADM, GOVRN. Default DEV.' },
+        task_module: { type: 'string', description: 'Task module tag. Default TASK.' },
+        target_roles: { type: 'array', items: { type: 'string' }, description: 'Target roles, e.g. ["DEV"].' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['title'],
+    },
+  },
+  {
+    name: 'dev_update_task',
+    description: 'DEVELOPER ONLY. Patch a VTID task\'s title/status/summary/assigned_to. Refuses terminal tasks. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID reference, e.g. "VTID-01234" or "1234".' },
+        title: { type: 'string' },
+        status: { type: 'string', description: 'scheduled, in_progress, completed, pending, blocked, cancelled.' },
+        summary: { type: 'string' },
+        assigned_to: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid'],
+    },
+  },
+  {
+    name: 'dev_cancel_task',
+    description: 'DEVELOPER ONLY. Cancel a VTID task (deletes it if not yet started, else marks it cancelled). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID reference.' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid'],
+    },
+  },
+  {
+    name: 'dev_complete_task',
+    description: 'DEVELOPER ONLY. Mark a VTID task complete with an outcome. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID reference.' },
+        terminal_outcome: { type: 'string', description: 'success, failed, or cancelled. Default success.' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid'],
+    },
+  },
+  {
+    name: 'dev_terminalize_vtid',
+    description: 'DEVELOPER ONLY. Set is_terminal + terminal_outcome on a VTID directly (idempotent). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID reference.' },
+        outcome: { type: 'string', description: 'success, failed, or cancelled. Required.' },
+        run_id: { type: 'string' },
+        commit_sha: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid', 'outcome'],
+    },
+  },
+  {
+    name: 'dev_discover_tasks',
+    description: 'DEVELOPER ONLY. List VTIDs eligible for worker pickup (scheduled/allocated/in_progress).',
+    parameters: {
+      type: 'object',
+      properties: {
+        statuses: { type: 'string', description: 'Comma-separated statuses to filter, e.g. "scheduled,in_progress".' },
+        limit: { type: 'integer', description: 'Max rows, 1-200. Default 20.' },
+      },
+    },
+  },
+  {
+    name: 'dev_get_vtid_projection',
+    description: 'DEVELOPER ONLY. VTID projection view: stage, status, attention flags for every non-deleted VTID.',
+    parameters: {
+      type: 'object',
+      properties: {
+        limit: { type: 'integer', description: 'Max rows, 1-200. Default 20.' },
+        offset: { type: 'integer', description: 'Pagination offset.' },
+      },
+    },
+  },
+  {
+    name: 'dev_get_allocator_status',
+    description: 'DEVELOPER ONLY. Whether the VTID allocator kill-switch is on or off, and why.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dev_query_oasis_events',
+    description: 'DEVELOPER ONLY. Query OASIS events by vtid/topic/source/status.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string' },
+        type: { type: 'string', description: 'Matched against the event topic (substring).' },
+        source: { type: 'string' },
+        status: { type: 'string' },
+        limit: { type: 'integer', description: '1-200. Default 10.' },
+      },
+    },
+  },
+  {
+    name: 'dev_execute_vtid',
+    description: 'DEVELOPER ONLY. Route a VTID to the worker orchestrator for execution. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID reference.' },
+        title: { type: 'string', description: 'Work order title. Required.' },
+        task_family: { type: 'string' },
+        task_domain: { type: 'string', description: 'frontend, backend, memory, infra, ai, or mixed.' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid', 'title'],
+    },
+  },
+  {
+    name: 'dev_run_exec_workflow',
+    description: 'DEVELOPER ONLY. Validate/log a workflow action for a VTID. NOTE: this backend endpoint is validation-only today, it does not execute real work. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID reference.' },
+        action: { type: 'string', description: 'Dotted action name, e.g. "deploy.trigger". Required.' },
+        params: { type: 'object', description: 'Arbitrary params for the action.' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['vtid', 'action'],
+    },
+  },
+  {
+    name: 'dev_submit_evidence',
+    description: 'DEVELOPER ONLY. Submit subagent completion evidence for a VTID (files changed, outcome).',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID reference.' },
+        domain: { type: 'string', description: 'frontend, backend, memory, infra, ai, or mixed. Required.' },
+        run_id: { type: 'string', description: 'Required.' },
+        result_ok: { type: 'boolean', description: 'Whether the work succeeded. Default true.' },
+        files_changed: { type: 'integer' },
+      },
+      required: ['vtid', 'domain', 'run_id'],
+    },
+  },
+  {
+    name: 'dev_list_work_orders',
+    description: 'DEVELOPER ONLY. List pending work orders (maps to task discovery — there is no separate work-order table).',
+    parameters: {
+      type: 'object',
+      properties: {
+        statuses: { type: 'string' },
+        limit: { type: 'integer' },
+      },
+    },
+  },
+  {
+    name: 'dev_get_work_order',
+    description: 'DEVELOPER ONLY. Get one task/work-order by VTID.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID reference. Required.' },
+      },
+      required: ['vtid'],
+    },
+  },
+];

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-12T19:38:52.054Z",
+  "generated_at": "2026-07-12T23:07:23.919Z",
   "source": "reconciled",
   "total": 594,
   "tools": [
@@ -7112,9 +7112,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Allocate a new VTID",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7129,9 +7132,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Create OASIS task",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7146,9 +7152,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Patch task fields",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7163,9 +7172,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Cancel task",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7180,9 +7192,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Mark complete",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7197,9 +7212,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Set is_terminal + outcome",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7214,9 +7232,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Discover eligible tasks",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7231,9 +7252,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "VTID projection",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7248,9 +7272,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Allocator on/off + health",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7265,9 +7292,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Query events by vtid/type/time",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7282,9 +7312,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Trigger execution",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7299,9 +7332,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Run a workflow",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7316,9 +7352,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Submit evidence for a VTID",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7333,9 +7372,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Work orders",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7350,9 +7392,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One work order",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C1 VTID / OASIS Lifecycle",
@@ -7367,9 +7412,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Evaluate action against rules",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7384,9 +7432,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Status snapshot",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7401,9 +7452,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Rules",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7418,9 +7472,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One rule by code",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7435,9 +7492,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Violations",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7452,9 +7512,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Enforcements",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7469,9 +7532,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Live feed",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7486,9 +7552,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Proposals",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7503,9 +7572,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "New proposal",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C2 Governance",
@@ -7520,9 +7592,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Update status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C2 Governance",
@@ -7537,9 +7612,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Read control key (EXECUTION_DISARMED etc.)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7554,9 +7632,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Flip control key",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C2 Governance",
@@ -7571,9 +7652,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Key history",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C2 Governance",
@@ -7588,9 +7672,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Create PR from branch",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7605,9 +7692,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "PR state + mergeability",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7622,9 +7712,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Check runs for a PR",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7639,9 +7732,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Open PRs w/ status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7656,9 +7752,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Merge via governed pipeline",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7673,9 +7772,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Safe-merge flow",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7690,9 +7792,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Create revert PR",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7707,9 +7812,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Dispatch a GH workflow",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7724,9 +7832,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Runs for a workflow",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7741,9 +7852,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Jobs + failures for a run",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7758,9 +7872,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Merge lock status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7775,9 +7892,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Release stuck lock",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7792,9 +7912,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "CI/CD pipeline health",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7809,9 +7932,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Approvals activity feed",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C3 CI/CD & Pull Requests",
@@ -7826,9 +7952,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Deploy a service (staging path)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C4 Deployment & Release",
@@ -7843,9 +7972,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "The PUBLISH button by voice (double confirm + reason)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "double_confirm",
       "plan_domain": "C4 Deployment & Release",
@@ -7860,9 +7992,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Cloud Run revisions",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C4 Deployment & Release",
@@ -7877,9 +8012,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Deployment history",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C4 Deployment & Release",
@@ -7894,9 +8032,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Deploy health",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C4 Deployment & Release",
@@ -7911,9 +8052,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Promote canary",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C4 Deployment & Release",
@@ -7928,9 +8072,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Abort canary",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C4 Deployment & Release",
@@ -7945,9 +8092,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Revert gateway",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C4 Deployment & Release",
@@ -7962,9 +8112,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Revert gateway + frontend",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "C4 Deployment & Release",
@@ -7979,9 +8132,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Canary target status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C4 Deployment & Release",
@@ -7996,9 +8152,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "What's on staging (env, build)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C4 Deployment & Release",
@@ -8013,9 +8172,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Diff staging vs prod builds",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C4 Deployment & Release",
@@ -8030,9 +8192,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Recent releases",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C4 Deployment & Release",
@@ -8948,9 +9113,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Running revision/build per service",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -8965,9 +9133,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "/alive + health across services",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -8982,9 +9153,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Recent error rates",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -8999,9 +9173,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Latency percentiles",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9016,9 +9193,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Telemetry snapshot",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9033,9 +9213,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Recent OASIS/system events",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9050,9 +9233,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "ORB agent trace",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9067,9 +9253,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Supervisor summary",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9084,9 +9273,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Voice session turns",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9101,9 +9293,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Session diagnostics",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9118,9 +9313,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Greeting/NBA decisions",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9135,9 +9333,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Recent tool failures",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9152,9 +9353,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Tool health dashboard",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9169,9 +9373,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Greeting monitor",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",
@@ -9186,9 +9393,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One registered agent detail",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "C9 Observability",

--- a/services/gateway/test/orb-tools/cicd-pr-tools.test.ts
+++ b/services/gateway/test/orb-tools/cicd-pr-tools.test.ts
@@ -1,0 +1,164 @@
+/**
+ * CI/CD & Pull Request voice tools (Wave 2, plan section C3) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  CICD_PR_TOOL_HANDLERS,
+  CICD_PR_TOOL_DECLARATIONS,
+  dev_create_pr,
+  dev_list_open_prs,
+  dev_merge_pr,
+  dev_get_merge_lock,
+  dev_release_merge_lock,
+  dev_cicd_health,
+  dev_trigger_workflow,
+} from '../../src/services/orb-tools/cicd-pr-tools';
+
+jest.mock('../../src/services/github-service', () => ({
+  __esModule: true,
+  default: {
+    getPrStatus: jest.fn(),
+    createRevertPullRequest: jest.fn(),
+    triggerWorkflow: jest.fn(),
+    getWorkflowRuns: jest.fn(),
+    getWorkflowRunJobs: jest.fn(),
+  },
+}));
+
+import githubServiceMock from '../../src/services/github-service';
+
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+function makeSb(): SupabaseClient {
+  return {} as unknown as SupabaseClient;
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('cicd-pr role gate', () => {
+  const names = Object.keys(CICD_PR_TOOL_HANDLERS);
+
+  it('exposes all 14 tools with matching declarations', () => {
+    expect(names).toHaveLength(14);
+    const declNames = CICD_PR_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const args = {
+      vtid: 'VTID-0001', title: 'x', head: 'branch', pr_number: 1, merge_sha: 'abc',
+      branch_name: 'revert-abc', workflow_id: 'STAGE-DEPLOY.yml', run_id: 1,
+    };
+    const r = await CICD_PR_TOOL_HANDLERS[name](args, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('developer_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await CICD_PR_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_create_pr', () => {
+  it('requires vtid/title/head', async () => {
+    const r = await dev_create_pr({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await dev_create_pr({ vtid: 'VTID-1', title: 'x', head: 'branch' }, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('creates after confirm=true', async () => {
+    mockFetch(201, { ok: true, pr_url: 'https://github.com/x/y/pull/5' });
+    const r = await dev_create_pr({ vtid: 'VTID-1', title: 'x', head: 'branch', confirm: true }, DEV_ID, makeSb());
+    expect(r.text).toContain('pull/5');
+  });
+});
+
+describe('dev_list_open_prs', () => {
+  it('speaks open PRs', async () => {
+    mockFetch(200, { ok: true, items: [{ pr_number: 7, branch: 'feat', ci_state: 'pass' }] });
+    const r = await dev_list_open_prs({}, DEV_ID, makeSb());
+    expect(r.text).toContain('PR #7');
+  });
+});
+
+describe('dev_merge_pr', () => {
+  it('requires vtid and pr_number', async () => {
+    const r = await dev_merge_pr({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await dev_merge_pr({ vtid: 'VTID-1', pr_number: 5 }, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('reports governance-blocked merges honestly', async () => {
+    mockFetch(200, { ok: false, reason: 'governance_blocked' });
+    const r = await dev_merge_pr({ vtid: 'VTID-1', pr_number: 5, confirm: true }, DEV_ID, makeSb());
+    expect(r.text).toContain('governance_blocked');
+  });
+});
+
+describe('dev_trigger_workflow', () => {
+  it('validates workflow_id looks like a workflow file', async () => {
+    const r = await dev_trigger_workflow({ workflow_id: 'not-a-workflow' }, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('dispatches after confirm=true', async () => {
+    (githubServiceMock.triggerWorkflow as jest.Mock).mockResolvedValue(undefined);
+    const r = await dev_trigger_workflow({ workflow_id: 'STAGE-DEPLOY.yml', confirm: true }, DEV_ID, makeSb());
+    expect(r.ok).toBe(true);
+    expect(githubServiceMock.triggerWorkflow).toHaveBeenCalledWith('exafyltd/vitana-platform', 'STAGE-DEPLOY.yml', 'main', {});
+  });
+});
+
+describe('dev_get_merge_lock', () => {
+  it('reports no locks', async () => {
+    mockFetch(200, { ok: true, active_merges: [] });
+    const r = await dev_get_merge_lock({}, DEV_ID, makeSb());
+    expect(r.text).toContain('No merges are locked');
+  });
+});
+
+describe('dev_release_merge_lock', () => {
+  it('requires a vtid', async () => {
+    const r = await dev_release_merge_lock({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await dev_release_merge_lock({ vtid: 'VTID-1' }, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});
+
+describe('dev_cicd_health', () => {
+  it('speaks pipeline status', async () => {
+    mockFetch(200, { ok: true, status: 'ok' });
+    const r = await dev_cicd_health({}, DEV_ID, makeSb());
+    expect(r.text).toContain('ok');
+  });
+});

--- a/services/gateway/test/orb-tools/deployment-release-tools.test.ts
+++ b/services/gateway/test/orb-tools/deployment-release-tools.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Deployment & Release voice tools (Wave 2, plan section C4) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  DEPLOYMENT_RELEASE_TOOL_HANDLERS,
+  DEPLOYMENT_RELEASE_TOOL_DECLARATIONS,
+  dev_deploy_service,
+  dev_publish_to_prod,
+  dev_list_revisions,
+  dev_list_deployments,
+  dev_promote_canary,
+  dev_compare_staging_prod,
+} from '../../src/services/orb-tools/deployment-release-tools';
+
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer', user_jwt: 'jwt-abc' };
+const DEV_ID_NO_JWT: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+function makeSb(): SupabaseClient {
+  return {} as unknown as SupabaseClient;
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('deployment-release role gate', () => {
+  const names = Object.keys(DEPLOYMENT_RELEASE_TOOL_HANDLERS);
+
+  it('exposes all 13 tools with matching declarations', () => {
+    expect(names).toHaveLength(13);
+    const declNames = DEPLOYMENT_RELEASE_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const args = {
+      vtid: 'VTID-0001', service: 'gateway', reason: 'incident fix', target_revision: 'gateway-00001-abc',
+    };
+    const r = await DEPLOYMENT_RELEASE_TOOL_HANDLERS[name](args, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('developer_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await DEPLOYMENT_RELEASE_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_deploy_service', () => {
+  it('refuses production (must use dev_publish_to_prod)', async () => {
+    const r = await dev_deploy_service({ vtid: 'VTID-1', service: 'gateway', environment: 'production' }, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('dev_publish_to_prod');
+  });
+
+  it('requires confirmation for staging', async () => {
+    const r = await dev_deploy_service({ vtid: 'VTID-1', service: 'gateway' }, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});
+
+describe('dev_publish_to_prod', () => {
+  it('requires a reason', async () => {
+    const r = await dev_publish_to_prod({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires the first confirmation', async () => {
+    const r = await dev_publish_to_prod({ reason: 'hotfix' }, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean; step: number } }).result.step).toBe(1);
+  });
+
+  it('requires the second confirmation', async () => {
+    const r = await dev_publish_to_prod({ reason: 'hotfix', confirm: true }, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean; step: number } }).result.step).toBe(2);
+  });
+
+  it('refuses without an admin session even after double confirm', async () => {
+    const r = await dev_publish_to_prod({ reason: 'hotfix', confirm: true, confirm_again: true }, DEV_ID_NO_JWT, makeSb());
+    expect((r.result as { reason: string }).reason).toBe('no_admin_session');
+  });
+
+  it('publishes after both confirms with an admin session', async () => {
+    mockFetch(200, { ok: true });
+    const r = await dev_publish_to_prod({ reason: 'hotfix', confirm: true, confirm_again: true }, DEV_ID, makeSb());
+    expect(r.ok).toBe(true);
+    expect(r.text).toContain('Published to production');
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    const publishCall = calls.find((c) => String(c[0]).includes('/operator/publish'));
+    expect(publishCall).toBeDefined();
+    expect((publishCall![1].headers as Record<string, string>).Authorization).toBe('Bearer jwt-abc');
+  });
+});
+
+describe('dev_list_revisions', () => {
+  it('refuses without an admin session', async () => {
+    const r = await dev_list_revisions({}, DEV_ID_NO_JWT, makeSb());
+    expect((r.result as { reason: string }).reason).toBe('no_admin_session');
+  });
+
+  it('rejects an unknown service', async () => {
+    const r = await dev_list_revisions({ service: 'nonsense' }, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('speaks revisions with an admin session', async () => {
+    mockFetch(200, { ok: true, revisions: [{ name: 'gateway-00001-abc', is_active: true }] });
+    const r = await dev_list_revisions({ service: 'gateway' }, DEV_ID, makeSb());
+    expect(r.text).toContain('gateway-00001-abc');
+  });
+});
+
+describe('dev_list_deployments', () => {
+  it('reports no deployments honestly', async () => {
+    mockFetch(200, { ok: true, deployments: [] });
+    const r = await dev_list_deployments({}, DEV_ID, makeSb());
+    expect(r.text).toContain('No deployments');
+  });
+});
+
+describe('dev_promote_canary', () => {
+  it('requires confirmation', async () => {
+    const r = await dev_promote_canary({}, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('refuses without an admin session', async () => {
+    const r = await dev_promote_canary({ confirm: true }, DEV_ID_NO_JWT, makeSb());
+    expect((r.result as { reason: string }).reason).toBe('no_admin_session');
+  });
+});
+
+describe('dev_compare_staging_prod', () => {
+  it('reports the same commit as matching', async () => {
+    mockFetch(200, { ok: true, deployments: [{ commit_sha: 'abc1234', created_at: new Date().toISOString() }] });
+    const r = await dev_compare_staging_prod({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(true);
+    expect(r.text).toContain('same commit');
+  });
+});

--- a/services/gateway/test/orb-tools/governance-tools.test.ts
+++ b/services/gateway/test/orb-tools/governance-tools.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Governance voice tools (Wave 2, plan section C2) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  GOVERNANCE_TOOL_HANDLERS,
+  GOVERNANCE_TOOL_DECLARATIONS,
+  dev_evaluate_governance,
+  dev_governance_status,
+  dev_list_violations,
+  dev_create_proposal,
+  dev_update_proposal,
+  dev_get_control,
+  dev_set_control,
+} from '../../src/services/orb-tools/governance-tools';
+
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+function makeSb(): SupabaseClient {
+  return {} as unknown as SupabaseClient;
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('governance role gate', () => {
+  const names = Object.keys(GOVERNANCE_TOOL_HANDLERS);
+
+  it('exposes all 13 tools with matching declarations', () => {
+    expect(names).toHaveLength(13);
+    const declNames = GOVERNANCE_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const args = {
+      action: 'deploy', service: 'gateway', environment: 'staging', rule_code: 'R1',
+      key: 'vtid_allocator_enabled', enabled: true, reason: 'test',
+      type: 'New Rule', proposed_rule: 'x', proposal_id: 'PROP-1', status: 'Approved',
+    };
+    const r = await GOVERNANCE_TOOL_HANDLERS[name](args, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('developer_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await GOVERNANCE_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_evaluate_governance', () => {
+  it('requires action/service/environment', async () => {
+    const r = await dev_evaluate_governance({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('speaks the allowed decision', async () => {
+    mockFetch(200, { ok: true, allowed: true, level: 'L1', violations: [] });
+    const r = await dev_evaluate_governance({ action: 'deploy', service: 'gateway', environment: 'staging' }, DEV_ID, makeSb());
+    expect(r.text).toContain('Allowed');
+  });
+});
+
+describe('dev_governance_status', () => {
+  it('summarizes disabled controls', async () => {
+    mockFetch(200, { ok: true, data: [{ key: 'a', enabled: true }, { key: 'b', enabled: false }] });
+    const r = await dev_governance_status({}, DEV_ID, makeSb());
+    expect(r.text).toContain('Disabled: b');
+  });
+});
+
+describe('dev_list_violations', () => {
+  it('reports zero violations honestly', async () => {
+    mockFetch(200, []);
+    const r = await dev_list_violations({}, DEV_ID, makeSb());
+    expect(r.text).toContain('No open governance violations');
+  });
+});
+
+describe('dev_create_proposal', () => {
+  it('validates type', async () => {
+    const r = await dev_create_proposal({ type: 'bogus', proposed_rule: 'x' }, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await dev_create_proposal({ type: 'New Rule', proposed_rule: 'x' }, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('creates after confirm=true', async () => {
+    mockFetch(201, { proposalId: 'PROP-1' });
+    const r = await dev_create_proposal({ type: 'New Rule', proposed_rule: 'x', confirm: true }, DEV_ID, makeSb());
+    expect(r.text).toContain('PROP-1');
+  });
+});
+
+describe('dev_update_proposal', () => {
+  it('validates status', async () => {
+    const r = await dev_update_proposal({ proposal_id: 'PROP-1', status: 'bogus' }, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_get_control / dev_set_control', () => {
+  it('dev_get_control reads a control key', async () => {
+    mockFetch(200, { ok: true, data: { enabled: true, reason: 'ok' } });
+    const r = await dev_get_control({ key: 'vtid_allocator_enabled' }, DEV_ID, makeSb());
+    expect(r.text).toContain('enabled');
+  });
+
+  it('dev_set_control requires a reason', async () => {
+    const r = await dev_set_control({ key: 'vtid_allocator_enabled', enabled: false }, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('dev_set_control requires confirmation', async () => {
+    const r = await dev_set_control({ key: 'vtid_allocator_enabled', enabled: false, reason: 'incident' }, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});

--- a/services/gateway/test/orb-tools/observability-tools.test.ts
+++ b/services/gateway/test/orb-tools/observability-tools.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Observability voice tools (Wave 2, plan section C9) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  OBSERVABILITY_TOOL_HANDLERS,
+  OBSERVABILITY_TOOL_DECLARATIONS,
+  dev_build_info,
+  dev_error_rate,
+  dev_latency_summary,
+  dev_recent_events,
+  dev_telemetry_snapshot,
+  dev_get_session_turns,
+  dev_conversation_decisions,
+  dev_tool_failures,
+  dev_tool_health,
+  dev_get_agent_detail,
+} from '../../src/services/orb-tools/observability-tools';
+
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer', user_jwt: 'jwt-abc' };
+const DEV_ID_NO_JWT: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+interface StubResp {
+  data: unknown;
+  error: { message: string } | null;
+}
+
+function makeSb(tables: Record<string, StubResp[]> = {}): SupabaseClient {
+  const used: Record<string, number> = {};
+  const sb = {
+    from(table: string) {
+      const queue = tables[table] ?? [];
+      const i = used[table] ?? 0;
+      used[table] = i + 1;
+      const resp: StubResp = queue[Math.min(i, queue.length - 1)] ?? { data: [], error: null };
+      const chain: Record<string, unknown> = {};
+      for (const m of ['select', 'eq', 'gte', 'lte', 'order', 'limit']) {
+        chain[m] = () => chain;
+      }
+      chain.then = (onOk: (v: StubResp) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(resp).then(onOk, onErr);
+      return chain;
+    },
+  };
+  return sb as unknown as SupabaseClient;
+}
+
+const ok = (data: unknown): StubResp => ({ data, error: null });
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('observability role gate', () => {
+  const names = Object.keys(OBSERVABILITY_TOOL_HANDLERS);
+
+  it('exposes all 15 tools with matching declarations', () => {
+    expect(names).toHaveLength(15);
+    const declNames = OBSERVABILITY_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const args = { session_id: 's-1', agent_id: 'a-1' };
+    const r = await OBSERVABILITY_TOOL_HANDLERS[name](args, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('developer_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await OBSERVABILITY_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_build_info', () => {
+  it('speaks the running commit and notes the gateway-only scope', async () => {
+    mockFetch(200, { git_commit: 'abc1234', cloud_run_revision: 'gateway-00001-abc', env: 'staging' });
+    const r = await dev_build_info({}, DEV_ID, makeSb());
+    expect(r.text).toContain('abc1234');
+    expect(r.text).toContain('this gateway instance');
+  });
+});
+
+describe('dev_error_rate', () => {
+  it('computes an error rate from oasis_events', async () => {
+    const sb = makeSb({
+      oasis_events: [ok([{ status: 'ok' }, { status: 'error' }, { status: 'ok' }, { status: 'ok' }])],
+    });
+    const r = await dev_error_rate({ hours: 24 }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r.result as { errors: number; total: number }).errors).toBe(1);
+    expect((r.result as { errors: number; total: number }).total).toBe(4);
+  });
+});
+
+describe('dev_latency_summary', () => {
+  it('computes p50/p95 from payload.total_ms', async () => {
+    const values = Array.from({ length: 10 }, (_, i) => ({ payload: { total_ms: (i + 1) * 100 } }));
+    const sb = makeSb({ oasis_events: [ok(values)] });
+    const r = await dev_latency_summary({ hours: 24 }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r.result as { count: number }).count).toBe(10);
+  });
+
+  it('handles zero samples honestly', async () => {
+    const sb = makeSb({ oasis_events: [ok([])] });
+    const r = await dev_latency_summary({}, DEV_ID, sb);
+    expect(r.text).toContain('No voice latency samples');
+  });
+});
+
+describe('dev_telemetry_snapshot', () => {
+  it('requires a session', async () => {
+    const r = await dev_telemetry_snapshot({}, DEV_ID_NO_JWT, makeSb());
+    expect((r.result as { reason: string }).reason).toBe('no_session');
+  });
+
+  it('forwards the session JWT', async () => {
+    mockFetch(200, { ok: true });
+    await dev_telemetry_snapshot({}, DEV_ID, makeSb());
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect((call[1].headers as Record<string, string>).Authorization).toBe('Bearer jwt-abc');
+  });
+});
+
+describe('dev_recent_events', () => {
+  it('speaks recent events', async () => {
+    mockFetch(200, { data: [{ type: 'vtid.lifecycle.completed', message: 'done', created_at: new Date().toISOString() }] });
+    const r = await dev_recent_events({}, DEV_ID, makeSb());
+    expect(r.text).toContain('vtid.lifecycle.completed');
+  });
+});
+
+describe('dev_get_session_turns', () => {
+  it('requires session_id', async () => {
+    const r = await dev_get_session_turns({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires a session', async () => {
+    const r = await dev_get_session_turns({ session_id: 's-1' }, DEV_ID_NO_JWT, makeSb());
+    expect((r.result as { reason: string }).reason).toBe('no_session');
+  });
+});
+
+describe('dev_conversation_decisions', () => {
+  it('requires a session', async () => {
+    const r = await dev_conversation_decisions({}, DEV_ID_NO_JWT, makeSb());
+    expect((r.result as { reason: string }).reason).toBe('no_session');
+  });
+
+  it('reports zero decisions honestly', async () => {
+    mockFetch(200, { data: [] });
+    const r = await dev_conversation_decisions({}, DEV_ID, makeSb());
+    expect(r.text).toContain('No greeting/NBA decisions');
+  });
+});
+
+describe('dev_tool_failures / dev_tool_health', () => {
+  it('dev_tool_failures groups by tool', async () => {
+    mockFetch(200, { data: [{ metadata: { tool: 'send_funds' } }, { metadata: { tool: 'send_funds' } }, { metadata: { tool: 'log_meal' } }] });
+    const r = await dev_tool_failures({}, DEV_ID, makeSb());
+    expect(r.text).toContain('send_funds: 2');
+  });
+
+  it('dev_tool_health reports healthy with no failures', async () => {
+    mockFetch(200, { data: [] });
+    const r = await dev_tool_health({}, DEV_ID, makeSb());
+    expect(r.text).toContain('healthy');
+  });
+});
+
+describe('dev_get_agent_detail', () => {
+  it('requires agent_id', async () => {
+    const r = await dev_get_agent_detail({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports not-found for a 404', async () => {
+    mockFetch(404, { error: 'not found' });
+    const r = await dev_get_agent_detail({ agent_id: 'nope' }, DEV_ID, makeSb());
+    expect((r.result as { found: boolean }).found).toBe(false);
+  });
+
+  it('speaks the agent detail', async () => {
+    mockFetch(200, { display_name: 'Worker Runner', tier: 'service', derived_status: 'healthy' });
+    const r = await dev_get_agent_detail({ agent_id: 'worker-runner' }, DEV_ID, makeSb());
+    expect(r.text).toContain('Worker Runner');
+  });
+});

--- a/services/gateway/test/orb-tools/vtid-lifecycle-tools.test.ts
+++ b/services/gateway/test/orb-tools/vtid-lifecycle-tools.test.ts
@@ -1,0 +1,234 @@
+/**
+ * VTID / OASIS Lifecycle voice tools (Wave 2, plan section C1) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  VTID_LIFECYCLE_TOOL_HANDLERS,
+  VTID_LIFECYCLE_TOOL_DECLARATIONS,
+  dev_allocate_vtid,
+  dev_create_task,
+  dev_update_task,
+  dev_cancel_task,
+  dev_complete_task,
+  dev_terminalize_vtid,
+  dev_discover_tasks,
+  dev_get_allocator_status,
+  dev_execute_vtid,
+} from '../../src/services/orb-tools/vtid-lifecycle-tools';
+
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+interface StubResp {
+  data: unknown;
+  error: { message: string } | null;
+}
+
+function makeSb(tables: Record<string, StubResp[]> = {}): SupabaseClient {
+  const used: Record<string, number> = {};
+  const sb = {
+    from(table: string) {
+      const queue = tables[table] ?? [];
+      const i = used[table] ?? 0;
+      used[table] = i + 1;
+      const resp: StubResp = queue[Math.min(i, queue.length - 1)] ?? { data: [], error: null };
+      const chain: Record<string, unknown> = {};
+      for (const m of ['select', 'eq', 'in', 'gte', 'lte', 'order', 'limit', 'filter', 'or', 'ilike']) {
+        chain[m] = () => chain;
+      }
+      chain.then = (onOk: (v: StubResp) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(resp).then(onOk, onErr);
+      return chain;
+    },
+  };
+  return sb as unknown as SupabaseClient;
+}
+
+const ok = (data: unknown): StubResp => ({ data, error: null });
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('vtid-lifecycle role gate', () => {
+  const names = Object.keys(VTID_LIFECYCLE_TOOL_HANDLERS);
+
+  it('exposes all 15 tools with matching declarations', () => {
+    expect(names).toHaveLength(15);
+    const declNames = VTID_LIFECYCLE_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await VTID_LIFECYCLE_TOOL_HANDLERS[name](
+      { vtid: 'VTID-0001', title: 'x', outcome: 'success', domain: 'backend', run_id: 'r1' },
+      COMMUNITY_ID,
+      makeSb(),
+    );
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('developer_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await VTID_LIFECYCLE_TOOL_HANDLERS[name](
+      { vtid: 'VTID-0001', title: 'x', outcome: 'success', domain: 'backend', run_id: 'r1' },
+      ANON_ID,
+      makeSb(),
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_allocate_vtid', () => {
+  it('requires confirmation before allocating', async () => {
+    const r = await dev_allocate_vtid({ title: 'New feature' }, DEV_ID, makeSb());
+    expect(r.ok).toBe(true);
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('allocates after confirm=true', async () => {
+    mockFetch(201, { ok: true, vtid: 'VTID-09999' });
+    const r = await dev_allocate_vtid({ title: 'New feature', confirm: true }, DEV_ID, makeSb());
+    expect(r.ok).toBe(true);
+    expect(r.text).toContain('VTID-09999');
+  });
+});
+
+describe('dev_create_task', () => {
+  it('requires a title', async () => {
+    const r = await dev_create_task({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await dev_create_task({ title: 'Do the thing' }, DEV_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('creates after confirm=true', async () => {
+    mockFetch(201, { ok: true, vtid: 'VTID-08888' });
+    const r = await dev_create_task({ title: 'Do the thing', confirm: true }, DEV_ID, makeSb());
+    expect(r.text).toContain('VTID-08888');
+  });
+});
+
+describe('dev_update_task', () => {
+  it('refuses to modify a terminal task', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'completed', is_terminal: true }])] });
+    const r = await dev_update_task({ vtid: '0001', title: 'renamed' }, DEV_ID, sb);
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('terminal');
+  });
+
+  it('requires confirmation for a non-terminal task', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'in_progress', is_terminal: false }])] });
+    const r = await dev_update_task({ vtid: '0001', title: 'renamed' }, DEV_ID, sb);
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});
+
+describe('dev_cancel_task', () => {
+  it('reports already-terminal tasks without calling the API', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'completed', is_terminal: true }])] });
+    const r = await dev_cancel_task({ vtid: '0001' }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { already_terminal: boolean } }).result.already_terminal).toBe(true);
+  });
+
+  it('deletes a pre-start task after confirm', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'scheduled', is_terminal: false }])] });
+    mockFetch(200, { ok: true });
+    const r = await dev_cancel_task({ vtid: '0001', confirm: true }, DEV_ID, sb);
+    expect(r.ok).toBe(true);
+    expect((global.fetch as jest.Mock).mock.calls[0][1].method).toBe('DELETE');
+  });
+
+  it('completes-as-cancelled an in-flight task after confirm', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'in_progress', is_terminal: false }])] });
+    mockFetch(200, { ok: true });
+    await dev_cancel_task({ vtid: '0001', confirm: true }, DEV_ID, sb);
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(String(call[0])).toContain('/complete');
+  });
+});
+
+describe('dev_complete_task', () => {
+  it('requires confirmation', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'in_progress', is_terminal: false }])] });
+    const r = await dev_complete_task({ vtid: '0001' }, DEV_ID, sb);
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('reports a retry-reset on failed outcome', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'in_progress', is_terminal: false }])] });
+    mockFetch(200, { status: 'scheduled', failure_count: 1 });
+    const r = await dev_complete_task({ vtid: '0001', terminal_outcome: 'failed', confirm: true }, DEV_ID, sb);
+    expect(r.text).toContain('reset for retry');
+  });
+});
+
+describe('dev_terminalize_vtid', () => {
+  it('rejects an invalid outcome', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'in_progress', is_terminal: false }])] });
+    const r = await dev_terminalize_vtid({ vtid: '0001', outcome: 'bogus' }, DEV_ID, sb);
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports already_terminal idempotently', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'completed', is_terminal: false }])] });
+    mockFetch(200, { ok: true, already_terminal: true });
+    const r = await dev_terminalize_vtid({ vtid: '0001', outcome: 'success', confirm: true }, DEV_ID, sb);
+    expect(r.text).toContain('already terminal');
+  });
+});
+
+describe('dev_discover_tasks', () => {
+  it('speaks eligible tasks', async () => {
+    mockFetch(200, { ok: true, pending: [{ vtid: 'VTID-0001', title: 'Fix bug', status: 'scheduled' }] });
+    const r = await dev_discover_tasks({}, DEV_ID, makeSb());
+    expect(r.ok).toBe(true);
+    expect(r.text).toContain('VTID-0001');
+  });
+
+  it('handles zero results honestly', async () => {
+    mockFetch(200, { ok: true, pending: [] });
+    const r = await dev_discover_tasks({}, DEV_ID, makeSb());
+    expect(r.text).toContain('No eligible tasks');
+  });
+});
+
+describe('dev_get_allocator_status', () => {
+  it('speaks enabled/disabled state', async () => {
+    mockFetch(200, { ok: true, enabled: true, message: 'all clear' });
+    const r = await dev_get_allocator_status({}, DEV_ID, makeSb());
+    expect(r.text).toContain('enabled');
+  });
+});
+
+describe('dev_execute_vtid', () => {
+  it('requires a title', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'scheduled', is_terminal: false }])] });
+    const r = await dev_execute_vtid({ vtid: '0001' }, DEV_ID, sb);
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation before routing to the orchestrator', async () => {
+    const sb = makeSb({ vtid_ledger: [ok([{ vtid: 'VTID-0001', status: 'scheduled', is_terminal: false }])] });
+    const r = await dev_execute_vtid({ vtid: '0001', title: 'Ship it' }, DEV_ID, sb);
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -6479,6 +6479,1359 @@ Optionally filter by tier (service, embedded, scheduled). Speak problem agents f
           "type": "object",
         },
       },
+      {
+        "description": "DEVELOPER ONLY. Allocate a new VTID. TWO-STEP: call without confirm first, then again with confirm=true after the developer agrees.",
+        "name": "dev_allocate_vtid",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "layer": {
+              "description": "Layer, e.g. DEV, ADM. Default DEV.",
+              "type": "string",
+            },
+            "module": {
+              "description": "Module tag. Default TASK.",
+              "type": "string",
+            },
+            "source": {
+              "description": "Origin tag, e.g. "orb-voice".",
+              "type": "string",
+            },
+            "title": {
+              "description": "Optional title for the new VTID.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Create a new OASIS task/VTID with a title. TWO-STEP confirm.",
+        "name": "dev_create_task",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "target_roles": {
+              "description": "Target roles, e.g. ["DEV"].",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "task_family": {
+              "description": "Task family, e.g. DEV, ADM, GOVRN. Default DEV.",
+              "type": "string",
+            },
+            "task_module": {
+              "description": "Task module tag. Default TASK.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Task title. Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "title",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Patch a VTID task's title/status/summary/assigned_to. Refuses terminal tasks. TWO-STEP confirm.",
+        "name": "dev_update_task",
+        "parameters": {
+          "properties": {
+            "assigned_to": {
+              "type": "string",
+            },
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "status": {
+              "description": "scheduled, in_progress, completed, pending, blocked, cancelled.",
+              "type": "string",
+            },
+            "summary": {
+              "type": "string",
+            },
+            "title": {
+              "type": "string",
+            },
+            "vtid": {
+              "description": "VTID reference, e.g. "VTID-01234" or "1234".",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Cancel a VTID task (deletes it if not yet started, else marks it cancelled). TWO-STEP confirm.",
+        "name": "dev_cancel_task",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "vtid": {
+              "description": "VTID reference.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Mark a VTID task complete with an outcome. TWO-STEP confirm.",
+        "name": "dev_complete_task",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "terminal_outcome": {
+              "description": "success, failed, or cancelled. Default success.",
+              "type": "string",
+            },
+            "vtid": {
+              "description": "VTID reference.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Set is_terminal + terminal_outcome on a VTID directly (idempotent). TWO-STEP confirm.",
+        "name": "dev_terminalize_vtid",
+        "parameters": {
+          "properties": {
+            "commit_sha": {
+              "type": "string",
+            },
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "outcome": {
+              "description": "success, failed, or cancelled. Required.",
+              "type": "string",
+            },
+            "run_id": {
+              "type": "string",
+            },
+            "vtid": {
+              "description": "VTID reference.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "outcome",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List VTIDs eligible for worker pickup (scheduled/allocated/in_progress).",
+        "name": "dev_discover_tasks",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max rows, 1-200. Default 20.",
+              "type": "integer",
+            },
+            "statuses": {
+              "description": "Comma-separated statuses to filter, e.g. "scheduled,in_progress".",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. VTID projection view: stage, status, attention flags for every non-deleted VTID.",
+        "name": "dev_get_vtid_projection",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max rows, 1-200. Default 20.",
+              "type": "integer",
+            },
+            "offset": {
+              "description": "Pagination offset.",
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Whether the VTID allocator kill-switch is on or off, and why.",
+        "name": "dev_get_allocator_status",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Query OASIS events by vtid/topic/source/status.",
+        "name": "dev_query_oasis_events",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "1-200. Default 10.",
+              "type": "integer",
+            },
+            "source": {
+              "type": "string",
+            },
+            "status": {
+              "type": "string",
+            },
+            "type": {
+              "description": "Matched against the event topic (substring).",
+              "type": "string",
+            },
+            "vtid": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Route a VTID to the worker orchestrator for execution. TWO-STEP confirm.",
+        "name": "dev_execute_vtid",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "task_domain": {
+              "description": "frontend, backend, memory, infra, ai, or mixed.",
+              "type": "string",
+            },
+            "task_family": {
+              "type": "string",
+            },
+            "title": {
+              "description": "Work order title. Required.",
+              "type": "string",
+            },
+            "vtid": {
+              "description": "VTID reference.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "title",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Validate/log a workflow action for a VTID. NOTE: this backend endpoint is validation-only today, it does not execute real work. TWO-STEP confirm.",
+        "name": "dev_run_exec_workflow",
+        "parameters": {
+          "properties": {
+            "action": {
+              "description": "Dotted action name, e.g. "deploy.trigger". Required.",
+              "type": "string",
+            },
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "params": {
+              "description": "Arbitrary params for the action.",
+              "type": "object",
+            },
+            "vtid": {
+              "description": "VTID reference.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "action",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Submit subagent completion evidence for a VTID (files changed, outcome).",
+        "name": "dev_submit_evidence",
+        "parameters": {
+          "properties": {
+            "domain": {
+              "description": "frontend, backend, memory, infra, ai, or mixed. Required.",
+              "type": "string",
+            },
+            "files_changed": {
+              "type": "integer",
+            },
+            "result_ok": {
+              "description": "Whether the work succeeded. Default true.",
+              "type": "boolean",
+            },
+            "run_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "vtid": {
+              "description": "VTID reference.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "domain",
+            "run_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List pending work orders (maps to task discovery — there is no separate work-order table).",
+        "name": "dev_list_work_orders",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "statuses": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Get one task/work-order by VTID.",
+        "name": "dev_get_work_order",
+        "parameters": {
+          "properties": {
+            "vtid": {
+              "description": "VTID reference. Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Evaluate whether an action would be allowed by governance rules for a service/environment.",
+        "name": "dev_evaluate_governance",
+        "parameters": {
+          "properties": {
+            "action": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "environment": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "service": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "vtid": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "action",
+            "service",
+            "environment",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Governance control-plane snapshot: which control keys are enabled/disabled.",
+        "name": "dev_governance_status",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List governance rules, optionally filtered by category/status/level/search.",
+        "name": "dev_list_governance_rules",
+        "parameters": {
+          "properties": {
+            "category": {
+              "type": "string",
+            },
+            "level": {
+              "type": "string",
+            },
+            "search": {
+              "type": "string",
+            },
+            "status": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Get one governance rule by its code, with recent evaluations.",
+        "name": "dev_get_governance_rule",
+        "parameters": {
+          "properties": {
+            "rule_code": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "rule_code",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List open/recent governance violations.",
+        "name": "dev_list_violations",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List recent governance enforcement actions.",
+        "name": "dev_list_enforcements",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent governance activity feed.",
+        "name": "dev_governance_feed",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List governance rule-change proposals, optionally filtered by status/rule_code.",
+        "name": "dev_list_proposals",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "ruleCode": {
+              "type": "string",
+            },
+            "status": {
+              "description": "Draft, Under Review, Approved, Rejected, Implemented.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Create a governance rule-change proposal. TWO-STEP confirm.",
+        "name": "dev_create_proposal",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "proposed_rule": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "rationale": {
+              "type": "string",
+            },
+            "rule_code": {
+              "description": "Required for Change/Deprecate.",
+              "type": "string",
+            },
+            "type": {
+              "description": ""New Rule", "Change Rule", or "Deprecate Rule". Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "type",
+            "proposed_rule",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Change a proposal's status (Draft/Under Review/Approved/Rejected/Implemented). TWO-STEP confirm.",
+        "name": "dev_update_proposal",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "proposal_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "status": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "proposal_id",
+            "status",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Read a governance control key (e.g. vtid_allocator_enabled, autopilot_execution_enabled).",
+        "name": "dev_get_control",
+        "parameters": {
+          "properties": {
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "key",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Flip a governance control key on/off — a real kill-switch, requires a reason. TWO-STEP confirm.",
+        "name": "dev_set_control",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "duration_minutes": {
+              "description": "Optional auto-expiry.",
+              "type": "integer",
+            },
+            "enabled": {
+              "description": "Required.",
+              "type": "boolean",
+            },
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "reason": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "key",
+            "enabled",
+            "reason",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Change history for a governance control key.",
+        "name": "dev_get_control_history",
+        "parameters": {
+          "properties": {
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "limit": {
+              "type": "integer",
+            },
+          },
+          "required": [
+            "key",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Create a PR from a branch into main. TWO-STEP confirm.",
+        "name": "dev_create_pr",
+        "parameters": {
+          "properties": {
+            "body": {
+              "type": "string",
+            },
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "head": {
+              "description": "Source branch. Required.",
+              "type": "string",
+            },
+            "repo": {
+              "description": "Default exafyltd/vitana-platform.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "title",
+            "head",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. PR state and mergeability.",
+        "name": "dev_get_pr_status",
+        "parameters": {
+          "properties": {
+            "pr_number": {
+              "description": "Required.",
+              "type": "integer",
+            },
+            "repo": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "pr_number",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. CI check runs for a PR.",
+        "name": "dev_get_pr_checks",
+        "parameters": {
+          "properties": {
+            "pr_number": {
+              "description": "Required.",
+              "type": "integer",
+            },
+            "repo": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "pr_number",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List open PRs with CI/mergeable status.",
+        "name": "dev_list_open_prs",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "repo": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Merge a PR through the governed pipeline (checks + governance + validator gate). TWO-STEP confirm.",
+        "name": "dev_merge_pr",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "pr_number": {
+              "description": "Required.",
+              "type": "integer",
+            },
+            "repo": {
+              "type": "string",
+            },
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "pr_number",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Safe-merge a PR (checks + governance gate, no validator step). TWO-STEP confirm.",
+        "name": "dev_safe_merge",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "merge_strategy": {
+              "type": "string",
+            },
+            "pr_number": {
+              "description": "Required.",
+              "type": "integer",
+            },
+            "repo": {
+              "type": "string",
+            },
+            "require_checks": {
+              "type": "boolean",
+            },
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "pr_number",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Open a revert PR for a given merge commit. TWO-STEP confirm.",
+        "name": "dev_revert_pr",
+        "parameters": {
+          "properties": {
+            "body": {
+              "type": "string",
+            },
+            "branch_name": {
+              "description": "Required — new branch name for the revert.",
+              "type": "string",
+            },
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "merge_sha": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "repo": {
+              "type": "string",
+            },
+            "title": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "merge_sha",
+            "branch_name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Dispatch a GitHub Actions workflow file by name. TWO-STEP confirm.",
+        "name": "dev_trigger_workflow",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "inputs": {
+              "description": "Workflow inputs.",
+              "type": "object",
+            },
+            "ref": {
+              "description": "Branch/ref. Default main.",
+              "type": "string",
+            },
+            "repo": {
+              "type": "string",
+            },
+            "workflow_id": {
+              "description": "Workflow filename, e.g. "STAGE-DEPLOY.yml". Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "workflow_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent runs for a GitHub Actions workflow.",
+        "name": "dev_list_workflow_runs",
+        "parameters": {
+          "properties": {
+            "repo": {
+              "type": "string",
+            },
+            "workflow_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "workflow_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Jobs and failures for a specific workflow run.",
+        "name": "dev_get_run_jobs",
+        "parameters": {
+          "properties": {
+            "repo": {
+              "type": "string",
+            },
+            "run_id": {
+              "description": "Required.",
+              "type": "integer",
+            },
+          },
+          "required": [
+            "run_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Current CI/CD merge lock status.",
+        "name": "dev_get_merge_lock",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Force-release a stuck merge lock for a VTID. TWO-STEP confirm.",
+        "name": "dev_release_merge_lock",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "reason": {
+              "type": "string",
+            },
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. CI/CD pipeline health (env config, runtime deploy, governance, AI services).",
+        "name": "dev_cicd_health",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. GitHub-authoritative feed of open PRs and their approval-readiness.",
+        "name": "dev_approvals_feed",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "repo": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Deploy a service to staging (never production — use dev_publish_to_prod for that). TWO-STEP confirm.",
+        "name": "dev_deploy_service",
+        "parameters": {
+          "properties": {
+            "branch": {
+              "description": "Default main.",
+              "type": "string",
+            },
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "environment": {
+              "description": "staging or dev. Default staging.",
+              "type": "string",
+            },
+            "service": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "service",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. The PUBLISH button by voice — promotes the tested staging build to production. DOUBLE-CONFIRM: requires a reason, then confirm=true, then confirm_again=true on a third call after re-confirming out loud. Requires a signed-in admin session.",
+        "name": "dev_publish_to_prod",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true after the first explicit confirmation.",
+              "type": "boolean",
+            },
+            "confirm_again": {
+              "description": "Set true after the SECOND explicit confirmation.",
+              "type": "boolean",
+            },
+            "confirm_short_sha": {
+              "type": "string",
+            },
+            "mode": {
+              "description": ""full" or "canary". Default full.",
+              "type": "string",
+            },
+            "reason": {
+              "description": "Required — why this publish is happening.",
+              "type": "string",
+            },
+            "vtid": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "reason",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Cloud Run revisions for a service. Requires an admin session.",
+        "name": "dev_list_revisions",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "service": {
+              "description": "gateway, gateway-staging, community-app, or community-app-staging.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Deployment history, optionally filtered by service/environment.",
+        "name": "dev_list_deployments",
+        "parameters": {
+          "properties": {
+            "environment": {
+              "type": "string",
+            },
+            "limit": {
+              "type": "integer",
+            },
+            "service": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Deployment pipeline config health.",
+        "name": "dev_deployment_health",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Promote the canary revision to 100% traffic. Requires an admin session. TWO-STEP confirm.",
+        "name": "dev_promote_canary",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "service": {
+              "description": "Default gateway.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Abort the canary and restore the stable revision to 100%. Requires an admin session. TWO-STEP confirm.",
+        "name": "dev_abort_canary",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "service": {
+              "description": "Default gateway.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Revert a service to a prior revision. Requires an admin session. TWO-STEP confirm.",
+        "name": "dev_revert_deploy",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "confirm_short_sha": {
+              "type": "string",
+            },
+            "service": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "target_revision": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "service",
+            "target_revision",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Revert a service AND its paired frontend/backend counterpart together. Requires an admin session. TWO-STEP confirm.",
+        "name": "dev_revert_both",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "service": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "target_created_at": {
+              "type": "string",
+            },
+            "target_revision": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "service",
+            "target_revision",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Whether a canary traffic split is currently active for a service. Requires an admin session.",
+        "name": "dev_canary_status",
+        "parameters": {
+          "properties": {
+            "service": {
+              "description": "Default gateway.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. What build/commit is currently on staging.",
+        "name": "dev_staging_status",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Whether staging and production are on the same build.",
+        "name": "dev_compare_staging_prod",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent releases across services.",
+        "name": "dev_release_feed",
+        "parameters": {
+          "properties": {
+            "environment": {
+              "type": "string",
+            },
+            "limit": {
+              "type": "integer",
+            },
+            "service": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Running revision/build info for this gateway instance.",
+        "name": "dev_build_info",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Health + /alive check for this gateway instance.",
+        "name": "dev_service_health",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent OASIS event error rate over a time window.",
+        "name": "dev_error_rate",
+        "parameters": {
+          "properties": {
+            "hours": {
+              "description": "Window size, default 24.",
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Voice turn latency percentiles (p50/p95) over a time window.",
+        "name": "dev_latency_summary",
+        "parameters": {
+          "properties": {
+            "hours": {
+              "description": "Window size, default 24.",
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Telemetry snapshot: recent events + pipeline stage counters.",
+        "name": "dev_telemetry_snapshot",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent OASIS/system events, most recent first.",
+        "name": "dev_recent_events",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent ORB agent trace(s).",
+        "name": "dev_agent_trace",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "phase": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Supervisor summary: dataset/shadow/finetune/canary/backlog sections.",
+        "name": "dev_supervisor_summary",
+        "parameters": {
+          "properties": {
+            "window_hours": {
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Per-turn timeline for a voice session.",
+        "name": "dev_get_session_turns",
+        "parameters": {
+          "properties": {
+            "session_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "session_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Diagnostics analysis for a voice session.",
+        "name": "dev_get_session_diagnostics",
+        "parameters": {
+          "properties": {
+            "session_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "session_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent greeting/next-best-action decisions. Requires exafy_admin session.",
+        "name": "dev_conversation_decisions",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "window_hours": {
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent voice-tool failures, grouped by tool. Requires exafy_admin session.",
+        "name": "dev_tool_failures",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "window_hours": {
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Tool health rollup derived from recent failures (no dedicated dashboard exists). Requires exafy_admin session.",
+        "name": "dev_tool_health",
+        "parameters": {
+          "properties": {
+            "window_hours": {
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Greeting-monitor view of recent conversation decisions (same source as dev_conversation_decisions). Requires exafy_admin session.",
+        "name": "dev_greeting_decisions",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "window_hours": {
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Detail for one registered agent by id.",
+        "name": "dev_get_agent_detail",
+        "parameters": {
+          "properties": {
+            "agent_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "agent_id",
+          ],
+          "type": "object",
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VOICE-CATALOG-WAVE-2` _(BOOTSTRAP-style tag, matching Wave 1's `VOICE-CATALOG-WAVE-1` — no individual VTID allocated for this catalog build)_

**Layer:** AGTL (voice/agent tooling)

**Priority:** P0

---

## 📋 Summary

Wave 2 of the approved [Voice Tools Expansion Plan v2](docs/VOICE_TOOLS_EXPANSION_PLAN.md): 70 new **developer-only** voice tools covering VTID/OASIS lifecycle (C1), governance (C2), CI/CD & pull requests (C3), deployment/release (C4), and observability (C9) — the plan's "Developer P0" wave, following the exact architecture the first 169+69 tools shipped with.

## ✅ Changes

- [x] 5 new handler modules under `services/gateway/src/services/orb-tools/`: `vtid-lifecycle-tools.ts` (15), `governance-tools.ts` (13), `cicd-pr-tools.ts` (14), `deployment-release-tools.ts` (13), `observability-tools.ts` (15) — each a thin dispatch layer over existing routes/services, no new backend behaviour invented
- [x] Two-step confirm on every mutating tool; `dev_publish_to_prod` requires a reason plus a **double** confirm and records the reason to OASIS (`production.publish.requested`), since `/api/v1/operator/publish` has no reason field of its own
- [x] Admin-auth routes (publish/promote/abort-canary/revert/revert-both/revisions) forward the caller's own session JWT and fail clearly (no fabricated credentials) when it's absent
- [x] Wired into `orb-tools-shared.ts`'s `ORB_TOOL_REGISTRY` + `DEVELOPER_DOMAIN_TOOL_DECLARATIONS` (role-gated developer/admin/exafy_admin, same as the existing 12 developer tools)
- [x] LiveKit `tools.py`: matching `@function_tool` wrappers + `all_tool_names()` entries for all 70
- [x] `tool-manifest.json`: 70 tools flipped `planned` → `live` via `voice-tools-manifest-reconcile.mjs --apply`; lift-scanner reports no drift
- [x] Jest coverage per module (role-gate across every handler + confirm-flow + representative happy paths — 5 new test files)
- [x] Characterization snapshot updated for the new developer tool declarations

## 🧪 Testing

- [x] Automated tests added/updated (5 new Jest suites, 757 orb-tools tests green)
- [x] `npx tsc --noEmit` clean
- [x] `node scripts/voice-tools-manifest-reconcile.mjs --check` clean after apply
- [x] `node scripts/orb-tools-lift-scanner.mjs` — no drift detected
- [x] Full gateway jest suite green (7393/7406 passing; the one pre-existing failure, `test/nav-manifest-sync.test.ts`, is unrelated navigation-catalog/vitana-v1 sibling-repo drift, reproduced identically on `main` before this change)
- [ ] Verified in staging/dev environment — pending staging deploy after merge (per the staging-first CI/CD model)

## 🚨 Breaking Changes

None. Purely additive: new tool modules, new manifest entries, new declarations gated to developer/admin/exafy_admin sessions.

## 📌 Additional Notes

Backing-route mapping for every one of the 70 tools was independently verified against the actual codebase (routes/vtid.ts, oasis-tasks.ts, vtid-terminalize.ts, worker-orchestrator.ts, governance.ts, governance-controls.ts, cicd.ts, github-service.ts, approvals.ts, operator.ts, admin-health.ts, telemetry.ts, events.ts, orb-agent-trace.ts, supervisor-summary.ts, voice-lab.ts, conversation-hub.ts, agents-registry.ts) before implementation — a few plan items had no dedicated backend route (e.g. `dev_canary_status`, `dev_staging_status`, `dev_compare_staging_prod`, `dev_tool_health`, work-order listing) and are implemented by composing existing reads rather than inventing new endpoints, with the gap noted in code comments and spoken tool text.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX)_