### PR TITLE
AWS staging: ledger update — SUPABASE_JWT_SECRET bound (task def :8), authenticated read verified

### DIFF
--- a/scripts/aws-staging-validation/reports/aws-run-20260717-gateway-deployed/FINDINGS.md
+++ b/scripts/aws-staging-validation/reports/aws-run-20260717-gateway-deployed/FINDINGS.md
@@ -47,6 +47,7 @@ serves the SPA at its hostname root with working deep-route fallback.
 | Task def `vitana-gateway:7` (image pin + env block above) | live only |
 | CORS allowlist for AWS staging hostnames | this branch (merge to `main`) |
 | ECR `vitana/gateway:latest` now = main+CORS fix (was 2026-07-14 build) | ECR |
+| Task def `vitana-gateway:8` — `SUPABASE_JWT_SECRET` bound as a plain env var (2026-07-17). Verified: e2e-test login via Supabase REST → `GET /api/v1/journey/state` on `preview-aws-gateway.vitanaland.com` returns 200 with real state, so authenticated JWT verification works on AWS. **Hygiene note:** plain task-def env is readable by anyone with `ecs:DescribeTaskDefinition` — move to AWS Secrets Manager (`secrets` block + execution-role read grant) when the remaining secrets (`GATEWAY_SERVICE_TOKEN`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, Gemini key) are wired | live only |
 
 ## Next steps to full parity + sign-off
 


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION`

**Layer:** CICDL

**Priority:** P2

---

## 📋 Summary

Follow-up to the merged #2888: records the next live AWS staging change in the live-change ledger. `SUPABASE_JWT_SECRET` was bound on the `vitana-gateway` task definition (revision 8, rolled to steady state), and the authenticated path was verified end-to-end: login as the e2e test user via Supabase REST, then `GET /api/v1/journey/state` on `preview-aws-gateway.vitanaland.com` → **200 with real journey state** — JWT verification now works on the AWS gateway.

---

## ✅ Changes

- [x] `reports/aws-run-20260717-gateway-deployed/FINDINGS.md` — ledger row for task def `vitana-gateway:8` (`SUPABASE_JWT_SECRET` as plain env), verification result, and a hygiene note to migrate it to AWS Secrets Manager together with the remaining unbound secrets

---

## 🧪 Testing

_How was this tested?_

- [x] Manual testing completed — Supabase REST password login (e2e test user) → bearer call to `/api/v1/journey/state` on the AWS staging gateway returned 200 `application/json` with populated state
- [ ] Automated tests added/updated (n/a — docs-only diff)
- [x] Verified in staging/dev environment — AWS staging, live

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [x] No workflow files added or changed
- [x] No lowercase workflow names present

### File Names
- [x] All files follow **kebab-case** convention
- [x] No files violate naming canon

### Code Standards
- [x] n/a — docs-only

### Cloud Run Deployments
- [x] n/a — no services deployed by this PR

### Documentation
- [x] BOOTSTRAP tag in commit message
- [x] No non-compliant files introduced

---

## 🔗 Links

- **Related PRs:** #2888 (merged — validation runs + gateway parity), #2887 (suite)
- **Documentation:** `scripts/aws-staging-validation/reports/aws-run-20260717-gateway-deployed/FINDINGS.md`

---

## 🚨 Breaking Changes

None. Live infra change (task def `vitana-gateway:8`) applied out-of-band — include it in the IaC mirroring along with the rest of the ledger.

---

## 📌 Additional Notes

Secret was provided via the session environment and bound per instruction as a plain task-def env var; the ledger notes it should move to a Secrets Manager `secrets` block when `GATEWAY_SERVICE_TOKEN` / `OPENAI_API_KEY` / `DEEPSEEK_API_KEY` / the Gemini key are wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcaMwh3VELBgvXA3msPtxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcaMwh3VELBgvXA3msPtxE)_