### PR TITLE
feat(discover): "Recommend & Earn" — user product recommendations + wallet commissions (VTID-02950)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -28,6 +28,12 @@ VITANA_BOT_USER_ID=
 # non-default port/host wiring).
 GATEWAY_INTERNAL_URL=
 
+# Base URL of the community frontend app, used to build user-facing share
+# links (e.g. VTID-02950's Recommend & Earn share_url). Optional: defaults
+# to the production Cloud Run alias when unset — only set this to override
+# for a non-default environment (e.g. staging).
+COMMUNITY_APP_URL=
+
 # Shared secret for the X-Gateway-Internal service-to-service auth bypass,
 # used by several internal-ops routes' requireDevRole-style middleware
 # (routes/autonomy-pulse.ts, autonomy-trace.ts, dev-autopilot.ts,

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -12535,74 +12535,6 @@ async function triggerMarketplaceSync(network) {
 }
 
 // =============================================================================
-// VTID-02950 · Recommend & Earn — Awin order-conversion sync + commission rate
-// =============================================================================
-
-async function triggerAwinOrderSync() {
-    try {
-        showToast('Pulling Awin conversions…', 'info');
-        var resp = await fetch('/api/v1/admin/marketplace/sync-orders/awin', {
-            method: 'POST',
-            headers: Object.assign({ 'Content-Type': 'application/json' }, buildContextHeaders()),
-        });
-        var json = await resp.json();
-        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
-        var r = json.result || {};
-        showToast(
-            'Awin orders — fetched ' + (r.fetched||0) + ', attributed ' + (r.attributed||0) +
-            ', credited ' + (r.credited||0) + ', unattributed ' + (r.unattributed||0),
-            'success'
-        );
-    } catch (err) {
-        console.error('[VTID-02950] Awin order sync failed:', err);
-        showToast('Awin order sync failed: ' + err.message, 'error');
-    }
-}
-
-async function fetchCommissionSettings() {
-    state.adminCommissionSettingsLoading = true;
-    renderApp();
-    try {
-        var resp = await fetch('/api/v1/admin/marketplace/commission-settings', {
-            method: 'GET',
-            headers: buildContextHeaders(),
-        });
-        var json = await resp.json();
-        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
-        state.adminCommissionDefaultRate = json.default_rate;
-        state.adminCommissionSettingsFetched = true;
-    } catch (err) {
-        console.error('[VTID-02950] fetch commission settings failed:', err);
-    } finally {
-        state.adminCommissionSettingsLoading = false;
-        renderApp();
-    }
-}
-
-async function submitCommissionSettings(ratePercent) {
-    var rate = Number(ratePercent) / 100;
-    if (!isFinite(rate) || rate <= 0 || rate > 1) {
-        showToast('Rate must be between 0 and 100%', 'error');
-        return;
-    }
-    try {
-        var resp = await fetch('/api/v1/admin/marketplace/commission-settings', {
-            method: 'PATCH',
-            headers: Object.assign({ 'Content-Type': 'application/json' }, buildContextHeaders()),
-            body: JSON.stringify({ default_rate: rate }),
-        });
-        var json = await resp.json();
-        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
-        state.adminCommissionDefaultRate = json.default_rate;
-        showToast('Default recommendation commission rate saved: ' + (rate * 100).toFixed(0) + '%', 'success');
-        renderApp();
-    } catch (err) {
-        console.error('[VTID-02950] save commission settings failed:', err);
-        showToast('Save failed: ' + err.message, 'error');
-    }
-}
-
-// =============================================================================
 // VTID-03107 · Billing v1 — operator dashboard
 // =============================================================================
 // Operator tab at /command-hub/admin/billing-dashboard/.
@@ -13383,45 +13315,7 @@ function renderAdminMarketplaceShopsView() {
         })(providers[si].key, providers[si].display_name);
     }
 
-    // VTID-02950: pulls real Awin purchase conversions (distinct from the
-    // product-catalog sync buttons above) and credits recommendation
-    // commissions for any that carry an attribution_recommendation_id.
-    var awinOrderSyncBtn = document.createElement('button');
-    awinOrderSyncBtn.className = 'btn btn-secondary btn-sm';
-    awinOrderSyncBtn.textContent = 'Sync Awin Orders now';
-    awinOrderSyncBtn.title = 'Pulls real Awin purchase conversions and credits recommendation commissions';
-    awinOrderSyncBtn.onclick = function () { triggerAwinOrderSync(); };
-    toolbar.appendChild(awinOrderSyncBtn);
-
     container.appendChild(toolbar);
-
-    // VTID-02950: Recommend & Earn commission-rate panel
-    if (!state.adminCommissionSettingsFetched && !state.adminCommissionSettingsLoading) {
-        fetchCommissionSettings();
-    }
-    var commissionPanel = document.createElement('div');
-    commissionPanel.className = 'admin-panel';
-    commissionPanel.style.cssText = 'margin:1rem 0;padding:1rem;border:1px solid var(--border-color,#e2e2e2);border-radius:8px;';
-    var currentRatePct = state.adminCommissionDefaultRate != null ? (state.adminCommissionDefaultRate * 100).toFixed(0) : '20';
-    commissionPanel.innerHTML =
-        '<h3 style="margin:0 0 0.5rem;font-size:1rem;">Recommend &amp; Earn — default commission rate</h3>' +
-        '<p class="admin-detail-note" style="margin:0 0 0.75rem;">Recommenders earn this % of Vitana\'s own earned commission on a sale. ' +
-        'Override per-merchant on the Merchants screen. Amazon.ae is always excluded (affiliate terms forbid it).</p>' +
-        '<div style="display:flex;align-items:center;gap:0.5rem;">' +
-        '<input id="commission-rate-input" type="number" min="0" max="100" step="1" value="' + escapeHtml(currentRatePct) + '" ' +
-        'style="width:80px;" class="admin-input" />' +
-        '<span>%</span>' +
-        '<button id="commission-rate-save" class="btn btn-primary btn-sm">Save</button>' +
-        '</div>';
-    container.appendChild(commissionPanel);
-    // Wired after append (element must exist in the DOM for getElementById).
-    setTimeout(function () {
-        var saveBtn = document.getElementById('commission-rate-save');
-        var input = document.getElementById('commission-rate-input');
-        if (saveBtn && input) {
-            saveBtn.onclick = function () { submitCommissionSettings(input.value); };
-        }
-    }, 0);
 
     // Create form (collapsible)
     if (state.adminMpShopsShowCreateForm) {

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -12535,6 +12535,74 @@ async function triggerMarketplaceSync(network) {
 }
 
 // =============================================================================
+// VTID-02950 · Recommend & Earn — Awin order-conversion sync + commission rate
+// =============================================================================
+
+async function triggerAwinOrderSync() {
+    try {
+        showToast('Pulling Awin conversions…', 'info');
+        var resp = await fetch('/api/v1/admin/marketplace/sync-orders/awin', {
+            method: 'POST',
+            headers: Object.assign({ 'Content-Type': 'application/json' }, buildContextHeaders()),
+        });
+        var json = await resp.json();
+        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+        var r = json.result || {};
+        showToast(
+            'Awin orders — fetched ' + (r.fetched||0) + ', attributed ' + (r.attributed||0) +
+            ', credited ' + (r.credited||0) + ', unattributed ' + (r.unattributed||0),
+            'success'
+        );
+    } catch (err) {
+        console.error('[VTID-02950] Awin order sync failed:', err);
+        showToast('Awin order sync failed: ' + err.message, 'error');
+    }
+}
+
+async function fetchCommissionSettings() {
+    state.adminCommissionSettingsLoading = true;
+    renderApp();
+    try {
+        var resp = await fetch('/api/v1/admin/marketplace/commission-settings', {
+            method: 'GET',
+            headers: buildContextHeaders(),
+        });
+        var json = await resp.json();
+        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+        state.adminCommissionDefaultRate = json.default_rate;
+        state.adminCommissionSettingsFetched = true;
+    } catch (err) {
+        console.error('[VTID-02950] fetch commission settings failed:', err);
+    } finally {
+        state.adminCommissionSettingsLoading = false;
+        renderApp();
+    }
+}
+
+async function submitCommissionSettings(ratePercent) {
+    var rate = Number(ratePercent) / 100;
+    if (!isFinite(rate) || rate <= 0 || rate > 1) {
+        showToast('Rate must be between 0 and 100%', 'error');
+        return;
+    }
+    try {
+        var resp = await fetch('/api/v1/admin/marketplace/commission-settings', {
+            method: 'PATCH',
+            headers: Object.assign({ 'Content-Type': 'application/json' }, buildContextHeaders()),
+            body: JSON.stringify({ default_rate: rate }),
+        });
+        var json = await resp.json();
+        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+        state.adminCommissionDefaultRate = json.default_rate;
+        showToast('Default recommendation commission rate saved: ' + (rate * 100).toFixed(0) + '%', 'success');
+        renderApp();
+    } catch (err) {
+        console.error('[VTID-02950] save commission settings failed:', err);
+        showToast('Save failed: ' + err.message, 'error');
+    }
+}
+
+// =============================================================================
 // VTID-03107 · Billing v1 — operator dashboard
 // =============================================================================
 // Operator tab at /command-hub/admin/billing-dashboard/.
@@ -13315,7 +13383,45 @@ function renderAdminMarketplaceShopsView() {
         })(providers[si].key, providers[si].display_name);
     }
 
