### PR TITLE
fix(gateway): retired Gemini models in API-key fallback (AWS staging Gemini was 404ing) + provider-key verification ledger

### DIFF
--- a/scripts/aws-staging-validation/reports/aws-run-20260717-provider-keys/FINDINGS.md
+++ b/scripts/aws-staging-validation/reports/aws-run-20260717-provider-keys/FINDINGS.md
@@ -65,3 +65,27 @@ so the key bindings on :13 carry forward across future deploys.
   revoked in Google Cloud Console and removed from source.
 - Telemetry labels still report `model: gemini-pro` in one legacy path
   (labels only — the actual calls use the 2.5 models).
+
+## Addendum: GATEWAY_SERVICE_TOKEN bound (task def :14, 2026-07-17)
+
+The last unbound secret. Investigation of the GCP staging value (Cloud Run
+console / Cloud Shell) revealed the "token" is a **literal placeholder
+sentence** — "Use your SUPABASE_SERVICE_ROLE key (the same one the gateway
+already uses)" — someone filled the secret with an instruction instead of a
+random value. The gateway compares bearer tokens byte-for-byte against the
+env var with no fallback, so that sentence IS the operative secret on GCP
+staging; for parity the same value is now bound on AWS (revision :14).
+
+Verified live on both platforms with identical behavior:
+- wrong bearer → 401 on `POST /api/v1/oasis/emit` (AWS and GCP)
+- placeholder-sentence bearer → 400 invalid-body with identical Zod issues
+  (AWS and GCP) — i.e. authentication passes
+
+**⚠️ Rotate this soon.** The effective secret is a guessable English
+sentence, visible in plaintext to anyone with Cloud Run viewer on the GCP
+project, in ECS DescribeTaskDefinition on AWS, and now in operational
+transcripts. Fix: set the GitHub org secret `GATEWAY_SERVICE_TOKEN` to a
+real random value, re-dispatch `BIND-STAGING-SERVICE-TOKEN.yml` (GCP) and
+an AWS twin (to be authored), and update every caller that holds the old
+value (orb-agent config etc.) in the same window as next week's key
+rotation.

