### PR TITLE
Wave 6 of Voice Tools Expansion Plan v2 — 37 final tools (VOICE-CATALOG-WAVE-6)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -5633,6 +5633,300 @@ async def dev_voice_lab_probe(context: RunContext) -> str:
 
 
 # ---------------------------------------------------------------------------
+# WAVE-6-VOICE-CATALOG-V2 — sixth and final wave of the approved 425-tool
+# expansion. Implementations live in services/gateway/src/services/orb-tools/*.ts,
+# reached through the shared dispatcher via POST /api/v1/orb/tool exactly
+# like the tools above.
+# ---------------------------------------------------------------------------
+
+
+# --- B10 Admin Specialists / Personas (9) -----------------------------------
+
+
+@function_tool
+async def admin_list_specialists(context: RunContext) -> str:
+    """ADMIN ONLY. List specialist personas."""
+    body = await _dispatch(context, "admin_list_specialists", {})
+    return summarize(body)
+
+
+@function_tool
+async def admin_get_specialist(context: RunContext, key: str) -> str:
+    """ADMIN ONLY. One persona + version history."""
+    body = await _dispatch(context, "admin_get_specialist", {"key": key})
+    return summarize(body)
+
+
+@function_tool
+async def admin_create_specialist(context: RunContext, key: str, display_name: str, role: str, system_prompt: str, voice_id: str | None = None, handles_kinds: list[str] | None = None, status: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Create a new specialist persona. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_create_specialist", {
+            "key": key, "display_name": display_name, "role": role, "system_prompt": system_prompt,
+            "voice_id": voice_id, "handles_kinds": handles_kinds, "status": status, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_update_specialist(context: RunContext, key: str, display_name: str | None = None, role: str | None = None, system_prompt: str | None = None, status: str | None = None, change_note: str | None = None, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Edit a specialist persona (snapshots the prior version). TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_update_specialist", {
+            "key": key, "display_name": display_name, "role": role, "system_prompt": system_prompt,
+            "status": status, "change_note": change_note, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def admin_rollback_specialist(context: RunContext, key: str, version: int, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Roll back a specialist to a prior version. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_rollback_specialist", {"key": key, "version": version, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_set_specialist_tools(context: RunContext, key: str, tool_keys: list[str], confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Replace the set of voice tools bound to a specialist. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_set_specialist_tools", {"key": key, "tool_keys": tool_keys, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_set_specialist_kb(context: RunContext, key: str, kb_keys: list[str], confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Replace the set of knowledge-base scopes bound to a specialist. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_set_specialist_kb", {"key": key, "kb_keys": kb_keys, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_set_specialist_status(context: RunContext, key: str, enabled: bool, confirm: bool | None = None) -> str:
+    """ADMIN ONLY. Enable or disable a specialist (the "vitana" persona can never be disabled). TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_set_specialist_status", {"key": key, "enabled": enabled, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_test_specialist_connection(context: RunContext, connection_id: str) -> str:
+    """ADMIN ONLY. Test a specialist's third-party connection (stub providers only today)."""
+    body = await _dispatch(context, "admin_test_specialist_connection", {"connection_id": connection_id})
+    return summarize(body)
+
+
+# --- B16 Admin Audit & Memory Ops (4) ---------------------------------------
+
+
+@function_tool
+async def admin_audit_actions_log(context: RunContext, limit: int | None = None, action: str | None = None) -> str:
+    """ADMIN ONLY. Recent admin actions audit log."""
+    body = await _dispatch(context, "admin_audit_actions_log", {"limit": limit, "action": action})
+    return summarize(body)
+
+
+@function_tool
+async def admin_audit_access_log(context: RunContext, limit: int | None = None) -> str:
+    """ADMIN ONLY. Recent login/logout/role-change access events."""
+    body = await _dispatch(context, "admin_audit_access_log", {"limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def admin_run_memory_consolidator(context: RunContext, user_id: str | None = None, tenant_id: str | None = None, loops: list[str] | None = None, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Run the nightly memory consolidator on demand. TWO-STEP confirm."""
+    body = await _dispatch(context, "admin_run_memory_consolidator", {"user_id": user_id, "tenant_id": tenant_id, "loops": loops, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def admin_run_embeddings_backfill(context: RunContext, batch_size: int | None = None, dry_run: bool | None = None, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Backfill missing memory_items embeddings. TWO-STEP confirm (dry_run=true skips confirmation)."""
+    body = await _dispatch(context, "admin_run_embeddings_backfill", {"batch_size": batch_size, "dry_run": dry_run, "confirm": confirm})
+    return summarize(body)
+
+
+# --- A13 Memory & Diary extras + A14 Profile & Social depth (10) -----------
+
+
+@function_tool
+async def edit_memory(context: RunContext, memory_item_id: str, new_content: str, correction_notes: str | None = None, confirm: bool | None = None) -> str:
+    """Correct the content of a stored memory. TWO-STEP confirm."""
+    body = await _dispatch(context, "edit_memory", {"memory_item_id": memory_item_id, "new_content": new_content, "correction_notes": correction_notes, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def reinforce_memory(context: RunContext, memory_item_id: str, confirmation_notes: str | None = None) -> str:
+    """Confirm a memory as accurate and trustworthy (raises its confidence score)."""
+    body = await _dispatch(context, "reinforce_memory", {"memory_item_id": memory_item_id, "confirmation_notes": confirmation_notes})
+    return summarize(body)
+
+
+@function_tool
+async def set_memory_permissions(context: RunContext, domain: str, visibility: str, confirm: bool | None = None) -> str:
+    """Set who can see a category of your memory (diary, garden, relationships, longevity, timeline). TWO-STEP confirm."""
+    body = await _dispatch(context, "set_memory_permissions", {"domain": domain, "visibility": visibility, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def get_what_vitana_knows(context: RunContext) -> str:
+    """"What do you know about me" — summary of your memory garden by category."""
+    body = await _dispatch(context, "get_what_vitana_knows", {})
+    return summarize(body)
+
+
+@function_tool
+async def add_diary_photo(context: RunContext) -> str:
+    """Opens the diary screen so you can attach a photo (voice cannot upload directly)."""
+    body = await _dispatch_with_directive(context, "add_diary_photo", {})
+    return summarize(body)
+
+
+@function_tool
+async def get_profile_completeness(context: RunContext) -> str:
+    """Your taste/lifestyle profile completeness percentage."""
+    body = await _dispatch(context, "get_profile_completeness", {})
+    return summarize(body)
+
+
+@function_tool
+async def share_my_profile(context: RunContext) -> str:
+    """Get your shareable profile link."""
+    body = await _dispatch(context, "share_my_profile", {})
+    return summarize(body)
+
+
+@function_tool
+async def get_my_milestones(context: RunContext, limit: int | None = None) -> str:
+    """Your achieved milestones."""
+    body = await _dispatch(context, "get_my_milestones", {"limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def view_member_profile(context: RunContext, user_id: str | None = None, handle: str | None = None) -> str:
+    """Spoken summary of a community member's public profile."""
+    body = await _dispatch(context, "view_member_profile", {"user_id": user_id, "handle": handle})
+    return summarize(body)
+
+
+@function_tool
+async def update_service_offerings(context: RunContext, offers: list[dict] | None = None, confirm: bool | None = None) -> str:
+    """Replace the service offerings shown on your profile. TWO-STEP confirm."""
+    body = await _dispatch(context, "update_service_offerings", {"offers": offers, "confirm": confirm})
+    return summarize(body)
+
+
+# --- C11 Database & Migrations (4) ------------------------------------------
+
+
+@function_tool
+async def dev_run_staging_migration(context: RunContext, migration_file: str, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Apply a SQL migration file to STAGING. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_run_staging_migration", {"migration_file": migration_file, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_run_prod_migration(context: RunContext, migration_file: str, reason: str, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY. Apply a SQL migration file DIRECTLY TO PRODUCTION. Requires a stated reason. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_run_prod_migration", {"migration_file": migration_file, "reason": reason, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_migration_status(context: RunContext, target: str | None = None, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Recent staging or production migration workflow runs."""
+    body = await _dispatch(context, "dev_migration_status", {"target": target, "limit": limit})
+    return summarize(body)
+
+
+@function_tool
+async def dev_run_backfill(context: RunContext, name: str, locales: str | None = None, curriculum: str | None = None, limit: int | None = None, batch_size: int | None = None, dry_run: bool | None = None, confirm: bool | None = None) -> str:
+    """DEVELOPER ONLY (embeddings additionally requires exafy_admin). Run a named backfill job: "journey_translations" or "embeddings". TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_run_backfill", {
+            "name": name, "locales": locales, "curriculum": curriculum, "limit": limit,
+            "batch_size": batch_size, "dry_run": dry_run, "confirm": confirm,
+        })
+    return summarize(body)
+
+
+# --- C12 Dev Access, Simulator & Meta (10) ----------------------------------
+
+
+@function_tool
+async def dev_list_dev_users(context: RunContext, query: str | None = None) -> str:
+    """EXAFY_ADMIN ONLY. List users with exafy_admin dev-hub access."""
+    body = await _dispatch(context, "dev_list_dev_users", {"query": query})
+    return summarize(body)
+
+
+@function_tool
+async def dev_grant_access(context: RunContext, email: str, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Grant exafy_admin dev-hub access to a user by email. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_grant_access", {"email": email, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_revoke_access(context: RunContext, email: str, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Revoke exafy_admin dev-hub access from a user by email. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_revoke_access", {"email": email, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_mint_token(context: RunContext, email: str, role: str, tenant_id: str | None = None, confirm: bool | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Mint a dev-sandbox session token for a user. TWO-STEP confirm."""
+    body = await _dispatch(context, "dev_mint_token", {"email": email, "role": role, "tenant_id": tenant_id, "confirm": confirm})
+    return summarize(body)
+
+
+@function_tool
+async def dev_open_hub_panel(context: RunContext, screen_id: str) -> str:
+    """DEVELOPER ONLY. Navigate to a Command Hub screen/panel by screen_id."""
+    body = await _dispatch_with_directive(context, "dev_open_hub_panel", {"screen_id": screen_id})
+    return summarize(body)
+
+
+@function_tool
+async def dev_run_simulator(context: RunContext, user_id: str, lang: str | None = None, timezone: str | None = None, bucket: str | None = None, first_time: bool | None = None, briefing_due: bool | None = None, current_route: str | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Dry-run the conversation-opening decision for a user, without speaking or emitting."""
+    body = await _dispatch(context, "dev_run_simulator", {
+            "user_id": user_id, "lang": lang, "timezone": timezone, "bucket": bucket,
+            "first_time": first_time, "briefing_due": briefing_due, "current_route": current_route,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def dev_journey_context(context: RunContext, user_id: str, tenant_id: str | None = None) -> str:
+    """EXAFY_ADMIN ONLY. Durable assistant-state signals stored for a user (journey/onboarding context)."""
+    body = await _dispatch(context, "dev_journey_context", {"user_id": user_id, "tenant_id": tenant_id})
+    return summarize(body)
+
+
+@function_tool
+async def dev_voice_catalog_stats(context: RunContext) -> str:
+    """DEVELOPER ONLY. Aggregate counts of this voice tool catalog."""
+    body = await _dispatch(context, "dev_voice_catalog_stats", {})
+    return summarize(body)
+
+
+@function_tool
+async def dev_get_voice_tool_detail(context: RunContext, name: str) -> str:
+    """DEVELOPER ONLY. Full manifest entry for one voice tool by name."""
+    body = await _dispatch(context, "dev_get_voice_tool_detail", {"name": name})
+    return summarize(body)
+
+
+@function_tool
+async def dev_system_briefing(context: RunContext, limit: int | None = None) -> str:
+    """DEVELOPER ONLY. Combined roll-up: service health, deployments, approvals, violations, CI/CD health."""
+    body = await _dispatch(context, "dev_system_briefing", {"limit": limit})
+    return summarize(body)
+
+
+# ---------------------------------------------------------------------------
 # Catalogue export — used by tests + libcst smoke
 # ---------------------------------------------------------------------------
 
@@ -5918,6 +6212,25 @@ def all_tool_names() -> list[str]:
         "dev_get_test_run", "dev_run_e2e", "dev_orb_monitor_status",
         "dev_trigger_orb_monitor", "dev_list_test_contracts", "dev_run_orb_selfcheck",
         "dev_voice_lab_probe",
+        # WAVE-6-VOICE-CATALOG-V2 — final wave (37)
+        # B10 Admin Specialists / Personas (9)
+        "admin_list_specialists", "admin_get_specialist", "admin_create_specialist",
+        "admin_update_specialist", "admin_rollback_specialist", "admin_set_specialist_tools",
+        "admin_set_specialist_kb", "admin_set_specialist_status", "admin_test_specialist_connection",
+        # B16 Admin Audit & Memory Ops (4)
+        "admin_audit_actions_log", "admin_audit_access_log", "admin_run_memory_consolidator",
+        "admin_run_embeddings_backfill",
+        # A13 Memory & Diary extras + A14 Profile & Social depth (10)
+        "edit_memory", "reinforce_memory", "set_memory_permissions", "get_what_vitana_knows",
+        "add_diary_photo", "get_profile_completeness", "share_my_profile", "get_my_milestones",
+        "view_member_profile", "update_service_offerings",
+        # C11 Database & Migrations (4)
+        "dev_run_staging_migration", "dev_run_prod_migration", "dev_migration_status",
+        "dev_run_backfill",
+        # C12 Dev Access, Simulator & Meta (10)
+        "dev_list_dev_users", "dev_grant_access", "dev_revoke_access", "dev_mint_token",
+        "dev_open_hub_panel", "dev_run_simulator", "dev_journey_context",
+        "dev_voice_catalog_stats", "dev_get_voice_tool_detail", "dev_system_briefing",
     ]
 
 

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -62,6 +62,14 @@ FRONTEND_DEPLOY_REPO=exafyltd/vitana-v1
 # product_analytics_events (default on; set to "false" to disable)
 PRODUCT_ANALYTICS_ROLLUP_ENABLED=true
 
+# Dev-sandbox-only auth (routes/dev-auth.ts POST /api/v1/dev/auth/token,
+# /request-context; also read by orb-tools/dev-access-simulator-meta-tools.ts'
+# dev_mint_token voice tool). Gated behind isDevSandbox() AND this shared
+# secret via the X-DEV-SECRET header — both checks must pass. OPTIONAL:
+# unset means the routes/tool always report DEV_AUTH_DISABLED /
+# no_dev_secret. Never set this in staging or production.
+DEV_AUTH_SECRET=
+
 # VCAOP Shopify own-store catalog sync.
 # Pulls a Shopify store's public products.json into the /discover catalog
 # (own-store products: full margin; prices converted to EUR at the fixed peg).

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -94,6 +94,15 @@ import { AUTOPILOT_CONTROLLER_TOOL_HANDLERS, AUTOPILOT_CONTROLLER_TOOL_DECLARATI
 import { DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS, DEV_AUTOPILOT_SCANNERS_TOOL_DECLARATIONS } from './orb-tools/dev-autopilot-scanners-tools';
 import { SELF_HEALING_TOOL_HANDLERS, SELF_HEALING_TOOL_DECLARATIONS } from './orb-tools/self-healing-tools';
 import { TESTING_QA_TOOL_HANDLERS, TESTING_QA_TOOL_DECLARATIONS } from './orb-tools/testing-qa-tools';
+// WAVE-6-VOICE-CATALOG-V2 — sixth and final wave of the approved 425-tool
+// expansion: admin specialists/personas, admin audit & memory ops, community
+// memory/diary extras + profile/social depth, developer database &
+// migrations, and developer access/simulator/meta.
+import { ADMIN_SPECIALISTS_TOOL_HANDLERS, ADMIN_SPECIALISTS_TOOL_DECLARATIONS } from './orb-tools/admin-specialists-tools';
+import { ADMIN_AUDIT_MEMORY_OPS_TOOL_HANDLERS, ADMIN_AUDIT_MEMORY_OPS_TOOL_DECLARATIONS } from './orb-tools/admin-audit-memory-ops-tools';
+import { MEMORY_DIARY_SOCIAL_TOOL_HANDLERS, MEMORY_DIARY_SOCIAL_TOOL_DECLARATIONS } from './orb-tools/memory-diary-social-tools';
+import { DATABASE_MIGRATIONS_TOOL_HANDLERS, DATABASE_MIGRATIONS_TOOL_DECLARATIONS } from './orb-tools/database-migrations-tools';
+import { DEV_ACCESS_SIMULATOR_META_TOOL_HANDLERS, DEV_ACCESS_SIMULATOR_META_TOOL_DECLARATIONS } from './orb-tools/dev-access-simulator-meta-tools';
 import {
   lookupScreen,
   lookupByAlias,
@@ -5224,6 +5233,12 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   ...DEV_AUTOPILOT_SCANNERS_TOOL_HANDLERS,
   ...SELF_HEALING_TOOL_HANDLERS,
   ...TESTING_QA_TOOL_HANDLERS,
+  // WAVE-6-VOICE-CATALOG-V2
+  ...ADMIN_SPECIALISTS_TOOL_HANDLERS,
+  ...ADMIN_AUDIT_MEMORY_OPS_TOOL_HANDLERS,
+  ...MEMORY_DIARY_SOCIAL_TOOL_HANDLERS,
+  ...DATABASE_MIGRATIONS_TOOL_HANDLERS,
+  ...DEV_ACCESS_SIMULATOR_META_TOOL_HANDLERS,
 };
 
 // BOOTSTRAP-VOICE-CATALOG-COMPLETE — combined Vertex/Gemini function
@@ -5254,6 +5269,8 @@ export const NEW_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
   ...LIVE_ROOMS_TOOL_DECLARATIONS,
   ...FEED_GOALS_TOOL_DECLARATIONS,
   ...BUSINESS_HUB_TOOL_DECLARATIONS,
+  // WAVE-6-VOICE-CATALOG-V2 (community)
+  ...MEMORY_DIARY_SOCIAL_TOOL_DECLARATIONS,
 ];
 
 // Developer tools are role-gated the same way ADMIN_TOOL_SCHEMAS is —
@@ -5274,6 +5291,9 @@ export const DEVELOPER_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> 
   ...DEV_AUTOPILOT_SCANNERS_TOOL_DECLARATIONS,
   ...SELF_HEALING_TOOL_DECLARATIONS,
   ...TESTING_QA_TOOL_DECLARATIONS,
+  // WAVE-6-VOICE-CATALOG-V2
+  ...DATABASE_MIGRATIONS_TOOL_DECLARATIONS,
+  ...DEV_ACCESS_SIMULATOR_META_TOOL_DECLARATIONS,
 ];
 
 // WAVE-3-VOICE-CATALOG-V2 — admin_* declarations, injected by
@@ -5291,6 +5311,9 @@ export const ADMIN_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
   ...ADMIN_OVERSIGHT_BILLING_TOOL_DECLARATIONS,
   ...ADMIN_KB_ASSISTANT_TOOL_DECLARATIONS,
   ...ADMIN_AUTOPILOT_ANALYTICS_TOOL_DECLARATIONS,
+  // WAVE-6-VOICE-CATALOG-V2
+  ...ADMIN_SPECIALISTS_TOOL_DECLARATIONS,
+  ...ADMIN_AUDIT_MEMORY_OPS_TOOL_DECLARATIONS,
 ];
 
 export const ORB_TOOL_NAMES = Object.keys(ORB_TOOL_REGISTRY);

--- a/services/gateway/src/services/orb-tools/admin-audit-memory-ops-tools.ts
+++ b/services/gateway/src/services/orb-tools/admin-audit-memory-ops-tools.ts
@@ -1,0 +1,162 @@
+/**
+ * Admin voice tools — Audit, i18n & Memory Ops (B16), Wave 6 (final wave)
+ * of docs/VOICE_TOOLS_EXPANSION_PLAN.md.
+ *
+ * Thin dispatch layer over routes/tenant-admin/audit-log.ts (requireTenantAdmin),
+ * routes/admin-memory-broker.ts (requireAuth + requireExafyAdmin), and
+ * routes/admin-embeddings-backfill.ts (requireAuth + requireExafyAdmin).
+ *
+ * admin_i18n_translate and admin_i18n_audit are SKIPPED. `translate-keys.mjs`
+ * and the `i18n-audit-llm.yml` workflow referenced in vitana-v1's CLAUDE.md
+ * live in the separate frontend repo — this gateway (vitana-platform) has no
+ * route, script, or workflow that wires up either job. There's a generic
+ * `dev_trigger_workflow` (Wave 2) that can dispatch any named workflow, but
+ * pointing it at a workflow that doesn't exist in this repo would silently
+ * fail rather than run a translation job; not built here. Both stay
+ * `status: planned`.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit } from './developer-tools';
+import { adminGate, authHeaders, NO_ADMIN_SESSION } from './admin-users-rbac-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+function requireExafyAdmin(id: OrbToolIdentity): OrbToolResult | null {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (String(id.role ?? '').toLowerCase() !== 'exafy_admin') {
+    return { ok: false, error: 'This tool requires an exafy_admin session (operator-only).' };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// 1. admin_audit_actions_log — GET .../audit/actions
+// ---------------------------------------------------------------------------
+
+export const admin_audit_actions_log: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt || !id.tenant_id) return NO_ADMIN_SESSION;
+  const limit = clampLimit(args.limit, 50, 200);
+  const qs = new URLSearchParams({ limit: String(limit) });
+  if (typeof args.action === 'string' && args.action) qs.set('action', args.action);
+  const { ok, status, body } = await gatewayApiCall(
+    `/api/v1/admin/tenants/${encodeURIComponent(id.tenant_id)}/audit/actions?${qs.toString()}`,
+    { headers: authHeaders(id) },
+  );
+  if (!ok) return { ok: false, error: `admin_audit_actions_log failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const actions = (Array.isArray(body.actions) ? body.actions : []) as unknown[];
+  if (actions.length === 0) return { ok: true, result: { actions: [] }, text: 'No admin actions logged.' };
+  return { ok: true, result: { actions }, text: `${actions.length} admin actions logged.` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. admin_audit_access_log — GET .../audit/access
+// ---------------------------------------------------------------------------
+
+export const admin_audit_access_log: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt || !id.tenant_id) return NO_ADMIN_SESSION;
+  const limit = clampLimit(args.limit, 50, 200);
+  const { ok, status, body } = await gatewayApiCall(
+    `/api/v1/admin/tenants/${encodeURIComponent(id.tenant_id)}/audit/access?limit=${limit}`,
+    { headers: authHeaders(id) },
+  );
+  if (!ok) return { ok: false, error: `admin_audit_access_log failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const accessLog = (Array.isArray(body.access_log) ? body.access_log : []) as unknown[];
+  if (accessLog.length === 0) return { ok: true, result: { access_log: [] }, text: 'No access events logged.' };
+  return { ok: true, result: { access_log: accessLog }, text: `${accessLog.length} access events logged.` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. admin_run_memory_consolidator — POST /api/v1/admin/consolidator/run
+// ---------------------------------------------------------------------------
+
+export const admin_run_memory_consolidator: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const targetUserId = typeof args.user_id === 'string' ? args.user_id.trim() : undefined;
+  const targetTenantId = typeof args.tenant_id === 'string' ? args.tenant_id.trim() : undefined;
+  const scoped = Boolean(targetUserId && targetTenantId);
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, scope: scoped ? { user_id: targetUserId, tenant_id: targetTenantId } : 'all_users' },
+      text: scoped
+        ? `About to run the memory consolidator for user ${targetUserId}. Confirm, then call again with confirm=true.`
+        : `About to run the memory consolidator across ALL users — this is a heavy platform-wide sweep. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/consolidator/run', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: {
+      tenant_id: targetTenantId,
+      user_id: targetUserId,
+      loops: Array.isArray(args.loops) ? args.loops : undefined,
+    },
+  });
+  if (!ok) return { ok: true, result: { ran: false, status, detail: body }, text: `Consolidator run failed to start: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: body, text: `Consolidator run ${String(body.run_id ?? '')}: ${String(body.status ?? 'unknown')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. admin_run_embeddings_backfill — POST /api/v1/admin/embeddings/backfill
+// ---------------------------------------------------------------------------
+
+export const admin_run_embeddings_backfill: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const batchSize = clampLimit(args.batch_size, 50, 200);
+  const dryRun = args.dry_run === true;
+  if (!dryRun && args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, batch_size: batchSize },
+      text: `About to backfill embeddings for up to ${batchSize} memory items. Confirm, then call again with confirm=true (or pass dry_run=true to preview without confirming).`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/embeddings/backfill', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { batch_size: batchSize, dry_run: dryRun },
+  });
+  if (!ok) return { ok: true, result: { ran: false, status, detail: body }, text: `Backfill failed: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  if (dryRun) return { ok: true, result: body, text: `Dry run: would process ${Number(body.would_process ?? 0)} items.` };
+  return { ok: true, result: body, text: `Backfilled ${Number(body.processed_count ?? 0)} items, ${Number(body.errors_count ?? 0)} errors.` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const ADMIN_AUDIT_MEMORY_OPS_TOOL_HANDLERS: Record<string, Handler> = {
+  admin_audit_actions_log,
+  admin_audit_access_log,
+  admin_run_memory_consolidator,
+  admin_run_embeddings_backfill,
+};
+
+export const ADMIN_AUDIT_MEMORY_OPS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  { name: 'admin_audit_actions_log', description: 'ADMIN ONLY. Recent admin actions audit log.', parameters: { type: 'object', properties: { limit: { type: 'number' }, action: { type: 'string' } } } },
+  { name: 'admin_audit_access_log', description: 'ADMIN ONLY. Recent login/logout/role-change access events.', parameters: { type: 'object', properties: { limit: { type: 'number' } } } },
+  {
+    name: 'admin_run_memory_consolidator',
+    description: 'EXAFY_ADMIN ONLY. Run the nightly memory consolidator on demand — scope to one user, or omit for a heavy all-users sweep. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { user_id: { type: 'string' }, tenant_id: { type: 'string' }, loops: { type: 'array', items: { type: 'string' } }, confirm: { type: 'boolean' } } },
+  },
+  {
+    name: 'admin_run_embeddings_backfill',
+    description: 'EXAFY_ADMIN ONLY. Backfill missing memory_items embeddings. TWO-STEP confirm (dry_run=true skips confirmation).',
+    parameters: { type: 'object', properties: { batch_size: { type: 'number', description: '1-200, default 50.' }, dry_run: { type: 'boolean' }, confirm: { type: 'boolean' } } },
+  },
+];

--- a/services/gateway/src/services/orb-tools/admin-specialists-tools.ts
+++ b/services/gateway/src/services/orb-tools/admin-specialists-tools.ts
@@ -1,0 +1,340 @@
+/**
+ * Admin voice tools — Specialists / Personas (B10), Wave 6 (final wave) of
+ * docs/VOICE_TOOLS_EXPANSION_PLAN.md.
+ *
+ * Thin dispatch layer over routes/specialists-admin.ts +
+ * specialists-connections.ts (mounted at /api/v1/admin/specialists). Those
+ * routes only check for a valid Bearer JWT (`ensureAuth`) — there is no
+ * server-side role check at all. `adminGate()` here is therefore the only
+ * real access control for these tools; treat it as mandatory.
+ *
+ * admin_approve_specialist_ticket is SKIPPED — there is no
+ * specialist/persona lifecycle-ticket table or route anywhere in the
+ * codebase. The only "approve a ticket" endpoints operate on the unrelated
+ * general feedback pipeline (`feedback_tickets`), not personas. Faking this
+ * against the wrong table would misrepresent what gets approved. Stays
+ * `status: planned`.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { gatewayApiCall, clampLimit } from './developer-tools';
+import { adminGate, authHeaders, NO_ADMIN_SESSION } from './admin-users-rbac-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const KEY_PATTERN = /^[a-z][a-z0-9_]{1,31}$/;
+
+// ---------------------------------------------------------------------------
+// 1. admin_list_specialists — GET /api/v1/admin/specialists
+// ---------------------------------------------------------------------------
+
+export const admin_list_specialists: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/specialists', { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `admin_list_specialists failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const personas = (Array.isArray(body.personas) ? body.personas : []) as Array<Record<string, unknown>>;
+  return { ok: true, result: { personas }, text: `${personas.length} specialist personas.` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. admin_get_specialist — GET /api/v1/admin/specialists/:key
+// ---------------------------------------------------------------------------
+
+export const admin_get_specialist: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const key = String(args.key ?? '').trim();
+  if (!key) return { ok: false, error: 'admin_get_specialist requires key.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/specialists/${encodeURIComponent(key)}`, { headers: authHeaders(id) });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No specialist persona found with key "${key}".` }
+      : { ok: false, error: `admin_get_specialist failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  return { ok: true, result: body, text: `Specialist "${key}" retrieved.` };
+};
+
+// ---------------------------------------------------------------------------
+// 3. admin_create_specialist — POST /api/v1/admin/specialists
+// ---------------------------------------------------------------------------
+
+export const admin_create_specialist: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const key = String(args.key ?? '').trim();
+  const displayName = String(args.display_name ?? '').trim();
+  const role = String(args.role ?? '').trim();
+  const systemPrompt = String(args.system_prompt ?? '').trim();
+  if (!KEY_PATTERN.test(key) || !displayName || !role || !systemPrompt) {
+    return { ok: false, error: 'admin_create_specialist requires key (lowercase, starts with a letter), display_name, role, and system_prompt.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, key, display_name: displayName },
+      text: `About to create specialist persona "${key}" ("${displayName}"). Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/admin/specialists', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: {
+      key,
+      display_name: displayName,
+      role,
+      system_prompt: systemPrompt,
+      voice_id: typeof args.voice_id === 'string' ? args.voice_id : undefined,
+      handles_kinds: Array.isArray(args.handles_kinds) ? args.handles_kinds : undefined,
+      status: typeof args.status === 'string' ? args.status : undefined,
+    },
+  });
+  if (!ok) {
+    if (status === 409) return { ok: true, result: { created: false, reason: 'key_taken' }, text: `A specialist with key "${key}" already exists.` };
+    return { ok: true, result: { created: false, status, detail: body }, text: `Could not create the specialist: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { created: true, detail: body }, text: `Specialist "${key}" created.` };
+};
+
+// ---------------------------------------------------------------------------
+// 4. admin_update_specialist — PUT /api/v1/admin/specialists/:key
+// ---------------------------------------------------------------------------
+
+export const admin_update_specialist: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const key = String(args.key ?? '').trim();
+  if (!key) return { ok: false, error: 'admin_update_specialist requires key.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, key },
+      text: `About to update specialist "${key}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/specialists/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    headers: authHeaders(id),
+    body: {
+      display_name: typeof args.display_name === 'string' ? args.display_name : undefined,
+      role: typeof args.role === 'string' ? args.role : undefined,
+      system_prompt: typeof args.system_prompt === 'string' ? args.system_prompt : undefined,
+      handles_kinds: Array.isArray(args.handles_kinds) ? args.handles_kinds : undefined,
+      status: typeof args.status === 'string' ? args.status : undefined,
+      change_note: typeof args.change_note === 'string' ? args.change_note : undefined,
+    },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update "${key}": ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Specialist "${key}" updated.` };
+};
+
+// ---------------------------------------------------------------------------
+// 5. admin_rollback_specialist — POST /api/v1/admin/specialists/:key/rollback/:version
+// ---------------------------------------------------------------------------
+
+export const admin_rollback_specialist: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const key = String(args.key ?? '').trim();
+  const version = Number(args.version);
+  if (!key || !Number.isInteger(version)) return { ok: false, error: 'admin_rollback_specialist requires key and version (integer).' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, key, version },
+      text: `About to roll back specialist "${key}" to version ${version}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/specialists/${encodeURIComponent(key)}/rollback/${version}`, {
+    method: 'POST',
+    headers: authHeaders(id),
+  });
+  if (!ok) return { ok: true, result: { rolled_back: false, status, detail: body }, text: `Could not roll back "${key}": ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { rolled_back: true, detail: body }, text: `Specialist "${key}" rolled back to version ${version}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 6. admin_set_specialist_tools — PUT /api/v1/admin/specialists/:key/tools
+// ---------------------------------------------------------------------------
+
+export const admin_set_specialist_tools: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const key = String(args.key ?? '').trim();
+  const keys = Array.isArray(args.tool_keys) ? args.tool_keys : [];
+  if (!key || keys.length === 0) return { ok: false, error: 'admin_set_specialist_tools requires key and a non-empty tool_keys array.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, key, tool_keys: keys },
+      text: `About to bind ${keys.length} tools to specialist "${key}" (replaces existing bindings). Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/specialists/${encodeURIComponent(key)}/tools`, {
+    method: 'PUT',
+    headers: authHeaders(id),
+    body: { keys },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not bind tools to "${key}": ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, bindings: body.bindings }, text: `${keys.length} tools bound to "${key}".` };
+};
+
+// ---------------------------------------------------------------------------
+// 7. admin_set_specialist_kb — PUT /api/v1/admin/specialists/:key/kb
+// ---------------------------------------------------------------------------
+
+export const admin_set_specialist_kb: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const key = String(args.key ?? '').trim();
+  const keys = Array.isArray(args.kb_keys) ? args.kb_keys : [];
+  if (!key || keys.length === 0) return { ok: false, error: 'admin_set_specialist_kb requires key and a non-empty kb_keys array.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, key, kb_keys: keys },
+      text: `About to bind ${keys.length} knowledge-base scopes to specialist "${key}" (replaces existing bindings). Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/specialists/${encodeURIComponent(key)}/kb`, {
+    method: 'PUT',
+    headers: authHeaders(id),
+    body: { keys },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not bind KB scopes to "${key}": ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, bindings: body.bindings }, text: `${keys.length} KB scopes bound to "${key}".` };
+};
+
+// ---------------------------------------------------------------------------
+// 8. admin_set_specialist_status — PATCH /api/v1/admin/specialists/:key/status
+// ---------------------------------------------------------------------------
+
+export const admin_set_specialist_status: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const key = String(args.key ?? '').trim();
+  if (!key || typeof args.enabled !== 'boolean') return { ok: false, error: 'admin_set_specialist_status requires key and enabled (boolean).' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, key, enabled: args.enabled },
+      text: `About to ${args.enabled ? 'enable' : 'disable'} specialist "${key}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/specialists/${encodeURIComponent(key)}/status`, {
+    method: 'PATCH',
+    headers: authHeaders(id),
+    body: { enabled: args.enabled },
+  });
+  if (!ok) {
+    if (status === 400 && String(body.error ?? '').includes('VITANA_ALWAYS_ON')) {
+      return { ok: true, result: { updated: false, reason: 'vitana_always_on' }, text: `The "vitana" receptionist persona can't be disabled — it's always on.` };
+    }
+    return { ok: true, result: { updated: false, status, detail: body }, text: `Could not change status for "${key}": ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  if (body.unchanged) return { ok: true, result: { updated: false, unchanged: true }, text: `"${key}" was already ${args.enabled ? 'enabled' : 'disabled'}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Specialist "${key}" ${args.enabled ? 'enabled' : 'disabled'}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 9. admin_test_specialist_connection — POST /api/v1/admin/specialists/connections/:id/test
+// ---------------------------------------------------------------------------
+
+export const admin_test_specialist_connection: Handler = async (args, id) => {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const connectionId = String(args.connection_id ?? '').trim();
+  if (!connectionId) return { ok: false, error: 'admin_test_specialist_connection requires connection_id (look it up via admin_get_specialist — its response includes connections[]).' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/specialists/connections/${encodeURIComponent(connectionId)}/test`, {
+    method: 'POST',
+    headers: authHeaders(id),
+  });
+  if (!ok) return { ok: false, error: `admin_test_specialist_connection failed (${status}): ${String(body.error ?? 'unknown')}` };
+  return {
+    ok: true,
+    result: body,
+    text: `${String(body.provider ?? 'connection')}: ${body.healthy ? 'healthy' : 'unhealthy'}${body.note ? ` (${body.note})` : ''}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const ADMIN_SPECIALISTS_TOOL_HANDLERS: Record<string, Handler> = {
+  admin_list_specialists,
+  admin_get_specialist,
+  admin_create_specialist,
+  admin_update_specialist,
+  admin_rollback_specialist,
+  admin_set_specialist_tools,
+  admin_set_specialist_kb,
+  admin_set_specialist_status,
+  admin_test_specialist_connection,
+};
+
+export const ADMIN_SPECIALISTS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  { name: 'admin_list_specialists', description: 'ADMIN ONLY. List specialist personas.', parameters: { type: 'object', properties: {} } },
+  { name: 'admin_get_specialist', description: 'ADMIN ONLY. One persona + version history.', parameters: { type: 'object', properties: { key: { type: 'string', description: 'Required.' } }, required: ['key'] } },
+  {
+    name: 'admin_create_specialist',
+    description: 'ADMIN ONLY. Create a new specialist persona. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        key: { type: 'string', description: 'Lowercase, starts with a letter. Required.' },
+        display_name: { type: 'string', description: 'Required.' },
+        role: { type: 'string', description: 'Required.' },
+        system_prompt: { type: 'string', description: 'Required.' },
+        voice_id: { type: 'string' },
+        handles_kinds: { type: 'array', items: { type: 'string' } },
+        status: { type: 'string', description: 'active, draft, or disabled.' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['key', 'display_name', 'role', 'system_prompt'],
+    },
+  },
+  {
+    name: 'admin_update_specialist',
+    description: 'ADMIN ONLY. Edit a specialist persona (snapshots the prior version). TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { key: { type: 'string', description: 'Required.' }, display_name: { type: 'string' }, role: { type: 'string' }, system_prompt: { type: 'string' }, status: { type: 'string' }, change_note: { type: 'string' }, confirm: { type: 'boolean' } }, required: ['key'] },
+  },
+  {
+    name: 'admin_rollback_specialist',
+    description: 'ADMIN ONLY. Roll back a specialist to a prior version. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { key: { type: 'string', description: 'Required.' }, version: { type: 'number', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['key', 'version'] },
+  },
+  {
+    name: 'admin_set_specialist_tools',
+    description: 'ADMIN ONLY. Replace the set of voice tools bound to a specialist. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { key: { type: 'string', description: 'Required.' }, tool_keys: { type: 'array', items: { type: 'string' }, description: 'Required, replaces existing bindings.' }, confirm: { type: 'boolean' } }, required: ['key', 'tool_keys'] },
+  },
+  {
+    name: 'admin_set_specialist_kb',
+    description: 'ADMIN ONLY. Replace the set of knowledge-base scopes bound to a specialist. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { key: { type: 'string', description: 'Required.' }, kb_keys: { type: 'array', items: { type: 'string' }, description: 'Required, replaces existing bindings.' }, confirm: { type: 'boolean' } }, required: ['key', 'kb_keys'] },
+  },
+  {
+    name: 'admin_set_specialist_status',
+    description: 'ADMIN ONLY. Enable or disable a specialist (the "vitana" persona can never be disabled). TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { key: { type: 'string', description: 'Required.' }, enabled: { type: 'boolean', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['key', 'enabled'] },
+  },
+  {
+    name: 'admin_test_specialist_connection',
+    description: 'ADMIN ONLY. Test a specialist\'s third-party connection (stub providers only today).',
+    parameters: { type: 'object', properties: { connection_id: { type: 'string', description: 'Required.' } }, required: ['connection_id'] },
+  },
+];

--- a/services/gateway/src/services/orb-tools/database-migrations-tools.ts
+++ b/services/gateway/src/services/orb-tools/database-migrations-tools.ts
@@ -1,0 +1,259 @@
+/**
+ * Developer voice tools — Database & Migrations (Wave 6, plan section C11,
+ * final wave of docs/VOICE_TOOLS_EXPANSION_PLAN.md).
+ *
+ * All four tools dispatch real GitHub Actions workflows / a real gateway
+ * route — no new backend behaviour:
+ *   - dev_run_staging_migration → RUN-STAGING-MIGRATION.yml (workflow_dispatch)
+ *   - dev_run_prod_migration    → RUN-MIGRATION.yml (workflow_dispatch, prod DB)
+ *   - dev_migration_status      → githubService.getWorkflowRuns() on either file
+ *   - dev_run_backfill          → JOURNEY-TRANSLATIONS-BACKFILL.yml, or
+ *                                 POST /api/v1/admin/embeddings/backfill
+ *
+ * dev_list_pending_migrations and dev_schema_info are SKIPPED: there is no
+ * runtime-accessible "list applied vs pending migrations" or "describe schema"
+ * mechanism in the deployed gateway container — migrations are plain .sql
+ * files applied ad hoc via the workflows above, with no migration-tracking
+ * table read back anywhere. Both stay `status: planned`.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { developerGate, clampLimit, relAge, gatewayApiCall } from './developer-tools';
+import { adminGate, authHeaders } from './admin-users-rbac-tools';
+import githubService from '../github-service';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+const DEFAULT_REPO = 'exafyltd/vitana-platform';
+
+function repoArg(args: OrbToolArgs): string {
+  return String(args.repo ?? DEFAULT_REPO);
+}
+
+function requireExafyAdmin(id: OrbToolIdentity): OrbToolResult | null {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (String(id.role ?? '').toLowerCase() !== 'exafy_admin') {
+    return { ok: false, error: 'This tool requires an exafy_admin session (operator-only).' };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// 1. dev_run_staging_migration — RUN-STAGING-MIGRATION.yml (workflow_dispatch)
+// ---------------------------------------------------------------------------
+
+export const dev_run_staging_migration: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const migrationFile = String(args.migration_file ?? '').trim();
+  if (!migrationFile.startsWith('supabase/migrations/') || !migrationFile.endsWith('.sql')) {
+    return { ok: false, error: 'dev_run_staging_migration requires migration_file matching supabase/migrations/*.sql.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, migration_file: migrationFile, target: 'staging' },
+      text: `About to apply ${migrationFile} to STAGING (project rsdakjqpvcpgomltdmxu). Confirm, then call again with confirm=true.`,
+    };
+  }
+  try {
+    await githubService.triggerWorkflow(repoArg(args), 'RUN-STAGING-MIGRATION.yml', String(args.ref ?? 'main'), {
+      migration_file: migrationFile,
+      confirm: 'I-mean-staging',
+    });
+    return { ok: true, result: { triggered: true, migration_file: migrationFile }, text: `Dispatched the staging migration run for ${migrationFile}.` };
+  } catch (err) {
+    return { ok: false, error: `dev_run_staging_migration failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 2. dev_run_prod_migration — RUN-MIGRATION.yml (workflow_dispatch, prod DB)
+// ---------------------------------------------------------------------------
+
+export const dev_run_prod_migration: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const migrationFile = String(args.migration_file ?? '').trim();
+  const reason = String(args.reason ?? '').trim();
+  if (!migrationFile.startsWith('supabase/migrations/') || !migrationFile.endsWith('.sql')) {
+    return { ok: false, error: 'dev_run_prod_migration requires migration_file matching supabase/migrations/*.sql.' };
+  }
+  if (!reason) {
+    return { ok: false, error: 'dev_run_prod_migration requires a reason — this runs against the PRODUCTION database directly, with no staging step. State why this is justified as a prod migration.' };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, migration_file: migrationFile, reason, target: 'production' },
+      text: `About to apply ${migrationFile} DIRECTLY TO PRODUCTION, reason: "${reason}". This has no built-in staging guard — confirm only if you mean it, then call again with confirm=true.`,
+    };
+  }
+  try {
+    await githubService.triggerWorkflow(repoArg(args), 'RUN-MIGRATION.yml', String(args.ref ?? 'main'), {
+      migration_file: migrationFile,
+    });
+    return { ok: true, result: { triggered: true, migration_file: migrationFile, reason }, text: `Dispatched the PRODUCTION migration run for ${migrationFile}.` };
+  } catch (err) {
+    return { ok: false, error: `dev_run_prod_migration failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 3. dev_migration_status — githubService.getWorkflowRuns() for either file
+// ---------------------------------------------------------------------------
+
+export const dev_migration_status: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const target = String(args.target ?? 'staging').toLowerCase();
+  const workflowId = target === 'production' || target === 'prod' ? 'RUN-MIGRATION.yml' : 'RUN-STAGING-MIGRATION.yml';
+  try {
+    const { workflow_runs } = await githubService.getWorkflowRuns(repoArg(args), workflowId);
+    const limit = clampLimit(args.limit, 5, 20);
+    const runs = workflow_runs.slice(0, limit);
+    if (runs.length === 0) return { ok: true, result: { runs: [] }, text: `No ${workflowId} runs found.` };
+    const lines = runs.map((r) => `run ${r.id} — ${r.conclusion ?? r.status} (${relAge(r.created_at)})`);
+    return { ok: true, result: { runs, target: workflowId === 'RUN-MIGRATION.yml' ? 'production' : 'staging' }, text: `Recent ${workflowId === 'RUN-MIGRATION.yml' ? 'production' : 'staging'} migration runs: ${lines.join('. ')}` };
+  } catch (err) {
+    return { ok: false, error: `dev_migration_status failed: ${String((err as Error)?.message || err)}` };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 4. dev_run_backfill — JOURNEY-TRANSLATIONS-BACKFILL.yml or embeddings backfill
+// ---------------------------------------------------------------------------
+
+export const dev_run_backfill: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const name = String(args.name ?? '').trim().toLowerCase();
+
+  if (name === 'journey_translations') {
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { requires_confirmation: true, name, locales: args.locales ?? 'en,es,sr' },
+        text: `About to run the Journey Translations backfill (locales: ${String(args.locales ?? 'en,es,sr')}). Confirm, then call again with confirm=true.`,
+      };
+    }
+    try {
+      await githubService.triggerWorkflow(repoArg(args), 'JOURNEY-TRANSLATIONS-BACKFILL.yml', String(args.ref ?? 'main'), {
+        locales: String(args.locales ?? 'en,es,sr'),
+        curriculum: String(args.curriculum ?? 'v2'),
+        limit: args.limit !== undefined ? String(args.limit) : '',
+        dry_run: args.dry_run === true ? 'true' : 'false',
+      });
+      return { ok: true, result: { triggered: true, name }, text: 'Dispatched the Journey Translations backfill.' };
+    } catch (err) {
+      return { ok: false, error: `dev_run_backfill (journey_translations) failed: ${String((err as Error)?.message || err)}` };
+    }
+  }
+
+  if (name === 'embeddings') {
+    // The real route (routes/admin-embeddings-backfill.ts) is gated
+    // requireAuth + requireExafyAdmin at the Express layer — mirror that
+    // gate here rather than the plain developerGate above.
+    const exafyDenied = requireExafyAdmin(id);
+    if (exafyDenied) return exafyDenied;
+    if (!id.user_jwt) return { ok: true, result: { reason: 'no_admin_session' }, text: "This needs a signed-in admin session — I don't have one for this voice session." };
+    const batchSize = clampLimit(args.batch_size, 50, 200);
+    const dryRun = args.dry_run === true;
+    if (!dryRun && args.confirm !== true) {
+      return {
+        ok: true,
+        result: { requires_confirmation: true, name, batch_size: batchSize },
+        text: `About to backfill embeddings for up to ${batchSize} memory items. Confirm, then call again with confirm=true (or pass dry_run=true to preview).`,
+      };
+    }
+    const { ok, status, body } = await gatewayApiCall('/api/v1/admin/embeddings/backfill', {
+      method: 'POST',
+      headers: authHeaders(id),
+      body: { batch_size: batchSize, dry_run: dryRun },
+    });
+    if (!ok) return { ok: true, result: { ran: false, status, detail: body }, text: `Embeddings backfill failed: ${String(body.error ?? `gateway returned ${status}`)}.` };
+    if (dryRun) return { ok: true, result: body, text: `Dry run: would process ${Number(body.would_process ?? 0)} items.` };
+    return { ok: true, result: body, text: `Backfilled ${Number(body.processed_count ?? 0)} items, ${Number(body.errors_count ?? 0)} errors.` };
+  }
+
+  return { ok: false, error: 'dev_run_backfill requires name to be one of: journey_translations, embeddings.' };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const DATABASE_MIGRATIONS_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_run_staging_migration,
+  dev_run_prod_migration,
+  dev_migration_status,
+  dev_run_backfill,
+};
+
+export const DATABASE_MIGRATIONS_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'dev_run_staging_migration',
+    description: 'DEVELOPER ONLY. Apply a SQL migration file to STAGING via RUN-STAGING-MIGRATION.yml. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        migration_file: { type: 'string', description: 'Path under supabase/migrations/, e.g. supabase/migrations/20260601_foo.sql. Required.' },
+        ref: { type: 'string', description: 'Branch/ref. Default main.' },
+        repo: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['migration_file'],
+    },
+  },
+  {
+    name: 'dev_run_prod_migration',
+    description: 'DEVELOPER ONLY. Apply a SQL migration file DIRECTLY TO PRODUCTION via RUN-MIGRATION.yml — no staging step. Requires a stated reason. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        migration_file: { type: 'string', description: 'Path under supabase/migrations/. Required.' },
+        reason: { type: 'string', description: 'Why this must run against prod directly. Required.' },
+        ref: { type: 'string', description: 'Branch/ref. Default main.' },
+        repo: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['migration_file', 'reason'],
+    },
+  },
+  {
+    name: 'dev_migration_status',
+    description: 'DEVELOPER ONLY. Recent staging or production migration workflow runs.',
+    parameters: {
+      type: 'object',
+      properties: {
+        target: { type: 'string', description: '"staging" (default) or "production".' },
+        limit: { type: 'integer' },
+        repo: { type: 'string' },
+      },
+    },
+  },
+  {
+    name: 'dev_run_backfill',
+    description: 'DEVELOPER ONLY (embeddings additionally requires exafy_admin). Run a named backfill job: "journey_translations" or "embeddings". TWO-STEP confirm (embeddings skips confirm when dry_run=true).',
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'One of: journey_translations, embeddings. Required.' },
+        locales: { type: 'string', description: 'journey_translations only. Default en,es,sr.' },
+        curriculum: { type: 'string', description: 'journey_translations only. Default v2.' },
+        limit: { type: 'integer', description: 'journey_translations only.' },
+        batch_size: { type: 'number', description: 'embeddings only. 1-200, default 50.' },
+        dry_run: { type: 'boolean' },
+        ref: { type: 'string' },
+        repo: { type: 'string' },
+        confirm: { type: 'boolean', description: 'Set true only after explicit confirmation.' },
+      },
+      required: ['name'],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/dev-access-simulator-meta-tools.ts
+++ b/services/gateway/src/services/orb-tools/dev-access-simulator-meta-tools.ts
@@ -1,0 +1,377 @@
+/**
+ * Developer voice tools — Dev Access, Simulator & Meta (Wave 6, plan
+ * section C12, final wave of docs/VOICE_TOOLS_EXPANSION_PLAN.md).
+ *
+ * Thin dispatch layer over three real route families plus one direct
+ * composite of already-built handlers:
+ *   - routes/dev-access.ts (exafy_admin dev-hub access list/grant/revoke,
+ *     `app_metadata.exafy_admin`, distinct from admin_grant_role's
+ *     community-facing RBAC roles)
+ *   - routes/dev-auth.ts (`/token`, dev-sandbox-only token minting, gated by
+ *     env + X-DEV-SECRET rather than a user JWT — mirrored here via
+ *     process.env.DEV_AUTH_SECRET, same pattern as dev_supervisor_summary
+ *     in observability-tools.ts)
+ *   - routes/conversation-hub.ts (`/admin/conversation/preview`, the
+ *     Simulator) and routes/voice-journey-context.ts (`/state`)
+ *   - routes/voice-tools-catalog.ts (`/catalog/stats`, `/catalog/:name` —
+ *     reads the same tool-manifest.json this whole project maintains)
+ *   - dev_system_briefing composites 5 already-built handlers directly
+ *     (dev_service_health, dev_list_deployments, dev_count_approvals,
+ *     dev_list_violations, dev_cicd_health) rather than adding a 6th
+ *     backend — no new business logic, just one spoken roll-up.
+ *
+ * dev_run_routine_now is SKIPPED — "routine" in this codebase means the
+ * Claude Code Remote scheduled-trigger concept (create_trigger/fire_trigger),
+ * which has no server-side representation in vitana-platform at all; there
+ * is no route, table, or workflow to fire a "routine" from voice. Stays
+ * `status: planned`.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { developerGate, clampLimit, gatewayApiCall } from './developer-tools';
+import { adminGate, authHeaders, NO_ADMIN_SESSION } from './admin-users-rbac-tools';
+import { dev_service_health } from './observability-tools';
+import { dev_list_deployments } from './deployment-release-tools';
+import { dev_count_approvals } from './developer-tools';
+import { dev_list_violations } from './governance-tools';
+import { dev_cicd_health } from './cicd-pr-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+function requireExafyAdmin(id: OrbToolIdentity): OrbToolResult | null {
+  const denied = adminGate(id);
+  if (denied) return denied;
+  if (String(id.role ?? '').toLowerCase() !== 'exafy_admin') {
+    return { ok: false, error: 'This tool requires an exafy_admin session (operator-only).' };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// 1. dev_list_dev_users — GET /api/v1/dev-access/users
+// ---------------------------------------------------------------------------
+
+export const dev_list_dev_users: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const query = typeof args.query === 'string' ? args.query.trim() : '';
+  const { ok, status, body } = await gatewayApiCall(
+    `/api/v1/dev-access/users${query ? `?query=${encodeURIComponent(query)}` : ''}`,
+    { headers: authHeaders(id) },
+  );
+  if (!ok) return { ok: false, error: `dev_list_dev_users failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const users = (Array.isArray(body.users) ? body.users : []) as Array<{ email: string }>;
+  if (users.length === 0) return { ok: true, result: { users: [] }, text: 'No exafy_admin dev-hub users found.' };
+  return { ok: true, result: { users }, text: `${users.length} dev-hub users: ${users.slice(0, 10).map((u) => u.email).join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 2. dev_grant_access — POST /api/v1/dev-access/grant
+// ---------------------------------------------------------------------------
+
+export const dev_grant_access: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const email = String(args.email ?? '').trim();
+  if (!email) return { ok: false, error: 'dev_grant_access requires email.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, email },
+      text: `About to grant exafy_admin dev-hub access to ${email}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/dev-access/grant', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { email },
+  });
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { granted: false, reason: 'user_not_found' }, text: `No user found with email ${email}.` }
+      : { ok: true, result: { granted: false, status, detail: body }, text: `Could not grant access: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { granted: true, detail: body }, text: String(body.message ?? `Dev access granted to ${email}.`) };
+};
+
+// ---------------------------------------------------------------------------
+// 3. dev_revoke_access — POST /api/v1/dev-access/revoke
+// ---------------------------------------------------------------------------
+
+export const dev_revoke_access: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const email = String(args.email ?? '').trim();
+  if (!email) return { ok: false, error: 'dev_revoke_access requires email.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, email },
+      text: `About to revoke exafy_admin dev-hub access from ${email}. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/dev-access/revoke', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { email },
+  });
+  if (!ok) {
+    if (status === 400 && body.error === 'SELF_REVOKE_FORBIDDEN') {
+      return { ok: true, result: { revoked: false, reason: 'self_revoke_forbidden' }, text: "You can't revoke your own dev-hub access." };
+    }
+    return status === 404
+      ? { ok: true, result: { revoked: false, reason: 'user_not_found' }, text: `No user found with email ${email}.` }
+      : { ok: true, result: { revoked: false, status, detail: body }, text: `Could not revoke access: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return { ok: true, result: { revoked: true, detail: body }, text: String(body.message ?? `Dev access revoked from ${email}.`) };
+};
+
+// ---------------------------------------------------------------------------
+// 4. dev_mint_token — POST /api/v1/dev/auth/token (dev-sandbox only)
+// ---------------------------------------------------------------------------
+
+const MINT_ROLES = new Set(['patient', 'community', 'professional', 'staff', 'admin', 'developer', 'infra']);
+
+export const dev_mint_token: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  const email = String(args.email ?? '').trim();
+  const role = String(args.role ?? '').trim().toLowerCase();
+  if (!email || !MINT_ROLES.has(role)) {
+    return { ok: false, error: `dev_mint_token requires email and role (one of ${Array.from(MINT_ROLES).join(', ')}).` };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, email, role },
+      text: `About to mint a ${role} session token for ${email} (dev-sandbox only). Confirm, then call again with confirm=true.`,
+    };
+  }
+  const devSecret = process.env.DEV_AUTH_SECRET;
+  if (!devSecret) {
+    return { ok: true, result: { reason: 'no_dev_secret' }, text: 'Token minting is unavailable — no DEV_AUTH_SECRET configured (this only works in the dev-sandbox environment).' };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/dev/auth/token', {
+    method: 'POST',
+    headers: { 'X-DEV-SECRET': devSecret },
+    body: { email, role, tenant_id: typeof args.tenant_id === 'string' ? args.tenant_id : undefined },
+  });
+  if (!ok) {
+    if (status === 403 && body.error === 'DEV_AUTH_DISABLED') {
+      return { ok: true, result: { minted: false, reason: 'not_dev_sandbox' }, text: 'Token minting only works in the dev-sandbox environment — this environment is not dev-sandbox.' };
+    }
+    return status === 404
+      ? { ok: true, result: { minted: false, reason: 'user_not_found' }, text: `No user found with email ${email}.` }
+      : { ok: true, result: { minted: false, status, detail: body }, text: `Could not mint a token: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  }
+  return {
+    ok: true,
+    result: { minted: true, expires_in: body.expires_in, email, role },
+    text: `Minted a ${role} token for ${email}, valid for ${Math.round(Number(body.expires_in ?? 0) / 60)} minutes. (Not repeating the token itself aloud.)`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 5. dev_open_hub_panel — navigation-only (Command Hub screens)
+// ---------------------------------------------------------------------------
+
+export const dev_open_hub_panel: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const screenId = String(args.screen_id ?? '').trim();
+  if (!screenId) return { ok: false, error: 'dev_open_hub_panel requires screen_id, e.g. "DEVHUB.OVERVIEW.SYSTEM_OVERVIEW" or "DEVHUB.ADMIN.USERS".' };
+  // Dynamic import (not a static one) — orb-tools-shared.ts imports this
+  // module's declarations, so a static import back would create a load-order
+  // cycle. Resolving lazily at call time sidesteps it.
+  const { tool_navigate_to_screen } = await import('../orb-tools-shared');
+  return tool_navigate_to_screen({ ...args, screen_id: screenId }, id, sb);
+};
+
+// ---------------------------------------------------------------------------
+// 6. dev_run_simulator — GET /api/v1/admin/conversation/preview
+// ---------------------------------------------------------------------------
+
+export const dev_run_simulator: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const userId = String(args.user_id ?? '').trim();
+  if (!userId) return { ok: false, error: 'dev_run_simulator requires user_id.' };
+  const qs = new URLSearchParams({ user_id: userId });
+  if (typeof args.lang === 'string' && args.lang) qs.set('lang', args.lang);
+  if (typeof args.timezone === 'string' && args.timezone) qs.set('timezone', args.timezone);
+  if (typeof args.bucket === 'string' && args.bucket) qs.set('bucket', args.bucket);
+  if (args.first_time === true) qs.set('first_time', 'true');
+  if (args.briefing_due === true) qs.set('briefing_due', 'true');
+  if (typeof args.current_route === 'string' && args.current_route) qs.set('current_route', args.current_route);
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/admin/conversation/preview?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_run_simulator failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const data = (body.data ?? {}) as Record<string, unknown>;
+  return {
+    ok: true,
+    result: data,
+    text: `Simulated register "${String(data.register ?? 'unknown')}" for ${userId}${data.chosen_nba ? `, chosen NBA: ${JSON.stringify(data.chosen_nba)}` : ''}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 7. dev_journey_context — GET /api/v1/voice/journey-context/state
+// ---------------------------------------------------------------------------
+
+export const dev_journey_context: Handler = async (args, id) => {
+  const denied = requireExafyAdmin(id);
+  if (denied) return denied;
+  if (!id.user_jwt) return NO_ADMIN_SESSION;
+  const userId = String(args.user_id ?? '').trim();
+  const tenantId = String(args.tenant_id ?? id.tenant_id ?? '').trim();
+  if (!userId || !tenantId) return { ok: false, error: 'dev_journey_context requires user_id (and a tenant context).' };
+  const qs = new URLSearchParams({ userId, tenantId });
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/voice/journey-context/state?${qs.toString()}`, { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `dev_journey_context failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const rows = (Array.isArray(body.rows) ? body.rows : []) as Array<{ signal_name: string; value: unknown }>;
+  if (rows.length === 0) return { ok: true, result: { rows: [] }, text: `No durable assistant-state signals stored for user ${userId}.` };
+  return { ok: true, result: { rows, source_health: body.source_health }, text: `${rows.length} assistant-state signals: ${rows.slice(0, 8).map((r) => r.signal_name).join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// 8. dev_voice_catalog_stats — GET /api/v1/voice-tools/catalog/stats
+// ---------------------------------------------------------------------------
+
+export const dev_voice_catalog_stats: Handler = async (_args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/voice-tools/catalog/stats');
+  if (!ok) return { ok: false, error: `dev_voice_catalog_stats failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const byStatus = (body.by_status ?? {}) as Record<string, number>;
+  return {
+    ok: true,
+    result: body,
+    text: `${Number(body.total ?? 0)} voice tools total — ${Number(byStatus.live ?? 0)} live, ${Number(byStatus.planned ?? 0)} planned.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 9. dev_get_voice_tool_detail — GET /api/v1/voice-tools/catalog/:name
+// ---------------------------------------------------------------------------
+
+export const dev_get_voice_tool_detail: Handler = async (args, id) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const name = String(args.name ?? '').trim();
+  if (!name) return { ok: false, error: 'dev_get_voice_tool_detail requires name.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/voice-tools/catalog/${encodeURIComponent(name)}`);
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `No voice tool named "${name}" in the catalog.` }
+      : { ok: false, error: `dev_get_voice_tool_detail failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const tool = (body.tool ?? {}) as Record<string, unknown>;
+  return {
+    ok: true,
+    result: tool,
+    text: `"${name}" — status ${String(tool.status ?? 'unknown')}, wired into ${Array.isArray(tool.wired_in) ? (tool.wired_in as string[]).join(' + ') || 'nothing yet' : 'unknown'}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// 10. dev_system_briefing — composite of 5 already-built handlers
+// ---------------------------------------------------------------------------
+
+export const dev_system_briefing: Handler = async (args, id, sb) => {
+  const denied = developerGate(id);
+  if (denied) return denied;
+  const limit = clampLimit(args.limit, 5, 20);
+  const [health, deployments, approvals, violations, cicd] = await Promise.all([
+    dev_service_health({}, id, sb),
+    dev_list_deployments({ limit }, id, sb),
+    dev_count_approvals({}, id, sb),
+    dev_list_violations({}, id, sb),
+    dev_cicd_health({}, id, sb),
+  ]);
+  const parts = [health, deployments, approvals, violations, cicd]
+    .filter((r): r is Extract<OrbToolResult, { ok: true }> => r.ok === true && Boolean(r.text))
+    .map((r) => r.text as string);
+  return {
+    ok: true,
+    result: { health: health.ok ? health.result : null, deployments: deployments.ok ? deployments.result : null, approvals: approvals.ok ? approvals.result : null, violations: violations.ok ? violations.result : null, cicd: cicd.ok ? cicd.result : null },
+    text: `System briefing — ${parts.join(' ')}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const DEV_ACCESS_SIMULATOR_META_TOOL_HANDLERS: Record<string, Handler> = {
+  dev_list_dev_users,
+  dev_grant_access,
+  dev_revoke_access,
+  dev_mint_token,
+  dev_open_hub_panel,
+  dev_run_simulator,
+  dev_journey_context,
+  dev_voice_catalog_stats,
+  dev_get_voice_tool_detail,
+  dev_system_briefing,
+};
+
+export const DEV_ACCESS_SIMULATOR_META_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  { name: 'dev_list_dev_users', description: 'EXAFY_ADMIN ONLY. List users with exafy_admin dev-hub access.', parameters: { type: 'object', properties: { query: { type: 'string', description: 'Optional email substring filter.' } } } },
+  {
+    name: 'dev_grant_access',
+    description: 'EXAFY_ADMIN ONLY. Grant exafy_admin dev-hub access to a user by email. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { email: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['email'] },
+  },
+  {
+    name: 'dev_revoke_access',
+    description: 'EXAFY_ADMIN ONLY. Revoke exafy_admin dev-hub access from a user by email (cannot self-revoke). TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { email: { type: 'string', description: 'Required.' }, confirm: { type: 'boolean' } }, required: ['email'] },
+  },
+  {
+    name: 'dev_mint_token',
+    description: 'EXAFY_ADMIN ONLY. Mint a dev-sandbox session token for a user (works only in the dev-sandbox environment). TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        email: { type: 'string', description: 'Required.' },
+        role: { type: 'string', description: 'patient, community, professional, staff, admin, developer, or infra. Required.' },
+        tenant_id: { type: 'string' },
+        confirm: { type: 'boolean' },
+      },
+      required: ['email', 'role'],
+    },
+  },
+  { name: 'dev_open_hub_panel', description: 'DEVELOPER ONLY. Navigate to a Command Hub screen/panel by screen_id.', parameters: { type: 'object', properties: { screen_id: { type: 'string', description: 'e.g. DEVHUB.OVERVIEW.SYSTEM_OVERVIEW. Required.' } }, required: ['screen_id'] } },
+  {
+    name: 'dev_run_simulator',
+    description: 'EXAFY_ADMIN ONLY. Dry-run the conversation-opening decision (register + next-best-actions) for a user, without speaking or emitting.',
+    parameters: {
+      type: 'object',
+      properties: {
+        user_id: { type: 'string', description: 'Required.' },
+        lang: { type: 'string' },
+        timezone: { type: 'string' },
+        bucket: { type: 'string', description: 'Temporal bucket, e.g. same_day.' },
+        first_time: { type: 'boolean' },
+        briefing_due: { type: 'boolean' },
+        current_route: { type: 'string' },
+      },
+      required: ['user_id'],
+    },
+  },
+  {
+    name: 'dev_journey_context',
+    description: 'EXAFY_ADMIN ONLY. Durable assistant-state signals stored for a user (journey/onboarding context).',
+    parameters: { type: 'object', properties: { user_id: { type: 'string', description: 'Required.' }, tenant_id: { type: 'string' } }, required: ['user_id'] },
+  },
+  { name: 'dev_voice_catalog_stats', description: 'DEVELOPER ONLY. Aggregate counts of this voice tool catalog (by status, surface, role, wiring).', parameters: { type: 'object', properties: {} } },
+  { name: 'dev_get_voice_tool_detail', description: 'DEVELOPER ONLY. Full manifest entry for one voice tool by name.', parameters: { type: 'object', properties: { name: { type: 'string', description: 'Required.' } }, required: ['name'] } },
+  { name: 'dev_system_briefing', description: 'DEVELOPER ONLY. Combined roll-up: service health, recent deployments, pending approvals, governance violations, CI/CD health.', parameters: { type: 'object', properties: { limit: { type: 'number' } } } },
+];

--- a/services/gateway/src/services/orb-tools/memory-diary-social-tools.ts
+++ b/services/gateway/src/services/orb-tools/memory-diary-social-tools.ts
@@ -1,0 +1,305 @@
+/**
+ * Community voice tools — Memory & Diary extras (A13) + Profile & Social
+ * depth (A14), Wave 6 (final wave) of docs/VOICE_TOOLS_EXPANSION_PLAN.md.
+ *
+ * A13: `archive_memory` and `promote_memory_to_knowledge` are SKIPPED.
+ * `archive_memory`'s only two candidate backends are dishonest to ship: the
+ * `POST /api/v1/memory/lock` route writes to `memory_locks`, but no
+ * retrieval/context/timeline code anywhere reads that table, so "locking" a
+ * memory currently has zero visible effect; and `DELETE /api/v1/memory/entity`
+ * is a real, permanent-ish cascade delete (`memory_delete_entity` RPC), not a
+ * reversible "soft-hide" — presenting either as "archive" would misrepresent
+ * what the action does. `promote_memory_to_knowledge` has no route at all:
+ * the only Knowledge Hub write surface is the tenant-admin KB CMS
+ * (requireTenantAdmin), with nothing linking a memory_items row into it.
+ * `reinforce_memory` maps to the real confidence-confirm RPC (raises trust,
+ * not a separate "importance" field — the tool is honest about this in its
+ * spoken text). `get_what_vitana_knows` is a thin alias of the already-built
+ * `get_memory_garden_summary` tool (same underlying function).
+ *
+ * A14: `set_profile_theme` is SKIPPED — identical gap to the already-built
+ * `set_theme` tool (no `profiles.theme` column exists anywhere); building a
+ * second tool with the same non-functional outcome would be redundant.
+ * `add_gallery_photo` and `list_member_posts` are SKIPPED — no gallery/photo
+ * table and no posts/feed table exist anywhere in the schema.
+ * `get_profile_completeness` is scoped to the real, existing taste/lifestyle
+ * completeness score (`taste_alignment_bundle_get` RPC) — there is no
+ * separate "general profile fields" completeness anywhere; the tool's
+ * spoken text is explicit about this narrower scope.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { tool_get_memory_garden_summary } from './diary-memory-tools';
+import { gatewayApiCall, clampLimit } from './developer-tools';
+
+type Handler = (
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+) => Promise<OrbToolResult>;
+
+function authHeaders(id: OrbToolIdentity): Record<string, string> {
+  return id.user_jwt ? { Authorization: `Bearer ${id.user_jwt}` } : {};
+}
+
+const NO_SESSION: OrbToolResult = {
+  ok: true,
+  result: { reason: 'no_session' },
+  text: "I need your signed-in session to do that — I don't have one for this voice session.",
+};
+
+// ---------------------------------------------------------------------------
+// A13.1 edit_memory — POST /api/v1/memory/confidence/correct
+// ---------------------------------------------------------------------------
+
+export const edit_memory: Handler = async (args, id) => {
+  if (!id.user_id) return { ok: false, error: 'edit_memory requires an authenticated user.' };
+  if (!id.user_jwt) return NO_SESSION;
+  const memoryItemId = String(args.memory_item_id ?? '').trim();
+  const newContent = typeof args.new_content === 'string' ? args.new_content.trim() : undefined;
+  if (!memoryItemId || !newContent) return { ok: false, error: 'edit_memory requires memory_item_id and new_content.' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, memory_item_id: memoryItemId, new_content: newContent },
+      text: `About to correct that memory to: "${newContent}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/memory/confidence/correct', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: {
+      memory_item_id: memoryItemId,
+      new_content: newContent,
+      correction_notes: typeof args.correction_notes === 'string' ? args.correction_notes : 'Corrected via voice',
+    },
+  });
+  if (!ok) return { ok: true, result: { corrected: false, status, detail: body }, text: `Could not correct that memory: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { corrected: true, detail: body }, text: `Memory corrected.` };
+};
+
+// ---------------------------------------------------------------------------
+// A13.3 reinforce_memory — POST /api/v1/memory/confidence/confirm
+// (raises confidence/trust — there's no separate "importance" field)
+// ---------------------------------------------------------------------------
+
+export const reinforce_memory: Handler = async (args, id) => {
+  if (!id.user_id) return { ok: false, error: 'reinforce_memory requires an authenticated user.' };
+  if (!id.user_jwt) return NO_SESSION;
+  const memoryItemId = String(args.memory_item_id ?? '').trim();
+  if (!memoryItemId) return { ok: false, error: 'reinforce_memory requires memory_item_id.' };
+  const { ok, status, body } = await gatewayApiCall('/api/v1/memory/confidence/confirm', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: {
+      memory_item_id: memoryItemId,
+      confirmation_notes: typeof args.confirmation_notes === 'string' ? args.confirmation_notes : 'Confirmed via voice',
+    },
+  });
+  if (!ok) return { ok: true, result: { confirmed: false, status, detail: body }, text: `Could not confirm that memory: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { confirmed: true, detail: body }, text: `Got it — I've marked that memory as confirmed and trustworthy.` };
+};
+
+// ---------------------------------------------------------------------------
+// A13.5 set_memory_permissions — POST /api/v1/memory/settings/visibility
+// ---------------------------------------------------------------------------
+
+const MEMORY_DOMAINS = ['diary', 'garden', 'relationships', 'longevity', 'timeline'];
+const MEMORY_VISIBILITIES = ['private', 'connections', 'professionals', 'custom'];
+
+export const set_memory_permissions: Handler = async (args, id) => {
+  if (!id.user_id) return { ok: false, error: 'set_memory_permissions requires an authenticated user.' };
+  if (!id.user_jwt) return NO_SESSION;
+  const domain = String(args.domain ?? '').trim();
+  const visibility = String(args.visibility ?? '').trim();
+  if (!MEMORY_DOMAINS.includes(domain) || !MEMORY_VISIBILITIES.includes(visibility)) {
+    return { ok: false, error: `set_memory_permissions requires domain (${MEMORY_DOMAINS.join(', ')}) and visibility (${MEMORY_VISIBILITIES.join(', ')}).` };
+  }
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, domain, visibility },
+      text: `About to set your "${domain}" memory visibility to "${visibility}". Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/memory/settings/visibility', {
+    method: 'POST',
+    headers: authHeaders(id),
+    body: { domain, visibility, custom_rules: typeof args.custom_rules === 'object' ? args.custom_rules : undefined },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update that setting: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Your "${domain}" memory visibility is now "${visibility}".` };
+};
+
+// ---------------------------------------------------------------------------
+// A13.6 get_what_vitana_knows — alias of get_memory_garden_summary
+// ---------------------------------------------------------------------------
+
+export const get_what_vitana_knows: Handler = async (args, id, sb) => tool_get_memory_garden_summary(args, id, sb);
+
+// ---------------------------------------------------------------------------
+// A13.7 add_diary_photo — navigation-only (no photo/media storage exists)
+// ---------------------------------------------------------------------------
+
+export const add_diary_photo: Handler = async (args, id, sb) => {
+  // Dynamic import (not a static one) — orb-tools-shared.ts imports this
+  // module's declarations, so a static import back would create a load-order
+  // cycle. Resolving lazily at call time sidesteps it.
+  const { tool_navigate_to_screen } = await import('../orb-tools-shared');
+  return tool_navigate_to_screen({ ...args, screen_id: 'MEMORY.DIARY' }, id, sb);
+};
+
+// ---------------------------------------------------------------------------
+// A14.2 get_profile_completeness — GET /api/v1/taste-alignment/bundle
+// (scoped to the real taste/lifestyle completeness score)
+// ---------------------------------------------------------------------------
+
+export const get_profile_completeness: Handler = async (args, id) => {
+  if (!id.user_id) return { ok: false, error: 'get_profile_completeness requires an authenticated user.' };
+  if (!id.user_jwt) return NO_SESSION;
+  const { ok, status, body } = await gatewayApiCall('/api/v1/taste-alignment/bundle', { headers: authHeaders(id) });
+  if (!ok) return { ok: false, error: `get_profile_completeness failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const bundle = (body.bundle ?? {}) as Record<string, unknown>;
+  const pct = Number(bundle.profile_completeness ?? 0);
+  return {
+    ok: true,
+    result: bundle,
+    text: `Your taste and lifestyle profile is ${pct}% complete${bundle.sparse_data ? ' — add a few more preferences for better matches' : ''}.`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// A14.4 share_my_profile — GET /api/v1/public/profile/:id (public route)
+// ---------------------------------------------------------------------------
+
+export const share_my_profile: Handler = async (args, id) => {
+  if (!id.user_id) return { ok: false, error: 'share_my_profile requires an authenticated user.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/public/profile/${encodeURIComponent(id.user_id)}`);
+  if (!ok) return { ok: false, error: `share_my_profile failed (${status}): ${String(body.error ?? 'unknown')}` };
+  const profile = (body.profile ?? {}) as Record<string, unknown>;
+  const handle = typeof profile.handle === 'string' && profile.handle ? profile.handle : id.user_id;
+  const url = `https://vitanaland.com/u/${handle}`;
+  return { ok: true, result: { profile, share_url: url }, text: `Your profile link: ${url}` };
+};
+
+// ---------------------------------------------------------------------------
+// A14.5 get_my_milestones — direct Supabase read (autopilot_recommendations)
+// ---------------------------------------------------------------------------
+
+export const get_my_milestones: Handler = async (args, id, sb) => {
+  if (!id.user_id) return { ok: false, error: 'get_my_milestones requires an authenticated user.' };
+  const limit = clampLimit(args.limit, 20, 100);
+  const { data, error } = await sb
+    .from('autopilot_recommendations')
+    .select('source_ref, title, summary, impact_score, created_at')
+    .eq('user_id', id.user_id)
+    .eq('source_type', 'milestone')
+    .eq('status', 'completed')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  if (error) return { ok: false, error: `get_my_milestones failed: ${error.message}` };
+  const milestones = (data ?? []) as Array<{ title?: string }>;
+  if (milestones.length === 0) return { ok: true, result: { milestones: [] }, text: 'No milestones achieved yet.' };
+  return { ok: true, result: { milestones }, text: `${milestones.length} milestones: ${milestones.slice(0, 8).map((m) => m.title).join(', ')}.` };
+};
+
+// ---------------------------------------------------------------------------
+// A14.6 view_member_profile — GET /api/v1/public/profile/:id (public route)
+// ---------------------------------------------------------------------------
+
+export const view_member_profile: Handler = async (args, id) => {
+  if (!id.user_id) return { ok: false, error: 'view_member_profile requires an authenticated user.' };
+  const targetId = String(args.user_id ?? args.handle ?? '').trim();
+  if (!targetId) return { ok: false, error: 'view_member_profile requires user_id or handle.' };
+  const { ok, status, body } = await gatewayApiCall(`/api/v1/public/profile/${encodeURIComponent(targetId)}`);
+  if (!ok) {
+    return status === 404
+      ? { ok: true, result: { found: false }, text: `I couldn't find a member matching "${targetId}".` }
+      : { ok: false, error: `view_member_profile failed (${status}): ${String(body.error ?? 'unknown')}` };
+  }
+  const profile = (body.profile ?? {}) as Record<string, unknown>;
+  return {
+    ok: true,
+    result: profile,
+    text: `${String(profile.display_name ?? profile.first_name ?? targetId)}${profile.longevity_archetype ? ` — ${String(profile.longevity_archetype)} archetype` : ''}${profile.bio ? `. ${String(profile.bio)}` : ''}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// A14.8 update_service_offerings — PATCH /api/v1/profiles/me/service-offerings
+// (profiles.service_offerings — distinct from services_catalog/create_service)
+// ---------------------------------------------------------------------------
+
+export const update_service_offerings: Handler = async (args, id) => {
+  if (!id.user_id) return { ok: false, error: 'update_service_offerings requires an authenticated user.' };
+  if (!id.user_jwt) return NO_SESSION;
+  const offers = Array.isArray(args.offers) ? args.offers : [];
+  if (offers.length === 0) return { ok: false, error: 'update_service_offerings requires a non-empty offers array (each with category and title).' };
+  if (args.confirm !== true) {
+    return {
+      ok: true,
+      result: { requires_confirmation: true, offer_count: offers.length },
+      text: `About to replace your profile service offerings with ${offers.length} entries. Confirm, then call again with confirm=true.`,
+    };
+  }
+  const { ok, status, body } = await gatewayApiCall('/api/v1/profiles/me/service-offerings', {
+    method: 'PATCH',
+    headers: authHeaders(id),
+    body: { offers },
+  });
+  if (!ok) return { ok: true, result: { updated: false, status, detail: body }, text: `Could not update your service offerings: ${String(body.error ?? `gateway returned ${status}`)}.` };
+  return { ok: true, result: { updated: true, detail: body }, text: `Profile service offerings updated.` };
+};
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const MEMORY_DIARY_SOCIAL_TOOL_HANDLERS: Record<string, Handler> = {
+  edit_memory,
+  reinforce_memory,
+  set_memory_permissions,
+  get_what_vitana_knows,
+  add_diary_photo,
+  get_profile_completeness,
+  share_my_profile,
+  get_my_milestones,
+  view_member_profile,
+  update_service_offerings,
+};
+
+export const MEMORY_DIARY_SOCIAL_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'edit_memory',
+    description: 'Correct the content of a stored memory. TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { memory_item_id: { type: 'string', description: 'Required.' }, new_content: { type: 'string', description: 'Required.' }, correction_notes: { type: 'string' }, confirm: { type: 'boolean' } }, required: ['memory_item_id', 'new_content'] },
+  },
+  { name: 'reinforce_memory', description: 'Confirm a memory as accurate and trustworthy (raises its confidence score).', parameters: { type: 'object', properties: { memory_item_id: { type: 'string', description: 'Required.' }, confirmation_notes: { type: 'string' } }, required: ['memory_item_id'] } },
+  {
+    name: 'set_memory_permissions',
+    description: 'Set who can see a category of your memory (diary, garden, relationships, longevity, timeline). TWO-STEP confirm.',
+    parameters: { type: 'object', properties: { domain: { type: 'string', description: 'diary, garden, relationships, longevity, or timeline. Required.' }, visibility: { type: 'string', description: 'private, connections, professionals, or custom. Required.' }, confirm: { type: 'boolean' } }, required: ['domain', 'visibility'] },
+  },
+  { name: 'get_what_vitana_knows', description: '"What do you know about me" — summary of your memory garden by category.', parameters: { type: 'object', properties: {} } },
+  { name: 'add_diary_photo', description: 'Opens the diary screen so you can attach a photo (voice cannot upload directly).', parameters: { type: 'object', properties: {} } },
+  { name: 'get_profile_completeness', description: 'Your taste/lifestyle profile completeness percentage.', parameters: { type: 'object', properties: {} } },
+  { name: 'share_my_profile', description: 'Get your shareable profile link.', parameters: { type: 'object', properties: {} } },
+  { name: 'get_my_milestones', description: 'Your achieved milestones.', parameters: { type: 'object', properties: { limit: { type: 'number' } } } },
+  { name: 'view_member_profile', description: "Spoken summary of a community member's public profile.", parameters: { type: 'object', properties: { user_id: { type: 'string' }, handle: { type: 'string' } } } },
+  {
+    name: 'update_service_offerings',
+    description: 'Replace the service offerings shown on your profile. TWO-STEP confirm.',
+    parameters: {
+      type: 'object',
+      properties: {
+        offers: {
+          type: 'array',
+          description: 'Required, replaces existing offerings. Each: {category, title, short_description?, price_min_cents?, price_max_cents?, currency?, contact_via?}.',
+          items: { type: 'object', properties: { category: { type: 'string' }, title: { type: 'string' } } },
+        },
+        confirm: { type: 'boolean' },
+      },
+      required: ['offers'],
+    },
+  },
+];

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-13T06:35:51.173Z",
+  "generated_at": "2026-07-13T09:25:47.290Z",
   "source": "reconciled",
   "total": 594,
   "tools": [
@@ -4768,9 +4768,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Correct a stored memory",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "write",
       "plan_domain": "A13 Memory & Diary extras",
@@ -4798,9 +4801,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Mark memory as important",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "write",
       "plan_domain": "A13 Memory & Diary extras",
@@ -4828,9 +4834,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Memory privacy controls",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "write",
       "plan_domain": "A13 Memory & Diary extras",
@@ -4843,9 +4852,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "\"What do you know about me\" summary",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "A13 Memory & Diary extras",
@@ -4858,9 +4870,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Attach photo to diary (navigates to picker)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "write",
       "plan_domain": "A13 Memory & Diary extras",
@@ -4888,9 +4903,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Completeness % + missing items",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "A14 Profile & Social depth",
@@ -4918,9 +4936,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Share profile link/QR",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "A14 Profile & Social depth",
@@ -4933,9 +4954,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Achievements & milestones",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "A14 Profile & Social depth",
@@ -4948,9 +4972,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Spoken summary of a member",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "A14 Profile & Social depth",
@@ -4978,9 +5005,12 @@
       "role": [
         "community"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Edit services shown on profile",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "write",
       "plan_domain": "A14 Profile & Social depth",
@@ -6535,9 +6565,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Personas",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "B10 Specialists / Personas",
@@ -6551,9 +6584,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One persona + versions",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "B10 Specialists / Personas",
@@ -6567,9 +6603,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "New persona",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "B10 Specialists / Personas",
@@ -6583,9 +6622,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Edit persona",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "B10 Specialists / Personas",
@@ -6599,9 +6641,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Roll back version",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "B10 Specialists / Personas",
@@ -6615,9 +6660,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Bind tools",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "B10 Specialists / Personas",
@@ -6631,9 +6679,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Bind KB",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "B10 Specialists / Personas",
@@ -6647,9 +6698,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Enable/disable",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "B10 Specialists / Personas",
@@ -6663,9 +6717,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Test connection",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "B10 Specialists / Personas",
@@ -7417,9 +7474,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Admin actions audit",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "B16 Audit, i18n & Memory Ops",
@@ -7433,9 +7493,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Access audit",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "B16 Audit, i18n & Memory Ops",
@@ -7481,9 +7544,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Run memory consolidation",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "B16 Audit, i18n & Memory Ops",
@@ -7497,9 +7563,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Run embeddings backfill",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "B16 Audit, i18n & Memory Ops",
@@ -10176,9 +10245,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Dispatch staging migration",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "C11 Database & Migrations",
@@ -10193,9 +10265,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Dispatch prod migration (double confirm + reason)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "double_confirm",
       "plan_domain": "C11 Database & Migrations",
@@ -10210,9 +10285,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Last migration run status",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "C11 Database & Migrations",
@@ -10227,9 +10305,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Run a named backfill",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "C11 Database & Migrations",
@@ -10261,9 +10342,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Dev-access users",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
@@ -10278,9 +10362,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Grant dev access",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
@@ -10295,9 +10382,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Revoke dev access",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
@@ -10312,9 +10402,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Mint a dev token",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "confirm",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
@@ -10329,9 +10422,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Navigate Command Hub to module/tab",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
@@ -10346,9 +10442,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Dry-run conversation decision for a user",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
@@ -10363,9 +10462,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Journey context readout",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
@@ -10380,9 +10482,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Catalog stats (live/planned/parity)",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
@@ -10397,9 +10502,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "One tool's manifest entry",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
@@ -10431,9 +10539,12 @@
         "admin",
         "exafy_admin"
       ],
-      "status": "planned",
+      "status": "live",
       "description": "Composite morning briefing: health + deploys + approvals + violations + failing checks",
-      "wired_in": [],
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
       "priority": "P2",
       "risk": "read",
       "plan_domain": "C12 Dev Access, Simulator & Meta",

--- a/services/gateway/test/orb-tools/admin-audit-memory-ops-tools.test.ts
+++ b/services/gateway/test/orb-tools/admin-audit-memory-ops-tools.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Admin Audit, i18n & Memory Ops voice tools (Wave 6, plan section B16) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  ADMIN_AUDIT_MEMORY_OPS_TOOL_HANDLERS,
+  ADMIN_AUDIT_MEMORY_OPS_TOOL_DECLARATIONS,
+  admin_audit_actions_log,
+  admin_audit_access_log,
+  admin_run_memory_consolidator,
+  admin_run_embeddings_backfill,
+} from '../../src/services/orb-tools/admin-audit-memory-ops-tools';
+
+const EXAFY_ID: OrbToolIdentity = { user_id: 'u-exafy', tenant_id: 't-1', role: 'exafy_admin', user_jwt: 'jwt-xyz' };
+const ADMIN_ID: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'admin', user_jwt: 'jwt-abc' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'admin' };
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(ADMIN_AUDIT_MEMORY_OPS_TOOL_HANDLERS);
+
+  it('exposes all 4 tools with matching declarations', () => {
+    expect(names).toHaveLength(4);
+    const declNames = ADMIN_AUDIT_MEMORY_OPS_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await ADMIN_AUDIT_MEMORY_OPS_TOOL_HANDLERS[name]({}, COMMUNITY_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await ADMIN_AUDIT_MEMORY_OPS_TOOL_HANDLERS[name]({}, ANON_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('admin_audit_actions_log / admin_audit_access_log', () => {
+  it('reports actions', async () => {
+    mockFetch(200, { actions: [{ action: 'grant_role' }] });
+    const r = await admin_audit_actions_log({}, ADMIN_ID, {} as SupabaseClient);
+    expect(r.text).toContain('1 admin actions');
+  });
+
+  it('handles empty access log', async () => {
+    mockFetch(200, { access_log: [] });
+    const r = await admin_audit_access_log({}, ADMIN_ID, {} as SupabaseClient);
+    expect(r.text).toBe('No access events logged.');
+  });
+});
+
+describe('admin_run_memory_consolidator', () => {
+  it('rejects a plain admin (exafy_admin only)', async () => {
+    const r = await admin_run_memory_consolidator({}, ADMIN_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first, scoped', async () => {
+    const r = await admin_run_memory_consolidator({ user_id: 'u1', tenant_id: 't1' }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean; scope: unknown }).requires_confirmation).toBe(true);
+    expect((r.result as { scope: unknown }).scope).toEqual({ user_id: 'u1', tenant_id: 't1' });
+  });
+
+  it('warns about all-users sweep when unscoped', async () => {
+    const r = await admin_run_memory_consolidator({}, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('ALL users');
+  });
+
+  it('runs on confirm', async () => {
+    mockFetch(200, { run_id: 'run-1', status: 'started' });
+    const r = await admin_run_memory_consolidator({ confirm: true }, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('run-1');
+  });
+});
+
+describe('admin_run_embeddings_backfill', () => {
+  it('requires confirmation unless dry_run', async () => {
+    const r = await admin_run_embeddings_backfill({}, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('skips confirmation on dry_run', async () => {
+    mockFetch(200, { would_process: 42 });
+    const r = await admin_run_embeddings_backfill({ dry_run: true }, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('42');
+  });
+
+  it('reports backfill results on confirm', async () => {
+    mockFetch(200, { processed_count: 10, errors_count: 0 });
+    const r = await admin_run_embeddings_backfill({ confirm: true }, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('Backfilled 10 items');
+  });
+});

--- a/services/gateway/test/orb-tools/admin-specialists-tools.test.ts
+++ b/services/gateway/test/orb-tools/admin-specialists-tools.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Admin Specialists / Personas voice tools (Wave 6, plan section B10) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  ADMIN_SPECIALISTS_TOOL_HANDLERS,
+  ADMIN_SPECIALISTS_TOOL_DECLARATIONS,
+  admin_list_specialists,
+  admin_get_specialist,
+  admin_create_specialist,
+  admin_set_specialist_status,
+  admin_test_specialist_connection,
+} from '../../src/services/orb-tools/admin-specialists-tools';
+
+const ADMIN_ID: OrbToolIdentity = { user_id: 'u-adm', tenant_id: 't-1', role: 'admin', user_jwt: 'jwt-abc' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'admin' };
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(ADMIN_SPECIALISTS_TOOL_HANDLERS);
+
+  it('exposes all 9 tools with matching declarations', () => {
+    expect(names).toHaveLength(9);
+    const declNames = ADMIN_SPECIALISTS_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await ADMIN_SPECIALISTS_TOOL_HANDLERS[name](
+      { key: 'nutrition', display_name: 'Nutrition', role: 'coach', system_prompt: 'x', version: 1, tool_keys: ['a'], kb_keys: ['b'], enabled: true, connection_id: 'c1' },
+      COMMUNITY_ID,
+      {} as SupabaseClient,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await ADMIN_SPECIALISTS_TOOL_HANDLERS[name]({}, ANON_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('admin_list_specialists / admin_get_specialist', () => {
+  it('lists personas', async () => {
+    mockFetch(200, { personas: [{ key: 'nutrition' }, { key: 'fitness' }] });
+    const r = await admin_list_specialists({}, ADMIN_ID, {} as SupabaseClient);
+    expect(r.text).toContain('2 specialist personas');
+  });
+
+  it('reports honestly on 404', async () => {
+    mockFetch(404, { error: 'not_found' });
+    const r = await admin_get_specialist({ key: 'ghost' }, ADMIN_ID, {} as SupabaseClient);
+    expect((r.result as { found: boolean }).found).toBe(false);
+  });
+});
+
+describe('admin_create_specialist', () => {
+  it('validates the key pattern', async () => {
+    const r = await admin_create_specialist(
+      { key: 'Bad-Key', display_name: 'X', role: 'coach', system_prompt: 'y' },
+      ADMIN_ID,
+      {} as SupabaseClient,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await admin_create_specialist(
+      { key: 'nutrition2', display_name: 'Nutrition 2', role: 'coach', system_prompt: 'y' },
+      ADMIN_ID,
+      {} as SupabaseClient,
+    );
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('reports a taken key on 409', async () => {
+    mockFetch(409, { error: 'conflict' });
+    const r = await admin_create_specialist(
+      { key: 'nutrition', display_name: 'Nutrition', role: 'coach', system_prompt: 'y', confirm: true },
+      ADMIN_ID,
+      {} as SupabaseClient,
+    );
+    expect((r.result as { reason: string }).reason).toBe('key_taken');
+  });
+});
+
+describe('admin_set_specialist_status', () => {
+  it('special-cases the vitana persona', async () => {
+    mockFetch(400, { error: 'VITANA_ALWAYS_ON' });
+    const r = await admin_set_specialist_status({ key: 'vitana', enabled: false, confirm: true }, ADMIN_ID, {} as SupabaseClient);
+    expect((r.result as { reason: string }).reason).toBe('vitana_always_on');
+  });
+});
+
+describe('admin_test_specialist_connection', () => {
+  it('requires connection_id', async () => {
+    const r = await admin_test_specialist_connection({}, ADMIN_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports health honestly', async () => {
+    mockFetch(200, { provider: 'stub', healthy: false, note: 'timeout' });
+    const r = await admin_test_specialist_connection({ connection_id: 'c1' }, ADMIN_ID, {} as SupabaseClient);
+    expect(r.text).toContain('unhealthy');
+  });
+});

--- a/services/gateway/test/orb-tools/database-migrations-tools.test.ts
+++ b/services/gateway/test/orb-tools/database-migrations-tools.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Developer Database & Migrations voice tools (Wave 6, plan section C11) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  DATABASE_MIGRATIONS_TOOL_HANDLERS,
+  DATABASE_MIGRATIONS_TOOL_DECLARATIONS,
+  dev_run_staging_migration,
+  dev_run_prod_migration,
+  dev_migration_status,
+  dev_run_backfill,
+} from '../../src/services/orb-tools/database-migrations-tools';
+
+jest.mock('../../src/services/github-service', () => ({
+  __esModule: true,
+  default: {
+    triggerWorkflow: jest.fn().mockResolvedValue(undefined),
+    getWorkflowRuns: jest.fn().mockResolvedValue({ workflow_runs: [{ id: 1, status: 'completed', conclusion: 'success', created_at: new Date().toISOString() }] }),
+  },
+}));
+
+import githubService from '../../src/services/github-service';
+
+const EXAFY_ID: OrbToolIdentity = { user_id: 'u-exafy', tenant_id: 't-1', role: 'exafy_admin', user_jwt: 'jwt-xyz' };
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer', user_jwt: 'jwt-dev' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(DATABASE_MIGRATIONS_TOOL_HANDLERS);
+
+  it('exposes all 4 tools with matching declarations', () => {
+    expect(names).toHaveLength(4);
+    const declNames = DATABASE_MIGRATIONS_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies community role', async (name) => {
+    const r = await DATABASE_MIGRATIONS_TOOL_HANDLERS[name](
+      { migration_file: 'supabase/migrations/x.sql', reason: 'r', name: 'embeddings' },
+      COMMUNITY_ID,
+      {} as SupabaseClient,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await DATABASE_MIGRATIONS_TOOL_HANDLERS[name]({}, ANON_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_run_staging_migration', () => {
+  it('validates the migration_file path', async () => {
+    const r = await dev_run_staging_migration({ migration_file: 'not/valid.sql' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await dev_run_staging_migration({ migration_file: 'supabase/migrations/x.sql' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('dispatches with the staging confirm phrase on confirm', async () => {
+    const r = await dev_run_staging_migration({ migration_file: 'supabase/migrations/x.sql', confirm: true }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(true);
+    expect(githubService.triggerWorkflow).toHaveBeenCalledWith(
+      'exafyltd/vitana-platform', 'RUN-STAGING-MIGRATION.yml', 'main',
+      expect.objectContaining({ confirm: 'I-mean-staging' }),
+    );
+  });
+});
+
+describe('dev_run_prod_migration', () => {
+  it('requires a reason', async () => {
+    const r = await dev_run_prod_migration({ migration_file: 'supabase/migrations/x.sql' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await dev_run_prod_migration({ migration_file: 'supabase/migrations/x.sql', reason: 'hotfix' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('dispatches RUN-MIGRATION.yml on confirm', async () => {
+    const r = await dev_run_prod_migration({ migration_file: 'supabase/migrations/x.sql', reason: 'hotfix', confirm: true }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(true);
+    expect(githubService.triggerWorkflow).toHaveBeenCalledWith('exafyltd/vitana-platform', 'RUN-MIGRATION.yml', 'main', { migration_file: 'supabase/migrations/x.sql' });
+  });
+});
+
+describe('dev_migration_status', () => {
+  it('defaults to staging', async () => {
+    const r = await dev_migration_status({}, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(true);
+    expect(githubService.getWorkflowRuns).toHaveBeenCalledWith('exafyltd/vitana-platform', 'RUN-STAGING-MIGRATION.yml');
+  });
+
+  it('switches to production when asked', async () => {
+    const r = await dev_migration_status({ target: 'production' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(true);
+    expect(githubService.getWorkflowRuns).toHaveBeenCalledWith('exafyltd/vitana-platform', 'RUN-MIGRATION.yml');
+  });
+});
+
+describe('dev_run_backfill', () => {
+  it('rejects an unknown name', async () => {
+    const r = await dev_run_backfill({ name: 'bogus' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('journey_translations requires confirmation first', async () => {
+    const r = await dev_run_backfill({ name: 'journey_translations' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('journey_translations dispatches on confirm', async () => {
+    const r = await dev_run_backfill({ name: 'journey_translations', confirm: true }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(true);
+    expect(githubService.triggerWorkflow).toHaveBeenCalledWith('exafyltd/vitana-platform', 'JOURNEY-TRANSLATIONS-BACKFILL.yml', 'main', expect.any(Object));
+  });
+
+  it('embeddings requires exafy_admin even for a plain developer', async () => {
+    const r = await dev_run_backfill({ name: 'embeddings' }, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('embeddings skips confirmation on dry_run for exafy_admin', async () => {
+    mockFetch(200, { would_process: 5 });
+    const r = await dev_run_backfill({ name: 'embeddings', dry_run: true }, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('5');
+  });
+
+  it('embeddings requires confirmation first for exafy_admin (non-dry-run)', async () => {
+    const r = await dev_run_backfill({ name: 'embeddings' }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+});

--- a/services/gateway/test/orb-tools/dev-access-simulator-meta-tools.test.ts
+++ b/services/gateway/test/orb-tools/dev-access-simulator-meta-tools.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Developer Dev Access, Simulator & Meta voice tools (Wave 6, plan
+ * section C12, final wave) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity, OrbToolResult } from '../../src/services/orb-tools-shared';
+import {
+  DEV_ACCESS_SIMULATOR_META_TOOL_HANDLERS,
+  DEV_ACCESS_SIMULATOR_META_TOOL_DECLARATIONS,
+  dev_list_dev_users,
+  dev_grant_access,
+  dev_revoke_access,
+  dev_mint_token,
+  dev_open_hub_panel,
+  dev_run_simulator,
+  dev_journey_context,
+  dev_voice_catalog_stats,
+  dev_get_voice_tool_detail,
+  dev_system_briefing,
+} from '../../src/services/orb-tools/dev-access-simulator-meta-tools';
+
+const EXAFY_ID: OrbToolIdentity = { user_id: 'u-exafy', tenant_id: 't-1', role: 'exafy_admin', user_jwt: 'jwt-xyz' };
+const DEV_ID: OrbToolIdentity = { user_id: 'u-dev', tenant_id: 't-1', role: 'developer', user_jwt: 'jwt-dev' };
+const COMMUNITY_ID: OrbToolIdentity = { user_id: 'u-com', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'developer' };
+
+const realFetch = global.fetch;
+const realEnv = { ...process.env };
+afterEach(() => {
+  global.fetch = realFetch;
+  process.env = { ...realEnv };
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(DEV_ACCESS_SIMULATOR_META_TOOL_HANDLERS);
+
+  it('exposes all 10 tools with matching declarations', () => {
+    expect(names).toHaveLength(10);
+    const declNames = DEV_ACCESS_SIMULATOR_META_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(names)('%s denies unauthenticated callers', async (name) => {
+    const r = await DEV_ACCESS_SIMULATOR_META_TOOL_HANDLERS[name](
+      { email: 'a@b.com', role: 'developer', user_id: 'u1', name: 'dev_list_dev_users', screen_id: 'DEVHUB.OVERVIEW.SYSTEM_OVERVIEW' },
+      ANON_ID,
+      {} as SupabaseClient,
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('exafy_admin-only tools reject a plain developer', () => {
+  it.each(['dev_list_dev_users', 'dev_grant_access', 'dev_revoke_access', 'dev_mint_token', 'dev_run_simulator', 'dev_journey_context'])('%s', async (name) => {
+    const r = await DEV_ACCESS_SIMULATOR_META_TOOL_HANDLERS[name](
+      { email: 'a@b.com', role: 'developer', user_id: 'u1' },
+      DEV_ID,
+      {} as SupabaseClient,
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('dev_list_dev_users', () => {
+  it('lists users', async () => {
+    mockFetch(200, { users: [{ email: 'a@b.com' }] });
+    const r = await dev_list_dev_users({}, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('a@b.com');
+  });
+});
+
+describe('dev_grant_access / dev_revoke_access', () => {
+  it('grant requires confirmation first', async () => {
+    const r = await dev_grant_access({ email: 'a@b.com' }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('revoke surfaces SELF_REVOKE_FORBIDDEN honestly', async () => {
+    mockFetch(400, { error: 'SELF_REVOKE_FORBIDDEN' });
+    const r = await dev_revoke_access({ email: 'a@b.com', confirm: true }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { reason: string }).reason).toBe('self_revoke_forbidden');
+  });
+});
+
+describe('dev_mint_token', () => {
+  it('validates role', async () => {
+    const r = await dev_mint_token({ email: 'a@b.com', role: 'bogus' }, EXAFY_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await dev_mint_token({ email: 'a@b.com', role: 'developer' }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('reports no_dev_secret honestly when unconfigured', async () => {
+    delete process.env.DEV_AUTH_SECRET;
+    const r = await dev_mint_token({ email: 'a@b.com', role: 'developer', confirm: true }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { reason: string }).reason).toBe('no_dev_secret');
+  });
+
+  it('surfaces DEV_AUTH_DISABLED honestly outside dev-sandbox', async () => {
+    process.env.DEV_AUTH_SECRET = 'shh';
+    mockFetch(403, { error: 'DEV_AUTH_DISABLED' });
+    const r = await dev_mint_token({ email: 'a@b.com', role: 'developer', confirm: true }, EXAFY_ID, {} as SupabaseClient);
+    expect((r.result as { reason: string }).reason).toBe('not_dev_sandbox');
+  });
+});
+
+describe('dev_open_hub_panel', () => {
+  it('requires screen_id', async () => {
+    const r = await dev_open_hub_panel({}, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('delegates to navigation (not an unknown-screen error) for a real screen_id', async () => {
+    const r = await dev_open_hub_panel({ screen_id: 'DEVHUB.OVERVIEW.SYSTEM_OVERVIEW' }, DEV_ID, {} as SupabaseClient);
+    if (!r.ok) expect(r.error).not.toContain('Unknown screen_id');
+  });
+});
+
+describe('dev_run_simulator', () => {
+  it('requires user_id', async () => {
+    const r = await dev_run_simulator({}, EXAFY_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports the simulated register', async () => {
+    mockFetch(200, { data: { register: 'continue', chosen_nba: null } });
+    const r = await dev_run_simulator({ user_id: 'u1' }, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('continue');
+  });
+});
+
+describe('dev_journey_context', () => {
+  it('requires user_id', async () => {
+    const r = await dev_journey_context({}, EXAFY_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(false);
+  });
+
+  it('handles no stored signals', async () => {
+    mockFetch(200, { rows: [] });
+    const r = await dev_journey_context({ user_id: 'u1' }, EXAFY_ID, {} as SupabaseClient);
+    expect(r.text).toContain('No durable assistant-state signals');
+  });
+});
+
+describe('dev_voice_catalog_stats / dev_get_voice_tool_detail', () => {
+  it('reports catalog stats', async () => {
+    mockFetch(200, { total: 594, by_status: { live: 300, planned: 294 } });
+    const r = await dev_voice_catalog_stats({}, DEV_ID, {} as SupabaseClient);
+    expect(r.text).toContain('594 voice tools');
+  });
+
+  it('reports 404 honestly for an unknown tool name', async () => {
+    mockFetch(404, { error: 'tool_not_found' });
+    const r = await dev_get_voice_tool_detail({ name: 'ghost_tool' }, DEV_ID, {} as SupabaseClient);
+    expect((r.result as { found: boolean }).found).toBe(false);
+  });
+});
+
+describe('dev_system_briefing', () => {
+  it('composites all 5 sub-tool texts', async () => {
+    mockFetch(200, { status: 'green' });
+    const r = await dev_system_briefing({}, DEV_ID, {} as SupabaseClient);
+    expect(r.ok).toBe(true);
+    expect(typeof (r as Extract<OrbToolResult, { ok: true }>).text).toBe('string');
+  });
+});

--- a/services/gateway/test/orb-tools/memory-diary-social-tools.test.ts
+++ b/services/gateway/test/orb-tools/memory-diary-social-tools.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Memory & Diary extras (A13) + Profile & Social depth (A14) voice tools
+ * (Wave 6) — unit tests.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity } from '../../src/services/orb-tools-shared';
+import {
+  MEMORY_DIARY_SOCIAL_TOOL_HANDLERS,
+  MEMORY_DIARY_SOCIAL_TOOL_DECLARATIONS,
+  edit_memory,
+  reinforce_memory,
+  set_memory_permissions,
+  get_what_vitana_knows,
+  add_diary_photo,
+  get_profile_completeness,
+  share_my_profile,
+  get_my_milestones,
+  view_member_profile,
+  update_service_offerings,
+} from '../../src/services/orb-tools/memory-diary-social-tools';
+
+const USER_ID: OrbToolIdentity = { user_id: 'u-1', tenant_id: 't-1', role: 'community', user_jwt: 'jwt-abc' };
+const NO_JWT_ID: OrbToolIdentity = { user_id: 'u-1', tenant_id: 't-1', role: 'community' };
+const ANON_ID: OrbToolIdentity = { user_id: '', tenant_id: null, role: 'community' };
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.clearAllMocks();
+});
+
+function mockFetch(status: number, body: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+function makeSb(rows: unknown[] = [], error: { message: string } | null = null): SupabaseClient {
+  const chain: any = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue({ data: rows, error }),
+  };
+  return { from: jest.fn(() => chain) } as unknown as SupabaseClient;
+}
+
+describe('catalogue', () => {
+  const names = Object.keys(MEMORY_DIARY_SOCIAL_TOOL_HANDLERS);
+  // add_diary_photo delegates straight to tool_navigate_to_screen, which
+  // treats a missing user_id as "anonymous" rather than "denied" — it
+  // resolves per-screen role gating instead of a blanket auth error.
+  const authGatedNames = names.filter((n) => n !== 'add_diary_photo');
+
+  it('exposes all 10 tools with matching declarations', () => {
+    expect(names).toHaveLength(10);
+    const declNames = MEMORY_DIARY_SOCIAL_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of names) expect(declNames).toContain(n);
+  });
+
+  it.each(authGatedNames)('%s denies unauthenticated callers', async (name) => {
+    const r = await MEMORY_DIARY_SOCIAL_TOOL_HANDLERS[name]({}, ANON_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('edit_memory', () => {
+  it('requires memory_item_id and new_content', async () => {
+    const r = await edit_memory({}, USER_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await edit_memory({ memory_item_id: 'm1', new_content: 'corrected' }, USER_ID, makeSb());
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+
+  it('needs a session JWT', async () => {
+    const r = await edit_memory({ memory_item_id: 'm1', new_content: 'x' }, NO_JWT_ID, makeSb());
+    expect((r.result as { reason: string }).reason).toBe('no_session');
+  });
+
+  it('corrects on confirm', async () => {
+    mockFetch(200, {});
+    const r = await edit_memory({ memory_item_id: 'm1', new_content: 'corrected', confirm: true }, USER_ID, makeSb());
+    expect(r.text).toBe('Memory corrected.');
+  });
+});
+
+describe('reinforce_memory', () => {
+  it('is not confirm-gated', async () => {
+    mockFetch(200, {});
+    const r = await reinforce_memory({ memory_item_id: 'm1' }, USER_ID, makeSb());
+    expect(r.text).toContain('confirmed and trustworthy');
+  });
+});
+
+describe('set_memory_permissions', () => {
+  it('validates domain and visibility', async () => {
+    const r = await set_memory_permissions({ domain: 'bogus', visibility: 'private' }, USER_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await set_memory_permissions({ domain: 'diary', visibility: 'private' }, USER_ID, makeSb());
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+});
+
+describe('get_what_vitana_knows (alias)', () => {
+  it('delegates to the memory garden summary route', async () => {
+    mockFetch(200, { categories: [] });
+    const r = await get_what_vitana_knows({}, USER_ID, makeSb());
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('add_diary_photo (navigation-only)', () => {
+  it('delegates to tool_navigate_to_screen for MEMORY.DIARY (not an unknown-screen error)', async () => {
+    const r = await add_diary_photo({}, USER_ID, makeSb());
+    if (!r.ok) expect(r.error).not.toContain('Unknown screen_id');
+  });
+});
+
+describe('get_profile_completeness', () => {
+  it('reports the taste-alignment percentage', async () => {
+    mockFetch(200, { bundle: { profile_completeness: 62, sparse_data: false } });
+    const r = await get_profile_completeness({}, USER_ID, makeSb());
+    expect(r.text).toContain('62%');
+  });
+});
+
+describe('share_my_profile', () => {
+  it('builds a shareable link', async () => {
+    mockFetch(200, { profile: { handle: 'jane' } });
+    const r = await share_my_profile({}, USER_ID, makeSb());
+    expect(r.text).toContain('https://vitanaland.com/u/jane');
+  });
+});
+
+describe('get_my_milestones', () => {
+  it('handles no milestones', async () => {
+    const r = await get_my_milestones({}, USER_ID, makeSb([]));
+    expect(r.text).toBe('No milestones achieved yet.');
+  });
+
+  it('lists milestones', async () => {
+    const r = await get_my_milestones({}, USER_ID, makeSb([{ title: 'First 10K steps' }]));
+    expect(r.text).toContain('First 10K steps');
+  });
+});
+
+describe('view_member_profile', () => {
+  it('requires user_id or handle', async () => {
+    const r = await view_member_profile({}, USER_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports 404 honestly', async () => {
+    mockFetch(404, { error: 'not_found' });
+    const r = await view_member_profile({ user_id: 'ghost' }, USER_ID, makeSb());
+    expect((r.result as { found: boolean }).found).toBe(false);
+  });
+});
+
+describe('update_service_offerings', () => {
+  it('requires a non-empty offers array', async () => {
+    const r = await update_service_offerings({ offers: [] }, USER_ID, makeSb());
+    expect(r.ok).toBe(false);
+  });
+
+  it('requires confirmation first', async () => {
+    const r = await update_service_offerings({ offers: [{ category: 'coaching', title: 'Life coaching' }] }, USER_ID, makeSb());
+    expect((r.result as { requires_confirmation: boolean }).requires_confirmation).toBe(true);
+  });
+});

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -2886,7 +2886,37 @@ Progress readout on your active goal.
 Checkpoints in your goal plan.
 
 ### create_service
-Create a service listing in the Business Hub catalog. NOTE: there is no way to list, edit, or archive services by voice yet. TWO-STEP confirm."
+Create a service listing in the Business Hub catalog. NOTE: there is no way to list, edit, or archive services by voice yet. TWO-STEP confirm.
+
+### edit_memory
+Correct the content of a stored memory. TWO-STEP confirm.
+
+### reinforce_memory
+Confirm a memory as accurate and trustworthy (raises its confidence score).
+
+### set_memory_permissions
+Set who can see a category of your memory (diary, garden, relationships, longevity, timeline). TWO-STEP confirm.
+
+### get_what_vitana_knows
+"What do you know about me" — summary of your memory garden by category.
+
+### add_diary_photo
+Opens the diary screen so you can attach a photo (voice cannot upload directly).
+
+### get_profile_completeness
+Your taste/lifestyle profile completeness percentage.
+
+### share_my_profile
+Get your shareable profile link.
+
+### get_my_milestones
+Your achieved milestones.
+
+### view_member_profile
+Spoken summary of a community member's public profile.
+
+### update_service_offerings
+Replace the service offerings shown on your profile. TWO-STEP confirm."
 `;
 
 exports[`A0.1 characterization: buildLiveSystemInstruction renders a stable system instruction for persona "day-180-veteran-reconnect": persona:day-180-veteran-reconnect 1`] = `
@@ -5517,5 +5547,35 @@ Progress readout on your active goal.
 Checkpoints in your goal plan.
 
 ### create_service
-Create a service listing in the Business Hub catalog. NOTE: there is no way to list, edit, or archive services by voice yet. TWO-STEP confirm."
+Create a service listing in the Business Hub catalog. NOTE: there is no way to list, edit, or archive services by voice yet. TWO-STEP confirm.
+
+### edit_memory
+Correct the content of a stored memory. TWO-STEP confirm.
+
+### reinforce_memory
+Confirm a memory as accurate and trustworthy (raises its confidence score).
+
+### set_memory_permissions
+Set who can see a category of your memory (diary, garden, relationships, longevity, timeline). TWO-STEP confirm.
+
+### get_what_vitana_knows
+"What do you know about me" — summary of your memory garden by category.
+
+### add_diary_photo
+Opens the diary screen so you can attach a photo (voice cannot upload directly).
+
+### get_profile_completeness
+Your taste/lifestyle profile completeness percentage.
+
+### share_my_profile
+Get your shareable profile link.
+
+### get_my_milestones
+Your achieved milestones.
+
+### view_member_profile
+Spoken summary of a community member's public profile.
+
+### update_service_offerings
+Replace the service offerings shown on your profile. TWO-STEP confirm."
 `;

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -6560,6 +6560,165 @@ CALL WHEN the user says: "connect my Oura ring", "pair my device",
         },
       },
       {
+        "description": "Correct the content of a stored memory. TWO-STEP confirm.",
+        "name": "edit_memory",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "correction_notes": {
+              "type": "string",
+            },
+            "memory_item_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "new_content": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "memory_item_id",
+            "new_content",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Confirm a memory as accurate and trustworthy (raises its confidence score).",
+        "name": "reinforce_memory",
+        "parameters": {
+          "properties": {
+            "confirmation_notes": {
+              "type": "string",
+            },
+            "memory_item_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "memory_item_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set who can see a category of your memory (diary, garden, relationships, longevity, timeline). TWO-STEP confirm.",
+        "name": "set_memory_permissions",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "domain": {
+              "description": "diary, garden, relationships, longevity, or timeline. Required.",
+              "type": "string",
+            },
+            "visibility": {
+              "description": "private, connections, professionals, or custom. Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "domain",
+            "visibility",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": ""What do you know about me" — summary of your memory garden by category.",
+        "name": "get_what_vitana_knows",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "Opens the diary screen so you can attach a photo (voice cannot upload directly).",
+        "name": "add_diary_photo",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "Your taste/lifestyle profile completeness percentage.",
+        "name": "get_profile_completeness",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get your shareable profile link.",
+        "name": "share_my_profile",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "Your achieved milestones.",
+        "name": "get_my_milestones",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "Spoken summary of a community member's public profile.",
+        "name": "view_member_profile",
+        "parameters": {
+          "properties": {
+            "handle": {
+              "type": "string",
+            },
+            "user_id": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "Replace the service offerings shown on your profile. TWO-STEP confirm.",
+        "name": "update_service_offerings",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "offers": {
+              "description": "Required, replaces existing offerings. Each: {category, title, short_description?, price_min_cents?, price_max_cents?, currency?, contact_via?}.",
+              "items": {
+                "properties": {
+                  "category": {
+                    "type": "string",
+                  },
+                  "title": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "offers",
+          ],
+          "type": "object",
+        },
+      },
+      {
         "description": "Return the top open admin_insights for this tenant, ranked by severity × confidence. Call this AT THE START of every admin orb session to know what needs attention. The bootstrap context already includes the briefing on session-open; only call again if the admin asks "what else?", "anything new?", or "give me the briefing again".",
         "name": "admin_briefing",
         "parameters": {
@@ -9163,6 +9322,313 @@ Optionally filter by tier (service, embedded, scheduled). Speak problem agents f
         },
       },
       {
+        "description": "DEVELOPER ONLY. Apply a SQL migration file to STAGING via RUN-STAGING-MIGRATION.yml. TWO-STEP confirm.",
+        "name": "dev_run_staging_migration",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "migration_file": {
+              "description": "Path under supabase/migrations/, e.g. supabase/migrations/20260601_foo.sql. Required.",
+              "type": "string",
+            },
+            "ref": {
+              "description": "Branch/ref. Default main.",
+              "type": "string",
+            },
+            "repo": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "migration_file",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Apply a SQL migration file DIRECTLY TO PRODUCTION via RUN-MIGRATION.yml — no staging step. Requires a stated reason. TWO-STEP confirm.",
+        "name": "dev_run_prod_migration",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "migration_file": {
+              "description": "Path under supabase/migrations/. Required.",
+              "type": "string",
+            },
+            "reason": {
+              "description": "Why this must run against prod directly. Required.",
+              "type": "string",
+            },
+            "ref": {
+              "description": "Branch/ref. Default main.",
+              "type": "string",
+            },
+            "repo": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "migration_file",
+            "reason",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Recent staging or production migration workflow runs.",
+        "name": "dev_migration_status",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "integer",
+            },
+            "repo": {
+              "type": "string",
+            },
+            "target": {
+              "description": ""staging" (default) or "production".",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY (embeddings additionally requires exafy_admin). Run a named backfill job: "journey_translations" or "embeddings". TWO-STEP confirm (embeddings skips confirm when dry_run=true).",
+        "name": "dev_run_backfill",
+        "parameters": {
+          "properties": {
+            "batch_size": {
+              "description": "embeddings only. 1-200, default 50.",
+              "type": "number",
+            },
+            "confirm": {
+              "description": "Set true only after explicit confirmation.",
+              "type": "boolean",
+            },
+            "curriculum": {
+              "description": "journey_translations only. Default v2.",
+              "type": "string",
+            },
+            "dry_run": {
+              "type": "boolean",
+            },
+            "limit": {
+              "description": "journey_translations only.",
+              "type": "integer",
+            },
+            "locales": {
+              "description": "journey_translations only. Default en,es,sr.",
+              "type": "string",
+            },
+            "name": {
+              "description": "One of: journey_translations, embeddings. Required.",
+              "type": "string",
+            },
+            "ref": {
+              "type": "string",
+            },
+            "repo": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. List users with exafy_admin dev-hub access.",
+        "name": "dev_list_dev_users",
+        "parameters": {
+          "properties": {
+            "query": {
+              "description": "Optional email substring filter.",
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Grant exafy_admin dev-hub access to a user by email. TWO-STEP confirm.",
+        "name": "dev_grant_access",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "email": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "email",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Revoke exafy_admin dev-hub access from a user by email (cannot self-revoke). TWO-STEP confirm.",
+        "name": "dev_revoke_access",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "email": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "email",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Mint a dev-sandbox session token for a user (works only in the dev-sandbox environment). TWO-STEP confirm.",
+        "name": "dev_mint_token",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "email": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "role": {
+              "description": "patient, community, professional, staff, admin, developer, or infra. Required.",
+              "type": "string",
+            },
+            "tenant_id": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "email",
+            "role",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Navigate to a Command Hub screen/panel by screen_id.",
+        "name": "dev_open_hub_panel",
+        "parameters": {
+          "properties": {
+            "screen_id": {
+              "description": "e.g. DEVHUB.OVERVIEW.SYSTEM_OVERVIEW. Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "screen_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Dry-run the conversation-opening decision (register + next-best-actions) for a user, without speaking or emitting.",
+        "name": "dev_run_simulator",
+        "parameters": {
+          "properties": {
+            "briefing_due": {
+              "type": "boolean",
+            },
+            "bucket": {
+              "description": "Temporal bucket, e.g. same_day.",
+              "type": "string",
+            },
+            "current_route": {
+              "type": "string",
+            },
+            "first_time": {
+              "type": "boolean",
+            },
+            "lang": {
+              "type": "string",
+            },
+            "timezone": {
+              "type": "string",
+            },
+            "user_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "user_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Durable assistant-state signals stored for a user (journey/onboarding context).",
+        "name": "dev_journey_context",
+        "parameters": {
+          "properties": {
+            "tenant_id": {
+              "type": "string",
+            },
+            "user_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "user_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Aggregate counts of this voice tool catalog (by status, surface, role, wiring).",
+        "name": "dev_voice_catalog_stats",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Full manifest entry for one voice tool by name.",
+        "name": "dev_get_voice_tool_detail",
+        "parameters": {
+          "properties": {
+            "name": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "DEVELOPER ONLY. Combined roll-up: service health, recent deployments, pending approvals, governance violations, CI/CD health.",
+        "name": "dev_system_briefing",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
         "description": "ADMIN ONLY. Find a user by name, email, or vitana_id.",
         "name": "admin_lookup_user",
         "parameters": {
@@ -11267,6 +11733,299 @@ Optionally filter by tier (service, embedded, scheduled). Speak problem agents f
             "older_than_days": {
               "description": "Default 90, min 7.",
               "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. List specialist personas.",
+        "name": "admin_list_specialists",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. One persona + version history.",
+        "name": "admin_get_specialist",
+        "parameters": {
+          "properties": {
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "key",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Create a new specialist persona. TWO-STEP confirm.",
+        "name": "admin_create_specialist",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "display_name": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "handles_kinds": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "key": {
+              "description": "Lowercase, starts with a letter. Required.",
+              "type": "string",
+            },
+            "role": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "status": {
+              "description": "active, draft, or disabled.",
+              "type": "string",
+            },
+            "system_prompt": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "voice_id": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "key",
+            "display_name",
+            "role",
+            "system_prompt",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Edit a specialist persona (snapshots the prior version). TWO-STEP confirm.",
+        "name": "admin_update_specialist",
+        "parameters": {
+          "properties": {
+            "change_note": {
+              "type": "string",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "display_name": {
+              "type": "string",
+            },
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "role": {
+              "type": "string",
+            },
+            "status": {
+              "type": "string",
+            },
+            "system_prompt": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "key",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Roll back a specialist to a prior version. TWO-STEP confirm.",
+        "name": "admin_rollback_specialist",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "version": {
+              "description": "Required.",
+              "type": "number",
+            },
+          },
+          "required": [
+            "key",
+            "version",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Replace the set of voice tools bound to a specialist. TWO-STEP confirm.",
+        "name": "admin_set_specialist_tools",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "tool_keys": {
+              "description": "Required, replaces existing bindings.",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "key",
+            "tool_keys",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Replace the set of knowledge-base scopes bound to a specialist. TWO-STEP confirm.",
+        "name": "admin_set_specialist_kb",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "kb_keys": {
+              "description": "Required, replaces existing bindings.",
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "key",
+            "kb_keys",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Enable or disable a specialist (the "vitana" persona can never be disabled). TWO-STEP confirm.",
+        "name": "admin_set_specialist_status",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "enabled": {
+              "description": "Required.",
+              "type": "boolean",
+            },
+            "key": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "key",
+            "enabled",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Test a specialist's third-party connection (stub providers only today).",
+        "name": "admin_test_specialist_connection",
+        "parameters": {
+          "properties": {
+            "connection_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "connection_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Recent admin actions audit log.",
+        "name": "admin_audit_actions_log",
+        "parameters": {
+          "properties": {
+            "action": {
+              "type": "string",
+            },
+            "limit": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "ADMIN ONLY. Recent login/logout/role-change access events.",
+        "name": "admin_audit_access_log",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Run the nightly memory consolidator on demand — scope to one user, or omit for a heavy all-users sweep. TWO-STEP confirm.",
+        "name": "admin_run_memory_consolidator",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "loops": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "tenant_id": {
+              "type": "string",
+            },
+            "user_id": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "EXAFY_ADMIN ONLY. Backfill missing memory_items embeddings. TWO-STEP confirm (dry_run=true skips confirmation).",
+        "name": "admin_run_embeddings_backfill",
+        "parameters": {
+          "properties": {
+            "batch_size": {
+              "description": "1-200, default 50.",
+              "type": "number",
+            },
+            "confirm": {
+              "type": "boolean",
+            },
+            "dry_run": {
+              "type": "boolean",
             },
           },
           "type": "object",
@@ -17734,6 +18493,165 @@ CALL WHEN the user says: "connect my Oura ring", "pair my device",
           "required": [
             "name",
             "service_type",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Correct the content of a stored memory. TWO-STEP confirm.",
+        "name": "edit_memory",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "correction_notes": {
+              "type": "string",
+            },
+            "memory_item_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+            "new_content": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "memory_item_id",
+            "new_content",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Confirm a memory as accurate and trustworthy (raises its confidence score).",
+        "name": "reinforce_memory",
+        "parameters": {
+          "properties": {
+            "confirmation_notes": {
+              "type": "string",
+            },
+            "memory_item_id": {
+              "description": "Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "memory_item_id",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Set who can see a category of your memory (diary, garden, relationships, longevity, timeline). TWO-STEP confirm.",
+        "name": "set_memory_permissions",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "domain": {
+              "description": "diary, garden, relationships, longevity, or timeline. Required.",
+              "type": "string",
+            },
+            "visibility": {
+              "description": "private, connections, professionals, or custom. Required.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "domain",
+            "visibility",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": ""What do you know about me" — summary of your memory garden by category.",
+        "name": "get_what_vitana_knows",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "Opens the diary screen so you can attach a photo (voice cannot upload directly).",
+        "name": "add_diary_photo",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "Your taste/lifestyle profile completeness percentage.",
+        "name": "get_profile_completeness",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get your shareable profile link.",
+        "name": "share_my_profile",
+        "parameters": {
+          "properties": {},
+          "type": "object",
+        },
+      },
+      {
+        "description": "Your achieved milestones.",
+        "name": "get_my_milestones",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "Spoken summary of a community member's public profile.",
+        "name": "view_member_profile",
+        "parameters": {
+          "properties": {
+            "handle": {
+              "type": "string",
+            },
+            "user_id": {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      },
+      {
+        "description": "Replace the service offerings shown on your profile. TWO-STEP confirm.",
+        "name": "update_service_offerings",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "type": "boolean",
+            },
+            "offers": {
+              "description": "Required, replaces existing offerings. Each: {category, title, short_description?, price_min_cents?, price_max_cents?, currency?, contact_via?}.",
+              "items": {
+                "properties": {
+                  "category": {
+                    "type": "string",
+                  },
+                  "title": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "offers",
           ],
           "type": "object",
         },


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-VOICE-CATALOG-WAVE-6` _(no VTID minted for this wave; follows the same bootstrap-style commit convention as Waves 1–5)_

**Layer:** APIL / AGTL (gateway voice-tool dispatcher + LiveKit agent)

**Priority:** P2

---

## 📋 Summary

Final wave (6 of 6) of the approved 425-tool Voice Tools Expansion Plan v2 (`docs/VOICE_TOOLS_EXPANSION_PLAN.md`). Adds 37 new voice tools across 5 domains, completing coverage decisions — build or honest skip — for every tool in the original plan across all six waves.

## ✅ Changes

- **B10 Admin Specialists/Personas (9/10)** — `admin-specialists-tools.ts`. Thin dispatch over `routes/specialists-admin.ts` + `specialists-connections.ts`. Skipped `admin_approve_specialist_ticket` — no specialist-lifecycle-ticket system exists anywhere in the repo.
- **B16 Admin Audit & Memory Ops (4/6)** — `admin-audit-memory-ops-tools.ts`. Over `tenant-admin/audit-log.ts` + `admin-memory-broker.ts` + `admin-embeddings-backfill.ts`. Skipped `admin_i18n_translate`/`admin_i18n_audit` — the translation script and audit workflow they'd need live only in the frontend repo (`vitana-v1`), not here.
- **A13 Memory & Diary extras + A14 Profile & Social depth (10/15)** — `memory-diary-social-tools.ts`. Over `routes/memory.ts`, `memory-governance.ts`, `taste-alignment.ts`, public-profile, `profile-prefs.ts`. Skipped `archive_memory` (both candidate backends misrepresent a reversible archive — one is inert, the other is a real cascade delete), `promote_memory_to_knowledge`, `set_profile_theme`, `add_gallery_photo`, `list_member_posts` — none have a real backend.
- **C11 Database & Migrations (4/6)** — `database-migrations-tools.ts`. Dispatches `RUN-STAGING-MIGRATION.yml` / `RUN-MIGRATION.yml` / `JOURNEY-TRANSLATIONS-BACKFILL.yml` GitHub workflows, plus the embeddings-backfill route. Skipped `dev_list_pending_migrations`/`dev_schema_info` — no runtime-accessible mechanism exists.
- **C12 Dev Access, Simulator & Meta (10/11)** — `dev-access-simulator-meta-tools.ts`. Over `routes/dev-access.ts`, `dev-auth.ts`, `conversation-hub.ts` (the Simulator), `voice-journey-context.ts`, `voice-tools-catalog.ts`. `dev_system_briefing` composites 5 already-built handlers directly rather than adding a new backend. Skipped `dev_run_routine_now` — no server-side "routine" concept exists in this repo.

All handlers wired into `ORB_TOOL_REGISTRY` + Vertex/LiveKit tool declarations in `orb-tools-shared.ts`; 37 Python `@function_tool` wrappers added to `tools.py` (515 total tools, verified zero AST drift against `all_tool_names()`); `tool-manifest.json` reconciled (594 tools total, 37 flipped planned→live); `orb-tools-lift-scanner.mjs` reports no drift.

Two handlers (`add_diary_photo`, `dev_open_hub_panel`) reuse the existing `tool_navigate_to_screen` dispatcher — this required switching to a dynamic `import()` instead of a static one, since a static import back into `orb-tools-shared.ts` (which imports these modules' declarations) created a module load-order cycle that only manifested when a test imported the domain module directly.

This is the **final wave** — all 425 originally-planned tools now have an explicit, documented disposition (built or honestly skipped) across Waves 1–6.

## 🧪 Testing

- [x] Automated tests added/updated — 5 new Jest test files, 128 new tests, all passing
- [x] `tsc --noEmit` clean across the gateway
- [x] Full gateway Jest suite green (8007 passed) except the pre-existing, unrelated `nav-manifest-sync.test.ts` failure (cross-repo nav-catalog drift check, untouched by this PR)
- [x] `voice-tools-manifest-reconcile.mjs --check` / `--apply` — exactly 37 drift, applied cleanly
- [x] `orb-tools-lift-scanner.mjs` — no drift detected
- [x] Python AST parity check — 515 `@function_tool` decorated functions == 515 names in `all_tool_names()`, zero set difference either direction
- [ ] Verified in staging/dev environment (voice tools are exercised via the live ORB pipeline; no standalone staging smoke test for this PR)

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] N/A — no new workflow files in this PR

### File Names
- [x] All new files follow kebab-case (`admin-specialists-tools.ts`, `database-migrations-tools.ts`, etc.)
- [x] No naming-canon violations

### Code Standards
- [x] Event types/kinds use snake_case where emitted
- [x] Status values use lowercase

### Cloud Run Deployments
- [x] N/A — no deployment changes in this PR

### Documentation
- [x] Commit message documents built + skipped tools with reasons
- [x] No non-compliant files introduced

## 🚨 Breaking Changes

None.

## 📌 Additional Notes

Expect the standard non-blocking bot comments on this PR (consistent with every prior wave): "Dev Autopilot — Impact Scan" (no impact findings), "orb-tools lift-not-duplicate parity report" (no drift detected), and "Voice Pipeline Parity Scan" (flags `spec.json` as not declaring new tools — a pre-existing, systemic gap shared by every prior wave's tools too, not introduced here).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX)_