### PR TITLE
fix(awin): default ships_to_countries to EU+US+MENA, not US-only

### DIFF
--- a/services/gateway/src/services/marketplace-sync/awin-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/awin-sync.ts
@@ -50,8 +50,8 @@
  *     "max_products_per_feed": 500,
  *     "max_rows_scanned": 50000,
  *     "merchant_country": "US",
- *     "ships_to_countries": ["US"],
- *     "ships_to_regions": ["US"]
+ *     "ships_to_countries": ["DE", "AT", "US", ...],
+ *     "ships_to_regions": ["EU", "US"]
  *   }
  *
  * The download_token in each feed_url is a personal export credential tied
@@ -90,8 +90,14 @@ interface AwinSourceConfig {
 }
 
 const DEFAULT_CATEGORY = 'skincare';
-const DEFAULT_SHIPS_TO_COUNTRIES = ['US'];
-const DEFAULT_SHIPS_TO_REGIONS = ['US'];
+// Confirmed with the operator: MISSHA US ships to the EU/Germany too, not
+// just the US despite the storefront name — the feed itself carries no
+// shipping data to derive this from. Mirrors admitad-sync.ts's default
+// (broad dropship-style coverage) rather than assuming "US" from a brand name.
+const DEFAULT_SHIPS_TO_COUNTRIES = [
+  'DE', 'AT', 'CH', 'FR', 'IT', 'ES', 'NL', 'BE', 'PL', 'SE', 'DK', 'FI', 'GB', 'IE', 'US', 'CA', 'AE', 'SA',
+];
+const DEFAULT_SHIPS_TO_REGIONS = ['EU', 'UK', 'US', 'MENA', 'GLOBAL'];
 
 async function loadSourceConfigs(): Promise<AwinSourceConfig[]> {
   const supabase = getSupabase();


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-02000`

**Layer:** Backend (marketplace-sync)

**Priority:** P1 — the entire Awin/MISSHA source was invisible to non-US users

---

## 📋 Summary

MISSHA's feed carries no shipping data, so the original config defaulted `ships_to_countries: ["US"]` based on the "MISSHA US" storefront name alone. `discover-search.ts`'s geo filter requires an exact `ships_to_countries`/`ships_to_regions` match against the requesting user's country — so every one of the 200 synced products was silently filtered out for any non-US user, making the whole source invisible to Vitana's German-first community. Confirmed with the operator that MISSHA does ship to the EU/Germany.

---

## ✅ Changes

- [x] `DEFAULT_SHIPS_TO_COUNTRIES`/`DEFAULT_SHIPS_TO_REGIONS` widened to the same broad EU+US+MENA list already used as the default in `admitad-sync.ts`, instead of assuming a narrow list from a brand name
- [x] Doc comment's example config updated to match
- [x] Already-synced 200 products + `merchants` row + `marketplace_sources_config` row backfilled directly in the DB (not part of this diff) so the fix is visible immediately, not just on the next sync

---

## 🧪 Testing

- [x] `npm run build` (tsc) passes clean
- [x] Verified in DB: all 200 MISSHA products now match `'DE' = ANY(ships_to_countries)`

---

## 🚨 Breaking Changes

None — widens visibility, doesn't narrow it. No other config currently sets `ships_to_countries` for `awin`, so no existing behavior narrows.

---
_Generated by [Claude Code](https://claude.ai/code/session_011JdP3fAJvzaKsd5FF2xHB1)_