### PR TITLE
feat(voice): Wave 3 of Voice Tools Expansion Plan v2 — 48 admin P0 tools

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -4133,6 +4133,406 @@ async def dev_get_agent_detail(context: RunContext, agent_id: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# WAVE-3-VOICE-CATALOG-V2 — Admin P0: users/RBAC, content moderation,
+# marketplace admin, notifications/broadcast, governance/controls,
+# feedback/support (48 tools). All dispatch through the shared gateway
+# registry (services/gateway/src/services/orb-tools/admin-*-tools.ts).
+# ---------------------------------------------------------------------------
+
+# B1 Users & RBAC (8)
+
+
+@function_tool
+async def admin_lookup_user(context: RunContext, query: str, limit: int | None = None) -> str:
+    """ADMIN ONLY. Find a user by name, email, or vitana_id."""
+    body = await _dispatch(context, "admin_lookup_user", {"query": query, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def admin_list_users(context: RunContext, query: str | None = None, role: str | None = None, limit: int | None = None) -> str:
+    """ADMIN ONLY. List/filter users by search query or role."""
+    body = await _dispatch(context, "admin_list_users", {"query": query, "role": role, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def admin_get_user_detail(context: RunContext, user_id: str) -> str:
+    """ADMIN ONLY. Full user record by user_id."""
+    body = await _dispatch(context, "admin_get_user_detail", {"user_id": user_id})
+    return summarize(body)
+
+
+@function_tool
+async def admin_roles_summary(context: RunContext) -> str:
+    """ADMIN ONLY. Role distribution counts."""
+    body = await _dispatch(context, "admin_roles_summary", {})
+    return summarize(body)
+
+
+@function_tool
+async def admin_grant_role(context: RunContext, user_id: str, role: str, tenant_id: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Grant a role to a user. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_grant_role", {"user_id": user_id, "role": role, "tenant_id": tenant_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_revoke_role(context: RunContext, user_id: str, role: str, tenant_id: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Revoke a role from a user (cannot revoke community). TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_revoke_role", {"user_id": user_id, "role": role, "tenant_id": tenant_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_set_trust_tier(context: RunContext, vitana_id: str, tier: str, reason: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY (exafy_admin/operator only). Change a user's trust tier. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_set_trust_tier", {"vitana_id": vitana_id, "tier": tier, "reason": reason, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_get_at_risk_members(context: RunContext) -> str:
+    """ADMIN ONLY. At-risk members overview for the current tenant."""
+    body = await _dispatch(context, "admin_get_at_risk_members", {})
+    return summarize(body)
+
+
+# B4 Content Moderation (8)
+
+
+@function_tool
+async def admin_list_moderation_queue(context: RunContext, status: str | None = None, type: str | None = None, limit: int | None = None) -> str:
+    """ADMIN ONLY. List pending content-moderation items."""
+    body = await _dispatch(context, "admin_list_moderation_queue", {"status": status, "type": type, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def admin_get_moderation_item(context: RunContext, item_id: str) -> str:
+    """ADMIN ONLY. Detail for one moderation queue item."""
+    body = await _dispatch(context, "admin_get_moderation_item", {"item_id": item_id})
+    return summarize(body)
+
+
+@function_tool
+async def admin_moderation_stats(context: RunContext) -> str:
+    """ADMIN ONLY. Moderation queue stats."""
+    body = await _dispatch(context, "admin_moderation_stats", {})
+    return summarize(body)
+
+
+@function_tool
+async def admin_approve_content(context: RunContext, item_id: str, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Approve a moderation item. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_approve_content", {"item_id": item_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_reject_content(context: RunContext, item_id: str, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Reject a moderation item. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_reject_content", {"item_id": item_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_flag_content(context: RunContext, item_id: str, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Flag a moderation item for further review. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_flag_content", {"item_id": item_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_list_reports(context: RunContext, limit: int | None = None) -> str:
+    """ADMIN ONLY. List user reports (falls back to flagged media — no report table exists yet)."""
+    body = await _dispatch(context, "admin_list_reports", {"limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def admin_get_report(context: RunContext) -> str:
+    """ADMIN ONLY. Get one user report. NOTE: not implemented in the backend yet."""
+    body = await _dispatch(context, "admin_get_report", {})
+    return summarize(body)
+
+
+# B6 Marketplace Admin (12)
+
+
+@function_tool
+async def admin_marketplace_overview(context: RunContext) -> str:
+    """ADMIN ONLY. Marketplace KPIs overview."""
+    body = await _dispatch(context, "admin_marketplace_overview", {})
+    return summarize(body)
+
+
+@function_tool
+async def admin_list_merchants(context: RunContext, source_network: str | None = None, is_active: bool | None = None, search: str | None = None, limit: int | None = None) -> str:
+    """ADMIN ONLY. List merchants."""
+    body = await _dispatch(context, "admin_list_merchants", {"source_network": source_network, "is_active": is_active, "search": search, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def admin_update_merchant(context: RunContext, merchant_id: str, name: str | None = None, is_active: bool | None = None, quality_score: float | None = None, customs_risk: str | None = None, commission_rate: float | None = None, admin_notes: str | None = None, requires_admin_review: bool | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Edit a merchant's status/quality/commission/notes. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_update_merchant", {
+            "merchant_id": merchant_id, "name": name, "is_active": is_active, "quality_score": quality_score,
+            "customs_risk": customs_risk, "commission_rate": commission_rate, "admin_notes": admin_notes,
+            "requires_admin_review": requires_admin_review, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_list_products(context: RunContext, source_network: str | None = None, category: str | None = None, origin_region: str | None = None, search: str | None = None, requires_admin_review: bool | None = None, is_active: bool | None = None, limit: int | None = None) -> str:
+    """ADMIN ONLY. List products (admin view)."""
+    body = await _dispatch(context, "admin_list_products", {
+            "source_network": source_network, "category": category, "origin_region": origin_region,
+            "search": search, "requires_admin_review": requires_admin_review, "is_active": is_active, "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_update_product(context: RunContext, product_id: str, title: str | None = None, description: str | None = None, is_active: bool | None = None, requires_admin_review: bool | None = None, admin_review_reason: str | None = None, admin_notes: str | None = None, customs_risk: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Edit/approve a product. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_update_product", {
+            "product_id": product_id, "title": title, "description": description, "is_active": is_active,
+            "requires_admin_review": requires_admin_review, "admin_review_reason": admin_review_reason,
+            "admin_notes": admin_notes, "customs_risk": customs_risk, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_bulk_product_action(context: RunContext, product_ids: list[str], action: str, reason: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Bulk enable/disable/flag products (max 100 per call). TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_bulk_product_action", {"product_ids": product_ids, "action": action, "reason": reason, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_get_feed_curation(context: RunContext) -> str:
+    """ADMIN ONLY. Read the feed curation config."""
+    body = await _dispatch(context, "admin_get_feed_curation", {})
+    return summarize(body)
+
+
+@function_tool
+async def admin_update_feed_curation(context: RunContext, config_id: str, max_products_per_merchant: int | None = None, max_products_per_category: int | None = None, personalization_weight_override: float | None = None, notes: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Change feed curation rules. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_update_feed_curation", {
+            "config_id": config_id, "max_products_per_merchant": max_products_per_merchant,
+            "max_products_per_category": max_products_per_category,
+            "personalization_weight_override": personalization_weight_override, "notes": notes, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_list_geo_policies(context: RunContext) -> str:
+    """ADMIN ONLY. List geo policies."""
+    body = await _dispatch(context, "admin_list_geo_policies", {})
+    return summarize(body)
+
+
+@function_tool
+async def admin_update_geo_policy(context: RunContext, policy_id: str, is_active: bool | None = None, weight: float | None = None, user_opt_out_scope: str | None = None, description: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Edit a geo policy. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_update_geo_policy", {
+            "policy_id": policy_id, "is_active": is_active, "weight": weight,
+            "user_opt_out_scope": user_opt_out_scope, "description": description, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_trigger_source_sync(context: RunContext, network: str, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Trigger a live product sync from a network. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_trigger_source_sync", {"network": network, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_get_ingestion_coverage(context: RunContext, view: str | None = None) -> str:
+    """ADMIN ONLY. Ingestion run history and origin/ships-to coverage matrix."""
+    body = await _dispatch(context, "admin_get_ingestion_coverage", {"view": view})
+    return summarize(body)
+
+
+# B11 Notifications & Broadcast (7)
+
+
+@function_tool
+async def admin_compose_broadcast(context: RunContext, title: str, body: str, recipient_ids: list[str] | None = None, recipient_role: str | None = None, send_to_all: bool | None = None, tenant_id: str | None = None) -> str:
+    """ADMIN ONLY. Preview a broadcast draft (audience size + text) WITHOUT sending."""
+    result = await _dispatch(context, "admin_compose_broadcast", {
+            "title": title, "body": body, "recipient_ids": recipient_ids,
+            "recipient_role": recipient_role, "send_to_all": send_to_all, "tenant_id": tenant_id,
+        })
+    return summarize(result)
+
+
+@function_tool
+async def admin_send_broadcast(context: RunContext, title: str, body: str, recipient_ids: list[str] | None = None, recipient_role: str | None = None, send_to_all: bool | None = None, tenant_id: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Send a notification NOW to the resolved audience. TWO-STEP confirm — no undo."""
+    result = await _dispatch(context, "admin_send_broadcast", {
+            "title": title, "body": body, "recipient_ids": recipient_ids, "recipient_role": recipient_role,
+            "send_to_all": send_to_all, "tenant_id": tenant_id, "confirm": confirm,
+        })
+    return summarize(result)
+
+
+@function_tool
+async def admin_list_broadcasts(context: RunContext, type: str | None = None, user_id: str | None = None, search: str | None = None, days: int | None = None, limit: int | None = None) -> str:
+    """ADMIN ONLY. Sent notification history."""
+    body = await _dispatch(context, "admin_list_broadcasts", {"type": type, "user_id": user_id, "search": search, "days": days, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def admin_notification_pref_stats(context: RunContext, tenant_id: str | None = None) -> str:
+    """ADMIN ONLY. Notification opt-in/out stats plus 30-day send/read counts."""
+    body = await _dispatch(context, "admin_notification_pref_stats", {"tenant_id": tenant_id})
+    return summarize(body)
+
+
+@function_tool
+async def admin_create_notification_category(context: RunContext, type: str, display_name: str, description: str | None = None, tenant_id: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Create a new notification category. TWO-STEP confirm."""
+    result = await _dispatch(context, "admin_create_notification_category", {
+            "type": type, "display_name": display_name, "description": description, "tenant_id": tenant_id, "confirm": confirm,
+        })
+    return summarize(result)
+
+
+@function_tool
+async def admin_update_notification_category(context: RunContext, category_id: str, display_name: str | None = None, description: str | None = None, is_active: bool | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Edit a notification category (type is immutable). TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_update_notification_category", {
+            "category_id": category_id, "display_name": display_name, "description": description,
+            "is_active": is_active, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_test_notification_category(context: RunContext, category_id: str) -> str:
+    """ADMIN ONLY. Send a test notification for a category to your own account."""
+    body = await _dispatch(context, "admin_test_notification_category", {"category_id": category_id})
+    return summarize(body)
+
+
+# B12 Governance & Controls (8)
+
+
+@function_tool
+async def admin_governance_status(context: RunContext) -> str:
+    """ADMIN ONLY. Governance control-plane snapshot."""
+    body = await _dispatch(context, "admin_governance_status", {})
+    return summarize(body)
+
+
+@function_tool
+async def admin_list_governance_rules(context: RunContext, category: str | None = None, status: str | None = None, level: str | None = None, search: str | None = None) -> str:
+    """ADMIN ONLY. List governance rules."""
+    body = await _dispatch(context, "admin_list_governance_rules", {"category": category, "status": status, "level": level, "search": search})
+    return summarize(body)
+
+
+@function_tool
+async def admin_list_violations(context: RunContext) -> str:
+    """ADMIN ONLY. List open/recent governance violations."""
+    body = await _dispatch(context, "admin_list_violations", {})
+    return summarize(body)
+
+
+@function_tool
+async def admin_list_proposals(context: RunContext, status: str | None = None, ruleCode: str | None = None, limit: int | None = None) -> str:
+    """ADMIN ONLY. List governance rule-change proposals."""
+    body = await _dispatch(context, "admin_list_proposals", {"status": status, "ruleCode": ruleCode, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def admin_create_proposal(context: RunContext, type: str, proposed_rule: str, rule_code: str | None = None, rationale: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Create a governance rule-change proposal. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_create_proposal", {
+            "type": type, "proposed_rule": proposed_rule, "rule_code": rule_code, "rationale": rationale, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_update_proposal_status(context: RunContext, proposal_id: str, status: str, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Change a proposal's status. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_update_proposal_status", {"proposal_id": proposal_id, "status": status, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_get_control_key(context: RunContext, key: str) -> str:
+    """ADMIN ONLY. Read a governance control key."""
+    body = await _dispatch(context, "admin_get_control_key", {"key": key})
+    return summarize(body)
+
+
+@function_tool
+async def admin_set_control_key(context: RunContext, key: str, enabled: bool, reason: str, duration_minutes: int | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Flip a governance control key on/off. Requires a reason. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_set_control_key", {
+            "key": key, "enabled": enabled, "reason": reason, "duration_minutes": duration_minutes, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+# B15 Feedback & Support Admin (5)
+
+
+@function_tool
+async def admin_list_feedback_tickets(context: RunContext, status: str | None = None, kind: str | None = None, priority: str | None = None, surface: str | None = None, resolver_agent: str | None = None, limit: int | None = None) -> str:
+    """ADMIN ONLY. List support/feedback tickets."""
+    body = await _dispatch(context, "admin_list_feedback_tickets", {
+            "status": status, "kind": kind, "priority": priority, "surface": surface,
+            "resolver_agent": resolver_agent, "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_get_feedback_ticket(context: RunContext, ticket_id: str) -> str:
+    """ADMIN ONLY. Full detail for one feedback ticket, including handoff history."""
+    body = await _dispatch(context, "admin_get_feedback_ticket", {"ticket_id": ticket_id})
+    return summarize(body)
+
+
+@function_tool
+async def admin_feedback_kpis(context: RunContext) -> str:
+    """ADMIN ONLY. Platform-wide support KPIs (last 30 days)."""
+    body = await _dispatch(context, "admin_feedback_kpis", {})
+    return summarize(body)
+
+
+@function_tool
+async def admin_list_handoffs(context: RunContext, limit: int | None = None) -> str:
+    """ADMIN ONLY. Recent specialist handoffs."""
+    body = await _dispatch(context, "admin_list_handoffs", {"limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def admin_act_on_ticket(context: RunContext, ticket_id: str, action: str, reason: str | None = None, duplicate_of: str | None = None, notes: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Act on a feedback ticket: draft_answer, draft_spec, draft_resolution, approve, send_answer, resolve, reject, or mark_duplicate. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_act_on_ticket", {
+            "ticket_id": ticket_id, "action": action, "reason": reason,
+            "duplicate_of": duplicate_of, "notes": notes, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+# ---------------------------------------------------------------------------
 # Catalogue export — used by tests + libcst smoke
 # ---------------------------------------------------------------------------
 
@@ -4325,6 +4725,32 @@ def all_tool_names() -> list[str]:
         "dev_get_session_diagnostics", "dev_conversation_decisions",
         "dev_tool_failures", "dev_tool_health", "dev_greeting_decisions",
         "dev_get_agent_detail",
+        # WAVE-3-VOICE-CATALOG-V2 — Admin P0 (48)
+        # B1 Users & RBAC (8)
+        "admin_lookup_user", "admin_list_users", "admin_get_user_detail",
+        "admin_roles_summary", "admin_grant_role", "admin_revoke_role",
+        "admin_set_trust_tier", "admin_get_at_risk_members",
+        # B4 Content Moderation (8)
+        "admin_list_moderation_queue", "admin_get_moderation_item",
+        "admin_moderation_stats", "admin_approve_content", "admin_reject_content",
+        "admin_flag_content", "admin_list_reports", "admin_get_report",
+        # B6 Marketplace Admin (12)
+        "admin_marketplace_overview", "admin_list_merchants", "admin_update_merchant",
+        "admin_list_products", "admin_update_product", "admin_bulk_product_action",
+        "admin_get_feed_curation", "admin_update_feed_curation",
+        "admin_list_geo_policies", "admin_update_geo_policy",
+        "admin_trigger_source_sync", "admin_get_ingestion_coverage",
+        # B11 Notifications & Broadcast (7)
+        "admin_compose_broadcast", "admin_send_broadcast", "admin_list_broadcasts",
+        "admin_notification_pref_stats", "admin_create_notification_category",
+        "admin_update_notification_category", "admin_test_notification_category",
+        # B12 Governance & Controls (8)
+        "admin_governance_status", "admin_list_governance_rules",
+        "admin_list_violations", "admin_list_proposals", "admin_create_proposal",
+        "admin_update_proposal_status", "admin_get_control_key", "admin_set_control_key",
+        # B15 Feedback & Support Admin (5)
+        "admin_list_feedback_tickets", "admin_get_feedback_ticket",
+        "admin_feedback_kpis", "admin_list_handoffs", "admin_act_on_ticket",
     ]
 
 

--- a/services/gateway/src/orb/live/tools/live-tool-catalog.ts
+++ b/services/gateway/src/orb/live/tools/live-tool-catalog.ts
@@ -28,6 +28,7 @@ import { ADMIN_TOOL_SCHEMAS } from '../../../services/admin-voice-tools';
 import {
   NEW_DOMAIN_TOOL_DECLARATIONS,
   DEVELOPER_DOMAIN_TOOL_DECLARATIONS,
+  ADMIN_DOMAIN_TOOL_DECLARATIONS,
 } from '../../../services/orb-tools-shared';
 
 
@@ -2494,6 +2495,12 @@ export function buildLiveApiTools(
         // server-side regardless (developer-tools.ts developerGate()).
         ...(activeRole && ['admin', 'exafy_admin', 'developer'].includes(activeRole)
           ? DEVELOPER_DOMAIN_TOOL_DECLARATIONS
+          : []),
+        // WAVE-3-VOICE-CATALOG-V2 — Admin voice tools (users/RBAC, moderation,
+        // marketplace, notifications, governance, feedback). Handlers re-check
+        // role server-side regardless (admin-users-rbac-tools.ts adminGate()).
+        ...(activeRole && ['admin', 'exafy_admin', 'developer'].includes(activeRole)
+          ? ADMIN_DOMAIN_TOOL_DECLARATIONS
           : []),
       ],
     },

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -65,6 +65,15 @@ import { GOVERNANCE_TOOL_HANDLERS, GOVERNANCE_TOOL_DECLARATIONS } from './orb-to
 import { CICD_PR_TOOL_HANDLERS, CICD_PR_TOOL_DECLARATIONS } from './orb-tools/cicd-pr-tools';
 import { DEPLOYMENT_RELEASE_TOOL_HANDLERS, DEPLOYMENT_RELEASE_TOOL_DECLARATIONS } from './orb-tools/deployment-release-tools';
 import { OBSERVABILITY_TOOL_HANDLERS, OBSERVABILITY_TOOL_DECLARATIONS } from './orb-tools/observability-tools';
+// WAVE-3-VOICE-CATALOG-V2 — third wave of the approved 425-tool expansion:
+// admin P0 domains covering users/RBAC, content moderation, marketplace
+// admin, notifications/broadcast, governance/controls, and feedback/support.
+import { ADMIN_USERS_RBAC_TOOL_HANDLERS, ADMIN_USERS_RBAC_TOOL_DECLARATIONS } from './orb-tools/admin-users-rbac-tools';
+import { ADMIN_MODERATION_TOOL_HANDLERS, ADMIN_MODERATION_TOOL_DECLARATIONS } from './orb-tools/admin-moderation-tools';
+import { ADMIN_MARKETPLACE_TOOL_HANDLERS, ADMIN_MARKETPLACE_TOOL_DECLARATIONS } from './orb-tools/admin-marketplace-tools';
+import { ADMIN_NOTIFICATIONS_TOOL_HANDLERS, ADMIN_NOTIFICATIONS_TOOL_DECLARATIONS } from './orb-tools/admin-notifications-tools';
+import { ADMIN_GOVERNANCE_TOOL_HANDLERS, ADMIN_GOVERNANCE_TOOL_DECLARATIONS } from './orb-tools/admin-governance-tools';
+import { ADMIN_FEEDBACK_TOOL_HANDLERS, ADMIN_FEEDBACK_TOOL_DECLARATIONS } from './orb-tools/admin-feedback-tools';
 import {
   lookupScreen,
   lookupByAlias,
@@ -5173,6 +5182,13 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   ...CICD_PR_TOOL_HANDLERS,
   ...DEPLOYMENT_RELEASE_TOOL_HANDLERS,
   ...OBSERVABILITY_TOOL_HANDLERS,
+  // WAVE-3-VOICE-CATALOG-V2
+  ...ADMIN_USERS_RBAC_TOOL_HANDLERS,
+  ...ADMIN_MODERATION_TOOL_HANDLERS,
+  ...ADMIN_MARKETPLACE_TOOL_HANDLERS,
+  ...ADMIN_NOTIFICATIONS_TOOL_HANDLERS,
+  ...ADMIN_GOVERNANCE_TOOL_HANDLERS,
+  ...ADMIN_FEEDBACK_TOOL_HANDLERS,
 };
 
 // BOOTSTRAP-VOICE-CATALOG-COMPLETE — combined Vertex/Gemini function
@@ -5212,6 +5228,18 @@ export const DEVELOPER_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> 
   ...CICD_PR_TOOL_DECLARATIONS,
   ...DEPLOYMENT_RELEASE_TOOL_DECLARATIONS,
   ...OBSERVABILITY_TOOL_DECLARATIONS,
+];
+
+// WAVE-3-VOICE-CATALOG-V2 — admin_* declarations, injected by
+// live-tool-catalog.ts alongside ADMIN_TOOL_SCHEMAS under the same
+// admin/exafy_admin/developer role gate.
+export const ADMIN_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  ...ADMIN_USERS_RBAC_TOOL_DECLARATIONS,
+  ...ADMIN_MODERATION_TOOL_DECLARATIONS,
+  ...ADMIN_MARKETPLACE_TOOL_DECLARATIONS,
+  ...ADMIN_NOTIFICATIONS_TOOL_DECLARATIONS,
+  ...ADMIN_GOVERNANCE_TOOL_DECLARATIONS,
+  ...ADMIN_FEEDBACK_TOOL_DECLARATIONS,
 ];
 
 export const ORB_TOOL_NAMES = Object.keys(ORB_TOOL_REGISTRY);

--- a/services/gateway/src/services/orb-tools/admin-feedback-tools.ts
+++ b/services/gateway/src/services/orb-tools/admin-feedback-tools.ts
@@ -1,0 +1,197 @@
+/**
+ * Admin voice tools — Feedback & Support Admin (Wave 3, plan section B15).
+ *
+ * Thin dispatch layer over routes/feedback-admin.ts (cross-tenant,
+ * service-role) and routes/feedback-actions.ts. Per research, these routes
+ * only require a valid bearer token today (no server-side admin-role
+ * check) — adminGate() is still enforced here so the voice surface itself
+ * is admin-only, matching the plan's intent even though the backend is
+ * more permissive. There is no human "assign to agent" concept in the
+ * schema (only automated resolver_agent stamping via draft-* actions) —
+ * flagged honestly rather than invented.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit, relAge } from './developer-tools';
+import { adminGate, authHeaders, NO_ADMIN_SESSION } from './admin-users-rbac-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// 1. admin_list_feedback_tickets — GET /api/v1/admin/feedback/tickets
+// ---------------------------------------------------------------------------
+
+export const admin_list_feedback_tickets: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const qs = new URLSearchParams({ limit: String(clampLimit(args.limit, 20, 200)) });
+  for (const k of ['status', 'kind', 'priority', 'surface', 'resolver_agent'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/feedback/tickets?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_list_feedback_tickets failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const tickets = (Array.isArray(body.tickets) ? body.tickets : []) as Array<{ ticket_number?: string; kind?: string; status?: string; priority?: string }>;
+  if (tickets.length === 0) return { ok: true, result: { tickets: [] }, text: 'No feedback tickets matched.' };
+  const lines = tickets.slice(0, 8).map((t) => `${t.ticket_number ?? '?'} — ${t.kind ?? 'unknown'}, ${t.status ?? 'unknown'} (${t.priority ?? 'normal'})`);
+  return { ok: true, result: { tickets }, text: `${tickets.length} tickets: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. admin_get_feedback_ticket — GET /api/v1/admin/feedback/tickets/:id
+// ---------------------------------------------------------------------------
+
+export const admin_get_feedback_ticket: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const ticketId = String(args.ticket_id ?? '').trim();
+  if (!ticketId) return { ok: false, error: 'admin_get_feedback_ticket requires ticket_id.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/feedback/tickets/${encodeURIComponent(ticketId)}`, { headers: authHeaders(id) });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No feedback ticket found with id ${ticketId}.` }
+      : { ok: false, error: `admin_get_feedback_ticket failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const ticket = (body.ticket ?? {}) as Record<string, unknown>;
+  return {
+    ok: true,
+    result: body,
+    text: `Ticket ${String(ticket.ticket_number ?? ticketId)} — ${String(ticket.kind ?? 'unknown')}, status ${String(ticket.status ?? 'unknown')}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 3. admin_feedback_kpis — GET /api/v1/admin/feedback/kpis
+// ---------------------------------------------------------------------------
+
+export const admin_feedback_kpis: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/feedback/kpis', { headers: authHeaders(id) });
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_feedback_kpis failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: `Platform-wide feedback KPIs over the last 30 days retrieved.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. admin_list_handoffs — GET /api/v1/admin/feedback/handoffs/recent
+// ---------------------------------------------------------------------------
+
+export const admin_list_handoffs: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const limit = clampLimit(args.limit, 20, 200);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/feedback/handoffs/recent?limit=${limit}`, { headers: authHeaders(id) });
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_list_handoffs failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const handoffs = (Array.isArray(body.handoffs) ? body.handoffs : []) as Array<{ from_agent?: string; to_agent?: string; ts?: string }>;
+  if (handoffs.length === 0) return { ok: true, result: { handoffs: [] }, text: 'No recent handoffs.' };
+  const lines = handoffs.slice(0, 8).map((h) => `${h.from_agent ?? '?'} → ${h.to_agent ?? '?'} (${relAge(h.ts)})`);
+  return { ok: true, result: { handoffs }, text: `${handoffs.length} recent handoffs: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. admin_act_on_ticket — POST /api/v1/admin/feedback/tickets/:id/<action>
+// ---------------------------------------------------------------------------
+
+const TICKET_ACTIONS: Record<string, { path: string; needsReason?: boolean; needsDuplicateOf?: boolean }> = {
+  draft_answer: { path: 'draft-answer' },
+  draft_spec: { path: 'draft-spec' },
+  draft_resolution: { path: 'draft-resolution' },
+  approve: { path: 'approve' },
+  send_answer: { path: 'send-answer' },
+  resolve: { path: 'resolve' },
+  reject: { path: 'reject', needsReason: false },
+  mark_duplicate: { path: 'mark-duplicate', needsDuplicateOf: true },
+};
+
+export const admin_act_on_ticket: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const ticketId = String(args.ticket_id ?? '').trim();
+  const action = String(args.action ?? '').trim();
+  if (action === 'assign') {
+    return {
+      ok: true,
+      result: { supported: false },
+      text: 'There is no human "assign to agent" concept in the feedback ticket schema — only automated resolver stamping via draft actions (draft_answer, draft_spec, draft_resolution). Use one of those instead.',
+    };
+  }
+  const spec = TICKET_ACTIONS[action];
+  if (!ticketId || !spec) {
+    return { ok: false, error: `admin_act_on_ticket requires ticket_id and action (one of ${Object.keys(TICKET_ACTIONS).join(', ')}).` };
+  }
+  if (spec.needsDuplicateOf && typeof args.duplicate_of !== 'string') {
+    return { ok: false, error: 'mark_duplicate requires duplicate_of (the uuid of the original ticket).' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, ticket_id: ticketId, action },
+      text: `About to ${action.replace('_', ' ')} ticket ${ticketId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const requestBody: Record<string, unknown> = {};
+  if (action === 'reject' && typeof args.reason === 'string') requestBody.reason = args.reason;
+  if (action === 'mark_duplicate') requestBody.duplicate_of = args.duplicate_of;
+  if (['draft_answer', 'draft_spec', 'draft_resolution'].includes(action) && typeof args.notes === 'string') requestBody.notes = args.notes;
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/feedback/tickets/${encodeURIComponent(ticketId)}/${spec.path}`, {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: requestBody,
+  });
+  if (!ok) return { ok: true, result: { done: false, status, detail: body }, text: `Could not ${action.replace('_', ' ')} ticket ${ticketId}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { done: true, detail: body }, text: `Ticket ${ticketId}: ${action.replace('_', ' ')} applied.` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const ADMIN_FEEDBACK_TOOL_HANDLERS: Record<string, Handler> = {
+  admin_list_feedback_tickets,
+  admin_get_feedback_ticket,
+  admin_feedback_kpis,
+  admin_list_handoffs,
+  admin_act_on_ticket,
+};
+
+export const ADMIN_FEEDBACK_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'admin_list_feedback_tickets',
+    description: 'ADMIN ONLY. List support/feedback tickets, filterable by status/kind/priority/surface/resolver_agent.',
+    parameters: {
+      type: 'object',
+      properties: { status: { type: 'string' }, kind: { type: 'string' }, priority: { type: 'string' }, surface: { type: 'string' }, resolver_agent: { type: 'string' }, limit: { type: 'integer' } },
+    },
+  },
+  {
+    name: 'admin_get_feedback_ticket',
+    description: 'ADMIN ONLY. Full detail for one feedback ticket, including handoff history.',
+    parameters: { type: 'object', properties: { ticket_id: { type: 'string', description: 'Required.' } }, required: ['ticket_id'] },
+  },
+  { name: 'admin_feedback_kpis', description: 'ADMIN ONLY. Platform-wide support KPIs (last 30 days).', parameters: { type: 'object', properties: {} } },
+  { name: 'admin_list_handoffs', description: 'ADMIN ONLY. Recent specialist handoffs.', parameters: { type: 'object', properties: { limit: { type: 'integer' } } } },
+  {
+    name: 'admin_act_on_ticket',
+    description: 'ADMIN ONLY. Act on a feedback ticket: draft_answer, draft_spec, draft_resolution, approve, send_answer, resolve, reject, or mark_duplicate. There is no "assign" action — that concept doesn\'t exist in the schema. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ticket_id: { type: 'string', description: 'Required.' },
+        action: { type: 'string', description: 'Required.' },
+        reason: { type: 'string', description: 'Required for reject.' },
+        duplicate_of: { type: 'string', description: 'Required for mark_duplicate.' },
+        notes: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['ticket_id', 'action'],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/admin-governance-tools.ts
+++ b/services/gateway/src/services/orb-tools/admin-governance-tools.ts
@@ -1,0 +1,248 @@
+/**
+ * Admin voice tools — Governance & Controls (Wave 3, plan section B12).
+ *
+ * Admin-facing wrappers over the SAME routes/governance.ts and
+ * routes/governance-controls.ts endpoints the developer governance tools
+ * (services/orb-tools/governance-tools.ts) already call — just gated to
+ * admin/exafy_admin instead of developer/admin/exafy_admin, and headed
+ * for admin_* naming per the plan. No new backend behaviour.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit } from './developer-tools';
+import { adminGate } from './admin-users-rbac-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+function adminHeaders(id: OrbToolIdentity): Record<string, string> {
+  return { 'x-user-id': id.user_id, 'x-user-role': 'admin' };
+}
+
+// ---------------------------------------------------------------------------
+// 1. admin_governance_status — GET /api/v1/governance/controls
+// ---------------------------------------------------------------------------
+
+export const admin_governance_status: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/governance/controls', { headers: adminHeaders(id) });
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_governance_status failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const controls = (Array.isArray(body.data) ? body.data : []) as Array<{ key: string; enabled: boolean }>;
+  const disabled = controls.filter((c) => !c.enabled);
+  return {
+    ok: true,
+    result: { controls },
+    text: `${controls.length} governance controls. ${disabled.length === 0 ? 'All enabled.' : `Disabled: ${disabled.map((c) => c.key).join(', ')}.`}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 2. admin_list_governance_rules — GET /api/v1/governance/rules
+// ---------------------------------------------------------------------------
+
+export const admin_list_governance_rules: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  const qs = new URLSearchParams();
+  for (const k of ['category', 'status', 'level', 'search'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/rules?${qs.toString()}`);
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_list_governance_rules failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rows = (Array.isArray(body.data) ? body.data : []) as Array<{ id: string; title: string; level: string; status: string }>;
+  if (rows.length === 0) return { ok: true, result: { data: [] }, text: 'No governance rules matched.' };
+  return { ok: true, result: { data: rows }, text: `${rows.length} rules: ${rows.slice(0, 8).map((r) => `${r.id} "${r.title}" (${r.level})`).join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. admin_list_violations — GET /api/v1/governance/violations
+// ---------------------------------------------------------------------------
+
+export const admin_list_violations: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/governance/violations');
+  if (!ok) return { ok: false, error: `admin_list_violations failed (${status}).` };
+  const rows = (Array.isArray(body) ? body : []) as Array<{ ruleCode: string; severity: string; status: string }>;
+  if (rows.length === 0) return { ok: true, result: { violations: [] }, text: 'No open governance violations.' };
+  const open = rows.filter((r) => r.status === 'Open');
+  return { ok: true, result: { violations: rows }, text: `${rows.length} violations (${open.length} open): ${open.slice(0, 8).map((r) => `${r.ruleCode} (${r.severity})`).join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. admin_list_proposals — GET /api/v1/governance/proposals
+// ---------------------------------------------------------------------------
+
+export const admin_list_proposals: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  const qs = new URLSearchParams();
+  for (const k of ['status', 'ruleCode'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  qs.set('limit', String(clampLimit(args.limit, 10, 100)));
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/proposals?${qs.toString()}`);
+  if (!ok) return { ok: false, error: `admin_list_proposals failed (${status}).` };
+  const rows = (Array.isArray(body) ? body : []) as Array<{ proposalId: string; type: string; status: string }>;
+  if (rows.length === 0) return { ok: true, result: { proposals: [] }, text: 'No governance proposals found.' };
+  return { ok: true, result: { proposals: rows }, text: `${rows.length} proposals: ${rows.slice(0, 8).map((r) => `${r.proposalId} (${r.status})`).join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. admin_create_proposal — POST /api/v1/governance/proposals
+// ---------------------------------------------------------------------------
+
+export const admin_create_proposal: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  const type = String(args.type ?? '').trim();
+  if (!['New Rule', 'Change Rule', 'Deprecate Rule'].includes(type)) {
+    return { ok: false, error: 'admin_create_proposal requires type: "New Rule", "Change Rule", or "Deprecate Rule".' };
+  }
+  const proposedRule = String(args.proposed_rule ?? '').trim();
+  if (!proposedRule) return { ok: false, error: 'admin_create_proposal requires proposed_rule.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, type, proposedRule },
+      text: `About to create a "${type}" governance proposal: "${proposedRule}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/governance/proposals', {
+    method: 'POST',
+    body: { type, ruleCode: typeof args.rule_code === 'string' ? args.rule_code : undefined, proposedRule, rationale: typeof args.rationale === 'string' ? args.rationale : undefined, source: 'orb-voice-admin' },
+  });
+  if (!ok) return { ok: true, result: { created: false, status, detail: body }, text: `Could not create the proposal: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { created: true, proposal: body }, text: `Proposal ${String(body.proposalId ?? '')} created.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. admin_update_proposal_status — PATCH .../proposals/:proposalId/status
+// ---------------------------------------------------------------------------
+
+export const admin_update_proposal_status: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  const proposalId = String(args.proposal_id ?? '').trim();
+  const newStatus = String(args.status ?? '').trim();
+  if (!proposalId || !['Draft', 'Under Review', 'Approved', 'Rejected', 'Implemented'].includes(newStatus)) {
+    return { ok: false, error: 'admin_update_proposal_status requires proposal_id and a valid status.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, proposal_id: proposalId, status: newStatus },
+      text: `About to set ${proposalId} to "${newStatus}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/proposals/${encodeURIComponent(proposalId)}/status`, {
+    method: 'PATCH',
+    body: { status: newStatus },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update ${proposalId}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, proposal: body }, text: `${proposalId} is now "${newStatus}".` };
+};
+
+// ---------------------------------------------------------------------------
+// 7. admin_get_control_key — GET /api/v1/governance/controls/:key
+// ---------------------------------------------------------------------------
+
+export const admin_get_control_key: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  const key = String(args.key ?? '').trim();
+  if (!key) return { ok: false, error: 'admin_get_control_key requires a control key.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/controls/${encodeURIComponent(key)}`, { headers: adminHeaders(id) });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No control key "${key}" found.` }
+      : { ok: false, error: `admin_get_control_key failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const data = (body.data ?? {}) as { enabled?: boolean };
+  return { ok: true, result: body, text: `${key} is ${data.enabled ? 'enabled' : 'disabled'}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 8. admin_set_control_key — POST /api/v1/governance/controls/:key
+// ---------------------------------------------------------------------------
+
+export const admin_set_control_key: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  const key = String(args.key ?? '').trim();
+  const enabled = Boolean(args.enabled);
+  const reason = String(args.reason ?? '').trim();
+  if (!key || !reason) return { ok: false, error: 'admin_set_control_key requires key and reason.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, key, enabled, reason },
+      text: `About to set control "${key}" to ${enabled ? 'enabled' : 'disabled'} — reason: "${reason}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/governance/controls/${encodeURIComponent(key)}`, {
+    method: 'POST',
+    headers: adminHeaders(id),
+    body: { enabled, reason, duration_minutes: typeof args.duration_minutes === 'number' ? args.duration_minutes : undefined },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update control "${key}": ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Control "${key}" is now ${enabled ? 'enabled' : 'disabled'}.` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const ADMIN_GOVERNANCE_TOOL_HANDLERS: Record<string, Handler> = {
+  admin_governance_status,
+  admin_list_governance_rules,
+  admin_list_violations,
+  admin_list_proposals,
+  admin_create_proposal,
+  admin_update_proposal_status,
+  admin_get_control_key,
+  admin_set_control_key,
+};
+
+export const ADMIN_GOVERNANCE_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  { name: 'admin_governance_status', description: 'ADMIN ONLY. Governance control-plane snapshot.', parameters: { type: 'object', properties: {} } },
+  {
+    name: 'admin_list_governance_rules',
+    description: 'ADMIN ONLY. List governance rules.',
+    parameters: { type: 'object', properties: { category: { type: 'string' }, status: { type: 'string' }, level: { type: 'string' }, search: { type: 'string' } } },
+  },
+  { name: 'admin_list_violations', description: 'ADMIN ONLY. List open/recent governance violations.', parameters: { type: 'object', properties: {} } },
+  {
+    name: 'admin_list_proposals',
+    description: 'ADMIN ONLY. List governance rule-change proposals.',
+    parameters: { type: 'object', properties: { status: { type: 'string' }, ruleCode: { type: 'string' }, limit: { type: 'integer' } } },
+  },
+  {
+    name: 'admin_create_proposal',
+    description: 'ADMIN ONLY. Create a governance rule-change proposal. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: { type: { type: 'string', description: 'Required.' }, rule_code: { type: 'string' }, proposed_rule: { type: 'string', description: 'Required.' }, rationale: { type: 'string' }, confirm: { type: 'boolean' } },
+      required: ['type', 'proposed_rule'],
+    },
+  },
+  {
+    name: 'admin_update_proposal_status',
+    description: 'ADMIN ONLY. Change a proposal\'s status. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { proposal_id: { type: 'string', description: 'Required.' }, status: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['proposal_id', 'status'] },
+  },
+  { name: 'admin_get_control_key', description: 'ADMIN ONLY. Read a governance control key.', parameters: { type: 'object', properties: { key: { type: 'string', description: 'Required.' } }, required: ['key'] } },
+  {
+    name: 'admin_set_control_key',
+    description: 'ADMIN ONLY. Flip a governance control key on/off — a real kill-switch, requires a reason. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: { key: { type: 'string', description: 'Required.' }, enabled: { type: 'boolean', description: 'Required.' }, reason: { type: 'string', description: 'Required.' }, duration_minutes: { type: 'integer' }, confirm: { type: 'boolean' } },
+      required: ['key', 'enabled', 'reason'],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/admin-marketplace-tools.ts
+++ b/services/gateway/src/services/orb-tools/admin-marketplace-tools.ts
@@ -1,0 +1,432 @@
+/**
+ * Admin voice tools — Marketplace Admin (Wave 3, plan section B6).
+ *
+ * Thin dispatch layer over routes/admin-marketplace.ts, mounted at
+ * /api/v1/admin/marketplace, gated by requireTenantAdmin. No route-level
+ * confirm tokens exist server-side — two-step confirm is applied here for
+ * every ⚠ write, mirroring dev_approve_pr's pattern.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit } from './developer-tools';
+import { adminGate, authHeaders, NO_ADMIN_SESSION } from './admin-users-rbac-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const BASE = '/api/v1/admin/marketplace';
+const SYNC_NETWORKS = ['shopify', 'cj', 'amazon', 'rakuten', 'awin', 'admitad'];
+
+// ---------------------------------------------------------------------------
+// 1. admin_marketplace_overview — GET /overview
+// ---------------------------------------------------------------------------
+
+export const admin_marketplace_overview: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/overview`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `admin_marketplace_overview failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: 'Marketplace overview retrieved.' };
+};
+
+// ---------------------------------------------------------------------------
+// 2. admin_list_merchants — GET /merchants
+// ---------------------------------------------------------------------------
+
+export const admin_list_merchants: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const qs = new URLSearchParams({ limit: String(clampLimit(args.limit, 20, 200)) });
+  for (const k of ['source_network', 'search'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  if (typeof args.is_active === 'boolean') qs.set('is_active', String(args.is_active));
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/merchants?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `admin_list_merchants failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const merchants = (Array.isArray((body as Record<string, unknown>).merchants) ? (body as Record<string, unknown>).merchants : []) as Array<{ name: string; is_active?: boolean }>;
+  if (merchants.length === 0) return { ok: true, result: { merchants: [] }, text: 'No merchants matched.' };
+  return { ok: true, result: { merchants }, text: `${merchants.length} merchants: ${merchants.slice(0, 8).map((m) => m.name).join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. admin_update_merchant — PATCH /merchants/:id
+// ---------------------------------------------------------------------------
+
+export const admin_update_merchant: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const merchantId = String(args.merchant_id ?? '').trim();
+  if (!merchantId) return { ok: false, error: 'admin_update_merchant requires merchant_id.' };
+  const patch: Record<string, unknown> = {};
+  for (const k of ['name', 'is_active', 'quality_score', 'customs_risk', 'commission_rate', 'admin_notes', 'requires_admin_review'] as const) {
+    if (args[k] !== undefined) patch[k] = args[k];
+  }
+  if (Object.keys(patch).length === 0) return { ok: false, error: 'admin_update_merchant requires at least one field to change.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, merchant_id: merchantId, patch },
+      text: `About to update merchant ${merchantId}: ${JSON.stringify(patch)}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/merchants/${encodeURIComponent(merchantId)}`, {
+    method: 'PATCH',
+    headers: authHeaders(id),
+    body: patch,
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update merchant ${merchantId}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Merchant ${merchantId} updated.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. admin_list_products — GET /products
+// ---------------------------------------------------------------------------
+
+export const admin_list_products: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const qs = new URLSearchParams({ limit: String(clampLimit(args.limit, 20, 200)) });
+  for (const k of ['source_network', 'category', 'origin_region', 'search'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  if (typeof args.requires_admin_review === 'boolean') qs.set('requires_admin_review', String(args.requires_admin_review));
+  if (typeof args.is_active === 'boolean') qs.set('is_active', String(args.is_active));
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/products?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `admin_list_products failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const products = (Array.isArray((body as Record<string, unknown>).products) ? (body as Record<string, unknown>).products : []) as Array<{ title: string }>;
+  if (products.length === 0) return { ok: true, result: { products: [] }, text: 'No products matched.' };
+  return { ok: true, result: { products }, text: `${products.length} products: ${products.slice(0, 8).map((p) => p.title).join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. admin_update_product — PATCH /products/:id
+// ---------------------------------------------------------------------------
+
+export const admin_update_product: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const productId = String(args.product_id ?? '').trim();
+  if (!productId) return { ok: false, error: 'admin_update_product requires product_id.' };
+  const patch: Record<string, unknown> = {};
+  for (const k of ['title', 'description', 'is_active', 'requires_admin_review', 'admin_review_reason', 'admin_notes', 'excluded_from_regions', 'customs_risk'] as const) {
+    if (args[k] !== undefined) patch[k] = args[k];
+  }
+  if (Object.keys(patch).length === 0) return { ok: false, error: 'admin_update_product requires at least one field to change.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, product_id: productId, patch },
+      text: `About to update product ${productId}: ${JSON.stringify(patch)}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/products/${encodeURIComponent(productId)}`, {
+    method: 'PATCH',
+    headers: authHeaders(id),
+    body: patch,
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update product ${productId}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Product ${productId} updated.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. admin_bulk_product_action — POST /products/bulk-action
+// ---------------------------------------------------------------------------
+
+const BULK_ACTIONS = ['hide', 'clear_review', 'flag_review', 'deactivate', 'reactivate'];
+
+export const admin_bulk_product_action: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const productIds = Array.isArray(args.product_ids) ? (args.product_ids as string[]) : [];
+  const action = String(args.action ?? '').trim();
+  if (productIds.length === 0 || !BULK_ACTIONS.includes(action)) {
+    return { ok: false, error: `admin_bulk_product_action requires product_ids and action (one of ${BULK_ACTIONS.join(', ')}).` };
+  }
+  if (productIds.length > 100) return { ok: false, error: 'admin_bulk_product_action supports at most 100 product_ids per call.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, count: productIds.length, action },
+      text: `About to ${action} ${productIds.length} products. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/products/bulk-action`, {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { product_ids: productIds, action, reason: typeof args.reason === 'string' ? args.reason : undefined },
+  });
+  if (!ok) return { ok: true, result: { done: false, status, detail: body }, text: `Bulk action failed: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { done: true, detail: body }, text: `${action} applied to ${productIds.length} products.` };
+};
+
+// ---------------------------------------------------------------------------
+// 7. admin_get_feed_curation — GET /feed-curation
+// ---------------------------------------------------------------------------
+
+export const admin_get_feed_curation: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/feed-curation`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `admin_get_feed_curation failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: 'Feed curation config retrieved.' };
+};
+
+// ---------------------------------------------------------------------------
+// 8. admin_update_feed_curation — PATCH /feed-curation/:id
+// ---------------------------------------------------------------------------
+
+export const admin_update_feed_curation: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const configId = String(args.config_id ?? '').trim();
+  if (!configId) return { ok: false, error: 'admin_update_feed_curation requires config_id.' };
+  const patch: Record<string, unknown> = {};
+  for (const k of ['featured_product_ids', 'category_mix', 'max_products_per_merchant', 'max_products_per_category', 'starter_conditions', 'personalization_weight_override', 'diversity_rules', 'notes'] as const) {
+    if (args[k] !== undefined) patch[k] = args[k];
+  }
+  if (Object.keys(patch).length === 0) return { ok: false, error: 'admin_update_feed_curation requires at least one field to change.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, config_id: configId, patch },
+      text: `About to update feed curation config ${configId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/feed-curation/${encodeURIComponent(configId)}`, {
+    method: 'PATCH',
+    headers: authHeaders(id),
+    body: patch,
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update feed curation: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Feed curation config ${configId} updated.` };
+};
+
+// ---------------------------------------------------------------------------
+// 9. admin_list_geo_policies — GET /geo-policy
+// ---------------------------------------------------------------------------
+
+export const admin_list_geo_policies: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/geo-policy`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `admin_list_geo_policies failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const policies = (Array.isArray((body as Record<string, unknown>).policies) ? (body as Record<string, unknown>).policies : Array.isArray(body) ? body : []) as Array<{ user_region: string; rule_type: string }>;
+  if (policies.length === 0) return { ok: true, result: { policies: [] }, text: 'No geo policies configured.' };
+  return { ok: true, result: { policies }, text: `${policies.length} geo policies: ${policies.slice(0, 8).map((p) => `${p.user_region}/${p.rule_type}`).join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 10. admin_update_geo_policy — PATCH /geo-policy/:id
+// ---------------------------------------------------------------------------
+
+export const admin_update_geo_policy: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const policyId = String(args.policy_id ?? '').trim();
+  if (!policyId) return { ok: false, error: 'admin_update_geo_policy requires policy_id.' };
+  const patch: Record<string, unknown> = {};
+  for (const k of ['is_active', 'weight', 'user_opt_out_scope', 'description'] as const) {
+    if (args[k] !== undefined) patch[k] = args[k];
+  }
+  if (Object.keys(patch).length === 0) return { ok: false, error: 'admin_update_geo_policy requires at least one field to change.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, policy_id: policyId, patch },
+      text: `About to update geo policy ${policyId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/geo-policy/${encodeURIComponent(policyId)}`, {
+    method: 'PATCH',
+    headers: authHeaders(id),
+    body: patch,
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update geo policy: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Geo policy ${policyId} updated.` };
+};
+
+// ---------------------------------------------------------------------------
+// 11. admin_trigger_source_sync — POST /sync/:network
+// ---------------------------------------------------------------------------
+
+export const admin_trigger_source_sync: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const network = String(args.network ?? '').trim();
+  if (!SYNC_NETWORKS.includes(network)) return { ok: false, error: `admin_trigger_source_sync requires network to be one of ${SYNC_NETWORKS.join(', ')}.` };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, network },
+      text: `About to trigger a live product sync from ${network}. This runs synchronously and may take a while. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`${BASE}/sync/${encodeURIComponent(network)}`, {
+    method: 'POST',
+    headers: authHeaders(id),
+  });
+  if (!ok) return { ok: true, result: { synced: false, status, detail: body }, text: `Sync of ${network} failed: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { synced: true, detail: body }, text: `Sync of ${network} completed.` };
+};
+
+// ---------------------------------------------------------------------------
+// 12. admin_get_ingestion_coverage — GET /ingestion/runs + /ingestion/coverage
+// ---------------------------------------------------------------------------
+
+export const admin_get_ingestion_coverage: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const view = args.view === 'runs' ? 'runs' : args.view === 'coverage' ? 'coverage' : 'both';
+  const calls: Array<Promise<{ ok: boolean; status: number; body: Record<string, unknown> }>> = [];
+  if (view === 'runs' || view === 'both') calls.push(gatewayApiCall(`${BASE}/ingestion/runs`, { headers: authHeaders(id) }));
+  if (view === 'coverage' || view === 'both') calls.push(gatewayApiCall(`${BASE}/ingestion/coverage`, { headers: authHeaders(id) }));
+  const results = await Promise.all(calls);
+  const failed = results.find((r) => !r.ok);
+  if (failed) return { ok: false, error: `admin_get_ingestion_coverage failed (${failed.status}): ${String(failed.body.error ?? 'unknown')}` };
+  const [runs, coverage] = view === 'both' ? results : view === 'runs' ? [results[0], undefined] : [undefined, results[0]];
+  return {
+    ok: true,
+    result: { runs: runs?.body, coverage: coverage?.body },
+    text: 'Ingestion runs/coverage retrieved.',
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const ADMIN_MARKETPLACE_TOOL_HANDLERS: Record<string, Handler> = {
+  admin_marketplace_overview,
+  admin_list_merchants,
+  admin_update_merchant,
+  admin_list_products,
+  admin_update_product,
+  admin_bulk_product_action,
+  admin_get_feed_curation,
+  admin_update_feed_curation,
+  admin_list_geo_policies,
+  admin_update_geo_policy,
+  admin_trigger_source_sync,
+  admin_get_ingestion_coverage,
+};
+
+export const ADMIN_MARKETPLACE_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  { name: 'admin_marketplace_overview', description: 'ADMIN ONLY. Marketplace KPIs overview.', parameters: { type: 'object', properties: {} } },
+  {
+    name: 'admin_list_merchants',
+    description: 'ADMIN ONLY. List merchants, filterable by source_network/is_active/search.',
+    parameters: { type: 'object', properties: { source_network: { type: 'string' }, is_active: { type: 'boolean' }, search: { type: 'string' }, limit: { type: 'integer' } } },
+  },
+  {
+    name: 'admin_update_merchant',
+    description: 'ADMIN ONLY. Edit a merchant\'s status/quality/commission/notes. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        merchant_id: { type: 'string', description: 'Required.' },
+        name: { type: 'string' }, is_active: { type: 'boolean' }, quality_score: { type: 'number' },
+        customs_risk: { type: 'string' }, commission_rate: { type: 'number' }, admin_notes: { type: 'string' },
+        requires_admin_review: { type: 'boolean' }, confirm: { type: 'boolean' },
+      },
+      required: ['merchant_id'],
+    },
+  },
+  {
+    name: 'admin_list_products',
+    description: 'ADMIN ONLY. List products (admin view), filterable by network/category/region/review-flag/search.',
+    parameters: {
+      type: 'object',
+      properties: {
+        source_network: { type: 'string' }, category: { type: 'string' }, origin_region: { type: 'string' },
+        search: { type: 'string' }, requires_admin_review: { type: 'boolean' }, is_active: { type: 'boolean' }, limit: { type: 'integer' },
+      },
+    },
+  },
+  {
+    name: 'admin_update_product',
+    description: 'ADMIN ONLY. Edit/approve a product. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Required.' },
+        title: { type: 'string' }, description: { type: 'string' }, is_active: { type: 'boolean' },
+        requires_admin_review: { type: 'boolean' }, admin_review_reason: { type: 'string' }, admin_notes: { type: 'string' },
+        excluded_from_regions: { type: 'array', items: { type: 'string' } }, customs_risk: { type: 'string' }, confirm: { type: 'boolean' },
+      },
+      required: ['product_id'],
+    },
+  },
+  {
+    name: 'admin_bulk_product_action',
+    description: 'ADMIN ONLY. Bulk enable/disable/flag products (max 100 per call). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        product_ids: { type: 'array', items: { type: 'string' }, description: 'Required, max 100.' },
+        action: { type: 'string', description: 'hide, clear_review, flag_review, deactivate, or reactivate. Required.' },
+        reason: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['product_ids', 'action'],
+    },
+  },
+  { name: 'admin_get_feed_curation', description: 'ADMIN ONLY. Read the feed curation config.', parameters: { type: 'object', properties: {} } },
+  {
+    name: 'admin_update_feed_curation',
+    description: 'ADMIN ONLY. Change feed curation rules. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        config_id: { type: 'string', description: 'Required.' },
+        featured_product_ids: { type: 'array', items: { type: 'string' } },
+        category_mix: { type: 'object' }, max_products_per_merchant: { type: 'integer' }, max_products_per_category: { type: 'integer' },
+        starter_conditions: { type: 'object' }, personalization_weight_override: { type: 'number' }, diversity_rules: { type: 'object' },
+        notes: { type: 'string' }, confirm: { type: 'boolean' },
+      },
+      required: ['config_id'],
+    },
+  },
+  { name: 'admin_list_geo_policies', description: 'ADMIN ONLY. List geo policies.', parameters: { type: 'object', properties: {} } },
+  {
+    name: 'admin_update_geo_policy',
+    description: 'ADMIN ONLY. Edit a geo policy. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        policy_id: { type: 'string', description: 'Required.' },
+        is_active: { type: 'boolean' }, weight: { type: 'number' }, user_opt_out_scope: { type: 'string' }, description: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['policy_id'],
+    },
+  },
+  {
+    name: 'admin_trigger_source_sync',
+    description: 'ADMIN ONLY. Trigger a live product sync from a network (runs synchronously). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: { network: { type: 'string', description: 'shopify, cj, amazon, rakuten, awin, or admitad. Required.' }, confirm: { type: 'boolean' } },
+      required: ['network'],
+    },
+  },
+  {
+    name: 'admin_get_ingestion_coverage',
+    description: 'ADMIN ONLY. Ingestion run history and origin/ships-to coverage matrix.',
+    parameters: { type: 'object', properties: { view: { type: 'string', description: '"runs", "coverage", or omit for both.' } } },
+  },
+];

--- a/services/gateway/src/services/orb-tools/admin-moderation-tools.ts
+++ b/services/gateway/src/services/orb-tools/admin-moderation-tools.ts
@@ -1,0 +1,213 @@
+/**
+ * Admin voice tools — Content Moderation (Wave 3, plan section B4).
+ *
+ * Thin dispatch layer over routes/tenant-admin/content-moderation.ts
+ * (media_uploads queue), gated by requireTenantAdmin. `admin_list_reports`
+ * and `admin_get_report` have no real backing table (`content_reports`
+ * doesn't exist) — per plan rule 4 ("no new backend features"), these
+ * degrade honestly to the closest real capability (the flagged-item view)
+ * rather than inventing a reports endpoint.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit } from './developer-tools';
+import { adminGate, authHeaders, NO_ADMIN_SESSION } from './admin-users-rbac-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+function contentBase(id: OrbToolIdentity): string | null {
+  if (!id.tenant_id) return null;
+  return `/api/v1/admin/tenants/${encodeURIComponent(id.tenant_id)}/content`;
+}
+
+// ---------------------------------------------------------------------------
+// 1. admin_list_moderation_queue — GET .../content/items
+// ---------------------------------------------------------------------------
+
+export const admin_list_moderation_queue: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const base = contentBase(id);
+  if (!base) return { ok: false, error: 'admin_list_moderation_queue requires a tenant context.' };
+  const qs = new URLSearchParams({ limit: String(clampLimit(args.limit, 20, 200)) });
+  if (typeof args.status === 'string' && args.status) qs.set('status', args.status);
+  if (typeof args.type === 'string' && args.type) qs.set('type', args.type);
+  const { ok, status, body } = await gatewayApiCall(`${base}/items?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_list_moderation_queue failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const items = (Array.isArray(body.items) ? body.items : []) as Array<{ id: string; media_type?: string; status?: string }>;
+  if (items.length === 0) return { ok: true, result: { items: [] }, text: 'The moderation queue is empty.' };
+  const lines = items.slice(0, 8).map((it) => `${it.id} — ${it.media_type ?? 'media'}, ${it.status ?? 'unknown'}`);
+  return { ok: true, result: { items }, text: `${items.length} items in the queue: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. admin_get_moderation_item — GET .../content/items/:id
+// ---------------------------------------------------------------------------
+
+export const admin_get_moderation_item: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const base = contentBase(id);
+  if (!base) return { ok: false, error: 'admin_get_moderation_item requires a tenant context.' };
+  const itemId = String(args.item_id ?? '').trim();
+  if (!itemId) return { ok: false, error: 'admin_get_moderation_item requires item_id.' };
+  const { ok, status, body } = await gatewayApiCall(`${base}/items/${encodeURIComponent(itemId)}`, { headers: authHeaders(id) });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No moderation item found with id ${itemId}.` }
+      : { ok: false, error: `admin_get_moderation_item failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return { ok: true, result: { found: true, item: body }, text: `Item ${itemId} — status ${String((body as Record<string, unknown>).status ?? 'unknown')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. admin_moderation_stats — GET .../content/items/stats
+// ---------------------------------------------------------------------------
+
+export const admin_moderation_stats: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const base = contentBase(id);
+  if (!base) return { ok: false, error: 'admin_moderation_stats requires a tenant context.' };
+  const { ok, status, body } = await gatewayApiCall(`${base}/items/stats`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `admin_moderation_stats failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const total = Number((body as Record<string, unknown>).total ?? 0);
+  return { ok: true, result: body, text: `${total} total items in moderation.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4/5/6. admin_approve_content / admin_reject_content / admin_flag_content
+// ---------------------------------------------------------------------------
+
+async function moderationAction(
+  action: 'approve' | 'reject' | 'flag',
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+): Promise<OrbToolResult> {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const base = contentBase(id);
+  if (!base) return { ok: false, error: `admin_${action}_content requires a tenant context.` };
+  const itemId = String(args.item_id ?? '').trim();
+  if (!itemId) return { ok: false, error: `admin_${action}_content requires item_id.` };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, item_id: itemId, action },
+      text: `About to ${action} content item ${itemId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`${base}/items/${encodeURIComponent(itemId)}/${action}`, {
+    method: 'POST',
+    headers: authHeaders(id),
+  });
+  if (!ok) return { ok: true, result: { done: false, status, detail: body }, text: `Could not ${action} item ${itemId}: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { done: true, detail: body }, text: `Item ${itemId} ${action}d.` };
+}
+
+export const admin_approve_content: Handler = (args, id) => moderationAction('approve', args, id);
+export const admin_reject_content: Handler = (args, id) => moderationAction('reject', args, id);
+export const admin_flag_content: Handler = (args, id) => moderationAction('flag', args, id);
+
+// ---------------------------------------------------------------------------
+// 7. admin_list_reports — no content_reports table; aliases to flagged items
+// ---------------------------------------------------------------------------
+
+export const admin_list_reports: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const base = contentBase(id);
+  if (!base) return { ok: false, error: 'admin_list_reports requires a tenant context.' };
+  const limit = clampLimit(args.limit, 20, 200);
+  const { ok, status, body } = await gatewayApiCall(`${base}/items?status=flagged&limit=${limit}`, { headers: authHeaders(id) });
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_list_reports failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const items = (Array.isArray(body.items) ? body.items : []) as Array<{ id: string; media_type?: string }>;
+  return {
+    ok: true,
+    result: { reports: items },
+    text: items.length === 0
+      ? 'No flagged content right now. (Note: there is no dedicated user-report table yet — this shows flagged media instead.)'
+      : `${items.length} flagged items (closest available to "reports" — no dedicated report table exists yet): ${items.slice(0, 8).map((i) => i.id).join(', ')}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 8. admin_get_report — no backing at all
+// ---------------------------------------------------------------------------
+
+export const admin_get_report: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  return {
+    ok: true,
+    result: { available: false },
+    text: 'There is no user-report system in the backend yet — only flagged media items. Use admin_get_moderation_item for a flagged item instead.',
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const ADMIN_MODERATION_TOOL_HANDLERS: Record<string, Handler> = {
+  admin_list_moderation_queue,
+  admin_get_moderation_item,
+  admin_moderation_stats,
+  admin_approve_content,
+  admin_reject_content,
+  admin_flag_content,
+  admin_list_reports,
+  admin_get_report,
+};
+
+export const ADMIN_MODERATION_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'admin_list_moderation_queue',
+    description: 'ADMIN ONLY. List pending content-moderation items, optionally filtered by status/type.',
+    parameters: { type: 'object', properties: { status: { type: 'string' }, type: { type: 'string' }, limit: { type: 'integer' } } },
+  },
+  {
+    name: 'admin_get_moderation_item',
+    description: 'ADMIN ONLY. Detail for one moderation queue item.',
+    parameters: { type: 'object', properties: { item_id: { type: 'string', description: 'Required.' } }, required: ['item_id'] },
+  },
+  {
+    name: 'admin_moderation_stats',
+    description: 'ADMIN ONLY. Moderation queue stats (counts by status/type).',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'admin_approve_content',
+    description: 'ADMIN ONLY. Approve a moderation item (makes it public). TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { item_id: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['item_id'] },
+  },
+  {
+    name: 'admin_reject_content',
+    description: 'ADMIN ONLY. Reject a moderation item (removes from public). TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { item_id: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['item_id'] },
+  },
+  {
+    name: 'admin_flag_content',
+    description: 'ADMIN ONLY. Flag a moderation item for further review. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { item_id: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['item_id'] },
+  },
+  {
+    name: 'admin_list_reports',
+    description: 'ADMIN ONLY. List user reports. NOTE: no dedicated report table exists yet — shows flagged media instead.',
+    parameters: { type: 'object', properties: { limit: { type: 'integer' } } },
+  },
+  {
+    name: 'admin_get_report',
+    description: 'ADMIN ONLY. Get one user report. NOTE: not implemented in the backend yet.',
+    parameters: { type: 'object', properties: {} },
+  },
+];

--- a/services/gateway/src/services/orb-tools/admin-notifications-tools.ts
+++ b/services/gateway/src/services/orb-tools/admin-notifications-tools.ts
@@ -1,0 +1,338 @@
+/**
+ * Admin voice tools — Notifications & Broadcast (Wave 3, plan section B11).
+ *
+ * Thin dispatch layer over routes/admin-notifications.ts and
+ * routes/admin-notification-categories.ts. Per research: there is no true
+ * draft/preview primitive backing "compose" — /compose always sends
+ * immediately. admin_compose_broadcast is therefore implemented as a
+ * client-side-only audience-size preview (direct Supabase reads), never
+ * calling /compose; admin_send_broadcast is the only tool that actually
+ * dispatches. "Broadcasts" list is really the general user_notifications
+ * log — flagged honestly in the tool text.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit, relAge } from './developer-tools';
+import { adminGate, authHeaders, NO_ADMIN_SESSION } from './admin-users-rbac-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+async function resolveAudienceCount(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<{ count: number; description: string } | { error: string }> {
+  const tenantId = typeof args.tenant_id === 'string' ? args.tenant_id : id.tenant_id;
+  if (Array.isArray(args.recipient_ids) && args.recipient_ids.length > 0) {
+    return { count: args.recipient_ids.length, description: `${args.recipient_ids.length} explicit recipients` };
+  }
+  if (!tenantId) return { error: 'A tenant_id is required to resolve the audience.' };
+  if (args.send_to_all === true) {
+    const { count, error } = await sb.from('user_tenants').select('user_id', { count: 'exact', head: true }).eq('tenant_id', tenantId);
+    if (error) return { error: error.message };
+    return { count: count ?? 0, description: `all ${count ?? 0} members of the tenant` };
+  }
+  if (typeof args.recipient_role === 'string' && args.recipient_role) {
+    const { count, error } = await sb
+      .from('user_tenants')
+      .select('user_id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .eq('active_role', args.recipient_role);
+    if (error) return { error: error.message };
+    return { count: count ?? 0, description: `${count ?? 0} members with role "${args.recipient_role}"` };
+  }
+  return { error: 'admin_compose_broadcast requires recipient_ids, or recipient_role + tenant_id, or send_to_all + tenant_id.' };
+}
+
+// ---------------------------------------------------------------------------
+// 1. admin_compose_broadcast — preview only, no /compose call
+// ---------------------------------------------------------------------------
+
+export const admin_compose_broadcast: Handler = async (args, id, sb) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  const title = String(args.title ?? '').trim();
+  const bodyText = String(args.body ?? '').trim();
+  if (!title || !bodyText) return { ok: false, error: 'admin_compose_broadcast requires title and body.' };
+  const audience = await resolveAudienceCount(args, id, sb);
+  if ('error' in audience) return { ok: false, error: audience.error };
+  if (audience.count > 500) {
+    return { ok: true, result: { audience }, text: `This would reach ${audience.count} recipients, which exceeds the 500-recipient send limit. Narrow the audience.` };
+  }
+  return {
+    ok: true,
+    result: { preview: true, title, body: bodyText, audience },
+    text: `Draft ready: "${title}" — "${bodyText}" — would reach ${audience.description}. There is no draft-storage backend; call admin_send_broadcast when ready to actually send.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 2. admin_send_broadcast — POST /api/v1/admin/notifications/compose
+// ---------------------------------------------------------------------------
+
+export const admin_send_broadcast: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const title = String(args.title ?? '').trim();
+  const bodyText = String(args.body ?? '').trim();
+  if (!title || !bodyText) return { ok: false, error: 'admin_send_broadcast requires title and body.' };
+  const hasAudience = Array.isArray(args.recipient_ids) && args.recipient_ids.length > 0
+    ? true
+    : args.send_to_all === true || typeof args.recipient_role === 'string';
+  if (!hasAudience) return { ok: false, error: 'admin_send_broadcast requires recipient_ids, or recipient_role, or send_to_all (with tenant_id).' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, title },
+      text: `About to send this notification NOW — this cannot be undone or previewed further. "${title}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/notifications/compose', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: {
+      title,
+      body: bodyText,
+      recipient_ids: args.recipient_ids,
+      recipient_role: args.recipient_role,
+      send_to_all: args.send_to_all,
+      tenant_id: typeof args.tenant_id === 'string' ? args.tenant_id : id.tenant_id,
+      type: args.type,
+      channel: args.channel,
+      priority: args.priority,
+    },
+  });
+  if (!ok) return { ok: true, result: { sent: false, status, detail: body }, text: `Broadcast was not sent: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { sent: true, detail: body }, text: `Broadcast sent to ${String(body.sent_to ?? 'the audience')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. admin_list_broadcasts — GET /api/v1/admin/notifications/sent
+// ---------------------------------------------------------------------------
+
+export const admin_list_broadcasts: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const qs = new URLSearchParams({ limit: String(clampLimit(args.limit, 20, 200)) });
+  for (const k of ['type', 'user_id', 'search'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  if (typeof args.days === 'number') qs.set('days', String(args.days));
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/notifications/sent?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `admin_list_broadcasts failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rows = (Array.isArray((body as Record<string, unknown>).data) ? (body as Record<string, unknown>).data : []) as Array<{ title?: string; created_at?: string }>;
+  if (rows.length === 0) return { ok: true, result: { data: [] }, text: 'No notifications sent in that window.' };
+  const lines = rows.slice(0, 8).map((r) => `${r.title ?? '(untitled)'} (${relAge(r.created_at)})`);
+  return {
+    ok: true,
+    result: { data: rows },
+    text: `${rows.length} notifications logged (this is the general notification log, not broadcast-only — no separate broadcast marker exists yet): ${lines.join('. ')}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 4. admin_notification_pref_stats — GET .../preferences/stats
+// ---------------------------------------------------------------------------
+
+export const admin_notification_pref_stats: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const qs = new URLSearchParams();
+  const tenantId = typeof args.tenant_id === 'string' ? args.tenant_id : id.tenant_id;
+  if (tenantId) qs.set('tenant_id', tenantId);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/notifications/preferences/stats?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `admin_notification_pref_stats failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: 'Notification preference stats retrieved.' };
+};
+
+// ---------------------------------------------------------------------------
+// 5. admin_create_notification_category — POST /api/v1/admin/notification-categories
+// ---------------------------------------------------------------------------
+
+const NOTIF_CATEGORY_TYPES = ['chat', 'calendar', 'community'];
+
+export const admin_create_notification_category: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const type = String(args.type ?? '').trim();
+  const displayName = String(args.display_name ?? '').trim();
+  if (!NOTIF_CATEGORY_TYPES.includes(type) || !displayName) {
+    return { ok: false, error: `admin_create_notification_category requires type (one of ${NOTIF_CATEGORY_TYPES.join(', ')}) and display_name.` };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, type, display_name: displayName },
+      text: `About to create notification category "${displayName}" (${type}). Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/notification-categories', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: {
+      type,
+      display_name: displayName,
+      description: typeof args.description === 'string' ? args.description : undefined,
+      icon: typeof args.icon === 'string' ? args.icon : undefined,
+      sort_order: typeof args.sort_order === 'number' ? args.sort_order : undefined,
+      default_enabled: typeof args.default_enabled === 'boolean' ? args.default_enabled : undefined,
+      mapped_types: Array.isArray(args.mapped_types) ? args.mapped_types : undefined,
+      tenant_id: typeof args.tenant_id === 'string' ? args.tenant_id : id.tenant_id,
+    },
+  });
+  if (!ok) return { ok: true, result: { created: false, status, detail: body }, text: `Could not create the category: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { created: true, detail: body }, text: `Category "${displayName}" created.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. admin_update_notification_category — PATCH .../notification-categories/:id
+// ---------------------------------------------------------------------------
+
+export const admin_update_notification_category: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const categoryId = String(args.category_id ?? '').trim();
+  if (!categoryId) return { ok: false, error: 'admin_update_notification_category requires category_id.' };
+  if (args.type !== undefined) return { ok: false, error: 'The category type cannot be changed after creation.' };
+  const patch: Record<string, unknown> = {};
+  for (const k of ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'] as const) {
+    if (args[k] !== undefined) patch[k] = args[k];
+  }
+  if (Object.keys(patch).length === 0) return { ok: false, error: 'admin_update_notification_category requires at least one field to change.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, category_id: categoryId, patch },
+      text: `About to update notification category ${categoryId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/notification-categories/${encodeURIComponent(categoryId)}`, {
+    method: 'PATCH',
+    headers: authHeaders(id),
+    body: patch,
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update the category: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Category ${categoryId} updated.` };
+};
+
+// ---------------------------------------------------------------------------
+// 7. admin_test_notification_category — POST .../notification-categories/:id/test
+// ---------------------------------------------------------------------------
+
+export const admin_test_notification_category: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const categoryId = String(args.category_id ?? '').trim();
+  if (!categoryId) return { ok: false, error: 'admin_test_notification_category requires category_id.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/notification-categories/${encodeURIComponent(categoryId)}/test`, {
+    method: 'POST',
+    headers: authHeaders(id),
+  });
+  if (!ok) return { ok: true, result: { sent: false, status, detail: body }, text: `Test notification failed: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { sent: true, detail: body }, text: `Test notification sent to your own account (self-test only — there is no target-user parameter on this endpoint).` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const ADMIN_NOTIFICATIONS_TOOL_HANDLERS: Record<string, Handler> = {
+  admin_compose_broadcast,
+  admin_send_broadcast,
+  admin_list_broadcasts,
+  admin_notification_pref_stats,
+  admin_create_notification_category,
+  admin_update_notification_category,
+  admin_test_notification_category,
+};
+
+export const ADMIN_NOTIFICATIONS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'admin_compose_broadcast',
+    description: 'ADMIN ONLY. Preview a broadcast draft (audience size + text) WITHOUT sending. There is no server-side draft storage.',
+    parameters: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'Required.' },
+        body: { type: 'string', description: 'Required.' },
+        recipient_ids: { type: 'array', items: { type: 'string' } },
+        recipient_role: { type: 'string' },
+        send_to_all: { type: 'boolean' },
+        tenant_id: { type: 'string' },
+      },
+      required: ['title', 'body'],
+    },
+  },
+  {
+    name: 'admin_send_broadcast',
+    description: 'ADMIN ONLY. Send a notification NOW to the resolved audience (max 500 recipients). TWO-STEP confirm — no undo.',
+    parameters: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'Required.' },
+        body: { type: 'string', description: 'Required.' },
+        recipient_ids: { type: 'array', items: { type: 'string' } },
+        recipient_role: { type: 'string' },
+        send_to_all: { type: 'boolean' },
+        tenant_id: { type: 'string' },
+        type: { type: 'string' }, channel: { type: 'string' }, priority: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['title', 'body'],
+    },
+  },
+  {
+    name: 'admin_list_broadcasts',
+    description: 'ADMIN ONLY. Sent notification history (general log, not broadcast-only).',
+    parameters: { type: 'object', properties: { type: { type: 'string' }, user_id: { type: 'string' }, search: { type: 'string' }, days: { type: 'integer' }, limit: { type: 'integer' } } },
+  },
+  {
+    name: 'admin_notification_pref_stats',
+    description: 'ADMIN ONLY. Notification opt-in/out stats plus 30-day send/read counts.',
+    parameters: { type: 'object', properties: { tenant_id: { type: 'string' } } },
+  },
+  {
+    name: 'admin_create_notification_category',
+    description: 'ADMIN ONLY. Create a new notification category. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        type: { type: 'string', description: 'chat, calendar, or community. Required.' },
+        display_name: { type: 'string', description: 'Required.' },
+        description: { type: 'string' }, icon: { type: 'string' }, sort_order: { type: 'integer' },
+        default_enabled: { type: 'boolean' }, mapped_types: { type: 'array', items: { type: 'string' } },
+        tenant_id: { type: 'string', description: 'Omit for a global category.' }, confirm: { type: 'boolean' },
+      },
+      required: ['type', 'display_name'],
+    },
+  },
+  {
+    name: 'admin_update_notification_category',
+    description: 'ADMIN ONLY. Edit a notification category (type is immutable). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        category_id: { type: 'string', description: 'Required.' },
+        display_name: { type: 'string' }, description: { type: 'string' }, icon: { type: 'string' },
+        sort_order: { type: 'integer' }, is_active: { type: 'boolean' }, default_enabled: { type: 'boolean' },
+        mapped_types: { type: 'array', items: { type: 'string' } }, confirm: { type: 'boolean' },
+      },
+      required: ['category_id'],
+    },
+  },
+  {
+    name: 'admin_test_notification_category',
+    description: 'ADMIN ONLY. Send a test notification for a category to your own account (self-test only).',
+    parameters: { type: 'object', properties: { category_id: { type: 'string', description: 'Required.' } }, required: ['category_id'] },
+  },
+];

--- a/services/gateway/src/services/orb-tools/admin-users-rbac-tools.ts
+++ b/services/gateway/src/services/orb-tools/admin-users-rbac-tools.ts
@@ -1,0 +1,330 @@
+/**
+ * Admin voice tools — Users & RBAC (Wave 3, plan section B1).
+ *
+ * Thin dispatch layer over existing routes/admin-users.ts,
+ * admin-users-lookup.ts, role-admin.ts, admin-trust-tier.ts,
+ * tenant-admin/overview.ts. No new backend behaviour.
+ *
+ * Every route here requires a real Supabase JWT (requireAdminAuth /
+ * verifyAdminAccess / canManageRoles / requireTenantAdmin) — handlers
+ * forward the caller's own session JWT (identity.user_jwt) as Bearer and
+ * fail clearly (no fabricated credentials) when it isn't present.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, relAge, clampLimit } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const ADMIN_ROLES = new Set(['admin', 'exafy_admin']);
+
+/** Returns a deny result when the identity may not use admin tools, else null. */
+export function adminGate(id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: 'admin tools require an authenticated user.' };
+  }
+  const role = String(id.role ?? '').toLowerCase();
+  if (!ADMIN_ROLES.has(role)) {
+    return { ok: false, error: 'admin_role_required' };
+  }
+  return null;
+}
+
+export const NO_ADMIN_SESSION: OrbToolResult = {
+  ok: true,
+  result: { reason: 'no_admin_session' },
+  text: "This needs a signed-in admin session — I don't have one for this voice session.",
+};
+
+export function authHeaders(id: OrbToolIdentity): Record<string, string> {
+  return id.user_jwt ? { Authorization: `Bearer ${id.user_jwt}` } : {};
+}
+
+// ---------------------------------------------------------------------------
+// 1. admin_lookup_user — GET /api/v1/admin/users/lookup
+// ---------------------------------------------------------------------------
+
+export const admin_lookup_user: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const token = String(args.query ?? args.token ?? '').trim();
+  if (!token) return { ok: false, error: 'admin_lookup_user requires a query (name, email, or vitana_id).' };
+  const limit = clampLimit(args.limit, 10, 50);
+  const { ok, status, body } = await gatewayApiCall(
+    `/api/v1/admin/users/lookup?token=${encodeURIComponent(token)}&limit=${limit}`,
+    { headers: authHeaders(id) },
+  );
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_lookup_user failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const candidates = (Array.isArray(body.candidates) ? body.candidates : []) as Array<Record<string, unknown>>;
+  if (candidates.length === 0) return { ok: true, result: { candidates: [] }, text: `No users matched "${token}".` };
+  return { ok: true, result: { candidates }, text: `${candidates.length} matches for "${token}".` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. admin_list_users — GET /api/v1/admin/users
+// ---------------------------------------------------------------------------
+
+export const admin_list_users: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const qs = new URLSearchParams({ limit: String(clampLimit(args.limit, 20, 200)) });
+  if (typeof args.query === 'string' && args.query) qs.set('query', args.query);
+  if (typeof args.role === 'string' && args.role) qs.set('role', args.role);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/users?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_list_users failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const users = (Array.isArray(body.users) ? body.users : []) as Array<{ email: string; active_role?: string }>;
+  if (users.length === 0) return { ok: true, result: { users: [] }, text: 'No users matched.' };
+  const lines = users.slice(0, 8).map((u) => `${u.email} (${u.active_role ?? 'unknown role'})`);
+  return { ok: true, result: { users }, text: `${users.length} users: ${lines.join('. ')}` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. admin_get_user_detail — GET /api/v1/admin/users/:userId
+// ---------------------------------------------------------------------------
+
+export const admin_get_user_detail: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const userId = String(args.user_id ?? '').trim();
+  if (!userId) return { ok: false, error: 'admin_get_user_detail requires user_id.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/users/${encodeURIComponent(userId)}`, { headers: authHeaders(id) });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No user found with id ${userId}.` }
+      : { ok: false, error: `admin_get_user_detail failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const user = (body.user ?? {}) as Record<string, unknown>;
+  return {
+    ok: true,
+    result: { found: true, user },
+    text: `${String(user.email ?? userId)} — ${String(user.active_role ?? 'unknown role')}, status ${String(user.status ?? 'unknown')}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 4. admin_roles_summary — GET /api/v1/admin/users/roles-summary
+// ---------------------------------------------------------------------------
+
+export const admin_roles_summary: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/users/roles-summary', { headers: authHeaders(id) });
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_roles_summary failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const roles = (Array.isArray(body.roles) ? body.roles : []) as Array<{ role: string; user_count: number }>;
+  const lines = roles.map((r) => `${r.role}: ${r.user_count}`);
+  return { ok: true, result: { roles }, text: `Role distribution: ${lines.join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. admin_grant_role — POST /api/v1/roles/grant
+// ---------------------------------------------------------------------------
+
+export const admin_grant_role: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const userId = String(args.user_id ?? '').trim();
+  const role = String(args.role ?? '').trim();
+  if (!userId || !role) return { ok: false, error: 'admin_grant_role requires user_id and role.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, user_id: userId, role },
+      text: `About to grant role "${role}" to user ${userId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/roles/grant', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { user_id: userId, role, tenant_id: typeof args.tenant_id === 'string' ? args.tenant_id : id.tenant_id },
+  });
+  if (!ok) return { ok: true, result: { granted: false, status, detail: body }, text: `Could not grant "${role}": ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { granted: true, detail: body }, text: `Granted "${role}" to ${userId}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. admin_revoke_role — POST /api/v1/roles/revoke
+// ---------------------------------------------------------------------------
+
+export const admin_revoke_role: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const userId = String(args.user_id ?? '').trim();
+  const role = String(args.role ?? '').trim();
+  if (!userId || !role) return { ok: false, error: 'admin_revoke_role requires user_id and role.' };
+  if (role === 'community') return { ok: false, error: 'The community role cannot be revoked — it is the floor role.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, user_id: userId, role },
+      text: `About to revoke role "${role}" from user ${userId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/roles/revoke', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { user_id: userId, role, tenant_id: typeof args.tenant_id === 'string' ? args.tenant_id : id.tenant_id },
+  });
+  if (!ok) return { ok: true, result: { revoked: false, status, detail: body }, text: `Could not revoke "${role}": ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { revoked: true, detail: body }, text: `Revoked "${role}" from ${userId}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 7. admin_set_trust_tier — POST /api/v1/admin/users/:vitana_id/trust-tier
+// (operator/exafy_admin only, per the route's own gate)
+// ---------------------------------------------------------------------------
+
+const VALID_TRUST_TIERS = ['unverified', 'community_verified', 'pro_verified', 'id_verified'];
+
+export const admin_set_trust_tier: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (String(id.role ?? '').toLowerCase() !== 'exafy_admin') {
+    return { ok: false, error: 'admin_set_trust_tier requires an exafy_admin session (operator-only).' };
+  }
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const vitanaId = String(args.vitana_id ?? '').trim();
+  const tier = String(args.tier ?? '').trim();
+  if (!vitanaId || !VALID_TRUST_TIERS.includes(tier)) {
+    return { ok: false, error: `admin_set_trust_tier requires vitana_id and tier (one of ${VALID_TRUST_TIERS.join(', ')}).` };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vitana_id: vitanaId, tier },
+      text: `About to set trust tier "${tier}" for ${vitanaId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/users/${encodeURIComponent(vitanaId)}/trust-tier`, {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { tier, reason: typeof args.reason === 'string' ? args.reason : undefined },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not set trust tier: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Trust tier for ${vitanaId} set to "${tier}".` };
+};
+
+// ---------------------------------------------------------------------------
+// 8. admin_get_at_risk_members — GET /api/v1/admin/tenants/:tenantId/overview/at-risk
+// ---------------------------------------------------------------------------
+
+export const admin_get_at_risk_members: Handler = async (_args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  if (!id.tenant_id) return { ok: false, error: 'admin_get_at_risk_members requires a tenant context.' };
+  const { ok, status, body } = await gatewayApiCall(
+    `/api/v1/admin/tenants/${encodeURIComponent(id.tenant_id)}/overview/at-risk`,
+    { headers: authHeaders(id) },
+  );
+  if (!ok || body.ok !== true) return { ok: false, error: `admin_get_at_risk_members failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const members = (Array.isArray(body.at_risk) ? body.at_risk : []) as Array<{ email: string; last_seen?: string }>;
+  if (members.length === 0) return { ok: true, result: { at_risk: [] }, text: 'No at-risk members flagged right now.' };
+  const lines = members.slice(0, 8).map((m) => `${m.email} — last seen ${relAge(m.last_seen)}`);
+  return {
+    ok: true,
+    result: { at_risk: members },
+    text: `${members.length} at-risk members (based on profile inactivity, not real session telemetry yet): ${lines.join('. ')}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const ADMIN_USERS_RBAC_TOOL_HANDLERS: Record<string, Handler> = {
+  admin_lookup_user,
+  admin_list_users,
+  admin_get_user_detail,
+  admin_roles_summary,
+  admin_grant_role,
+  admin_revoke_role,
+  admin_set_trust_tier,
+  admin_get_at_risk_members,
+};
+
+export const ADMIN_USERS_RBAC_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'admin_lookup_user',
+    description: 'ADMIN ONLY. Find a user by name, email, or vitana_id.',
+    parameters: {
+      type: 'object',
+      properties: { query: { type: 'string', description: 'Required.' }, limit: { type: 'integer' } },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'admin_list_users',
+    description: 'ADMIN ONLY. List/filter users by search query or role.',
+    parameters: {
+      type: 'object',
+      properties: { query: { type: 'string' }, role: { type: 'string' }, limit: { type: 'integer' } },
+    },
+  },
+  {
+    name: 'admin_get_user_detail',
+    description: 'ADMIN ONLY. Full user record by user_id.',
+    parameters: { type: 'object', properties: { user_id: { type: 'string', description: 'Required.' } }, required: ['user_id'] },
+  },
+  {
+    name: 'admin_roles_summary',
+    description: 'ADMIN ONLY. Role distribution counts.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'admin_grant_role',
+    description: 'ADMIN ONLY. Grant a role to a user. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        user_id: { type: 'string', description: 'Required.' },
+        role: { type: 'string', description: 'community, patient, professional, staff, admin, developer, or infra. Required.' },
+        tenant_id: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['user_id', 'role'],
+    },
+  },
+  {
+    name: 'admin_revoke_role',
+    description: 'ADMIN ONLY. Revoke a role from a user (cannot revoke community). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        user_id: { type: 'string', description: 'Required.' },
+        role: { type: 'string', description: 'Required.' },
+        tenant_id: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['user_id', 'role'],
+    },
+  },
+  {
+    name: 'admin_set_trust_tier',
+    description: 'ADMIN ONLY (exafy_admin/operator only). Change a user\'s trust tier. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vitana_id: { type: 'string', description: 'Required.' },
+        tier: { type: 'string', description: 'unverified, community_verified, pro_verified, or id_verified. Required.' },
+        reason: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['vitana_id', 'tier'],
+    },
+  },
+  {
+    name: 'admin_get_at_risk_members',
+    description: 'ADMIN ONLY. At-risk members overview for the current tenant (profile-inactivity heuristic).',
+    parameters: { type: 'object', properties: {} },
+  },
+];

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-12T23:07:23.919Z",
+  "generated_at": "2026-07-13T00:10:55.347Z",
   "source": "reconciled",
   "total": 594,
   "tools": [
@@ -5111,9 +5111,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Find user by name/email/vitana_id",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B1 Users & RBAC",
@@ -5127,9 +5130,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "List/filter users",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B1 Users & RBAC",
@@ -5143,9 +5149,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Full user record",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B1 Users & RBAC",
@@ -5159,9 +5168,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Role distribution",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B1 Users & RBAC",
@@ -5175,9 +5187,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Grant a role",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B1 Users & RBAC",
@@ -5191,9 +5206,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Revoke a role",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B1 Users & RBAC",
@@ -5207,9 +5225,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Change trust tier",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B1 Users & RBAC",
@@ -5223,9 +5244,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "At-risk members (overview)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B1 Users & RBAC",
@@ -5463,9 +5487,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Pending items",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B4 Content Moderation",
@@ -5479,9 +5506,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One item detail",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B4 Content Moderation",
@@ -5495,9 +5525,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Queue stats",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B4 Content Moderation",
@@ -5511,9 +5544,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Approve item",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B4 Content Moderation",
@@ -5527,9 +5563,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Reject/remove item",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B4 Content Moderation",
@@ -5543,9 +5582,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Flag for review",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "B4 Content Moderation",
@@ -5559,9 +5601,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "User reports",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B4 Content Moderation",
@@ -5575,9 +5620,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One report",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B4 Content Moderation",
@@ -5719,9 +5767,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Marketplace KPIs",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B6 Marketplace Admin",
@@ -5735,9 +5786,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Merchants",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B6 Marketplace Admin",
@@ -5751,9 +5805,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Edit merchant status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B6 Marketplace Admin",
@@ -5767,9 +5824,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Products (admin view)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B6 Marketplace Admin",
@@ -5783,9 +5843,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Edit/approve product",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B6 Marketplace Admin",
@@ -5799,9 +5862,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Bulk enable/disable",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B6 Marketplace Admin",
@@ -5815,9 +5881,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Curation rules",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B6 Marketplace Admin",
@@ -5831,9 +5900,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Change curation",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B6 Marketplace Admin",
@@ -5847,9 +5919,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Geo policies",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B6 Marketplace Admin",
@@ -5863,9 +5938,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Edit geo policy",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B6 Marketplace Admin",
@@ -5879,9 +5957,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Sync a product network",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B6 Marketplace Admin",
@@ -5895,9 +5976,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Ingestion runs & coverage",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B6 Marketplace Admin",
@@ -6407,9 +6491,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Draft a broadcast (returns preview)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "B11 Notifications & Broadcast",
@@ -6423,9 +6510,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Send to audience",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B11 Notifications & Broadcast",
@@ -6439,9 +6529,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Sent history",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B11 Notifications & Broadcast",
@@ -6455,9 +6548,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Opt-in/out stats",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B11 Notifications & Broadcast",
@@ -6471,9 +6567,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "New category",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B11 Notifications & Broadcast",
@@ -6487,9 +6586,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Edit category",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B11 Notifications & Broadcast",
@@ -6503,9 +6605,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Send test",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "write",
       "plan_domain": "B11 Notifications & Broadcast",
@@ -6519,9 +6624,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Governance status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B12 Governance & Controls",
@@ -6535,9 +6643,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Rules",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B12 Governance & Controls",
@@ -6551,9 +6662,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Violations feed",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B12 Governance & Controls",
@@ -6567,9 +6681,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Proposals",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B12 Governance & Controls",
@@ -6583,9 +6700,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "New proposal",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B12 Governance & Controls",
@@ -6599,9 +6719,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Approve/reject proposal",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B12 Governance & Controls",
@@ -6615,9 +6738,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Read a control (kill switches)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B12 Governance & Controls",
@@ -6631,9 +6757,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Flip a control key",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B12 Governance & Controls",
@@ -6935,9 +7064,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Support tickets",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B15 Feedback & Support Admin",
@@ -6951,9 +7083,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One ticket",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B15 Feedback & Support Admin",
@@ -6967,9 +7102,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Support KPIs",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B15 Feedback & Support Admin",
@@ -6983,9 +7121,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Recent handoffs",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "read",
       "plan_domain": "B15 Feedback & Support Admin",
@@ -6999,9 +7140,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Resolve/assign/respond",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P0",
       "risk": "confirm",
       "plan_domain": "B15 Feedback & Support Admin",

--- a/services/gateway/test/orb-tools/admin-feedback-tools.test.ts
+++ b/services/gateway/test/orb-tools/admin-feedback-tools.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Admin Feedback & Support voice tools (Wave 3, plan section B15) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  ADMIN_FEEDBACK_TOOL_HANDLERS,
+  ADMIN_FEEDBACK_TOOL_DECLARATIONS,
+  admin_act_on_ticket,
+} from '../../src/services/orb-tools/admin-feedback-tools';
+
+const ADMIN_ID: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'admin', user_jwt: 'jwt-abc' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'admin' };
+
+function makeSb(): SupabaseClient {
+  return {} as unknown as SupabaseClient;
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('admin feedback role gate', () => {
+  const names = Object.keys(ADMIN_FEEDBACK_TOOL_HANDLERS);
+
+  it('exposes all 5 tools with matching declarations', () => {
+    expect(names).toHaveLength(5);
+    const declNames = ADMIN_FEEDBACK_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const args = { ticket_id: 't1', action: 'resolve' };
+    const r = await ADMIN_FEEDBACK_TOOL_HANDLERS[name](args, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('admin_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await ADMIN_FEEDBACK_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('admin_act_on_ticket', () => {
+  it('rejects the unsupported "assign" action honestly', async () => {
+    const r = await admin_act_on_ticket({ ticket_id: 't1', action: 'assign' }, ADMIN_ID, makeSb());
+    expect((r.result as { supported: boolean }).supported).toBe(false);
+  });
+
+  it('rejects an unknown action', async () => {
+    const r = await admin_act_on_ticket({ ticket_id: 't1', action: 'bogus' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('mark_duplicate requires duplicate_of', async () => {
+    const r = await admin_act_on_ticket({ ticket_id: 't1', action: 'mark_duplicate' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await admin_act_on_ticket({ ticket_id: 't1', action: 'resolve' }, ADMIN_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('resolves after confirm=true', async () => {
+    mockFetch(200, { ok: true });
+    const r = await admin_act_on_ticket({ ticket_id: 't1', action: 'resolve', confirm: true }, ADMIN_ID, makeSb());
+    expect(r.text).toContain('resolve');
+  });
+});

--- a/services/gateway/test/orb-tools/admin-governance-tools.test.ts
+++ b/services/gateway/test/orb-tools/admin-governance-tools.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Admin Governance & Controls voice tools (Wave 3, plan section B12) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  ADMIN_GOVERNANCE_TOOL_HANDLERS,
+  ADMIN_GOVERNANCE_TOOL_DECLARATIONS,
+  admin_set_control_key,
+  admin_create_proposal,
+} from '../../src/services/orb-tools/admin-governance-tools';
+
+const ADMIN_ID: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'admin' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'admin' };
+
+function makeSb(): SupabaseClient {
+  return {} as unknown as SupabaseClient;
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('admin governance role gate', () => {
+  const names = Object.keys(ADMIN_GOVERNANCE_TOOL_HANDLERS);
+
+  it('exposes all 8 tools with matching declarations', () => {
+    expect(names).toHaveLength(8);
+    const declNames = ADMIN_GOVERNANCE_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const args = { key: 'x', enabled: true, reason: 'r', type: 'New Rule', proposed_rule: 'p', proposal_id: 'P1', status: 'Approved' };
+    const r = await ADMIN_GOVERNANCE_TOOL_HANDLERS[name](args, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('admin_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await ADMIN_GOVERNANCE_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('admin_set_control_key', () => {
+  it('requires key and reason', async () => {
+    const r = await admin_set_control_key({ key: 'x', enabled: true }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await admin_set_control_key({ key: 'x', enabled: true, reason: 'incident' }, ADMIN_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('sets the control after confirm=true', async () => {
+    mockFetch(200, { ok: true });
+    const r = await admin_set_control_key({ key: 'x', enabled: false, reason: 'incident', confirm: true }, ADMIN_ID, makeSb());
+    expect(r.text).toContain('disabled');
+  });
+});
+
+describe('admin_create_proposal', () => {
+  it('validates type', async () => {
+    const r = await admin_create_proposal({ type: 'bogus', proposed_rule: 'x' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/admin-marketplace-tools.test.ts
+++ b/services/gateway/test/orb-tools/admin-marketplace-tools.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Admin Marketplace voice tools (Wave 3, plan section B6) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  ADMIN_MARKETPLACE_TOOL_HANDLERS,
+  ADMIN_MARKETPLACE_TOOL_DECLARATIONS,
+  admin_update_merchant,
+  admin_bulk_product_action,
+  admin_trigger_source_sync,
+  admin_get_ingestion_coverage,
+} from '../../src/services/orb-tools/admin-marketplace-tools';
+
+const ADMIN_ID: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'admin', user_jwt: 'jwt-abc' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'admin' };
+
+function makeSb(): SupabaseClient {
+  return {} as unknown as SupabaseClient;
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('admin marketplace role gate', () => {
+  const names = Object.keys(ADMIN_MARKETPLACE_TOOL_HANDLERS);
+
+  it('exposes all 12 tools with matching declarations', () => {
+    expect(names).toHaveLength(12);
+    const declNames = ADMIN_MARKETPLACE_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const args = { merchant_id: 'm1', product_id: 'p1', product_ids: ['p1'], action: 'hide', config_id: 'c1', policy_id: 'g1', network: 'shopify' };
+    const r = await ADMIN_MARKETPLACE_TOOL_HANDLERS[name](args, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('admin_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await ADMIN_MARKETPLACE_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('admin_update_merchant', () => {
+  it('requires at least one field to change', async () => {
+    const r = await admin_update_merchant({ merchant_id: 'm1' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await admin_update_merchant({ merchant_id: 'm1', is_active: false }, ADMIN_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});
+
+describe('admin_bulk_product_action', () => {
+  it('validates action and product_ids', async () => {
+    const r = await admin_bulk_product_action({ product_ids: [], action: 'hide' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects more than 100 ids', async () => {
+    const ids = Array.from({ length: 101 }, (_, i) => `p${i}`);
+    const r = await admin_bulk_product_action({ product_ids: ids, action: 'hide' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await admin_bulk_product_action({ product_ids: ['p1'], action: 'hide' }, ADMIN_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});
+
+describe('admin_trigger_source_sync', () => {
+  it('validates network', async () => {
+    const r = await admin_trigger_source_sync({ network: 'bogus' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await admin_trigger_source_sync({ network: 'shopify' }, ADMIN_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});
+
+describe('admin_get_ingestion_coverage', () => {
+  it('fetches both runs and coverage by default', async () => {
+    const fn = mockFetch(200, { ok: true });
+    await admin_get_ingestion_coverage({}, ADMIN_ID, makeSb());
+    expect(fn.mock.calls.length).toBe(2);
+  });
+});

--- a/services/gateway/test/orb-tools/admin-moderation-tools.test.ts
+++ b/services/gateway/test/orb-tools/admin-moderation-tools.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Admin Content Moderation voice tools (Wave 3, plan section B4) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  ADMIN_MODERATION_TOOL_HANDLERS,
+  ADMIN_MODERATION_TOOL_DECLARATIONS,
+  admin_list_moderation_queue,
+  admin_approve_content,
+  admin_list_reports,
+  admin_get_report,
+} from '../../src/services/orb-tools/admin-moderation-tools';
+
+const ADMIN_ID: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'admin', user_jwt: 'jwt-abc' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'admin' };
+
+function makeSb(): SupabaseClient {
+  return {} as unknown as SupabaseClient;
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('admin moderation role gate', () => {
+  const names = Object.keys(ADMIN_MODERATION_TOOL_HANDLERS);
+
+  it('exposes all 8 tools with matching declarations', () => {
+    expect(names).toHaveLength(8);
+    const declNames = ADMIN_MODERATION_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await ADMIN_MODERATION_TOOL_HANDLERS[name]({ item_id: 'i1' }, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('admin_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await ADMIN_MODERATION_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('admin_list_moderation_queue', () => {
+  it('reports empty queue honestly', async () => {
+    mockFetch(200, { ok: true, items: [] });
+    const r = await admin_list_moderation_queue({}, ADMIN_ID, makeSb());
+    expect(r.text).toContain('empty');
+  });
+});
+
+describe('admin_approve_content', () => {
+  it('requires item_id', async () => {
+    const r = await admin_approve_content({}, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await admin_approve_content({ item_id: 'i1' }, ADMIN_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('approves after confirm=true', async () => {
+    mockFetch(200, { ok: true });
+    const r = await admin_approve_content({ item_id: 'i1', confirm: true }, ADMIN_ID, makeSb());
+    expect(r.text).toContain('approved');
+  });
+});
+
+describe('admin_list_reports / admin_get_report gaps', () => {
+  it('admin_list_reports flags the missing report table', async () => {
+    mockFetch(200, { ok: true, items: [] });
+    const r = await admin_list_reports({}, ADMIN_ID, makeSb());
+    expect(r.text).toContain('no dedicated user-report table');
+  });
+
+  it('admin_get_report reports not-implemented honestly', async () => {
+    const r = await admin_get_report({}, ADMIN_ID, makeSb());
+    expect((r.result as { available: boolean }).available).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/admin-notifications-tools.test.ts
+++ b/services/gateway/test/orb-tools/admin-notifications-tools.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Admin Notifications & Broadcast voice tools (Wave 3, plan section B11) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  ADMIN_NOTIFICATIONS_TOOL_HANDLERS,
+  ADMIN_NOTIFICATIONS_TOOL_DECLARATIONS,
+  admin_compose_broadcast,
+  admin_send_broadcast,
+  admin_create_notification_category,
+  admin_update_notification_category,
+} from '../../src/services/orb-tools/admin-notifications-tools';
+
+const ADMIN_ID: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'admin', user_jwt: 'jwt-abc' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'admin' };
+
+interface StubResp {
+  data: unknown;
+  error: { message: string } | null;
+}
+
+function makeSb(count = 0): SupabaseClient {
+  const sb = {
+    from() {
+      const chain: Record<string, unknown> = {};
+      for (const m of ['select', 'eq']) chain[m] = () => chain;
+      chain.then = (onOk: (v: StubResp & { count: number }) => unknown) =>
+        Promise.resolve({ data: null, error: null, count }).then(onOk);
+      return chain;
+    },
+  };
+  return sb as unknown as SupabaseClient;
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('admin notifications role gate', () => {
+  const names = Object.keys(ADMIN_NOTIFICATIONS_TOOL_HANDLERS);
+
+  it('exposes all 7 tools with matching declarations', () => {
+    expect(names).toHaveLength(7);
+    const declNames = ADMIN_NOTIFICATIONS_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const args = { title: 't', body: 'b', send_to_all: true, tenant_id: 't-1', category_id: 'c1', type: 'chat', display_name: 'D' };
+    const r = await ADMIN_NOTIFICATIONS_TOOL_HANDLERS[name](args, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('admin_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await ADMIN_NOTIFICATIONS_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('admin_compose_broadcast', () => {
+  it('requires title and body', async () => {
+    const r = await admin_compose_broadcast({}, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('never calls the network — preview only', async () => {
+    const fn = mockFetch(200, {});
+    await admin_compose_broadcast({ title: 't', body: 'b', send_to_all: true, tenant_id: 't-1' }, ADMIN_ID, makeSb(42));
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('reports the resolved audience size', async () => {
+    const r = await admin_compose_broadcast({ title: 't', body: 'b', send_to_all: true, tenant_id: 't-1' }, ADMIN_ID, makeSb(42));
+    expect(r.text).toContain('42');
+  });
+});
+
+describe('admin_send_broadcast', () => {
+  it('requires an audience', async () => {
+    const r = await admin_send_broadcast({ title: 't', body: 'b' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await admin_send_broadcast({ title: 't', body: 'b', send_to_all: true, tenant_id: 't-1' }, ADMIN_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('sends after confirm=true', async () => {
+    mockFetch(200, { ok: true, sent_to: 5 });
+    const r = await admin_send_broadcast({ title: 't', body: 'b', send_to_all: true, tenant_id: 't-1', confirm: true }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('admin_create_notification_category', () => {
+  it('validates type', async () => {
+    const r = await admin_create_notification_category({ type: 'bogus', display_name: 'X' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation', async () => {
+    const r = await admin_create_notification_category({ type: 'chat', display_name: 'X' }, ADMIN_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});
+
+describe('admin_update_notification_category', () => {
+  it('refuses to change type', async () => {
+    const r = await admin_update_notification_category({ category_id: 'c1', type: 'community' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});

--- a/services/gateway/test/orb-tools/admin-users-rbac-tools.test.ts
+++ b/services/gateway/test/orb-tools/admin-users-rbac-tools.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Admin Users & RBAC voice tools (Wave 3, plan section B1) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  ADMIN_USERS_RBAC_TOOL_HANDLERS,
+  ADMIN_USERS_RBAC_TOOL_DECLARATIONS,
+  adminGate,
+  admin_grant_role,
+  admin_revoke_role,
+  admin_set_trust_tier,
+  admin_lookup_user,
+} from '../../src/services/orb-tools/admin-users-rbac-tools';
+
+const ADMIN_ID: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'admin', user_jwt: 'jwt-abc' };
+const EXAFY_ID: OrbToolIdentity = { user_id: 'u-exafy', tenant_id: 't-1', role: 'exafy_admin', user_jwt: 'jwt-xyz' };
+const ADMIN_ID_NO_JWT: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'admin' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'admin' };
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer', user_jwt: 'jwt' };
+
+function makeSb(): SupabaseClient {
+  return {} as unknown as SupabaseClient;
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('admin role gate', () => {
+  it('allows admin and exafy_admin, denies developer', () => {
+    expect(adminGate(ADMIN_ID)).toBeNull();
+    expect(adminGate(EXAFY_ID)).toBeNull();
+    expect(adminGate(DEV_ID)).not.toBeNull();
+  });
+
+  const names = Object.keys(ADMIN_USERS_RBAC_TOOL_HANDLERS);
+
+  it('exposes all 8 tools with matching declarations', () => {
+    expect(names).toHaveLength(8);
+    const declNames = ADMIN_USERS_RBAC_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const args = { user_id: 'u1', role: 'community', vitana_id: 'v1', tier: 'unverified', query: 'x' };
+    const r = await ADMIN_USERS_RBAC_TOOL_HANDLERS[name](args, COMMUNITY_ID, makeSb());
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toBe('admin_role_required');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await ADMIN_USERS_RBAC_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('admin_lookup_user', () => {
+  it('requires a session JWT', async () => {
+    const r = await admin_lookup_user({ query: 'x' }, ADMIN_ID_NO_JWT, makeSb());
+    expect((r.result as { reason: string }).reason).toBe('no_admin_session');
+  });
+
+  it('reports no matches honestly', async () => {
+    mockFetch(200, { ok: true, candidates: [] });
+    const r = await admin_lookup_user({ query: 'nobody' }, ADMIN_ID, makeSb());
+    expect(r.text).toContain('No users matched');
+  });
+});
+
+describe('admin_grant_role / admin_revoke_role', () => {
+  it('grant requires confirmation', async () => {
+    const r = await admin_grant_role({ user_id: 'u1', role: 'staff' }, ADMIN_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+
+  it('revoke refuses to revoke community', async () => {
+    const r = await admin_revoke_role({ user_id: 'u1', role: 'community' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('grants after confirm=true', async () => {
+    mockFetch(200, { ok: true });
+    const r = await admin_grant_role({ user_id: 'u1', role: 'staff', confirm: true }, ADMIN_ID, makeSb());
+    expect(r.text).toContain('Granted');
+  });
+});
+
+describe('admin_set_trust_tier', () => {
+  it('requires exafy_admin, not just admin', async () => {
+    const r = await admin_set_trust_tier({ vitana_id: 'v1', tier: 'id_verified' }, ADMIN_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation for exafy_admin', async () => {
+    const r = await admin_set_trust_tier({ vitana_id: 'v1', tier: 'id_verified' }, EXAFY_ID, makeSb());
+    expect((r as { result: { requires_confirmation: boolean } }).result.requires_confirmation).toBe(true);
+  });
+});

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -7832,6 +7832,1055 @@ Optionally filter by tier (service, embedded, scheduled). Speak problem agents f
           "type": "object",
         },
       },
+      {
+        "description": "ADMIN ONLY. Find a user by name, email, or vitana_id.",
+        "name": "admin_lookup_user",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "query": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "query",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List/filter users by search query or role.",
+        "name": "admin_list_users",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "query": {
+              "type": "string",
+            },
+            "role": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Full user record by user_id.",
+        "name": "admin_get_user_detail",
+        "parameters": {
+          "properties": {
+            "user_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "user_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Role distribution counts.",
+        "name": "admin_roles_summary",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Grant a role to a user. TWO-STEP confirm.",
+        "name": "admin_grant_role",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "role": {
+              "description": "community, patient, professional, staff, admin, developer, or infra. Required.",
+              "type": "string",
+            },
+            "tenant_id": {
+              "type": "string",
+            },
+            "user_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "user_id",
+            "role",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Revoke a role from a user (cannot revoke community). TWO-STEP confirm.",
+        "name": "admin_revoke_role",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "role": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "tenant_id": {
+              "type": "string",
+            },
+            "user_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "user_id",
+            "role",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY (exafy_admin/operator only). Change a user's trust tier. TWO-STEP confirm.",
+        "name": "admin_set_trust_tier",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "reason": {
+              "type": "string",
+            },
+            "tier": {
+              "description": "unverified, community_verified, pro_verified, or id_verified. Required.",
+              "type": "string",
+            },
+            "vitana_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vitana_id",
+            "tier",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. At-risk members overview for the current tenant (profile-inactivity heuristic).",
+        "name": "admin_get_at_risk_members",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List pending content-moderation items, optionally filtered by status/type.",
+        "name": "admin_list_moderation_queue",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "status": {
+              "type": "string",
+            },
+            "type": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Detail for one moderation queue item.",
+        "name": "admin_get_moderation_item",
+        "parameters": {
+          "properties": {
+            "item_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "item_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Moderation queue stats (counts by status/type).",
+        "name": "admin_moderation_stats",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Approve a moderation item (makes it public). TWO-STEP confirm.",
+        "name": "admin_approve_content",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "item_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "item_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Reject a moderation item (removes from public). TWO-STEP confirm.",
+        "name": "admin_reject_content",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "item_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "item_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Flag a moderation item for further review. TWO-STEP confirm.",
+        "name": "admin_flag_content",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "item_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "item_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List user reports. NOTE: no dedicated report table exists yet — shows flagged media instead.",
+        "name": "admin_list_reports",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Get one user report. NOTE: not implemented in the backend yet.",
+        "name": "admin_get_report",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Marketplace KPIs overview.",
+        "name": "admin_marketplace_overview",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List merchants, filterable by source_network/is_active/search.",
+        "name": "admin_list_merchants",
+        "parameters": {
+          "properties": {
+            "is_active": {
+              "type": "boolean",
+            },
+            "limit": {
+              "type": "integer",
+            },
+            "search": {
+              "type": "string",
+            },
+            "source_network": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Edit a merchant's status/quality/commission/notes. TWO-STEP confirm.",
+        "name": "admin_update_merchant",
+        "parameters": {
+          "properties": {
+            "admin_notes": {
+              "type": "string",
+            },
+            "commission_rate": {
+              "type": "number",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "customs_risk": {
+              "type": "string",
+            },
+            "is_active": {
+              "type": "boolean",
+            },
+            "merchant_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "name": {
+              "type": "string",
+            },
+            "quality_score": {
+              "type": "number",
+            },
+            "requires_admin_review": {
+              "type": "boolean",
+            },
+          },
+          "required": [
+            "merchant_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List products (admin view), filterable by network/category/region/review-flag/search.",
+        "name": "admin_list_products",
+        "parameters": {
+          "properties": {
+            "category": {
+              "type": "string",
+            },
+            "is_active": {
+              "type": "boolean",
+            },
+            "limit": {
+              "type": "integer",
+            },
+            "origin_region": {
+              "type": "string",
+            },
+            "requires_admin_review": {
+              "type": "boolean",
+            },
+            "search": {
+              "type": "string",
+            },
+            "source_network": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Edit/approve a product. TWO-STEP confirm.",
+        "name": "admin_update_product",
+        "parameters": {
+          "properties": {
+            "admin_notes": {
+              "type": "string",
+            },
+            "admin_review_reason": {
+              "type": "string",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "customs_risk": {
+              "type": "string",
+            },
+            "description": {
+              "type": "string",
+            },
+            "excluded_from_regions": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "is_active": {
+              "type": "boolean",
+            },
+            "product_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "requires_admin_review": {
+              "type": "boolean",
+            },
+            "title": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "product_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Bulk enable/disable/flag products (max 100 per call). TWO-STEP confirm.",
+        "name": "admin_bulk_product_action",
+        "parameters": {
+          "properties": {
+            "action": {
+              "description": "hide, clear_review, flag_review, deactivate, or reactivate. Required.",
+              "type": "string",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "product_ids": {
+              "description": "Required, max 100.",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "reason": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "product_ids",
+            "action",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Read the feed curation config.",
+        "name": "admin_get_feed_curation",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Change feed curation rules. TWO-STEP confirm.",
+        "name": "admin_update_feed_curation",
+        "parameters": {
+          "properties": {
+            "category_mix": {
+              "type": "object",
+            },
+            "config_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "diversity_rules": {
+              "type": "object",
+            },
+            "featured_product_ids": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "max_products_per_category": {
+              "type": "integer",
+            },
+            "max_products_per_merchant": {
+              "type": "integer",
+            },
+            "notes": {
+              "type": "string",
+            },
+            "personalization_weight_override": {
+              "type": "number",
+            },
+            "starter_conditions": {
+              "type": "object",
+            },
+          },
+          "required": [
+            "config_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List geo policies.",
+        "name": "admin_list_geo_policies",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Edit a geo policy. TWO-STEP confirm.",
+        "name": "admin_update_geo_policy",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "description": {
+              "type": "string",
+            },
+            "is_active": {
+              "type": "boolean",
+            },
+            "policy_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "user_opt_out_scope": {
+              "type": "string",
+            },
+            "weight": {
+              "type": "number",
+            },
+          },
+          "required": [
+            "policy_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Trigger a live product sync from a network (runs synchronously). TWO-STEP confirm.",
+        "name": "admin_trigger_source_sync",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "network": {
+              "description": "shopify, cj, amazon, rakuten, awin, or admitad. Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "network",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Ingestion run history and origin/ships-to coverage matrix.",
+        "name": "admin_get_ingestion_coverage",
+        "parameters": {
+          "properties": {
+            "view": {
+              "description": ""runs", "coverage", or omit for both.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Preview a broadcast draft (audience size + text) WITHOUT sending. There is no server-side draft storage.",
+        "name": "admin_compose_broadcast",
+        "parameters": {
+          "properties": {
+            "body": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "recipient_ids": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "recipient_role": {
+              "type": "string",
+            },
+            "send_to_all": {
+              "type": "boolean",
+            },
+            "tenant_id": {
+              "type": "string",
+            },
+            "title": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "title",
+            "body",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Send a notification NOW to the resolved audience (max 500 recipients). TWO-STEP confirm — no undo.",
+        "name": "admin_send_broadcast",
+        "parameters": {
+          "properties": {
+            "body": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "channel": {
+              "type": "string",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "priority": {
+              "type": "string",
+            },
+            "recipient_ids": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "recipient_role": {
+              "type": "string",
+            },
+            "send_to_all": {
+              "type": "boolean",
+            },
+            "tenant_id": {
+              "type": "string",
+            },
+            "title": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "type": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "title",
+            "body",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Sent notification history (general log, not broadcast-only).",
+        "name": "admin_list_broadcasts",
+        "parameters": {
+          "properties": {
+            "days": {
+              "type": "integer",
+            },
+            "limit": {
+              "type": "integer",
+            },
+            "search": {
+              "type": "string",
+            },
+            "type": {
+              "type": "string",
+            },
+            "user_id": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Notification opt-in/out stats plus 30-day send/read counts.",
+        "name": "admin_notification_pref_stats",
+        "parameters": {
+          "properties": {
+            "tenant_id": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Create a new notification category. TWO-STEP confirm.",
+        "name": "admin_create_notification_category",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "default_enabled": {
+              "type": "boolean",
+            },
+            "description": {
+              "type": "string",
+            },
+            "display_name": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "icon": {
+              "type": "string",
+            },
+            "mapped_types": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "sort_order": {
+              "type": "integer",
+            },
+            "tenant_id": {
+              "description": "Omit for a global category.",
+              "type": "string",
+            },
+            "type": {
+              "description": "chat, calendar, or community. Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "type",
+            "display_name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Edit a notification category (type is immutable). TWO-STEP confirm.",
+        "name": "admin_update_notification_category",
+        "parameters": {
+          "properties": {
+            "category_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "default_enabled": {
+              "type": "boolean",
+            },
+            "description": {
+              "type": "string",
+            },
+            "display_name": {
+              "type": "string",
+            },
+            "icon": {
+              "type": "string",
+            },
+            "is_active": {
+              "type": "boolean",
+            },
+            "mapped_types": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "sort_order": {
+              "type": "integer",
+            },
+          },
+          "required": [
+            "category_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Send a test notification for a category to your own account (self-test only).",
+        "name": "admin_test_notification_category",
+        "parameters": {
+          "properties": {
+            "category_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "category_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Governance control-plane snapshot.",
+        "name": "admin_governance_status",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List governance rules.",
+        "name": "admin_list_governance_rules",
+        "parameters": {
+          "properties": {
+            "category": {
+              "type": "string",
+            },
+            "level": {
+              "type": "string",
+            },
+            "search": {
+              "type": "string",
+            },
+            "status": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List open/recent governance violations.",
+        "name": "admin_list_violations",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List governance rule-change proposals.",
+        "name": "admin_list_proposals",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "ruleCode": {
+              "type": "string",
+            },
+            "status": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Create a governance rule-change proposal. TWO-STEP confirm.",
+        "name": "admin_create_proposal",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "proposed_rule": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "rationale": {
+              "type": "string",
+            },
+            "rule_code": {
+              "type": "string",
+            },
+            "type": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "type",
+            "proposed_rule",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Change a proposal's status. TWO-STEP confirm.",
+        "name": "admin_update_proposal_status",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "proposal_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "status": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "proposal_id",
+            "status",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Read a governance control key.",
+        "name": "admin_get_control_key",
+        "parameters": {
+          "properties": {
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "key",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Flip a governance control key on/off — a real kill-switch, requires a reason. TWO-STEP confirm.",
+        "name": "admin_set_control_key",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "duration_minutes": {
+              "type": "integer",
+            },
+            "enabled": {
+              "description": "Required.",
+              "type": "boolean",
+            },
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "reason": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "key",
+            "enabled",
+            "reason",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List support/feedback tickets, filterable by status/kind/priority/surface/resolver_agent.",
+        "name": "admin_list_feedback_tickets",
+        "parameters": {
+          "properties": {
+            "kind": {
+              "type": "string",
+            },
+            "limit": {
+              "type": "integer",
+            },
+            "priority": {
+              "type": "string",
+            },
+            "resolver_agent": {
+              "type": "string",
+            },
+            "status": {
+              "type": "string",
+            },
+            "surface": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Full detail for one feedback ticket, including handoff history.",
+        "name": "admin_get_feedback_ticket",
+        "parameters": {
+          "properties": {
+            "ticket_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "ticket_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Platform-wide support KPIs (last 30 days).",
+        "name": "admin_feedback_kpis",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Recent specialist handoffs.",
+        "name": "admin_list_handoffs",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Act on a feedback ticket: draft_answer, draft_spec, draft_resolution, approve, send_answer, resolve, reject, or mark_duplicate. There is no "assign" action — that concept doesn't exist in the schema. TWO-STEP confirm.",
+        "name": "admin_act_on_ticket",
+        "parameters": {
+          "properties": {
+            "action": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "duplicate_of": {
+              "description": "Required for mark_duplicate.",
+              "type": "string",
+            },
+            "notes": {
+              "type": "string",
+            },
+            "reason": {
+              "description": "Required for reject.",
+              "type": "string",
+            },
+            "ticket_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "ticket_id",
+            "action",
+          ],
+          "type": "object",
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VOICE-CATALOG-WAVE-3` _(BOOTSTRAP-style tag, matching Waves 1-2 — no individual VTID allocated for this catalog build)_

**Layer:** AGTL (voice/agent tooling)

**Priority:** P0

---

## 📋 Summary

Wave 3 of the approved [Voice Tools Expansion Plan v2](docs/VOICE_TOOLS_EXPANSION_PLAN.md): 48 new **admin-only** voice tools covering Users/RBAC (B1), Content Moderation (B4), Marketplace Admin (B6), Notifications/Broadcast (B11), Governance/Controls (B12), and Feedback/Support Admin (B15) — the plan's admin P0 domains.

## ✅ Changes

- [x] 6 new handler modules: `admin-users-rbac-tools.ts` (8), `admin-moderation-tools.ts` (8), `admin-marketplace-tools.ts` (12), `admin-notifications-tools.ts` (7), `admin-governance-tools.ts` (8), `admin-feedback-tools.ts` (5) — thin dispatch layers over existing admin routes, no new backend behaviour
- [x] Shared `adminGate()` (admin/exafy_admin only) in `admin-users-rbac-tools.ts`, reused across all six modules
- [x] Two-step confirm on every mutating tool; `admin_set_trust_tier` further restricted to exafy_admin (operator-only, matching the route's own gate)
- [x] Admin routes mostly require a real session JWT — handlers forward `identity.user_jwt` and fail clearly (no fabricated credentials) when absent
- [x] Honest gap-handling instead of invented backend surface: `admin_list_reports`/`admin_get_report` degrade to the flagged-media view (no `content_reports` table exists); `admin_compose_broadcast` previews audience size via a direct Supabase count instead of calling the send-only `/compose` endpoint; `admin_act_on_ticket` explicitly rejects an "assign" action since no human-assignee concept exists in the schema
- [x] Wired into `orb-tools-shared.ts`'s `ORB_TOOL_REGISTRY` + new `ADMIN_DOMAIN_TOOL_DECLARATIONS`, injected by `live-tool-catalog.ts` alongside `ADMIN_TOOL_SCHEMAS`
- [x] LiveKit `tools.py`: matching `@function_tool` wrappers + `all_tool_names()` entries for all 48
- [x] `tool-manifest.json`: 48 tools flipped `planned` → `live`; lift-scanner reports no drift
- [x] Jest coverage per module (6 new test files, 899 orb-tools tests green); characterization snapshot updated

## 🧪 Testing

- [x] `npx tsc --noEmit` clean
- [x] `node scripts/voice-tools-manifest-reconcile.mjs --check` clean after apply
- [x] `node scripts/orb-tools-lift-scanner.mjs` — no drift detected
- [x] Full gateway jest suite green (7491/7504 passing; the one pre-existing failure, `test/nav-manifest-sync.test.ts`, is unrelated navigation-catalog/vitana-v1 sibling-repo drift, same as Waves 1-2)
- [ ] Verified in staging/dev environment — pending staging deploy after merge

## 🚨 Breaking Changes

None. Purely additive.

## 📌 Additional Notes

Backing-route mapping for all 48 tools was independently verified against the actual codebase before implementation. This is Wave 3 of 6 in the approved expansion plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX)_