--- a/scripts/aws-staging-validation/reports/aws-run-20260717-provider-keys/FINDINGS.md
+++ b/scripts/aws-staging-validation/reports/aws-run-20260717-provider-keys/FINDINGS.md
@@ -1,0 +1,67 @@
+# AWS staging — provider keys bound + verified, Gemini fallback bug fixed (2026-07-17)
+
+## What was done
+
+Provider API keys were bound on the `vitana-gateway` task definition and
+verified live through the gateway (the sandbox running this session cannot
+reach the provider APIs directly — egress blocked — so all verification is
+end-to-end through AWS staging):
+
+| Revision | Change |
+|----------|--------|
+| :9 | (pipeline `AWS-STAGE-DEPLOY-GATEWAY.yml` — image `03e4be971672` from merged main) |
+| :10 | dead end — derived from :8 in a race with the pipeline's :9; never used, superseded |
+| :11 | :9 + `GOOGLE_GEMINI_API_KEY`, `GEMINI_API_KEY` (same value — services prefer the `GOOGLE_` name with the short name as fallback), `OPENAI_API_KEY`, `DEEPSEEK_API_KEY` |
+| :12 | image → `eb2b4f4` (retired-Gemini-model fix, see below) + commit stamps |
+| :13 | `DEEPSEEK_API_KEY` corrected to lowercase `sk-` prefix (as provided it began with `Sk-` and DeepSeek returned 401 invalid key) |
+
+## Verification results (all through `preview-aws-gateway.vitanaland.com`)
+
+| Provider | Test | Result |
+|----------|------|--------|
+| Gemini | `POST /api/v1/orb/chat` as e2e user | Real LLM reply, `meta.provider=gemini-api` (Vertex ADC fails on AWS as expected → API-key fallback used) |
+| DeepSeek | fact-bearing chat turn + `session/finalize` → inline fact extraction | `[VTID-01225-inline] DeepSeek response: [{"fact_key":"user_favorite_fruit","fact_value":"mango",...}]` |
+| OpenAI | fact embedding on the extracted fact | `[VTID-01192] Embedding stored` with NO `OpenAI fact-embedding failed, trying Gemini` warning — OpenAI primary path succeeded |
+
+## Bug found and fixed: retired Gemini models in the API-key fallback
+
+First Gemini test came back from the **local keyword router** ("fallback
+mode"). Logs: Vertex ADC error (expected — no GCP metadata server on AWS) →
+`Falling back to Gemini API key` → **`Gemini API error: 404`**. The
+API-key fallback paths called models retired from the generativelanguage
+API: `gemini-pro` (gemini-operator.ts ×2, knowledge-hub.ts),
+`gemini-pro-vision` and `gemini-1.5-flash` (assistant-core.ts). These
+paths never ran on GCP because Vertex always succeeded — a latent
+AWS-only failure exactly of the class flagged in the validation plan's
+GCP-coupled-code inventory.
+
+Fixed in commit `eb2b4f4` (this PR): `gemini-pro` → `gemini-2.5-pro`,
+vision/1.5-flash → `gemini-2.5-flash`. Deployed to AWS staging as image
+`vitana/gateway:eb2b4f4` (built on the pipeline image `03e4be971672` +
+recompiled dist). After the fix: real Gemini replies.
+
+**⚠️ Merge-ordering constraint:** `AWS-STAGE-DEPLOY-GATEWAY.yml` builds
+from `main`. Until this PR merges, its next run would deploy an image
+WITHOUT the model fix and Gemini falls back to 404/keyword-router again.
+Merge this PR before (or immediately after) the next gateway push to main.
+
+## Pipeline interaction (checked — no wipe risk)
+
+`AWS-STAGE-DEPLOY-GATEWAY.yml` derives each new task definition from the
+service's CURRENT one (image swap + commit-stamp upsert, env preserved),
+so the key bindings on :13 carry forward across future deploys.
+
+## Security notes
+
+- The three key values were shared in the session conversation (owner's
+  decision, rotation already planned). **Rotate on schedule regardless**;
+  bind replacements via AWS Secrets Manager (`secrets` block + execution
+  role grant), not chat and not plain task-def env.
+- Still missing: `GATEWAY_SERVICE_TOKEN` (not provided) — service-token
+  auth paths remain unverified on AWS.
+- Found in source, unrelated to this session's keys:
+  `services/gateway/src/services/natural-language-service.ts:5` contains a
+  **hardcoded fallback Gemini API key** (`AIzaSyDCbka2...`). It should be
+  revoked in Google Cloud Console and removed from source.
+- Telemetry labels still report `model: gemini-pro` in one legacy path
+  (labels only — the actual calls use the 2.5 models).

--- a/services/gateway/src/services/assistant-core.ts
+++ b/services/gateway/src/services/assistant-core.ts
@@ -355,7 +355,7 @@ export async function processFrame(request: FrameProcessRequest): Promise<FrameP
     route: request.route,
     selectedId: request.selectedId,
     sizeBytes: frameSizeBytes,
-    model: GOOGLE_GEMINI_API_KEY ? 'gemini-pro-vision' : undefined
+    model: GOOGLE_GEMINI_API_KEY ? 'gemini-2.5-flash' : undefined
   });
 
   // Optional: Send to Gemini Vision API for analysis (stub)