+    // VTID-02950: pulls real Awin purchase conversions (distinct from the
+    // product-catalog sync buttons above) and credits recommendation
+    // commissions for any that carry an attribution_recommendation_id.
+    var awinOrderSyncBtn = document.createElement('button');
+    awinOrderSyncBtn.className = 'btn btn-secondary btn-sm';
+    awinOrderSyncBtn.textContent = 'Sync Awin Orders now';
+    awinOrderSyncBtn.title = 'Pulls real Awin purchase conversions and credits recommendation commissions';
+    awinOrderSyncBtn.onclick = function () { triggerAwinOrderSync(); };
+    toolbar.appendChild(awinOrderSyncBtn);
+
     container.appendChild(toolbar);
+
+    // VTID-02950: Recommend & Earn commission-rate panel
+    if (!state.adminCommissionSettingsFetched && !state.adminCommissionSettingsLoading) {
+        fetchCommissionSettings();
+    }
+    var commissionPanel = document.createElement('div');
+    commissionPanel.className = 'admin-panel';
+    commissionPanel.style.cssText = 'margin:1rem 0;padding:1rem;border:1px solid var(--border-color,#e2e2e2);border-radius:8px;';
+    var currentRatePct = state.adminCommissionDefaultRate != null ? (state.adminCommissionDefaultRate * 100).toFixed(0) : '20';
+    commissionPanel.innerHTML =
+        '<h3 style="margin:0 0 0.5rem;font-size:1rem;">Recommend &amp; Earn — default commission rate</h3>' +
+        '<p class="admin-detail-note" style="margin:0 0 0.75rem;">Recommenders earn this % of Vitana\'s own earned commission on a sale. ' +
+        'Override per-merchant on the Merchants screen. Amazon.ae is always excluded (affiliate terms forbid it).</p>' +
+        '<div style="display:flex;align-items:center;gap:0.5rem;">' +
+        '<input id="commission-rate-input" type="number" min="0" max="100" step="1" value="' + escapeHtml(currentRatePct) + '" ' +
+        'style="width:80px;" class="admin-input" />' +
+        '<span>%</span>' +
+        '<button id="commission-rate-save" class="btn btn-primary btn-sm">Save</button>' +
+        '</div>';
+    container.appendChild(commissionPanel);
+    // Wired after append (element must exist in the DOM for getElementById).
+    setTimeout(function () {
+        var saveBtn = document.getElementById('commission-rate-save');
+        var input = document.getElementById('commission-rate-input');
+        if (saveBtn && input) {
+            saveBtn.onclick = function () { submitCommissionSettings(input.value); };
+        }
+    }, 0);
 
     // Create form (collapsible)
     if (state.adminMpShopsShowCreateForm) {

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -171,6 +171,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const publicProfileOgRouter = require('./routes/public-profile-og').default;
   // VTID-02000: Discover feed (lifecycle-aware default browse)
   const discoverFeedRouter = require('./routes/discover-feed').default;
+  // VTID-02950: Recommend & Earn — user product recommendations + commission stats
+  const discoverRecommendationsRouter = require('./routes/discover-recommendations').default;
   // VTID-02000: Maxina admin marketplace routes
   const adminMarketplaceRouter = require('./routes/admin-marketplace').default;
   // VTID-02000: Internal scheduler-authed sync trigger (shared secret, no user JWT)
@@ -1019,6 +1021,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // VTID-02000: Discover search + feed (unified marketplace query surface)
   mountRouterSync(app, '/api/v1/discover', discoverSearchRouter, { owner: 'discover-search' });
   mountRouterSync(app, '/api/v1/discover', discoverFeedRouter, { owner: 'discover-feed' });
+  mountRouterSync(app, '/api/v1/discover', discoverRecommendationsRouter, { owner: 'discover-recommendations' });
   // Public, auth-less profile lookup for crawler OG previews
   mountRouterSync(app, '/api/v1/public', publicProfileOgRouter, { owner: 'public-profile-og' });
   // VTID-02000: Maxina admin marketplace

--- a/services/gateway/src/routes/admin-marketplace.ts
+++ b/services/gateway/src/routes/admin-marketplace.ts
@@ -378,6 +378,8 @@ router.post('/sync/:network', requireTenantAdmin, async (req: Request, res: Resp
 // /sync/:network above (which pulls the product catalog); this pulls real
 // purchase conversions and credits recommendation commissions.
 router.post('/sync-orders/awin', requireTenantAdmin, async (req: Request, res: Response) => {
+  // impact-allow-no-oasis: emitAdminActivity() below wraps emitOasisEvent —
+  // the static impact-scan can't see through the indirection.
   try {
     const { runAwinOrderSync } = await import('../services/marketplace-sync/awin-order-sync');
     const lookbackDays = Number(req.body?.lookback_days) || 30;
@@ -419,6 +421,8 @@ router.get('/commission-settings', requireTenantAdmin, async (_req: Request, res
 });
 
 router.patch('/commission-settings', requireTenantAdmin, async (req: Request, res: Response) => {
+  // impact-allow-no-oasis: emitAdminActivity() below wraps emitOasisEvent —
+  // the static impact-scan can't see through the indirection.
   const supabase = getSupabase();
   if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
   const rate = Number(req.body?.default_rate);

--- a/services/gateway/src/routes/admin-marketplace.ts
+++ b/services/gateway/src/routes/admin-marketplace.ts
@@ -106,7 +106,7 @@ router.patch('/merchants/:id', requireTenantAdmin, async (req: Request, res: Res
   const supabase = getSupabase();
   if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
   const { id } = req.params;
-  const allowed = ['name', 'is_active', 'quality_score', 'customs_risk', 'commission_rate', 'admin_notes', 'requires_admin_review'];
+  const allowed = ['name', 'is_active', 'quality_score', 'customs_risk', 'commission_rate', 'admin_notes', 'requires_admin_review', 'recommendation_commission_eligible', 'recommendation_commission_rate_override'];
   const patch: Record<string, unknown> = {};
   for (const k of allowed) if (k in req.body) patch[k] = req.body[k];
   if (Object.keys(patch).length === 0) return res.status(400).json({ ok: false, error: 'No allowed fields to update' });
@@ -374,6 +374,22 @@ router.post('/sync/:network', requireTenantAdmin, async (req: Request, res: Resp
   }
 });
 
+// Manual Awin order-conversion sync trigger (VTID-02950) — distinct from
+// /sync/:network above (which pulls the product catalog); this pulls real
+// purchase conversions and credits recommendation commissions.
+router.post('/sync-orders/awin', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const { runAwinOrderSync } = await import('../services/marketplace-sync/awin-order-sync');
+    const lookbackDays = Number(req.body?.lookback_days) || 30;
+    const result = await runAwinOrderSync(lookbackDays);
+    await emitAdminActivity(getTenantId(req), getUserId(req), 'awin_order_sync.triggered', { result });
+    res.json({ ok: true, result });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ ok: false, error: message });
+  }
+});
+
 router.post('/geo-policy', requireTenantAdmin, async (req: Request, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
@@ -385,6 +401,39 @@ router.post('/geo-policy', requireTenantAdmin, async (req: Request, res: Respons
   if (error) return res.status(500).json({ ok: false, error: error.message });
   await emitAdminActivity(getTenantId(req), getUserId(req), 'geo_policy.created', { policy_id: data.id, payload });
   res.json({ ok: true, policy: data });
+});
+
+// ==================== Operations: Recommendation commission settings (VTID-02950) ====================
+
+router.get('/commission-settings', requireTenantAdmin, async (_req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const { data, error } = await supabase
+    .from('admin_settings')
+    .select('value, updated_at')
+    .eq('key', 'recommendation_commission_default_rate')
+    .maybeSingle();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  const rate = (data?.value as { rate?: number } | undefined)?.rate ?? 0.2;
+  res.json({ ok: true, default_rate: rate, updated_at: data?.updated_at ?? null });
+});
+
+router.patch('/commission-settings', requireTenantAdmin, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const rate = Number(req.body?.default_rate);
+  if (!Number.isFinite(rate) || rate <= 0 || rate > 1) {
+    return res.status(400).json({ ok: false, error: 'default_rate must be a number between 0 and 1' });
+  }
+  const { error } = await supabase
+    .from('admin_settings')
+    .upsert(
+      { key: 'recommendation_commission_default_rate', value: { rate }, updated_by: getUserId(req), updated_at: new Date().toISOString() },
+      { onConflict: 'key' }
+    );
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  await emitAdminActivity(getTenantId(req), getUserId(req), 'commission_settings.updated', { default_rate: rate });
+  res.json({ ok: true, default_rate: rate });
 });
 
 export default router;

--- a/services/gateway/src/routes/click-redirect.ts
+++ b/services/gateway/src/routes/click-redirect.ts
@@ -111,6 +111,11 @@ function stampAffiliateUrl(baseUrl: string, clickId: string, userIdHash: string 
     if (url.hostname.includes('cj.com') || url.hostname.includes('cj.dotomi.com')) {
       url.searchParams.set('sid', clickId);
     }
+    // Awin-specific clickref — read back by awin-order-sync.ts's Transactions
+    // API pull (VTID-02950) to reverse-attribute a conversion to this click.
+    if (url.hostname.includes('awin1.com') || url.hostname.includes('awin.com')) {
+      url.searchParams.set('clickref', clickId);
+    }
     return url.toString();
   } catch {
     // Malformed URL — return as-is
@@ -295,8 +300,10 @@ router.get('/:product_id', async (req: Request, res: Response) => {
     return;
   }
 
-  // Log click + generate stable click_id
-  const clickId = randomUUID();
+  // Log click + generate stable click_id. Compact (no dashes, 32 hex chars) so
+  // it fits comfortably inside affiliate networks' sub-id length limits (Awin's
+  // clickref, for example) — still effectively unique (from a random UUID).
+  const clickId = randomUUID().replace(/-/g, '');
   const userIdHash = user_id ? createHash('sha256').update(user_id).digest('hex').slice(0, 16) : null;
   const stampedUrl = stampAffiliateUrl(product.affiliate_url, clickId, userIdHash);
 
@@ -321,6 +328,13 @@ router.get('/:product_id', async (req: Request, res: Response) => {
     })
     .then(({ error }) => {
       if (error) console.error('[click-redirect] click log insert failed (non-fatal):', error);
+      if (attribution_recommendation_id) {
+        supabase
+          .rpc('increment_product_recommendation_click', { p_recommendation_id: attribution_recommendation_id })
+          .then(({ error: rpcError }: { error: unknown }) => {
+            if (rpcError) console.error('[click-redirect] recommendation click-count bump failed (non-fatal):', rpcError);
+          });
+      }
     });
 
   // Emit outbound event for reward-system consumption (fire-and-forget)

--- a/services/gateway/src/routes/discover-recommendations.ts
+++ b/services/gateway/src/routes/discover-recommendations.ts
@@ -1,0 +1,138 @@
+/**
+ * VTID-02950: "Recommend & Earn" — user product recommendations.
+ *
+ *   POST /api/v1/discover/recommendations       — create/find a recommendation, get a share link
+ *   GET  /api/v1/discover/my-recommendations    — the caller's recommended products + stats
+ *
+ * A recommendation is per (user, product) — resharing the same product reuses
+ * the same row and share link rather than minting duplicates.
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { randomUUID } from 'crypto';
+import { getSupabase } from '../lib/supabase';
+import { requireAuth } from '../middleware/auth-supabase-jwt';
+
+const router = Router();
+router.use(requireAuth as any);
+
+function getUserId(req: Request): string {
+  return String((req as any).identity?.user_id || '');
+}
+function getTenantId(req: Request): string | null {
+  return (req as any).identity?.tenant_id ?? null;
+}
+
+function shortCode(): string {
+  return randomUUID().replace(/-/g, '').slice(0, 10);
+}
+
+const CreateRecommendationSchema = z.object({
+  product_id: z.string().uuid(),
+});
+
+router.post('/recommendations', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+  const parsed = CreateRecommendationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: 'INVALID_BODY', message: parsed.error.message });
+  }
+  const userId = getUserId(req);
+  const tenantId = getTenantId(req);
+  const { product_id } = parsed.data;
+
+  const { data: product, error: productErr } = await supabase
+    .from('products')
+    .select('id, merchant_id, title, is_active')
+    .eq('id', product_id)
+    .eq('is_active', true)
+    .maybeSingle();
+  if (productErr || !product) return res.status(404).json({ ok: false, error: 'PRODUCT_NOT_FOUND' });
+
+  // Find-or-create — one recommendation per (user, product).
+  const { data: existing } = await supabase
+    .from('product_recommendations')
+    .select('id, sharing_link_id')
+    .eq('user_id', userId)
+    .eq('product_id', product_id)
+    .maybeSingle();
+
+  let recommendationId: string;
+  if (existing) {
+    recommendationId = existing.id;
+  } else {
+    const { data: link, error: linkErr } = await supabase
+      .from('sharing_links')
+      .insert({
+        tenant_id: tenantId,
+        user_id: userId,
+        target_type: 'product',
+        target_id: product_id,
+        short_code: shortCode(),
+        utm_source: 'vitana',
+        utm_medium: 'recommend',
+        utm_campaign: 'discover_recommend',
+      })
+      .select('id')
+      .single();
+    if (linkErr || !link) {
+      return res.status(500).json({ ok: false, error: 'SHARING_LINK_FAILED', message: linkErr?.message });
+    }
+
+    const { data: created, error: createErr } = await supabase
+      .from('product_recommendations')
+      .insert({
+        tenant_id: tenantId,
+        user_id: userId,
+        product_id,
+        merchant_id: product.merchant_id,
+        sharing_link_id: link.id,
+      })
+      .select('id')
+      .single();
+    if (createErr || !created) {
+      return res.status(500).json({ ok: false, error: 'RECOMMENDATION_CREATE_FAILED', message: createErr?.message });
+    }
+    recommendationId = created.id;
+  }
+
+  const origin = (process.env.COMMUNITY_APP_URL || 'https://community-app-q74ibpv6ia-uc.a.run.app').replace(/\/+$/, '');
+  const share_url = `${origin}/discover/product/${product_id}?rec=${recommendationId}`;
+
+  res.json({ ok: true, recommendation_id: recommendationId, share_url, product_title: product.title });
+});
+
+router.get('/my-recommendations', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const userId = getUserId(req);
+
+  const { data, error } = await supabase
+    .from('product_recommendations')
+    .select(
+      'id, product_id, status, click_count, conversion_count, commission_earned_minor, commission_currency, created_at, products(title, images)'
+    )
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+
+  const items = (data ?? []).map((r: any) => ({
+    id: r.id,
+    product_id: r.product_id,
+    product_title: r.products?.title ?? null,
+    product_thumbnail_url: r.products?.images?.[0] ?? null,
+    status: r.status,
+    click_count: r.click_count,
+    conversion_count: r.conversion_count,
+    commission_earned_minor: r.commission_earned_minor,
+    currency: r.commission_currency,
+    created_at: r.created_at,
+  }));
+
+  res.json({ ok: true, items });
+});
+
+export default router;

--- a/services/gateway/src/routes/discover-recommendations.ts
+++ b/services/gateway/src/routes/discover-recommendations.ts
@@ -99,15 +99,17 @@ router.post('/recommendations', async (req: Request, res: Response) => {
     }
     recommendationId = created.id;
 
-    await emitOasisEvent({
-      type: 'discover.recommendation.created' as any,
-      source: 'gateway',
-      vtid: 'VTID-02950',
-      status: 'info',
-      message: `User recommended product ${product_id}`,
-      actor_id: userId,
-      payload: { tenant_id: tenantId, user_id: userId, product_id, recommendation_id: recommendationId },
-    }).catch(() => { /* non-fatal, mirrors emitAdminActivity's swallow pattern */ });
+    try {
+      await emitOasisEvent({
+        type: 'discover.recommendation.created' as any,
+        source: 'gateway',
+        vtid: 'VTID-02950',
+        status: 'info',
+        message: `User recommended product ${product_id}`,
+        actor_id: userId,
+        payload: { tenant_id: tenantId, user_id: userId, product_id, recommendation_id: recommendationId },
+      });
+    } catch { /* non-fatal */ }
   }
 
   const origin = (process.env.COMMUNITY_APP_URL || 'https://community-app-q74ibpv6ia-uc.a.run.app').replace(/\/+$/, '');

--- a/services/gateway/src/routes/discover-recommendations.ts
+++ b/services/gateway/src/routes/discover-recommendations.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 import { randomUUID } from 'crypto';
 import { getSupabase } from '../lib/supabase';
 import { requireAuth } from '../middleware/auth-supabase-jwt';
+import { emitOasisEvent } from '../services/oasis-event-service';
 
 const router = Router();
 router.use(requireAuth as any);
@@ -97,6 +98,16 @@ router.post('/recommendations', async (req: Request, res: Response) => {
       return res.status(500).json({ ok: false, error: 'RECOMMENDATION_CREATE_FAILED', message: createErr?.message });
     }
     recommendationId = created.id;
+
+    await emitOasisEvent({
+      type: 'discover.recommendation.created' as any,
+      source: 'gateway',
+      vtid: 'VTID-02950',
+      status: 'info',
+      message: `User recommended product ${product_id}`,
+      actor_id: userId,
+      payload: { tenant_id: tenantId, user_id: userId, product_id, recommendation_id: recommendationId },
+    }).catch(() => { /* non-fatal, mirrors emitAdminActivity's swallow pattern */ });
   }
 
   const origin = (process.env.COMMUNITY_APP_URL || 'https://community-app-q74ibpv6ia-uc.a.run.app').replace(/\/+$/, '');

--- a/services/gateway/src/routes/wallet-admin.ts
+++ b/services/gateway/src/routes/wallet-admin.ts
@@ -35,6 +35,7 @@ const ALLOWED_REFERENCE_TYPES: ReadonlySet<string> = new Set<SpendEarningReferen
   'marketplace_order',
   'marketplace_earning',
   'live_room_tip',
+  'recommendation_commission',
   'manual',
 ]);
 

--- a/services/gateway/src/services/checkout/checkout-service.ts
+++ b/services/gateway/src/services/checkout/checkout-service.ts
@@ -33,6 +33,7 @@
 import { randomUUID } from 'crypto';
 import { getSupabase } from '../../lib/supabase';
 import { debitWalletForSpend } from '../wallet/spend-earning-service';
+import { creditRecommenderForOrder } from '../recommendation-commissions/credit-recommender';
 import type { WalletCurrency } from '../../types/wallet';
 
 export const VTID = 'VTID-03237';
@@ -363,6 +364,16 @@ export async function checkoutUniversalCart(input: CheckoutCartInput): Promise<C
       .in('external_order_id', walletExts);
     if (updRes.error) {
       console.error(`[${VTID}] order convert failed for checkout ${checkoutId}:`, updRes.error.message);
+    }
+
+    // 9a-ii. Recommendation-commission crediting — a no-op today for first-party
+    // orders (they don't carry commission_cents yet), but future-proofs the
+    // hook point if a margin-based commission is ever added for these SKUs.
+    for (const line of walletLines) {
+      if (!line.orderId) continue;
+      creditRecommenderForOrder(line.orderId).catch((e) =>
+        console.error(`[${VTID}] creditRecommenderForOrder failed (non-fatal):`, e)
+      );
     }
 
     walletOrder = {

--- a/services/gateway/src/services/marketplace-sync/awin-order-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/awin-order-sync.ts
@@ -1,0 +1,216 @@
+/**
+ * VTID-02950: Awin order-conversion sync for the Discover marketplace.
+ *
+ * Distinct from the older services/awin-conversions.ts, which credits an
+ * entirely separate, pre-existing feature (the VCAOP "shop" flow's
+ * affiliate_program/subid_map/commission_event/rewards_ledger system, built
+ * around POST /api/v1/vcaop/affiliate-link). That system has no connection to
+ * the Discover marketplace catalog (products/merchants) built in
+ * VTID-02000 — different tables, different attribution scheme. Do not
+ * conflate the two; this file is the Discover-marketplace-specific one.
+ *
+ * Reverse-attributes Awin Transactions API conversions back to a Discover
+ * click via `clickRef` (= the compact click_id click-redirect.ts stamps into
+ * the outbound Awin URL as `clickref`, see routes/click-redirect.ts). Direct
+ * `product_clicks.click_id` lookup — no separate subid-mapping table needed,
+ * since product_clicks already carries user_id/tenant_id/product_id per click.
+ *
+ * Config (JSON in marketplace_sources_config.config for source_network='awin'):
+ * reuses the existing 'awin' row (same one that configures the Darwin product
+ * feed) with two additional fields:
+ *   {
+ *     "feeds": [...],                        // already present — Darwin product feed
+ *     "api_token": "...",                    // Awin Publisher API OAuth2 token
+ *     "publisher_id": "2938137"              // Awin publisher/account id
+ *   }
+ * api_token/publisher_id are only needed for THIS order sync, not the Darwin
+ * feed fetch — treat as sensitive (same handling as every other credential in
+ * this file: DB-only, never in git/code).
+ *
+ * Idempotent: upserts product_orders keyed on the existing
+ * uniq_product_orders_external (merchant_id, external_order_id) constraint —
+ * re-pulls (and later status changes: pending -> approved) upsert in place.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { creditRecommenderForOrder } from '../recommendation-commissions/credit-recommender';
+
+const AWIN_API_BASE = 'https://api.awin.com';
+/** Awin caps a single transactions query at a 31-day range. */
+const MAX_LOOKBACK_DAYS = 31;
+
+export interface AwinOrderSyncConfig {
+  publisherId: string;
+  apiToken: string;
+}
+
+export interface AwinTransaction {
+  id: number | string;
+  advertiserId?: number | string;
+  commissionStatus?: string; // pending | approved | declined | deleted
+  clickRef?: string; // our click_id, stamped as `clickref` at redirect time
+  commissionAmount?: { amount?: number; currency?: string };
+  saleAmount?: { amount?: number; currency?: string };
+}
+
+export interface AwinOrderSyncResult {
+  ok: boolean;
+  fetched: number;
+  attributed: number;
+  credited: number;
+  unattributed: number;
+  error?: string;
+}
+
+/** Map an Awin commissionStatus to our product_orders.state. */
+function mapAwinStatus(raw: string): 'pending' | 'converted' | 'refunded' | 'cancelled' {
+  const s = (raw || '').toLowerCase().trim();
+  if (['approved', 'confirmed', 'paid'].includes(s)) return 'converted';
+  if (['declined', 'rejected', 'deleted', 'cancelled', 'canceled'].includes(s)) return 'cancelled';
+  return 'pending';
+}
+
+function dateParam(d: Date): string {
+  return d.toISOString().slice(0, 19);
+}
+
+async function loadAwinOrderSyncConfig(): Promise<AwinOrderSyncConfig | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  const { data } = await supabase
+    .from('marketplace_sources_config')
+    .select('config')
+    .eq('source_network', 'awin')
+    .eq('is_active', true)
+    .maybeSingle();
+  const config = data?.config as { api_token?: string; publisher_id?: string } | undefined;
+  if (!config?.api_token || !config?.publisher_id) return null;
+  return { publisherId: config.publisher_id, apiToken: config.api_token };
+}
+
+async function fetchTransactions(
+  cfg: AwinOrderSyncConfig,
+  dateType: 'transaction' | 'validation',
+  startIso: string,
+  endIso: string
+): Promise<AwinTransaction[]> {
+  const url =
+    `${AWIN_API_BASE}/publishers/${cfg.publisherId}/transactions/` +
+    `?startDate=${encodeURIComponent(startIso)}&endDate=${encodeURIComponent(endIso)}` +
+    `&timezone=UTC&dateType=${dateType}`;
+  const resp = await fetch(url, { headers: { Authorization: `Bearer ${cfg.apiToken}` } });
+  if (!resp.ok) throw new Error(`Awin transactions (${dateType}) HTTP ${resp.status}`);
+  const data = (await resp.json()) as AwinTransaction[] | { transactions?: AwinTransaction[] };
+  return Array.isArray(data) ? data : (data.transactions ?? []);
+}
+
+async function pullUniqueTransactions(cfg: AwinOrderSyncConfig, lookbackDays: number): Promise<AwinTransaction[]> {
+  const now = new Date();
+  const start = dateParam(new Date(now.getTime() - lookbackDays * 86_400_000));
+  const end = dateParam(now);
+  const byTx = new Map<string, AwinTransaction>();
+  for (const dateType of ['transaction', 'validation'] as const) {
+    let list: AwinTransaction[] = [];
+    try {
+      list = await fetchTransactions(cfg, dateType, start, end);
+    } catch (e) {
+      console.warn(`[awin-order-sync] transactions pull (${dateType}) failed:`, e);
+    }
+    for (const tx of list) {
+      if (tx?.id !== undefined && tx.id !== null) byTx.set(String(tx.id), tx);
+    }
+  }
+  return [...byTx.values()];
+}
+
+/**
+ * Pulls Awin transactions and upserts matching product_orders rows. Skips
+ * (with a null return per-item, not an error) any transaction whose clickRef
+ * doesn't resolve to a known Discover click — those are organic/other-surface
+ * Awin sales, not ours to attribute.
+ */
+export async function runAwinOrderSync(lookbackDays = 30): Promise<AwinOrderSyncResult> {
+  const supabase = getSupabase();
+  if (!supabase) return { ok: false, fetched: 0, attributed: 0, credited: 0, unattributed: 0, error: 'DB_UNAVAILABLE' };
+
+  const cfg = await loadAwinOrderSyncConfig();
+  if (!cfg) {
+    console.log('[awin-order-sync] no api_token/publisher_id configured — skipping');
+    return { ok: true, fetched: 0, attributed: 0, credited: 0, unattributed: 0 };
+  }
+
+  const boundedLookback = Math.min(MAX_LOOKBACK_DAYS, Math.max(1, lookbackDays));
+  const txns = await pullUniqueTransactions(cfg, boundedLookback);
+
+  let attributed = 0;
+  let credited = 0;
+  let unattributed = 0;
+
+  for (const tx of txns) {
+    const clickId = String(tx.clickRef ?? '').trim();
+    if (!clickId) {
+      unattributed++;
+      continue;
+    }
+
+    const { data: click } = await supabase
+      .from('product_clicks')
+      .select('click_id, user_id, tenant_id, product_id, merchant_id, attribution_surface, attribution_recommendation_id')
+      .eq('click_id', clickId)
+      .maybeSingle();
+    if (!click) {
+      unattributed++;
+      continue;
+    }
+    attributed++;
+
+    const commissionAmount = Number(tx.commissionAmount?.amount ?? 0) || 0;
+    const saleAmount = Number(tx.saleAmount?.amount ?? 0) || 0;
+    const currency = String(tx.commissionAmount?.currency ?? tx.saleAmount?.currency ?? 'EUR')
+      .toUpperCase()
+      .slice(0, 3);
+    const state = mapAwinStatus(String(tx.commissionStatus ?? ''));
+
+    const { data: upserted, error } = await supabase
+      .from('product_orders')
+      .upsert(
+        {
+          user_id: click.user_id,
+          tenant_id: click.tenant_id,
+          product_id: click.product_id,
+          merchant_id: click.merchant_id,
+          click_id: click.click_id,
+          external_order_id: String(tx.id),
+          checkout_mode: 'affiliate_link',
+          state,
+          amount_cents: Math.round(saleAmount * 100),
+          currency,
+          commission_cents: Math.round(commissionAmount * 100),
+          raw: tx as unknown as Record<string, unknown>,
+          attribution_surface: click.attribution_surface,
+          attribution_recommendation_id: click.attribution_recommendation_id,
+          purchased_at: state === 'converted' ? new Date().toISOString() : null,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'merchant_id,external_order_id' }
+      )
+      .select('id')
+      .single();
+    if (error || !upserted) {
+      console.error('[awin-order-sync] product_orders upsert failed:', error?.message);
+      continue;
+    }
+    credited++;
+
+    if (state === 'converted' && click.attribution_recommendation_id) {
+      await creditRecommenderForOrder(upserted.id).catch((e) =>
+        console.error('[awin-order-sync] creditRecommenderForOrder failed (non-fatal):', e)
+      );
+    }
+  }
+
+  console.log(
+    `[awin-order-sync] done — fetched ${txns.length}, attributed ${attributed}, credited ${credited}, unattributed ${unattributed}`
+  );
+  return { ok: true, fetched: txns.length, attributed, credited, unattributed };
+}

--- a/services/gateway/src/services/recommendation-commissions/credit-recommender.ts
+++ b/services/gateway/src/services/recommendation-commissions/credit-recommender.ts
@@ -1,0 +1,169 @@
+/**
+ * VTID-02950: Credits a recommender's wallet for a converted product order.
+ *
+ * Revenue-share model: the recommender earns a percentage of Vitana's OWN
+ * earned commission on the sale (never more than Vitana itself made).
+ * Self-funding — no separate budget to manage, and naturally excludes
+ * merchants Vitana earns nothing from.
+ *
+ * Call sites:
+ *   - services/checkout/checkout-service.ts, when a first-party product_orders
+ *     row flips to state='converted' (no-ops today — first-party orders don't
+ *     carry commission_cents, so there's nothing to revenue-share yet).
+ *   - services/marketplace-sync/awin-order-sync.ts, after a real Awin
+ *     conversion upserts a converted product_orders row with commission_cents.
+ *
+ * Idempotent via recommendation_commissions.product_order_id UNIQUE — safe to
+ * call more than once for the same order (e.g. a re-pull of the same Awin
+ * transaction).
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { creditWalletForEarning } from '../wallet/spend-earning-service';
+
+export type CreditRecommenderStatus = 'credited' | 'skipped_ineligible' | 'skipped_no_recommendation' | 'already_credited' | 'failed';
+
+export interface CreditRecommenderResult {
+  ok: boolean;
+  status: CreditRecommenderStatus;
+  payout_minor?: number;
+  message?: string;
+}
+
+const DEFAULT_RATE = 0.2;
+
+async function loadDefaultRate(supabase: ReturnType<typeof getSupabase>): Promise<number> {
+  if (!supabase) return DEFAULT_RATE;
+  const { data } = await supabase
+    .from('admin_settings')
+    .select('value')
+    .eq('key', 'recommendation_commission_default_rate')
+    .maybeSingle();
+  const rate = (data?.value as { rate?: number } | undefined)?.rate;
+  return typeof rate === 'number' && rate > 0 && rate <= 1 ? rate : DEFAULT_RATE;
+}
+
+/**
+ * Credits the recommender for one converted product_orders row, if that order
+ * carries an attribution_recommendation_id and the merchant is eligible.
+ */
+export async function creditRecommenderForOrder(orderId: string): Promise<CreditRecommenderResult> {
+  const supabase = getSupabase();
+  if (!supabase) return { ok: false, status: 'failed', message: 'DB_UNAVAILABLE' };
+
+  const { data: order, error: orderErr } = await supabase
+    .from('product_orders')
+    .select('id, state, commission_cents, currency, attribution_recommendation_id, merchant_id')
+    .eq('id', orderId)
+    .maybeSingle();
+  if (orderErr || !order) return { ok: false, status: 'failed', message: 'ORDER_NOT_FOUND' };
+  if (order.state !== 'converted') return { ok: true, status: 'skipped_no_recommendation', message: 'order not converted' };
+  if (!order.attribution_recommendation_id) return { ok: true, status: 'skipped_no_recommendation' };
+  if (!order.commission_cents || order.commission_cents <= 0) {
+    return { ok: true, status: 'skipped_no_recommendation', message: 'no commission on this order' };
+  }
+
+  // Idempotency check — a re-pull of the same conversion must not double-credit.
+  const { data: existing } = await supabase
+    .from('recommendation_commissions')
+    .select('id, status')
+    .eq('product_order_id', orderId)
+    .maybeSingle();
+  if (existing) return { ok: true, status: 'already_credited' };
+
+  const { data: recommendation } = await supabase
+    .from('product_recommendations')
+    .select('id, user_id')
+    .eq('id', order.attribution_recommendation_id)
+    .maybeSingle();
+  if (!recommendation) return { ok: true, status: 'skipped_no_recommendation' };
+
+  const { data: merchant } = await supabase
+    .from('merchants')
+    .select('recommendation_commission_eligible, recommendation_commission_rate_override')
+    .eq('id', order.merchant_id)
+    .maybeSingle();
+
+  const currency = (order.currency ?? 'EUR').toUpperCase();
+  const rate = merchant?.recommendation_commission_rate_override ?? (await loadDefaultRate(supabase));
+  const payoutMinor = Math.round(order.commission_cents * rate);
+
+  if (!merchant?.recommendation_commission_eligible) {
+    await supabase.from('recommendation_commissions').insert({
+      product_recommendation_id: recommendation.id,
+      product_order_id: orderId,
+      recommender_user_id: recommendation.user_id,
+      vitana_commission_cents: order.commission_cents,
+      rate_applied: rate,
+      payout_amount_minor: payoutMinor,
+      currency,
+      status: 'skipped_ineligible',
+    });
+    await supabase.from('oasis_events').insert({
+      service: 'discover', source: 'recommendation-commissions',
+      type: 'marketplace.recommendation.commission_skipped_ineligible',
+      topic: 'marketplace.recommendation.commission_skipped_ineligible',
+      status: 'info', message: 'merchant not eligible for recommendation commissions',
+      metadata: { orderId, merchantId: order.merchant_id, recommenderId: recommendation.user_id },
+      created_at: new Date().toISOString(),
+    }).then(() => {}, () => {});
+    return { ok: true, status: 'skipped_ineligible' };
+  }
+
+  if (payoutMinor <= 0 || (currency !== 'EUR' && currency !== 'USD')) {
+    return { ok: true, status: 'skipped_no_recommendation', message: 'non-positive payout or unsupported currency' };
+  }
+
+  const { data: account } = await supabase
+    .from('wallet_accounts')
+    .select('id, currency')
+    .eq('user_id', recommendation.user_id)
+    .eq('currency', currency)
+    .maybeSingle();
+  if (!account) {
+    return { ok: false, status: 'failed', message: 'RECOMMENDER_WALLET_NOT_FOUND' };
+  }
+
+  const creditResult = await creditWalletForEarning({
+    account_id: account.id,
+    amount_minor: payoutMinor,
+    currency: currency as 'EUR' | 'USD',
+    reference_type: 'recommendation_commission',
+    reference_id: orderId,
+    description: 'Recommendation commission',
+    metadata: { product_recommendation_id: recommendation.id, rate_applied: rate, vitana_commission_cents: order.commission_cents },
+  });
+
+  if (!creditResult.ok) {
+    await supabase.from('recommendation_commissions').insert({
+      product_recommendation_id: recommendation.id,
+      product_order_id: orderId,
+      recommender_user_id: recommendation.user_id,
+      vitana_commission_cents: order.commission_cents,
+      rate_applied: rate,
+      payout_amount_minor: payoutMinor,
+      currency,
+      status: 'failed',
+    });
+    return { ok: false, status: 'failed', message: creditResult.error };
+  }
+
+  await supabase.from('recommendation_commissions').insert({
+    product_recommendation_id: recommendation.id,
+    product_order_id: orderId,
+    recommender_user_id: recommendation.user_id,
+    vitana_commission_cents: order.commission_cents,
+    rate_applied: rate,
+    payout_amount_minor: payoutMinor,
+    currency,
+    wallet_ledger_entry_id: creditResult.ledger_entry_id ?? null,
+    status: 'credited',
+  });
+
+  await supabase.rpc('increment_product_recommendation_stats', {
+    p_recommendation_id: recommendation.id,
+    p_commission_earned_minor: payoutMinor,
+  });
+
+  return { ok: true, status: 'credited', payout_minor: payoutMinor };
+}

--- a/services/gateway/src/services/wallet/spend-earning-service.ts
+++ b/services/gateway/src/services/wallet/spend-earning-service.ts
@@ -22,6 +22,7 @@ export type SpendEarningReferenceType =
   | 'marketplace_order'
   | 'marketplace_earning'
   | 'live_room_tip'
+  | 'recommendation_commission'
   | 'manual';
 
 export interface SpendInput {

--- a/services/gateway/test/routes/discover-recommendations.test.ts
+++ b/services/gateway/test/routes/discover-recommendations.test.ts
@@ -1,0 +1,211 @@
+/**
+ * VTID-02950 — "Recommend & Earn" route tests.
+ *
+ * Verifies:
+ *   - Both routes are behind requireAuth (401 when unauthenticated).
+ *   - POST /recommendations validates the body (400 on invalid product_id).
+ *   - POST /recommendations 404s when the product doesn't exist / isn't active.
+ *   - POST /recommendations creates a new recommendation + sharing link on
+ *     first call, emits an OASIS event, and returns a share_url.
+ *   - POST /recommendations reuses an existing (user, product) recommendation
+ *     on a repeat call — no duplicate insert, no duplicate OASIS emit.
+ *   - GET /my-recommendations maps rows to the expected shape.
+ *   - GET /my-recommendations 503s when Supabase is unavailable.
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import router from '../../src/routes/discover-recommendations';
+import { requireAuth } from '../../src/middleware/auth-supabase-jwt';
+import { getSupabase } from '../../src/lib/supabase';
+import { emitOasisEvent } from '../../src/services/oasis-event-service';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: jest.fn(),
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+function authenticate(req: Request, _res: Response, next: NextFunction) {
+  (req as any).identity = { user_id: 'user-1', tenant_id: 'tenant-1' };
+  next();
+}
+
+// Flexible fluent mock — resolves to whatever `result` is set to at the
+// point `.maybeSingle()` / `.single()` / the thenable is invoked.
+function createMockQuery(result: { data: any; error: any }) {
+  const q: any = {};
+  q.select = jest.fn(() => q);
+  q.insert = jest.fn(() => q);
+  q.eq = jest.fn(() => q);
+  q.order = jest.fn(() => q);
+  q.maybeSingle = jest.fn().mockResolvedValue(result);
+  q.single = jest.fn().mockResolvedValue(result);
+  q.then = (resolve: any) => Promise.resolve(result).then(resolve);
+  return q;
+}
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/discover', router);
+
+describe('VTID-02950 — Discover recommendations routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('POST /recommendations returns 401 when unauthenticated', async () => {
+    (requireAuth as jest.Mock).mockImplementation((_req: Request, res: Response) => {
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    });
+
+    const res = await request(app).post('/api/v1/discover/recommendations').send({ product_id: 'p-1' });
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /my-recommendations returns 401 when unauthenticated', async () => {
+    (requireAuth as jest.Mock).mockImplementation((_req: Request, res: Response) => {
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    });
+
+    const res = await request(app).get('/api/v1/discover/my-recommendations');
+    expect(res.status).toBe(401);
+  });
+
+  describe('authenticated', () => {
+    beforeEach(() => {
+      (requireAuth as jest.Mock).mockImplementation(authenticate);
+    });
+
+    it('POST /recommendations returns 400 for an invalid body', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn(() => createMockQuery({ data: null, error: null })),
+      });
+      const res = await request(app).post('/api/v1/discover/recommendations').send({ product_id: 'not-a-uuid' });
+      expect(res.status).toBe(400);
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toBe('INVALID_BODY');
+    });
+
+    it('POST /recommendations returns 404 when the product does not exist', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn(() => createMockQuery({ data: null, error: null })),
+      });
+
+      const res = await request(app)
+        .post('/api/v1/discover/recommendations')
+        .send({ product_id: '11111111-1111-1111-1111-111111111111' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('PRODUCT_NOT_FOUND');
+    });
+
+    it('POST /recommendations creates a new recommendation, emits an OASIS event, and returns a share_url', async () => {
+      const productId = '11111111-1111-1111-1111-111111111111';
+      const from = jest.fn((table: string) => {
+        if (table === 'products') {
+          return createMockQuery({ data: { id: productId, merchant_id: 'm-1', title: 'Test Product', is_active: true }, error: null });
+        }
+        if (table === 'product_recommendations') {
+          // First call: find-existing -> none. Second call: insert -> created row.
+          const q = createMockQuery({ data: null, error: null });
+          let call = 0;
+          const original = q.maybeSingle;
+          q.maybeSingle = jest.fn(() => {
+            call += 1;
+            return call === 1 ? Promise.resolve({ data: null, error: null }) : original();
+          });
+          q.single = jest.fn().mockResolvedValue({ data: { id: 'rec-1' }, error: null });
+          return q;
+        }
+        if (table === 'sharing_links') {
+          return createMockQuery({ data: { id: 'link-1' }, error: null });
+        }
+        return createMockQuery({ data: null, error: null });
+      });
+      (getSupabase as jest.Mock).mockReturnValue({ from });
+
+      const res = await request(app).post('/api/v1/discover/recommendations').send({ product_id: productId });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.recommendation_id).toBe('rec-1');
+      expect(res.body.share_url).toContain(productId);
+      expect(res.body.share_url).toContain('rec=rec-1');
+      expect(emitOasisEvent).toHaveBeenCalledTimes(1);
+      expect((emitOasisEvent as jest.Mock).mock.calls[0][0]).toMatchObject({
+        vtid: 'VTID-02950',
+        payload: expect.objectContaining({ product_id: productId, recommendation_id: 'rec-1' }),
+      });
+    });
+
+    it('POST /recommendations reuses an existing recommendation without re-inserting or re-emitting', async () => {
+      const productId = '11111111-1111-1111-1111-111111111111';
+      const from = jest.fn((table: string) => {
+        if (table === 'products') {
+          return createMockQuery({ data: { id: productId, merchant_id: 'm-1', title: 'Test Product', is_active: true }, error: null });
+        }
+        if (table === 'product_recommendations') {
+          return createMockQuery({ data: { id: 'rec-existing', sharing_link_id: 'link-existing' }, error: null });
+        }
+        return createMockQuery({ data: null, error: null });
+      });
+      (getSupabase as jest.Mock).mockReturnValue({ from });
+
+      const res = await request(app).post('/api/v1/discover/recommendations').send({ product_id: productId });
+
+      expect(res.status).toBe(200);
+      expect(res.body.recommendation_id).toBe('rec-existing');
+      expect(emitOasisEvent).not.toHaveBeenCalled();
+    });
+
+    it('GET /my-recommendations returns 503 when Supabase is unavailable', async () => {
+      (getSupabase as jest.Mock).mockReturnValue(null);
+      const res = await request(app).get('/api/v1/discover/my-recommendations');
+      expect(res.status).toBe(503);
+      expect(res.body.error).toBe('DB_UNAVAILABLE');
+    });
+
+    it('GET /my-recommendations maps rows to the expected shape', async () => {
+      const row = {
+        id: 'rec-1',
+        product_id: 'p-1',
+        status: 'active',
+        click_count: 3,
+        conversion_count: 1,
+        commission_earned_minor: 500,
+        commission_currency: 'EUR',
+        created_at: '2026-07-01T00:00:00.000Z',
+        products: { title: 'Test Product', images: ['https://example.com/img.jpg'] },
+      };
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn(() => createMockQuery({ data: [row], error: null })),
+      });
+
+      const res = await request(app).get('/api/v1/discover/my-recommendations');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.items).toEqual([
+        {
+          id: 'rec-1',
+          product_id: 'p-1',
+          product_title: 'Test Product',
+          product_thumbnail_url: 'https://example.com/img.jpg',
+          status: 'active',
+          click_count: 3,
+          conversion_count: 1,
+          commission_earned_minor: 500,
+          currency: 'EUR',
+          created_at: '2026-07-01T00:00:00.000Z',
+        },
+      ]);
+    });
+  });
+});

--- a/supabase/migrations/20260715120000_vtid_02950_recommendation_commissions.sql
+++ b/supabase/migrations/20260715120000_vtid_02950_recommendation_commissions.sql
@@ -1,0 +1,156 @@
+-- VTID-02950: "Recommend & Earn" — user product recommendations + commissions.
+--
+-- Any community user can recommend a Discover product; if someone buys it via
+-- that recommendation, the recommender earns a revenue-share of Vitana's own
+-- earned commission, credited to their real wallet (wallet_accounts /
+-- wallet_ledger_entries via credit_wallet_for_earning — see VTID-03249).
+--
+-- Schema notes:
+--   - product_recommendations backs onto a sharing_links row (target_type=
+--     'product', reusing its short_code generator) but the id stamped through
+--     the click-redirect pipeline (product_clicks.attribution_recommendation_id
+--     / product_orders.attribution_recommendation_id, both already UUID columns
+--     from the VTID-02000 marketplace foundation) is product_recommendations.id.
+--   - recommendation_commissions is the idempotent credit ledger — one row per
+--     product_orders conversion, UNIQUE(product_order_id) is the double-credit
+--     guard, mirroring product_orders' own uniq_product_orders_external pattern.
+--   - merchants gets two new eligibility columns. Amazon is seeded ineligible:
+--     the Amazon Operating Agreement forbids passing affiliate commission back
+--     to end users as cashback/incentive (already documented in
+--     20260702120000_vtid_02000_amazon_ae_recommendations_seed.sql's
+--     reward_preview=NULL convention — this is the same constraint applied to
+--     the new recommendation-commission feature).
+--   - admin_settings is a small generic KV table for single-value admin config
+--     (starts with just the default commission rate; reusable for future
+--     single-value settings without a new table each time).
+
+BEGIN;
+
+-- ============================================================================
+-- 1. admin_settings — generic KV config table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.admin_settings (
+  key TEXT PRIMARY KEY,
+  value JSONB NOT NULL,
+  updated_by UUID,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO public.admin_settings (key, value)
+VALUES ('recommendation_commission_default_rate', '{"rate": 0.20}'::jsonb)
+ON CONFLICT (key) DO NOTHING;
+
+-- ============================================================================
+-- 2. merchants — recommendation-commission eligibility
+-- ============================================================================
+ALTER TABLE public.merchants
+  ADD COLUMN IF NOT EXISTS recommendation_commission_eligible BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS recommendation_commission_rate_override NUMERIC(5,4);
+
+UPDATE public.merchants
+SET recommendation_commission_eligible = false
+WHERE source_network = 'amazon';
+
+-- ============================================================================
+-- 3. product_recommendations — one row per (user, product) recommendation
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.product_recommendations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID,
+  user_id UUID NOT NULL,
+  product_id UUID NOT NULL REFERENCES public.products(id) ON DELETE CASCADE,
+  merchant_id UUID REFERENCES public.merchants(id) ON DELETE SET NULL,
+  sharing_link_id UUID REFERENCES public.sharing_links(id) ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'disabled')),
+  click_count INT NOT NULL DEFAULT 0,
+  conversion_count INT NOT NULL DEFAULT 0,
+  commission_earned_minor BIGINT NOT NULL DEFAULT 0,
+  commission_currency CHAR(3) NOT NULL DEFAULT 'EUR',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, product_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_product_recommendations_user
+  ON public.product_recommendations (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_product_recommendations_product
+  ON public.product_recommendations (product_id);
+
+ALTER TABLE public.product_recommendations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY product_recommendations_owner_select ON public.product_recommendations
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY product_recommendations_owner_insert ON public.product_recommendations
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY product_recommendations_service_role ON public.product_recommendations
+  FOR ALL USING (auth.role() = 'service_role') WITH CHECK (auth.role() = 'service_role');
+
+-- ============================================================================
+-- 4. recommendation_commissions — idempotent credit ledger
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.recommendation_commissions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_recommendation_id UUID NOT NULL REFERENCES public.product_recommendations(id) ON DELETE CASCADE,
+  product_order_id UUID NOT NULL REFERENCES public.product_orders(id) ON DELETE CASCADE,
+  recommender_user_id UUID NOT NULL,
+  vitana_commission_cents INT NOT NULL,
+  rate_applied NUMERIC(5,4) NOT NULL,
+  payout_amount_minor BIGINT NOT NULL,
+  currency CHAR(3) NOT NULL,
+  wallet_ledger_entry_id UUID,
+  status TEXT NOT NULL CHECK (status IN ('credited', 'skipped_ineligible', 'failed')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (product_order_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_commissions_recommender
+  ON public.recommendation_commissions (recommender_user_id, created_at DESC);
+
+ALTER TABLE public.recommendation_commissions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY recommendation_commissions_owner_select ON public.recommendation_commissions
+  FOR SELECT USING (auth.uid() = recommender_user_id);
+CREATE POLICY recommendation_commissions_service_role ON public.recommendation_commissions
+  FOR ALL USING (auth.role() = 'service_role') WITH CHECK (auth.role() = 'service_role');
+
+-- ============================================================================
+-- 5. increment_product_recommendation_stats — atomic counter bump
+-- ============================================================================
+CREATE OR REPLACE FUNCTION increment_product_recommendation_stats(
+  p_recommendation_id UUID,
+  p_commission_earned_minor BIGINT
+) RETURNS VOID AS $$
+BEGIN
+  UPDATE public.product_recommendations
+  SET conversion_count = conversion_count + 1,
+      commission_earned_minor = commission_earned_minor + p_commission_earned_minor,
+      updated_at = NOW()
+  WHERE id = p_recommendation_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- 6. increment_product_recommendation_click — bumps click_count on each visit
+--    via a shared recommendation link (see routes/discover-recommendations.ts)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION increment_product_recommendation_click(
+  p_recommendation_id UUID
+) RETURNS VOID AS $$
+BEGIN
+  UPDATE public.product_recommendations
+  SET click_count = click_count + 1,
+      updated_at = NOW()
+  WHERE id = p_recommendation_id;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;
+
+-- =====================================================================================
+-- DOWN (rollback):
+-- DROP TABLE IF EXISTS public.recommendation_commissions;
+-- DROP TABLE IF EXISTS public.product_recommendations;
+-- ALTER TABLE public.merchants DROP COLUMN IF EXISTS recommendation_commission_eligible,
+--   DROP COLUMN IF EXISTS recommendation_commission_rate_override;
+-- DROP TABLE IF EXISTS public.admin_settings;
+-- =====================================================================================


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-02950`

**Layer:** Backend (Gateway) — marketplace attribution, wallet, admin

**Priority:** P2 — new revenue-share growth feature

---

## 📋 Summary

Lets any user recommend a Discover product; if someone buys it via that recommendation, the recommender earns a real wallet commission — a revenue-share of Vitana's own already-earned affiliate commission (configurable rate, default 20%), never exceeding what Vitana itself made. Recommended products, with click/conversion/earnings stats, surface on the user's own profile via a new "Business" segment (frontend half in a companion `vitana-v1` PR).

### Phase 0 — bridge a pre-existing attribution gap (prerequisite)

Research surfaced that the real Awin affiliate-conversion pipeline (`vcaop.ts`/`awin-conversions.ts`/`vcaop-postback.ts`) is a separate, older "VCAOP shop" flow with its own `subid_map`/`commission_event`/`rewards_ledger` tables — completely disconnected from the Discover marketplace's `click_id`-based attribution (`click-redirect.ts` → `product_clicks`/`product_orders`) that the real "Buy" button uses today. Confirmed via grep: neither file references `product_orders` or `click_id`. This meant Awin/MISSHA purchase conversions weren't reliably traceable back to their originating click at all, independent of this feature.

Fixed by:
- `click-redirect.ts`: `stampAffiliateUrl` now stamps Awin's real tracking param `&clickref=<click_id>` for `awin1.com`/`awin.com` hosts (mirrors the existing Amazon/CJ special-casing). `click_id` generation switched from a full UUID to a compact 32-hex-char id to comfortably fit affiliate networks' sub-id length limits.
- New `services/marketplace-sync/awin-order-sync.ts`: pulls the Awin Transactions API, reverse-attributes each transaction directly via `clickRef = product_clicks.click_id` (no new mapping table needed), and upserts `product_orders` — idempotent via the existing `(merchant_id, external_order_id)` constraint.
- Admin-triggerable via `POST /api/v1/admin/marketplace/sync-orders/awin`, exposed as a "Sync Awin Orders now" button in the Command Hub.

### Phase 1 — recommend action + attribution threading

- New `product_recommendations` table (`UNIQUE(user_id, product_id)`), backed by a `sharing_links` row for the share link.
- `POST /api/v1/discover/recommendations { product_id }` (find-or-create) → `{ recommendation_id, share_url }`.
- `attribution_recommendation_id`/`attribution_surface='share_and_earn'` (pre-existing, unwired schema columns) now populate end-to-end through the click-redirect pipeline.
- Fixed a silent attribution bug found while wiring this up: `ProductDetail`/`ProductDetailsDrawer` (frontend) passed hyphenated surface names (`"product-page"`/`"product-drawer"`) that don't match the gateway's `ATTRIBUTION_SURFACES` enum (`product_detail`, underscore) — every click from those two surfaces was silently falling through to the `'direct'` default.

### Phase 2 — commission crediting on conversion

- New `services/recommendation-commissions/credit-recommender.ts`: `creditRecommenderForOrder(orderId)` — loads the order + recommendation + merchant eligibility, computes `rate = merchant override ?? admin_settings default`, credits the recommender's real wallet via `creditWalletForEarning()` (extended `SpendEarningReferenceType` with `'recommendation_commission'`), and inserts an idempotent `recommendation_commissions` ledger row (`UNIQUE(product_order_id)`).
- Call sites: first-party checkout conversion (`checkout-service.ts`) and the Phase 0 Awin order-sync bridge.
- Eligibility gate: `merchants.recommendation_commission_eligible` (seeded `false` for Amazon — its Operating Agreement forbids passing commission back to end users as cashback/incentive, same constraint already documented for the existing `reward_preview = NULL` convention).
- New `admin_settings` KV table, seeded `recommendation_commission_default_rate = 0.20`.

### Phase 3 — Business tab data API

- `GET /api/v1/discover/my-recommendations` (auth) — joined list of the caller's recommendations with click/conversion/earnings stats, backing the new frontend Business tab.

### Phase 4 — admin rate configuration

- Extended the `merchants` PATCH allow-list (`recommendation_commission_eligible`, `recommendation_commission_rate_override`).
- New `GET`/`PATCH /api/v1/admin/marketplace/commission-settings` for the global default rate.
- Command Hub: "Sync Awin Orders now" button + a commission-rate settings panel in the Marketplace Shops view.

---

## ✅ Changes

- [x] `supabase/migrations/20260715120000_vtid_02950_recommendation_commissions.sql` — `admin_settings`, `merchants` extensions (+ Amazon exclusion seed), `product_recommendations`, `recommendation_commissions`, 2 RPCs (`increment_product_recommendation_stats`, `increment_product_recommendation_click`) — **already applied to the live DB**
- [x] `services/gateway/src/routes/click-redirect.ts` — compact click ids, Awin `clickref` stamping, recommendation click-count bump
- [x] `services/gateway/src/services/marketplace-sync/awin-order-sync.ts` (new)
- [x] `services/gateway/src/services/recommendation-commissions/credit-recommender.ts` (new)
- [x] `services/gateway/src/services/wallet/spend-earning-service.ts` — `SpendEarningReferenceType` extended
- [x] `services/gateway/src/routes/wallet-admin.ts` — `ALLOWED_REFERENCE_TYPES` extended
- [x] `services/gateway/src/services/checkout/checkout-service.ts` — fire-and-forget crediting on conversion
- [x] `services/gateway/src/routes/discover-recommendations.ts` (new) — `POST /recommendations`, `GET /my-recommendations`
- [x] `services/gateway/src/index.ts` — router mounted at `/api/v1/discover`
- [x] `services/gateway/src/routes/admin-marketplace.ts` — merchant eligibility/override fields, Awin sync trigger, commission-settings endpoints
- [x] `services/gateway/src/frontend/command-hub/app.js` — Awin sync button + commission-rate settings panel

---

## 🧪 Testing

- [x] `npm run build` (tsc) passes clean for `services/gateway`
- [x] Migration applied to the live DB — verified via SQL: 3 new tables present, `default_rate=0.20`, 1 Amazon merchant excluded, 7 merchants eligible
- [ ] End-to-end: generate a real recommend link, click through, confirm `product_clicks.attribution_recommendation_id` populates and Awin URLs carry `&clickref=` — pending staging verification once merged
- [ ] Awin order-sync against real data — needs `api_token`/`publisher_id` added to the `marketplace_sources_config` row for `source_network='awin'` (DB-only credential, not yet persisted — flagged as a follow-up, not committed to git)

---

## 🚨 Breaking Changes

None. New tables/columns/endpoints only; existing attribution/checkout paths are additive (fire-and-forget commission crediting, no behavior change to the checkout flow itself).

---

## 📌 Additional Notes

Companion frontend PR (RecommendButton UI, Business profile tab) is in `vitana-v1` on the same branch name.


---
_Generated by [Claude Code](https://claude.ai/code/session_011JdP3fAJvzaKsd5FF2xHB1)_