### PR TITLE
Wave 5 of Voice Tools Expansion Plan v2 — 58 developer P1 tools (VOICE-CATALOG-WAVE-5)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -5201,6 +5201,438 @@ async def admin_archive_intent(context: RunContext, older_than_days: int | None 
 
 
 # ---------------------------------------------------------------------------
+# WAVE-5-VOICE-CATALOG-V2 — Developer P1 (63)
+# Implementations live in services/gateway/src/services/orb-tools/*.ts,
+# reached through the shared dispatcher via POST /api/v1/orb/tool exactly
+# like the tools above.
+# ---------------------------------------------------------------------------
+
+
+# --- C5 Worker Orchestrator (9) ---------------------------------------------
+
+
+@function_tool
+async def dev_list_workers(context: RunContext) -> str:
+    """DEVELOPER ONLY. List registered orchestrator workers."""
+    body = await _dispatch(context, "dev_list_workers", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_orchestrator_stats(context: RunContext) -> str:
+    """DEVELOPER ONLY. Worker connector stats."""
+    body = await _dispatch(context, "dev_orchestrator_stats", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_pending_worker_tasks(context: RunContext, worker_id: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Pending worker task queue."""
+    body = await _dispatch(context, "dev_list_pending_worker_tasks", {"worker_id": worker_id, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_release_claim(context: RunContext, vtid: str, worker_id: str, reason: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Release a stuck VTID claim. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_release_claim", {"vtid": vtid, "worker_id": worker_id, "reason": reason, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_subagents(context: RunContext) -> str:
+    """DEVELOPER ONLY. List legacy subagent registry entries."""
+    body = await _dispatch(context, "dev_list_subagents", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_worker_skills(context: RunContext) -> str:
+    """DEVELOPER ONLY. Worker skills + preflight chains."""
+    body = await _dispatch(context, "dev_list_worker_skills", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_cleanup_stale_claims(context: RunContext, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Expire all stale worker claims platform-wide. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_cleanup_stale_claims", {"confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_orchestrator_health(context: RunContext) -> str:
+    """DEVELOPER ONLY. Orchestrator service health + subagent lanes."""
+    body = await _dispatch(context, "dev_orchestrator_health", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_route_to_subagent(context: RunContext, vtid: str, title: str, task_family: str | None = None, task_domain: str | None = None, target_paths: list[str] | None = None, spec_content: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Route a VTID work order to a subagent for execution. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_route_to_subagent", {
+            "vtid": vtid, "title": title, "task_family": task_family, "task_domain": task_domain,
+            "target_paths": target_paths, "spec_content": spec_content, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+# --- C6 Autopilot Controller & Loop (12) ------------------------------------
+
+
+@function_tool
+async def dev_autopilot_loop_status(context: RunContext) -> str:
+    """DEVELOPER ONLY. Autopilot event loop status."""
+    body = await _dispatch(context, "dev_autopilot_loop_status", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_start_autopilot_loop(context: RunContext, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Start the autopilot event loop. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_start_autopilot_loop", {"confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_stop_autopilot_loop(context: RunContext, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Stop the autopilot event loop. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_stop_autopilot_loop", {"confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_autopilot_loop_history(context: RunContext, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Recent autopilot loop events."""
+    body = await _dispatch(context, "dev_autopilot_loop_history", {"limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_reset_loop_cursor(context: RunContext, timestamp: str | None = None, reason: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Reset the autopilot loop cursor to a timestamp (or "now"). TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_reset_loop_cursor", {"timestamp": timestamp, "reason": reason, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_controller_status(context: RunContext) -> str:
+    """DEVELOPER ONLY. Autopilot controller status."""
+    body = await _dispatch(context, "dev_controller_status", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_controller_runs(context: RunContext) -> str:
+    """DEVELOPER ONLY. Active controller runs."""
+    body = await _dispatch(context, "dev_list_controller_runs", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_controller_run(context: RunContext, vtid: str) -> str:
+    """DEVELOPER ONLY. One controller run by VTID."""
+    body = await _dispatch(context, "dev_get_controller_run", {"vtid": vtid})
+    return summarize(body)
+
+
+@function_tool
+async def dev_validate_task(context: RunContext, vtid: str, mode: str | None = None) -> str:
+    """DEVELOPER ONLY. Run governance validation for a VTID."""
+    body = await _dispatch(context, "dev_validate_task", {"vtid": vtid, "mode": mode})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_pending_plans(context: RunContext) -> str:
+    """DEVELOPER ONLY. Tasks awaiting a plan."""
+    body = await _dispatch(context, "dev_list_pending_plans", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_task_spec(context: RunContext, vtid: str) -> str:
+    """DEVELOPER ONLY. Spec snapshot for a VTID."""
+    body = await _dispatch(context, "dev_get_task_spec", {"vtid": vtid})
+    return summarize(body)
+
+
+@function_tool
+async def dev_autopilot_pipeline_health(context: RunContext) -> str:
+    """DEVELOPER ONLY. Autopilot pipeline health + task funnel summary."""
+    body = await _dispatch(context, "dev_autopilot_pipeline_health", {})
+    return summarize(body)
+
+
+# --- C7 Dev-Autopilot Scanners & Findings (14) ------------------------------
+
+
+@function_tool
+async def dev_list_scanners(context: RunContext) -> str:
+    """EXAFY_ADMIN ONLY. List dev-autopilot scanners."""
+    body = await _dispatch(context, "dev_list_scanners", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_impact_rules(context: RunContext) -> str:
+    """EXAFY_ADMIN ONLY. List impact rules."""
+    body = await _dispatch(context, "dev_list_impact_rules", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_auto_approve_config(context: RunContext) -> str:
+    """EXAFY_ADMIN ONLY. Auto-approve config, budget, and autonomy progress."""
+    body = await _dispatch(context, "dev_get_auto_approve_config", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_scan_runs(context: RunContext, limit: int | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Recent scan runs."""
+    body = await _dispatch(context, "dev_list_scan_runs", {"limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_scan_run(context: RunContext, run_id: str) -> str:
+    """EXAFY_ADMIN ONLY. One scan run by id."""
+    body = await _dispatch(context, "dev_get_scan_run", {"run_id": run_id})
+    return summarize(body)
+
+
+@function_tool
+async def dev_findings_queue(context: RunContext, kind: str | None = None, status: str | None = None, risk: str | None = None, domain: str | None = None, sort: str | None = None, limit: int | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Findings queue."""
+    body = await _dispatch(context, "dev_findings_queue", {"kind": kind, "status": status, "risk": risk, "domain": domain, "sort": sort, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_finding(context: RunContext, finding_id: str) -> str:
+    """EXAFY_ADMIN ONLY. One finding + plan versions."""
+    body = await _dispatch(context, "dev_get_finding", {"finding_id": finding_id})
+    return summarize(body)
+
+
+@function_tool
+async def dev_generate_finding_plan(context: RunContext, finding_id: str, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Generate a fix plan for a finding. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_generate_finding_plan", {"finding_id": finding_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_reject_finding(context: RunContext, finding_id: str, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Reject a finding. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_reject_finding", {"finding_id": finding_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_snooze_finding(context: RunContext, finding_id: str, hours: int | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Snooze a finding for N hours (default 24, max 720)."""
+    body = await _dispatch(context, "dev_snooze_finding", {"finding_id": finding_id, "hours": hours})
+    return summarize(body)
+
+
+@function_tool
+async def dev_approve_auto_execute(context: RunContext, finding_id: str, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Approve a finding for autonomous execution + merge, no further review. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_approve_auto_execute", {"finding_id": finding_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_cancel_execution(context: RunContext, execution_id: str, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Cancel a running execution. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_cancel_execution", {"execution_id": execution_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_executions(context: RunContext, status: str | None = None, limit: int | None = None) -> str:
+    """EXAFY_ADMIN ONLY. List executions (defaults to active only)."""
+    body = await _dispatch(context, "dev_list_executions", {"status": status, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_execution_lineage(context: RunContext, execution_id: str) -> str:
+    """EXAFY_ADMIN ONLY. Execution lineage (root + all descendants)."""
+    body = await _dispatch(context, "dev_get_execution_lineage", {"execution_id": execution_id})
+    return summarize(body)
+
+
+# --- C8 Self-Healing (13) ----------------------------------------------------
+
+
+@function_tool
+async def dev_report_incident(context: RunContext, service: str, summary: str, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. File a manual incident for a service. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_report_incident", {"service": service, "summary": summary, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_healing_config(context: RunContext) -> str:
+    """DEVELOPER ONLY. Self-healing enabled state + autonomy level."""
+    body = await _dispatch(context, "dev_healing_config", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_set_healing_mode(context: RunContext, autonomy_level: int, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Set the self-healing autonomy level (0-4). TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_set_healing_mode", {"autonomy_level": autonomy_level, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_healing_kill_switch(context: RunContext, action: str, reason: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Activate or deactivate the self-healing kill switch. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_healing_kill_switch", {"action": action, "reason": reason, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_healing_history(context: RunContext, limit: int | None = None, failure_class: str | None = None, outcome: str | None = None) -> str:
+    """DEVELOPER ONLY. Recent self-healing events."""
+    body = await _dispatch(context, "dev_healing_history", {"limit": limit, "failure_class": failure_class, "outcome": outcome})
+    return summarize(body)
+
+
+@function_tool
+async def dev_healing_metrics(context: RunContext, days: int | None = None) -> str:
+    """DEVELOPER ONLY. Self-healing metrics summary over N days (default 7)."""
+    body = await _dispatch(context, "dev_healing_metrics", {"days": days})
+    return summarize(body)
+
+
+@function_tool
+async def dev_approve_heal(context: RunContext, heal_id: str, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Approve a pending heal. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_approve_heal", {"heal_id": heal_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_reject_heal(context: RunContext, heal_id: str, reason: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Reject a pending heal. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_reject_heal", {"heal_id": heal_id, "reason": reason, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_verify_heal(context: RunContext, vtid: str) -> str:
+    """DEVELOPER ONLY. Run a blast-radius verification check for a heal."""
+    body = await _dispatch(context, "dev_verify_heal", {"vtid": vtid})
+    return summarize(body)
+
+
+@function_tool
+async def dev_rollback_heal(context: RunContext, vtid: str, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Roll back a heal to its pre-fix snapshot. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_rollback_heal", {"vtid": vtid, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_quarantine(context: RunContext, failure_class: str, signature: str) -> str:
+    """DEVELOPER ONLY. Look up a quarantine entry by failure class + signature (no browsable list exists)."""
+    body = await _dispatch(context, "dev_list_quarantine", {"failure_class": failure_class, "signature": signature})
+    return summarize(body)
+
+
+@function_tool
+async def dev_release_quarantine(context: RunContext, failure_class: str, signature: str, reason: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Release a class/signature pair from quarantine. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_release_quarantine", {"failure_class": failure_class, "signature": signature, "reason": reason, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_shadow_comparison(context: RunContext, window_hours: int | None = None) -> str:
+    """DEVELOPER ONLY. Staging shadow-comparison report over a time window (default 48h)."""
+    body = await _dispatch(context, "dev_shadow_comparison", {"window_hours": window_hours})
+    return summarize(body)
+
+
+# --- C10 Testing & QA (10) ---------------------------------------------------
+
+
+@function_tool
+async def dev_run_test_suite(context: RunContext, projects: list[str], type: str | None = None, community_url: str | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Run one or more named test suites/projects. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_run_test_suite", {"projects": projects, "type": type, "community_url": community_url, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_test_suites(context: RunContext) -> str:
+    """DEVELOPER ONLY. List available test suites/projects."""
+    body = await _dispatch(context, "dev_list_test_suites", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_test_runs(context: RunContext, type: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Recent test runs."""
+    body = await _dispatch(context, "dev_list_test_runs", {"type": type, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_test_run(context: RunContext, run_id: str) -> str:
+    """DEVELOPER ONLY. One test run + its results."""
+    body = await _dispatch(context, "dev_get_test_run", {"run_id": run_id})
+    return summarize(body)
+
+
+@function_tool
+async def dev_run_e2e(context: RunContext, projects: list[str] | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Run the full E2E test suite. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_run_e2e", {"projects": projects, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_orb_monitor_status(context: RunContext) -> str:
+    """DEVELOPER ONLY. Recent ORB monitor workflow runs."""
+    body = await _dispatch(context, "dev_orb_monitor_status", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_trigger_orb_monitor(context: RunContext, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Trigger the ORB monitor workflow. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_trigger_orb_monitor", {"confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_list_test_contracts(context: RunContext, service: str | None = None, environment: str | None = None, owner: str | None = None, status: str | None = None, contract_type: str | None = None) -> str:
+    """EXAFY_ADMIN ONLY. List registered test contracts."""
+    body = await _dispatch(context, "dev_list_test_contracts", {"service": service, "environment": environment, "owner": owner, "status": status, "contract_type": contract_type})
+    return summarize(body)
+
+
+@function_tool
+async def dev_run_orb_selfcheck(context: RunContext, user_id: str | None = None, tools: list[str] | None = None, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Run the curated ORB tools selfcheck against real user data. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_run_orb_selfcheck", {"user_id": user_id, "tools": tools, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_voice_lab_probe(context: RunContext) -> str:
+    """DEVELOPER ONLY. Run a synthetic voice-lab probe."""
+    body = await _dispatch(context, "dev_voice_lab_probe", {})
+    return summarize(body)
+
+
+# ---------------------------------------------------------------------------
 # Catalogue export — used by tests + libcst smoke
 # ---------------------------------------------------------------------------
 
@@ -5460,6 +5892,32 @@ def all_tool_names() -> list[str]:
         "admin_feature_analytics", "admin_interest_analytics", "admin_intent_engine_stats",
         "admin_close_intent", "admin_recompute_intent", "admin_resolve_dispute",
         "admin_archive_intent",
+        # WAVE-5-VOICE-CATALOG-V2 — Developer P1 (63)
+        # C5 Worker Orchestrator (9)
+        "dev_list_workers", "dev_orchestrator_stats", "dev_list_pending_worker_tasks",
+        "dev_release_claim", "dev_list_subagents", "dev_list_worker_skills",
+        "dev_cleanup_stale_claims", "dev_orchestrator_health", "dev_route_to_subagent",
+        # C6 Autopilot Controller & Loop (12)
+        "dev_autopilot_loop_status", "dev_start_autopilot_loop", "dev_stop_autopilot_loop",
+        "dev_autopilot_loop_history", "dev_reset_loop_cursor", "dev_controller_status",
+        "dev_list_controller_runs", "dev_get_controller_run", "dev_validate_task",
+        "dev_list_pending_plans", "dev_get_task_spec", "dev_autopilot_pipeline_health",
+        # C7 Dev-Autopilot Scanners & Findings (14)
+        "dev_list_scanners", "dev_list_impact_rules", "dev_get_auto_approve_config",
+        "dev_list_scan_runs", "dev_get_scan_run", "dev_findings_queue", "dev_get_finding",
+        "dev_generate_finding_plan", "dev_reject_finding", "dev_snooze_finding",
+        "dev_approve_auto_execute", "dev_cancel_execution", "dev_list_executions",
+        "dev_get_execution_lineage",
+        # C8 Self-Healing (13)
+        "dev_report_incident", "dev_healing_config", "dev_set_healing_mode",
+        "dev_healing_kill_switch", "dev_healing_history", "dev_healing_metrics",
+        "dev_approve_heal", "dev_reject_heal", "dev_verify_heal", "dev_rollback_heal",
+        "dev_list_quarantine", "dev_release_quarantine", "dev_shadow_comparison",
+        # C10 Testing & QA (10)
+        "dev_run_test_suite", "dev_list_test_suites", "dev_list_test_runs",
+        "dev_get_test_run", "dev_run_e2e", "dev_orb_monitor_status",
+        "dev_trigger_orb_monitor", "dev_list_test_contracts", "dev_run_orb_selfcheck",
+        "dev_voice_lab_probe",
     ]
 
 

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -86,6 +86,14 @@ import { ADMIN_TENANTS_SIGNUPS_TOOL_HANDLERS, ADMIN_TENANTS_SIGNUPS_TOOL_DECLARA
 import { ADMIN_OVERSIGHT_BILLING_TOOL_HANDLERS, ADMIN_OVERSIGHT_BILLING_TOOL_DECLARATIONS } from './orb-tools/admin-oversight-billing-tools';
 import { ADMIN_KB_ASSISTANT_TOOL_HANDLERS, ADMIN_KB_ASSISTANT_TOOL_DECLARATIONS } from './orb-tools/admin-kb-assistant-tools';
 import { ADMIN_AUTOPILOT_ANALYTICS_TOOL_HANDLERS, ADMIN_AUTOPILOT_ANALYTICS_TOOL_DECLARATIONS } from './orb-tools/admin-autopilot-analytics-tools';
+// WAVE-5-VOICE-CATALOG-V2 — fifth wave of the approved 425-tool expansion:
+// developer P1 domains covering worker orchestrator, autopilot controller &
+// loop, dev-autopilot scanners/findings, self-healing, and testing & QA.
+import { WORKER_ORCHESTRATOR_TOOL_HANDLERS, WORKER_ORCHESTRATOR_TOOL_DECLARATIONS } from './orb-tools/worker-orchestrator-tools';
+import { AUTOPILOT_CONTROLLER_TOOL_HANDLERS, AUTOPILOT_CONTROLLER_TOOL_DECLARATIONS } from './orb-tools/autopilot-controller-tools';
+import { DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS, DEV_AUTOPILOT_SCANNERS_TOOL_DECLARATIONS } from './orb-tools/dev-autopilot-scanners-tools';
+import { SELF_HEALING_TOOL_HANDLERS, SELF_HEALING_TOOL_DECLARATIONS } from './orb-tools/self-healing-tools';
+import { TESTING_QA_TOOL_HANDLERS, TESTING_QA_TOOL_DECLARATIONS } from './orb-tools/testing-qa-tools';
 import {
   lookupScreen,
   lookupByAlias,
@@ -5210,6 +5218,12 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   ...ADMIN_OVERSIGHT_BILLING_TOOL_HANDLERS,
   ...ADMIN_KB_ASSISTANT_TOOL_HANDLERS,
   ...ADMIN_AUTOPILOT_ANALYTICS_TOOL_HANDLERS,
+  // WAVE-5-VOICE-CATALOG-V2
+  ...WORKER_ORCHESTRATOR_TOOL_HANDLERS,
+  ...AUTOPILOT_CONTROLLER_TOOL_HANDLERS,
+  ...DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS,
+  ...SELF_HEALING_TOOL_HANDLERS,
+  ...TESTING_QA_TOOL_HANDLERS,
 };
 
 // BOOTSTRAP-VOICE-CATALOG-COMPLETE — combined Vertex/Gemini function
@@ -5254,6 +5268,12 @@ export const DEVELOPER_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> 
   ...CICD_PR_TOOL_DECLARATIONS,
   ...DEPLOYMENT_RELEASE_TOOL_DECLARATIONS,
   ...OBSERVABILITY_TOOL_DECLARATIONS,
+  // WAVE-5-VOICE-CATALOG-V2
+  ...WORKER_ORCHESTRATOR_TOOL_DECLARATIONS,
+  ...AUTOPILOT_CONTROLLER_TOOL_DECLARATIONS,
+  ...DEV_AUTOPILOT_SCANNERS_TOOL_DECLARATIONS,
+  ...SELF_HEALING_TOOL_DECLARATIONS,
+  ...TESTING_QA_TOOL_DECLARATIONS,
 ];
 
 // WAVE-3-VOICE-CATALOG-V2 — admin_* declarations, injected by

--- a/services/gateway/src/services/orb-tools/autopilot-controller-tools.ts
+++ b/services/gateway/src/services/orb-tools/autopilot-controller-tools.ts
@@ -1,0 +1,253 @@
+/**
+ * Developer voice tools — Autopilot Controller & Loop (C6), Wave 5 of
+ * docs/VOICE_TOOLS_EXPANSION_PLAN.md.
+ *
+ * Thin dispatch layer over routes/autopilot.ts (mounted at
+ * /api/v1/autopilot — the VTID-execution-loop controller; distinct from
+ * routes/admin-autopilot.ts, the tenant-facing recommendations admin
+ * surface already built in Wave 4 as B13). No HTTP-level auth middleware
+ * on this router — `developerGate()` is the real access control here.
+ *
+ * dev_plan_task / dev_start_task_work / dev_complete_task_work are
+ * SKIPPED. Their backing routes (POST .../plan, .../work/start,
+ * .../work/complete) are explicitly DEPRECATED (VTID-01170) and return 400
+ * unless the caller sets `X-BYPASS-ORCHESTRATOR: EMERGENCY-BYPASS` — the
+ * platform's documented emergency-only escape hatch. Building a voice tool
+ * that has to silently set that header on every routine call would turn an
+ * emergency bypass into normal behavior, which the platform's own IF-THEN
+ * rule forbids ("IF emergency bypass is used → THEN log + escalate" — not
+ * "use it as a default"). The canonical, non-deprecated replacements
+ * already exist as other tools: dev_route_to_subagent (C5, Wave 5) and the
+ * worker/subagent start+complete routes reached by dev_run_exec_workflow /
+ * dev_submit_evidence (C1, Wave 2). All three stay `status: planned`.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit, developerGate } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+function vtidOk(v: unknown): v is string {
+  return typeof v === 'string' && /^VTID-\d{4,}$/.test(v);
+}
+
+// ---------------------------------------------------------------------------
+// 1. dev_autopilot_loop_status — GET /api/v1/autopilot/loop/status
+// ---------------------------------------------------------------------------
+
+export const dev_autopilot_loop_status: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/autopilot/loop/status');
+  if (!ok) return { ok: false, error: `dev_autopilot_loop_status failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: `Autopilot loop is ${body.is_running ? 'running' : 'stopped'}${body.errors_1h ? `, ${Number(body.errors_1h)} errors in the last hour` : ''}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 2/3. dev_start_autopilot_loop / dev_stop_autopilot_loop
+// ---------------------------------------------------------------------------
+
+async function toggleLoop(args: OrbToolArgs, id: OrbToolIdentity, action: 'start' | 'stop'): Promise<OrbToolResult> {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, action },
+      text: `About to ${action} the autopilot event loop platform-wide. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/autopilot/loop/${action}`, { method: 'POST' });
+  if (!ok) return { ok: true, result: { changed: false, status, detail: body }, text: `Could not ${action} the loop: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { changed: true, detail: body }, text: String(body.message ?? `Loop ${action}ed.`) };
+}
+
+export const dev_start_autopilot_loop: Handler = async (args, id) => toggleLoop(args, id, 'start');
+export const dev_stop_autopilot_loop: Handler = async (args, id) => toggleLoop(args, id, 'stop');
+
+// ---------------------------------------------------------------------------
+// 4. dev_autopilot_loop_history — GET /api/v1/autopilot/loop/history
+// ---------------------------------------------------------------------------
+
+export const dev_autopilot_loop_history: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 100, 500);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/autopilot/loop/history?limit=${limit}`);
+  if (!ok) return { ok: false, error: `dev_autopilot_loop_history failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const events = (Array.isArray(body.events) ? body.events : []) as unknown[];
+  return { ok: true, result: body, text: `${events.length} loop history events.` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. dev_reset_loop_cursor — POST /api/v1/autopilot/loop/cursor/reset
+// ---------------------------------------------------------------------------
+
+export const dev_reset_loop_cursor: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const timestamp = typeof args.timestamp === 'string' && args.timestamp.trim() ? args.timestamp.trim() : 'now';
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, timestamp },
+      text: `About to reset the autopilot loop cursor to "${timestamp}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/autopilot/loop/cursor/reset', {
+    method: 'POST',
+    body: { timestamp, reason: typeof args.reason === 'string' ? args.reason : undefined },
+  });
+  if (!ok) return { ok: true, result: { reset: false, status, detail: body }, text: `Could not reset the cursor: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { reset: true, detail: body }, text: `Loop cursor reset to ${timestamp}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. dev_controller_status — GET /api/v1/autopilot/controller/status
+// ---------------------------------------------------------------------------
+
+export const dev_controller_status: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/autopilot/controller/status');
+  if (!ok) return { ok: false, error: `dev_controller_status failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: 'Autopilot controller status retrieved.' };
+};
+
+// ---------------------------------------------------------------------------
+// 7. dev_list_controller_runs — GET /api/v1/autopilot/controller/runs
+// ---------------------------------------------------------------------------
+
+export const dev_list_controller_runs: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/autopilot/controller/runs');
+  if (!ok) return { ok: false, error: `dev_list_controller_runs failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const runs = (Array.isArray(body.runs) ? body.runs : []) as Array<Record<string, unknown>>;
+  if (runs.length === 0) return { ok: true, result: { runs: [] }, text: 'No active controller runs.' };
+  return { ok: true, result: { runs }, text: `${runs.length} active controller runs.` };
+};
+
+// ---------------------------------------------------------------------------
+// 8. dev_get_controller_run — GET /api/v1/autopilot/controller/runs/:vtid
+// ---------------------------------------------------------------------------
+
+export const dev_get_controller_run: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (!vtidOk(args.vtid)) return { ok: false, error: 'dev_get_controller_run requires vtid (VTID-NNNN...).' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/autopilot/controller/runs/${encodeURIComponent(args.vtid)}`);
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No controller run found for ${args.vtid}.` }
+      : { ok: false, error: `dev_get_controller_run failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return { ok: true, result: body.run ?? body, text: `Controller run for ${args.vtid} retrieved.` };
+};
+
+// ---------------------------------------------------------------------------
+// 9. dev_validate_task — POST /api/v1/autopilot/tasks/:vtid/validate
+// (not confirm-gated — validation/inspection, not a mutation of task state)
+// ---------------------------------------------------------------------------
+
+export const dev_validate_task: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (!vtidOk(args.vtid)) return { ok: false, error: 'dev_validate_task requires vtid (VTID-NNNN...).' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/autopilot/tasks/${encodeURIComponent(args.vtid)}/validate`, {
+    method: 'POST',
+    body: { mode: typeof args.mode === 'string' ? args.mode : undefined },
+  });
+  if (!ok) return { ok: false, error: `dev_validate_task failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const validation = (body.validation ?? {}) as Record<string, unknown>;
+  return { ok: true, result: validation, text: `Validation for ${args.vtid}: ${String(validation.final_status ?? 'unknown')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 10. dev_list_pending_plans — GET /api/v1/autopilot/tasks/pending-plan
+// ---------------------------------------------------------------------------
+
+export const dev_list_pending_plans: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/autopilot/tasks/pending-plan');
+  if (!ok) return { ok: false, error: `dev_list_pending_plans failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const tasks = (Array.isArray(body.data) ? body.data : []) as unknown[];
+  if (tasks.length === 0) return { ok: true, result: { tasks: [] }, text: 'No tasks pending a plan.' };
+  return { ok: true, result: { tasks }, text: `${tasks.length} tasks pending a plan.` };
+};
+
+// ---------------------------------------------------------------------------
+// 11. dev_get_task_spec — GET /api/v1/autopilot/spec/:vtid
+// ---------------------------------------------------------------------------
+
+export const dev_get_task_spec: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (!vtidOk(args.vtid)) return { ok: false, error: 'dev_get_task_spec requires vtid (VTID-NNNN...).' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/autopilot/spec/${encodeURIComponent(args.vtid)}`);
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No spec snapshot found for ${args.vtid}.` }
+      : { ok: false, error: `dev_get_task_spec failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return { ok: true, result: body, text: `Spec snapshot for ${args.vtid}${body.integrity_valid === false ? ' — integrity check FAILED' : ''}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 12. dev_autopilot_pipeline_health — GET /api/v1/autopilot/pipeline/health
+// ---------------------------------------------------------------------------
+
+export const dev_autopilot_pipeline_health: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/autopilot/pipeline/health');
+  if (!ok) return { ok: false, error: `dev_autopilot_pipeline_health failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return {
+    ok: true,
+    result: body,
+    text: `Loop ${body.loop_running ? 'running' : 'stopped'}, execution ${body.execution_armed ? 'armed' : 'disarmed'}, ${Number(body.stuck_count ?? 0)} stuck tasks, ${Number(body.workers_active ?? 0)} active workers.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const AUTOPILOT_CONTROLLER_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_autopilot_loop_status,
+  dev_start_autopilot_loop,
+  dev_stop_autopilot_loop,
+  dev_autopilot_loop_history,
+  dev_reset_loop_cursor,
+  dev_controller_status,
+  dev_list_controller_runs,
+  dev_get_controller_run,
+  dev_validate_task,
+  dev_list_pending_plans,
+  dev_get_task_spec,
+  dev_autopilot_pipeline_health,
+};
+
+export const AUTOPILOT_CONTROLLER_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  { name: 'dev_autopilot_loop_status', description: 'DEVELOPER ONLY. Autopilot event loop status.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_start_autopilot_loop', description: 'DEVELOPER ONLY. Start the autopilot event loop. TWO-STEP confirm.', parameters: { type: 'object', properties: { confirm: { type: 'boolean' } } } },
+  { name: 'dev_stop_autopilot_loop', description: 'DEVELOPER ONLY. Stop the autopilot event loop. TWO-STEP confirm.', parameters: { type: 'object', properties: { confirm: { type: 'boolean' } } } },
+  { name: 'dev_autopilot_loop_history', description: 'DEVELOPER ONLY. Recent autopilot loop events.', parameters: { type: 'object', properties: { limit: { type: 'number' } } } },
+  {
+    name: 'dev_reset_loop_cursor',
+    description: 'DEVELOPER ONLY. Reset the autopilot loop cursor to a timestamp (or "now"). TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { timestamp: { type: 'string', description: 'ISO timestamp or "now". Defaults to "now".' }, reason: { type: 'string' }, confirm: { type: 'boolean' } } },
+  },
+  { name: 'dev_controller_status', description: 'DEVELOPER ONLY. Autopilot controller status.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_list_controller_runs', description: 'DEVELOPER ONLY. Active controller runs.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_get_controller_run', description: 'DEVELOPER ONLY. One controller run by VTID.', parameters: { type: 'object', properties: { vtid: { type: 'string', description: 'Required.' } }, required: ['vtid'] } },
+  { name: 'dev_validate_task', description: 'DEVELOPER ONLY. Run governance validation for a VTID.', parameters: { type: 'object', properties: { vtid: { type: 'string', description: 'Required.' }, mode: { type: 'string' } }, required: ['vtid'] } },
+  { name: 'dev_list_pending_plans', description: 'DEVELOPER ONLY. Tasks awaiting a plan.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_get_task_spec', description: 'DEVELOPER ONLY. Spec snapshot for a VTID.', parameters: { type: 'object', properties: { vtid: { type: 'string', description: 'Required.' } }, required: ['vtid'] } },
+  { name: 'dev_autopilot_pipeline_health', description: 'DEVELOPER ONLY. Autopilot pipeline health + task funnel summary.', parameters: { type: 'object', properties: {} } },
+];

--- a/services/gateway/src/services/orb-tools/dev-autopilot-scanners-tools.ts
+++ b/services/gateway/src/services/orb-tools/dev-autopilot-scanners-tools.ts
@@ -1,0 +1,376 @@
+/**
+ * Developer voice tools — Dev-Autopilot Scanners & Findings (C7), Wave 5 of
+ * docs/VOICE_TOOLS_EXPANSION_PLAN.md.
+ *
+ * Thin dispatch layer over routes/dev-autopilot.ts (mounted at
+ * /api/v1/dev-autopilot). Every route below is gated server-side by
+ * `requireDevRole` (Supabase JWT + `identity.exafy_admin === true`), so
+ * these tools additionally require id.role === 'exafy_admin' and forward
+ * id.user_jwt as Bearer.
+ *
+ * dev_trigger_scan is SKIPPED. The only ingestion route, POST
+ * /api/v1/dev-autopilot/scan, is gated by `requireScanToken` (a CI-only
+ * `X-DevAutopilot-Scan-Token` header matching an env var) — it's built for
+ * the GitHub Actions workflow to push scanner results, not for interactive
+ * use, and there is no user-facing "run a scanner now" endpoint. Faking a
+ * scan token would mean fabricating CI credentials; stays `status: planned`.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit, developerGate } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const NO_DEV_SESSION: OrbToolResult = {
+  ok: true,
+  result: { reason: 'no_dev_session' },
+  text: "This needs a signed-in exafy_admin session — I don't have one for this voice session.",
+};
+
+function requireExafyAdmin(id: OrbToolIdentity): OrbToolResult | null {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (String(id.role ?? '').toLowerCase() !== 'exafy_admin') {
+    return { ok: false, error: 'This tool requires an exafy_admin session (dev-autopilot is operator-only).' };
+  }
+  return null;
+}
+
+function authHeaders(id: OrbToolIdentity): Record<string, string> {
+  return id.user_jwt ? { Authorization: `Bearer ${id.user_jwt}` } : {};
+}
+
+// ---------------------------------------------------------------------------
+// 1. dev_list_scanners — GET /api/v1/dev-autopilot/scanners
+// ---------------------------------------------------------------------------
+
+export const dev_list_scanners: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/dev-autopilot/scanners', { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_list_scanners failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const scanners = (Array.isArray(body.scanners) ? body.scanners : []) as Array<Record<string, unknown>>;
+  return { ok: true, result: { scanners }, text: `${scanners.length} scanners registered.` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. dev_list_impact_rules — GET /api/v1/dev-autopilot/impact-rules
+// ---------------------------------------------------------------------------
+
+export const dev_list_impact_rules: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/dev-autopilot/impact-rules', { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_list_impact_rules failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rules = (Array.isArray(body.rules) ? body.rules : []) as Array<Record<string, unknown>>;
+  return { ok: true, result: { rules }, text: `${rules.length} impact rules registered.` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. dev_get_auto_approve_config — GET /api/v1/dev-autopilot/auto-approve
+// ---------------------------------------------------------------------------
+
+export const dev_get_auto_approve_config: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/dev-autopilot/auto-approve', { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_get_auto_approve_config failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const config = (body.config ?? {}) as Record<string, unknown>;
+  return { ok: true, result: body, text: `Auto-approve kill switch ${config.kill_switch ? 'ON' : 'off'}, daily budget ${Number(config.daily_budget ?? 0)}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. dev_list_scan_runs — GET /api/v1/dev-autopilot/runs
+// ---------------------------------------------------------------------------
+
+export const dev_list_scan_runs: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const limit = clampLimit(args.limit, 20, 100);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/runs?limit=${limit}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_list_scan_runs failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const runs = (Array.isArray(body.runs) ? body.runs : []) as unknown[];
+  return { ok: true, result: { runs }, text: `${runs.length} scan runs.` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. dev_get_scan_run — GET /api/v1/dev-autopilot/runs/:run_id
+// ---------------------------------------------------------------------------
+
+export const dev_get_scan_run: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const runId = String(args.run_id ?? '').trim();
+  if (!runId) return { ok: false, error: 'dev_get_scan_run requires run_id.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/runs/${encodeURIComponent(runId)}`, { headers: authHeaders(id) });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No scan run found with id ${runId}.` }
+      : { ok: false, error: `dev_get_scan_run failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return { ok: true, result: body.run ?? body, text: `Scan run ${runId} retrieved.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. dev_findings_queue — GET /api/v1/dev-autopilot/queue
+// ---------------------------------------------------------------------------
+
+export const dev_findings_queue: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const limit = clampLimit(args.limit, 200, 500);
+  const qs = new URLSearchParams({ limit: String(limit) });
+  for (const k of ['kind', 'status', 'risk', 'domain', 'sort'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/queue?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_findings_queue failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const findings = (Array.isArray(body.findings) ? body.findings : []) as unknown[];
+  if (findings.length === 0) return { ok: true, result: { findings: [] }, text: 'No findings in the queue.' };
+  return { ok: true, result: { findings }, text: `${findings.length} findings in the queue.` };
+};
+
+// ---------------------------------------------------------------------------
+// 7. dev_get_finding — GET /api/v1/dev-autopilot/findings/:id
+// ---------------------------------------------------------------------------
+
+export const dev_get_finding: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const findingId = String(args.finding_id ?? '').trim();
+  if (!findingId) return { ok: false, error: 'dev_get_finding requires finding_id.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/findings/${encodeURIComponent(findingId)}`, { headers: authHeaders(id) });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No finding found with id ${findingId}.` }
+      : { ok: false, error: `dev_get_finding failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return { ok: true, result: body, text: `Finding ${findingId} retrieved.` };
+};
+
+// ---------------------------------------------------------------------------
+// 8. dev_generate_finding_plan — POST /api/v1/dev-autopilot/findings/:id/generate-plan
+// ---------------------------------------------------------------------------
+
+export const dev_generate_finding_plan: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const findingId = String(args.finding_id ?? '').trim();
+  if (!findingId) return { ok: false, error: 'dev_generate_finding_plan requires finding_id.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, finding_id: findingId },
+      text: `About to generate a fix plan for finding ${findingId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/findings/${encodeURIComponent(findingId)}/generate-plan`, {
+    method: 'POST',
+    headers: authHeaders(id),
+  });
+  if (!ok) return { ok: true, result: { generated: false, status, detail: body }, text: `Could not generate a plan: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { generated: true, detail: body }, text: `Fix plan generated for finding ${findingId}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 9. dev_reject_finding — POST /api/v1/dev-autopilot/findings/:id/reject
+// ---------------------------------------------------------------------------
+
+export const dev_reject_finding: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const findingId = String(args.finding_id ?? '').trim();
+  if (!findingId) return { ok: false, error: 'dev_reject_finding requires finding_id.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, finding_id: findingId },
+      text: `About to reject finding ${findingId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/findings/${encodeURIComponent(findingId)}/reject`, {
+    method: 'POST',
+    headers: authHeaders(id),
+  });
+  if (!ok) return { ok: true, result: { rejected: false, status, detail: body }, text: `Could not reject the finding: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { rejected: true }, text: `Finding ${findingId} rejected.` };
+};
+
+// ---------------------------------------------------------------------------
+// 10. dev_snooze_finding — POST /api/v1/dev-autopilot/findings/:id/snooze
+// (read-ish per the plan's "Snooze (R)" — no confirm gate, low-risk toggle)
+// ---------------------------------------------------------------------------
+
+export const dev_snooze_finding: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const findingId = String(args.finding_id ?? '').trim();
+  if (!findingId) return { ok: false, error: 'dev_snooze_finding requires finding_id.' };
+  const hours = typeof args.hours === 'number' && args.hours > 0 && args.hours <= 720 ? args.hours : undefined;
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/findings/${encodeURIComponent(findingId)}/snooze`, {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { hours },
+  });
+  if (!ok) return { ok: true, result: { snoozed: false, status, detail: body }, text: `Could not snooze the finding: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { snoozed: true }, text: `Finding ${findingId} snoozed for ${hours ?? 24} hours.` };
+};
+
+// ---------------------------------------------------------------------------
+// 11. dev_approve_auto_execute — POST /api/v1/dev-autopilot/findings/:id/approve-auto-execute
+// ---------------------------------------------------------------------------
+
+export const dev_approve_auto_execute: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const findingId = String(args.finding_id ?? '').trim();
+  if (!findingId) return { ok: false, error: 'dev_approve_auto_execute requires finding_id.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, finding_id: findingId },
+      text: `About to approve finding ${findingId} for auto-execution — this lets it run and merge without further human review. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/findings/${encodeURIComponent(findingId)}/approve-auto-execute`, {
+    method: 'POST',
+    headers: authHeaders(id),
+  });
+  if (!ok) return { ok: true, result: { approved: false, status, detail: body }, text: `Could not approve auto-execution: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { approved: true, detail: body }, text: `Finding ${findingId} approved for auto-execution.` };
+};
+
+// ---------------------------------------------------------------------------
+// 12. dev_cancel_execution — POST /api/v1/dev-autopilot/executions/:id/cancel
+// ---------------------------------------------------------------------------
+
+export const dev_cancel_execution: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const executionId = String(args.execution_id ?? '').trim();
+  if (!executionId) return { ok: false, error: 'dev_cancel_execution requires execution_id.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, execution_id: executionId },
+      text: `About to cancel execution ${executionId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/executions/${encodeURIComponent(executionId)}/cancel`, {
+    method: 'POST',
+    headers: authHeaders(id),
+  });
+  if (!ok) return { ok: true, result: { cancelled: false, status, detail: body }, text: `Could not cancel the execution: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { cancelled: true }, text: `Execution ${executionId} cancelled.` };
+};
+
+// ---------------------------------------------------------------------------
+// 13. dev_list_executions — GET /api/v1/dev-autopilot/executions
+// ---------------------------------------------------------------------------
+
+export const dev_list_executions: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const limit = clampLimit(args.limit, 100, 500);
+  const qs = new URLSearchParams({ limit: String(limit) });
+  if (typeof args.status === 'string' && args.status) qs.set('status', args.status);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/executions?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_list_executions failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const executions = (Array.isArray(body.executions) ? body.executions : []) as unknown[];
+  return { ok: true, result: { executions }, text: `${executions.length} executions.` };
+};
+
+// ---------------------------------------------------------------------------
+// 14. dev_get_execution_lineage — GET /api/v1/dev-autopilot/executions/:id/lineage
+// ---------------------------------------------------------------------------
+
+export const dev_get_execution_lineage: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const executionId = String(args.execution_id ?? '').trim();
+  if (!executionId) return { ok: false, error: 'dev_get_execution_lineage requires execution_id.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/dev-autopilot/executions/${encodeURIComponent(executionId)}/lineage`, { headers: authHeaders(id) });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No execution found with id ${executionId}.` }
+      : { ok: false, error: `dev_get_execution_lineage failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const lineage = (Array.isArray(body.lineage) ? body.lineage : []) as unknown[];
+  return { ok: true, result: body, text: `Lineage for ${executionId}: ${lineage.length} related executions.` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_list_scanners,
+  dev_list_impact_rules,
+  dev_get_auto_approve_config,
+  dev_list_scan_runs,
+  dev_get_scan_run,
+  dev_findings_queue,
+  dev_get_finding,
+  dev_generate_finding_plan,
+  dev_reject_finding,
+  dev_snooze_finding,
+  dev_approve_auto_execute,
+  dev_cancel_execution,
+  dev_list_executions,
+  dev_get_execution_lineage,
+};
+
+export const DEV_AUTOPILOT_SCANNERS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  { name: 'dev_list_scanners', description: 'EXAFY_ADMIN ONLY. List dev-autopilot scanners.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_list_impact_rules', description: 'EXAFY_ADMIN ONLY. List impact rules.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_get_auto_approve_config', description: 'EXAFY_ADMIN ONLY. Auto-approve config, budget, and autonomy progress.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_list_scan_runs', description: 'EXAFY_ADMIN ONLY. Recent scan runs.', parameters: { type: 'object', properties: { limit: { type: 'number' } } } },
+  { name: 'dev_get_scan_run', description: 'EXAFY_ADMIN ONLY. One scan run by id.', parameters: { type: 'object', properties: { run_id: { type: 'string', description: 'Required.' } }, required: ['run_id'] } },
+  { name: 'dev_findings_queue', description: 'EXAFY_ADMIN ONLY. Findings queue.', parameters: { type: 'object', properties: { kind: { type: 'string' }, status: { type: 'string' }, risk: { type: 'string' }, domain: { type: 'string' }, sort: { type: 'string' }, limit: { type: 'number' } } } },
+  { name: 'dev_get_finding', description: 'EXAFY_ADMIN ONLY. One finding + plan versions.', parameters: { type: 'object', properties: { finding_id: { type: 'string', description: 'Required.' } }, required: ['finding_id'] } },
+  {
+    name: 'dev_generate_finding_plan',
+    description: 'EXAFY_ADMIN ONLY. Generate a fix plan for a finding. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { finding_id: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['finding_id'] },
+  },
+  {
+    name: 'dev_reject_finding',
+    description: 'EXAFY_ADMIN ONLY. Reject a finding. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { finding_id: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['finding_id'] },
+  },
+  {
+    name: 'dev_snooze_finding',
+    description: 'EXAFY_ADMIN ONLY. Snooze a finding for N hours (default 24, max 720).',
+    parameters: { type: 'object', properties: { finding_id: { type: 'string', description: 'Required.' }, hours: { type: 'number' } }, required: ['finding_id'] },
+  },
+  {
+    name: 'dev_approve_auto_execute',
+    description: 'EXAFY_ADMIN ONLY. Approve a finding for autonomous execution + merge, no further review. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { finding_id: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['finding_id'] },
+  },
+  {
+    name: 'dev_cancel_execution',
+    description: 'EXAFY_ADMIN ONLY. Cancel a running execution. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { execution_id: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['execution_id'] },
+  },
+  { name: 'dev_list_executions', description: 'EXAFY_ADMIN ONLY. List executions (defaults to active only).', parameters: { type: 'object', properties: { status: { type: 'string' }, limit: { type: 'number' } } } },
+  { name: 'dev_get_execution_lineage', description: 'EXAFY_ADMIN ONLY. Execution lineage (root + all descendants).', parameters: { type: 'object', properties: { execution_id: { type: 'string', description: 'Required.' } }, required: ['execution_id'] } },
+];

--- a/services/gateway/src/services/orb-tools/self-healing-tools.ts
+++ b/services/gateway/src/services/orb-tools/self-healing-tools.ts
@@ -1,0 +1,370 @@
+/**
+ * Developer voice tools — Self-Healing (C8), Wave 5 of
+ * docs/VOICE_TOOLS_EXPANSION_PLAN.md.
+ *
+ * Thin dispatch layer over routes/self-healing.ts (mounted at
+ * /api/v1/self-healing — served anonymously, no auth middleware at all;
+ * `developerGate()` is the only real access control) plus a "healing"
+ * subset of routes/voice-lab.ts (mounted at /api/v1/voice-lab, gated by
+ * requireAuth — those three forward id.user_jwt as Bearer).
+ *
+ * dev_report_incident uses the real POST /report endpoint's documented
+ * `routine-incident://<service>/<slug>` synthetic-endpoint convention —
+ * this is an existing, intentional pattern in the route (not invented).
+ * dev_verify_heal's backing route is a POST (a live blast-radius check),
+ * not a read, despite the plan labeling it R — it's non-destructive
+ * (verification only) so it isn't confirm-gated. dev_list_quarantine has
+ * no true "list all"; the only route is a single {class, signature} pair
+ * lookup, so both are required arguments here rather than a browsable list.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit, developerGate } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const NO_DEV_SESSION: OrbToolResult = {
+  ok: true,
+  result: { reason: 'no_dev_session' },
+  text: "This needs a signed-in session — I don't have one for this voice session.",
+};
+
+function authHeaders(id: OrbToolIdentity): Record<string, string> {
+  return id.user_jwt ? { Authorization: `Bearer ${id.user_jwt}` } : {};
+}
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60) || 'incident';
+}
+
+// ---------------------------------------------------------------------------
+// 1. dev_report_incident — POST /api/v1/self-healing/report
+// (uses the routine-incident:// synthetic-endpoint convention)
+// ---------------------------------------------------------------------------
+
+export const dev_report_incident: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const service = String(args.service ?? '').trim();
+  const summary = String(args.summary ?? '').trim();
+  if (!service || !summary) return { ok: false, error: 'dev_report_incident requires service and summary.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, service, summary },
+      text: `About to file an incident for "${service}": "${summary}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const endpoint = `routine-incident://${slugify(service)}/${slugify(summary)}`;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/self-healing/report', {
+    method: 'POST',
+    body: {
+      total: 1,
+      live: 0,
+      services: [{ service, endpoint, status: 'down', detail: summary }],
+    },
+  });
+  if (!ok) return { ok: true, result: { filed: false, status, detail: body }, text: `Could not file the incident: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  const vtids = (Array.isArray(body.details) ? body.details : []) as Array<{ vtid?: string }>;
+  const vtid = vtids.find((d) => d.vtid)?.vtid;
+  return { ok: true, result: { filed: true, detail: body }, text: vtid ? `Incident filed as ${vtid}.` : `Incident report submitted.` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. dev_healing_config — GET /api/v1/self-healing/config
+// ---------------------------------------------------------------------------
+
+export const dev_healing_config: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/self-healing/config');
+  if (!ok) return { ok: false, error: `dev_healing_config failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: `Self-healing is ${body.enabled ? 'enabled' : 'disabled'}, autonomy level ${Number(body.autonomy_level ?? 0)} (${String(body.autonomy_name ?? 'unknown')}).` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. dev_set_healing_mode — PATCH /api/v1/self-healing/config
+// ---------------------------------------------------------------------------
+
+export const dev_set_healing_mode: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const level = Number(args.autonomy_level);
+  if (!Number.isInteger(level) || level < 0 || level > 4) {
+    return { ok: false, error: 'dev_set_healing_mode requires autonomy_level, an integer 0-4.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, autonomy_level: level },
+      text: `About to set self-healing autonomy level to ${level}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/self-healing/config', {
+    method: 'PATCH',
+    body: { autonomy_level: level },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not change the autonomy level: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Self-healing autonomy level set to ${level} (${String(body.autonomy_name ?? '')}).` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. dev_healing_kill_switch — POST /api/v1/self-healing/kill-switch
+// ---------------------------------------------------------------------------
+
+export const dev_healing_kill_switch: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const action = String(args.action ?? '').trim();
+  if (!['activate', 'deactivate'].includes(action)) {
+    return { ok: false, error: 'dev_healing_kill_switch requires action: activate or deactivate.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, action },
+      text: `About to ${action} the self-healing kill switch. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/self-healing/kill-switch', {
+    method: 'POST',
+    body: { action, reason: typeof args.reason === 'string' ? args.reason : undefined },
+  });
+  if (!ok) return { ok: true, result: { changed: false, status, detail: body }, text: `Could not flip the kill switch: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { changed: true, detail: body }, text: `Self-healing kill switch is now ${String(body.status ?? action)}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. dev_healing_history — GET /api/v1/self-healing/history
+// ---------------------------------------------------------------------------
+
+export const dev_healing_history: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 50, 100);
+  const qs = new URLSearchParams({ limit: String(limit) });
+  if (typeof args.failure_class === 'string' && args.failure_class) qs.set('failure_class', args.failure_class);
+  if (typeof args.outcome === 'string' && args.outcome) qs.set('outcome', args.outcome);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/self-healing/history?${qs.toString()}`);
+  if (!ok) return { ok: false, error: `dev_healing_history failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const items = (Array.isArray(body.items) ? body.items : []) as unknown[];
+  if (items.length === 0) return { ok: true, result: { items: [] }, text: 'No healing history yet.' };
+  return { ok: true, result: { items, total: body.total }, text: `${items.length} of ${Number(body.total ?? items.length)} healing events.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. dev_healing_metrics — GET /api/v1/self-healing/metrics/summary
+// ---------------------------------------------------------------------------
+
+export const dev_healing_metrics: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const days = clampLimit(args.days, 7, 90);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/self-healing/metrics/summary?days=${days}`);
+  if (!ok) return { ok: false, error: `dev_healing_metrics failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body.metrics ?? body, text: `Self-healing metrics for the last ${days} days retrieved.` };
+};
+
+// ---------------------------------------------------------------------------
+// 7/8. dev_approve_heal / dev_reject_heal
+// ---------------------------------------------------------------------------
+
+async function decideHeal(args: OrbToolArgs, id: OrbToolIdentity, decision: 'approve' | 'reject'): Promise<OrbToolResult> {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const healId = String(args.heal_id ?? '').trim();
+  if (!healId) return { ok: false, error: `dev_${decision}_heal requires heal_id.` };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, heal_id: healId },
+      text: `About to ${decision} pending heal ${healId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/self-healing/${decision}`, {
+    method: 'POST',
+    body: { id: healId, reason: typeof args.reason === 'string' ? args.reason : undefined },
+  });
+  if (!ok) return { ok: true, result: { decided: false, status, detail: body }, text: `Could not ${decision} the heal: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { decided: true, detail: body }, text: `Heal ${healId} ${decision}d.` };
+}
+
+export const dev_approve_heal: Handler = async (args, id) => decideHeal(args, id, 'approve');
+export const dev_reject_heal: Handler = async (args, id) => decideHeal(args, id, 'reject');
+
+// ---------------------------------------------------------------------------
+// 9. dev_verify_heal — POST /api/v1/self-healing/verify/:vtid (inspection, no confirm)
+// ---------------------------------------------------------------------------
+
+export const dev_verify_heal: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const vtid = String(args.vtid ?? '').trim();
+  if (!vtid) return { ok: false, error: 'dev_verify_heal requires vtid.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/self-healing/verify/${encodeURIComponent(vtid)}`, { method: 'POST' });
+  if (!ok) return { ok: false, error: `dev_verify_heal failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body.result ?? body, text: `Blast-radius verification for ${vtid} complete.` };
+};
+
+// ---------------------------------------------------------------------------
+// 10. dev_rollback_heal — POST /api/v1/self-healing/rollback/:vtid
+// ---------------------------------------------------------------------------
+
+export const dev_rollback_heal: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const vtid = String(args.vtid ?? '').trim();
+  if (!vtid) return { ok: false, error: 'dev_rollback_heal requires vtid.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid },
+      text: `About to roll back the heal for ${vtid} to its pre-fix snapshot. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/self-healing/rollback/${encodeURIComponent(vtid)}`, { method: 'POST' });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { rolled_back: false, reason: 'no_snapshot' }, text: `No pre-fix snapshot exists for ${vtid} — nothing to roll back to.` }
+      : { ok: true, result: { rolled_back: false, status, detail: body }, text: `Could not roll back: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { rolled_back: true }, text: String(body.message ?? `${vtid} rolled back.`) };
+};
+
+// ---------------------------------------------------------------------------
+// 11. dev_list_quarantine — GET /api/v1/voice-lab/healing/quarantine (requires class+signature)
+// ---------------------------------------------------------------------------
+
+export const dev_list_quarantine: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const cls = String(args.failure_class ?? '').trim();
+  const signature = String(args.signature ?? '').trim();
+  if (!cls || !signature) {
+    return { ok: false, error: 'dev_list_quarantine requires both failure_class and signature — there is no "list all quarantined items" endpoint, only a single lookup.' };
+  }
+  const { ok, status, body } = await gatewayApiCall(
+    `/api/v1/voice-lab/healing/quarantine?class=${encodeURIComponent(cls)}&signature=${encodeURIComponent(signature)}`,
+    { headers: authHeaders(id) },
+  );
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No quarantine entry for that class/signature pair.` }
+      : { ok: false, error: `dev_list_quarantine failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return { ok: true, result: body, text: `Quarantine entry found for ${cls}/${signature}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 12. dev_release_quarantine — POST /api/v1/voice-lab/healing/quarantine/release
+// ---------------------------------------------------------------------------
+
+export const dev_release_quarantine: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const cls = String(args.failure_class ?? '').trim();
+  const signature = String(args.signature ?? '').trim();
+  if (!cls || !signature) return { ok: false, error: 'dev_release_quarantine requires failure_class and signature.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, failure_class: cls, signature },
+      text: `About to release ${cls}/${signature} from quarantine. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/voice-lab/healing/quarantine/release', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { class: cls, signature, reason: typeof args.reason === 'string' ? args.reason : undefined },
+  });
+  if (!ok) return { ok: true, result: { released: false, status, detail: body }, text: `Could not release from quarantine: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { released: true, detail: body }, text: `Released from quarantine — new status: ${String(body.new_status ?? 'unknown')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 13. dev_shadow_comparison — GET /api/v1/voice-lab/healing/shadow-comparison
+// ---------------------------------------------------------------------------
+
+export const dev_shadow_comparison: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const windowHours = clampLimit(args.window_hours, 48, 720);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/voice-lab/healing/shadow-comparison?window_hours=${windowHours}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_shadow_comparison failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: `Shadow comparison over the last ${windowHours}h: match rate ${Number(body.match_rate ?? 0)}.` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const SELF_HEALING_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_report_incident,
+  dev_healing_config,
+  dev_set_healing_mode,
+  dev_healing_kill_switch,
+  dev_healing_history,
+  dev_healing_metrics,
+  dev_approve_heal,
+  dev_reject_heal,
+  dev_verify_heal,
+  dev_rollback_heal,
+  dev_list_quarantine,
+  dev_release_quarantine,
+  dev_shadow_comparison,
+};
+
+export const SELF_HEALING_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'dev_report_incident',
+    description: 'DEVELOPER ONLY. File a manual incident for a service. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { service: { type: 'string', description: 'Required.' }, summary: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['service', 'summary'] },
+  },
+  { name: 'dev_healing_config', description: 'DEVELOPER ONLY. Self-healing enabled state + autonomy level.', parameters: { type: 'object', properties: {} } },
+  {
+    name: 'dev_set_healing_mode',
+    description: 'DEVELOPER ONLY. Set the self-healing autonomy level (0-4). TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { autonomy_level: { type: 'number', description: '0-4. Required.' }, confirm: { type: 'boolean' } }, required: ['autonomy_level'] },
+  },
+  {
+    name: 'dev_healing_kill_switch',
+    description: 'DEVELOPER ONLY. Activate or deactivate the self-healing kill switch. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { action: { type: 'string', description: 'activate or deactivate. Required.' }, reason: { type: 'string' }, confirm: { type: 'boolean' } }, required: ['action'] },
+  },
+  { name: 'dev_healing_history', description: 'DEVELOPER ONLY. Recent self-healing events.', parameters: { type: 'object', properties: { limit: { type: 'number' }, failure_class: { type: 'string' }, outcome: { type: 'string' } } } },
+  { name: 'dev_healing_metrics', description: 'DEVELOPER ONLY. Self-healing metrics summary over N days (default 7).', parameters: { type: 'object', properties: { days: { type: 'number' } } } },
+  {
+    name: 'dev_approve_heal',
+    description: 'DEVELOPER ONLY. Approve a pending heal. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { heal_id: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['heal_id'] },
+  },
+  {
+    name: 'dev_reject_heal',
+    description: 'DEVELOPER ONLY. Reject a pending heal. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { heal_id: { type: 'string', description: 'Required.' }, reason: { type: 'string' }, confirm: { type: 'boolean' } }, required: ['heal_id'] },
+  },
+  { name: 'dev_verify_heal', description: 'DEVELOPER ONLY. Run a blast-radius verification check for a heal.', parameters: { type: 'object', properties: { vtid: { type: 'string', description: 'Required.' } }, required: ['vtid'] } },
+  {
+    name: 'dev_rollback_heal',
+    description: 'DEVELOPER ONLY. Roll back a heal to its pre-fix snapshot. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { vtid: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['vtid'] },
+  },
+  {
+    name: 'dev_list_quarantine',
+    description: 'DEVELOPER ONLY. Look up a quarantine entry by failure class + signature (no browsable list exists).',
+    parameters: { type: 'object', properties: { failure_class: { type: 'string', description: 'Required.' }, signature: { type: 'string', description: 'Required.' } }, required: ['failure_class', 'signature'] },
+  },
+  {
+    name: 'dev_release_quarantine',
+    description: 'DEVELOPER ONLY. Release a class/signature pair from quarantine. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { failure_class: { type: 'string', description: 'Required.' }, signature: { type: 'string', description: 'Required.' }, reason: { type: 'string' }, confirm: { type: 'boolean' } }, required: ['failure_class', 'signature'] },
+  },
+  { name: 'dev_shadow_comparison', description: 'DEVELOPER ONLY. Staging shadow-comparison report over a time window (default 48h).', parameters: { type: 'object', properties: { window_hours: { type: 'number' } } } },
+];

--- a/services/gateway/src/services/orb-tools/testing-qa-tools.ts
+++ b/services/gateway/src/services/orb-tools/testing-qa-tools.ts
@@ -1,0 +1,265 @@
+/**
+ * Developer voice tools — Testing & QA (C10), Wave 5 of
+ * docs/VOICE_TOOLS_EXPANSION_PLAN.md.
+ *
+ * Thin dispatch layer over routes/testing.ts (mounted at /api/v1/testing,
+ * no HTTP auth — developerGate() is the real gate), routes/test-contracts.ts
+ * (mounted at /api/v1/test-contracts, requireDevAccess = exafy_admin),
+ * routes/orb-tools-selfcheck.ts (requireAuth + requireExafyAdmin), and
+ * routes/voice-lab.ts's /probe (requireAuth).
+ *
+ * dev_run_e2e shares its exact backend (POST /api/v1/testing/run) with
+ * dev_run_test_suite — there is no separate "trigger E2E workflow" route.
+ * Rather than duplicating business logic under a second name, it defaults
+ * `projects` to `['all']` when the caller doesn't specify a subset, giving
+ * it a distinct voice affordance ("run the full E2E suite") without
+ * inventing a second endpoint.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit, developerGate } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const NO_DEV_SESSION: OrbToolResult = {
+  ok: true,
+  result: { reason: 'no_dev_session' },
+  text: "This needs a signed-in session — I don't have one for this voice session.",
+};
+
+function authHeaders(id: OrbToolIdentity): Record<string, string> {
+  return id.user_jwt ? { Authorization: `Bearer ${id.user_jwt}` } : {};
+}
+
+function requireExafyAdmin(id: OrbToolIdentity): OrbToolResult | null {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (String(id.role ?? '').toLowerCase() !== 'exafy_admin') {
+    return { ok: false, error: 'This tool requires an exafy_admin session.' };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// 1/5. dev_run_test_suite / dev_run_e2e — both POST /api/v1/testing/run
+// ---------------------------------------------------------------------------
+
+async function runSuite(args: OrbToolArgs, id: OrbToolIdentity, defaultProjects: string[]): Promise<OrbToolResult> {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const projects = Array.isArray(args.projects) && args.projects.length > 0 ? args.projects : defaultProjects;
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, projects },
+      text: `About to run the test suite for: ${projects.join(', ')}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/testing/run', {
+    method: 'POST',
+    body: {
+      projects,
+      type: typeof args.type === 'string' ? args.type : undefined,
+      community_url: typeof args.community_url === 'string' ? args.community_url : undefined,
+    },
+  });
+  if (!ok) return { ok: true, result: { started: false, status, detail: body }, text: `Could not start the test run: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return {
+    ok: true,
+    result: { started: true, detail: body },
+    text: body.run_id ? `Test run ${body.run_id} started.` : `Test run dispatched via ${String(body.via ?? 'CI')}.`,
+  };
+}
+
+export const dev_run_test_suite: Handler = async (args, id) => runSuite(args, id, Array.isArray(args.projects) ? args.projects : []);
+export const dev_run_e2e: Handler = async (args, id) => runSuite(args, id, ['all']);
+
+// ---------------------------------------------------------------------------
+// 2. dev_list_test_suites — GET /api/v1/testing/suites
+// ---------------------------------------------------------------------------
+
+export const dev_list_test_suites: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/testing/suites');
+  if (!ok) return { ok: false, error: `dev_list_test_suites failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const suites = (Array.isArray(body.suites) ? body.suites : []) as unknown[];
+  return { ok: true, result: body, text: `${suites.length} test suites available.` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. dev_list_test_runs — GET /api/v1/testing/runs
+// ---------------------------------------------------------------------------
+
+export const dev_list_test_runs: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 50, 100);
+  const qs = new URLSearchParams({ limit: String(limit) });
+  if (typeof args.type === 'string' && args.type) qs.set('type', args.type);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/testing/runs?${qs.toString()}`);
+  if (!ok) return { ok: false, error: `dev_list_test_runs failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const runs = (Array.isArray(body.runs) ? body.runs : []) as unknown[];
+  if (runs.length === 0) return { ok: true, result: { runs: [] }, text: 'No test runs found.' };
+  return { ok: true, result: { runs }, text: `${runs.length} test runs.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. dev_get_test_run — GET /api/v1/testing/runs/:id
+// ---------------------------------------------------------------------------
+
+export const dev_get_test_run: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const runId = String(args.run_id ?? '').trim();
+  if (!runId) return { ok: false, error: 'dev_get_test_run requires run_id.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/testing/runs/${encodeURIComponent(runId)}`);
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No test run found with id ${runId}.` }
+      : { ok: false, error: `dev_get_test_run failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const results = (Array.isArray(body.results) ? body.results : []) as Array<{ status?: string }>;
+  const failed = results.filter((r) => r.status && r.status !== 'passed').length;
+  return { ok: true, result: body, text: `Run ${runId}: ${results.length} results, ${failed} not passed.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. dev_orb_monitor_status — GET /api/v1/testing/orb-monitor/status
+// ---------------------------------------------------------------------------
+
+export const dev_orb_monitor_status: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/testing/orb-monitor/status');
+  if (!ok) return { ok: false, error: `dev_orb_monitor_status failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const runs = (Array.isArray(body.runs) ? body.runs : []) as Array<{ conclusion?: string }>;
+  return { ok: true, result: body, text: `${runs.length} recent ORB monitor runs; latest: ${String(runs[0]?.conclusion ?? 'unknown')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 7. dev_trigger_orb_monitor — POST /api/v1/testing/orb-monitor/trigger
+// ---------------------------------------------------------------------------
+
+export const dev_trigger_orb_monitor: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true },
+      text: `About to trigger the ORB monitor workflow. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/testing/orb-monitor/trigger', { method: 'POST' });
+  if (!ok) return { ok: true, result: { triggered: false, status, detail: body }, text: `Could not trigger the ORB monitor: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { triggered: true }, text: `ORB monitor workflow triggered.` };
+};
+
+// ---------------------------------------------------------------------------
+// 8. dev_list_test_contracts — GET /api/v1/test-contracts (exafy_admin)
+// ---------------------------------------------------------------------------
+
+export const dev_list_test_contracts: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const qs = new URLSearchParams();
+  for (const k of ['service', 'environment', 'owner', 'status', 'contract_type'] as const) {
+    if (typeof args[k] === 'string' && args[k]) qs.set(k, args[k] as string);
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/test-contracts?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_list_test_contracts failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const contracts = (Array.isArray(body.contracts) ? body.contracts : []) as unknown[];
+  return { ok: true, result: { contracts }, text: `${contracts.length} test contracts.` };
+};
+
+// ---------------------------------------------------------------------------
+// 9. dev_run_orb_selfcheck — POST /api/v1/admin/orb-tools/selfcheck (exafy_admin)
+// ---------------------------------------------------------------------------
+
+export const dev_run_orb_selfcheck: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const targetUserId = String(args.user_id ?? id.user_id ?? '').trim();
+  if (!targetUserId) return { ok: false, error: 'dev_run_orb_selfcheck requires user_id.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, user_id: targetUserId },
+      text: `About to run the ORB tools selfcheck against real data for user ${targetUserId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/orb-tools/selfcheck', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { user_id: targetUserId, tools: Array.isArray(args.tools) ? args.tools : undefined },
+  });
+  if (!ok) return { ok: true, result: { ran: false, status, detail: body }, text: `Selfcheck failed to run: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  const summary = (body.summary ?? {}) as Record<string, unknown>;
+  return { ok: true, result: body, text: `Selfcheck: ${Number(summary.passed ?? 0)} of ${Number(summary.total ?? 0)} tools passed.` };
+};
+
+// ---------------------------------------------------------------------------
+// 10. dev_voice_lab_probe — POST /api/v1/voice-lab/probe (requireAuth)
+// ---------------------------------------------------------------------------
+
+export const dev_voice_lab_probe: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_DEV_SESSION;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/voice-lab/probe', { method: 'POST', headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_voice_lab_probe failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: body.ok === false ? `Probe failed: ${String(body.failure_mode_code ?? 'unknown')}.` : `Voice-lab probe passed.` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const TESTING_QA_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_run_test_suite,
+  dev_list_test_suites,
+  dev_list_test_runs,
+  dev_get_test_run,
+  dev_run_e2e,
+  dev_orb_monitor_status,
+  dev_trigger_orb_monitor,
+  dev_list_test_contracts,
+  dev_run_orb_selfcheck,
+  dev_voice_lab_probe,
+};
+
+export const TESTING_QA_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'dev_run_test_suite',
+    description: 'DEVELOPER ONLY. Run one or more named test suites/projects. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { projects: { type: 'array', items: { type: 'string' }, description: 'Required — suite/project names.' }, type: { type: 'string' }, community_url: { type: 'string' }, confirm: { type: 'boolean' } }, required: ['projects'] },
+  },
+  { name: 'dev_list_test_suites', description: 'DEVELOPER ONLY. List available test suites/projects.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_list_test_runs', description: 'DEVELOPER ONLY. Recent test runs.', parameters: { type: 'object', properties: { type: { type: 'string' }, limit: { type: 'number' } } } },
+  { name: 'dev_get_test_run', description: 'DEVELOPER ONLY. One test run + its results.', parameters: { type: 'object', properties: { run_id: { type: 'string', description: 'Required.' } }, required: ['run_id'] } },
+  {
+    name: 'dev_run_e2e',
+    description: 'DEVELOPER ONLY. Run the full E2E test suite. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { projects: { type: 'array', items: { type: 'string' }, description: 'Optional subset; defaults to all.' }, confirm: { type: 'boolean' } } },
+  },
+  { name: 'dev_orb_monitor_status', description: 'DEVELOPER ONLY. Recent ORB monitor workflow runs.', parameters: { type: 'object', properties: {} } },
+  {
+    name: 'dev_trigger_orb_monitor',
+    description: 'DEVELOPER ONLY. Trigger the ORB monitor workflow. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { confirm: { type: 'boolean' } } },
+  },
+  { name: 'dev_list_test_contracts', description: 'EXAFY_ADMIN ONLY. List registered test contracts.', parameters: { type: 'object', properties: { service: { type: 'string' }, environment: { type: 'string' }, owner: { type: 'string' }, status: { type: 'string' }, contract_type: { type: 'string' } } } },
+  {
+    name: 'dev_run_orb_selfcheck',
+    description: 'EXAFY_ADMIN ONLY. Run the curated ORB tools selfcheck against real user data. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { user_id: { type: 'string' }, tools: { type: 'array', items: { type: 'string' } }, confirm: { type: 'boolean' } } },
+  },
+  { name: 'dev_voice_lab_probe', description: 'DEVELOPER ONLY. Run a synthetic voice-lab probe.', parameters: { type: 'object', properties: {} } },
+];

--- a/services/gateway/src/services/orb-tools/worker-orchestrator-tools.ts
+++ b/services/gateway/src/services/orb-tools/worker-orchestrator-tools.ts
@@ -1,0 +1,248 @@
+/**
+ * Developer voice tools — Worker Orchestrator (C5), Wave 5 of
+ * docs/VOICE_TOOLS_EXPANSION_PLAN.md.
+ *
+ * Thin dispatch layer over routes/worker-orchestrator.ts (mounted at '/' —
+ * no path prefix, no HTTP-level auth middleware). `developerGate()` is
+ * therefore the ONLY real access control for these tools; treat it as
+ * mandatory on every handler.
+ *
+ * dev_get_task_progress is SKIPPED — the only progress-related route,
+ * POST /api/v1/worker/orchestrator/tasks/:vtid/progress, is write-only (it
+ * reports/emits a progress event and extends the claim); there is no GET
+ * that returns current progress state, so building a "read progress" tool
+ * against it would misrepresent a write as a read. Stays `status: planned`.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit, developerGate } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// 1. dev_list_workers — GET /api/v1/worker/orchestrator/workers
+// ---------------------------------------------------------------------------
+
+export const dev_list_workers: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/worker/orchestrator/workers');
+  if (!ok) return { ok: false, error: `dev_list_workers failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const workers = (Array.isArray(body.workers) ? body.workers : []) as Array<Record<string, unknown>>;
+  if (workers.length === 0) return { ok: true, result: { workers: [] }, text: 'No active workers registered.' };
+  return { ok: true, result: { workers }, text: `${workers.length} active workers.` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. dev_orchestrator_stats — GET /api/v1/worker/orchestrator/stats
+// ---------------------------------------------------------------------------
+
+export const dev_orchestrator_stats: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/worker/orchestrator/stats');
+  if (!ok) return { ok: false, error: `dev_orchestrator_stats failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body.stats ?? body, text: 'Orchestrator stats retrieved.' };
+};
+
+// ---------------------------------------------------------------------------
+// 3. dev_list_pending_worker_tasks — GET /api/v1/worker/orchestrator/tasks/pending
+// ---------------------------------------------------------------------------
+
+export const dev_list_pending_worker_tasks: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 100, 200);
+  const qs = new URLSearchParams({ limit: String(limit) });
+  if (typeof args.worker_id === 'string' && args.worker_id) qs.set('worker_id', args.worker_id);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/worker/orchestrator/tasks/pending?${qs.toString()}`);
+  if (!ok) return { ok: false, error: `dev_list_pending_worker_tasks failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const tasks = (Array.isArray(body.tasks) ? body.tasks : []) as Array<Record<string, unknown>>;
+  if (tasks.length === 0) return { ok: true, result: { tasks: [] }, text: 'No pending worker tasks.' };
+  return { ok: true, result: { tasks }, text: `${tasks.length} pending worker tasks.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. dev_release_claim — POST /api/v1/worker/orchestrator/tasks/:vtid/release
+// ---------------------------------------------------------------------------
+
+export const dev_release_claim: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const vtid = String(args.vtid ?? '').trim();
+  const workerId = String(args.worker_id ?? '').trim();
+  if (!vtid || !workerId) return { ok: false, error: 'dev_release_claim requires vtid and worker_id.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid, worker_id: workerId },
+      text: `About to release the claim on ${vtid} held by ${workerId}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/worker/orchestrator/tasks/${encodeURIComponent(vtid)}/release`, {
+    method: 'POST',
+    body: { worker_id: workerId, reason: typeof args.reason === 'string' ? args.reason : undefined },
+  });
+  if (!ok) return { ok: true, result: { released: false, status, detail: body }, text: `Could not release the claim: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { released: true, detail: body }, text: `Claim on ${vtid} released.` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. dev_list_subagents — GET /api/v1/worker/subagents (legacy registry)
+// ---------------------------------------------------------------------------
+
+export const dev_list_subagents: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/worker/subagents');
+  if (!ok) return { ok: false, error: `dev_list_subagents failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const subagents = (Array.isArray(body.subagents) ? body.subagents : []) as Array<Record<string, unknown>>;
+  if (subagents.length === 0) return { ok: true, result: { subagents: [] }, text: 'No subagents registered.' };
+  return { ok: true, result: { subagents }, text: `${subagents.length} subagents.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. dev_list_worker_skills — GET /api/v1/worker/skills
+// ---------------------------------------------------------------------------
+
+export const dev_list_worker_skills: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/worker/skills');
+  if (!ok) return { ok: false, error: `dev_list_worker_skills failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const skills = (Array.isArray(body.skills) ? body.skills : []) as unknown[];
+  return { ok: true, result: body, text: `${skills.length} worker skills registered.` };
+};
+
+// ---------------------------------------------------------------------------
+// 7. dev_cleanup_stale_claims — POST /api/v1/worker/orchestrator/cleanup
+// ---------------------------------------------------------------------------
+
+export const dev_cleanup_stale_claims: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true },
+      text: `About to expire all stale worker claims platform-wide. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/worker/orchestrator/cleanup', { method: 'POST' });
+  if (!ok) return { ok: true, result: { cleaned: false, status, detail: body }, text: `Cleanup failed: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { cleaned: true, expired_count: body.expired_count }, text: `${Number(body.expired_count ?? 0)} stale claims expired.` };
+};
+
+// ---------------------------------------------------------------------------
+// 8. dev_orchestrator_health — GET /api/v1/worker/orchestrator/health
+// ---------------------------------------------------------------------------
+
+export const dev_orchestrator_health: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/worker/orchestrator/health');
+  if (!ok) return { ok: false, error: `dev_orchestrator_health failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return { ok: true, result: body, text: `Orchestrator service: ${String(body.service ?? 'worker-orchestrator')}, ${Object.keys((body.subagents as object) ?? {}).length} subagent lanes.` };
+};
+
+// ---------------------------------------------------------------------------
+// 9. dev_route_to_subagent — POST /api/v1/worker/orchestrator/route
+// ---------------------------------------------------------------------------
+
+const TASK_DOMAINS = ['frontend', 'backend', 'memory', 'infra', 'ai', 'mixed'];
+
+export const dev_route_to_subagent: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const vtid = String(args.vtid ?? '').trim();
+  const title = String(args.title ?? '').trim();
+  if (!/^VTID-\d{4,}$/.test(vtid) || !title) {
+    return { ok: false, error: 'dev_route_to_subagent requires vtid (VTID-NNNN...) and title.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, vtid, title },
+      text: `About to route ${vtid} ("${title}") to a subagent for execution. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const taskDomain = typeof args.task_domain === 'string' && TASK_DOMAINS.includes(args.task_domain) ? args.task_domain : undefined;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/worker/orchestrator/route', {
+    method: 'POST',
+    body: {
+      vtid,
+      title,
+      task_family: typeof args.task_family === 'string' ? args.task_family : undefined,
+      task_domain: taskDomain,
+      target_paths: Array.isArray(args.target_paths) ? args.target_paths : undefined,
+      spec_content: typeof args.spec_content === 'string' ? args.spec_content : undefined,
+    },
+  });
+  if (!ok) {
+    const err = String(body.error ?? '');
+    if (err.includes('EXECUTION_DISARMED')) {
+      return { ok: true, result: { routed: false, reason: 'execution_disarmed' }, text: `Execution is currently disarmed platform-wide — nothing can be routed to a subagent right now.` };
+    }
+    if (err.includes('GOVERNANCE_BLOCKED')) {
+      return { ok: true, result: { routed: false, reason: 'governance_blocked', detail: body }, text: `Governance blocked this route: ${err}.` };
+    }
+    return { ok: true, result: { routed: false, status, detail: body }, text: `Could not route to a subagent: ${err || `gateway returned ${status}`}.` };
+  }
+  return { ok: true, result: { routed: true, detail: body }, text: `${vtid} routed to a subagent.` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const WORKER_ORCHESTRATOR_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_list_workers,
+  dev_orchestrator_stats,
+  dev_list_pending_worker_tasks,
+  dev_release_claim,
+  dev_list_subagents,
+  dev_list_worker_skills,
+  dev_cleanup_stale_claims,
+  dev_orchestrator_health,
+  dev_route_to_subagent,
+};
+
+export const WORKER_ORCHESTRATOR_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  { name: 'dev_list_workers', description: 'DEVELOPER ONLY. List registered orchestrator workers.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_orchestrator_stats', description: 'DEVELOPER ONLY. Worker connector stats.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_list_pending_worker_tasks', description: 'DEVELOPER ONLY. Pending worker task queue.', parameters: { type: 'object', properties: { worker_id: { type: 'string' }, limit: { type: 'number' } } } },
+  {
+    name: 'dev_release_claim',
+    description: 'DEVELOPER ONLY. Release a stuck VTID claim. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { vtid: { type: 'string', description: 'Required.' }, worker_id: { type: 'string', description: 'Required.' }, reason: { type: 'string' }, confirm: { type: 'boolean' } }, required: ['vtid', 'worker_id'] },
+  },
+  { name: 'dev_list_subagents', description: 'DEVELOPER ONLY. List legacy subagent registry entries.', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_list_worker_skills', description: 'DEVELOPER ONLY. Worker skills + preflight chains.', parameters: { type: 'object', properties: {} } },
+  {
+    name: 'dev_cleanup_stale_claims',
+    description: 'DEVELOPER ONLY. Expire all stale worker claims platform-wide. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { confirm: { type: 'boolean' } } },
+  },
+  { name: 'dev_orchestrator_health', description: 'DEVELOPER ONLY. Orchestrator service health + subagent lanes.', parameters: { type: 'object', properties: {} } },
+  {
+    name: 'dev_route_to_subagent',
+    description: 'DEVELOPER ONLY. Route a VTID work order to a subagent for execution. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        vtid: { type: 'string', description: 'VTID-NNNN format. Required.' },
+        title: { type: 'string', description: 'Required.' },
+        task_family: { type: 'string' },
+        task_domain: { type: 'string', description: 'frontend, backend, memory, infra, ai, or mixed.' },
+        target_paths: { type: 'array', items: { type: 'string' } },
+        spec_content: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['vtid', 'title'],
+    },
+  },
+];

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-13T00:41:26.079Z",
+  "generated_at": "2026-07-13T06:35:51.173Z",
   "source": "reconciled",
   "total": 594,
   "tools": [
@@ -8614,9 +8614,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Registered workers",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C5 Worker Orchestrator",
@@ -8631,9 +8634,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Stats",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C5 Worker Orchestrator",
@@ -8648,9 +8654,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Pending queue",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C5 Worker Orchestrator",
@@ -8682,9 +8691,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Release a stuck claim",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C5 Worker Orchestrator",
@@ -8699,9 +8711,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Subagents",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C5 Worker Orchestrator",
@@ -8716,9 +8731,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Skills",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C5 Worker Orchestrator",
@@ -8733,9 +8751,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Cleanup stale claims",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C5 Worker Orchestrator",
@@ -8750,9 +8771,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Health",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C5 Worker Orchestrator",
@@ -8767,9 +8791,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Route task to subagent",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C5 Worker Orchestrator",
@@ -8784,9 +8811,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Loop status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -8801,9 +8831,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Start loop",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -8818,9 +8851,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Stop loop",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -8835,9 +8871,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Loop history",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -8852,9 +8891,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Reset cursor",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -8869,9 +8911,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Controller status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -8886,9 +8931,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Runs",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -8903,9 +8951,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One run",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -8971,9 +9022,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Validate",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -8988,9 +9042,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Pending plans",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -9005,9 +9062,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Spec for VTID",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -9022,9 +9082,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Pipeline health + summary",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C6 Autopilot Controller & Loop",
@@ -9056,9 +9119,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Scanners",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9073,9 +9139,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Impact rules",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9090,9 +9159,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Auto-approve config",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9107,9 +9179,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Scan runs",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9124,9 +9199,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One run",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9141,9 +9219,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Findings queue",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9158,9 +9239,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One finding",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9175,9 +9259,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Generate fix plan",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9192,9 +9279,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Reject finding",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9209,9 +9299,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Snooze",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "write",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9226,9 +9319,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Approve auto-execution",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9243,9 +9339,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Cancel execution",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9260,9 +9359,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Executions",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9277,9 +9379,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Lineage",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C7 Dev-Autopilot Scanners & Findings",
@@ -9294,9 +9399,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "File an incident",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C8 Self-Healing",
@@ -9311,9 +9419,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Config",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C8 Self-Healing",
@@ -9328,9 +9439,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Change mode",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C8 Self-Healing",
@@ -9345,9 +9459,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Flip kill switch",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C8 Self-Healing",
@@ -9362,9 +9479,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Heal history",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C8 Self-Healing",
@@ -9379,9 +9499,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Metrics summary",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C8 Self-Healing",
@@ -9396,9 +9519,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Approve pending heal",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C8 Self-Healing",
@@ -9413,9 +9539,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Reject heal",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C8 Self-Healing",
@@ -9430,9 +9559,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Verify a heal",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C8 Self-Healing",
@@ -9447,9 +9579,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Roll back a heal",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C8 Self-Healing",
@@ -9464,9 +9599,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Quarantined items",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C8 Self-Healing",
@@ -9481,9 +9619,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Release from quarantine",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C8 Self-Healing",
@@ -9498,9 +9639,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Staging shadow-comparison report",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C8 Self-Healing",
@@ -9815,9 +9959,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Run a suite",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C10 Testing & QA",
@@ -9832,9 +9979,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Suites",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C10 Testing & QA",
@@ -9849,9 +9999,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Runs",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C10 Testing & QA",
@@ -9866,9 +10019,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One run + failures",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C10 Testing & QA",
@@ -9883,9 +10039,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Trigger E2E workflow",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C10 Testing & QA",
@@ -9900,9 +10059,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "ORB monitor status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C10 Testing & QA",
@@ -9917,9 +10079,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Trigger ORB monitor",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C10 Testing & QA",
@@ -9934,9 +10099,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Test contracts",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C10 Testing & QA",
@@ -9951,9 +10119,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "ORB tools selfcheck",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "confirm",
       "plan_domain": "C10 Testing & QA",
@@ -9968,9 +10139,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Voice-lab probe",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P1",
       "risk": "read",
       "plan_domain": "C10 Testing & QA",

--- a/services/gateway/test/orb-tools/autopilot-controller-tools.test.ts
+++ b/services/gateway/test/orb-tools/autopilot-controller-tools.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Developer Autopilot Controller & Loop voice tools (Wave 5, plan section
+ * C6) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  AUTOPILOT_CONTROLLER_TOOL_HANDLERS,
+  AUTOPILOT_CONTROLLER_TOOL_DECLARATIONS,
+  dev_autopilot_loop_status,
+  dev_start_autopilot_loop,
+  dev_reset_loop_cursor,
+  dev_get_controller_run,
+  dev_validate_task,
+  dev_get_task_spec,
+  dev_autopilot_pipeline_health,
+} from '../../src/services/orb-tools/autopilot-controller-tools';
+
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(AUTOPILOT_CONTROLLER_TOOL_HANDLERS);
+
+  it('exposes 12 tools (dev_plan_task/dev_start_task_work/dev_complete_task_work intentionally skipped)', () => {
+    expect(names).toHaveLength(12);
+    const declNames = AUTOPILOT_CONTROLLER_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await AUTOPILOT_CONTROLLER_TOOL_HANDLERS[name]({ vtid: 'VTID-0001' }, COMMUNITY_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await AUTOPILOT_CONTROLLER_TOOL_HANDLERS[name]({}, ANON_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_autopilot_loop_status', () => {
+  it('reports running state', async () => {
+    mockFetch(200, { is_running: true, errors_1h: 0 });
+    const r = await dev_autopilot_loop_status({}, DEV_ID, {} as SupabaseClient);
+    expect(r.text).toContain('running');
+  });
+});
+
+describe('dev_start_autopilot_loop', () => {
+  it('requires confirmation first', async () => {
+    const r = await dev_start_autopilot_loop({}, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+});
+
+describe('dev_reset_loop_cursor', () => {
+  it('defaults to "now" and requires confirmation first', async () => {
+    const r = await dev_reset_loop_cursor({}, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { timestamp: string }).timestamp).toBe('now');
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+});
+
+describe('dev_get_controller_run / dev_get_task_spec', () => {
+  it('dev_get_controller_run validates vtid format', async () => {
+    const r = await dev_get_controller_run({ vtid: 'bad' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('dev_get_controller_run reports honestly on 404', async () => {
+    mockFetch(404, { error: 'not_found' });
+    const r = await dev_get_controller_run({ vtid: 'VTID-0001' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { found: boolean }).found).toBe(false);
+  });
+
+  it('dev_get_task_spec reports honestly on 404', async () => {
+    mockFetch(404, { error: 'not_found' });
+    const r = await dev_get_task_spec({ vtid: 'VTID-0001' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { found: boolean }).found).toBe(false);
+  });
+});
+
+describe('dev_validate_task', () => {
+  it('reports the validation status', async () => {
+    mockFetch(200, { validation: { final_status: 'passed' } });
+    const r = await dev_validate_task({ vtid: 'VTID-0001' }, DEV_ID, {} as SupabaseClient);
+    expect(r.text).toContain('passed');
+  });
+});
+
+describe('dev_autopilot_pipeline_health', () => {
+  it('summarizes loop + execution + stuck tasks', async () => {
+    mockFetch(200, { loop_running: true, execution_armed: false, stuck_count: 2, workers_active: 1 });
+    const r = await dev_autopilot_pipeline_health({}, DEV_ID, {} as SupabaseClient);
+    expect(r.text).toContain('disarmed');
+    expect(r.text).toContain('2 stuck tasks');
+  });
+});

--- a/services/gateway/test/orb-tools/dev-autopilot-scanners-tools.test.ts
+++ b/services/gateway/test/orb-tools/dev-autopilot-scanners-tools.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Developer Dev-Autopilot Scanners & Findings voice tools (Wave 5, plan
+ * section C7) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS,
+  DEV_AUTOPILOT_SCANNERS_TOOL_DECLARATIONS,
+  dev_list_scanners,
+  dev_findings_queue,
+  dev_generate_finding_plan,
+  dev_snooze_finding,
+  dev_approve_auto_execute,
+} from '../../src/services/orb-tools/dev-autopilot-scanners-tools';
+
+const EXAFY_ID: OrbToolIdentity = { user_id: 'u-exafy', tenant_id: 't-1', role: 'exafy_admin', user_jwt: 'jwt-xyz' };
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer', user_jwt: 'jwt-dev' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'exafy_admin' };
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS);
+
+  it('exposes 14 tools (dev_trigger_scan intentionally skipped)', () => {
+    expect(names).toHaveLength(14);
+    const declNames = DEV_AUTOPILOT_SCANNERS_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS[name](
+      { finding_id: 'f1', run_id: 'r1', execution_id: 'e1' },
+      COMMUNITY_ID,
+      {} as SupabaseClient,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it.each(names)('%s rejects a plain developer session (exafy_admin only)', async (name) => {
+    const r = await DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS[name]({ finding_id: 'f1', run_id: 'r1', execution_id: 'e1' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('exafy_admin');
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS[name]({}, ANON_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_list_scanners', () => {
+  it('needs a session JWT', async () => {
+    const r = await dev_list_scanners({}, { ...EXAFY_ID, user_jwt: undefined }, {} as SupabaseClient);
+    expect((r.result as { reason: string }).reason).toBe('no_dev_session');
+  });
+
+  it('reports scanner count', async () => {
+    mockFetch(200, { scanners: [{ id: 's1' }, { id: 's2' }] });
+    const r = await dev_list_scanners({}, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('2 scanners');
+  });
+});
+
+describe('dev_findings_queue', () => {
+  it('reports queue count', async () => {
+    mockFetch(200, { findings: [{ id: 'f1' }] });
+    const r = await dev_findings_queue({}, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('1 findings');
+  });
+});
+
+describe('dev_generate_finding_plan / dev_approve_auto_execute', () => {
+  it('generate_finding_plan requires confirmation first', async () => {
+    const r = await dev_generate_finding_plan({ finding_id: 'f1' }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('approve_auto_execute requires confirmation first', async () => {
+    const r = await dev_approve_auto_execute({ finding_id: 'f1' }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+});
+
+describe('dev_snooze_finding', () => {
+  it('is not confirm-gated (low-risk toggle)', async () => {
+    mockFetch(200, { ok: true });
+    const r = await dev_snooze_finding({ finding_id: 'f1', hours: 48 }, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('48 hours');
+  });
+});

--- a/services/gateway/test/orb-tools/self-healing-tools.test.ts
+++ b/services/gateway/test/orb-tools/self-healing-tools.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Developer Self-Healing voice tools (Wave 5, plan section C8) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  SELF_HEALING_TOOL_HANDLERS,
+  SELF_HEALING_TOOL_DECLARATIONS,
+  dev_report_incident,
+  dev_set_healing_mode,
+  dev_healing_kill_switch,
+  dev_verify_heal,
+  dev_rollback_heal,
+  dev_list_quarantine,
+} from '../../src/services/orb-tools/self-healing-tools';
+
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer', user_jwt: 'jwt-dev' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(SELF_HEALING_TOOL_HANDLERS);
+
+  it('exposes all 13 tools with matching declarations', () => {
+    expect(names).toHaveLength(13);
+    const declNames = SELF_HEALING_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await SELF_HEALING_TOOL_HANDLERS[name](
+      { service: 's', summary: 'x', autonomy_level: 2, action: 'activate', heal_id: 'h1', vtid: 'VTID-0001', failure_class: 'fc', signature: 'sig' },
+      COMMUNITY_ID,
+      {} as SupabaseClient,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await SELF_HEALING_TOOL_HANDLERS[name]({}, ANON_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_report_incident', () => {
+  it('requires service and summary', async () => {
+    const r = await dev_report_incident({}, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await dev_report_incident({ service: 'gateway', summary: 'high latency' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('files using the routine-incident:// convention on confirm', async () => {
+    const fn = mockFetch(200, { total: 1, live: 0, details: [{ vtid: 'VTID-9999' }] });
+    const r = await dev_report_incident({ service: 'gateway', summary: 'high latency', confirm: true }, DEV_ID, {} as SupabaseClient);
+    expect(r.text).toContain('VTID-9999');
+    const call = fn.mock.calls[0];
+    const body = JSON.parse(call[1].body);
+    expect(body.services[0].endpoint).toMatch(/^routine-incident:\/\//);
+  });
+});
+
+describe('dev_set_healing_mode', () => {
+  it('validates autonomy_level range', async () => {
+    const r = await dev_set_healing_mode({ autonomy_level: 9 }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await dev_set_healing_mode({ autonomy_level: 2 }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+});
+
+describe('dev_healing_kill_switch', () => {
+  it('validates action', async () => {
+    const r = await dev_healing_kill_switch({ action: 'bogus' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_verify_heal', () => {
+  it('is not confirm-gated (verification only)', async () => {
+    mockFetch(200, { result: { verified: true } });
+    const r = await dev_verify_heal({ vtid: 'VTID-0001' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(true);
+    expect(r.text).toContain('VTID-0001');
+  });
+});
+
+describe('dev_rollback_heal', () => {
+  it('requires confirmation first', async () => {
+    const r = await dev_rollback_heal({ vtid: 'VTID-0001' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('reports honestly when no snapshot exists', async () => {
+    mockFetch(404, { error: 'not_found' });
+    const r = await dev_rollback_heal({ vtid: 'VTID-0001', confirm: true }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { reason: string }).reason).toBe('no_snapshot');
+  });
+});
+
+describe('dev_list_quarantine', () => {
+  it('requires both failure_class and signature', async () => {
+    const r = await dev_list_quarantine({ failure_class: 'fc' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('needs a session JWT', async () => {
+    const r = await dev_list_quarantine({ failure_class: 'fc', signature: 'sig' }, { ...DEV_ID, user_jwt: undefined }, {} as SupabaseClient);
+    expect((r.result as { reason: string }).reason).toBe('no_dev_session');
+  });
+});

--- a/services/gateway/test/orb-tools/testing-qa-tools.test.ts
+++ b/services/gateway/test/orb-tools/testing-qa-tools.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Developer Testing & QA voice tools (Wave 5, plan section C10) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  TESTING_QA_TOOL_HANDLERS,
+  TESTING_QA_TOOL_DECLARATIONS,
+  dev_run_test_suite,
+  dev_run_e2e,
+  dev_get_test_run,
+  dev_list_test_contracts,
+  dev_run_orb_selfcheck,
+  dev_voice_lab_probe,
+} from '../../src/services/orb-tools/testing-qa-tools';
+
+const EXAFY_ID: OrbToolIdentity = { user_id: 'u-exafy', tenant_id: 't-1', role: 'exafy_admin', user_jwt: 'jwt-xyz' };
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer', user_jwt: 'jwt-dev' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(TESTING_QA_TOOL_HANDLERS);
+
+  it('exposes all 10 tools with matching declarations', () => {
+    expect(names).toHaveLength(10);
+    const declNames = TESTING_QA_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await TESTING_QA_TOOL_HANDLERS[name](
+      { projects: ['all'], run_id: 'r1', user_id: 'u1' },
+      COMMUNITY_ID,
+      {} as SupabaseClient,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await TESTING_QA_TOOL_HANDLERS[name]({}, ANON_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_run_test_suite / dev_run_e2e', () => {
+  it('dev_run_test_suite requires confirmation first', async () => {
+    const r = await dev_run_test_suite({ projects: ['desktop-suite'] }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('dev_run_e2e defaults to "all" projects', async () => {
+    const r = await dev_run_e2e({}, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { projects: string[] }).projects).toEqual(['all']);
+  });
+
+  it('starts the run on confirm', async () => {
+    mockFetch(200, { run_id: 'run-1', status: 'running' });
+    const r = await dev_run_test_suite({ projects: ['desktop-suite'], confirm: true }, DEV_ID, {} as SupabaseClient);
+    expect(r.text).toContain('run-1');
+  });
+});
+
+describe('dev_get_test_run', () => {
+  it('requires run_id', async () => {
+    const r = await dev_get_test_run({}, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports honestly on 404', async () => {
+    mockFetch(404, { error: 'not_found' });
+    const r = await dev_get_test_run({ run_id: 'r1' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { found: boolean }).found).toBe(false);
+  });
+});
+
+describe('exafy_admin-only tools', () => {
+  it('dev_list_test_contracts rejects a plain developer session', async () => {
+    const r = await dev_list_test_contracts({}, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('exafy_admin');
+  });
+
+  it('dev_run_orb_selfcheck requires confirmation first for exafy_admin', async () => {
+    const r = await dev_run_orb_selfcheck({ user_id: 'u1' }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+});
+
+describe('dev_voice_lab_probe', () => {
+  it('needs a session JWT', async () => {
+    const r = await dev_voice_lab_probe({}, { ...DEV_ID, user_jwt: undefined }, {} as SupabaseClient);
+    expect((r.result as { reason: string }).reason).toBe('no_dev_session');
+  });
+
+  it('reports probe failure honestly', async () => {
+    mockFetch(200, { ok: false, failure_mode_code: 'timeout' });
+    const r = await dev_voice_lab_probe({}, DEV_ID, {} as SupabaseClient);
+    expect(r.text).toContain('timeout');
+  });
+});

--- a/services/gateway/test/orb-tools/worker-orchestrator-tools.test.ts
+++ b/services/gateway/test/orb-tools/worker-orchestrator-tools.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Developer Worker Orchestrator voice tools (Wave 5, plan section C5) —
+ * unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  WORKER_ORCHESTRATOR_TOOL_HANDLERS,
+  WORKER_ORCHESTRATOR_TOOL_DECLARATIONS,
+  dev_list_workers,
+  dev_release_claim,
+  dev_cleanup_stale_claims,
+  dev_route_to_subagent,
+} from '../../src/services/orb-tools/worker-orchestrator-tools';
+
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(WORKER_ORCHESTRATOR_TOOL_HANDLERS);
+
+  it('exposes 9 tools with matching declarations (dev_get_task_progress intentionally skipped)', () => {
+    expect(names).toHaveLength(9);
+    const declNames = WORKER_ORCHESTRATOR_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await WORKER_ORCHESTRATOR_TOOL_HANDLERS[name](
+      { vtid: 'VTID-0001', worker_id: 'w1', title: 'x' },
+      COMMUNITY_ID,
+      {} as SupabaseClient,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await WORKER_ORCHESTRATOR_TOOL_HANDLERS[name]({}, ANON_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_list_workers', () => {
+  it('reports active workers', async () => {
+    mockFetch(200, { workers: [{ id: 'w1' }] });
+    const r = await dev_list_workers({}, DEV_ID, {} as SupabaseClient);
+    expect(r.text).toContain('1 active workers');
+  });
+});
+
+describe('dev_release_claim', () => {
+  it('requires vtid and worker_id', async () => {
+    const r = await dev_release_claim({}, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await dev_release_claim({ vtid: 'VTID-0001', worker_id: 'w1' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+});
+
+describe('dev_cleanup_stale_claims', () => {
+  it('requires confirmation first', async () => {
+    const r = await dev_cleanup_stale_claims({}, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('reports the expired count on confirm', async () => {
+    mockFetch(200, { expired_count: 3 });
+    const r = await dev_cleanup_stale_claims({ confirm: true }, DEV_ID, {} as SupabaseClient);
+    expect(r.text).toContain('3 stale claims');
+  });
+});
+
+describe('dev_route_to_subagent', () => {
+  it('validates vtid format and title', async () => {
+    const r = await dev_route_to_subagent({ vtid: 'bad', title: 'x' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await dev_route_to_subagent({ vtid: 'VTID-0001', title: 'Fix bug' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('surfaces EXECUTION_DISARMED honestly', async () => {
+    mockFetch(403, { error: 'EXECUTION_DISARMED' });
+    const r = await dev_route_to_subagent({ vtid: 'VTID-0001', title: 'Fix bug', confirm: true }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { reason: string }).reason).toBe('execution_disarmed');
+  });
+});

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -8264,6 +8264,905 @@ Optionally filter by tier (service, embedded, scheduled). Speak problem agents f
         },
       },
       {
+        "description": "DEVELOPER ONLY. List registered orchestrator workers.",
+        "name": "dev_list_workers",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Worker connector stats.",
+        "name": "dev_orchestrator_stats",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Pending worker task queue.",
+        "name": "dev_list_pending_worker_tasks",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "number",
+            },
+            "worker_id": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Release a stuck VTID claim. TWO-STEP confirm.",
+        "name": "dev_release_claim",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "reason": {
+              "type": "string",
+            },
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "worker_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "worker_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List legacy subagent registry entries.",
+        "name": "dev_list_subagents",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Worker skills + preflight chains.",
+        "name": "dev_list_worker_skills",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Expire all stale worker claims platform-wide. TWO-STEP confirm.",
+        "name": "dev_cleanup_stale_claims",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Orchestrator service health + subagent lanes.",
+        "name": "dev_orchestrator_health",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Route a VTID work order to a subagent for execution. TWO-STEP confirm.",
+        "name": "dev_route_to_subagent",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "spec_content": {
+              "type": "string",
+            },
+            "target_paths": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "task_domain": {
+              "description": "frontend, backend, memory, infra, ai, or mixed.",
+              "type": "string",
+            },
+            "task_family": {
+              "type": "string",
+            },
+            "title": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "vtid": {
+              "description": "VTID-NNNN format. Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+            "title",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Autopilot event loop status.",
+        "name": "dev_autopilot_loop_status",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Start the autopilot event loop. TWO-STEP confirm.",
+        "name": "dev_start_autopilot_loop",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Stop the autopilot event loop. TWO-STEP confirm.",
+        "name": "dev_stop_autopilot_loop",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent autopilot loop events.",
+        "name": "dev_autopilot_loop_history",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Reset the autopilot loop cursor to a timestamp (or "now"). TWO-STEP confirm.",
+        "name": "dev_reset_loop_cursor",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "reason": {
+              "type": "string",
+            },
+            "timestamp": {
+              "description": "ISO timestamp or "now". Defaults to "now".",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Autopilot controller status.",
+        "name": "dev_controller_status",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Active controller runs.",
+        "name": "dev_list_controller_runs",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. One controller run by VTID.",
+        "name": "dev_get_controller_run",
+        "parameters": {
+          "properties": {
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Run governance validation for a VTID.",
+        "name": "dev_validate_task",
+        "parameters": {
+          "properties": {
+            "mode": {
+              "type": "string",
+            },
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Tasks awaiting a plan.",
+        "name": "dev_list_pending_plans",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Spec snapshot for a VTID.",
+        "name": "dev_get_task_spec",
+        "parameters": {
+          "properties": {
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Autopilot pipeline health + task funnel summary.",
+        "name": "dev_autopilot_pipeline_health",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. List dev-autopilot scanners.",
+        "name": "dev_list_scanners",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. List impact rules.",
+        "name": "dev_list_impact_rules",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Auto-approve config, budget, and autonomy progress.",
+        "name": "dev_get_auto_approve_config",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Recent scan runs.",
+        "name": "dev_list_scan_runs",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. One scan run by id.",
+        "name": "dev_get_scan_run",
+        "parameters": {
+          "properties": {
+            "run_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "run_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Findings queue.",
+        "name": "dev_findings_queue",
+        "parameters": {
+          "properties": {
+            "domain": {
+              "type": "string",
+            },
+            "kind": {
+              "type": "string",
+            },
+            "limit": {
+              "type": "number",
+            },
+            "risk": {
+              "type": "string",
+            },
+            "sort": {
+              "type": "string",
+            },
+            "status": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. One finding + plan versions.",
+        "name": "dev_get_finding",
+        "parameters": {
+          "properties": {
+            "finding_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "finding_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Generate a fix plan for a finding. TWO-STEP confirm.",
+        "name": "dev_generate_finding_plan",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "finding_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "finding_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Reject a finding. TWO-STEP confirm.",
+        "name": "dev_reject_finding",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "finding_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "finding_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Snooze a finding for N hours (default 24, max 720).",
+        "name": "dev_snooze_finding",
+        "parameters": {
+          "properties": {
+            "finding_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "hours": {
+              "type": "number",
+            },
+          },
+          "required": [
+            "finding_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Approve a finding for autonomous execution + merge, no further review. TWO-STEP confirm.",
+        "name": "dev_approve_auto_execute",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "finding_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "finding_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Cancel a running execution. TWO-STEP confirm.",
+        "name": "dev_cancel_execution",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "execution_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "execution_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. List executions (defaults to active only).",
+        "name": "dev_list_executions",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "number",
+            },
+            "status": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Execution lineage (root + all descendants).",
+        "name": "dev_get_execution_lineage",
+        "parameters": {
+          "properties": {
+            "execution_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "execution_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. File a manual incident for a service. TWO-STEP confirm.",
+        "name": "dev_report_incident",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "service": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "summary": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "service",
+            "summary",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Self-healing enabled state + autonomy level.",
+        "name": "dev_healing_config",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Set the self-healing autonomy level (0-4). TWO-STEP confirm.",
+        "name": "dev_set_healing_mode",
+        "parameters": {
+          "properties": {
+            "autonomy_level": {
+              "description": "0-4. Required.",
+              "type": "number",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+          },
+          "required": [
+            "autonomy_level",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Activate or deactivate the self-healing kill switch. TWO-STEP confirm.",
+        "name": "dev_healing_kill_switch",
+        "parameters": {
+          "properties": {
+            "action": {
+              "description": "activate or deactivate. Required.",
+              "type": "string",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "reason": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "action",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent self-healing events.",
+        "name": "dev_healing_history",
+        "parameters": {
+          "properties": {
+            "failure_class": {
+              "type": "string",
+            },
+            "limit": {
+              "type": "number",
+            },
+            "outcome": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Self-healing metrics summary over N days (default 7).",
+        "name": "dev_healing_metrics",
+        "parameters": {
+          "properties": {
+            "days": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Approve a pending heal. TWO-STEP confirm.",
+        "name": "dev_approve_heal",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "heal_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "heal_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Reject a pending heal. TWO-STEP confirm.",
+        "name": "dev_reject_heal",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "heal_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "reason": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "heal_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Run a blast-radius verification check for a heal.",
+        "name": "dev_verify_heal",
+        "parameters": {
+          "properties": {
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Roll back a heal to its pre-fix snapshot. TWO-STEP confirm.",
+        "name": "dev_rollback_heal",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "vtid": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "vtid",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Look up a quarantine entry by failure class + signature (no browsable list exists).",
+        "name": "dev_list_quarantine",
+        "parameters": {
+          "properties": {
+            "failure_class": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "signature": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "failure_class",
+            "signature",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Release a class/signature pair from quarantine. TWO-STEP confirm.",
+        "name": "dev_release_quarantine",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "failure_class": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "reason": {
+              "type": "string",
+            },
+            "signature": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "failure_class",
+            "signature",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Staging shadow-comparison report over a time window (default 48h).",
+        "name": "dev_shadow_comparison",
+        "parameters": {
+          "properties": {
+            "window_hours": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Run one or more named test suites/projects. TWO-STEP confirm.",
+        "name": "dev_run_test_suite",
+        "parameters": {
+          "properties": {
+            "community_url": {
+              "type": "string",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "projects": {
+              "description": "Required — suite/project names.",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "type": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "projects",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. List available test suites/projects.",
+        "name": "dev_list_test_suites",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent test runs.",
+        "name": "dev_list_test_runs",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "number",
+            },
+            "type": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. One test run + its results.",
+        "name": "dev_get_test_run",
+        "parameters": {
+          "properties": {
+            "run_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "run_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Run the full E2E test suite. TWO-STEP confirm.",
+        "name": "dev_run_e2e",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "projects": {
+              "description": "Optional subset; defaults to all.",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent ORB monitor workflow runs.",
+        "name": "dev_orb_monitor_status",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Trigger the ORB monitor workflow. TWO-STEP confirm.",
+        "name": "dev_trigger_orb_monitor",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. List registered test contracts.",
+        "name": "dev_list_test_contracts",
+        "parameters": {
+          "properties": {
+            "contract_type": {
+              "type": "string",
+            },
+            "environment": {
+              "type": "string",
+            },
+            "owner": {
+              "type": "string",
+            },
+            "service": {
+              "type": "string",
+            },
+            "status": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Run the curated ORB tools selfcheck against real user data. TWO-STEP confirm.",
+        "name": "dev_run_orb_selfcheck",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "tools": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "user_id": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Run a synthetic voice-lab probe.",
+        "name": "dev_voice_lab_probe",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
         "description": "ADMIN ONLY. Find a user by name, email, or vitana_id.",
         "name": "admin_lookup_user",
         "parameters": {


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-VOICE-CATALOG-WAVE-5`

**Layer:** AGTL (voice/agent tooling)

**Priority:** P1

---

## 📋 Summary

Wave 5 of the approved 425-tool Voice Tools Expansion Plan v2
(`docs/VOICE_TOOLS_EXPANSION_PLAN.md`), continuing directly from the merged
Wave 4 (#2877). Builds out the Developer P1 domains: 58 net-new tools
wired end-to-end (5 tools deliberately skipped and documented, see below).

---

## ✅ Changes

- [x] C5 Worker Orchestrator (9 of 10) — `worker-orchestrator-tools.ts`
- [x] C6 Autopilot Controller & Loop (12 of 15) — `autopilot-controller-tools.ts`
- [x] C7 Dev-Autopilot Scanners & Findings (14 of 15) — `dev-autopilot-scanners-tools.ts`
- [x] C8 Self-Healing (13 of 13) — `self-healing-tools.ts`
- [x] C10 Testing & QA (10 of 10) — `testing-qa-tools.ts`

**Wiring:**
- [x] All 5 modules spread into `ORB_TOOL_REGISTRY`
- [x] Declarations added to `DEVELOPER_DOMAIN_TOOL_DECLARATIONS` (all Wave 5 tools are developer/exafy_admin-gated)
- [x] 58 new `@function_tool` wrappers + `all_tool_names()` entries in `services/agents/orb-agent/src/orb_agent/tools.py`
- [x] `tool-manifest.json` reconciled (594 tools total, 58 flipped planned→live)

**Deliberately left `status: planned` (5 tools, no fabricated backend/governance bypass):**
- `dev_get_task_progress` (C5) — the only progress route is write-only (reports/extends a claim); no read endpoint exists.
- `dev_plan_task`, `dev_start_task_work`, `dev_complete_task_work` (C6) — their routes are explicitly deprecated (VTID-01170) and gated behind the `X-BYPASS-ORCHESTRATOR: EMERGENCY-BYPASS` header. Wiring a voice tool to silently set that header on every routine call would turn an emergency-only escape hatch into normal behavior. The canonical, non-deprecated replacements already exist as other tools (`dev_route_to_subagent` from this same wave; `dev_run_exec_workflow`/`dev_submit_evidence` from Wave 2).
- `dev_trigger_scan` (C7) — its only route is gated by a CI-only scan token (`X-DevAutopilot-Scan-Token`), not interactive developer auth; there's no user-facing "run a scanner now" endpoint.

---

## 🧪 Testing

- [x] Automated tests added: 5 new Jest files, 177 tests, all passing
- [x] `tsc --noEmit` clean
- [x] Full gateway Jest suite green except the pre-existing, unrelated `nav-manifest-sync.test.ts` failure (requires a separate `vitana-v1` checkout — not touched by this PR)
- [x] `voice-tools-manifest-reconcile.mjs --check`/`--apply` — 58 tools, matches expected Wave 5 count exactly
- [x] `orb-tools-lift-scanner.mjs` — no drift detected
- [x] Characterization snapshot (`tool-catalog`) updated to reflect the new declarations
- [ ] Manual/staging verification (post-merge, per repo's staging-first CI/CD protocol)

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] N/A — no workflow files touched

### File Names
- [x] All new files follow kebab-case
- [x] No files violate naming canon

### Code Standards
- [x] Event/status conventions unaffected (no new OASIS events emitted by this wave)

### Cloud Run Deployments
- [x] N/A — no deploy/infra changes

### Documentation
- [x] VTID referenced in commit message and PR title

---

## 🚨 Breaking Changes

None. Purely additive — new tool handlers registered in the shared dispatcher; no existing tool behavior changed.

---

## 📌 Additional Notes

Continues the "merge and keep building" authorization from prior waves.
Following merge, the branch will restart from `origin/main` and Wave 6
(the final wave — community A13/A14, admin B10/B16, developer C11/C12 —
all remaining P2 tools) begins immediately, completing all six waves of
the plan.

Expect the `VALIDATOR-CHECK.yml` CI check to fail (non-blocking, same as
every prior wave, if it runs at all) since no `docs/validation/<VTID>/`
evidence pack was fabricated for a VTID that doesn't exist in the OASIS
ledger.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX)_