### PR TITLE
fix(awin): title-keyword fallback for subcategory inference

### DIFF
--- a/services/gateway/src/services/marketplace-sync/awin-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/awin-sync.ts
@@ -247,11 +247,27 @@ const SUBCATEGORY_RULES: Array<{ key: string; patterns: RegExp[] }> = [
   { key: 'face-care', patterns: [/skin\s*care/, /facial/, /\bface\b/] },
 ];
 
-function guessSubcategory(googleProductCategory: string | undefined, productType: string | undefined): string | undefined {
+// MISSHA's feed leaves google_product_category/product_type BLANK for a
+// meaningful chunk of SKUs (verified: ~20% of a real 200-row sync). Title
+// keywords are a weaker signal than a real taxonomy field, so this only
+// runs as a fallback when the primary rules above found nothing.
+const TITLE_FALLBACK_RULES: Array<{ key: string; patterns: RegExp[] }> = [
+  { key: 'makeup', patterns: [/\blip\s*(balm|tint|stick)\b/, /\bmascara\b/, /\bbb\s*cream\b/, /\bcc\s*cream\b/, /\bblush(er)?\b/, /\beyeliner\b/, /\beyebrow\b/, /\bconcealer\b/, /\bfoundation\b/] },
+  { key: 'hair-care', patterns: [/\bhair\b/] },
+  { key: 'body-care', patterns: [/\bbody\s*lotion\b/, /\bbody\s*wash\b/] },
+  { key: 'face-care', patterns: [/\bessence\b/, /\bampoule\b/, /\bserum\b/, /\btoner\b/, /\beye\s*cream\b/, /\bnight\s*repair\b/, /\bemulsion\b/, /\bcollagen\b/, /\bmoistur/] },
+];
+
+function guessSubcategory(googleProductCategory: string | undefined, productType: string | undefined, title: string | undefined): string | undefined {
   const hay = `${googleProductCategory ?? ''} ${productType ?? ''}`.toLowerCase();
-  if (!hay.trim()) return undefined;
-  for (const rule of SUBCATEGORY_RULES) {
-    if (rule.patterns.some((p) => p.test(hay))) return rule.key;
+  if (hay.trim()) {
+    for (const rule of SUBCATEGORY_RULES) {
+      if (rule.patterns.some((p) => p.test(hay))) return rule.key;
+    }
+  }
+  const titleHay = (title ?? '').toLowerCase();
+  for (const rule of TITLE_FALLBACK_RULES) {
+    if (rule.patterns.some((p) => p.test(titleHay))) return rule.key;
   }
   return undefined;
 }
@@ -293,7 +309,7 @@ function normalizeAwinRow(
     description_long: row.description,
     brand: row.brand,
     category: cfg.category ?? DEFAULT_CATEGORY,
-    subcategory: guessSubcategory(row.google_product_category, row.product_type),
+    subcategory: guessSubcategory(row.google_product_category, row.product_type, row.title),
     price_cents: priceCents,
     currency,
     compare_at_price_cents: compareCents,


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-02000`

**Layer:** Backend (marketplace-sync)

**Priority:** P3

---

## 📋 Summary

Live-verified against the first real Awin/MISSHA sync (200 products, 0 errors): 40/200 rows (20%) got `subcategory = NULL` because MISSHA's feed leaves `google_product_category`/`product_type` blank for a meaningful chunk of SKUs — e.g. "Time Revolution The First Essence Enriched", "A'pieu Mint Scalp Hair Vinegar", "Dare Tint Lip Balm".

---

## ✅ Changes

- [x] `guessSubcategory()` now falls back to title-keyword matching **only when** the primary `google_product_category`/`product_type` rules found nothing — never overrides a real taxonomy signal:
  - lip balm/tint/stick, mascara, BB/CC cream, blush(er), eyeliner, eyebrow, concealer, foundation → `makeup`
  - "hair" → `hair-care`
  - body lotion/wash → `body-care`
  - essence, ampoule, serum, toner, eye cream, night repair, emulsion, collagen, moistur(izer) → `face-care`
- [x] One-time SQL backfill applied directly to the 40 already-synced NULL rows (not part of this diff — DB-only, same reasoning applied by hand)

---

## 🧪 Testing

- [x] `npm run build` (tsc) passes clean
- [x] Verified against real synced data (200 MISSHA rows) — this is a follow-up to the already-merged Awin Darwin rewrite (#2858), refining subcategory coverage after seeing real feed gaps

---

## 🚨 Breaking Changes

None — subcategory is best-effort metadata for thematic-collection grouping; a NULL value never blocked the product from showing in `category='skincare'` search results, just from a specific "Face Care"/"Makeup" collection.

---
_Generated by [Claude Code](https://claude.ai/code/session_011JdP3fAJvzaKsd5FF2xHB1)_