@@ -423,7 +423,7 @@ async function analyzeFrameWithGemini(frameBase64: string, source: 'camera' | 's
   };
 
   const response = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -548,7 +548,7 @@ async function transcribeAudioWithGemini(audioBase64: string): Promise<{
   };
 
   const response = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -3515,7 +3515,7 @@ async function callGeminiWithTools(
     console.log(`[VTID-01027] Calling Gemini API with ${conversationHistory.length} history messages`);
 
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
       {
         method: 'POST',
         headers: {
@@ -3640,7 +3640,7 @@ CRITICAL — Sharing links:
   };
 
   const response = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
     {
       method: 'POST',
       headers: {

--- a/services/gateway/src/services/knowledge-hub.ts
+++ b/services/gateway/src/services/knowledge-hub.ts
@@ -163,7 +163,7 @@ Answer (be specific and reference the documentation):`;
     const prompt = basePrompt;
 
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
       {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION`

**Layer:** APIL

**Priority:** P1 — **merge before the next gateway push to main** (see ordering note)

---

## 📋 Summary

While binding + verifying the provider API keys on AWS staging, a latent bug surfaced: the `GOOGLE_GEMINI_API_KEY` fallback paths call **retired models** (`gemini-pro`, `gemini-pro-vision`, `gemini-1.5-flash`) which the generativelanguage API now 404s. These paths never executed on GCP because Vertex ADC always succeeded — on AWS (no metadata server) they are the primary path, so ORB operator chat silently degraded to the local keyword router ("fallback mode").

Fix: `gemini-pro` → `gemini-2.5-pro` (operator + knowledge hub, matching the Vertex primary), `gemini-pro-vision`/`gemini-1.5-flash` → `gemini-2.5-flash`. Already deployed to AWS staging as `vitana/gateway:eb2b4f4` (task def :12/:13) and verified: real Gemini replies via `meta.provider=gemini-api`.

Also includes the ledger for task-def revisions 9–13 with the full provider-key verification: **Gemini** (ORB chat), **DeepSeek** (inline fact extraction — key needed lowercase `sk-` prefix; as first provided it 401'd), **OpenAI** (fact embedding via primary path, no fallback warning).

**⚠️ Merge ordering:** `AWS-STAGE-DEPLOY-GATEWAY.yml` builds from `main`. Until this merges, its next run deploys an image WITHOUT this fix and AWS Gemini goes back to 404 → keyword-router. (Env keys themselves are safe — the pipeline preserves the task-def env block.)

---

## ✅ Changes

- [x] `services/gateway/src/services/gemini-operator.ts` — 2× `gemini-pro` → `gemini-2.5-pro`
- [x] `services/gateway/src/services/knowledge-hub.ts` — `gemini-pro` → `gemini-2.5-pro`
- [x] `services/gateway/src/services/assistant-core.ts` — `gemini-pro-vision`/`gemini-1.5-flash` → `gemini-2.5-flash` (+ telemetry label)
- [x] `reports/aws-run-20260717-provider-keys/FINDINGS.md` — verification ledger, task defs :9–:13, security notes

---

## 🧪 Testing

_How was this tested?_

- [x] Manual testing completed — live on AWS staging: before the fix, `POST /api/v1/orb/chat` returned the keyword-router fallback with `[VTID-01023] Gemini API error: 404` in logs; after deploying the fix, a real LLM reply with `meta.provider=gemini-api`. DeepSeek extraction and OpenAI fact-embedding verified in the same session (log evidence in FINDINGS.md)
- [ ] Automated tests added/updated (n/a — model-name constants in URLs)
- [x] Verified in staging/dev environment — AWS staging (`preview-aws-gateway.vitanaland.com`), task def `vitana-gateway:13`

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [x] No workflow files added or changed
- [x] No lowercase workflow names present

### File Names
- [x] All new files follow **kebab-case** convention
- [x] No files violate naming canon

### Code Standards
- [x] No events or VTID constants introduced; status values unchanged

### Cloud Run Deployments
- [x] n/a — no Cloud Run services deployed by this PR (GCP behavior unchanged: Vertex remains the primary there)

### Documentation
- [x] BOOTSTRAP tag in commit messages
- [x] No non-compliant files introduced

---

## 🔗 Links

- **Related PRs:** #2892 (AWS deploy pipeline), #2888/#2890/#2891 (validation series)
- **Documentation:** `scripts/aws-staging-validation/reports/aws-run-20260717-provider-keys/FINDINGS.md`

---

## 🚨 Breaking Changes

None. GCP is unaffected (Vertex path unchanged and still primary there).

---

## 📌 Additional Notes

Security follow-ups recorded in FINDINGS.md: rotate the shared keys on schedule and rebind via Secrets Manager; `natural-language-service.ts:5` contains a hardcoded fallback Gemini API key that should be revoked and removed; `GATEWAY_SERVICE_TOKEN` is still unbound on AWS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcaMwh3VELBgvXA3msPtxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcaMwh3VELBgvXA3msPtxE)_