### PR TITLE
feat(e2e): integrate sim-use device-testing layer — eyes+hands on iOS Simulator / Android

### DIFF
--- a/.claude/skills/sim-use/LICENSE
+++ b/.claude/skills/sim-use/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work, excluding
+          those notices that do not pertain to any part of the Derivative
+          Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one of
+          the following places: within a NOTICE text file distributed as
+          part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and do
+          not modify the License. You may add Your own attribution notices
+          within Derivative Works that You distribute, alongside or as an
+          addendum to the NOTICE text from the Work, provided that such
+          additional attribution notices cannot be construed as modifying
+          the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 LY Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.claude/skills/sim-use/NOTICE
+++ b/.claude/skills/sim-use/NOTICE
@@ -1,0 +1,26 @@
+sim-use
+Copyright 2026 LY Corporation
+
+This product includes software developed at LY Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use the files in this project except in compliance with the License. A copy
+of the License is provided in the LICENSE file at the root of this repository
+and is also available at http://www.apache.org/licenses/LICENSE-2.0.
+
+--------------------------------------------------------------------------------
+
+This product is derived from AXe (https://github.com/cameroncooke/AXe),
+Copyright (c) 2025 Cameron Cooke, originally licensed under the MIT License.
+The fork was cut from AXe v1.6.0 in April 2026 and has since been substantially
+modified by LY Corporation. The relicensing of this derivative work under the
+Apache License, Version 2.0 is permitted by the sublicensing grant of the MIT
+License.
+
+This product includes software developed by Facebook idb
+(https://github.com/facebook/idb), Copyright (c) Meta Platforms, Inc. and
+affiliates, licensed under the MIT License. sim-use links against XCFrameworks
+built from idb to drive the iOS Simulator HID and accessibility pipelines.
+
+The full text of the above third-party licenses is reproduced in the
+THIRD_PARTY_LICENSES file at the root of this repository.

--- a/.claude/skills/sim-use/SKILL.md
+++ b/.claude/skills/sim-use/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: sim-use
+description: Drive iOS Simulator and Android emulator/device screens for AI agents. Use when asked to automate a simulator or emulator, tap/swipe/type on a device, describe UI, take a screenshot, or interact with a mobile app.
+---
+
+## 0. Preflight
+
+Before first interaction with a device, run the preflight check:
+
+```bash
+python3 scripts/preflight.py --device <UDID>
+```
+
+This verifies sim-use is installed, the device is reachable, and the daemon is healthy. If you don't have the script, do the checks manually:
+
+1. `sim-use --version` — confirm sim-use is on PATH.
+2. `sim-use devices` — confirm the target device is listed and booted/connected.
+3. `sim-use ui --device <UDID>` — confirm you can read the screen.
+
+`--device` is optional when only one simulator is booted or one daemon is running. For Android, run `sim-use android init --device <serial>` once to install the bridge APK.
+
+## 1. The observe-act loop
+
+Every interaction follows the same cycle: **observe → act → verify**.
+
+### Observe
+
+```bash
+sim-use ui --device <UDID>
+```
+
+Read the outline. Each element has an `@N` alias and optionally a `#<id>` identifier. List cells carry `#N` (dominant list) or `#N@M` (scoped).
+
+Frames in the JSON output (`--json`: `entries[].frame`, `screen`) are in platform-native units — iOS **points**, Android **pixels**. Key off the envelope's `platform` field before doing math on coordinates across platforms.
+
+### Act
+
+Pick a selector, in order of preference:
+
+| Selector | When to use |
+|---|---|
+| `tap @N` | Right after `ui`. Fastest, cache-backed. |
+| `tap #<id>` | Stable across minor layout changes. Paste from the outline. |
+| `tap --label 'X'` | Scripted flows. Combine with `--wait-timeout` for transitions. |
+| `tap --label-regex '...'` | Dynamic labels with counters/timestamps. Anchor with `^...$`. |
+| `tap --label-contains 'X'` | Substring match when exact label is unknown. |
+| `tap -x N -y N` / `tap --point x,y` | Last resort for elements with no AX data. |
+
+Disambiguate collisions with `--element-type` or `--frame minY=0.7r` (see `references/cheatsheet.md`).
+
+### Verify
+
+Always verify after acting — commands are fire-and-forget:
+
+```bash
+sim-use ui --device <UDID>       # read the new screen state
+sim-use screenshot --device <UDID> --output after.png
+```
+
+### Common moves
+
+| Task | Command |
+|---|---|
+| Scroll down | `sim-use gesture scroll-up --device <UDID>` (scroll-up = content moves up = page down) |
+| Type text | `sim-use type 'hello' --device <UDID>` |
+| Paste unicode | `sim-use paste 'こんにちは 🎉' --device <UDID>` (iOS: needs hardware keyboard) |
+| Hardware button | `sim-use button home --device <UDID>` |
+| Android back | `sim-use button back --device <UDID>` |
+| Wait for animation | `sleep 0.4` between commands, or `--pre-delay 0.5` |
+| Toggle/switch | `sim-use tap @N --duration 0.05 --device <UDID>` (UISwitch needs a brief hold) |
+| Swipe | `sim-use swipe --from 50,500 --to 350,500 --device <UDID>` |
+| Pinch zoom in | `sim-use gesture pinch-out --device <UDID>` (two-finger spread) |
+| Rotate | `sim-use gesture rotate-cw --angle 90 --device <UDID>` |
+
+## 2. Pitfalls
+
+Quick symptom index — see `references/pitfalls.md` for detailed recipes.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `tap --label` hits wrong element | Label collision (e.g. header and tab bar share text) | Add `--frame minY=0.7r` or `--element-type` to narrow |
+| `tap @N` fails after navigation | Alias cache is stale | Re-run `ui` before tapping |
+| `App:` line shows wrong app | System layer (alert, share sheet) is on top | Dismiss it first, then re-run `ui` |
+| `multipleMatches` error | Several elements share the selector | Use `--frame`, `--element-type`, or a more specific selector |
+| Tap lands but nothing happens | Animation in progress, or element not yet interactive | Add `--pre-delay 0.3` or `--wait-timeout 3` |
+| iOS: `paste` drops text | Soft keyboard only; HID Cmd+V is ignored | Use `paste --via-menu --target-id <id>` |
+| Android: `paste` denied | Background clipboard access blocked | Use `type` instead |
+| Outline shows `U+FFFC` in label | iOS icon placeholder character | Match with `--label-regex` excluding the prefix |
+| `[i] … covers ~N% of the screen` warning (text output, or `--json` top-level `advisory` key) | The selector resolved to a near-full-screen wrapper (common on Flutter/canvas UIs) and the tap hit its center, likely missing the intended control | Re-run `ui` and target the control via `@N`/`#<id>`, or pass explicit `-x/-y`/`--point` |
+| `[i] Screen orientation could not be confirmed…` / `…coordinates may be stale…` advisory | Device/app is rotated (the `App:` header shows a tag like `(landscape-right)`) and orientation self-calibration couldn't verify the mapping, or the `@N` snapshot predates a rotation | Re-run `ui` and tap again; selectors handle rotation automatically once calibration succeeds. Explicit `-x/-y`/`--point` is always device-native portrait space |
+
+## 3. Crash awareness
+
+See `references/crash-awareness.md` for the full protocol. Summary:
+
+sim-use watches for the target process disappearing between commands. When it detects a crash:
+
+```
+================ PROCESS DISAPPEARED ================
+com.example.app (pid 12345) was alive at the previous command and is GONE now.
+```
+
+On Android, `ui` also detects the AOSP system crash dialog directly from the accessibility tree.
+
+**Mandatory response:**
+1. **STOP.** Do not silently relaunch or continue.
+2. Report the crash to the user with the banner text.
+3. Wait for instructions before proceeding.
+
+After an intentional relaunch, call `sim-use app-state --reset` to clear the signal.
+
+## 4. Escalation
+
+Stop and ask the user when:
+- A selector collision cannot be resolved with available disambiguators.
+- Preflight fails and autofix does not recover.
+- The task requires a destructive action (deleting data, uninstalling an app).
+- You've retried the same action 3 times without progress.
+
+## 5. Exit checklist
+
+Before reporting a task as complete:
+1. Run `sim-use ui` (or `screenshot`) to capture the final state.
+2. Confirm the screen matches the intended outcome.
+3. If the outcome is ambiguous, show the final `ui` output or screenshot to the user.

--- a/.claude/skills/sim-use/references/batch-reference.md
+++ b/.claude/skills/sim-use/references/batch-reference.md
@@ -1,0 +1,95 @@
+# sim-use Batch Reference
+
+Use this reference when generating or reviewing `sim-use ios batch` commands.
+
+## Supported step commands
+- `tap`
+- `swipe` (`--from x,y --to x,y`, positional `x,y x,y`, or legacy `--start-x/--start-y/--end-x/--end-y`)
+- `gesture`
+- `touch`
+- `type`
+- `button`
+- `key`
+- `key-sequence`
+- `key-combo`
+- `sleep <seconds>` (batch pseudo-step)
+
+## Batch flags
+- `--device <UDID>`: required simulator target.
+- `--step "..."`: repeatable inline step source.
+- `--file <path>`: read one step per line from file.
+- `--stdin`: read one step per line from stdin.
+- `--continue-on-error`: keep running after a failed step; report failures at end.
+- `--ax-cache perBatch|perStep|none`: selector tap AX snapshot reuse policy. `perBatch` (default) resolves every selector against one snapshot fetched at first use; `perStep` refetches at each step; `none` never caches. `--wait-timeout` polling always refetches (and updates the cache).
+- `--type-submission chunked|composite`: submission mode for `type` steps.
+- `--type-chunk-size <n>`: chunk size when using chunked submission.
+- `--wait-timeout <seconds>`: maximum seconds to poll for selector-based elements before failing (0 = no waiting, default).
+- `--poll-interval <seconds>`: seconds between accessibility tree polls when `--wait-timeout` is active (default 0.25).
+- `--verbose`: enable detailed stderr logs for troubleshooting (default quiet output).
+
+## Input rules
+- Use exactly one source: `--step` OR `--file` OR `--stdin`.
+- Empty lines are ignored.
+- `#` comment lines are ignored in file/stdin input.
+- Do not pass `--device` inside step lines; keep it at batch command level.
+
+## Example: inline steps
+```bash
+sim-use ios batch --device SIMULATOR_UDID \
+  --step "tap --id EmailField" \
+  --step "type 'cam@example.com'" \
+  --step "key 43" \
+  --step "type 'super-secret'" \
+  --step "key 40"
+```
+
+## Example: stdin steps
+```bash
+cat <<'EOF' | sim-use ios batch --device SIMULATOR_UDID --stdin
+tap --id EmailField
+type 'cam@example.com'
+key 43
+type 'super-secret'
+key 40
+EOF
+```
+
+## Example: file steps
+`login.steps`
+```text
+# login flow
+tap --id EmailField
+type 'cam@example.com'
+key 43
+type 'super-secret'
+key 40
+```
+
+Run:
+```bash
+sim-use ios batch --device SIMULATOR_UDID --file login.steps
+```
+
+## Example: explicit timing and policy
+```bash
+sim-use ios batch --device SIMULATOR_UDID \
+  --ax-cache perStep \
+  --type-submission chunked \
+  --type-chunk-size 150 \
+  --continue-on-error \
+  --step "tap --label Settings" \
+  --step "sleep 0.5" \
+  --step "tap --id SaveButton"
+```
+
+## Example: multi-screen flow with element waiting
+```bash
+sim-use ios batch --device SIMULATOR_UDID \
+  --wait-timeout 5 \
+  --step "tap --id LoginButton" \
+  --step "tap --id WelcomeMessage"
+```
+
+The second step polls for up to 5 seconds for `WelcomeMessage` to appear after the login tap triggers navigation.
+
+If label selectors are ambiguous and sim-use reports no `AXUniqueId` values for matches, switch that step to coordinates (`tap --point x,y` or `-x/-y`).

--- a/.claude/skills/sim-use/references/cheatsheet.md
+++ b/.claude/skills/sim-use/references/cheatsheet.md
@@ -1,0 +1,218 @@
+# sim-use Command Cheatsheet
+
+## Command namespaces
+
+| Namespace | Scope | Examples |
+|---|---|---|
+| `sim-use <verb>` | Cross-platform (iOS + Android) | `ui`, `tap`, `swipe`, `type`, `paste`, `button`, `gesture`, `screenshot`, `record-video`, `app-state` |
+| `sim-use ios <verb>` | iOS Simulator only | `key`, `key-combo`, `key-sequence`, `stream-video`, `batch` |
+| `sim-use android <verb>` | Android device only | `init`, `devices`, `ping` |
+
+## Device resolution
+
+`--device` is optional. Resolution order: `--device` flag → `$SIM_USE_DEVICE` env → only live daemon → only booted simulator.
+
+When multiple devices exist, pass `--device <UDID>` explicitly. Run `sim-use devices` to list all connected devices across platforms.
+
+## Selectors
+
+```bash
+sim-use tap @5                          # alias from last `ui` snapshot
+sim-use tap '#3'                        # 3rd cell of dominant list
+sim-use tap '#2@2'                      # 2nd cell of 2nd list (quote for shell)
+sim-use tap '#settingsButton'           # AXUniqueId (live AX lookup)
+sim-use tap --id Safari                 # by accessibility identifier
+sim-use tap --label "General"           # by exact label
+sim-use tap --label-contains "Order"    # substring match
+sim-use tap --label-regex '^Chat.*\d+$' # ICU regex
+sim-use tap -x 100 -y 200              # absolute coordinates (last resort)
+sim-use tap --point 100,200             # same, pair form
+```
+
+## Disambiguating with --frame
+
+Narrow matches by screen region when selectors collide:
+
+```bash
+sim-use tap --label 'Tab' --frame minY=0.7r    # bottom 30% of screen
+sim-use tap --label 'Tab' --frame maxY=0.2r    # top 20% of screen
+sim-use tap --label 'OK' --frame 'minX=200,maxX=400,minY=600,maxY=700'
+```
+
+- Values: absolute pixels (`700`) or fraction with `r` suffix (`0.7r`).
+- Keys: `minX`, `maxX`, `minY`, `maxY`. Each appears at most once.
+- Composes with all selectors and `--element-type`.
+
+## Text input
+
+```bash
+sim-use type 'Hello World!'                    # HID keyboard (ASCII)
+echo "complex text" | sim-use type --stdin     # stdin for special chars
+sim-use paste 'こんにちは 🎉'                    # pasteboard + Cmd+V (iOS)
+sim-use paste 'text' --replace                  # Cmd+A then paste
+sim-use paste 'text' --via-menu --target-id <id>  # iOS edit menu (soft keyboard)
+```
+
+- iOS: `paste` needs hardware keyboard connected; use `--via-menu` for soft-keyboard-only.
+- Android: `paste` uses native `ACTION_PASTE`; `type` works for all unicode.
+
+## Gestures and timing
+
+```bash
+sim-use gesture scroll-up           # scroll-up = content moves up = page down
+sim-use gesture scroll-down         # page up
+sim-use swipe --from 50,500 --to 350,500
+sim-use long-press @5               # default 0.8s hold
+sim-use long-press --label "Photos" # selector targeting
+sim-use long-press @5 --duration 1.2  # custom hold time
+sim-use tap @5 --duration 0.05      # brief hold for toggles/switches
+sim-use tap @5 --pre-delay 0.3      # wait before tapping
+```
+
+`long-press` is sugar over `tap --duration 0.8`. Same targeting surface as `tap`. Use for action menus, launcher popups, drag-handle activation.
+
+Note: some Android apps render long-press menus in a `PopupWindow` overlay that the bridge's `describe-ui` cannot walk — verify with a screenshot when this matters.
+
+**Naming gotcha:** `scroll-up` scrolls the *content* up (like swiping up), which shows content *below* — it's "page down" in reading order.
+
+## Pinch and rotate (two-finger gestures)
+
+```bash
+sim-use gesture pinch-out                             # zoom in (default scale 2.0)
+sim-use gesture pinch-in                              # zoom out (default scale 0.5)
+sim-use gesture pinch-out --scale 3.0 --radius 60     # wider zoom, smaller start circle
+sim-use gesture rotate-cw                             # clockwise 90° (default)
+sim-use gesture rotate-ccw --angle 45                 # counter-clockwise 45°
+sim-use gesture pinch-out --center-x 200 --center-y 400  # off-center pivot
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `--scale` | 2.0 (out) / 0.5 (in) | End radius / start radius ratio |
+| `--angle` | 90 | Rotation sweep in degrees |
+| `--center-x/y` | screen center | Pivot point (pixels) |
+| `--radius` | 80 | Start radius (pixels) |
+| `--steps` | 10 | Interpolated HID Move events (iOS only) |
+| `--step-ms` | derived from duration/steps | Sleep between Move events (iOS only) |
+
+## Multi-touch (low-level)
+
+For gestures the presets don't cover, use `multi-touch` directly with two contact points:
+
+```bash
+# Pinch-zoom in by moving two fingers apart vertically
+sim-use multi-touch \
+  --x1 195 --y1 472 --x1-end 195 --y1-end 322 \
+  --x2 195 --y2 472 --x2-end 195 --y2-end 622 \
+  --steps 10 --step-ms 30
+```
+
+Also available: `tap --fingers 2` and `long-press --fingers 2` for two-finger tap/hold.
+
+## Touch (low-level, single finger)
+
+```bash
+sim-use touch -x 150 -y 250 --down                # touch down only
+sim-use touch -x 150 -y 250 --up                  # touch up only
+sim-use touch -x 150 -y 250 --down --up            # tap
+sim-use touch -x 150 -y 250 --down --up --delay 1.0  # long press
+```
+
+## Screenshots and video
+
+```bash
+sim-use screenshot --output shot.png
+sim-use record-video --output recording.mp4 --fps 15   # Ctrl+C to stop
+sim-use ios stream-video --fps 10 --format mjpeg        # iOS only
+```
+
+### Stopping a backgrounded recording
+
+Send `SIGTERM` and `wait` — do **not** `SIGKILL`, which skips the MP4 trailer and produces an unplayable file.
+
+```bash
+sim-use record-video --output recording.mp4 &
+PID=$!
+# ... drive the simulator ...
+kill -TERM "$PID"
+wait "$PID"               # blocks ~50–150 ms while the trailer is written
+```
+
+## Batch (iOS only)
+
+```bash
+sim-use ios batch --device <UDID> \
+  --step "tap --id SearchField" \
+  --step "type 'query'" \
+  --step "key 40" \
+  --wait-timeout 5
+```
+
+- One step source per run: `--step`, `--file`, or `--stdin`.
+- `--wait-timeout` makes selector taps poll for the element.
+- `--ax-cache perStep` refreshes the AX snapshot between steps.
+- Do not put `--device` inside step lines.
+- See `references/batch-reference.md` for full semantics, flags, and examples.
+
+## Daemon
+
+```bash
+sim-use daemon status
+sim-use daemon stop --device <UDID>
+sim-use daemon stop --all
+SIM_USE_NO_DAEMON=1 sim-use ui     # bypass daemon for one call
+```
+
+Daemon is iOS-only (auto-spawned, 600s idle TTL). Android commands go through adb directly.
+
+## iOS keyboard (HID keycodes)
+
+```bash
+sim-use ios key 40                                    # Enter
+sim-use ios key 42 --duration 1.0                     # Hold Backspace
+sim-use ios key-sequence --keycodes 11,8,15,15,18     # "hello"
+sim-use ios key-combo --modifiers 227 --key 4         # Cmd+A
+sim-use ios key-combo --modifiers 227 --key 6         # Cmd+C
+sim-use ios key-combo --modifiers 227 --key 25        # Cmd+V
+sim-use ios key-combo --modifiers 227,225 --key 4     # Cmd+Shift+A
+```
+
+### Common keycodes
+
+| Key | Code | Key | Code | Key | Code |
+|---|---|---|---|---|---|
+| Enter | 40 | Escape | 41 | Backspace | 42 |
+| Tab | 43 | Space | 44 | a | 4 |
+| LeftGUI (Cmd) | 227 | LeftShift | 225 | LeftCtrl | 224 |
+| LeftAlt | 226 | F1 | 58 | F12 | 69 |
+
+## Timing parameters
+
+| Parameter | Range | Description | Available on |
+|---|---|---|---|
+| `--pre-delay` | 0–10s | Delay before action | tap, swipe, gesture |
+| `--post-delay` | 0–10s | Delay after action | tap, swipe, gesture |
+| `--duration` | 0–10s | Action duration | swipe, gesture, button, key, tap (opt-in for toggles) |
+| `--delay` | 0–5s | Between-item delay | key-sequence, touch |
+
+## UDID auto-resolution
+
+`--device` is optional. Resolution order:
+
+1. Explicit `--device <UDID>` flag
+2. `$SIM_USE_DEVICE` environment variable
+3. The only live sim-use daemon under `/tmp/sim-use-<uid>/` (<1 ms)
+4. The only simulator with `state == "Booted"` via `xcrun simctl list` (~150 ms)
+
+Edge cases:
+- **Stale daemon**: if you shut down a simulator outside sim-use but its daemon is still alive, the next command fails loudly — run `sim-use daemon stop --all` then retry.
+- **Multiple daemons + multiple booted**: falls through to step 4 and errors with a disambiguation message listing all booted devices.
+- For CI fan-out (many simulators in parallel), keep `--device` explicit.
+
+## --json envelope
+
+Every command supports `--json`. Shape: `{ "ok": true/false, "data": {...}, "error": "...", "hint": "..." }`.
+
+The `hint` field on errors contains actionable guidance (e.g. candidate labels on `multipleMatches`). Use it for self-correcting retries.
+
+For `ui --json`, prefer `data.outline` / `data.entries` / `data.lists`. The `data.raw` field is the full AX tree (~3x larger); omit with `jq 'del(.data.raw)'` in agent loops.

--- a/.claude/skills/sim-use/references/crash-awareness.md
+++ b/.claude/skills/sim-use/references/crash-awareness.md
@@ -1,0 +1,59 @@
+# Crash Awareness Protocol
+
+sim-use automatically tracks the target app's process liveness while the daemon is running. When the tracked process disappears between commands, sim-use surfaces a banner on the next `ui` call.
+
+## Signals
+
+### Process liveness (iOS + Android)
+
+```
+================ PROCESS DISAPPEARED ================
+com.example.app (pid 12345) was alive at the previous command and is GONE now.
+Likely crash or termination, not a backgrounding. Verify before trusting subsequent actions.
+=====================================================
+App: SpringBoard  402x874
+```
+
+The signal is process liveness — a PID that was alive and is now gone. Backgrounding (permission dialogs, share sheets, app switcher) does **not** trip it.
+
+### Crash dialog (Android only)
+
+```
+=============== CRASH DIALOG DETECTED ===============
+An Android system app-crash dialog is on screen ("MyApp keeps stopping").
+=====================================================
+```
+
+Detected directly from the accessibility tree via the AOSP framework resource IDs (`android:id/aerr_close` / `aerr_app_info`). Works without the daemon, locale-independent, and fires while the dialog is visible — even before the process fully exits.
+
+Either signal alone is a sufficient crash hint.
+
+## Mandatory response
+
+1. **STOP** all automation. Do not silently relaunch or continue tapping.
+2. **Report** the crash to the user, including the banner text and context (what action preceded the crash).
+3. **Wait** for user instructions before proceeding.
+
+Never assume you can recover from a crash by relaunching the app — the user may need to inspect crash logs, capture state, or change strategy.
+
+## Confidence and idle gaps
+
+Deaths observed after a long idle gap (default 120s, tunable with `SIM_USE_CRASH_WINDOW`) are downgraded to a quiet `[i]` line and the baseline is reset. This prevents false alarms from out-of-band kills while the agent was idle.
+
+## Resetting the baseline
+
+After intentionally relaunching the app or accepting a known crash:
+
+```bash
+sim-use app-state --reset --device <UDID>
+```
+
+This clears pending signals so subsequent commands don't re-surface a stale death.
+
+## Disabling detection
+
+```bash
+SIM_USE_NO_CRASH_DETECT=1 sim-use ui --device <UDID>
+```
+
+Detection is on by default in daemon mode.

--- a/.claude/skills/sim-use/references/pitfalls.md
+++ b/.claude/skills/sim-use/references/pitfalls.md
@@ -1,0 +1,93 @@
+# Pitfalls and Recipes
+
+Detailed solutions for common sim-use issues. The symptom index in SKILL.md points here.
+
+## Label collision
+
+**Symptom:** `tap --label 'X'` hits the wrong element, or returns `multipleMatches`.
+
+**Why:** Multiple elements share the same accessibility label (e.g. a segmented control at the top and a tab bar at the bottom both say "Chat").
+
+**Recipes:**
+1. Add `--element-type RadioButton` (or whatever the outline shows) to narrow by type.
+2. Add `--frame minY=0.7r` to restrict to a screen region. Use `r`-suffixed fractions for device-independent targeting.
+3. Combine both: `--label 'Chat' --element-type RadioButton --frame minY=0.7r`.
+4. If the element has a `#<id>` in the outline, use `tap '#<id>'` instead — it bypasses label matching entirely.
+
+## Alias staleness
+
+**Symptom:** `tap @N` fails or taps the wrong element after navigating to a new screen.
+
+**Why:** `@N` aliases are cached from the last `ui` snapshot. Any screen change invalidates them.
+
+**Rule:** Always re-run `sim-use ui` after any action that changes the screen (navigation, dismissing a dialog, scrolling). Then use the fresh `@N` values.
+
+## iOS: rotated simulator
+
+**Symptom:** The `App:` header shows an orientation tag like `(landscape-right)` or `(portrait-upside-down)`, or a tap emits an `[i] Screen orientation could not be confirmed…` advisory.
+
+**Why:** iOS accessibility frames rotate with the app while HID taps target the fixed portrait framebuffer. sim-use bridges the two automatically: every AX-derived tap (`@N`, `#<id>`, `--label` family, batch steps) self-calibrates the current orientation with 1–3 hit-test probes and transforms coordinates before dispatch.
+
+**Recipes:**
+1. Normally nothing to do — selectors work in any orientation, and outline/tap coordinates always read in UI space (what you see).
+2. The calibration-fallback advisory means the mapping could not be verified (empty or symmetric screen) and portrait was assumed; re-run `ui` and retry, or use explicit `-x/-y`/`--point`.
+3. A "snapshot was captured at WxH…" advisory means the device rotated after the last `ui`; re-run `ui` to refresh the `@N` table.
+4. Explicit `-x/-y`/`--point` (and `--target-x/y`) are never transformed — they are device-native portrait coordinates by contract.
+5. `batch` calibrates once per run. If a step rotates the device (or navigates to a screen that forces a different orientation), later selector steps may mis-target — split the flow into separate batches around the rotation.
+
+## System layer detection
+
+**Symptom:** `ui` output shows unexpected content — the `App:` header names a system process like `SpringBoard` (iOS) or `com.android.systemui` (Android).
+
+**Why:** A system alert, permission dialog, or share sheet is covering the app. The accessibility tree reflects whatever is on top.
+
+**Recipe:**
+1. Read the outline to identify the overlay (e.g. "Allow Paste", location permission, share sheet).
+2. Dismiss it: tap the appropriate button (`Allow`, `Don't Allow`, `Cancel`), or `sim-use button home` to go home.
+3. Re-run `ui` to confirm you're back in the app.
+
+## iOS: paste drops text
+
+**Symptom:** `sim-use paste 'text'` succeeds but the text field stays empty.
+
+**Why:** The default path sends HID Cmd+V, which requires Simulator's hardware keyboard to be connected (Simulator > I/O > Keyboard > Connect Hardware Keyboard). In soft-keyboard-only mode, HID Cmd+V is silently dropped.
+
+**Recipes:**
+1. Check keyboard state: `sim-use keyboard-state`. If `soft`, use the menu path.
+2. Menu path: `sim-use paste 'text' --via-menu --target-id <field-id>` — long-presses the field and taps the iOS edit menu "Paste" button.
+3. If you control the simulator setup, enable hardware keyboard for all subsequent paste calls.
+
+## iOS: U+FFFC icon placeholder
+
+**Symptom:** An element's label in the outline contains a replacement character (often invisible or rendered as `￼`) before the actual text.
+
+**Why:** iOS uses U+FFFC as an object-replacement character for inline icons. The accessibility label includes it.
+
+**Recipe:** Use `--label-regex` with a pattern that skips the prefix: `--label-regex '.*Settings$'` or `--label-contains 'Settings'`.
+
+## Android: paste denied
+
+**Symptom:** `sim-use paste` succeeds but the field is empty, or the command errors.
+
+**Why:** Android 10+ blocks background processes from setting the clipboard on some devices/configurations.
+
+**Recipe:** Use `sim-use type 'text'` instead. On Android, `type` handles full unicode including CJK and emoji.
+
+## Android: button back unpredictability
+
+**Symptom:** `sim-use button back` navigates somewhere unexpected.
+
+**Why:** Android's back behavior is app-defined. It might close a dialog, pop a nav stack, minimize the app, or do nothing.
+
+**Recipe:** Always `ui` after `button back` to confirm where you ended up. If the result is wrong, use `tap` on a visible "Close" or "Cancel" button instead.
+
+## Tap lands but nothing happens
+
+**Symptom:** `tap` reports success but the UI doesn't change.
+
+**Why:** The element wasn't interactive yet (animation in progress, view still loading), or it's a toggle that needs a brief hold.
+
+**Recipes:**
+1. For animation: add `--pre-delay 0.3` to wait before tapping, or `sleep 0.4` between commands.
+2. For toggles/switches (shown as `CheckBox` in the outline): add `--duration 0.05`.
+3. For elements that appear after navigation: use `--wait-timeout 3` to poll until the element exists.

--- a/.claude/skills/sim-use/scripts/preflight.py
+++ b/.claude/skills/sim-use/scripts/preflight.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+sim-use preflight check.
+
+Verifies that sim-use is installed, the target device is reachable,
+and the daemon is healthy. Run before first interaction with a device.
+
+Usage:
+    python3 preflight.py --device <UDID>
+    python3 preflight.py                    # auto-resolve single device
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+
+# ---------------------------------------------------------------------------
+# Check framework
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Check:
+    id: str
+    description: str
+    run: Callable[["Ctx"], bool]
+    on_fail: str = "abort"  # abort | auto | prompt
+    autofix: Optional[Callable[["Ctx"], bool]] = None
+    fix_hint: str = ""
+
+
+@dataclass
+class Ctx:
+    device: Optional[str] = None
+    sim_use_bin: str = "sim-use"
+    platform: Optional[str] = None  # "ios" or "android", detected
+    errors: list = field(default_factory=list)
+
+    def run_sim_use(self, *args: str, check: bool = False) -> subprocess.CompletedProcess:
+        cmd = [self.sim_use_bin] + list(args)
+        if self.device:
+            cmd.extend(["--device", self.device])
+        return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+    def run_sim_use_json(self, *args: str) -> Optional[dict]:
+        result = self.run_sim_use(*args, "--json")
+        if result.returncode != 0:
+            return None
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return None
+
+
+def run_checks(checks: list[Check], ctx: Ctx) -> bool:
+    all_passed = True
+    for c in checks:
+        passed = c.run(ctx)
+        if passed:
+            print(f"  PASS  {c.description}")
+            continue
+
+        if c.on_fail == "auto" and c.autofix:
+            print(f"  FIX   {c.description} -- attempting autofix...")
+            if c.autofix(ctx) and c.run(ctx):
+                print(f"  PASS  {c.description} (after autofix)")
+                continue
+
+        print(f"  FAIL  {c.description}")
+        if c.fix_hint:
+            print(f"        hint: {c.fix_hint}")
+        ctx.errors.append(c.id)
+        all_passed = False
+
+        if c.on_fail == "abort":
+            print("\n  Aborting -- later checks depend on this one.")
+            break
+
+    return all_passed
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+def check_sim_use_installed(ctx: Ctx) -> bool:
+    return shutil.which(ctx.sim_use_bin) is not None
+
+
+def check_device_listed(ctx: Ctx) -> bool:
+    result = subprocess.run(
+        [ctx.sim_use_bin, "devices", "--json"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        data = json.loads(result.stdout)
+        devices = data.get("data", {}).get("devices", [])
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+    if not ctx.device:
+        booted = [d for d in devices if d.get("state", "").lower() in ("booted", "device")]
+        if len(booted) == 1:
+            ctx.device = booted[0].get("deviceId") or booted[0].get("udid")
+            ctx.platform = booted[0].get("platform")
+            return True
+        if len(booted) > 1:
+            names = [f"{d.get('name')} ({d.get('deviceId') or d.get('udid')})" for d in booted]
+            print(f"        Multiple devices found: {', '.join(names)}")
+            print("        Re-run with --device <UDID> to pick one.")
+        return False
+
+    for d in devices:
+        # `deviceId` is the canonical key; `udid` covers older sim-use
+        # binaries that predate the rename.
+        did = d.get("deviceId") or d.get("udid", "")
+        if did == ctx.device:
+            ctx.platform = d.get("platform")
+            return True
+    return False
+
+
+def autofix_boot_simulator(ctx: Ctx) -> bool:
+    if not ctx.device:
+        return False
+    result = subprocess.run(
+        ["xcrun", "simctl", "boot", ctx.device],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        import time
+        time.sleep(2)
+    return result.returncode == 0
+
+
+def check_ui_responds(ctx: Ctx) -> bool:
+    envelope = ctx.run_sim_use_json("ui")
+    return envelope is not None and envelope.get("ok") is True
+
+
+def autofix_daemon_restart(ctx: Ctx) -> bool:
+    # `daemon stop --all` is mutually exclusive with `--device`, so bypass
+    # run_sim_use (which appends --device when a device is set and would make
+    # the command fail with "Specify either --device <id> or --all").
+    subprocess.run(
+        [ctx.sim_use_bin, "daemon", "stop", "--all"],
+        capture_output=True, text=True,
+    )
+    return True
+
+
+def shared_checks() -> list[Check]:
+    return [
+        Check(
+            id="sim_use_installed",
+            description="sim-use is on PATH",
+            run=check_sim_use_installed,
+            on_fail="abort",
+            fix_hint="Install sim-use: brew tap lycorp-jp/tap && brew install lycorp-jp/tap/sim-use (run 'brew trust lycorp-jp/tap' first if you see an untrusted-tap error)",
+        ),
+        Check(
+            id="device_listed",
+            description="target device is listed and reachable",
+            run=check_device_listed,
+            on_fail="abort",
+            fix_hint="Boot a simulator or connect an Android device, then retry.",
+        ),
+        Check(
+            id="ui_responds",
+            description="sim-use ui returns a valid response",
+            run=check_ui_responds,
+            on_fail="auto",
+            autofix=autofix_daemon_restart,
+            fix_hint="Try: sim-use daemon stop --all, then retry.",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="sim-use preflight check")
+    parser.add_argument("--device", help="Device UDID or serial (auto-detected if omitted)")
+    parser.add_argument("--sim-use-bin", default="sim-use", help="Path to sim-use binary")
+    args = parser.parse_args()
+
+    ctx = Ctx(device=args.device, sim_use_bin=args.sim_use_bin)
+
+    print("sim-use preflight\n")
+    passed = run_checks(shared_checks(), ctx)
+    print()
+
+    if passed:
+        device_label = ctx.device or "(auto-resolved)"
+        platform_label = ctx.platform or "unknown"
+        print(f"All checks passed. Device: {device_label} ({platform_label})")
+        sys.exit(0)
+    else:
+        print(f"Preflight failed: {', '.join(ctx.errors)}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/vitana-mobile-testing/SKILL.md
+++ b/.claude/skills/vitana-mobile-testing/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: vitana-mobile-testing
+description: Test the Vitana frontend on a real iOS Simulator or Android device using sim-use — eyes (accessibility outline, screenshots) and hands (tap, swipe, type) on the actual rendered app. Use when asked to test buttons/features on a device, verify mobile UX beyond viewport emulation, or run the device-level smoke suite.
+---
+
+# Vitana mobile device testing (sim-use)
+
+Vitana's frontend (`vitana-v1`, deployed as `community-app`) is a React SPA.
+The device layer runs it in a real device browser and drives it through the
+platform accessibility tree using the `sim-use` CLI. This tests what viewport
+emulation cannot: real rendering, real touch pipeline, real keyboard, real
+Safari/Chrome behavior.
+
+**Companion skill:** `.claude/skills/sim-use/SKILL.md` (vendored upstream)
+covers the full sim-use command surface, selector styles, pitfalls, and crash
+protocol. Read it before driving a device manually.
+
+## 0. Which layer am I on?
+
+| Host | Capability | Use |
+|---|---|---|
+| macOS 14+ (local Mac, macOS CI runner) | Full device layer | This skill |
+| Linux (cloud container, WSL) | No simulators possible | Playwright emulation: `cd e2e && npm run test:mobile` |
+
+Check first: `cd e2e && npm run sim:doctor` — it verifies host, sim-use
+install, simulators, and Android toolchain, and prints fixes.
+
+## 1. Scripted flows (preferred starting point)
+
+```bash
+cd e2e
+npm run sim:doctor                                     # preflight
+npm run test:device                                    # iOS, staging, smoke flow
+npm run test:device -- --url https://vitanaland.com    # against prod
+npm run test:device -- --flow observe                  # eyes only, no taps
+npm run test:device:android -- --device emulator-5554  # Android
+```
+
+The **smoke flow** opens the app in the device browser, logs in through the
+real form (env `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`; defaults to the
+shared e2e user `e2e-test@vitana.dev`), discovers the bottom navigation from
+the live accessibility tree, taps every tab, verifies each screen changes,
+and saves a screenshot + outline per step to `e2e/mobile-sim/artifacts/`.
+
+In CI: dispatch `.github/workflows/MOBILE-DEVICE-E2E.yml` (macOS runner,
+iOS Simulator; artifacts uploaded).
+
+## 2. Interactive testing (agent loop)
+
+For exploratory "test this button/feature" work, drive sim-use directly with
+the observe → act → verify loop:
+
+```bash
+UDID=$(xcrun simctl list devices booted -j | python3 -c "import json,sys; print(json.load(sys.stdin)['devices'].__iter__().__next__() if False else [d['udid'] for l in json.load(sys.stdin)['devices'].values() for d in l][0])" 2>/dev/null || sim-use devices)
+xcrun simctl openurl "$UDID" "https://preview.vitanaland.com"   # open the app
+sim-use ui --device "$UDID"                                     # observe
+sim-use tap --label "Anmelden" --device "$UDID"                 # act
+sim-use ui --device "$UDID"                                     # verify
+sim-use screenshot --output /tmp/state.png --device "$UDID"     # evidence
+```
+
+Vitana specifics to keep in mind:
+
+- **German-default UI (du-form).** Labels are DE first: "Anmelden" not
+  "Sign in", "Startseite" not "Home". Match with
+  `--label-regex '(Anmelden|Sign in)'` when unsure.
+- **It's a WebView tree.** sim-use walks web content fully, but ids are
+  sparser than native apps — prefer `--label` / `--label-contains` selectors
+  and re-run `ui` after every navigation (SPA route changes invalidate `@N`
+  aliases).
+- **Umlauts/emoji input:** use `sim-use paste 'Müller 🎉'`, not `type`
+  (needs hardware keyboard connected; fall back to `paste --via-menu`).
+- **Login:** the scripted flow (`flows/login.mjs`) drives the real form. For
+  quick manual sessions the browser may still hold a previous session —
+  navigate to `/logout` to reset.
+- **Environments:** staging `https://preview.vitanaland.com` (default),
+  prod `https://vitanaland.com`, per-PR previews
+  `https://community-app-pr-<n>-*.run.app`. Test staging/PR previews unless
+  explicitly asked to check prod.
+
+## 3. Android
+
+One-time per device: `sim-use android init --device <serial>` (installs the
+accessibility bridge APK). Then all the same top-level verbs work; open the
+app with `adb -s <serial> shell am start -a android.intent.action.VIEW -d <url>`.
+Use `sim-use button back` for Android back. No GitHub-hosted CI path yet —
+Android runs are local (Mac with emulator or USB device).
+
+## 4. Reporting results
+
+Follow the repo verification protocol (CLAUDE.md §Targeted Visual
+Verification): report completion WITH the screenshots you inspected — read
+each screenshot file, check layout/clipping/tap targets, and attach the
+outline of the final state. A run that ends without looking at its own
+screenshots is not a verification.

--- a/.github/workflows/MOBILE-DEVICE-E2E.yml
+++ b/.github/workflows/MOBILE-DEVICE-E2E.yml
@@ -1,0 +1,93 @@
+# MOBILE-DEVICE-E2E — real-device-layer frontend testing via sim-use
+# (https://github.com/lycorp-jp/sim-use)
+#
+# Runs the Vitana web frontend on a REAL iOS Simulator (macOS runner) and
+# drives it through the platform accessibility tree: opens the app in Safari,
+# logs in through the actual form, taps every bottom-nav tab, and captures a
+# screenshot + accessibility outline of every screen state.
+#
+# This complements (does not replace) the Playwright suites in e2e/ — those
+# run viewport *emulation* on Linux; this workflow exercises the real device
+# rendering + touch pipeline.
+#
+# Dispatch-only by design: macOS runners are expensive and the run hits a
+# deployed environment. No push/schedule trigger.
+#
+# Android note: sim-use also drives Android emulators/devices, but the CLI
+# itself needs a macOS host and GitHub-hosted macOS runners cannot reliably
+# host an Android emulator. Run Android locally on a Mac:
+#   sim-use android init --device <serial>
+#   cd e2e && npm run test:device:android
+name: MOBILE-DEVICE-E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: 'Frontend URL to test'
+        required: false
+        default: 'https://preview.vitanaland.com'
+      flow:
+        description: 'Flow to run'
+        type: choice
+        options: [smoke, observe]
+        default: smoke
+      device_name:
+        description: 'Simulator device name (substring match)'
+        required: false
+        default: 'iPhone 16'
+
+jobs:
+  ios-simulator:
+    name: iOS Simulator (${{ inputs.device_name }})
+    runs-on: macos-15
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install sim-use
+        run: |
+          brew tap lycorp-jp/tap || { brew trust lycorp-jp/tap && brew tap lycorp-jp/tap; }
+          brew install lycorp-jp/tap/sim-use
+          sim-use --version
+
+      - name: Boot iOS Simulator
+        id: sim
+        run: |
+          UDID=$(xcrun simctl list devices available -j | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          sims = [d for l in data['devices'].values() for d in l if 'iPhone' in d['name']]
+          prefer = [d for d in sims if '${{ inputs.device_name }}' in d['name']]
+          pick = (prefer or sims)[-1]
+          print(pick['udid'])
+          ")
+          echo "Booting $UDID"
+          xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
+      - name: Preflight (sim-use doctor)
+        run: cd e2e && npm run sim:doctor
+
+      - name: Run device flow
+        env:
+          TEST_USER_EMAIL: e2e-test@vitana.dev
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+        run: |
+          cd e2e
+          node mobile-sim/run.mjs \
+            --platform ios \
+            --device "${{ steps.sim.outputs.udid }}" \
+            --url "${{ inputs.url }}" \
+            --flow "${{ inputs.flow }}" \
+            --out mobile-sim/artifacts/run
+
+      - name: Upload artifacts (screenshots + outlines + summary)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-device-e2e-ios
+          path: e2e/mobile-sim/artifacts/
+          if-no-files-found: warn
+          retention-days: 14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -578,6 +578,7 @@ gcloud logging read "resource.type=cloud_run_revision AND resource.labels.servic
 | `DATABASE_SCHEMA.md` | Canonical database schema reference |
 | `config/service-path-map.json` | Service to path mapping |
 | `.github/workflows/EXEC-DEPLOY.yml` | Deployment workflow |
+| `docs/MOBILE_DEVICE_TESTING.md` | Device-level frontend testing (sim-use: iOS Simulator / Android) |
 
 ---
 
@@ -1024,6 +1025,7 @@ Use these PATs with the GitHub REST API (`api.github.com`) for all PR and deploy
 
 | Date | Change | VTID |
 |------|--------|------|
+| 2026-07-13 | Integrated lycorp-jp/sim-use device-testing layer: `e2e/mobile-sim/` driver + smoke flow (iOS Simulator / Android), `MOBILE-DEVICE-E2E.yml` macOS-runner workflow, vendored sim-use agent skill + `vitana-mobile-testing` glue skill, `docs/MOBILE_DEVICE_TESTING.md` | BOOTSTRAP-SIM-USE-DEVICE-TESTING |
 | 2026-06-04 | Staging-first cutover (time-gated, effective Mon 8 Jun 2026 10:00 Europe/Berlin): added a `cutover_gate` job to every auto-to-prod workflow (`AUTO-DEPLOY`, `DEPLOY-ORB-AGENT`, `DEPLOY-AUTOPILOT-JOB`, `VTID-02409-BOOTSTRAP`) that freezes the push path post-cutover while leaving manual dispatch open; added manual escape hatch `scripts/deploy/publish-to-prod.sh`; rewrote §15/§16 + IF-THEN CI/CD rules. Before cutover all paths still reach prod; after, auto = staging, prod = PUBLISH button / manual exception. Frontend (`vitana-v1`) gated in parallel. | BOOTSTRAP-STAGING-FIRST-CUTOVER |
 | 2026-04-14 | Replaced broad visual verification with targeted protocol: screenshot what you changed, interact with it, verify it works | VTID-01917 |
 | 2026-03-19 | Added CI/CD deployment pipeline critical lessons (Auto Deploy ≠ actual deploy) | BOOTSTRAP-OPERATOR-NAV-FIX |

--- a/docs/MOBILE_DEVICE_TESTING.md
+++ b/docs/MOBILE_DEVICE_TESTING.md
@@ -1,0 +1,91 @@
+# Mobile Device Testing — sim-use integration
+
+**Added: 2026-07-13 · Upstream: [lycorp-jp/sim-use](https://github.com/lycorp-jp/sim-use) (Apache-2.0)**
+
+This document describes the device-level testing layer that gives agents and
+engineers *eyes and hands* on the Vitana frontend running in a real iOS
+Simulator or Android emulator/device — beyond the viewport emulation the
+Playwright suites provide.
+
+## The two testing layers
+
+| | Layer 1 — Playwright emulation | Layer 2 — sim-use device layer |
+|---|---|---|
+| What it is | Chromium with iPhone-14 viewport/touch flags | Real Simulator/emulator browser, driven via platform accessibility APIs |
+| Lives in | `e2e/` (projects `mobile-*`) | `e2e/mobile-sim/` |
+| Runs on | Anywhere (Linux CI, cloud containers, Mac) | **macOS 14+ only** (sim-use is a Swift CLI; iOS Simulator needs Xcode) |
+| Auth | Injected Supabase session (localStorage) | Real login form, real taps and keystrokes |
+| Catches | Route errors, console errors, layout at mobile width | Real rendering, touch pipeline, soft keyboard, Safari quirks, tap-target reachability |
+| Command | `cd e2e && npm run test:mobile` | `cd e2e && npm run test:device` |
+
+Both layers test the same deployed URLs (staging
+`preview.vitanaland.com` by default; prod `vitanaland.com`; per-PR
+previews `community-app-pr-<n>`).
+
+## What sim-use is
+
+A cross-platform CLI (LY Corporation) built for AI-agent loops:
+
+- `sim-use ui` — renders the current screen as a token-efficient
+  accessibility outline (`@N` aliases per element), including WebView content
+  — which is what makes it work for our SPA.
+- `sim-use tap @9` / `--label 'Anmelden'` / `#id` — taps by alias, label, or
+  accessibility id; plus `swipe`, `type`, `paste` (IME-safe Unicode),
+  `gesture`, `button`, `screenshot`, `record-video`, `app-state` (crash
+  detection).
+- One command surface for **iOS Simulator** (via idb/HID) and **Android**
+  (via an on-device accessibility-bridge APK over `adb forward`).
+
+Install (macOS): `brew tap lycorp-jp/tap && brew install lycorp-jp/tap/sim-use`
+
+## What was integrated
+
+1. **`e2e/mobile-sim/`** — driver + flows (see its README):
+   - `doctor.mjs` preflight, `run.mjs` entry point;
+   - `flows/smoke.mjs` — open app in device browser → UI-driven login →
+     discover bottom nav from the live accessibility tree (label-agnostic,
+     i18n-safe) → tap every tab → verify each screen changes → screenshot +
+     outline per step → `summary.json`;
+   - npm scripts: `sim:doctor`, `test:device`, `test:device:ios`,
+     `test:device:android`.
+2. **`.github/workflows/MOBILE-DEVICE-E2E.yml`** — dispatch-only workflow on
+   a `macos-15` runner: installs sim-use, boots an iPhone simulator, runs the
+   smoke flow against a chosen URL, uploads screenshots/outlines. Needs the
+   existing `TEST_USER_PASSWORD` repo secret for the authenticated part.
+3. **Agent skills** (auto-loaded by Claude Code sessions in this repo):
+   - `.claude/skills/sim-use/` — vendored upstream skill (SKILL.md,
+     cheatsheet, pitfalls, crash protocol, preflight script) with its
+     Apache-2.0 LICENSE and NOTICE;
+   - `.claude/skills/vitana-mobile-testing/` — Vitana glue: layer selection
+     per host, DE-first labels, auth, environment URLs.
+
+## Host capability matrix
+
+| Host | iOS Simulator | Android | What to run |
+|---|---|---|---|
+| Mac (dev machine) | ✅ | ✅ (emulator or USB device) | `npm run test:device[:android]` |
+| GitHub `macos-15` runner | ✅ (MOBILE-DEVICE-E2E.yml) | ❌ (no reliable nested virt) | dispatch the workflow |
+| Linux CI / Claude cloud container | ❌ (no macOS, no KVM) | ❌ | `npm run test:mobile` (Layer 1) |
+
+`npm run sim:doctor` encodes this matrix — run it on any host and it tells
+you what that host can do and how to fix or where to fall back.
+
+## Android one-time setup
+
+```bash
+sim-use android init --device <serial>   # installs the bridge APK
+adb -s <serial> shell am start -a android.intent.action.VIEW -d https://preview.vitanaland.com
+sim-use ui --device <serial>
+```
+
+## Conventions
+
+- Test **staging or PR previews** by default; prod only when explicitly
+  asked (consistent with the staging-first cutover, CLAUDE.md §16).
+- The smoke flow discovers nav from the accessibility tree instead of
+  hardcoding labels — keep new flows label-agnostic or match both DE and EN
+  variants (`--label-regex '(Anmelden|Sign in)'`).
+- Artifacts are gitignored (`e2e/mobile-sim/artifacts/`); CI uploads them as
+  workflow artifacts instead.
+- Per the repo verification protocol: a device run isn't "done" until the
+  screenshots have actually been read and inspected.

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 playwright-report/
 test-results/
 results.json
+mobile-sim/artifacts/

--- a/e2e/mobile-sim/README.md
+++ b/e2e/mobile-sim/README.md
@@ -1,0 +1,82 @@
+# mobile-sim — device-level frontend testing via sim-use
+
+Real eyes and hands on the Vitana frontend: this layer runs the app in an
+**iOS Simulator or Android emulator/device browser** and drives it through
+the platform accessibility tree using
+[`sim-use`](https://github.com/lycorp-jp/sim-use) (LY Corporation,
+Apache-2.0) — a CLI built for AI-agent loops that reads any screen as a
+compact accessibility outline (`sim-use ui`) and acts on it
+(`sim-use tap/type/swipe`).
+
+It complements the Playwright projects in `e2e/` — those emulate an
+iPhone-14 *viewport* on Chromium and run anywhere (including the Linux CI
+and cloud containers); this layer exercises the **real** device rendering,
+touch pipeline, and keyboard, and only runs on a **macOS 14+ host**.
+
+```
+e2e/mobile-sim/
+├── run.mjs            # CLI entry — flows against a device
+├── doctor.mjs         # preflight: host / sim-use / simulators / adb
+├── lib/
+│   ├── simuse.mjs     # Node wrapper around the sim-use CLI (--json envelopes)
+│   ├── device.mjs     # simctl/adb: discovery, boot, open URL in device browser
+│   └── report.mjs     # artifacts: screenshots, outlines, summary.json
+└── flows/
+    ├── login.mjs      # UI-driven login through the REAL form (taps + keys)
+    └── smoke.mjs      # open app → login → walk bottom nav → verify + capture
+```
+
+## Quick start (on a Mac)
+
+```bash
+brew tap lycorp-jp/tap && brew install lycorp-jp/tap/sim-use
+
+cd e2e
+npm run sim:doctor        # verify the host is ready
+npm run test:device       # iOS Simulator, staging URL, smoke flow
+```
+
+Options (after `--`): `--url <url>` (default `$COMMUNITY_URL` or
+`https://preview.vitanaland.com`), `--flow smoke|observe`,
+`--platform ios|android`, `--device <UDID|serial>`, `--out <dir>`.
+
+Login credentials come from `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` (same
+envs as the Playwright fixtures). Without a password the smoke flow runs
+unauthenticated and covers public screens only.
+
+Artifacts land in `mobile-sim/artifacts/<platform>-<timestamp>/`:
+numbered screenshots, per-step accessibility outlines (`*.outline.txt`),
+and `summary.json`.
+
+## CI
+
+Dispatch `.github/workflows/MOBILE-DEVICE-E2E.yml` — boots an iOS Simulator
+on a `macos-15` runner, installs sim-use via Homebrew, runs the smoke flow,
+and uploads all artifacts. Dispatch-only (macOS minutes + hits a deployed
+environment).
+
+## Android
+
+```bash
+sim-use android init --device <serial>     # one-time: installs bridge APK
+cd e2e && npm run test:device:android
+```
+
+Runs locally against an emulator or USB device on a Mac. GitHub-hosted
+macOS runners can't reliably host an Android emulator, so there is no
+hosted CI path yet.
+
+## Agent usage
+
+Claude Code sessions get two skills from this integration:
+
+- `.claude/skills/sim-use/` — the vendored upstream skill: full command
+  surface, selector styles, pitfalls, crash protocol.
+- `.claude/skills/vitana-mobile-testing/` — Vitana glue: which layer to use
+  per host, DE-first labels, login/logout, environment URLs.
+
+On hosts that can't run the device layer (Linux containers), agents fall
+back to the Playwright mobile projects (`npm run test:mobile`) —
+`doctor.mjs` says exactly this when run on a non-mac host.
+
+See `docs/MOBILE_DEVICE_TESTING.md` for the full architecture writeup.

--- a/e2e/mobile-sim/README.md
+++ b/e2e/mobile-sim/README.md
@@ -44,6 +44,9 @@ Login credentials come from `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` (same
 envs as the Playwright fixtures). Without a password the smoke flow runs
 unauthenticated and covers public screens only.
 
+Optional: set `SIM_USE_VERBOSE=1` to echo every sim-use CLI invocation to
+stderr (off by default).
+
 Artifacts land in `mobile-sim/artifacts/<platform>-<timestamp>/`:
 numbered screenshots, per-step accessibility outlines (`*.outline.txt`),
 and `summary.json`.

--- a/e2e/mobile-sim/doctor.mjs
+++ b/e2e/mobile-sim/doctor.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Preflight for the sim-use device-testing layer. Run with:
+ *   npm run sim:doctor        (from e2e/)
+ *
+ * Checks, in order: host OS → sim-use binary → iOS toolchain → Android
+ * toolchain → reachable devices. Prints actionable fixes instead of stack
+ * traces, and exits 0 with guidance when the host simply can't run the
+ * device layer (e.g. the Linux cloud container — use the Playwright mobile
+ * projects there instead).
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import os from 'node:os';
+
+const execFileP = promisify(execFile);
+const ok = m => console.log(`  ✓ ${m}`);
+const warn = m => console.log(`  ! ${m}`);
+const fail = m => console.log(`  ✗ ${m}`);
+
+async function has(bin, args = ['--version']) {
+  try {
+    const { stdout } = await execFileP(bin, args, { timeout: 15_000 });
+    return stdout.trim().split('\n')[0];
+  } catch {
+    return null;
+  }
+}
+
+export async function doctor() {
+  console.log('sim-use device-testing preflight\n');
+  let usable = true;
+
+  // 1. Host OS
+  if (process.platform === 'darwin') {
+    ok(`macOS ${os.release()} — device layer supported`);
+  } else {
+    fail(`Host is ${process.platform} — sim-use requires a macOS 14+ host.`);
+    console.log(`
+  This host cannot run the iOS Simulator or the sim-use CLI.
+  Options:
+    • Run this suite on a Mac:            cd e2e && npm run test:device
+    • Run it in CI (macOS runner):        gh workflow run MOBILE-DEVICE-E2E.yml
+    • Viewport-emulation fallback here:   cd e2e && npm run test:mobile
+      (Playwright iPhone-14 emulation — same routes, no real device layer)
+`);
+    return false;
+  }
+
+  // 2. sim-use binary
+  const simUseVersion = await has('sim-use');
+  if (simUseVersion) {
+    ok(`sim-use ${simUseVersion}`);
+  } else {
+    fail('sim-use not found on PATH');
+    console.log('    Install: brew tap lycorp-jp/tap && brew install lycorp-jp/tap/sim-use');
+    console.log('    (Homebrew 6.0.5+: run `brew trust lycorp-jp/tap` first if the tap is untrusted)');
+    usable = false;
+  }
+
+  // 3. iOS toolchain
+  const xcrun = await has('xcrun', ['simctl', 'help']);
+  if (xcrun !== null) {
+    ok('xcrun simctl available');
+    try {
+      const { stdout } = await execFileP('xcrun', ['simctl', 'list', 'devices', 'available', '-j']);
+      const parsed = JSON.parse(stdout);
+      const sims = Object.values(parsed.devices || {}).flat();
+      const booted = sims.filter(d => d.state === 'Booted');
+      ok(`${sims.length} simulator(s) available, ${booted.length} booted`);
+      if (sims.length === 0) warn('Install an iOS runtime via Xcode > Settings > Platforms');
+    } catch (err) {
+      warn(`could not list simulators: ${err.message}`);
+    }
+  } else {
+    warn('xcrun not available — install Xcode for iOS Simulator support');
+  }
+
+  // 4. Android toolchain (optional)
+  const adb = await has('adb', ['version']);
+  if (adb) {
+    ok(adb);
+    try {
+      const { stdout } = await execFileP('adb', ['devices']);
+      const devices = stdout.split('\n').slice(1).filter(l => l.trim().endsWith('device'));
+      if (devices.length > 0) {
+        ok(`${devices.length} Android device(s) connected`);
+        console.log('    First-time setup per device: sim-use android init --device <serial>');
+      } else {
+        warn('no Android devices/emulators connected (iOS-only is fine)');
+      }
+    } catch { /* adb server issues — non-fatal */ }
+  } else {
+    warn('adb not found — Android testing unavailable (iOS-only is fine)');
+  }
+
+  // 5. sim-use device view
+  if (simUseVersion) {
+    try {
+      const { stdout } = await execFileP('sim-use', ['devices'], { timeout: 30_000 });
+      console.log('\nsim-use devices:');
+      console.log(stdout.trim().split('\n').map(l => `  ${l}`).join('\n'));
+    } catch (err) {
+      warn(`sim-use devices failed: ${err.message}`);
+    }
+  }
+
+  console.log(usable
+    ? '\nReady. Run: npm run test:device -- --url https://preview.vitanaland.com'
+    : '\nFix the ✗ items above, then re-run: npm run sim:doctor');
+  return usable;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  doctor().then(u => process.exit(u ? 0 : 1));
+}

--- a/e2e/mobile-sim/flows/login.mjs
+++ b/e2e/mobile-sim/flows/login.mjs
@@ -1,0 +1,94 @@
+/**
+ * UI-driven login flow — exercises the REAL login form with taps and
+ * keystrokes (unlike the Playwright suites, which inject a Supabase session
+ * into localStorage). This is deliberate: the point of the device layer is to
+ * test the actual buttons a user touches.
+ *
+ * Works on the German-default UI: selectors match DE and EN label variants.
+ * Credentials come from the same env vars as the Playwright fixtures
+ * (TEST_USER_EMAIL / TEST_USER_PASSWORD, default e2e-test@vitana.dev).
+ */
+import { outlineUtils } from '../lib/simuse.mjs';
+import { sleep } from '../lib/device.mjs';
+
+const LOGIN_BUTTON_RE = /^(anmelden|einloggen|sign\s?in|log\s?in|login)$/i;
+const TEXTFIELD_RE = /TextField|TextInput|EditText/i;
+const SECURE_RE = /Secure/i;
+
+export async function loginFlow({ sim, report, email, password }) {
+  if (!password) {
+    report.record({
+      label: 'login skipped',
+      ok: true,
+      detail: 'TEST_USER_PASSWORD not set — continuing unauthenticated',
+    });
+    return false;
+  }
+
+  const { outline, data } = await sim.ui();
+  report.record({ label: 'login screen observe', ok: true, outline });
+
+  const fields = outlineUtils.entriesByRole(data, TEXTFIELD_RE);
+  if (fields.length === 0) {
+    // Already authenticated (session persisted in the browser) or login is
+    // behind an entry button — try a visible login button first.
+    const entryBtn = outlineUtils.findByLabel(data, LOGIN_BUTTON_RE);
+    if (!entryBtn) {
+      report.record({
+        label: 'login form',
+        ok: true,
+        detail: 'no login form on screen — assuming already authenticated',
+      });
+      return true;
+    }
+    await sim.tap({ label: entryBtn.label }, { waitTimeout: 5 });
+    await sleep(1200);
+    return loginFlow({ sim, report, email, password });
+  }
+
+  const emailField = fields.find(f => !SECURE_RE.test(f.role || '')) || fields[0];
+  const passField = fields.find(f => SECURE_RE.test(f.role || '')) || fields[1];
+
+  // Email
+  await sim.tap(
+    emailField.aliases?.at ? { alias: emailField.aliases.at } : { point: center(emailField) },
+  );
+  await sleep(300);
+  await sim.type(email);
+  report.record({ label: 'typed email', ok: true, detail: email });
+
+  // Password
+  if (!passField) throw new Error('login: no password field found in outline');
+  await sim.tap(
+    passField.aliases?.at ? { alias: passField.aliases.at } : { point: center(passField) },
+  );
+  await sleep(300);
+  await sim.type(password);
+  report.record({ label: 'typed password', ok: true });
+
+  // Submit
+  await sim.tap({ labelRegex: LOGIN_BUTTON_RE.source }, { waitTimeout: 5 });
+  await sleep(3000); // auth round-trip + redirect
+
+  const after = await sim.ui();
+  const stillOnLogin = outlineUtils
+    .entriesByRole(after.data, TEXTFIELD_RE)
+    .some(f => SECURE_RE.test(f.role || ''));
+  const shot = report.screenshotPath('after login');
+  await sim.screenshot(shot);
+  report.record({
+    label: 'login submitted',
+    ok: !stillOnLogin,
+    outline: after.outline,
+    screenshot: shot,
+    detail: stillOnLogin ? 'password field still visible — login may have failed' : 'redirected',
+  });
+  return !stillOnLogin;
+}
+
+function center(entry) {
+  const f = entry.frame || {};
+  const x = (f.x ?? f.minX ?? 0) + (f.width ?? f.w ?? 0) / 2;
+  const y = (f.y ?? f.minY ?? 0) + (f.height ?? f.h ?? 0) / 2;
+  return [Math.round(x), Math.round(y)];
+}

--- a/e2e/mobile-sim/flows/smoke.mjs
+++ b/e2e/mobile-sim/flows/smoke.mjs
@@ -1,0 +1,94 @@
+/**
+ * Device-level smoke flow: open the Vitana web app in the device browser,
+ * optionally log in through the real form, then walk the bottom navigation —
+ * tapping every tab, verifying the screen actually changes, and capturing a
+ * screenshot + accessibility outline of each state.
+ *
+ * The tab walk is label-agnostic on purpose: it discovers tappable elements
+ * in the bottom band of the live accessibility tree instead of hardcoding
+ * nav labels, so it survives i18n (DE default) and nav reorganisation.
+ */
+import { outlineUtils } from '../lib/simuse.mjs';
+import { openUrl, sleep } from '../lib/device.mjs';
+import { loginFlow } from './login.mjs';
+
+const TAPPABLE_RE = /Button|Link|Tab|Cell/i;
+
+export async function smokeFlow({ sim, report, device, platform, url, email, password }) {
+  // 1. Open the app in the device browser
+  await openUrl({ device, platform, url });
+  await sleep(6000); // browser launch + SPA boot
+  const first = await sim.ui();
+  const firstShot = report.screenshotPath('app loaded');
+  await sim.screenshot(firstShot);
+  const blank = first.outline.split('\n').length < 4;
+  report.record({
+    label: 'app loaded',
+    ok: !blank,
+    outline: first.outline,
+    screenshot: firstShot,
+    detail: blank ? 'outline nearly empty — page may not have rendered' : url,
+  });
+
+  // 2. Login through the real form (skipped if no credentials)
+  await loginFlow({ sim, report, email, password });
+
+  // 3. Discover bottom navigation from the live accessibility tree
+  await sleep(1500);
+  const home = await sim.ui();
+  const bottom = outlineUtils
+    .bottomBandEntries(home.data)
+    .filter(e => TAPPABLE_RE.test(e.role || e.type || ''))
+    .filter(e => (e.label || '').trim().length > 0);
+  report.record({
+    label: 'bottom nav discovery',
+    ok: bottom.length > 0,
+    outline: home.outline,
+    detail: `${bottom.length} tappable bottom-band elements: ${bottom.map(e => e.label).join(', ')}`,
+  });
+
+  // 4. Walk each tab: tap → wait → verify the screen changed → screenshot
+  let prevOutline = home.outline;
+  for (const entry of bottom) {
+    const label = entry.label;
+    try {
+      await sim.tap({ label }, { waitTimeout: 5, preDelay: 0.2 });
+      await sleep(2500);
+      const { outline } = await sim.ui();
+      const shot = report.screenshotPath(`tab ${label}`);
+      await sim.screenshot(shot);
+      const changed = outline !== prevOutline;
+      report.record({
+        label: `tab: ${label}`,
+        ok: changed,
+        outline,
+        screenshot: shot,
+        detail: changed ? 'screen updated' : 'outline identical to previous screen',
+      });
+      prevOutline = outline;
+    } catch (err) {
+      report.record({ label: `tab: ${label}`, ok: false, detail: err.message });
+    }
+  }
+
+  // 5. Crash check — sim-use flags the browser process disappearing
+  try {
+    const state = await sim.appState();
+    report.record({ label: 'app-state check', ok: true, detail: state.split('\n')[0] });
+  } catch (err) {
+    report.record({ label: 'app-state check', ok: false, detail: err.message });
+  }
+}
+
+/**
+ * Observe-only flow: open the URL and dump outline + screenshot. Useful as a
+ * quick "eyes on the app" check without any interaction.
+ */
+export async function observeFlow({ sim, report, device, platform, url }) {
+  await openUrl({ device, platform, url });
+  await sleep(6000);
+  const { outline } = await sim.ui();
+  const shot = report.screenshotPath('observe');
+  await sim.screenshot(shot);
+  report.record({ label: 'observe', ok: outline.length > 0, outline, screenshot: shot, detail: url });
+}

--- a/e2e/mobile-sim/lib/device.mjs
+++ b/e2e/mobile-sim/lib/device.mjs
@@ -1,0 +1,117 @@
+/**
+ * Device discovery, boot, and URL-opening for the two backends sim-use drives:
+ *  - iOS Simulator  → `xcrun simctl` (UDID-shaped device IDs)
+ *  - Android        → `adb` (serial-shaped device IDs, e.g. emulator-5554)
+ *
+ * The Vitana frontend is a web app, so "opening the app" means opening
+ * COMMUNITY_URL in the device browser (Safari / Chrome). From there sim-use
+ * drives the real rendered UI through the platform accessibility tree —
+ * including the WebView content, which sim-use walks without skipping.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+const IOS_UDID_RE = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+
+export function platformForDevice(deviceId) {
+  return IOS_UDID_RE.test(deviceId) ? 'ios' : 'android';
+}
+
+// ── iOS Simulator ────────────────────────────────────────────────────────────
+
+export async function listIosSimulators() {
+  const { stdout } = await execFileP('xcrun', ['simctl', 'list', 'devices', 'available', '-j']);
+  const parsed = JSON.parse(stdout);
+  const devices = [];
+  for (const [runtime, list] of Object.entries(parsed.devices || {})) {
+    for (const d of list) {
+      devices.push({ udid: d.udid, name: d.name, state: d.state, runtime });
+    }
+  }
+  return devices;
+}
+
+/** Find a booted iPhone, or boot one (preferring `preferName`). Returns UDID. */
+export async function ensureIosSimulator({ preferName = 'iPhone', log = console.error } = {}) {
+  const devices = await listIosSimulators();
+  const iphones = devices.filter(d => d.name.includes('iPhone'));
+  if (iphones.length === 0) {
+    throw new Error('No available iPhone simulators. Install an iOS runtime via Xcode.');
+  }
+  const booted = iphones.find(d => d.state === 'Booted');
+  if (booted) {
+    log(`Using booted simulator: ${booted.name} (${booted.udid})`);
+    return booted.udid;
+  }
+  const pick =
+    iphones.find(d => d.name === preferName) ||
+    iphones.find(d => d.name.includes(preferName)) ||
+    iphones[iphones.length - 1]; // newest runtime tends to sort last
+  log(`Booting simulator: ${pick.name} (${pick.udid})`);
+  await execFileP('xcrun', ['simctl', 'boot', pick.udid]).catch(err => {
+    if (!/current state: Booted/.test(String(err.stderr))) throw err;
+  });
+  await execFileP('xcrun', ['simctl', 'bootstatus', pick.udid, '-b'], { timeout: 180_000 });
+  return pick.udid;
+}
+
+export async function openUrlIos(udid, url) {
+  await execFileP('xcrun', ['simctl', 'openurl', udid, url]);
+}
+
+// ── Android emulator / device ────────────────────────────────────────────────
+
+export async function listAndroidDevices() {
+  const { stdout } = await execFileP('adb', ['devices']);
+  return stdout
+    .split('\n')
+    .slice(1)
+    .map(l => l.trim())
+    .filter(l => l.endsWith('device'))
+    .map(l => l.split(/\s+/)[0]);
+}
+
+export async function openUrlAndroid(serial, url) {
+  await execFileP('adb', [
+    '-s', serial,
+    'shell', 'am', 'start',
+    '-a', 'android.intent.action.VIEW',
+    '-d', url,
+  ]);
+}
+
+// ── Unified ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a target device for the requested platform.
+ * Returns { device, platform }.
+ */
+export async function resolveDevice({ platform, device, log = console.error }) {
+  if (device) return { device, platform: platform || platformForDevice(device) };
+
+  if (platform === 'android') {
+    const serials = await listAndroidDevices();
+    if (serials.length === 0) {
+      throw new Error(
+        'No Android devices/emulators connected (adb devices is empty). ' +
+        'Start an emulator or plug in a device with USB debugging, then run ' +
+        '`sim-use android init --device <serial>` once to install the bridge APK.',
+      );
+    }
+    log(`Using Android device: ${serials[0]}`);
+    return { device: serials[0], platform: 'android' };
+  }
+
+  // default: iOS Simulator
+  const udid = await ensureIosSimulator({ log });
+  return { device: udid, platform: 'ios' };
+}
+
+export async function openUrl({ device, platform, url }) {
+  if (platform === 'ios') return openUrlIos(device, url);
+  return openUrlAndroid(device, url);
+}
+
+export const sleep = ms => new Promise(r => setTimeout(r, ms));

--- a/e2e/mobile-sim/lib/report.mjs
+++ b/e2e/mobile-sim/lib/report.mjs
@@ -1,0 +1,53 @@
+/**
+ * Artifact collection for device-level runs: screenshots, screen outlines,
+ * and a machine-readable summary. CI uploads the whole directory.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export class RunReport {
+  constructor(outDir) {
+    this.outDir = outDir;
+    this.steps = [];
+    this.startedAt = new Date().toISOString();
+    mkdirSync(outDir, { recursive: true });
+  }
+
+  stepName(label) {
+    const n = String(this.steps.length + 1).padStart(2, '0');
+    return `${n}-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`;
+  }
+
+  screenshotPath(label) {
+    return join(this.outDir, `${this.stepName(label)}.png`);
+  }
+
+  /** Record one observe/act step, persisting the outline alongside. */
+  record({ label, ok, outline, screenshot, detail }) {
+    const name = this.stepName(label);
+    if (outline) writeFileSync(join(this.outDir, `${name}.outline.txt`), outline + '\n');
+    this.steps.push({ name, label, ok, screenshot, detail, at: new Date().toISOString() });
+    const mark = ok ? '✓' : '✗';
+    console.error(`${mark} ${label}${detail ? ` — ${detail}` : ''}`);
+  }
+
+  finish({ device, platform, url }) {
+    const failed = this.steps.filter(s => !s.ok);
+    const summary = {
+      startedAt: this.startedAt,
+      finishedAt: new Date().toISOString(),
+      device,
+      platform,
+      url,
+      total: this.steps.length,
+      failed: failed.length,
+      steps: this.steps,
+    };
+    writeFileSync(join(this.outDir, 'summary.json'), JSON.stringify(summary, null, 2) + '\n');
+    console.error(
+      `\nRun complete: ${summary.total - summary.failed}/${summary.total} steps ok. ` +
+      `Artifacts in ${this.outDir}`,
+    );
+    return summary;
+  }
+}

--- a/e2e/mobile-sim/lib/simuse.mjs
+++ b/e2e/mobile-sim/lib/simuse.mjs
@@ -1,0 +1,226 @@
+/**
+ * Thin Node wrapper around the `sim-use` CLI (https://github.com/lycorp-jp/sim-use).
+ *
+ * sim-use gives agents "eyes and hands" on iOS Simulators and Android
+ * emulators/devices: `ui` reads the screen as a token-efficient accessibility
+ * outline, `tap`/`type`/`swipe` act on it. This wrapper shells out to the CLI
+ * and parses the `--json` envelopes, so flows can be written as plain
+ * observe → act → verify JavaScript.
+ *
+ * Requires a macOS host with sim-use installed (`brew tap lycorp-jp/tap &&
+ * brew install lycorp-jp/tap/sim-use`). Run `npm run sim:doctor` to verify.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export class SimUseError extends Error {
+  constructor(message, { command, stdout, stderr, hint } = {}) {
+    super(message);
+    this.name = 'SimUseError';
+    this.command = command;
+    this.stdout = stdout;
+    this.stderr = stderr;
+    this.hint = hint;
+  }
+}
+
+export class SimUse {
+  /**
+   * @param {object} opts
+   * @param {string} [opts.device]  UDID (iOS Simulator) or serial (Android).
+   *                                Optional when exactly one simulator is booted.
+   * @param {string} [opts.bin]     Path to the sim-use binary (default: "sim-use" on PATH).
+   * @param {(msg: string) => void} [opts.log]
+   */
+  constructor({ device, bin = 'sim-use', log = () => {} } = {}) {
+    this.device = device;
+    this.bin = bin;
+    this.log = log;
+  }
+
+  deviceArgs() {
+    return this.device ? ['--device', this.device] : [];
+  }
+
+  /** Run a raw sim-use command. Returns { stdout, stderr }. */
+  async raw(args, { timeoutMs = DEFAULT_TIMEOUT_MS, scoped = true } = {}) {
+    const full = scoped ? [...args, ...this.deviceArgs()] : args;
+    this.log(`$ ${this.bin} ${full.join(' ')}`);
+    try {
+      return await execFileP(this.bin, full, { timeout: timeoutMs, maxBuffer: 32 * 1024 * 1024 });
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        throw new SimUseError('sim-use binary not found on PATH', {
+          command: `${this.bin} ${full.join(' ')}`,
+          hint: 'Install on macOS: brew tap lycorp-jp/tap && brew install lycorp-jp/tap/sim-use',
+        });
+      }
+      throw new SimUseError(`sim-use command failed: ${err.message}`, {
+        command: `${this.bin} ${full.join(' ')}`,
+        stdout: err.stdout,
+        stderr: err.stderr,
+      });
+    }
+  }
+
+  /** Run a sim-use command with --json and return the parsed data payload. */
+  async json(args, opts = {}) {
+    const { stdout } = await this.raw([...args, '--json'], opts);
+    let envelope;
+    try {
+      envelope = JSON.parse(stdout);
+    } catch {
+      throw new SimUseError('sim-use returned non-JSON output', {
+        command: `${this.bin} ${args.join(' ')} --json`,
+        stdout,
+      });
+    }
+    if (envelope.ok === false) {
+      throw new SimUseError(envelope.error?.message || 'sim-use reported an error', {
+        command: `${this.bin} ${args.join(' ')} --json`,
+        hint: envelope.error?.hint,
+      });
+    }
+    return envelope.data ?? envelope;
+  }
+
+  async version() {
+    const { stdout } = await this.raw(['--version'], { scoped: false });
+    return stdout.trim();
+  }
+
+  /** List devices sim-use can see (text output, one per line). */
+  async devices() {
+    const { stdout } = await this.raw(['devices'], { scoped: false });
+    return stdout.trim();
+  }
+
+  /**
+   * Observe: read the current screen.
+   * Returns { outline, data } — the compact text outline (for logs/LLM) and
+   * the structured JSON envelope data (entries with frames, aliases, lists).
+   */
+  async ui() {
+    const [{ stdout }, data] = [
+      await this.raw(['ui']),
+      await this.json(['ui']),
+    ];
+    return { outline: stdout.trim(), data };
+  }
+
+  /** Outline only — cheapest observe call. */
+  async outline() {
+    const { stdout } = await this.raw(['ui']);
+    return stdout.trim();
+  }
+
+  /**
+   * Act: tap an element.
+   * @param {object} sel  One of: { alias: '@9' } | { id: 'loginButton' } |
+   *                      { label: 'Anmelden' } | { labelContains: 'Sign' } |
+   *                      { point: [x, y] }
+   * @param {object} [opts] { waitTimeout, preDelay, postDelay, frame, elementType }
+   */
+  async tap(sel, opts = {}) {
+    const args = ['tap'];
+    if (sel.alias) args.push(sel.alias.startsWith('@') ? sel.alias : `@${sel.alias}`);
+    else if (sel.id) args.push(`#${sel.id.replace(/^#/, '')}`);
+    else if (sel.label) args.push('--label', sel.label);
+    else if (sel.labelRegex) args.push('--label-regex', sel.labelRegex);
+    else if (sel.labelContains) args.push('--label-contains', sel.labelContains);
+    else if (sel.point) args.push('--point', `${sel.point[0]},${sel.point[1]}`);
+    else throw new SimUseError('tap: no selector given');
+    if (opts.waitTimeout) args.push('--wait-timeout', String(opts.waitTimeout));
+    if (opts.preDelay) args.push('--pre-delay', String(opts.preDelay));
+    if (opts.postDelay) args.push('--post-delay', String(opts.postDelay));
+    if (opts.frame) args.push('--frame', opts.frame);
+    if (opts.elementType) args.push('--element-type', opts.elementType);
+    return this.raw(args);
+  }
+
+  /** Type ASCII text into the focused field. Use paste() for Unicode. */
+  async type(text) {
+    return this.raw(['type', text]);
+  }
+
+  /** IME-safe Unicode paste (German umlauts, emoji, …). */
+  async paste(text, { replace = false, viaMenu = false, targetId } = {}) {
+    const args = ['paste', text];
+    if (replace) args.push('--replace');
+    if (viaMenu) {
+      args.push('--via-menu');
+      if (targetId) args.push('--target-id', targetId);
+    }
+    return this.raw(args);
+  }
+
+  async swipe(from, to, { duration } = {}) {
+    const args = ['swipe', '--from', `${from[0]},${from[1]}`, '--to', `${to[0]},${to[1]}`];
+    if (duration) args.push('--duration', String(duration));
+    return this.raw(args);
+  }
+
+  /** Gesture presets: scroll-up, scroll-down, swipe-from-left-edge, pinch-out, … */
+  async gesture(preset, opts = {}) {
+    const args = ['gesture', preset];
+    if (opts.preDelay) args.push('--pre-delay', String(opts.preDelay));
+    if (opts.postDelay) args.push('--post-delay', String(opts.postDelay));
+    return this.raw(args);
+  }
+
+  /** Hardware button: home, lock, back (Android), siri, … */
+  async button(name) {
+    return this.raw(['button', name]);
+  }
+
+  /** Screenshot to a file path. Returns the output path. */
+  async screenshot(outputPath) {
+    const { stdout } = await this.raw(['screenshot', '--output', outputPath]);
+    return stdout.trim() || outputPath;
+  }
+
+  /** `soft` | `hidden` — decides between paste default and --via-menu. */
+  async keyboardState() {
+    const { stdout } = await this.raw(['keyboard-state']);
+    return stdout.trim();
+  }
+
+  /** App/process liveness. Without bundleId: list of running apps. */
+  async appState(bundleId) {
+    const args = ['app-state'];
+    if (bundleId) args.push('--bundle-id', bundleId);
+    const { stdout } = await this.raw(args);
+    return stdout.trim();
+  }
+}
+
+/**
+ * Helpers over the `ui --json` envelope.
+ * Frames are platform-native units: iOS points, Android pixels — key off
+ * `data.platform` before mixing coordinates across platforms.
+ */
+export const outlineUtils = {
+  /** All entries whose role matches (e.g. /TextField/, /Button/). */
+  entriesByRole(data, roleRegex) {
+    return (data.entries || []).filter(e => roleRegex.test(e.role || e.type || ''));
+  },
+
+  /** First entry whose label matches. */
+  findByLabel(data, labelRegex) {
+    return (data.entries || []).find(e => labelRegex.test(e.label || ''));
+  },
+
+  /** Entries in the bottom band of the screen (tab bars, bottom nav). */
+  bottomBandEntries(data, band = 0.85) {
+    const screenH = data.screen?.height || data.screen?.h;
+    if (!screenH) return [];
+    return (data.entries || []).filter(e => {
+      const y = e.frame?.y ?? e.frame?.minY;
+      return typeof y === 'number' && y >= screenH * band;
+    });
+  },
+};

--- a/e2e/mobile-sim/run.mjs
+++ b/e2e/mobile-sim/run.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Entry point for device-level frontend testing via sim-use.
+ *
+ *   node run.mjs [--platform ios|android] [--device <UDID|serial>]
+ *                [--url <app url>] [--flow smoke|observe] [--out <dir>]
+ *
+ * Defaults: iOS Simulator (auto-boot), staging URL, smoke flow.
+ * Credentials for the UI login: TEST_USER_EMAIL / TEST_USER_PASSWORD
+ * (same envs as the Playwright fixtures). Without a password the run
+ * continues unauthenticated and only covers public screens.
+ *
+ * Examples:
+ *   npm run test:device                                  # iOS, staging, smoke
+ *   npm run test:device -- --url https://vitanaland.com  # against prod
+ *   npm run test:device:android -- --device emulator-5554
+ *   npm run test:device -- --flow observe                # eyes only, no taps
+ */
+import { parseArgs } from 'node:util';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SimUse } from './lib/simuse.mjs';
+import { resolveDevice } from './lib/device.mjs';
+import { RunReport } from './lib/report.mjs';
+import { smokeFlow, observeFlow } from './flows/smoke.mjs';
+import { doctor } from './doctor.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const DEFAULT_URL =
+  process.env.COMMUNITY_URL || 'https://preview.vitanaland.com';
+
+const { values: args } = parseArgs({
+  options: {
+    platform: { type: 'string', default: 'ios' },
+    device: { type: 'string' },
+    url: { type: 'string', default: DEFAULT_URL },
+    flow: { type: 'string', default: 'smoke' },
+    out: { type: 'string' },
+    help: { type: 'boolean', default: false },
+  },
+});
+
+if (args.help) {
+  console.log(
+    'Usage: node run.mjs [--platform ios|android] [--device ID] ' +
+    '[--url URL] [--flow smoke|observe] [--out DIR]',
+  );
+  process.exit(0);
+}
+
+async function main() {
+  if (process.platform !== 'darwin') {
+    // doctor() prints the full explanation + fallback options
+    await doctor();
+    process.exit(2);
+  }
+
+  const { device, platform } = await resolveDevice({
+    platform: args.platform,
+    device: args.device,
+  });
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const outDir = args.out || join(HERE, 'artifacts', `${platform}-${stamp}`);
+  const report = new RunReport(outDir);
+  const sim = new SimUse({ device, log: msg => process.env.SIM_USE_VERBOSE && console.error(msg) });
+
+  console.error(`Device: ${device} (${platform})  URL: ${args.url}  Flow: ${args.flow}\n`);
+
+  const ctx = {
+    sim,
+    report,
+    device,
+    platform,
+    url: args.url,
+    email: process.env.TEST_USER_EMAIL || 'e2e-test@vitana.dev',
+    password: process.env.TEST_USER_PASSWORD || '',
+  };
+
+  if (args.flow === 'observe') await observeFlow(ctx);
+  else await smokeFlow(ctx);
+
+  const summary = report.finish({ device, platform, url: args.url });
+  process.exit(summary.failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error(`\nFatal: ${err.message}`);
+  if (err.hint) console.error(`Hint: ${err.hint}`);
+  process.exit(1);
+});

--- a/e2e/mobile-sim/run.mjs
+++ b/e2e/mobile-sim/run.mjs
@@ -64,7 +64,9 @@ async function main() {
   const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
   const outDir = args.out || join(HERE, 'artifacts', `${platform}-${stamp}`);
   const report = new RunReport(outDir);
-  const sim = new SimUse({ device, log: msg => process.env.SIM_USE_VERBOSE && console.error(msg) });
+  // optional debug flag — never required by any workflow or deploy config
+  const verbose = (process.env.SIM_USE_VERBOSE ?? '') !== '';
+  const sim = new SimUse({ device, log: msg => verbose && console.error(msg) });
 
   console.error(`Device: ${device} (${platform})  URL: ${args.url}  Flow: ${args.flow}\n`);
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,11 @@
     "test:community": "npx playwright test --project=desktop-community --project=mobile-community",
     "test:shared": "npx playwright test --project=desktop-shared --project=mobile-shared --project=hub-shared",
     "test:headed": "npx playwright test --headed",
-    "report": "npx playwright show-report"
+    "report": "npx playwright show-report",
+    "sim:doctor": "node mobile-sim/doctor.mjs",
+    "test:device": "node mobile-sim/run.mjs",
+    "test:device:ios": "node mobile-sim/run.mjs --platform ios",
+    "test:device:android": "node mobile-sim/run.mjs --platform android"
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-SIM-USE-DEVICE-TESTING` _(bootstrap change — no ledger VTID allocated; testing-infrastructure only, no service deploys)_

**Layer:** CICDL / E2E

**Priority:** P2

---

## 📋 Summary

Integrates [lycorp-jp/sim-use](https://github.com/lycorp-jp/sim-use) (LY Corporation, Apache-2.0) into the e2e testing unit as a **device-level testing layer**: real eyes (accessibility outline + screenshots) and hands (tap/swipe/type) on the Vitana frontend running in an actual **iOS Simulator or Android emulator/device browser** — complementing the existing Playwright viewport-emulation projects, which only approximate mobile in Chromium.

sim-use reads any screen (including WebView content, i.e. our SPA) as a token-efficient accessibility outline and acts on it by element alias/label — built for AI-agent observe → act → verify loops.

---

## ✅ Changes

- [x] `e2e/mobile-sim/` — driver + flows: Node wrapper around the sim-use CLI (`--json` envelopes), device discovery/boot (`simctl` + `adb`), UI-driven login through the **real form** (not localStorage injection), label-agnostic smoke flow that walks the bottom nav on-device with screenshot + outline per step, `summary.json` report
- [x] `e2e/package.json` — new scripts: `sim:doctor`, `test:device`, `test:device:ios`, `test:device:android`
- [x] `.github/workflows/MOBILE-DEVICE-E2E.yml` — dispatch-only macOS-runner workflow: installs sim-use via Homebrew, boots an iPhone simulator, runs the smoke flow against a chosen URL (default staging), uploads artifacts
- [x] `.claude/skills/sim-use/` — vendored upstream agent skill (with LICENSE + NOTICE) — full command surface, pitfalls, crash protocol
- [x] `.claude/skills/vitana-mobile-testing/` — Vitana glue skill: layer selection per host, DE-first labels, auth, environment URLs
- [x] `docs/MOBILE_DEVICE_TESTING.md` — architecture + host capability matrix; CLAUDE.md references + change log updated

---

## 🧪 Testing

_How was this tested?_

- [x] Manual testing completed — all `.mjs` modules pass `node --check`; workflow YAML validated; `doctor.mjs` and `run.mjs --help` executed on a Linux host and correctly detect the incapable host, printing the Playwright-emulation fallback (`npm run test:mobile`)
- [x] Automated tests added/updated — the smoke/observe flows themselves are the added automation
- [ ] Verified in staging/dev environment — full device run requires a macOS host: dispatch `MOBILE-DEVICE-E2E.yml` after merge (needs existing `TEST_USER_PASSWORD` secret) or run `cd e2e && npm run test:device` on a Mac

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [x] All workflow files use **UPPERCASE** names (`MOBILE-DEVICE-E2E.yml`)
- [ ] All workflows include `run-name` with VTID — dispatch-only test workflow, no ledger VTID; can add `run-name` with the bootstrap tag if required
- [x] No lowercase workflow names present

### File Names
- [x] All new files follow **kebab-case** convention (`mobile-sim/`, `simuse.mjs`, `device.mjs`, …)
- [x] Directory names use **kebab-case**
- [x] No files violate naming canon

### Code Standards
- [x] VTID constants are in **UPPERCASE** — n/a (no VTID constants introduced)
- [x] Event types/kinds use **snake_case** — n/a (no OASIS events; test tooling only)
- [x] Status values use **lowercase** (`summary.json` uses lowercase fields)

### Cloud Run Deployments
- [x] All Cloud Run services include required labels — n/a (no deployments; testing tooling only)
- [x] Deploy scripts use `ensure-vtid.sh` guard — n/a

### Documentation
- [x] VTID mentioned in commit messages (`BOOTSTRAP-SIM-USE-DEVICE-TESTING`)
- [x] Phase 2B compliance verified
- [x] No non-compliant files introduced

---

## 🔗 Links

- **Upstream:** https://github.com/lycorp-jp/sim-use
- **Documentation:** `docs/MOBILE_DEVICE_TESTING.md`, `e2e/mobile-sim/README.md`

---

## 🚨 Breaking Changes

None — additive only. Existing Playwright projects and scripts are untouched.

---

## 📸 Screenshots (if applicable)

Device screenshots + accessibility outlines are produced per step by the smoke flow into `e2e/mobile-sim/artifacts/` (gitignored; uploaded as workflow artifacts in CI). This container (Linux, no macOS/KVM) cannot host a simulator, so no live-run captures are attached here — first captures will come from a `MOBILE-DEVICE-E2E.yml` dispatch.

---

## 📌 Additional Notes

**Host capability matrix** (encoded in `e2e/mobile-sim/doctor.mjs`):

| Host | iOS Simulator | Android | What to run |
|---|---|---|---|
| Mac dev machine | ✅ | ✅ (emulator/USB) | `npm run test:device[:android]` |
| GitHub `macos-15` runner | ✅ | ❌ | dispatch `MOBILE-DEVICE-E2E.yml` |
| Linux CI / cloud container | ❌ | ❌ | `npm run test:mobile` (Playwright emulation) |

Android needs one-time `sim-use android init --device <serial>` (installs the accessibility-bridge APK); no hosted CI path yet, local Mac only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L41p2JvfT7yWhzCmDi8VPq

---
_Generated by [Claude Code](https://claude.ai/code/session_01L41p2JvfT7yWhzCmDi8VPq)_