### PR TITLE
feat(voice): Marketplace Voice Assistant — 89-tool catalog + Wave MVA-1 (35 live) (BOOTSTRAP-MARKETPLACE-VOICE-ASSISTANT)

### DIFF
--- a/docs/VOICE_TOOLS_EXPANSION_PLAN.md
+++ b/docs/VOICE_TOOLS_EXPANSION_PLAN.md
@@ -771,3 +771,220 @@ Goal: a developer can run the platform's whole operational loop by voice — VTI
 ## Review outcome
 
 The four open questions were resolved on 2026-07-12 — see "Approved decisions" at the top of this document.
+
+---
+
+# Marketplace Voice Assistant (Discover) — expansion v3
+
+**APPROVED 2026-07-20 (owner request: complete conversational shopping journey).**
+
+Vitana becomes a **Marketplace Discover Assistant**: understand the need →
+clarify → discover options → explain relevance (concise, never spec-dumps) →
+compare → choose → confirmed add-to-basket → book/order → follow up. Covers
+products, services, practitioners, and health diagnostics (blood tests,
+metabolomics, microbiome, genomics, cardiovascular assessment).
+
+**Wave MVA-1 (this PR)** builds the 35 tools whose backing systems exist today
+(`products`, `services_catalog`, universal cart, shopping-agent `runPropose`,
+`memory_facts`, `memory_items`, `shop_saved_products`, `user_offers_memory`).
+Everything else seeds as `planned` — honest roadmap entries that go live when
+their backends (diagnostic-test catalog, practitioner booking/availability,
+bundles, returns) exist. No tool ever fabricates data for a missing backend.
+
+**Health-domain boundary (hard rule for every A24/A25 tool and any
+health-adjacent recommendation):** the assistant may explain what a test
+measures, why it could be relevant to a stated goal, compare scope/logistics,
+and facilitate ordering — it must NEVER diagnose, prescribe, promise outcomes,
+present a test as medically necessary, hide limitations, or use health context
+without consent. Payment is never taken by voice: cart-staging + screen
+handoff only.
+
+## A17. Marketplace Discover Assistant orchestrators (5) — P0
+
+The user-facing conversational layer that coordinates the atomic tools below.
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `start_marketplace_discover_assistant` | Start a guided shopping conversation for a product, service, practitioner or diagnostic need; records the goal and returns the first clarifying step | W |
+| 2 | `build_personalized_shopping_guide` | Convert a broad need into a concise recommendation path across products and services, grounded in the shopping agent | R |
+| 3 | `refine_marketplace_recommendations` | Update the current picks from conversational feedback (cheaper, no pills, at home, different brand) | R |
+| 4 | `explain_marketplace_recommendation` | The concise what-it-is / what-for / why-for-you / limits explanation of a current pick | R |
+| 5 | `complete_marketplace_selection` ⚠️ | Confirm the selected option and route it to the basket (two-step confirm; never charges) | W |
+
+## A18. Shopping intent & preferences (8) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `capture_shopping_goal` | Record what the user wants to achieve, solve, explore or purchase in the active guide | W |
+| 2 | `clarify_shopping_need` | Return the smallest set of missing criteria (budget, format, urgency, exclusions) still needed | R |
+| 3 | `classify_marketplace_intent` | Determine whether the need maps to a product, service, diagnostic test, practitioner or combination | R |
+| 4 | `extract_purchase_criteria` | Extract budget, location, urgency, format, priorities, exclusions and desired outcome from natural language | R |
+| 5 | `save_marketplace_preferences` ⚠️ | Save reusable shopping preferences (dietary, values, exclusions, budget) with user permission | W |
+| 6 | `get_marketplace_preferences` | Retrieve saved shopping preferences relevant to the current request | R |
+| 7 | `reset_marketplace_preferences` ⚠️ | Remove saved marketplace preferences after confirmation | W |
+| 8 | `exclude_marketplace_brand_or_category` ⚠️ | Persistently exclude a brand or category from future recommendations | W |
+
+## A19. Personalization & transparency (5) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `get_marketplace_context` | Return the minimum relevant user context (saved preferences, budget, recent orders) for the current request | R |
+| 2 | `explain_personalization_basis` | Explain in plain language which stored information shaped a recommendation | R |
+| 3 | `dismiss_marketplace_recommendation` | Dismiss a recommended product or service so it is not proposed again | W |
+| 4 | `show_sponsored_status` | State whether an item is sponsored, promoted or commission-bearing | R |
+| 5 | `explain_no_suitable_option` | Explain honestly when no appropriate marketplace option was found | R |
+
+## A20. Unified discovery (8) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `discover_marketplace_options` | Unified search across products AND services for one stated need | R |
+| 2 | `search_products_by_need` | Search products by purpose and outcome rather than exact product name | R |
+| 3 | `search_services_by_need` | Search services (wellness, nutrition, therapy, labs) by desired outcome | R |
+| 4 | `search_marketplace_by_values` | Filter products by dietary tags, certifications and value preferences | R |
+| 5 | `search_marketplace_alternatives` | Find alternatives to a product the user dislikes or cannot use | R |
+| 6 | `search_marketplace_by_budget` | Find options within a defined total budget across categories | R |
+| 7 | `search_local_services` | Search services available near the user | R |
+| 8 | `search_marketplace_by_availability` | Search by delivery date or appointment availability | R |
+
+## A21. Guided recommendation (7) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `generate_top_marketplace_picks` | Return a small number of best-fit options with short per-pick rationales (never stages the cart silently) | R |
+| 2 | `recommend_marketplace_path` | Recommend whether to start with a product, service, diagnostic or combination for the stated goal | R |
+| 3 | `rerank_marketplace_options` | Re-rank current options when the user changes a priority | R |
+| 4 | `recommend_lower_cost_option` | Find a suitable less expensive alternative to a current pick | R |
+| 5 | `recommend_premium_option` | Find a higher-quality or more comprehensive alternative | R |
+| 6 | `recommend_non_product_alternative` | Suggest a service or non-purchase approach when a product is not the best fit | R |
+| 7 | `recommend_complete_solution` | Build a product-and-service combination that addresses one broader goal | R |
+
+## A22. Concise explanation (6) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `explain_why_recommended` | Explain why the assistant selected this option for this user, from the recorded rationale | R |
+| 2 | `summarize_product_for_user` | Personalized short summary: what it is, what for, why it may fit, key limits — never the full spec | R |
+| 3 | `get_key_product_facts` | Only the most important facts: price, form, usage, availability, safety notes | R |
+| 4 | `explain_how_to_use_product` | Practical use instructions (dosage, serving) without overwhelming detail | R |
+| 5 | `explain_relevant_limitations` | Surface only the limitations relevant to this user | R |
+| 6 | `explain_evidence_summary` | Concise description of evidence strength and uncertainty for a product or service claim | R |
+
+## A23. Comparison & shortlist (7) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `compare_marketplace_options` | Compare up to three options on the criteria that matter to this user | R |
+| 2 | `highlight_meaningful_differences` | Explain only the differences likely to affect the user's choice | R |
+| 3 | `identify_best_value_option` | Determine the strongest value for the user's needs, not just the lowest price | R |
+| 4 | `answer_product_question` | Answer one focused question about one product | R |
+| 5 | `shortlist_marketplace_options` ⚠️ | Save products to the user's shortlist for later comparison | W |
+| 6 | `view_marketplace_shortlist` | Read the current shortlist aloud | R |
+| 7 | `remove_from_marketplace_shortlist` ⚠️ | Remove an option from the shortlist | W |
+
+## A24. Diagnostics & health services (10) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `browse_diagnostic_tests` | Browse diagnostic services by type: blood, metabolomics, microbiome, genomics, hormones, longevity panels | R |
+| 2 | `find_test_by_health_goal` | Find diagnostic categories matching a stated goal without diagnosing | R |
+| 3 | `find_test_by_biomarker` | Search tests containing a named biomarker | R |
+| 4 | `get_test_details` | Biomarker list, sample method, preparation and result timeline for one test | R |
+| 5 | `check_home_collection_availability` | Check whether home sample collection is available for a test | R |
+| 6 | `order_home_test_kit` ⚠️ | Stage an eligible home test kit into the basket after confirmation | W |
+| 7 | `book_lab_appointment` ⚠️ | Book a laboratory or sample-collection appointment | W |
+| 8 | `get_ordered_test_status` | Track kit shipment, sample receipt, processing and result readiness | R |
+| 9 | `prepare_for_diagnostic_service` | Concise preparation checklist (fasting, timing, medication questions for a professional) | R |
+| 10 | `recommend_diagnostic_test` | Recommend suitable diagnostic categories for a stated information need, never a diagnosis | R |
+
+## A25. Practitioner selection (6) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `find_practitioner_by_specialty` | Find practitioners by specialty, goal and user preferences | R |
+| 2 | `get_practitioner_credentials` | Relevant qualifications and verification status | R |
+| 3 | `get_practitioner_availability` | Open appointment slots | R |
+| 4 | `get_practitioner_pricing` | Session and package pricing | R |
+| 5 | `compare_practitioners_for_user` | Compare a practitioner shortlist on the user's priorities | R |
+| 6 | `book_practitioner_appointment` ⚠️ | Book an available appointment after confirmation | W |
+
+## A26. Bundles & plans (5) — P2
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `build_marketplace_solution_plan` | Concise multi-step product and service plan for one goal | R |
+| 2 | `create_diagnostic_and_consultation_bundle` | Pair a diagnostic service with suitable result interpretation | R |
+| 3 | `check_bundle_compatibility` | Check whether bundle components logically work together, without duplication | R |
+| 4 | `add_bundle_to_cart` ⚠️ | Stage all purchasable bundle items into the basket after confirmation | W |
+| 5 | `save_marketplace_plan` | Save a marketplace plan to resume later | W |
+
+## A27. Suitability & compatibility (6) — P1
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `check_product_suitability` | Check one product against saved preferences, exclusions and dietary needs | R |
+| 2 | `check_dietary_compatibility` | Check vegan, vegetarian, gluten-free or other dietary requirements for a product | R |
+| 3 | `check_cart_duplication` | Detect repeated or overlapping products in the basket | R |
+| 4 | `check_delivery_restrictions` | Check country and shipping limitations for a product | R |
+| 5 | `check_test_overlap` | Identify duplicated biomarkers across diagnostic packages | R |
+| 6 | `check_service_prerequisites` | Identify referrals, preparation or eligibility requirements for a service | R |
+
+## A28. Pricing & value (4) — P2
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `compare_marketplace_prices` | Compare prices of equivalent options including reference prices | R |
+| 2 | `explain_price_difference` | Explain why two similar options are priced differently | R |
+| 3 | `review_shopping_budget` | Read the monthly shopping budget, current spend and remaining headroom | R |
+| 4 | `estimate_total_ownership_cost` | Show recurring or long-term cost rather than only the initial price | R |
+
+## A29. Cart confirmation & checkout handoff (6) — P0
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `confirm_marketplace_selection` ⚠️ | Read back the exact selected option (name, price, key terms) and obtain explicit confirmation before any cart action | R |
+| 2 | `add_selected_option_to_cart` ⚠️ | Stage the confirmed option into the universal basket (never charges; screen handoff for payment) | W |
+| 3 | `add_shortlist_item_to_cart` ⚠️ | Stage an item from the shortlist into the basket after confirmation | W |
+| 4 | `review_cart_suitability` | Check duplicates and conflicts with saved preferences before checkout | R |
+| 5 | `explain_cart_item` | Explain why a specific basket item is there (origin, rationale) | R |
+| 6 | `confirm_cart_total` | Read back total price and any recurring charges before the screen handoff | R |
+
+## A30. Post-purchase & follow-up (6) — P2
+
+| # | Tool | Does | R/W |
+|---|---|---|---|
+| 1 | `get_next_order_action` | Tell the user the next required step for an order (delivery, sample, appointment) | R |
+| 2 | `submit_marketplace_review` ⚠️ | Record the user's rating of a purchased product or service after confirmation | W |
+| 3 | `schedule_reorder_reminder` | Schedule an optional reorder reminder | W |
+| 4 | `start_return_request` | Start a return process for an eligible order | W |
+| 5 | `cancel_marketplace_order` ⚠️ | Cancel an eligible order after confirmation | W |
+| 6 | `report_marketplace_issue` | Report an order, product or service problem | W |
+
+## Wave MVA-1 build slice (35 live in this PR)
+
+- **A17 (5/5)** — guide state persisted per-user in `memory_items`
+  (`content_json.type = 'marketplace_guide_state'`); picks grounded in
+  `runPropose()` + `services_catalog`; completion routes through the
+  two-step confirm + universal-cart staging path.
+- **A18 (6/8)** — `capture_shopping_goal`, `clarify_shopping_need`,
+  `classify_marketplace_intent`, `save/get/reset_marketplace_preferences`
+  (`memory_facts` `marketplace_pref_*` keys via `write_fact`).
+- **A19 (2/5)** — `get_marketplace_context`,
+  `dismiss_marketplace_recommendation` (`user_offers_memory.state='dismissed'`).
+- **A20 (5/8)** — unified/need/values/alternatives search over `products` +
+  `services_catalog` (same query family as A1).
+- **A21 (3/7)** — `generate_top_marketplace_picks` (propose-only `runPropose`
+  wrapper), `recommend_marketplace_path`, `recommend_lower_cost_option`.
+- **A22 (3/6)** — `explain_why_recommended`, `summarize_product_for_user`,
+  `get_key_product_facts`.
+- **A23 (4/7)** — compare + shortlist trio (`shop_saved_products`).
+- **A27 (2/6)** — `check_product_suitability`, `check_cart_duplication`.
+- **A28 (1/4)** — `review_shopping_budget` (`user_limitations` cap +
+  monthly spend).
+- **A29 (4/6)** — `confirm_marketplace_selection`,
+  `add_selected_option_to_cart`, `review_cart_suitability`,
+  `explain_cart_item`.
+
+The remaining 54 tools stay `planned` until their backends exist
+(diagnostic-test catalog with biomarker data, practitioner
+booking/availability, bundles, returns/refunds, geo search).

--- a/scripts/voice-tools-plan-seed.mjs
+++ b/scripts/voice-tools-plan-seed.mjs
@@ -41,7 +41,16 @@ const SECTION_SURFACE = {
   A5: 'Referrals', A6: 'Business', A7: 'LiveRooms', A8: 'Chat',
   A9: 'Community', A10: 'Events', A11: 'Health', A12: 'Goals',
   A13: 'Memory', A14: 'Profile', A15: 'Campaigns', A16: 'Settings',
+  // Marketplace Voice Assistant — expansion v3 (A17–A30 in the same plan doc)
+  A17: 'Marketplace', A18: 'Marketplace', A19: 'Marketplace', A20: 'Marketplace',
+  A21: 'Marketplace', A22: 'Marketplace', A23: 'Marketplace', A24: 'Marketplace',
+  A25: 'Marketplace', A26: 'Marketplace', A27: 'Marketplace', A28: 'Marketplace',
+  A29: 'Marketplace', A30: 'Marketplace',
 };
+
+// Section id → plan tag. A17+ belong to the Marketplace Voice Assistant
+// expansion (v3); everything before it is the original 425-tool plan (v2).
+const planTag = (sectionId) => (Number(sectionId.slice(1)) >= 17 && sectionId[0] === 'A' ? 'marketplace-va-v3' : 'expansion-v2');
 
 const SECTION_RE = /^## ([ABC]\d+)\.\s+(.+?)\s+\((\d+)\)\s+—\s+(P\d)/;
 const ROW_RE = /^\|\s*\d+\s*\|\s*`([a-z0-9_]+)`\s*(⚠️⚠️|⚠️)?\s*\|\s*(.+?)\s*\|\s*(R|W)\s*\|/;
@@ -86,7 +95,7 @@ function parsePlan(md) {
       priority: section.priority,
       risk,
       plan_domain: `${section.id} ${section.title}`,
-      plan: 'expansion-v2',
+      plan: planTag(section.id),
     });
     sectionCount++;
   }
@@ -107,19 +116,22 @@ function parsePlan(md) {
 }
 
 function main() {
-  const planned = parsePlan(readFileSync(PLAN, 'utf8'));
+  const parsed = parsePlan(readFileSync(PLAN, 'utf8'));
   const manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'));
   const existing = new Set(manifest.tools.map((t) => t.name));
 
-  const collisions = planned.filter((t) => existing.has(t.name));
-  if (collisions.length) {
-    for (const c of collisions) console.error(`[seed] name already in manifest: ${c.name}`);
-    throw new Error('plan tool names collide with existing manifest entries — rename in the plan');
+  // Idempotent (per the header contract): plan entries whose name already
+  // exists in the manifest are skipped, never touched — re-running after a
+  // previous seed (or after a wave went live) must not downgrade or duplicate.
+  const skipped = parsed.filter((t) => existing.has(t.name));
+  const planned = parsed.filter((t) => !existing.has(t.name));
+  if (skipped.length) {
+    console.log(`[seed] skipping ${skipped.length} plan entries already in the manifest (idempotent re-run)`);
   }
 
   const byPart = { A: 0, B: 0, C: 0 };
   for (const t of planned) byPart[t.plan_domain[0]]++;
-  console.log(`[seed] parsed ${planned.length} planned tools (community=${byPart.A}, admin=${byPart.B}, developer=${byPart.C})`);
+  console.log(`[seed] parsed ${planned.length} new planned tools (community=${byPart.A}, admin=${byPart.B}, developer=${byPart.C})`);
 
   if (DRY_RUN) {
     console.log('[seed] dry-run: manifest not written');

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -5926,6 +5926,372 @@ async def dev_system_briefing(context: RunContext, limit: int | None = None) -> 
     return summarize(body)
 
 
+
+
+# --- MVA Marketplace Voice Assistant (35) -----------------------------------
+
+
+@function_tool
+async def start_marketplace_discover_assistant(context: RunContext, goal: str | None = None, budget_max_amount: float | None = None, exclusions: str | None = None) -> str:
+    """Start a guided marketplace conversation for a product, service, practitioner or diagnostic need."""
+    body = await _dispatch_with_directive(context, "start_marketplace_discover_assistant", {
+            "goal": goal,
+            "budget_max_amount": budget_max_amount,
+            "exclusions": exclusions,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def build_personalized_shopping_guide(context: RunContext, goal: str | None = None, budget_max_amount: float | None = None, max_items: float | None = None) -> str:
+    """Build a concise personalized recommendation set (max 3 options with rationales); adds nothing to the cart."""
+    body = await _dispatch_with_directive(context, "build_personalized_shopping_guide", {
+            "goal": goal,
+            "budget_max_amount": budget_max_amount,
+            "max_items": max_items,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def refine_marketplace_recommendations(context: RunContext, exclude: str | None = None, prefer: str | None = None, budget_max_amount: float | None = None) -> str:
+    """Update the current recommendations from conversational feedback (cheaper, exclusions, preferences)."""
+    body = await _dispatch_with_directive(context, "refine_marketplace_recommendations", {
+            "exclude": exclude,
+            "prefer": prefer,
+            "budget_max_amount": budget_max_amount,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def explain_marketplace_recommendation(context: RunContext, position: float | None = None, title: str | None = None, product_id: str | None = None) -> str:
+    """Explain one current pick: what it is, why chosen for this user, use, and relevant limitations."""
+    body = await _dispatch_with_directive(context, "explain_marketplace_recommendation", {
+            "position": position,
+            "title": title,
+            "product_id": product_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def complete_marketplace_selection(context: RunContext, position: float | None = None, title: str | None = None, product_id: str | None = None, confirm: bool | None = None) -> str:
+    """Confirm the chosen option and stage it into the basket (never charges). Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "complete_marketplace_selection", {
+            "position": position,
+            "title": title,
+            "product_id": product_id,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def capture_shopping_goal(context: RunContext, goal: str, budget_max_amount: float | None = None, exclusions: str | None = None, urgency: str | None = None) -> str:
+    """Record what the user wants to achieve, solve, explore or purchase."""
+    body = await _dispatch_with_directive(context, "capture_shopping_goal", {
+            "goal": goal,
+            "budget_max_amount": budget_max_amount,
+            "exclusions": exclusions,
+            "urgency": urgency,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def clarify_shopping_need(context: RunContext) -> str:
+    """Get the smallest set of still-missing criteria for the recorded shopping goal."""
+    body = await _dispatch_with_directive(context, "clarify_shopping_need", {})
+    return summarize(body)
+
+
+@function_tool
+async def classify_marketplace_intent(context: RunContext, need: str | None = None) -> str:
+    """Determine whether a need maps to a product, service, diagnostic test, practitioner or combination."""
+    body = await _dispatch_with_directive(context, "classify_marketplace_intent", {
+            "need": need,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def save_marketplace_preferences(context: RunContext, budget_monthly_amount: float | None = None, dietary: str | None = None, values: str | None = None, exclusions: str | None = None, excluded_brands: str | None = None, excluded_categories: str | None = None, format: str | None = None) -> str:
+    """Save shopping preferences the user explicitly stated (budget, dietary, values, exclusions, format)."""
+    body = await _dispatch_with_directive(context, "save_marketplace_preferences", {
+            "budget_monthly_amount": budget_monthly_amount,
+            "dietary": dietary,
+            "values": values,
+            "exclusions": exclusions,
+            "excluded_brands": excluded_brands,
+            "excluded_categories": excluded_categories,
+            "format": format,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_marketplace_preferences(context: RunContext) -> str:
+    """Read the user's saved marketplace preferences."""
+    body = await _dispatch_with_directive(context, "get_marketplace_preferences", {})
+    return summarize(body)
+
+
+@function_tool
+async def reset_marketplace_preferences(context: RunContext, confirm: bool | None = None) -> str:
+    """Clear all saved marketplace preferences. Call once without confirm first."""
+    body = await _dispatch_with_directive(context, "reset_marketplace_preferences", {
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_marketplace_context(context: RunContext) -> str:
+    """Minimum relevant shopping context: saved preferences, budget and spend, recent orders, active goal."""
+    body = await _dispatch_with_directive(context, "get_marketplace_context", {})
+    return summarize(body)
+
+
+@function_tool
+async def dismiss_marketplace_recommendation(context: RunContext, position: float | None = None, title: str | None = None, product_id: str | None = None) -> str:
+    """Dismiss a recommended product so it is not proposed again."""
+    body = await _dispatch_with_directive(context, "dismiss_marketplace_recommendation", {
+            "position": position,
+            "title": title,
+            "product_id": product_id,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def discover_marketplace_options(context: RunContext, need: str, budget_max_amount: float | None = None, limit: float | None = None) -> str:
+    """Unified marketplace search across products AND services for one stated need."""
+    body = await _dispatch_with_directive(context, "discover_marketplace_options", {
+            "need": need,
+            "budget_max_amount": budget_max_amount,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def search_products_by_need(context: RunContext, need: str, budget_max_amount: float | None = None, limit: float | None = None) -> str:
+    """Search products by purpose rather than product name, filtered against saved preferences."""
+    body = await _dispatch_with_directive(context, "search_products_by_need", {
+            "need": need,
+            "budget_max_amount": budget_max_amount,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def search_services_by_need(context: RunContext, need: str, service_types: str | None = None, limit: float | None = None) -> str:
+    """Search marketplace services (wellness, nutrition, therapy, labs) by desired outcome."""
+    body = await _dispatch_with_directive(context, "search_services_by_need", {
+            "need": need,
+            "service_types": service_types,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def search_marketplace_by_values(context: RunContext, dietary_tags: str | None = None, certifications: str | None = None, need: str | None = None, limit: float | None = None) -> str:
+    """Filter products by declared dietary tags and certifications (vegan, gluten-free, organic)."""
+    body = await _dispatch_with_directive(context, "search_marketplace_by_values", {
+            "dietary_tags": dietary_tags,
+            "certifications": certifications,
+            "need": need,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def search_marketplace_alternatives(context: RunContext, product_id: str | None = None, title: str | None = None, position: float | None = None, reason: str | None = None, different_brand: bool | None = None, limit: float | None = None) -> str:
+    """Find alternatives to a product the user dislikes or cannot use, in the same category."""
+    body = await _dispatch_with_directive(context, "search_marketplace_alternatives", {
+            "product_id": product_id,
+            "title": title,
+            "position": position,
+            "reason": reason,
+            "different_brand": different_brand,
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def generate_top_marketplace_picks(context: RunContext, prompt: str, max_items: float | None = None) -> str:
+    """Return up to 3 best-fit product picks with short rationales, WITHOUT staging the cart."""
+    body = await _dispatch_with_directive(context, "generate_top_marketplace_picks", {
+            "prompt": prompt,
+            "max_items": max_items,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def recommend_marketplace_path(context: RunContext, goal: str | None = None) -> str:
+    """Recommend whether to start with a product, service/assessment, practitioner, or combination."""
+    body = await _dispatch_with_directive(context, "recommend_marketplace_path", {
+            "goal": goal,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def recommend_lower_cost_option(context: RunContext, product_id: str | None = None, title: str | None = None, position: float | None = None) -> str:
+    """Find a suitable cheaper alternative to a current pick or named product."""
+    body = await _dispatch_with_directive(context, "recommend_lower_cost_option", {
+            "product_id": product_id,
+            "title": title,
+            "position": position,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def explain_why_recommended(context: RunContext, product_id: str | None = None, title: str | None = None, position: float | None = None) -> str:
+    """Explain why an option was recommended, from the recorded rationale — never an algorithm score."""
+    body = await _dispatch_with_directive(context, "explain_why_recommended", {
+            "product_id": product_id,
+            "title": title,
+            "position": position,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def summarize_product_for_user(context: RunContext, product_id: str | None = None, title: str | None = None, position: float | None = None) -> str:
+    """Personalized SHORT product summary: what it is, what for, why it may fit, one limitation."""
+    body = await _dispatch_with_directive(context, "summarize_product_for_user", {
+            "product_id": product_id,
+            "title": title,
+            "position": position,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def get_key_product_facts(context: RunContext, product_id: str | None = None, title: str | None = None, position: float | None = None) -> str:
+    """Only the most important product facts: price, dosage, allergens, safety notes, availability."""
+    body = await _dispatch_with_directive(context, "get_key_product_facts", {
+            "product_id": product_id,
+            "title": title,
+            "position": position,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def compare_marketplace_options(context: RunContext, product_ids: str | None = None, titles: str | None = None) -> str:
+    """Compare up to 3 options on price, rating, availability and dietary fit — meaningful differences only."""
+    body = await _dispatch_with_directive(context, "compare_marketplace_options", {
+            "product_ids": product_ids,
+            "titles": titles,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def shortlist_marketplace_options(context: RunContext, product_id: str | None = None, title: str | None = None, position: float | None = None, all_picks: bool | None = None) -> str:
+    """Save one product (or all current picks) to the user's shortlist."""
+    body = await _dispatch_with_directive(context, "shortlist_marketplace_options", {
+            "product_id": product_id,
+            "title": title,
+            "position": position,
+            "all_picks": all_picks,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def view_marketplace_shortlist(context: RunContext, limit: float | None = None) -> str:
+    """Read the user's saved marketplace shortlist."""
+    body = await _dispatch_with_directive(context, "view_marketplace_shortlist", {
+            "limit": limit,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def remove_from_marketplace_shortlist(context: RunContext, product_id: str | None = None, title: str | None = None) -> str:
+    """Remove one product from the shortlist."""
+    body = await _dispatch_with_directive(context, "remove_from_marketplace_shortlist", {
+            "product_id": product_id,
+            "title": title,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def check_product_suitability(context: RunContext, product_id: str | None = None, title: str | None = None, position: float | None = None) -> str:
+    """Check one product against saved preferences using only declared product data."""
+    body = await _dispatch_with_directive(context, "check_product_suitability", {
+            "product_id": product_id,
+            "title": title,
+            "position": position,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def check_cart_duplication(context: RunContext) -> str:
+    """Detect repeated or overlapping products in the basket."""
+    body = await _dispatch_with_directive(context, "check_cart_duplication", {})
+    return summarize(body)
+
+
+@function_tool
+async def review_shopping_budget(context: RunContext) -> str:
+    """Read the monthly shopping budget, spend, remaining headroom, and whether the basket would exceed it."""
+    body = await _dispatch_with_directive(context, "review_shopping_budget", {})
+    return summarize(body)
+
+
+@function_tool
+async def confirm_marketplace_selection(context: RunContext, product_id: str | None = None, title: str | None = None, position: float | None = None) -> str:
+    """Read back the exact selected option (name, price, availability) before any cart action."""
+    body = await _dispatch_with_directive(context, "confirm_marketplace_selection", {
+            "product_id": product_id,
+            "title": title,
+            "position": position,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def add_selected_option_to_cart(context: RunContext, product_id: str | None = None, title: str | None = None, position: float | None = None, confirm: bool | None = None) -> str:
+    """Stage the confirmed selection into the basket (never charges). Pass confirm true only after the user's yes."""
+    body = await _dispatch_with_directive(context, "add_selected_option_to_cart", {
+            "product_id": product_id,
+            "title": title,
+            "position": position,
+            "confirm": confirm,
+        })
+    return summarize(body)
+
+
+@function_tool
+async def review_cart_suitability(context: RunContext) -> str:
+    """Check the basket for duplicates, preference conflicts, allergens and availability problems before checkout."""
+    body = await _dispatch_with_directive(context, "review_cart_suitability", {})
+    return summarize(body)
+
+
+@function_tool
+async def explain_cart_item(context: RunContext, product_id: str | None = None, title: str | None = None) -> str:
+    """Explain why a specific basket item is there (origin and recorded rationale)."""
+    body = await _dispatch_with_directive(context, "explain_cart_item", {
+            "product_id": product_id,
+            "title": title,
+        })
+    return summarize(body)
+
+
 # ---------------------------------------------------------------------------
 # Catalogue export — used by tests + libcst smoke
 # ---------------------------------------------------------------------------
@@ -6231,6 +6597,19 @@ def all_tool_names() -> list[str]:
         "dev_list_dev_users", "dev_grant_access", "dev_revoke_access", "dev_mint_token",
         "dev_open_hub_panel", "dev_run_simulator", "dev_journey_context",
         "dev_voice_catalog_stats", "dev_get_voice_tool_detail", "dev_system_briefing",
+        # MVA Marketplace Voice Assistant (35)
+        "start_marketplace_discover_assistant", "build_personalized_shopping_guide", "refine_marketplace_recommendations",
+        "explain_marketplace_recommendation", "complete_marketplace_selection", "capture_shopping_goal",
+        "clarify_shopping_need", "classify_marketplace_intent", "save_marketplace_preferences",
+        "get_marketplace_preferences", "reset_marketplace_preferences", "get_marketplace_context",
+        "dismiss_marketplace_recommendation", "discover_marketplace_options", "search_products_by_need",
+        "search_services_by_need", "search_marketplace_by_values", "search_marketplace_alternatives",
+        "generate_top_marketplace_picks", "recommend_marketplace_path", "recommend_lower_cost_option",
+        "explain_why_recommended", "summarize_product_for_user", "get_key_product_facts",
+        "compare_marketplace_options", "shortlist_marketplace_options", "view_marketplace_shortlist",
+        "remove_from_marketplace_shortlist", "check_product_suitability", "check_cart_duplication",
+        "review_shopping_budget", "confirm_marketplace_selection", "add_selected_option_to_cart",
+        "review_cart_suitability", "explain_cart_item",
     ]
 
 

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -103,6 +103,13 @@ import { ADMIN_AUDIT_MEMORY_OPS_TOOL_HANDLERS, ADMIN_AUDIT_MEMORY_OPS_TOOL_DECLA
 import { MEMORY_DIARY_SOCIAL_TOOL_HANDLERS, MEMORY_DIARY_SOCIAL_TOOL_DECLARATIONS } from './orb-tools/memory-diary-social-tools';
 import { DATABASE_MIGRATIONS_TOOL_HANDLERS, DATABASE_MIGRATIONS_TOOL_DECLARATIONS } from './orb-tools/database-migrations-tools';
 import { DEV_ACCESS_SIMULATOR_META_TOOL_HANDLERS, DEV_ACCESS_SIMULATOR_META_TOOL_DECLARATIONS } from './orb-tools/dev-access-simulator-meta-tools';
+// WAVE-MVA-1 — Marketplace Voice Assistant (expansion v3, plan sections
+// A17–A30): guided-shopping orchestrators + intent/preferences, and the
+// discovery/recommendation/explanation/compare/suitability/cart-confirm
+// journey layer (docs/VOICE_TOOLS_EXPANSION_PLAN.md, "Marketplace Voice
+// Assistant" part).
+import { MARKETPLACE_GUIDE_TOOL_HANDLERS, MARKETPLACE_GUIDE_TOOL_DECLARATIONS } from './orb-tools/marketplace-guide-tools';
+import { MARKETPLACE_JOURNEY_TOOL_HANDLERS, MARKETPLACE_JOURNEY_TOOL_DECLARATIONS } from './orb-tools/marketplace-journey-tools';
 import {
   lookupScreen,
   lookupByAlias,
@@ -5261,6 +5268,9 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   ...MEMORY_DIARY_SOCIAL_TOOL_HANDLERS,
   ...DATABASE_MIGRATIONS_TOOL_HANDLERS,
   ...DEV_ACCESS_SIMULATOR_META_TOOL_HANDLERS,
+  // WAVE-MVA-1 (Marketplace Voice Assistant)
+  ...MARKETPLACE_GUIDE_TOOL_HANDLERS,
+  ...MARKETPLACE_JOURNEY_TOOL_HANDLERS,
 };
 
 // BOOTSTRAP-VOICE-CATALOG-COMPLETE — combined Vertex/Gemini function
@@ -5293,6 +5303,9 @@ export const NEW_DOMAIN_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
   ...BUSINESS_HUB_TOOL_DECLARATIONS,
   // WAVE-6-VOICE-CATALOG-V2 (community)
   ...MEMORY_DIARY_SOCIAL_TOOL_DECLARATIONS,
+  // WAVE-MVA-1 (Marketplace Voice Assistant, community)
+  ...MARKETPLACE_GUIDE_TOOL_DECLARATIONS,
+  ...MARKETPLACE_JOURNEY_TOOL_DECLARATIONS,
 ];
 
 // Developer tools are role-gated the same way ADMIN_TOOL_SCHEMAS is —

--- a/services/gateway/src/services/orb-tools/marketplace-guide-tools.ts
+++ b/services/gateway/src/services/orb-tools/marketplace-guide-tools.ts
@@ -1,0 +1,1219 @@
+/**
+ * A17–A19 Marketplace Voice Assistant — guide orchestrators, shopping intent
+ * & preferences, personalization context (expansion v3, Wave MVA-1).
+ *
+ * The Discover Assistant layer: understand the need → clarify → recommend a
+ * path → keep concise picks with recorded rationales → confirmed selection
+ * into the basket. Atomic discovery/compare/cart tools live in
+ * marketplace-journey-tools.ts; shared state/pref/cart helpers in
+ * marketplace-va-shared.ts (which documents the real backings).
+ *
+ * Real backings:
+ *   - Guide state → `memory_items` (content_json.type='marketplace_guide_state').
+ *   - Preferences → `memory_facts` `marketplace_pref_*` via writeFact()
+ *     (memory-facts-service.ts: identity-lock + OASIS events + supersession).
+ *     Reset writes EMPTY values through the same supersession path — the
+ *     append-only fact history is preserved, nothing is deleted.
+ *   - Picks → shopping-agent runPropose() (services/shopping-agent/agent-core.ts)
+ *     with a COLLECT-ONLY insertPick (nothing is staged into the cart at
+ *     recommendation time — staging happens only in the confirmed
+ *     complete_marketplace_selection step), falling back to a deterministic
+ *     `products` search when no LLM provider is reachable.
+ *   - Dismissals → `user_offers_memory` (VTID-01092) state='dismissed'.
+ *   - Cart staging → stageProductInCart() (universal cart + emitCartEvent),
+ *     two-step confirm, NEVER payment (screen handoff to /cart).
+ *
+ * Health boundary: recommendations never diagnose, never promise outcomes,
+ * and health-adjacent answers carry HEALTH_BOUNDARY_NOTE.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { writeFact } from '../memory-facts-service';
+import { getUserHealthContext } from '../user-health-context';
+import { getMonthlySpend } from '../budget/spend-service';
+import { runPropose, type AnnotatedPick, type InsertPickFn } from '../shopping-agent/agent-core';
+import {
+  authGate,
+  resolveTenantId,
+  navDirective,
+  clampInt,
+  fmtPrice,
+  toList,
+  UUID_RE,
+  DEFAULT_CURRENCY,
+  type ProductRow,
+  PRODUCT_COLS,
+  resolveProduct,
+  type ServiceRow,
+  SERVICE_COLS,
+  loadMarketplacePrefs,
+  describePrefs,
+  applyPrefExclusions,
+  type MarketplacePrefs,
+  type GuidePick,
+  type GuideState,
+  emptyGuideState,
+  loadGuideState,
+  saveGuideState,
+  stageProductInCart,
+  HEALTH_BOUNDARY_NOTE,
+} from './marketplace-va-shared';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// Intent classification (deterministic keyword heuristic — no invented data;
+// it only routes to categories the marketplace actually has).
+// ---------------------------------------------------------------------------
+
+const DIAGNOSTIC_TERMS = [
+  'test', 'panel', 'blood', 'blut', 'lab', 'labor', 'biomarker', 'metabolom', 'microbiome', 'mikrobiom',
+  'genom', 'genetic', 'dna', 'hormone', 'hormon', 'screening', 'diagnos', 'messen', 'measure',
+];
+const PRACTITIONER_TERMS = [
+  'doctor', 'arzt', 'coach', 'therapist', 'therapeut', 'nutritionist', 'ernährungsberat', 'practitioner',
+  'specialist', 'spezialist', 'consultation', 'beratung',
+];
+const SERVICE_TERMS = [
+  'service', 'massage', 'course', 'kurs', 'class', 'session', 'training', 'program', 'programm',
+  'treatment', 'behandlung', 'appointment', 'termin',
+];
+
+export function classifyIntent(need: string): { intent: string; reasons: string[] } {
+  const lc = need.toLowerCase();
+  const hits = (terms: string[]) => terms.filter((t) => lc.includes(t));
+  const diag = hits(DIAGNOSTIC_TERMS);
+  const pract = hits(PRACTITIONER_TERMS);
+  const svc = hits(SERVICE_TERMS);
+  const reasons: string[] = [];
+  if (diag.length) reasons.push(`diagnostic terms: ${diag.slice(0, 3).join(', ')}`);
+  if (pract.length) reasons.push(`practitioner terms: ${pract.slice(0, 3).join(', ')}`);
+  if (svc.length) reasons.push(`service terms: ${svc.slice(0, 3).join(', ')}`);
+
+  if (diag.length && (pract.length || svc.length)) return { intent: 'combination', reasons };
+  if (diag.length) return { intent: 'diagnostic_test', reasons };
+  if (pract.length) return { intent: 'practitioner', reasons };
+  if (svc.length) return { intent: 'service', reasons };
+  reasons.push('no service/diagnostic/practitioner terms — defaulting to product search');
+  return { intent: 'product', reasons };
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic product search used by the guide when the shopping-agent LLM
+// is unreachable (and by refine). Token search + saved-preference exclusions.
+// ---------------------------------------------------------------------------
+
+async function searchProductsForGoal(
+  sb: SupabaseClient,
+  goal: string,
+  prefs: MarketplacePrefs,
+  budgetMaxCents: number | null,
+  limit: number,
+): Promise<{ items: ProductRow[]; dropped: Array<{ title: string; reason: string }> }> {
+  let query = sb.from('products').select(PRODUCT_COLS).eq('is_active', true);
+  const sanitized = goal.replace(/[&|!<>()]/g, ' ').trim();
+  if (sanitized) query = query.textSearch('search_text', sanitized, { config: 'simple', type: 'websearch' });
+  if (budgetMaxCents != null) query = query.lte('price_cents', budgetMaxCents);
+  query = query.order('rating', { ascending: false, nullsFirst: false }).limit(Math.max(limit * 3, 12));
+
+  let rows: ProductRow[] = [];
+  const first = await query;
+  if (!first.error) rows = (first.data as unknown as ProductRow[]) ?? [];
+
+  // Websearch too strict (multi-word goals often miss) → ilike fallback on
+  // the longest token, same degradation the A1 tools use.
+  if (rows.length === 0 && sanitized) {
+    const token = sanitized.split(/\s+/).sort((a, b) => b.length - a.length)[0];
+    if (token && token.length >= 3) {
+      let fb = sb.from('products').select(PRODUCT_COLS).eq('is_active', true).ilike('search_text', `%${token}%`);
+      if (budgetMaxCents != null) fb = fb.lte('price_cents', budgetMaxCents);
+      const second = await fb.order('rating', { ascending: false, nullsFirst: false }).limit(Math.max(limit * 3, 12));
+      if (!second.error) rows = (second.data as unknown as ProductRow[]) ?? [];
+    }
+  }
+
+  const { kept, dropped } = applyPrefExclusions(rows, prefs);
+  return { items: kept.slice(0, limit), dropped };
+}
+
+async function searchServicesForGoal(
+  sb: SupabaseClient,
+  tenantId: string,
+  goal: string,
+  limit: number,
+): Promise<ServiceRow[]> {
+  const token = goal
+    .replace(/[%,()]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length >= 3)
+    .sort((a, b) => b.length - a.length)[0];
+  let query = sb.from('services_catalog').select(SERVICE_COLS).eq('tenant_id', tenantId);
+  if (token) query = query.or(`name.ilike.%${token}%,provider_name.ilike.%${token}%`);
+  const { data, error } = await query.limit(limit);
+  if (error) return [];
+  return (data as ServiceRow[]) ?? [];
+}
+
+function productPick(p: ProductRow, rationale: string): GuidePick {
+  return { kind: 'product', id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency, rationale };
+}
+
+function speakPicks(picks: GuidePick[]): string {
+  return picks
+    .map((p, i) => `${i + 1}. ${p.kind === 'service' ? '[service] ' : ''}"${p.title}" (${fmtPrice(p.price_cents, p.currency)}) — ${p.rationale}`)
+    .join('; ');
+}
+
+/** Find a pick in the current guide state by id, spoken title, or 1-based position. */
+function matchPick(picks: GuidePick[], args: OrbToolArgs): GuidePick | null {
+  const ref = String(args.product_id ?? args.item_id ?? '').trim();
+  if (ref && UUID_RE.test(ref)) return picks.find((p) => p.id === ref) ?? null;
+  const idx = Number(args.position ?? args.index);
+  if (Number.isFinite(idx) && idx >= 1 && idx <= picks.length) return picks[Math.floor(idx) - 1];
+  const title = String(args.title ?? args.query ?? args.reference ?? '').trim().toLowerCase();
+  if (title) {
+    return (
+      picks.find((p) => p.title.toLowerCase() === title) ??
+      picks.find((p) => p.title.toLowerCase().includes(title)) ??
+      null
+    );
+  }
+  return picks.length === 1 ? picks[0] : null;
+}
+
+/** Criteria still missing before recommendations can be well-grounded. */
+function missingCriteria(state: GuideState, prefs: MarketplacePrefs): string[] {
+  const missing: string[] = [];
+  if (state.criteria.budget_max_cents == null && prefs.budget_monthly_cents == null) missing.push('budget');
+  if (!state.criteria.formats?.length && !prefs.format.length) missing.push('format (home delivery, online, or in person)');
+  if (!state.criteria.exclusions?.length && !prefs.exclusions.length) missing.push('anything to avoid (e.g. no pills)');
+  if (!state.criteria.urgency) missing.push('urgency');
+  return missing;
+}
+
+function parseCriteriaArgs(args: OrbToolArgs): Partial<GuideState['criteria']> {
+  const out: Partial<GuideState['criteria']> = {};
+  if (args.budget_max_amount !== undefined || args.budget_max_cents !== undefined) {
+    const n =
+      args.budget_max_cents !== undefined ? Number(args.budget_max_cents) : Number(args.budget_max_amount) * 100;
+    if (Number.isFinite(n) && n >= 0) out.budget_max_cents = Math.round(n);
+  }
+  const formats = toList(args.formats ?? args.format);
+  if (formats.length) out.formats = formats;
+  const exclusions = toList(args.exclusions ?? args.exclude);
+  if (exclusions.length) out.exclusions = exclusions;
+  const priorities = toList(args.priorities);
+  if (priorities.length) out.priorities = priorities;
+  const urgency = String(args.urgency ?? '').trim();
+  if (urgency) out.urgency = urgency;
+  const location = String(args.location ?? '').trim();
+  if (location) out.location = location;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// A17.1 start_marketplace_discover_assistant
+// ---------------------------------------------------------------------------
+
+export async function tool_start_marketplace_discover_assistant(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('start_marketplace_discover_assistant', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'start_marketplace_discover_assistant requires a known tenant context.' };
+  const goal = String(args.goal ?? args.need ?? '').trim();
+
+  try {
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const state = emptyGuideState(goal);
+    if (goal) {
+      const { intent } = classifyIntent(goal);
+      state.intent = intent;
+    }
+    state.criteria = { ...state.criteria, ...parseCriteriaArgs(args) };
+    const saved = await saveGuideState(sb, tenantId, id.user_id, state);
+    if (!saved.ok) return { ok: false, error: saved.error };
+
+    const missing = missingCriteria(state, prefs);
+    const nextStep = goal
+      ? missing.length
+        ? `Ask ONE short question to learn the most important missing detail (${missing[0]}), then call build_personalized_shopping_guide.`
+        : 'Call build_personalized_shopping_guide now.'
+      : 'Ask what the user wants to achieve, solve, explore or purchase, then call capture_shopping_goal.';
+
+    return {
+      ok: true,
+      result: {
+        started: true,
+        goal: goal || null,
+        intent: state.intent,
+        saved_preferences: describePrefs(prefs),
+        missing_criteria: missing,
+      },
+      text:
+        `Marketplace guide started${goal ? ` for: "${goal}"` : ''}. ` +
+        `Saved preferences: ${describePrefs(prefs)}. ${nextStep} ` +
+        'Keep answers short — never read long product specifications aloud.',
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'start_marketplace_discover_assistant failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A18.1 capture_shopping_goal
+// ---------------------------------------------------------------------------
+
+export async function tool_capture_shopping_goal(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('capture_shopping_goal', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'capture_shopping_goal requires a known tenant context.' };
+  const goal = String(args.goal ?? '').trim();
+  if (!goal) return { ok: false, error: 'capture_shopping_goal requires the goal the user stated.' };
+
+  try {
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    const state = existing?.state ?? emptyGuideState(goal);
+    state.goal = goal;
+    state.intent = classifyIntent(goal).intent;
+    state.criteria = { ...state.criteria, ...parseCriteriaArgs(args) };
+    // A new goal invalidates picks made for the old one.
+    state.picks = [];
+    state.selected = null;
+    const saved = await saveGuideState(sb, tenantId, id.user_id, state);
+    if (!saved.ok) return { ok: false, error: saved.error };
+
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const missing = missingCriteria(state, prefs);
+    return {
+      ok: true,
+      result: { goal, intent: state.intent, criteria: state.criteria, missing_criteria: missing },
+      text:
+        `Goal recorded: "${goal}" (likely a ${state.intent} need). ` +
+        (missing.length
+          ? `Ask ONE short question about: ${missing[0]}. Then call build_personalized_shopping_guide.`
+          : 'Enough context — call build_personalized_shopping_guide now.'),
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'capture_shopping_goal failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A18.2 clarify_shopping_need
+// ---------------------------------------------------------------------------
+
+export async function tool_clarify_shopping_need(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('clarify_shopping_need', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'clarify_shopping_need requires a known tenant context.' };
+
+  try {
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    if (!existing || !existing.state.goal) {
+      return {
+        ok: true,
+        result: { has_goal: false, missing_criteria: ['goal'] },
+        text: 'No shopping goal recorded yet — ask what the user wants to achieve, then call capture_shopping_goal.',
+      };
+    }
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const missing = missingCriteria(existing.state, prefs);
+    return {
+      ok: true,
+      result: { has_goal: true, goal: existing.state.goal, criteria: existing.state.criteria, missing_criteria: missing },
+      text: missing.length
+        ? `Still missing: ${missing.join('; ')}. Ask ONLY about the first one (${missing[0]}) — one short question, not a questionnaire.`
+        : 'Nothing important is missing — proceed to build_personalized_shopping_guide.',
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'clarify_shopping_need failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A18.3 classify_marketplace_intent
+// ---------------------------------------------------------------------------
+
+export async function tool_classify_marketplace_intent(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('classify_marketplace_intent', id);
+  if (gate) return gate;
+  let need = String(args.need ?? args.goal ?? args.query ?? '').trim();
+
+  try {
+    if (!need) {
+      const tenantId = await resolveTenantId(id, sb);
+      if (tenantId) {
+        const existing = await loadGuideState(sb, tenantId, id.user_id);
+        need = existing?.state.goal ?? '';
+      }
+    }
+    if (!need) return { ok: false, error: 'classify_marketplace_intent requires the stated need (or a recorded goal).' };
+    const { intent, reasons } = classifyIntent(need);
+    const nextTool =
+      intent === 'diagnostic_test'
+        ? 'browse_wellness_services (labs) — note the dedicated diagnostic-test catalog is not built yet'
+        : intent === 'practitioner'
+          ? 'browse_doctors_coaches or find_perfect_practitioner'
+          : intent === 'service'
+            ? 'search_services_by_need'
+            : intent === 'combination'
+              ? 'recommend_marketplace_path'
+              : 'search_products_by_need';
+    return {
+      ok: true,
+      result: { need, intent, reasons, suggested_next_tool: nextTool },
+      text: `This sounds like a ${intent.replace(/_/g, ' ')} need (${reasons[0] ?? 'default'}). Suggested next step: ${nextTool}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'classify_marketplace_intent failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A17.2 build_personalized_shopping_guide
+// ---------------------------------------------------------------------------
+
+export async function tool_build_personalized_shopping_guide(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('build_personalized_shopping_guide', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'build_personalized_shopping_guide requires a known tenant context.' };
+
+  try {
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    const goal = String(args.goal ?? '').trim() || existing?.state.goal || '';
+    if (!goal) {
+      return { ok: false, error: 'build_personalized_shopping_guide needs a goal — call capture_shopping_goal first.' };
+    }
+    const state = existing?.state ?? emptyGuideState(goal);
+    state.goal = goal;
+    const { intent } = classifyIntent(goal);
+    state.intent = intent;
+    state.criteria = { ...state.criteria, ...parseCriteriaArgs(args) };
+
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const budgetMax = state.criteria.budget_max_cents ?? prefs.budget_monthly_cents ?? null;
+    const maxPicks = clampInt(args.max_items, 1, 3, 3);
+
+    // 1. Product picks — shopping agent first (LLM planning + limitations
+    //    filter), collect-only so NOTHING is staged into the cart here.
+    let productPicks: GuidePick[] = [];
+    let advisory: string[] = [];
+    try {
+      const collected: AnnotatedPick[] = [];
+      const collectOnly: InsertPickFn = async (pick) => {
+        collected.push(pick);
+        // Not a cart write — synthetic id marks the pick as proposal-only.
+        return { ok: true, item_id: `proposal-${collected.length}` };
+      };
+      const ctx = await getUserHealthContext(id.user_id);
+      const monthlySpendCents = await getMonthlySpend(sb, id.user_id, ctx.currency ?? DEFAULT_CURRENCY);
+      const proposeRes = await runPropose({
+        prompt: goal,
+        maxItems: maxPicks,
+        ctx,
+        supabase: sb,
+        insertPick: collectOnly,
+        runId: randomUUID(),
+        monthly_spend_cents: monthlySpendCents,
+      });
+      if (proposeRes.ok) {
+        advisory = proposeRes.advisory ?? [];
+        productPicks = collected.map((p) => ({
+          kind: 'product' as const,
+          id: p.product_id,
+          title: p.title,
+          price_cents: p.unit_price_cents_snapshot,
+          currency: p.currency_snapshot,
+          rationale: p.rationale,
+          safety_flags: p.safety_flags,
+        }));
+      }
+    } catch {
+      /* degrade to the deterministic search below */
+    }
+
+    // 2. Deterministic fallback / top-up when the agent found nothing.
+    let droppedNote = '';
+    if (productPicks.length === 0) {
+      const { items, dropped } = await searchProductsForGoal(sb, goal, prefs, budgetMax, maxPicks);
+      productPicks = items.map((p) =>
+        productPick(p, `matches "${goal}"${budgetMax != null ? ' within budget' : ''}${p.rating != null ? `, rated ${p.rating.toFixed(1)}/5` : ''}`),
+      );
+      if (dropped.length) {
+        droppedNote = ` I filtered out ${dropped.length} option${dropped.length === 1 ? '' : 's'} against saved preferences (${dropped[0].reason}${dropped.length > 1 ? ', …' : ''}).`;
+      }
+    }
+
+    // 3. Service options for non-pure-product intents.
+    let servicePicks: GuidePick[] = [];
+    if (intent !== 'product') {
+      const services = await searchServicesForGoal(sb, tenantId, goal, 2);
+      servicePicks = services.map((s) => ({
+        kind: 'service' as const,
+        id: s.id,
+        title: s.name,
+        price_cents: null,
+        currency: null,
+        rationale: `${s.service_type} service${s.provider_name ? ` with ${s.provider_name}` : ''} relevant to "${goal}"`,
+      }));
+    }
+
+    state.picks = [...productPicks, ...servicePicks].slice(0, 4);
+    state.selected = null;
+    const saved = await saveGuideState(sb, tenantId, id.user_id, state);
+    if (!saved.ok) return { ok: false, error: saved.error };
+
+    if (state.picks.length === 0) {
+      return {
+        ok: true,
+        result: { goal, intent, picks: [], advisory },
+        text:
+          `I couldn't find suitable marketplace options for "${goal}" right now. ` +
+          'Tell the user honestly and offer to widen the search or change the criteria — do not invent options.',
+      };
+    }
+
+    const pathNote =
+      intent === 'diagnostic_test' || intent === 'combination'
+        ? ` Since this is about understanding a health question first, suggest starting with a service/assessment rather than a product. ${HEALTH_BOUNDARY_NOTE}`
+        : '';
+    return {
+      ok: true,
+      result: { goal, intent, picks: state.picks, advisory },
+      text:
+        `Guide for "${goal}" — ${state.picks.length} option${state.picks.length === 1 ? '' : 's'}: ${speakPicks(state.picks)}.${droppedNote}${pathNote} ` +
+        'Present at most 3, each in one sentence (what it is + why it fits). Then offer: compare, explain one, refine, or add one to the basket.',
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'build_personalized_shopping_guide failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A17.3 refine_marketplace_recommendations
+// ---------------------------------------------------------------------------
+
+export async function tool_refine_marketplace_recommendations(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('refine_marketplace_recommendations', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'refine_marketplace_recommendations requires a known tenant context.' };
+
+  try {
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    if (!existing || !existing.state.goal) {
+      return { ok: false, error: 'No active shopping guide to refine — call capture_shopping_goal first.' };
+    }
+    const state = existing.state;
+    const updates = parseCriteriaArgs(args);
+    const extraExclusions = toList(args.exclude ?? args.exclusions);
+    state.criteria = {
+      ...state.criteria,
+      ...updates,
+      exclusions: Array.from(new Set([...(state.criteria.exclusions ?? []), ...extraExclusions])),
+    };
+    const preferTerm = String(args.prefer ?? '').trim();
+    const searchGoal = preferTerm ? `${state.goal} ${preferTerm}` : state.goal;
+
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    // Session-level exclusions stack on top of the saved ones for this search.
+    const effectivePrefs: MarketplacePrefs = {
+      ...prefs,
+      exclusions: Array.from(new Set([...prefs.exclusions, ...(state.criteria.exclusions ?? [])])),
+    };
+    const budgetMax = state.criteria.budget_max_cents ?? prefs.budget_monthly_cents ?? null;
+
+    const { items, dropped } = await searchProductsForGoal(sb, searchGoal, effectivePrefs, budgetMax, 3);
+    state.picks = items.map((p) =>
+      productPick(
+        p,
+        `matches "${state.goal}"${preferTerm ? ` with preference "${preferTerm}"` : ''}${budgetMax != null ? ' within budget' : ''}`,
+      ),
+    );
+    state.selected = null;
+    const saved = await saveGuideState(sb, tenantId, id.user_id, state);
+    if (!saved.ok) return { ok: false, error: saved.error };
+
+    if (state.picks.length === 0) {
+      return {
+        ok: true,
+        result: { picks: [], dropped },
+        text:
+          'After applying that feedback, nothing suitable is left. Say so honestly and ask whether to relax the budget or one exclusion.',
+      };
+    }
+    return {
+      ok: true,
+      result: { picks: state.picks, dropped },
+      text: `Updated options: ${speakPicks(state.picks)}. Offer: compare, explain, refine again, or add one to the basket.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'refine_marketplace_recommendations failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A17.4 explain_marketplace_recommendation
+// ---------------------------------------------------------------------------
+
+export async function tool_explain_marketplace_recommendation(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('explain_marketplace_recommendation', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'explain_marketplace_recommendation requires a known tenant context.' };
+
+  try {
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    if (!existing || existing.state.picks.length === 0) {
+      return { ok: false, error: 'No current recommendations to explain — build the shopping guide first.' };
+    }
+    const pick = matchPick(existing.state.picks, args);
+    if (!pick) {
+      return {
+        ok: true,
+        result: { found: false, picks: existing.state.picks.map((p) => p.title) },
+        text: `Which option? Current picks: ${existing.state.picks.map((p, i) => `${i + 1}. "${p.title}"`).join('; ')}.`,
+      };
+    }
+
+    let limits = '';
+    let usage = '';
+    if (pick.kind === 'product') {
+      const res = await resolveProduct(sb, pick.id, '');
+      if (res.ok && res.product) {
+        if (res.product.safety_notes) limits = ` Relevant limitation: ${res.product.safety_notes}.`;
+        if (res.product.dosage || res.product.serving_size) {
+          usage = ` Practical use: ${[res.product.dosage, res.product.serving_size].filter(Boolean).join(', ')}.`;
+        }
+      }
+    }
+    const flags = pick.safety_flags?.length ? ` Safety notes for this user: ${pick.safety_flags.join(', ')}.` : '';
+    return {
+      ok: true,
+      result: { pick, limits: limits || null },
+      text:
+        `"${pick.title}" (${fmtPrice(pick.price_cents, pick.currency)}): ${pick.rationale}.${usage}${limits}${flags} ` +
+        `Keep it to what/why/why-for-them — no spec dump. ${HEALTH_BOUNDARY_NOTE}`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'explain_marketplace_recommendation failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A17.5 complete_marketplace_selection (⚠️ two-step confirm)
+// ---------------------------------------------------------------------------
+
+export async function tool_complete_marketplace_selection(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('complete_marketplace_selection', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'complete_marketplace_selection requires a known tenant context.' };
+
+  try {
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    const state = existing?.state ?? null;
+    const pick = state ? matchPick(state.picks, args) ?? state.selected : null;
+    if (!pick) {
+      return { ok: false, error: 'No selected option found — name one of the current picks (or build the guide first).' };
+    }
+    if (pick.kind === 'service') {
+      return {
+        ok: true,
+        result: { kind: 'service', service_id: pick.id, title: pick.title },
+        text:
+          `"${pick.title}" is a service — service booking by voice is not available yet. ` +
+          'Offer to open the provider profile on screen instead (get_provider_profile).',
+      };
+    }
+
+    const res = await resolveProduct(sb, pick.id, '');
+    if (!res.ok) return { ok: false, error: res.error };
+    if (!res.product) return { ok: false, error: 'That product is no longer available in the marketplace.' };
+    const product = res.product;
+
+    if (args.confirm !== true) {
+      if (state) {
+        state.selected = pick;
+        await saveGuideState(sb, tenantId, id.user_id, state);
+      }
+      return {
+        ok: true,
+        result: {
+          needs_confirmation: true,
+          product_id: product.id,
+          title: product.title,
+          price_cents: product.price_cents,
+          currency: product.currency,
+          availability: product.availability,
+        },
+        text:
+          `Confirm with the user: add "${product.title}" (${fmtPrice(product.price_cents, product.currency)}${
+            product.availability !== 'in_stock' ? `, availability: ${product.availability}` : ''
+          }) to the basket? When they say yes, call complete_marketplace_selection again with confirm:true. Payment stays on screen.`,
+      };
+    }
+
+    const staged = await stageProductInCart(sb, id, product, 'discover_assistant', pick.rationale);
+    if (!staged.ok) return { ok: false, error: staged.error };
+    if (state) {
+      state.selected = pick;
+      await saveGuideState(sb, tenantId, id.user_id, state);
+    }
+    const route = '/cart';
+    return {
+      ok: true,
+      result: {
+        added: true,
+        item_id: staged.itemId,
+        product_id: product.id,
+        title: product.title,
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.CART', route, 'Shopping Cart', 'complete_marketplace_selection added'),
+        redirect: { route },
+      },
+      text: `Done — "${product.title}" is in the basket. Review and confirm payment on the screen; nothing has been charged.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'complete_marketplace_selection failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A18.5–7 preferences (memory_facts marketplace_pref_* via writeFact)
+// ---------------------------------------------------------------------------
+
+export async function tool_save_marketplace_preferences(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('save_marketplace_preferences', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'save_marketplace_preferences requires a known tenant context.' };
+
+  try {
+    const writes: Array<{ key: string; value: string; spoken: string }> = [];
+    if (args.budget_monthly_amount !== undefined || args.budget_monthly_cents !== undefined) {
+      const n =
+        args.budget_monthly_cents !== undefined
+          ? Number(args.budget_monthly_cents)
+          : Number(args.budget_monthly_amount) * 100;
+      if (Number.isFinite(n) && n >= 0) {
+        const cents = Math.round(n);
+        writes.push({
+          key: 'marketplace_pref_budget_monthly_cents',
+          value: String(cents),
+          spoken: `monthly budget ${fmtPrice(cents, null)}`,
+        });
+      }
+    }
+    const listFields: Array<{ arg: string; key: string; label: string }> = [
+      { arg: 'dietary', key: 'marketplace_pref_dietary', label: 'dietary' },
+      { arg: 'values', key: 'marketplace_pref_values', label: 'values' },
+      { arg: 'exclusions', key: 'marketplace_pref_exclusions', label: 'avoids' },
+      { arg: 'excluded_brands', key: 'marketplace_pref_excluded_brands', label: 'excluded brands' },
+      { arg: 'excluded_categories', key: 'marketplace_pref_excluded_categories', label: 'excluded categories' },
+      { arg: 'format', key: 'marketplace_pref_format', label: 'preferred format' },
+    ];
+    for (const f of listFields) {
+      if (args[f.arg] === undefined) continue;
+      const list = toList(args[f.arg]);
+      writes.push({ key: f.key, value: list.join(', '), spoken: `${f.label}: ${list.join(', ') || 'cleared'}` });
+    }
+    if (writes.length === 0) {
+      return {
+        ok: false,
+        error:
+          'save_marketplace_preferences needs at least one preference: budget_monthly_amount, dietary, values, exclusions, excluded_brands, excluded_categories, or format.',
+      };
+    }
+
+    for (const w of writes) {
+      const res = await writeFact({
+        tenant_id: tenantId,
+        user_id: id.user_id,
+        fact_key: w.key,
+        fact_value: w.value,
+        entity: 'self',
+        fact_value_type: 'text',
+        provenance_source: 'user_stated',
+        provenance_confidence: 0.95,
+      });
+      if (!res.ok) return { ok: false, error: res.error ?? `could not save ${w.key}` };
+    }
+
+    return {
+      ok: true,
+      result: { saved: writes.map((w) => w.key) },
+      text: `Saved: ${writes.map((w) => w.spoken).join('; ')}. These now shape future marketplace recommendations.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'save_marketplace_preferences failed' };
+  }
+}
+
+export async function tool_get_marketplace_preferences(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_marketplace_preferences', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'get_marketplace_preferences requires a known tenant context.' };
+  try {
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    return {
+      ok: true,
+      result: { preferences: prefs },
+      text: `Saved marketplace preferences: ${describePrefs(prefs)}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_marketplace_preferences failed' };
+  }
+}
+
+export async function tool_reset_marketplace_preferences(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('reset_marketplace_preferences', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'reset_marketplace_preferences requires a known tenant context.' };
+
+  try {
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const current = describePrefs(prefs);
+    if (current === 'no saved marketplace preferences') {
+      return { ok: true, result: { reset: false }, text: 'There are no saved marketplace preferences to reset.' };
+    }
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { needs_confirmation: true, current_preferences: current },
+        text:
+          `Confirm with the user: clear all saved marketplace preferences (${current})? ` +
+          'When they say yes, call reset_marketplace_preferences again with confirm:true.',
+      };
+    }
+    // Clear via the same supersession path as writing — the fact history
+    // stays intact (append-only), the current value just becomes empty.
+    const populated: Array<{ key: string; has: boolean }> = [
+      { key: 'marketplace_pref_budget_monthly_cents', has: prefs.budget_monthly_cents != null },
+      { key: 'marketplace_pref_dietary', has: prefs.dietary.length > 0 },
+      { key: 'marketplace_pref_values', has: prefs.values.length > 0 },
+      { key: 'marketplace_pref_exclusions', has: prefs.exclusions.length > 0 },
+      { key: 'marketplace_pref_excluded_brands', has: prefs.excluded_brands.length > 0 },
+      { key: 'marketplace_pref_excluded_categories', has: prefs.excluded_categories.length > 0 },
+      { key: 'marketplace_pref_format', has: prefs.format.length > 0 },
+    ];
+    for (const p of populated.filter((x) => x.has)) {
+      const res = await writeFact({
+        tenant_id: tenantId,
+        user_id: id.user_id,
+        fact_key: p.key,
+        fact_value: '',
+        entity: 'self',
+        fact_value_type: 'text',
+        provenance_source: 'user_stated',
+        provenance_confidence: 0.95,
+      });
+      if (!res.ok) return { ok: false, error: res.error ?? `could not reset ${p.key}` };
+    }
+    return { ok: true, result: { reset: true }, text: 'Done — all saved marketplace preferences are cleared.' };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'reset_marketplace_preferences failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A19.1 get_marketplace_context
+// ---------------------------------------------------------------------------
+
+export async function tool_get_marketplace_context(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_marketplace_context', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'get_marketplace_context requires a known tenant context.' };
+
+  try {
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+
+    let budgetCapCents: number | null = null;
+    try {
+      const { data } = await sb
+        .from('user_limitations')
+        .select('budget_monthly_cap_cents')
+        .eq('user_id', id.user_id)
+        .maybeSingle();
+      budgetCapCents = (data as { budget_monthly_cap_cents?: number | null } | null)?.budget_monthly_cap_cents ?? null;
+    } catch {
+      /* budget cap is optional context */
+    }
+    let monthlySpendCents = 0;
+    try {
+      monthlySpendCents = await getMonthlySpend(sb, id.user_id, DEFAULT_CURRENCY);
+    } catch {
+      /* spend is optional context */
+    }
+
+    const { data: orderRows } = await sb
+      .from('product_orders')
+      .select('product_id, state, amount_cents, currency, created_at')
+      .eq('user_id', id.user_id)
+      .order('created_at', { ascending: false })
+      .limit(3);
+    const orders = (orderRows as Array<{ product_id: string | null; state: string; amount_cents: number | null; currency: string | null }>) ?? [];
+
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    return {
+      ok: true,
+      result: {
+        preferences: prefs,
+        budget_monthly_cap_cents: budgetCapCents,
+        monthly_spend_cents: monthlySpendCents,
+        recent_order_count: orders.length,
+        active_goal: existing?.state.goal ?? null,
+      },
+      text:
+        `Marketplace context — preferences: ${describePrefs(prefs)}. ` +
+        `Shopping budget: ${budgetCapCents != null ? `${fmtPrice(budgetCapCents, null)}/month, ${fmtPrice(monthlySpendCents, null)} spent this month` : 'none set'}. ` +
+        `Recent orders: ${orders.length}. ${existing?.state.goal ? `Active shopping goal: "${existing.state.goal}".` : 'No active shopping goal.'} ` +
+        'Use only what is relevant; if the user asks why a recommendation was made, cite these stated preferences — never an opaque score.',
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_marketplace_context failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A19.3 dismiss_marketplace_recommendation
+// ---------------------------------------------------------------------------
+
+export async function tool_dismiss_marketplace_recommendation(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('dismiss_marketplace_recommendation', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'dismiss_marketplace_recommendation requires a known tenant context.' };
+
+  try {
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    let target: { type: 'product' | 'service'; targetId: string; title: string } | null = null;
+
+    const fromPicks = existing ? matchPick(existing.state.picks, args) : null;
+    if (fromPicks) {
+      target = { type: fromPicks.kind, targetId: fromPicks.id, title: fromPicks.title };
+    } else {
+      const res = await resolveProduct(sb, String(args.product_id ?? '').trim(), String(args.title ?? args.query ?? '').trim());
+      if (!res.ok) return { ok: false, error: res.error };
+      if (res.product) target = { type: 'product', targetId: res.product.id, title: res.product.title };
+    }
+    if (!target) {
+      return { ok: false, error: 'Could not resolve which recommendation to dismiss — name the product.' };
+    }
+
+    const { error } = await sb.from('user_offers_memory').upsert(
+      {
+        tenant_id: tenantId,
+        user_id: id.user_id,
+        target_type: target.type,
+        target_id: target.targetId,
+        state: 'dismissed',
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'tenant_id,user_id,target_type,target_id' },
+    );
+    if (error) return { ok: false, error: error.message };
+
+    if (existing && fromPicks) {
+      existing.state.picks = existing.state.picks.filter((p) => p.id !== fromPicks.id);
+      if (existing.state.selected?.id === fromPicks.id) existing.state.selected = null;
+      await saveGuideState(sb, tenantId, id.user_id, existing.state);
+    }
+    return {
+      ok: true,
+      result: { dismissed: true, title: target.title },
+      text: `Understood — "${target.title}" is dismissed and won't be recommended again.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'dismiss_marketplace_recommendation failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const MARKETPLACE_GUIDE_TOOL_HANDLERS: Record<string, Handler> = {
+  start_marketplace_discover_assistant: tool_start_marketplace_discover_assistant,
+  build_personalized_shopping_guide: tool_build_personalized_shopping_guide,
+  refine_marketplace_recommendations: tool_refine_marketplace_recommendations,
+  explain_marketplace_recommendation: tool_explain_marketplace_recommendation,
+  complete_marketplace_selection: tool_complete_marketplace_selection,
+  capture_shopping_goal: tool_capture_shopping_goal,
+  clarify_shopping_need: tool_clarify_shopping_need,
+  classify_marketplace_intent: tool_classify_marketplace_intent,
+  save_marketplace_preferences: tool_save_marketplace_preferences,
+  get_marketplace_preferences: tool_get_marketplace_preferences,
+  reset_marketplace_preferences: tool_reset_marketplace_preferences,
+  get_marketplace_context: tool_get_marketplace_context,
+  dismiss_marketplace_recommendation: tool_dismiss_marketplace_recommendation,
+};
+
+export const MARKETPLACE_GUIDE_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'start_marketplace_discover_assistant',
+    description: [
+      'Start a guided marketplace conversation for a product, service,',
+      'practitioner or diagnostic need. CALL WHEN the user asks for shopping',
+      'guidance rather than a specific item: "I want a full shopping guide",',
+      '"help me find something for my energy", "ich brauche eine Einkaufsberatung".',
+      'Then follow the returned next step. Never read long specifications aloud.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        goal: { type: 'string', description: 'The stated goal/need, if the user already said it.' },
+        budget_max_amount: { type: 'number', description: 'Budget ceiling in whole currency units (e.g. 150).' },
+        exclusions: { type: 'string', description: 'Comma-separated things to avoid (e.g. "pills").' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'build_personalized_shopping_guide',
+    description: [
+      'Build a concise personalized recommendation set (max 3 options with',
+      'short rationales) for the recorded shopping goal, across products and',
+      'services. Nothing is added to the cart. CALL WHEN the goal (and the most',
+      'important criteria) are known. Present each option in ONE sentence.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        goal: { type: 'string', description: 'Override goal (otherwise the recorded one is used).' },
+        budget_max_amount: { type: 'number', description: 'Budget ceiling in whole currency units.' },
+        max_items: { type: 'number', description: 'Max options (default 3).' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'refine_marketplace_recommendations',
+    description: [
+      'Update the current recommendations from conversational feedback.',
+      'CALL WHEN the user reacts to picks: "cheaper", "nothing with pills",',
+      '"I prefer something for home", "etwas Günstigeres bitte".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        exclude: { type: 'string', description: 'Comma-separated new exclusions from the feedback.' },
+        prefer: { type: 'string', description: 'What the user now prefers (e.g. "tea", "home test").' },
+        budget_max_amount: { type: 'number', description: 'New budget ceiling in whole currency units.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'explain_marketplace_recommendation',
+    description: [
+      'Explain one current pick: what it is, why it was chosen for this user,',
+      'practical use, and relevant limitations. CALL WHEN the user asks "why',
+      'this one?", "tell me more about the second option", "warum empfiehlst du',
+      'mir das?". Answer concisely — what/why/limits, never the full spec.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        position: { type: 'number', description: '1-based position of the pick ("the second one" → 2).' },
+        title: { type: 'string', description: 'Spoken name of the pick.' },
+        product_id: { type: 'string', description: 'Exact product UUID when known.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'complete_marketplace_selection',
+    description: [
+      'Confirm the chosen option and stage it into the basket (NEVER charges;',
+      'payment stays on screen). ALWAYS call once WITHOUT confirm first — it',
+      'returns a read-back of name and price; after the user says yes, call',
+      'again with confirm:true. CALL WHEN the user picks an option: "take the',
+      'second one", "add it to my basket", "nimm das erste".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        position: { type: 'number', description: '1-based position of the chosen pick.' },
+        title: { type: 'string', description: 'Spoken name of the chosen pick.' },
+        product_id: { type: 'string', description: 'Exact product UUID when known.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the read-back.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'capture_shopping_goal',
+    description: [
+      'Record what the user wants to achieve, solve, explore or purchase.',
+      'CALL WHEN the user states a shopping goal in a guided conversation:',
+      '"I want to improve my sleep", "ich will meine Energie verbessern".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        goal: { type: 'string', description: 'The goal in the user\'s words.' },
+        budget_max_amount: { type: 'number', description: 'Budget ceiling if stated.' },
+        exclusions: { type: 'string', description: 'Comma-separated exclusions if stated (e.g. "pills").' },
+        urgency: { type: 'string', description: 'Urgency if stated (e.g. "this week").' },
+      },
+      required: ['goal'],
+    },
+  },
+  {
+    name: 'clarify_shopping_need',
+    description: [
+      'Get the smallest set of still-missing criteria (budget, format,',
+      'exclusions, urgency) for the recorded goal so you ask only the most',
+      'important follow-up question. CALL BEFORE building the guide when the',
+      'request was vague. Ask ONE question at a time, never a questionnaire.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'classify_marketplace_intent',
+    description: [
+      'Determine whether a need maps to a product, service, diagnostic test,',
+      'practitioner or combination, with the suggested next tool. CALL WHEN',
+      'unsure which direction a marketplace request should take.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { need: { type: 'string', description: 'The stated need (defaults to the recorded goal).' } },
+      required: [],
+    },
+  },
+  {
+    name: 'save_marketplace_preferences',
+    description: [
+      'Save reusable shopping preferences the user explicitly stated: budget,',
+      'dietary needs, values, exclusions, excluded brands/categories, preferred',
+      'format. CALL ONLY after the user stated the preference or agreed to save',
+      'it: "remember that I\'m vegan", "merk dir, dass ich keine Kapseln will".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        budget_monthly_amount: { type: 'number', description: 'Monthly budget in whole currency units.' },
+        dietary: { type: 'string', description: 'Comma-separated dietary needs (e.g. "vegan, gluten-free").' },
+        values: { type: 'string', description: 'Comma-separated values (e.g. "sustainable, local").' },
+        exclusions: { type: 'string', description: 'Comma-separated things to avoid (e.g. "pills").' },
+        excluded_brands: { type: 'string', description: 'Comma-separated brands to exclude.' },
+        excluded_categories: { type: 'string', description: 'Comma-separated categories to exclude.' },
+        format: { type: 'string', description: 'Preferred formats (e.g. "home, online").' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_marketplace_preferences',
+    description: [
+      'Read the user\'s saved marketplace preferences. CALL WHEN the user asks',
+      '"what do you know about my shopping preferences?" or before explaining',
+      'why a recommendation was personalized.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'reset_marketplace_preferences',
+    description: [
+      'Clear all saved marketplace preferences. ALWAYS call once WITHOUT',
+      'confirm first — it reads back what would be cleared; after the user says',
+      'yes, call again with confirm:true. CALL WHEN the user asks to forget or',
+      'reset their shopping preferences.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed.' } },
+      required: [],
+    },
+  },
+  {
+    name: 'get_marketplace_context',
+    description: [
+      'Get the minimum relevant context for a shopping request: saved',
+      'preferences, shopping budget and spend, recent orders, active goal.',
+      'CALL at the start of a guided shopping conversation, or when the user',
+      'asks "why are you recommending this to me?" — then answer citing their',
+      'stated preferences in plain language, never an algorithm score.',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'dismiss_marketplace_recommendation',
+    description: [
+      'Dismiss a recommended product so it is not proposed again. CALL WHEN',
+      'the user rejects a recommendation: "not that one", "don\'t show me this',
+      'again", "das interessiert mich nicht".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        position: { type: 'number', description: '1-based position of the pick to dismiss.' },
+        title: { type: 'string', description: 'Spoken name of the item to dismiss.' },
+        product_id: { type: 'string', description: 'Exact product UUID when known.' },
+      },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/marketplace-journey-tools.ts
+++ b/services/gateway/src/services/orb-tools/marketplace-journey-tools.ts
@@ -1,0 +1,1776 @@
+/**
+ * A20–A29 Marketplace Voice Assistant — unified discovery, guided
+ * recommendation, concise explanation, comparison & shortlist, suitability
+ * checks, budget review, and confirmed cart actions (expansion v3, Wave MVA-1).
+ *
+ * Real backings (same verification discipline as marketplace-discovery-tools.ts):
+ *   - Product search → `public.products` (VTID-02000) with the discover-search
+ *     column set; dietary/certification filters use the real `dietary_tags` /
+ *     `certifications` array columns (`.contains`), never guessed data.
+ *   - Service search → `public.services_catalog` (VTID-01092).
+ *   - Picks → shopping-agent runPropose() with a COLLECT-ONLY insertPick
+ *     (propose, don't stage); deterministic search fallback when the LLM is
+ *     unreachable. Pick rationales are persisted in the guide state
+ *     (marketplace-va-shared.ts) so "why this one?" answers cite the real
+ *     recorded reason.
+ *   - Shortlist → `public.shop_saved_products` (VTID-03237 — the existing
+ *     saved-products/wishlist table the Video Shop drawer writes; video_id
+ *     stays NULL for voice saves). Products only: services have no saved-list
+ *     backing yet and are said so honestly.
+ *   - Cart reads/writes → `universal_carts`/`universal_cart_items` via the
+ *     shared stageProductInCart() (emitCartEvent audit; source_surface
+ *     'voice'). Payment policy: staging + /cart screen handoff ONLY.
+ *   - Budget → `user_limitations.budget_monthly_cap_cents` (the same column
+ *     set_shopping_budget writes) + getMonthlySpend().
+ *
+ * Health boundary: nothing here diagnoses or promises outcomes; suitability
+ * checks are limited to DECLARED product data and say what they could not
+ * check rather than guessing.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+import type { OrbToolArgs, OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { getUserHealthContext } from '../user-health-context';
+import { getMonthlySpend } from '../budget/spend-service';
+import { runPropose, type AnnotatedPick, type InsertPickFn } from '../shopping-agent/agent-core';
+import {
+  authGate,
+  resolveTenantId,
+  navDirective,
+  clampInt,
+  fmtPrice,
+  toList,
+  UUID_RE,
+  DEFAULT_CURRENCY,
+  type ProductRow,
+  PRODUCT_COLS,
+  speakProduct,
+  resolveProduct,
+  type ServiceRow,
+  SERVICE_COLS,
+  loadMarketplacePrefs,
+  applyPrefExclusions,
+  type MarketplacePrefs,
+  type GuidePick,
+  emptyGuideState,
+  loadGuideState,
+  saveGuideState,
+  stageProductInCart,
+  HEALTH_BOUNDARY_NOTE,
+} from './marketplace-va-shared';
+import { classifyIntent } from './marketplace-guide-tools';
+
+type Handler = (args: OrbToolArgs, id: OrbToolIdentity, sb: SupabaseClient) => Promise<OrbToolResult>;
+
+// ---------------------------------------------------------------------------
+// Shared query helpers
+// ---------------------------------------------------------------------------
+
+async function productNeedSearch(
+  sb: SupabaseClient,
+  need: string,
+  prefs: MarketplacePrefs,
+  opts: { budgetMaxCents?: number | null; dietary?: string[]; certifications?: string[]; excludeId?: string; category?: string | null; limit: number },
+): Promise<{ items: ProductRow[]; dropped: Array<{ title: string; reason: string }>; error?: string }> {
+  const run = async (useWebsearch: boolean): Promise<{ rows: ProductRow[]; error?: string }> => {
+    let query = sb.from('products').select(PRODUCT_COLS).eq('is_active', true);
+    const sanitized = need.replace(/[&|!<>()]/g, ' ').trim();
+    if (sanitized) {
+      if (useWebsearch) {
+        query = query.textSearch('search_text', sanitized, { config: 'simple', type: 'websearch' });
+      } else {
+        const token = sanitized.split(/\s+/).sort((a, b) => b.length - a.length)[0];
+        if (token && token.length >= 3) query = query.ilike('search_text', `%${token}%`);
+      }
+    }
+    if (opts.budgetMaxCents != null) query = query.lte('price_cents', opts.budgetMaxCents);
+    if (opts.dietary?.length) query = query.contains('dietary_tags', opts.dietary);
+    if (opts.certifications?.length) query = query.contains('certifications', opts.certifications);
+    if (opts.category) query = query.eq('category', opts.category);
+    if (opts.excludeId) query = query.neq('id', opts.excludeId);
+    const { data, error } = await query
+      .order('rating', { ascending: false, nullsFirst: false })
+      .limit(Math.max(opts.limit * 3, 12));
+    if (error) return { rows: [], error: error.message };
+    return { rows: (data as unknown as ProductRow[]) ?? [] };
+  };
+
+  let res = await run(true);
+  if (res.error) return { items: [], dropped: [], error: res.error };
+  if (res.rows.length === 0 && need.trim()) {
+    res = await run(false);
+    if (res.error) return { items: [], dropped: [], error: res.error };
+  }
+  const { kept, dropped } = applyPrefExclusions(res.rows, prefs);
+  return { items: kept.slice(0, opts.limit), dropped };
+}
+
+async function serviceNeedSearch(
+  sb: SupabaseClient,
+  tenantId: string,
+  need: string,
+  limit: number,
+  serviceTypes?: string[],
+): Promise<ServiceRow[]> {
+  const tokens = need
+    .replace(/[%,()]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length >= 3)
+    .sort((a, b) => b.length - a.length)
+    .slice(0, 2);
+  let query = sb.from('services_catalog').select(SERVICE_COLS).eq('tenant_id', tenantId);
+  if (serviceTypes?.length) query = query.in('service_type', serviceTypes);
+  if (tokens.length) {
+    query = query.or(tokens.map((t) => `name.ilike.%${t}%,provider_name.ilike.%${t}%`).join(','));
+  }
+  const { data, error } = await query.limit(limit);
+  if (error) return [];
+  return (data as ServiceRow[]) ?? [];
+}
+
+interface CartItemRow {
+  id: string;
+  product_id: string | null;
+  item_type: string;
+  quantity: number;
+  status: string;
+  unit_price_cents_snapshot: number | null;
+  currency_snapshot: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+async function loadActiveCartItems(
+  sb: SupabaseClient,
+  userId: string,
+): Promise<{ ok: true; cartId: string | null; items: CartItemRow[] } | { ok: false; error: string }> {
+  const cart = await sb.from('universal_carts').select('id').eq('user_id', userId).eq('status', 'active').maybeSingle();
+  if (cart.error && (cart.error as { code?: string }).code !== 'PGRST116') return { ok: false, error: cart.error.message };
+  const cartId = (cart.data?.id as string | undefined) ?? null;
+  if (!cartId) return { ok: true, cartId: null, items: [] };
+  const { data, error } = await sb
+    .from('universal_cart_items')
+    .select('id, product_id, item_type, quantity, status, unit_price_cents_snapshot, currency_snapshot, metadata')
+    .eq('cart_id', cartId)
+    .eq('status', 'active');
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, cartId, items: (data as CartItemRow[]) ?? [] };
+}
+
+async function productTitles(sb: SupabaseClient, ids: string[]): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const unique = Array.from(new Set(ids.filter(Boolean)));
+  if (unique.length === 0) return map;
+  const { data } = await sb.from('products').select('id, title').in('id', unique);
+  for (const p of (data as Array<{ id: string; title: string }>) ?? []) map.set(p.id, p.title);
+  return map;
+}
+
+/** Resolve a product referenced by id, guide-pick position/title, or spoken name. */
+async function resolveReferencedProduct(
+  sb: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  args: OrbToolArgs,
+): Promise<{ ok: true; product: ProductRow | null; rationale: string | null } | { ok: false; error: string }> {
+  const existing = await loadGuideState(sb, tenantId, userId);
+  const picks = existing?.state.picks ?? [];
+  let pick: GuidePick | null = null;
+  const refId = String(args.product_id ?? '').trim();
+  const idx = Number(args.position ?? args.index);
+  const title = String(args.title ?? args.query ?? '').trim().toLowerCase();
+  if (refId && UUID_RE.test(refId)) pick = picks.find((p) => p.id === refId) ?? null;
+  if (!pick && Number.isFinite(idx) && idx >= 1 && idx <= picks.length) pick = picks[Math.floor(idx) - 1];
+  if (!pick && title) pick = picks.find((p) => p.title.toLowerCase().includes(title)) ?? null;
+  if (!pick && !refId && !title && existing?.state.selected) pick = existing.state.selected;
+
+  const res = await resolveProduct(sb, pick?.id ?? refId, pick ? '' : String(args.title ?? args.query ?? '').trim());
+  if (!res.ok) return res;
+  return { ok: true, product: res.product, rationale: pick?.rationale ?? null };
+}
+
+function conciseSummary(p: ProductRow): string {
+  const firstSentence = (p.description ?? '').split(/(?<=[.!?])\s/)[0]?.slice(0, 180) ?? '';
+  const bits = [
+    `${speakProduct(p)}`,
+    firstSentence ? `Purpose: ${firstSentence}` : '',
+    p.dosage || p.serving_size ? `Use: ${[p.dosage, p.serving_size].filter(Boolean).join(', ')}` : '',
+    p.availability !== 'in_stock' ? `Availability: ${p.availability}` : '',
+    p.safety_notes ? `Limitation: ${p.safety_notes}` : '',
+  ].filter(Boolean);
+  return bits.join('. ');
+}
+
+// ---------------------------------------------------------------------------
+// A20.1 discover_marketplace_options
+// ---------------------------------------------------------------------------
+
+export async function tool_discover_marketplace_options(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('discover_marketplace_options', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'discover_marketplace_options requires a known tenant context.' };
+  const need = String(args.need ?? args.q ?? args.query ?? '').trim();
+  if (!need) return { ok: false, error: 'discover_marketplace_options requires the stated need.' };
+  const limit = clampInt(args.limit, 1, 6, 4);
+
+  try {
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const budgetMax = args.budget_max_amount != null ? Math.round(Number(args.budget_max_amount) * 100) : prefs.budget_monthly_cents;
+    const [productRes, services] = await Promise.all([
+      productNeedSearch(sb, need, prefs, { budgetMaxCents: budgetMax ?? null, limit }),
+      serviceNeedSearch(sb, tenantId, need, 2),
+    ]);
+    if (productRes.error) return { ok: false, error: productRes.error };
+
+    const options = [
+      ...productRes.items.map((p) => ({ kind: 'product', id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency, rating: p.rating })),
+      ...services.map((s) => ({ kind: 'service', id: s.id, title: s.name, service_type: s.service_type, provider_name: s.provider_name })),
+    ];
+    if (options.length === 0) {
+      return {
+        ok: true,
+        result: { options: [] },
+        text: `Nothing in the marketplace matches "${need}" right now. Say so honestly and offer to widen the search.`,
+      };
+    }
+    const spokenProducts = productRes.items.map(speakProduct).join('; ');
+    const spokenServices = services.map((s) => `"${s.name}" (${s.service_type} service)`).join('; ');
+    return {
+      ok: true,
+      result: { options },
+      text:
+        `For "${need}" I found${spokenProducts ? ` products: ${spokenProducts}` : ''}${spokenProducts && spokenServices ? ' — and' : ''}${
+          spokenServices ? ` services: ${spokenServices}` : ''
+        }. Mention at most 3 options, one sentence each.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'discover_marketplace_options failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A20.2 search_products_by_need
+// ---------------------------------------------------------------------------
+
+export async function tool_search_products_by_need(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('search_products_by_need', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'search_products_by_need requires a known tenant context.' };
+  const need = String(args.need ?? args.q ?? args.query ?? '').trim();
+  if (!need) return { ok: false, error: 'search_products_by_need requires the purpose/need to search for.' };
+  const limit = clampInt(args.limit, 1, 8, 5);
+
+  try {
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const budgetMax = args.budget_max_amount != null ? Math.round(Number(args.budget_max_amount) * 100) : prefs.budget_monthly_cents;
+    const { items, dropped, error } = await productNeedSearch(sb, need, prefs, { budgetMaxCents: budgetMax ?? null, limit });
+    if (error) return { ok: false, error };
+    const route = `/discover/marketplace?q=${encodeURIComponent(need)}`;
+    if (items.length === 0) {
+      return {
+        ok: true,
+        result: { items: [], dropped },
+        text:
+          `No products match "${need}"${dropped.length ? ` after filtering ${dropped.length} against saved preferences` : ''}. ` +
+          'Offer to widen the search or adjust a preference.',
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        items: items.map((p) => ({ product_id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency, rating: p.rating })),
+        dropped,
+        decision: 'list_only',
+        directive: navDirective('DISCOVER.MARKETPLACE', route, 'Marketplace', 'search_products_by_need results'),
+      },
+      text: `For "${need}": ${items.map(speakProduct).join('; ')}.${dropped.length ? ` (${dropped.length} filtered out by saved preferences.)` : ''}`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'search_products_by_need failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A20.3 search_services_by_need
+// ---------------------------------------------------------------------------
+
+export async function tool_search_services_by_need(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('search_services_by_need', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'search_services_by_need requires a known tenant context.' };
+  const need = String(args.need ?? args.q ?? args.query ?? '').trim();
+  if (!need) return { ok: false, error: 'search_services_by_need requires the desired outcome to search for.' };
+  const limit = clampInt(args.limit, 1, 8, 5);
+
+  try {
+    const requestedTypes = toList(args.service_types);
+    const services = await serviceNeedSearch(sb, tenantId, need, limit, requestedTypes.length ? requestedTypes : undefined);
+    const route = '/discover/wellness-services';
+    if (services.length === 0) {
+      return {
+        ok: true,
+        result: { items: [] },
+        text: `No services match "${need}" right now. Say so honestly — do not invent providers.`,
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        items: services.map((s) => ({ service_id: s.id, name: s.name, service_type: s.service_type, provider_name: s.provider_name })),
+        decision: 'list_only',
+        directive: navDirective('DISCOVER.WELLNESS_SERVICES', route, 'Wellness Services', 'search_services_by_need results'),
+      },
+      text: `Services for "${need}": ${services.map((s) => `"${s.name}" (${s.service_type}${s.provider_name ? `, ${s.provider_name}` : ''})`).join('; ')}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'search_services_by_need failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A20.4 search_marketplace_by_values
+// ---------------------------------------------------------------------------
+
+export async function tool_search_marketplace_by_values(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('search_marketplace_by_values', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'search_marketplace_by_values requires a known tenant context.' };
+  const need = String(args.need ?? args.q ?? args.query ?? '').trim();
+  const dietary = toList(args.dietary_tags ?? args.dietary);
+  const certifications = toList(args.certifications);
+  if (!dietary.length && !certifications.length) {
+    return {
+      ok: false,
+      error: 'search_marketplace_by_values requires at least one dietary tag (e.g. "vegan") or certification to filter by.',
+    };
+  }
+  const limit = clampInt(args.limit, 1, 8, 5);
+
+  try {
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const { items, error } = await productNeedSearch(sb, need, prefs, { dietary, certifications, limit });
+    if (error) return { ok: false, error };
+    const label = [...dietary, ...certifications].join(', ');
+    if (items.length === 0) {
+      return {
+        ok: true,
+        result: { items: [] },
+        text: `No products declare ${label}${need ? ` for "${need}"` : ''}. Only declared product data counts here — offer to search without the filter.`,
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        items: items.map((p) => ({ product_id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency, dietary_tags: p.dietary_tags })),
+      },
+      text: `Matching ${label}: ${items.map(speakProduct).join('; ')}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'search_marketplace_by_values failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A20.5 search_marketplace_alternatives
+// ---------------------------------------------------------------------------
+
+export async function tool_search_marketplace_alternatives(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('search_marketplace_alternatives', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'search_marketplace_alternatives requires a known tenant context.' };
+
+  try {
+    const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+    if (!ref.ok) return { ok: false, error: ref.error };
+    if (!ref.product) return { ok: false, error: 'Could not resolve which product to find alternatives for — name it.' };
+    const base = ref.product;
+    const limit = clampInt(args.limit, 1, 6, 3);
+
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const avoidBrand = args.different_brand === true && base.brand ? base.brand : null;
+    const { items, error } = await productNeedSearch(sb, String(args.reason ?? '').trim() || base.title, prefs, {
+      category: base.category,
+      excludeId: base.id,
+      limit: limit + (avoidBrand ? 3 : 0),
+    });
+    if (error) return { ok: false, error };
+    const alternatives = (avoidBrand ? items.filter((p) => p.brand !== avoidBrand) : items).slice(0, limit);
+
+    if (alternatives.length === 0) {
+      return {
+        ok: true,
+        result: { alternatives: [] },
+        text: `No alternatives to "${base.title}" in the same category right now. Say so honestly.`,
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        base: { product_id: base.id, title: base.title },
+        alternatives: alternatives.map((p) => ({ product_id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency, rating: p.rating })),
+      },
+      text: `Alternatives to "${base.title}": ${alternatives.map(speakProduct).join('; ')}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'search_marketplace_alternatives failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A21.1 generate_top_marketplace_picks (propose-only — nothing staged)
+// ---------------------------------------------------------------------------
+
+export async function tool_generate_top_marketplace_picks(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('generate_top_marketplace_picks', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'generate_top_marketplace_picks requires a known tenant context.' };
+  const prompt = String(args.prompt ?? args.need ?? args.goal ?? '').trim();
+  if (!prompt) return { ok: false, error: 'generate_top_marketplace_picks requires what the user is looking for.' };
+  const maxItems = clampInt(args.max_items, 1, 3, 3);
+
+  try {
+    let picks: GuidePick[] = [];
+    let advisory: string[] = [];
+    try {
+      const collected: AnnotatedPick[] = [];
+      const collectOnly: InsertPickFn = async (pick) => {
+        collected.push(pick);
+        return { ok: true, item_id: `proposal-${collected.length}` };
+      };
+      const ctx = await getUserHealthContext(id.user_id);
+      const monthlySpendCents = await getMonthlySpend(sb, id.user_id, ctx.currency ?? DEFAULT_CURRENCY);
+      const res = await runPropose({
+        prompt,
+        maxItems,
+        ctx,
+        supabase: sb,
+        insertPick: collectOnly,
+        runId: randomUUID(),
+        monthly_spend_cents: monthlySpendCents,
+      });
+      if (res.ok) {
+        advisory = res.advisory ?? [];
+        picks = collected.map((p) => ({
+          kind: 'product' as const,
+          id: p.product_id,
+          title: p.title,
+          price_cents: p.unit_price_cents_snapshot,
+          currency: p.currency_snapshot,
+          rationale: p.rationale,
+          safety_flags: p.safety_flags,
+        }));
+      }
+    } catch {
+      /* deterministic fallback below */
+    }
+    if (picks.length === 0) {
+      const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+      const { items } = await productNeedSearch(sb, prompt, prefs, { budgetMaxCents: prefs.budget_monthly_cents, limit: maxItems });
+      picks = items.map((p) => ({
+        kind: 'product' as const,
+        id: p.id,
+        title: p.title,
+        price_cents: p.price_cents,
+        currency: p.currency,
+        rationale: `matches "${prompt}"${p.rating != null ? `, rated ${p.rating.toFixed(1)}/5` : ''}`,
+      }));
+    }
+
+    // Persist as the current picks so explain/compare/select can reference them.
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    const state = existing?.state ?? emptyGuideState(prompt);
+    if (!state.goal) state.goal = prompt;
+    state.picks = picks;
+    state.selected = null;
+    await saveGuideState(sb, tenantId, id.user_id, state);
+
+    if (picks.length === 0) {
+      return {
+        ok: true,
+        result: { picks: [], advisory },
+        text: `I couldn't find suitable options for "${prompt}". Tell the user honestly — never invent products.`,
+      };
+    }
+    return {
+      ok: true,
+      result: { picks, advisory },
+      text:
+        `Top picks for "${prompt}" (nothing added to the cart): ${picks
+          .map((p, i) => `${i + 1}. "${p.title}" (${fmtPrice(p.price_cents, p.currency)}) — ${p.rationale}`)
+          .join('; ')}. Offer to compare, explain, or add one to the basket.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'generate_top_marketplace_picks failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A21.2 recommend_marketplace_path
+// ---------------------------------------------------------------------------
+
+export async function tool_recommend_marketplace_path(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('recommend_marketplace_path', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'recommend_marketplace_path requires a known tenant context.' };
+
+  try {
+    let goal = String(args.goal ?? args.need ?? '').trim();
+    if (!goal) {
+      const existing = await loadGuideState(sb, tenantId, id.user_id);
+      goal = existing?.state.goal ?? '';
+    }
+    if (!goal) return { ok: false, error: 'recommend_marketplace_path requires a goal (or a recorded one).' };
+
+    const { intent } = classifyIntent(goal);
+    const wantsUnderstanding = /why|warum|understand|verstehen|cause|ursache|tired|müde|fatigue|energy|energie|sleep|schlaf/i.test(goal);
+
+    let path: string;
+    let spoken: string;
+    if (intent === 'diagnostic_test' || (wantsUnderstanding && intent === 'product')) {
+      path = 'assessment_first';
+      spoken =
+        `For "${goal}", understanding the situation first is usually more useful than starting with a product — ` +
+        'suggest a relevant assessment or lab service (browse_wellness_services), then deciding on products with that information. ' +
+        HEALTH_BOUNDARY_NOTE;
+    } else if (intent === 'practitioner') {
+      path = 'practitioner_first';
+      spoken = `For "${goal}", a practitioner is the right starting point — offer browse_doctors_coaches or find_perfect_practitioner.`;
+    } else if (intent === 'service') {
+      path = 'service_first';
+      spoken = `For "${goal}", a service fits better than a product — offer search_services_by_need.`;
+    } else if (intent === 'combination') {
+      path = 'combination';
+      spoken =
+        `"${goal}" spans both — suggest starting with the service/assessment part, then products. ${HEALTH_BOUNDARY_NOTE}`;
+    } else {
+      path = 'product_first';
+      spoken = `For "${goal}", a product search is the direct path — offer search_products_by_need or generate_top_marketplace_picks.`;
+    }
+    return { ok: true, result: { goal, intent, path }, text: spoken };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'recommend_marketplace_path failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A21.4 recommend_lower_cost_option
+// ---------------------------------------------------------------------------
+
+export async function tool_recommend_lower_cost_option(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('recommend_lower_cost_option', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'recommend_lower_cost_option requires a known tenant context.' };
+
+  try {
+    const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+    if (!ref.ok) return { ok: false, error: ref.error };
+    if (!ref.product) return { ok: false, error: 'Could not resolve which option to find a cheaper alternative for.' };
+    const base = ref.product;
+    if (base.price_cents == null) {
+      return { ok: false, error: `"${base.title}" has no listed price to compare against.` };
+    }
+
+    const { data, error } = await sb
+      .from('products')
+      .select(PRODUCT_COLS)
+      .eq('is_active', true)
+      .eq('category', base.category ?? '')
+      .lt('price_cents', base.price_cents)
+      .neq('id', base.id)
+      .order('rating', { ascending: false, nullsFirst: false })
+      .limit(6);
+    if (error) return { ok: false, error: error.message };
+
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const { kept } = applyPrefExclusions(((data as unknown as ProductRow[]) ?? []), prefs);
+    const cheaper = kept.slice(0, 2);
+    if (cheaper.length === 0) {
+      return {
+        ok: true,
+        result: { alternatives: [] },
+        text: `There's no cheaper comparable option to "${base.title}" in its category right now — say so honestly.`,
+      };
+    }
+    return {
+      ok: true,
+      result: {
+        base: { product_id: base.id, title: base.title, price_cents: base.price_cents, currency: base.currency },
+        alternatives: cheaper.map((p) => ({ product_id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency, rating: p.rating })),
+      },
+      text:
+        `Cheaper than "${base.title}" (${fmtPrice(base.price_cents, base.currency)}): ${cheaper
+          .map((p) => `${speakProduct(p)} — saves ${fmtPrice(base.price_cents! - (p.price_cents ?? 0), base.currency)}`)
+          .join('; ')}. Mention any relevant trade-off (rating, size) briefly.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'recommend_lower_cost_option failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A22.1 explain_why_recommended
+// ---------------------------------------------------------------------------
+
+export async function tool_explain_why_recommended(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('explain_why_recommended', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'explain_why_recommended requires a known tenant context.' };
+
+  try {
+    const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+    if (!ref.ok) return { ok: false, error: ref.error };
+    if (!ref.product) return { ok: false, error: 'Could not resolve which recommendation to explain — name it.' };
+    if (!ref.rationale) {
+      // Not one of the recorded picks — check the cart's recorded agent rationale.
+      const cart = await loadActiveCartItems(sb, id.user_id);
+      const item = cart.ok ? cart.items.find((i) => i.product_id === ref.product!.id) : undefined;
+      const rationale = (item?.metadata as { rationale?: string } | null)?.rationale;
+      if (!rationale) {
+        return {
+          ok: true,
+          result: { has_recorded_rationale: false, title: ref.product.title },
+          text:
+            `"${ref.product.title}" wasn't recommended by me in this conversation, so there is no recorded reason. ` +
+            'Say so honestly — do not invent a rationale.',
+        };
+      }
+      return {
+        ok: true,
+        result: { title: ref.product.title, rationale },
+        text: `"${ref.product.title}" was proposed because: ${rationale}. Cite this stated reason, in plain language.`,
+      };
+    }
+    return {
+      ok: true,
+      result: { title: ref.product.title, rationale: ref.rationale },
+      text:
+        `"${ref.product.title}" was recommended because: ${ref.rationale}. ` +
+        'Explain it citing the user\'s stated goal and preferences — never an opaque match score.',
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'explain_why_recommended failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A22.2 summarize_product_for_user + A22.3 get_key_product_facts
+// ---------------------------------------------------------------------------
+
+export async function tool_summarize_product_for_user(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('summarize_product_for_user', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'summarize_product_for_user requires a known tenant context.' };
+
+  try {
+    const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+    if (!ref.ok) return { ok: false, error: ref.error };
+    if (!ref.product) return { ok: false, error: 'Could not resolve which product to summarize — name it.' };
+    const p = ref.product;
+
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const fitNotes: string[] = [];
+    if (prefs.dietary.length && p.dietary_tags?.length) {
+      const tags = new Set(p.dietary_tags.map((t) => t.toLowerCase()));
+      const matched = prefs.dietary.filter((d) => tags.has(d.toLowerCase()));
+      if (matched.length) fitNotes.push(`matches your ${matched.join(', ')} preference`);
+    }
+    if (ref.rationale) fitNotes.push(ref.rationale);
+
+    return {
+      ok: true,
+      result: { product_id: p.id, title: p.title, summary: conciseSummary(p), fit_notes: fitNotes },
+      text:
+        `${conciseSummary(p)}${fitNotes.length ? ` Why it may fit: ${fitNotes.join('; ')}.` : ''} ` +
+        'Keep it to 2–3 spoken sentences — what it is, what for, why it fits, one limitation.',
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'summarize_product_for_user failed' };
+  }
+}
+
+export async function tool_get_key_product_facts(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('get_key_product_facts', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'get_key_product_facts requires a known tenant context.' };
+
+  try {
+    const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+    if (!ref.ok) return { ok: false, error: ref.error };
+    if (!ref.product) return { ok: false, error: 'Could not resolve which product — name it.' };
+    const p = ref.product;
+    const facts: Record<string, unknown> = {
+      title: p.title,
+      brand: p.brand,
+      price: fmtPrice(p.price_cents, p.currency),
+      category: p.category,
+      availability: p.availability,
+      rating: p.rating,
+      dosage: p.dosage,
+      serving_size: p.serving_size,
+      servings_per_container: p.servings_per_container,
+      dietary_tags: p.dietary_tags,
+      contains_allergens: p.contains_allergens,
+      safety_notes: p.safety_notes,
+    };
+    const spoken = [
+      speakProduct(p),
+      p.dosage ? `dosage ${p.dosage}` : '',
+      p.servings_per_container != null ? `${p.servings_per_container} servings` : '',
+      p.contains_allergens?.length ? `contains: ${p.contains_allergens.join(', ')}` : '',
+      p.safety_notes ? `note: ${p.safety_notes}` : '',
+      p.availability !== 'in_stock' ? `availability: ${p.availability}` : '',
+    ]
+      .filter(Boolean)
+      .join('; ');
+    return { ok: true, result: { facts }, text: `Key facts — ${spoken}. Read only what the user asked about.` };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'get_key_product_facts failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A23.1 compare_marketplace_options
+// ---------------------------------------------------------------------------
+
+export async function tool_compare_marketplace_options(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('compare_marketplace_options', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'compare_marketplace_options requires a known tenant context.' };
+
+  try {
+    // Resolve up to 3 products: explicit ids/titles, else the current picks.
+    const products: ProductRow[] = [];
+    const explicitIds = toList(args.product_ids).filter((v) => UUID_RE.test(v));
+    const explicitTitles = toList(args.titles);
+    for (const pid of explicitIds.slice(0, 3)) {
+      const res = await resolveProduct(sb, pid, '');
+      if (res.ok && res.product) products.push(res.product);
+    }
+    for (const t of explicitTitles.slice(0, 3 - products.length)) {
+      const res = await resolveProduct(sb, '', t);
+      if (res.ok && res.product && !products.some((p) => p.id === res.product!.id)) products.push(res.product);
+    }
+    let rationaleById = new Map<string, string>();
+    if (products.length < 2) {
+      const existing = await loadGuideState(sb, tenantId, id.user_id);
+      const pickProducts = (existing?.state.picks ?? []).filter((p) => p.kind === 'product').slice(0, 3);
+      rationaleById = new Map(pickProducts.map((p) => [p.id, p.rationale]));
+      for (const pick of pickProducts) {
+        if (products.some((p) => p.id === pick.id)) continue;
+        const res = await resolveProduct(sb, pick.id, '');
+        if (res.ok && res.product) products.push(res.product);
+      }
+    }
+    if (products.length < 2) {
+      return { ok: false, error: 'compare_marketplace_options needs at least two options (current picks or named products).' };
+    }
+    const compared = products.slice(0, 3);
+
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const rows = compared.map((p) => ({
+      product_id: p.id,
+      title: p.title,
+      price_cents: p.price_cents,
+      currency: p.currency,
+      rating: p.rating,
+      availability: p.availability,
+      dietary_tags: p.dietary_tags,
+      safety_notes: p.safety_notes,
+      rationale: rationaleById.get(p.id) ?? null,
+    }));
+
+    // Meaningful differences only: price spread, rating spread, availability,
+    // dietary fit against saved preferences.
+    const diffs: string[] = [];
+    const priced = compared.filter((p) => p.price_cents != null);
+    if (priced.length >= 2) {
+      const cheapest = priced.reduce((a, b) => (a.price_cents! <= b.price_cents! ? a : b));
+      const priciest = priced.reduce((a, b) => (a.price_cents! >= b.price_cents! ? a : b));
+      if (cheapest.id !== priciest.id) {
+        diffs.push(
+          `"${cheapest.title}" is ${fmtPrice(priciest.price_cents! - cheapest.price_cents!, cheapest.currency)} cheaper than "${priciest.title}"`,
+        );
+      }
+    }
+    const rated = compared.filter((p) => p.rating != null);
+    if (rated.length >= 2) {
+      const best = rated.reduce((a, b) => (a.rating! >= b.rating! ? a : b));
+      const worst = rated.reduce((a, b) => (a.rating! <= b.rating! ? a : b));
+      if (best.id !== worst.id && best.rating! - worst.rating! >= 0.3) {
+        diffs.push(`"${best.title}" is rated higher (${best.rating!.toFixed(1)} vs ${worst.rating!.toFixed(1)})`);
+      }
+    }
+    const outOfStock = compared.filter((p) => p.availability !== 'in_stock');
+    for (const p of outOfStock) diffs.push(`"${p.title}" is ${p.availability}`);
+    if (prefs.dietary.length) {
+      for (const p of compared) {
+        const tags = new Set((p.dietary_tags ?? []).map((t) => t.toLowerCase()));
+        const matched = prefs.dietary.filter((d) => tags.has(d.toLowerCase()));
+        if (matched.length) diffs.push(`"${p.title}" matches your ${matched.join(', ')} preference`);
+      }
+    }
+
+    return {
+      ok: true,
+      result: { options: rows, differences: diffs },
+      text:
+        `Comparing ${compared.map((p) => `"${p.title}" (${fmtPrice(p.price_cents, p.currency)})`).join(' vs ')}. ` +
+        `${diffs.length ? `What actually differs: ${diffs.join('; ')}.` : 'They are very similar on price, rating and availability.'} ` +
+        'Speak only the differences that matter to this user, then ask which direction they lean.',
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'compare_marketplace_options failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A23.5–7 shortlist (shop_saved_products)
+// ---------------------------------------------------------------------------
+
+export async function tool_shortlist_marketplace_options(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('shortlist_marketplace_options', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'shortlist_marketplace_options requires a known tenant context.' };
+
+  try {
+    const targets: ProductRow[] = [];
+    if (args.all_picks === true) {
+      const existing = await loadGuideState(sb, tenantId, id.user_id);
+      for (const pick of (existing?.state.picks ?? []).filter((p) => p.kind === 'product')) {
+        const res = await resolveProduct(sb, pick.id, '');
+        if (res.ok && res.product) targets.push(res.product);
+      }
+    } else {
+      const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+      if (!ref.ok) return { ok: false, error: ref.error };
+      if (ref.product) targets.push(ref.product);
+    }
+    if (targets.length === 0) {
+      return { ok: false, error: 'Could not resolve which product(s) to shortlist — name one or pass all_picks:true.' };
+    }
+
+    const savedTitles: string[] = [];
+    for (const p of targets) {
+      const { data: existingRow } = await sb
+        .from('shop_saved_products')
+        .select('id')
+        .eq('user_id', id.user_id)
+        .eq('product_id', p.id)
+        .maybeSingle();
+      if (!existingRow) {
+        const { error } = await sb.from('shop_saved_products').insert({ user_id: id.user_id, product_id: p.id });
+        if (error) return { ok: false, error: error.message };
+      }
+      savedTitles.push(p.title);
+    }
+    return {
+      ok: true,
+      result: { shortlisted: savedTitles },
+      text: `Shortlisted: ${savedTitles.map((t) => `"${t}"`).join(', ')}. The user can hear it anytime with "show my shortlist".`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'shortlist_marketplace_options failed' };
+  }
+}
+
+export async function tool_view_marketplace_shortlist(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('view_marketplace_shortlist', id);
+  if (gate) return gate;
+  const limit = clampInt(args.limit, 1, 20, 10);
+
+  try {
+    const { data, error } = await sb
+      .from('shop_saved_products')
+      .select('product_id, created_at')
+      .eq('user_id', id.user_id)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (error) return { ok: false, error: error.message };
+    const rows = (data as Array<{ product_id: string }>) ?? [];
+    if (rows.length === 0) {
+      return { ok: true, result: { items: [] }, text: 'The shortlist is empty.' };
+    }
+    const ids = rows.map((r) => r.product_id);
+    const { data: products, error: pErr } = await sb.from('products').select(PRODUCT_COLS).in('id', ids);
+    if (pErr) return { ok: false, error: pErr.message };
+    const byId = new Map(((products as unknown as ProductRow[]) ?? []).map((p) => [p.id, p]));
+    const items = ids
+      .map((pid) => byId.get(pid))
+      .filter((p): p is ProductRow => !!p);
+    return {
+      ok: true,
+      result: {
+        items: items.map((p) => ({ product_id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency, availability: p.availability })),
+      },
+      text: `Shortlist (${items.length}): ${items.map(speakProduct).join('; ')}. Offer to compare them or add one to the basket.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'view_marketplace_shortlist failed' };
+  }
+}
+
+export async function tool_remove_from_marketplace_shortlist(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('remove_from_marketplace_shortlist', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'remove_from_marketplace_shortlist requires a known tenant context.' };
+
+  try {
+    const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+    if (!ref.ok) return { ok: false, error: ref.error };
+    if (!ref.product) return { ok: false, error: 'Could not resolve which shortlist item to remove — name it.' };
+    const { data, error } = await sb
+      .from('shop_saved_products')
+      .delete()
+      .eq('user_id', id.user_id)
+      .eq('product_id', ref.product.id)
+      .select('id');
+    if (error) return { ok: false, error: error.message };
+    const removed = ((data as Array<{ id: string }>) ?? []).length > 0;
+    return {
+      ok: true,
+      result: { removed, title: ref.product.title },
+      text: removed ? `Removed "${ref.product.title}" from the shortlist.` : `"${ref.product.title}" wasn't on the shortlist.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'remove_from_marketplace_shortlist failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A27.1 check_product_suitability
+// ---------------------------------------------------------------------------
+
+export async function tool_check_product_suitability(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('check_product_suitability', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'check_product_suitability requires a known tenant context.' };
+
+  try {
+    const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+    if (!ref.ok) return { ok: false, error: ref.error };
+    if (!ref.product) return { ok: false, error: 'Could not resolve which product to check — name it.' };
+    const p = ref.product;
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+
+    const conflicts: string[] = [];
+    const matches: string[] = [];
+    const unchecked: string[] = [];
+
+    if (p.brand && prefs.excluded_brands.some((b) => b.toLowerCase() === p.brand!.toLowerCase())) {
+      conflicts.push(`brand ${p.brand} is on your excluded list`);
+    }
+    const cat = (p.category ?? '').toLowerCase();
+    if (cat && prefs.excluded_categories.some((c) => c.toLowerCase() === cat)) {
+      conflicts.push(`category ${p.category} is on your excluded list`);
+    }
+    const haystack = `${p.title} ${p.category ?? ''} ${p.subcategory ?? ''}`.toLowerCase();
+    for (const term of prefs.exclusions) {
+      if (term && haystack.includes(term.toLowerCase())) conflicts.push(`matches your exclusion "${term}"`);
+    }
+    if (prefs.dietary.length) {
+      if (p.dietary_tags?.length) {
+        const tags = new Set(p.dietary_tags.map((t) => t.toLowerCase()));
+        for (const d of prefs.dietary) {
+          if (tags.has(d.toLowerCase())) matches.push(`declared ${d}`);
+          else unchecked.push(`${d} (not declared by the product)`);
+        }
+      } else {
+        unchecked.push(`dietary needs (${prefs.dietary.join(', ')}) — product declares no dietary tags`);
+      }
+    }
+    if (p.contains_allergens?.length) {
+      matches.push(`declared allergens: ${p.contains_allergens.join(', ')} — mention them`);
+    }
+    if (prefs.budget_monthly_cents != null && p.price_cents != null && p.price_cents > prefs.budget_monthly_cents) {
+      conflicts.push(`price ${fmtPrice(p.price_cents, p.currency)} exceeds your ${fmtPrice(prefs.budget_monthly_cents, null)} budget`);
+    }
+
+    const verdict = conflicts.length ? 'conflicts_found' : 'no_conflicts_in_declared_data';
+    return {
+      ok: true,
+      result: { product_id: p.id, title: p.title, verdict, conflicts, matches, unchecked },
+      text:
+        `Suitability of "${p.title}": ${conflicts.length ? `conflicts — ${conflicts.join('; ')}.` : 'no conflicts with your saved preferences in the declared product data.'}` +
+        `${matches.length ? ` Positive: ${matches.join('; ')}.` : ''}` +
+        `${unchecked.length ? ` Could NOT verify: ${unchecked.join('; ')} — say so instead of guessing.` : ''} ` +
+        HEALTH_BOUNDARY_NOTE,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'check_product_suitability failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A27.3 check_cart_duplication
+// ---------------------------------------------------------------------------
+
+export async function tool_check_cart_duplication(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('check_cart_duplication', id);
+  if (gate) return gate;
+  try {
+    const cart = await loadActiveCartItems(sb, id.user_id);
+    if (!cart.ok) return { ok: false, error: cart.error };
+    if (cart.items.length === 0) return { ok: true, result: { duplicates: [] }, text: 'The basket is empty — nothing to check.' };
+
+    const byProduct = new Map<string, CartItemRow[]>();
+    for (const item of cart.items) {
+      if (!item.product_id) continue;
+      const list = byProduct.get(item.product_id) ?? [];
+      list.push(item);
+      byProduct.set(item.product_id, list);
+    }
+    const dupIds = Array.from(byProduct.entries()).filter(([, list]) => list.length > 1 || list.some((i) => i.quantity > 1));
+    if (dupIds.length === 0) {
+      return { ok: true, result: { duplicates: [] }, text: 'No duplicates in the basket.' };
+    }
+    const titles = await productTitles(sb, dupIds.map(([pid]) => pid));
+    const duplicates = dupIds.map(([pid, list]) => ({
+      product_id: pid,
+      title: titles.get(pid) ?? 'an item',
+      total_quantity: list.reduce((sum, i) => sum + (i.quantity || 1), 0),
+      line_count: list.length,
+    }));
+    return {
+      ok: true,
+      result: { duplicates },
+      text:
+        `Possible duplicates: ${duplicates.map((d) => `"${d.title}" appears ${d.line_count > 1 ? `${d.line_count} times` : `with quantity ${d.total_quantity}`}`).join('; ')}. ` +
+        'Ask whether to keep both or remove one (update_cart_item / remove_from_cart).',
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'check_cart_duplication failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A28.3 review_shopping_budget
+// ---------------------------------------------------------------------------
+
+export async function tool_review_shopping_budget(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('review_shopping_budget', id);
+  if (gate) return gate;
+  try {
+    let capCents: number | null = null;
+    try {
+      const { data } = await sb
+        .from('user_limitations')
+        .select('budget_monthly_cap_cents')
+        .eq('user_id', id.user_id)
+        .maybeSingle();
+      capCents = (data as { budget_monthly_cap_cents?: number | null } | null)?.budget_monthly_cap_cents ?? null;
+    } catch {
+      /* no limitations row → no cap */
+    }
+    const spentCents = await getMonthlySpend(sb, id.user_id, DEFAULT_CURRENCY);
+
+    const cart = await loadActiveCartItems(sb, id.user_id);
+    const cartTotalCents = cart.ok
+      ? cart.items.reduce((sum, i) => sum + (i.unit_price_cents_snapshot ?? 0) * (i.quantity || 1), 0)
+      : 0;
+
+    if (capCents == null) {
+      return {
+        ok: true,
+        result: { budget_monthly_cap_cents: null, monthly_spend_cents: spentCents, cart_total_cents: cartTotalCents },
+        text:
+          `No monthly shopping budget is set. This month's spend: ${fmtPrice(spentCents, null)}; current basket: ${fmtPrice(cartTotalCents, null)}. ` +
+          'Offer to set a budget with set_shopping_budget.',
+      };
+    }
+    const remaining = capCents - spentCents;
+    const wouldExceed = cartTotalCents > remaining;
+    return {
+      ok: true,
+      result: {
+        budget_monthly_cap_cents: capCents,
+        monthly_spend_cents: spentCents,
+        remaining_cents: remaining,
+        cart_total_cents: cartTotalCents,
+        cart_would_exceed_budget: wouldExceed,
+      },
+      text:
+        `Budget: ${fmtPrice(capCents, null)}/month, spent ${fmtPrice(spentCents, null)}, remaining ${fmtPrice(Math.max(remaining, 0), null)}. ` +
+        `Basket total: ${fmtPrice(cartTotalCents, null)}${wouldExceed ? ' — WARN the user this would exceed the remaining budget and offer cheaper alternatives (recommend_lower_cost_option).' : '.'}`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'review_shopping_budget failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A29.1 confirm_marketplace_selection + A29.2 add_selected_option_to_cart
+// ---------------------------------------------------------------------------
+
+export async function tool_confirm_marketplace_selection(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('confirm_marketplace_selection', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'confirm_marketplace_selection requires a known tenant context.' };
+
+  try {
+    const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+    if (!ref.ok) return { ok: false, error: ref.error };
+    if (!ref.product) return { ok: false, error: 'Could not resolve which option to confirm — name it.' };
+    const p = ref.product;
+
+    // Record the selection so add_selected_option_to_cart can act on "yes".
+    const existing = await loadGuideState(sb, tenantId, id.user_id);
+    const state = existing?.state ?? emptyGuideState('');
+    state.selected = {
+      kind: 'product',
+      id: p.id,
+      title: p.title,
+      price_cents: p.price_cents,
+      currency: p.currency,
+      rationale: ref.rationale ?? 'user selection',
+    };
+    await saveGuideState(sb, tenantId, id.user_id, state);
+
+    return {
+      ok: true,
+      result: {
+        selection: { product_id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency, availability: p.availability },
+      },
+      text:
+        `Read back to the user: "${p.title}"${p.brand ? ` by ${p.brand}` : ''}, ${fmtPrice(p.price_cents, p.currency)}${
+          p.availability !== 'in_stock' ? `, availability ${p.availability}` : ''
+        }. Ask: "Shall I add it to your basket?" — on yes, call add_selected_option_to_cart with confirm:true. Payment stays on screen.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'confirm_marketplace_selection failed' };
+  }
+}
+
+export async function tool_add_selected_option_to_cart(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('add_selected_option_to_cart', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'add_selected_option_to_cart requires a known tenant context.' };
+
+  try {
+    const ref = await resolveReferencedProduct(sb, tenantId, id.user_id, args);
+    if (!ref.ok) return { ok: false, error: ref.error };
+    if (!ref.product) {
+      return { ok: false, error: 'No confirmed selection found — call confirm_marketplace_selection first (or name the product).' };
+    }
+    const p = ref.product;
+
+    if (args.confirm !== true) {
+      return {
+        ok: true,
+        result: { needs_confirmation: true, product_id: p.id, title: p.title, price_cents: p.price_cents, currency: p.currency },
+        text:
+          `Confirm with the user: add "${p.title}" (${fmtPrice(p.price_cents, p.currency)}) to the basket? ` +
+          'On yes, call add_selected_option_to_cart again with confirm:true.',
+      };
+    }
+
+    const staged = await stageProductInCart(sb, id, p, 'voice_confirmed_selection', ref.rationale ?? 'user selection');
+    if (!staged.ok) return { ok: false, error: staged.error };
+    const route = '/cart';
+    return {
+      ok: true,
+      result: {
+        added: true,
+        item_id: staged.itemId,
+        product_id: p.id,
+        title: p.title,
+        decision: 'auto_nav',
+        directive: navDirective('DISCOVER.CART', route, 'Shopping Cart', 'add_selected_option_to_cart added'),
+        redirect: { route },
+      },
+      text: `Done — "${p.title}" is in the basket. Review and confirm payment on the screen; nothing has been charged.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'add_selected_option_to_cart failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A29.4 review_cart_suitability + A29.5 explain_cart_item
+// ---------------------------------------------------------------------------
+
+export async function tool_review_cart_suitability(
+  _args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('review_cart_suitability', id);
+  if (gate) return gate;
+  const tenantId = await resolveTenantId(id, sb);
+  if (!tenantId) return { ok: false, error: 'review_cart_suitability requires a known tenant context.' };
+
+  try {
+    const cart = await loadActiveCartItems(sb, id.user_id);
+    if (!cart.ok) return { ok: false, error: cart.error };
+    if (cart.items.length === 0) return { ok: true, result: { findings: [] }, text: 'The basket is empty — nothing to review.' };
+
+    const prefs = await loadMarketplacePrefs(sb, tenantId, id.user_id);
+    const ids = cart.items.map((i) => i.product_id).filter((v): v is string => !!v);
+    const { data } = await sb.from('products').select(PRODUCT_COLS).in('id', Array.from(new Set(ids)));
+    const products = new Map(((data as unknown as ProductRow[]) ?? []).map((p) => [p.id, p]));
+
+    const findings: string[] = [];
+    // Duplicates
+    const seen = new Map<string, number>();
+    for (const item of cart.items) {
+      if (!item.product_id) continue;
+      seen.set(item.product_id, (seen.get(item.product_id) ?? 0) + 1);
+    }
+    for (const [pid, count] of seen.entries()) {
+      if (count > 1) findings.push(`"${products.get(pid)?.title ?? 'an item'}" appears ${count} times`);
+    }
+    // Preference conflicts + availability
+    for (const item of cart.items) {
+      const p = item.product_id ? products.get(item.product_id) : undefined;
+      if (!p) continue;
+      const { dropped } = applyPrefExclusions([p], prefs);
+      if (dropped.length) findings.push(`"${p.title}": ${dropped[0].reason}`);
+      if (p.availability !== 'in_stock') findings.push(`"${p.title}" is ${p.availability}`);
+      if (p.contains_allergens?.length && prefs.dietary.length) {
+        findings.push(`"${p.title}" declares allergens (${p.contains_allergens.join(', ')}) — worth mentioning`);
+      }
+    }
+
+    return {
+      ok: true,
+      result: { findings, item_count: cart.items.length },
+      text: findings.length
+        ? `Before checkout: ${findings.join('; ')}. Ask whether to adjust anything.`
+        : `The basket (${cart.items.length} item${cart.items.length === 1 ? '' : 's'}) has no duplicates or conflicts with saved preferences.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'review_cart_suitability failed' };
+  }
+}
+
+export async function tool_explain_cart_item(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const gate = authGate('explain_cart_item', id);
+  if (gate) return gate;
+  try {
+    const cart = await loadActiveCartItems(sb, id.user_id);
+    if (!cart.ok) return { ok: false, error: cart.error };
+    if (cart.items.length === 0) return { ok: true, result: { found: false }, text: 'The basket is empty.' };
+
+    const titles = await productTitles(sb, cart.items.map((i) => i.product_id).filter((v): v is string => !!v));
+    const wanted = String(args.title ?? args.query ?? '').trim().toLowerCase();
+    const item =
+      cart.items.find((i) => i.product_id && UUID_RE.test(String(args.product_id ?? '')) && i.product_id === args.product_id) ??
+      (wanted ? cart.items.find((i) => (titles.get(i.product_id ?? '') ?? '').toLowerCase().includes(wanted)) : undefined) ??
+      (cart.items.length === 1 ? cart.items[0] : undefined);
+    if (!item) {
+      return {
+        ok: true,
+        result: { found: false, items: cart.items.map((i) => titles.get(i.product_id ?? '') ?? 'an item') },
+        text: `Which item? The basket has: ${cart.items.map((i) => `"${titles.get(i.product_id ?? '') ?? 'an item'}"`).join(', ')}.`,
+      };
+    }
+    const meta = (item.metadata ?? {}) as { origin?: string; rationale?: string };
+    const title = titles.get(item.product_id ?? '') ?? 'This item';
+    const originSpoken =
+      meta.origin === 'agent'
+        ? 'proposed by the shopping agent'
+        : meta.origin === 'reorder'
+          ? 'a reorder of a previous purchase'
+          : meta.origin === 'discover_assistant' || meta.origin === 'voice_confirmed_selection'
+            ? 'added by you via the voice assistant after confirmation'
+            : 'added by you';
+    return {
+      ok: true,
+      result: { title, origin: meta.origin ?? 'user', rationale: meta.rationale ?? null, quantity: item.quantity },
+      text: `"${title}" (quantity ${item.quantity}) was ${originSpoken}${meta.rationale ? ` — reason recorded: ${meta.rationale}` : ''}.`,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'explain_cart_item failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const MARKETPLACE_JOURNEY_TOOL_HANDLERS: Record<string, Handler> = {
+  discover_marketplace_options: tool_discover_marketplace_options,
+  search_products_by_need: tool_search_products_by_need,
+  search_services_by_need: tool_search_services_by_need,
+  search_marketplace_by_values: tool_search_marketplace_by_values,
+  search_marketplace_alternatives: tool_search_marketplace_alternatives,
+  generate_top_marketplace_picks: tool_generate_top_marketplace_picks,
+  recommend_marketplace_path: tool_recommend_marketplace_path,
+  recommend_lower_cost_option: tool_recommend_lower_cost_option,
+  explain_why_recommended: tool_explain_why_recommended,
+  summarize_product_for_user: tool_summarize_product_for_user,
+  get_key_product_facts: tool_get_key_product_facts,
+  compare_marketplace_options: tool_compare_marketplace_options,
+  shortlist_marketplace_options: tool_shortlist_marketplace_options,
+  view_marketplace_shortlist: tool_view_marketplace_shortlist,
+  remove_from_marketplace_shortlist: tool_remove_from_marketplace_shortlist,
+  check_product_suitability: tool_check_product_suitability,
+  check_cart_duplication: tool_check_cart_duplication,
+  review_shopping_budget: tool_review_shopping_budget,
+  confirm_marketplace_selection: tool_confirm_marketplace_selection,
+  add_selected_option_to_cart: tool_add_selected_option_to_cart,
+  review_cart_suitability: tool_review_cart_suitability,
+  explain_cart_item: tool_explain_cart_item,
+};
+
+export const MARKETPLACE_JOURNEY_TOOL_DECLARATIONS: Array<Record<string, unknown>> = [
+  {
+    name: 'discover_marketplace_options',
+    description: [
+      'Unified marketplace search across products AND services for one stated',
+      'need. CALL WHEN the user describes a need without saying whether they',
+      'want a product or a service: "something for my back pain", "etwas für',
+      'besseren Schlaf". Mention at most 3 options, one sentence each.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        need: { type: 'string', description: 'The stated need or desired outcome.' },
+        budget_max_amount: { type: 'number', description: 'Budget ceiling in whole currency units.' },
+        limit: { type: 'number', description: 'Max options (default 4, max 6).' },
+      },
+      required: ['need'],
+    },
+  },
+  {
+    name: 'search_products_by_need',
+    description: [
+      'Search products by PURPOSE rather than product name, filtered against',
+      'saved preferences (exclusions, budget). CALL WHEN the user describes',
+      'what they want to achieve: "something that helps me focus", "etwas',
+      'gegen Müdigkeit".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        need: { type: 'string', description: 'The purpose/need to search for.' },
+        budget_max_amount: { type: 'number', description: 'Budget ceiling in whole currency units.' },
+        limit: { type: 'number', description: 'Max results (default 5, max 8).' },
+      },
+      required: ['need'],
+    },
+  },
+  {
+    name: 'search_services_by_need',
+    description: [
+      'Search marketplace services (wellness, nutrition, therapy, labs) by the',
+      'desired outcome. CALL WHEN the user wants help through a service rather',
+      'than a product: "a sleep consultation", "eine Ernährungsberatung".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        need: { type: 'string', description: 'The desired outcome.' },
+        service_types: { type: 'string', description: 'Optional comma-separated types: coach, doctor, lab, wellness, nutrition, fitness, therapy.' },
+        limit: { type: 'number', description: 'Max results (default 5, max 8).' },
+      },
+      required: ['need'],
+    },
+  },
+  {
+    name: 'search_marketplace_by_values',
+    description: [
+      'Filter products by declared dietary tags and certifications (vegan,',
+      'gluten-free, organic, …). CALL WHEN values/dietary constraints are the',
+      'point of the request: "only vegan options", "nur vegane Produkte".',
+      'Only DECLARED product data counts — say so if nothing declares the tag.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        dietary_tags: { type: 'string', description: 'Comma-separated dietary tags (e.g. "vegan, gluten-free").' },
+        certifications: { type: 'string', description: 'Comma-separated certifications (e.g. "organic").' },
+        need: { type: 'string', description: 'Optional need to combine with the filter.' },
+        limit: { type: 'number', description: 'Max results (default 5, max 8).' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'search_marketplace_alternatives',
+    description: [
+      'Find alternatives to a product the user dislikes or cannot use, in the',
+      'same category. CALL WHEN the user says "what else is there like this",',
+      '"not this brand", "gibt es Alternativen dazu?".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'UUID of the product to replace, when known.' },
+        title: { type: 'string', description: 'Spoken name of the product to replace.' },
+        position: { type: 'number', description: '1-based position among the current picks.' },
+        reason: { type: 'string', description: 'Why the user wants an alternative (improves the search).' },
+        different_brand: { type: 'boolean', description: 'True if the user wants a different brand.' },
+        limit: { type: 'number', description: 'Max alternatives (default 3, max 6).' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'generate_top_marketplace_picks',
+    description: [
+      'Return up to 3 best-fit product picks with short rationales — WITHOUT',
+      'adding anything to the cart (unlike get_ai_product_picks, which stages',
+      'the cart). CALL WHEN the user wants recommendations to hear first:',
+      '"what would you recommend for ...", "was würdest du mir empfehlen?".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        prompt: { type: 'string', description: 'What the user is looking for.' },
+        max_items: { type: 'number', description: 'Max picks (default 3).' },
+      },
+      required: ['prompt'],
+    },
+  },
+  {
+    name: 'recommend_marketplace_path',
+    description: [
+      'Recommend whether to start with a product, a service/assessment, a',
+      'practitioner, or a combination for the stated goal. CALL WHEN the user',
+      'is unsure what kind of help they need: "I don\'t know whether I need',
+      'supplements or a blood test", "ich weiß nicht, was ich brauche".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { goal: { type: 'string', description: 'The goal (defaults to the recorded one).' } },
+      required: [],
+    },
+  },
+  {
+    name: 'recommend_lower_cost_option',
+    description: [
+      'Find a suitable cheaper alternative to a current pick or named product.',
+      'CALL WHEN the user says "too expensive", "something cheaper", "zu teuer,',
+      'gibt es was Günstigeres?". Mention the saving and any trade-off.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'UUID of the too-expensive product, when known.' },
+        title: { type: 'string', description: 'Spoken name of the product.' },
+        position: { type: 'number', description: '1-based position among the current picks.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'explain_why_recommended',
+    description: [
+      'Explain why an option was recommended, from the RECORDED rationale.',
+      'CALL WHEN the user asks "why are you recommending this?", "warum',
+      'empfiehlst du mir das?". Cite stated preferences and the recorded',
+      'reason in plain language — never an algorithm score. If there is no',
+      'recorded reason, say so honestly.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'UUID of the recommended product, when known.' },
+        title: { type: 'string', description: 'Spoken name.' },
+        position: { type: 'number', description: '1-based position among the current picks.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'summarize_product_for_user',
+    description: [
+      'Personalized SHORT product summary: what it is, what it is for, why it',
+      'may fit this user, one relevant limitation. CALL instead of reading a',
+      'product description aloud. 2–3 spoken sentences maximum.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Product UUID, when known.' },
+        title: { type: 'string', description: 'Spoken product name.' },
+        position: { type: 'number', description: '1-based position among the current picks.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_key_product_facts',
+    description: [
+      'Only the most important product facts: price, dosage/serving, declared',
+      'allergens, safety notes, availability. CALL WHEN the user asks a',
+      'factual detail: "how many servings?", "what\'s the dosage?", "welche',
+      'Allergene enthält es?". Read only what was asked.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Product UUID, when known.' },
+        title: { type: 'string', description: 'Spoken product name.' },
+        position: { type: 'number', description: '1-based position among the current picks.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'compare_marketplace_options',
+    description: [
+      'Compare up to 3 options on price, rating, availability, dietary fit —',
+      'speaking only the differences that matter to this user. CALL WHEN the',
+      'user asks to compare: "compare the first two", "was ist der',
+      'Unterschied?". Defaults to the current picks.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_ids: { type: 'string', description: 'Comma-separated product UUIDs, when known.' },
+        titles: { type: 'string', description: 'Comma-separated spoken product names.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'shortlist_marketplace_options',
+    description: [
+      'Save one product (or all current picks) to the user\'s shortlist for',
+      'later. CALL WHEN the user says "save that one", "put it on my list",',
+      '"merk dir das". Products only — services cannot be shortlisted yet.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Product UUID, when known.' },
+        title: { type: 'string', description: 'Spoken product name.' },
+        position: { type: 'number', description: '1-based position among the current picks.' },
+        all_picks: { type: 'boolean', description: 'True to shortlist all current picks.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'view_marketplace_shortlist',
+    description: [
+      'Read the user\'s saved shortlist. CALL WHEN the user asks "what\'s on my',
+      'shortlist?", "zeig mir meine Merkliste".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: { limit: { type: 'number', description: 'Max items (default 10, max 20).' } },
+      required: [],
+    },
+  },
+  {
+    name: 'remove_from_marketplace_shortlist',
+    description: [
+      'Remove one product from the shortlist. CALL WHEN the user says "remove',
+      '... from my list", "nimm das von meiner Merkliste".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Product UUID, when known.' },
+        title: { type: 'string', description: 'Spoken product name.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'check_product_suitability',
+    description: [
+      'Check one product against the user\'s saved preferences (dietary,',
+      'exclusions, brands, budget) using only DECLARED product data. CALL WHEN',
+      'the user asks "is this suitable for me?", "ist das für mich geeignet?".',
+      'Report what could NOT be verified instead of guessing. Never a medical',
+      'judgement.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Product UUID, when known.' },
+        title: { type: 'string', description: 'Spoken product name.' },
+        position: { type: 'number', description: '1-based position among the current picks.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'check_cart_duplication',
+    description: [
+      'Detect repeated or overlapping products in the basket. CALL before',
+      'checkout or WHEN the user asks "is anything doubled in my basket?",',
+      '"habe ich etwas doppelt im Warenkorb?".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'review_shopping_budget',
+    description: [
+      'Read the monthly shopping budget, spend so far, remaining headroom, and',
+      'whether the current basket would exceed it. CALL WHEN the user asks',
+      'about their budget or before an expensive addition: "how is my shopping',
+      'budget?", "wie steht mein Einkaufsbudget?".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'confirm_marketplace_selection',
+    description: [
+      'Read back the exact selected option (name, price, availability) and ask',
+      'for explicit confirmation BEFORE any cart action. CALL WHEN the user',
+      'picks an option in conversation. On the user\'s yes, follow with',
+      'add_selected_option_to_cart confirm:true. Never skip this read-back.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Product UUID, when known.' },
+        title: { type: 'string', description: 'Spoken product name.' },
+        position: { type: 'number', description: '1-based position among the current picks.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'add_selected_option_to_cart',
+    description: [
+      'Stage the confirmed selection into the universal basket. NEVER charges —',
+      'payment is a screen handoff. ALWAYS run the confirm_marketplace_selection',
+      'read-back (or call once without confirm) first; pass confirm:true only',
+      'after the user said yes. CALL WHEN the user confirms adding the chosen',
+      'item: "yes, add it", "ja, in den Warenkorb".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Product UUID, when known.' },
+        title: { type: 'string', description: 'Spoken product name.' },
+        position: { type: 'number', description: '1-based position among the current picks.' },
+        confirm: { type: 'boolean', description: 'Pass true ONLY after the user confirmed the read-back.' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'review_cart_suitability',
+    description: [
+      'Check the whole basket for duplicates, conflicts with saved preferences,',
+      'declared allergens and availability problems before checkout. CALL WHEN',
+      'the user says "check my basket", "is everything in my cart okay?",',
+      '"prüf meinen Warenkorb".',
+    ].join('\n'),
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'explain_cart_item',
+    description: [
+      'Explain why a specific basket item is there (added by the user, the',
+      'shopping agent, a reorder — with the recorded rationale). CALL WHEN the',
+      'user asks "why is this in my basket?", "warum ist das in meinem',
+      'Warenkorb?".',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Product UUID, when known.' },
+        title: { type: 'string', description: 'Spoken product name.' },
+      },
+      required: [],
+    },
+  },
+];

--- a/services/gateway/src/services/orb-tools/marketplace-va-shared.ts
+++ b/services/gateway/src/services/orb-tools/marketplace-va-shared.ts
@@ -1,0 +1,513 @@
+/**
+ * Marketplace Voice Assistant (expansion v3, sections A17–A30) — shared
+ * helpers for the two MVA tool modules (marketplace-guide-tools.ts,
+ * marketplace-journey-tools.ts).
+ *
+ * Real backings (verified against routes/migrations before writing, same
+ * discipline as marketplace-discovery-tools.ts):
+ *
+ *   - Guide state (goal, criteria, current picks + rationales, selection)
+ *     lives as ONE per-user row in `memory_items`
+ *     (content_json.type = 'marketplace_guide_state'), the canonical
+ *     infinite-memory table (VTID-01104). No new table.
+ *   - Preferences live in `memory_facts` under `marketplace_pref_*` keys,
+ *     written through writeFact() (memory-facts-service.ts — identity-lock
+ *     checks + OASIS events + auto-supersession) and read directly with the
+ *     same superseded_by-null filter awareness-tools.ts uses.
+ *   - Products come from `public.products` (VTID-02000 live catalog) with
+ *     the exact column set routes/discover-search.ts selects (incl.
+ *     dietary_tags, contains_allergens, ships_to_countries, safety_notes).
+ *   - Cart staging mirrors marketplace-discovery-tools.ts: one active
+ *     `universal_carts` row per user, items into `universal_cart_items`
+ *     with source_surface 'voice', audit via emitCartEvent() imported from
+ *     routes/universal-cart.ts. NEVER calls checkout/Stripe/wallet debit.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrbToolIdentity, OrbToolResult } from '../orb-tools-shared';
+import { emitCartEvent } from '../../routes/universal-cart';
+
+export const MVA_VTID = 'MVA-MARKETPLACE-VA';
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const DEFAULT_CURRENCY = 'EUR';
+
+// ---------------------------------------------------------------------------
+// Generic helpers (same shapes as the sibling tool modules)
+// ---------------------------------------------------------------------------
+
+export function authGate(tool: string, id: OrbToolIdentity): OrbToolResult | null {
+  if (!id.user_id) {
+    return { ok: false, error: `${tool} requires an authenticated user.` };
+  }
+  return null;
+}
+
+export async function resolveTenantId(id: OrbToolIdentity, sb: SupabaseClient): Promise<string | null> {
+  if (id.tenant_id) return id.tenant_id;
+  try {
+    const { data } = await sb
+      .from('app_users')
+      .select('tenant_id')
+      .eq('user_id', id.user_id)
+      .maybeSingle();
+    return (data as { tenant_id?: string | null } | null)?.tenant_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function navDirective(
+  screen_id: string,
+  route: string,
+  title: string,
+  reason: string,
+): Record<string, unknown> {
+  return { type: 'orb_directive', directive: 'navigate', screen_id, route, title, reason, vtid: MVA_VTID };
+}
+
+export function clampInt(raw: unknown, min: number, max: number, fallback: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(n)));
+}
+
+export function fmtPrice(cents: number | null | undefined, currency: string | null | undefined): string {
+  if (cents == null) return 'price unavailable';
+  const amount = (cents / 100).toFixed(2);
+  return `${amount} ${currency ?? DEFAULT_CURRENCY}`;
+}
+
+/** Normalizes a string-or-array tool arg into a trimmed string array. */
+export function toList(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.map((v) => String(v).trim()).filter((v) => v !== '');
+  }
+  const s = String(raw ?? '').trim();
+  if (!s) return [];
+  return s
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v !== '');
+}
+
+// ---------------------------------------------------------------------------
+// Products (public.products — VTID-02000 live catalog)
+// ---------------------------------------------------------------------------
+
+export interface ProductRow {
+  id: string;
+  title: string;
+  description: string | null;
+  brand: string | null;
+  category: string | null;
+  subcategory: string | null;
+  price_cents: number | null;
+  currency: string | null;
+  compare_at_price_cents: number | null;
+  rating: number | null;
+  review_count: number | null;
+  availability: string;
+  dietary_tags: string[] | null;
+  health_goals: string[] | null;
+  ingredients_primary: string[] | null;
+  contains_allergens: string[] | null;
+  ships_to_countries: string[] | null;
+  dosage: string | null;
+  serving_size: string | null;
+  servings_per_container: number | null;
+  safety_notes: string | null;
+}
+
+export const PRODUCT_COLS =
+  'id, title, description, brand, category, subcategory, price_cents, currency, compare_at_price_cents, ' +
+  'rating, review_count, availability, dietary_tags, health_goals, ingredients_primary, contains_allergens, ' +
+  'ships_to_countries, dosage, serving_size, servings_per_container, safety_notes';
+
+export function speakProduct(p: ProductRow): string {
+  return `"${p.title}"${p.brand ? ` by ${p.brand}` : ''} — ${fmtPrice(p.price_cents, p.currency)}${
+    p.rating != null ? `, rated ${p.rating.toFixed(1)}/5` : ''
+  }`;
+}
+
+/** Resolve one product by UUID or fuzzy title (rating-ranked, active only). */
+export async function resolveProduct(
+  sb: SupabaseClient,
+  productId: string,
+  query: string,
+): Promise<{ ok: true; product: ProductRow | null } | { ok: false; error: string }> {
+  if (UUID_RE.test(productId)) {
+    const { data, error } = await sb
+      .from('products')
+      .select(PRODUCT_COLS)
+      .eq('id', productId)
+      .eq('is_active', true)
+      .maybeSingle();
+    if (error) return { ok: false, error: error.message };
+    return { ok: true, product: (data as unknown as ProductRow | null) ?? null };
+  }
+  if (query) {
+    const { data, error } = await sb
+      .from('products')
+      .select(PRODUCT_COLS)
+      .eq('is_active', true)
+      .ilike('title', `%${query}%`)
+      .order('rating', { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) return { ok: false, error: error.message };
+    return { ok: true, product: (data as unknown as ProductRow | null) ?? null };
+  }
+  return { ok: true, product: null };
+}
+
+// ---------------------------------------------------------------------------
+// Services (public.services_catalog — VTID-01092)
+// ---------------------------------------------------------------------------
+
+export interface ServiceRow {
+  id: string;
+  name: string;
+  service_type: string;
+  provider_name: string | null;
+  topic_keys: string[] | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export const SERVICE_COLS = 'id, name, service_type, provider_name, topic_keys, metadata';
+
+// ---------------------------------------------------------------------------
+// Marketplace preferences (memory_facts `marketplace_pref_*` keys)
+// ---------------------------------------------------------------------------
+
+/** The full closed set of preference fact keys the MVA reads/writes. */
+export const MARKETPLACE_PREF_KEYS = [
+  'marketplace_pref_budget_monthly_cents',
+  'marketplace_pref_dietary',
+  'marketplace_pref_values',
+  'marketplace_pref_exclusions',
+  'marketplace_pref_excluded_brands',
+  'marketplace_pref_excluded_categories',
+  'marketplace_pref_format',
+] as const;
+
+export type MarketplacePrefKey = (typeof MARKETPLACE_PREF_KEYS)[number];
+
+export interface MarketplacePrefs {
+  budget_monthly_cents: number | null;
+  dietary: string[];
+  values: string[];
+  exclusions: string[];
+  excluded_brands: string[];
+  excluded_categories: string[];
+  format: string[];
+}
+
+export function emptyPrefs(): MarketplacePrefs {
+  return {
+    budget_monthly_cents: null,
+    dietary: [],
+    values: [],
+    exclusions: [],
+    excluded_brands: [],
+    excluded_categories: [],
+    format: [],
+  };
+}
+
+/** Current (non-superseded) marketplace preference facts for the user. */
+export async function loadMarketplacePrefs(
+  sb: SupabaseClient,
+  tenantId: string,
+  userId: string,
+): Promise<MarketplacePrefs> {
+  const prefs = emptyPrefs();
+  try {
+    const { data } = await sb
+      .from('memory_facts')
+      .select('fact_key, fact_value')
+      .eq('tenant_id', tenantId)
+      .eq('user_id', userId)
+      .in('fact_key', [...MARKETPLACE_PREF_KEYS])
+      .eq('entity', 'self')
+      .is('superseded_by', null);
+    for (const row of (data as Array<{ fact_key: string; fact_value: string }>) ?? []) {
+      const v = (row.fact_value ?? '').trim();
+      if (!v) continue;
+      switch (row.fact_key as MarketplacePrefKey) {
+        case 'marketplace_pref_budget_monthly_cents': {
+          const n = Number(v);
+          if (Number.isFinite(n) && n >= 0) prefs.budget_monthly_cents = Math.round(n);
+          break;
+        }
+        case 'marketplace_pref_dietary':
+          prefs.dietary = toList(v);
+          break;
+        case 'marketplace_pref_values':
+          prefs.values = toList(v);
+          break;
+        case 'marketplace_pref_exclusions':
+          prefs.exclusions = toList(v);
+          break;
+        case 'marketplace_pref_excluded_brands':
+          prefs.excluded_brands = toList(v);
+          break;
+        case 'marketplace_pref_excluded_categories':
+          prefs.excluded_categories = toList(v);
+          break;
+        case 'marketplace_pref_format':
+          prefs.format = toList(v);
+          break;
+      }
+    }
+  } catch {
+    /* prefs are best-effort personalization seed data */
+  }
+  return prefs;
+}
+
+export function describePrefs(prefs: MarketplacePrefs): string {
+  const parts: string[] = [];
+  if (prefs.budget_monthly_cents != null) parts.push(`budget ${fmtPrice(prefs.budget_monthly_cents, null)}/month`);
+  if (prefs.dietary.length) parts.push(`dietary: ${prefs.dietary.join(', ')}`);
+  if (prefs.values.length) parts.push(`values: ${prefs.values.join(', ')}`);
+  if (prefs.exclusions.length) parts.push(`avoids: ${prefs.exclusions.join(', ')}`);
+  if (prefs.excluded_brands.length) parts.push(`excluded brands: ${prefs.excluded_brands.join(', ')}`);
+  if (prefs.excluded_categories.length) parts.push(`excluded categories: ${prefs.excluded_categories.join(', ')}`);
+  if (prefs.format.length) parts.push(`preferred format: ${prefs.format.join(', ')}`);
+  return parts.length ? parts.join('; ') : 'no saved marketplace preferences';
+}
+
+/**
+ * Drop products that conflict with the user's saved exclusions. Only checks
+ * DECLARED product data (brand, category, dietary_tags, contains_allergens,
+ * title keywords) — never guesses. Returns kept items + per-drop reasons so
+ * handlers can be transparent about what was filtered and why.
+ */
+export function applyPrefExclusions(
+  items: ProductRow[],
+  prefs: MarketplacePrefs,
+): { kept: ProductRow[]; dropped: Array<{ title: string; reason: string }> } {
+  const kept: ProductRow[] = [];
+  const dropped: Array<{ title: string; reason: string }> = [];
+  const brandBlock = new Set(prefs.excluded_brands.map((b) => b.toLowerCase()));
+  const categoryBlock = new Set(prefs.excluded_categories.map((c) => c.toLowerCase()));
+  const exclusionTerms = prefs.exclusions.map((e) => e.toLowerCase());
+
+  for (const p of items) {
+    if (p.brand && brandBlock.has(p.brand.toLowerCase())) {
+      dropped.push({ title: p.title, reason: `excluded brand ${p.brand}` });
+      continue;
+    }
+    const cat = (p.category ?? '').toLowerCase();
+    const subcat = (p.subcategory ?? '').toLowerCase();
+    if ((cat && categoryBlock.has(cat)) || (subcat && categoryBlock.has(subcat))) {
+      dropped.push({ title: p.title, reason: `excluded category ${p.category ?? p.subcategory}` });
+      continue;
+    }
+    const haystack = `${p.title} ${p.category ?? ''} ${p.subcategory ?? ''}`.toLowerCase();
+    const hitTerm = exclusionTerms.find((t) => t && haystack.includes(t));
+    if (hitTerm) {
+      dropped.push({ title: p.title, reason: `matches exclusion "${hitTerm}"` });
+      continue;
+    }
+    kept.push(p);
+  }
+  return { kept, dropped };
+}
+
+// ---------------------------------------------------------------------------
+// Guide state (memory_items content_json.type = 'marketplace_guide_state')
+// ---------------------------------------------------------------------------
+
+export interface GuidePick {
+  kind: 'product' | 'service';
+  id: string;
+  title: string;
+  price_cents: number | null;
+  currency: string | null;
+  rationale: string;
+  safety_flags?: string[];
+}
+
+export interface GuideCriteria {
+  budget_max_cents?: number | null;
+  formats?: string[];
+  urgency?: string | null;
+  exclusions?: string[];
+  location?: string | null;
+  priorities?: string[];
+}
+
+export interface GuideState {
+  goal: string;
+  intent: string | null;
+  criteria: GuideCriteria;
+  picks: GuidePick[];
+  selected: GuidePick | null;
+  updated_at: string;
+}
+
+export function emptyGuideState(goal: string): GuideState {
+  return { goal, intent: null, criteria: {}, picks: [], selected: null, updated_at: new Date().toISOString() };
+}
+
+const GUIDE_STATE_TYPE = 'marketplace_guide_state';
+
+/** Latest guide-state row for the user, or null if none exists yet. */
+export async function loadGuideState(
+  sb: SupabaseClient,
+  tenantId: string,
+  userId: string,
+): Promise<{ rowId: string; state: GuideState } | null> {
+  try {
+    const { data } = await sb
+      .from('memory_items')
+      .select('id, content_json')
+      .eq('tenant_id', tenantId)
+      .eq('user_id', userId)
+      .eq('content_json->>type', GUIDE_STATE_TYPE)
+      .order('occurred_at', { ascending: false })
+      .limit(1);
+    const row = (data as Array<{ id: string; content_json: Record<string, unknown> }>)?.[0];
+    if (!row) return null;
+    const cj = row.content_json ?? {};
+    const state: GuideState = {
+      goal: typeof cj.goal === 'string' ? cj.goal : '',
+      intent: typeof cj.intent === 'string' ? cj.intent : null,
+      criteria: (cj.criteria as GuideCriteria) ?? {},
+      picks: Array.isArray(cj.picks) ? (cj.picks as GuidePick[]) : [],
+      selected: (cj.selected as GuidePick | null) ?? null,
+      updated_at: typeof cj.updated_at === 'string' ? cj.updated_at : new Date(0).toISOString(),
+    };
+    return { rowId: row.id, state };
+  } catch {
+    return null;
+  }
+}
+
+/** Upsert the guide state: update the existing row or insert the first one. */
+export async function saveGuideState(
+  sb: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  state: GuideState,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const stamped: GuideState = { ...state, updated_at: new Date().toISOString() };
+  const content = `Marketplace guide: ${stamped.goal || 'no goal yet'}`;
+  const contentJson = { type: GUIDE_STATE_TYPE, ...stamped };
+  try {
+    const existing = await loadGuideState(sb, tenantId, userId);
+    if (existing) {
+      const { error } = await sb
+        .from('memory_items')
+        .update({ content, content_json: contentJson, occurred_at: stamped.updated_at })
+        .eq('id', existing.rowId);
+      if (error) return { ok: false, error: error.message };
+      return { ok: true };
+    }
+    const { error } = await sb.from('memory_items').insert({
+      tenant_id: tenantId,
+      user_id: userId,
+      category_key: 'preferences',
+      source: 'system',
+      content,
+      content_json: contentJson,
+      importance: 30,
+      occurred_at: stamped.updated_at,
+    });
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'guide_state_save_failed' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Universal cart staging (mirror of marketplace-discovery-tools.ts)
+// ---------------------------------------------------------------------------
+
+function isNoRowsError(error: unknown): boolean {
+  return (error as { code?: string } | null)?.code === 'PGRST116';
+}
+function isUniqueViolation(error: unknown): boolean {
+  return (error as { code?: string } | null)?.code === '23505';
+}
+
+/**
+ * Get-or-create the caller's ONE active universal cart (same resolution
+ * block as marketplace-discovery-tools.ts / routes/shopping-agent.ts).
+ */
+export async function getOrCreateActiveCart(
+  sb: SupabaseClient,
+  userId: string,
+  tenantId: string | null,
+): Promise<{ ok: true; cartId: string } | { ok: false; error: string }> {
+  const lookup = await sb.from('universal_carts').select('id').eq('user_id', userId).eq('status', 'active').maybeSingle();
+  if (lookup.error && !isNoRowsError(lookup.error)) return { ok: false, error: lookup.error.message };
+  if (lookup.data?.id) return { ok: true, cartId: lookup.data.id as string };
+
+  const created = await sb
+    .from('universal_carts')
+    .insert({ user_id: userId, tenant_id: tenantId, status: 'active', metadata: {} })
+    .select('id')
+    .single();
+  if (created.error && isUniqueViolation(created.error)) {
+    const raced = await sb.from('universal_carts').select('id').eq('user_id', userId).eq('status', 'active').maybeSingle();
+    if (raced.data?.id) return { ok: true, cartId: raced.data.id as string };
+    return { ok: false, error: 'cart_create_failed' };
+  }
+  if (created.error || !created.data?.id) return { ok: false, error: created.error?.message ?? 'cart_create_failed' };
+
+  await emitCartEvent({ cart_id: created.data.id as string, user_id: userId, event_type: 'cart.created', event_payload: {} });
+  return { ok: true, cartId: created.data.id as string };
+}
+
+/**
+ * Stage ONE product into the user's active cart with a voice-origin audit
+ * trail. Payment policy: staging only + /cart screen handoff — this helper
+ * (and everything that calls it) never touches checkout/Stripe/wallet.
+ */
+export async function stageProductInCart(
+  sb: SupabaseClient,
+  id: OrbToolIdentity,
+  product: ProductRow,
+  origin: string,
+  rationale: string,
+): Promise<{ ok: true; itemId: string; cartId: string } | { ok: false; error: string }> {
+  const cartRes = await getOrCreateActiveCart(sb, id.user_id, id.tenant_id);
+  if (!cartRes.ok) return { ok: false, error: cartRes.error };
+  const cartId = cartRes.cartId;
+
+  const itemType = product.category === 'supplements' ? 'supplement' : 'partner_product';
+  const insertPayload: Record<string, unknown> = {
+    cart_id: cartId,
+    item_type: itemType,
+    product_id: product.id,
+    quantity: 1,
+    status: 'active',
+    source_surface: 'voice',
+    metadata: { origin, rationale, vtid: MVA_VTID },
+  };
+  if (product.price_cents !== null) insertPayload.unit_price_cents_snapshot = product.price_cents;
+  if (product.currency !== null) insertPayload.currency_snapshot = product.currency;
+
+  const inserted = await sb.from('universal_cart_items').insert(insertPayload).select('id').single();
+  if (inserted.error || !inserted.data) return { ok: false, error: inserted.error?.message ?? 'item_insert_failed' };
+  const itemId = inserted.data.id as string;
+  await emitCartEvent({
+    cart_id: cartId,
+    user_id: id.user_id,
+    event_type: 'item.added',
+    event_payload: { cart_item_id: itemId, product_id: product.id, quantity_before: 0, quantity_after: 1, source_surface: 'voice' },
+  });
+  return { ok: true, itemId, cartId };
+}
+
+// ---------------------------------------------------------------------------
+// Health-domain boundary — appended to every diagnostics/health-adjacent
+// answer so the model repeats it instead of improvising medical framing.
+// ---------------------------------------------------------------------------
+
+export const HEALTH_BOUNDARY_NOTE =
+  'Remind the user: this does not diagnose any condition or replace medical evaluation — ' +
+  'a qualified professional should interpret health concerns.';

--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-07-13T09:25:47.290Z",
+  "generated_at": "2026-07-20T09:46:17.624Z",
   "source": "reconciled",
-  "total": 594,
+  "total": 683,
   "tools": [
     {
       "name": "search_knowledge",
@@ -10549,6 +10549,1446 @@
       "risk": "read",
       "plan_domain": "C12 Dev Access, Simulator & Meta",
       "plan": "expansion-v2"
+    },
+    {
+      "name": "start_marketplace_discover_assistant",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Start a guided shopping conversation for a product, service, practitioner or diagnostic need; records the goal and returns the first clarifying step",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A17 Marketplace Discover Assistant orchestrators",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "build_personalized_shopping_guide",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Convert a broad need into a concise recommendation path across products and services, grounded in the shopping agent",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A17 Marketplace Discover Assistant orchestrators",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "refine_marketplace_recommendations",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Update the current picks from conversational feedback (cheaper, no pills, at home, different brand)",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A17 Marketplace Discover Assistant orchestrators",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "explain_marketplace_recommendation",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "The concise what-it-is / what-for / why-for-you / limits explanation of a current pick",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A17 Marketplace Discover Assistant orchestrators",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "complete_marketplace_selection",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Confirm the selected option and route it to the basket (two-step confirm; never charges)",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A17 Marketplace Discover Assistant orchestrators",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "capture_shopping_goal",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Record what the user wants to achieve, solve, explore or purchase in the active guide",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "write",
+      "plan_domain": "A18 Shopping intent & preferences",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "clarify_shopping_need",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Return the smallest set of missing criteria (budget, format, urgency, exclusions) still needed",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A18 Shopping intent & preferences",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "classify_marketplace_intent",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Determine whether the need maps to a product, service, diagnostic test, practitioner or combination",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A18 Shopping intent & preferences",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "extract_purchase_criteria",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Extract budget, location, urgency, format, priorities, exclusions and desired outcome from natural language",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A18 Shopping intent & preferences",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "save_marketplace_preferences",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Save reusable shopping preferences (dietary, values, exclusions, budget) with user permission",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A18 Shopping intent & preferences",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "get_marketplace_preferences",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Retrieve saved shopping preferences relevant to the current request",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A18 Shopping intent & preferences",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "reset_marketplace_preferences",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Remove saved marketplace preferences after confirmation",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A18 Shopping intent & preferences",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "exclude_marketplace_brand_or_category",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Persistently exclude a brand or category from future recommendations",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A18 Shopping intent & preferences",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "get_marketplace_context",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Return the minimum relevant user context (saved preferences, budget, recent orders) for the current request",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A19 Personalization & transparency",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "explain_personalization_basis",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Explain in plain language which stored information shaped a recommendation",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A19 Personalization & transparency",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "dismiss_marketplace_recommendation",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Dismiss a recommended product or service so it is not proposed again",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P1",
+      "risk": "write",
+      "plan_domain": "A19 Personalization & transparency",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "show_sponsored_status",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "State whether an item is sponsored, promoted or commission-bearing",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A19 Personalization & transparency",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "explain_no_suitable_option",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Explain honestly when no appropriate marketplace option was found",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A19 Personalization & transparency",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "discover_marketplace_options",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Unified search across products AND services for one stated need",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A20 Unified discovery",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "search_products_by_need",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Search products by purpose and outcome rather than exact product name",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A20 Unified discovery",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "search_services_by_need",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Search services (wellness, nutrition, therapy, labs) by desired outcome",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A20 Unified discovery",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "search_marketplace_by_values",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Filter products by dietary tags, certifications and value preferences",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A20 Unified discovery",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "search_marketplace_alternatives",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Find alternatives to a product the user dislikes or cannot use",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A20 Unified discovery",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "search_marketplace_by_budget",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Find options within a defined total budget across categories",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A20 Unified discovery",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "search_local_services",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Search services available near the user",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A20 Unified discovery",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "search_marketplace_by_availability",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Search by delivery date or appointment availability",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A20 Unified discovery",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "generate_top_marketplace_picks",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Return a small number of best-fit options with short per-pick rationales (never stages the cart silently)",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A21 Guided recommendation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "recommend_marketplace_path",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Recommend whether to start with a product, service, diagnostic or combination for the stated goal",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A21 Guided recommendation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "rerank_marketplace_options",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Re-rank current options when the user changes a priority",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A21 Guided recommendation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "recommend_lower_cost_option",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Find a suitable less expensive alternative to a current pick",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A21 Guided recommendation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "recommend_premium_option",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Find a higher-quality or more comprehensive alternative",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A21 Guided recommendation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "recommend_non_product_alternative",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Suggest a service or non-purchase approach when a product is not the best fit",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A21 Guided recommendation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "recommend_complete_solution",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Build a product-and-service combination that addresses one broader goal",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A21 Guided recommendation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "explain_why_recommended",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Explain why the assistant selected this option for this user, from the recorded rationale",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A22 Concise explanation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "summarize_product_for_user",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Personalized short summary: what it is, what for, why it may fit, key limits — never the full spec",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A22 Concise explanation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "get_key_product_facts",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Only the most important facts: price, form, usage, availability, safety notes",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A22 Concise explanation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "explain_how_to_use_product",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Practical use instructions (dosage, serving) without overwhelming detail",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A22 Concise explanation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "explain_relevant_limitations",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Surface only the limitations relevant to this user",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A22 Concise explanation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "explain_evidence_summary",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Concise description of evidence strength and uncertainty for a product or service claim",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A22 Concise explanation",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "compare_marketplace_options",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Compare up to three options on the criteria that matter to this user",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A23 Comparison & shortlist",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "highlight_meaningful_differences",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Explain only the differences likely to affect the user's choice",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A23 Comparison & shortlist",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "identify_best_value_option",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Determine the strongest value for the user's needs, not just the lowest price",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A23 Comparison & shortlist",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "answer_product_question",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Answer one focused question about one product",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A23 Comparison & shortlist",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "shortlist_marketplace_options",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Save products to the user's shortlist for later comparison",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A23 Comparison & shortlist",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "view_marketplace_shortlist",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Read the current shortlist aloud",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A23 Comparison & shortlist",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "remove_from_marketplace_shortlist",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Remove an option from the shortlist",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A23 Comparison & shortlist",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "browse_diagnostic_tests",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Browse diagnostic services by type: blood, metabolomics, microbiome, genomics, hormones, longevity panels",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "find_test_by_health_goal",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Find diagnostic categories matching a stated goal without diagnosing",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "find_test_by_biomarker",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Search tests containing a named biomarker",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "get_test_details",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Biomarker list, sample method, preparation and result timeline for one test",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "check_home_collection_availability",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Check whether home sample collection is available for a test",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "order_home_test_kit",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Stage an eligible home test kit into the basket after confirmation",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "book_lab_appointment",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Book a laboratory or sample-collection appointment",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "get_ordered_test_status",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Track kit shipment, sample receipt, processing and result readiness",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "prepare_for_diagnostic_service",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Concise preparation checklist (fasting, timing, medication questions for a professional)",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "recommend_diagnostic_test",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Recommend suitable diagnostic categories for a stated information need, never a diagnosis",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A24 Diagnostics & health services",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "find_practitioner_by_specialty",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Find practitioners by specialty, goal and user preferences",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A25 Practitioner selection",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "get_practitioner_credentials",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Relevant qualifications and verification status",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A25 Practitioner selection",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "get_practitioner_availability",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Open appointment slots",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A25 Practitioner selection",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "get_practitioner_pricing",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Session and package pricing",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A25 Practitioner selection",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "compare_practitioners_for_user",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Compare a practitioner shortlist on the user's priorities",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A25 Practitioner selection",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "book_practitioner_appointment",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Book an available appointment after confirmation",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "confirm",
+      "plan_domain": "A25 Practitioner selection",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "build_marketplace_solution_plan",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Concise multi-step product and service plan for one goal",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A26 Bundles & plans",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "create_diagnostic_and_consultation_bundle",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Pair a diagnostic service with suitable result interpretation",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A26 Bundles & plans",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "check_bundle_compatibility",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Check whether bundle components logically work together, without duplication",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A26 Bundles & plans",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "add_bundle_to_cart",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Stage all purchasable bundle items into the basket after confirmation",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "A26 Bundles & plans",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "save_marketplace_plan",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Save a marketplace plan to resume later",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A26 Bundles & plans",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "check_product_suitability",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Check one product against saved preferences, exclusions and dietary needs",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A27 Suitability & compatibility",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "check_dietary_compatibility",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Check vegan, vegetarian, gluten-free or other dietary requirements for a product",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A27 Suitability & compatibility",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "check_cart_duplication",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Detect repeated or overlapping products in the basket",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A27 Suitability & compatibility",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "check_delivery_restrictions",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Check country and shipping limitations for a product",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A27 Suitability & compatibility",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "check_test_overlap",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Identify duplicated biomarkers across diagnostic packages",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A27 Suitability & compatibility",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "check_service_prerequisites",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Identify referrals, preparation or eligibility requirements for a service",
+      "wired_in": [],
+      "priority": "P1",
+      "risk": "read",
+      "plan_domain": "A27 Suitability & compatibility",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "compare_marketplace_prices",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Compare prices of equivalent options including reference prices",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A28 Pricing & value",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "explain_price_difference",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Explain why two similar options are priced differently",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A28 Pricing & value",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "review_shopping_budget",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Read the monthly shopping budget, current spend and remaining headroom",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A28 Pricing & value",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "estimate_total_ownership_cost",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Show recurring or long-term cost rather than only the initial price",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A28 Pricing & value",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "confirm_marketplace_selection",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Read back the exact selected option (name, price, key terms) and obtain explicit confirmation before any cart action",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A29 Cart confirmation & checkout handoff",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "add_selected_option_to_cart",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Stage the confirmed option into the universal basket (never charges; screen handoff for payment)",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A29 Cart confirmation & checkout handoff",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "add_shortlist_item_to_cart",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Stage an item from the shortlist into the basket after confirmation",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "confirm",
+      "plan_domain": "A29 Cart confirmation & checkout handoff",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "review_cart_suitability",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Check duplicates and conflicts with saved preferences before checkout",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A29 Cart confirmation & checkout handoff",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "explain_cart_item",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "description": "Explain why a specific basket item is there (origin, rationale)",
+      "wired_in": [
+        "livekit",
+        "vertex"
+      ],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A29 Cart confirmation & checkout handoff",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "confirm_cart_total",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Read back total price and any recurring charges before the screen handoff",
+      "wired_in": [],
+      "priority": "P0",
+      "risk": "read",
+      "plan_domain": "A29 Cart confirmation & checkout handoff",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "get_next_order_action",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Tell the user the next required step for an order (delivery, sample, appointment)",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "read",
+      "plan_domain": "A30 Post-purchase & follow-up",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "submit_marketplace_review",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Record the user's rating of a purchased product or service after confirmation",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "A30 Post-purchase & follow-up",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "schedule_reorder_reminder",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Schedule an optional reorder reminder",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A30 Post-purchase & follow-up",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "start_return_request",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Start a return process for an eligible order",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A30 Post-purchase & follow-up",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "cancel_marketplace_order",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Cancel an eligible order after confirmation",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "confirm",
+      "plan_domain": "A30 Post-purchase & follow-up",
+      "plan": "marketplace-va-v3"
+    },
+    {
+      "name": "report_marketplace_issue",
+      "surface": "Marketplace",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "description": "Report an order, product or service problem",
+      "wired_in": [],
+      "priority": "P2",
+      "risk": "write",
+      "plan_domain": "A30 Post-purchase & follow-up",
+      "plan": "marketplace-va-v3"
     }
   ]
 }

--- a/services/gateway/test/orb-tools/marketplace-guide-tools.test.ts
+++ b/services/gateway/test/orb-tools/marketplace-guide-tools.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Marketplace Voice Assistant — guide tools (Wave MVA-1, plan sections
+ * A17–A19) — unit tests.
+ *
+ * Cross-module backings are mocked (universal-cart emitCartEvent,
+ * memory-facts writeFact, shopping-agent runPropose, health context, spend
+ * service); table reads/writes go through the same chainable fake
+ * SupabaseClient the discovery-tools tests use (per-table FIFO queues).
+ *
+ * Covered: exports/declarations parity, unauthenticated gates, goal capture
+ * + intent classification, preference save/read/reset supersession-clear
+ * semantics, and the two-step confirm on complete_marketplace_selection
+ * (read-back first, cart staged only with confirm:true, never any payment).
+ */
+
+jest.mock('../../src/routes/universal-cart', () => ({
+  emitCartEvent: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../src/services/memory-facts-service', () => ({
+  writeFact: jest.fn().mockResolvedValue({ ok: true, fact_id: 'f-1' }),
+}));
+jest.mock('../../src/services/user-health-context', () => ({
+  getUserHealthContext: jest.fn().mockResolvedValue({
+    stale: true,
+    active_goals: [],
+    active_conditions: [],
+    allergies: [],
+    dietary_restrictions: [],
+    current_medications: [],
+    currency: 'EUR',
+  }),
+}));
+jest.mock('../../src/services/budget/spend-service', () => ({
+  getMonthlySpend: jest.fn().mockResolvedValue(0),
+}));
+jest.mock('../../src/services/shopping-agent/agent-core', () => ({
+  runPropose: jest.fn().mockResolvedValue({ ok: false, error: 'llm_unavailable' }),
+}));
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { emitCartEvent } from '../../src/routes/universal-cart';
+import { writeFact } from '../../src/services/memory-facts-service';
+import {
+  MARKETPLACE_GUIDE_TOOL_HANDLERS,
+  MARKETPLACE_GUIDE_TOOL_DECLARATIONS,
+  classifyIntent,
+  tool_capture_shopping_goal,
+  tool_classify_marketplace_intent,
+  tool_save_marketplace_preferences,
+  tool_get_marketplace_preferences,
+  tool_reset_marketplace_preferences,
+  tool_complete_marketplace_selection,
+  tool_clarify_shopping_need,
+} from '../../src/services/orb-tools/marketplace-guide-tools';
+
+const IDENT = { user_id: 'u-1', tenant_id: 't-1', role: 'community' };
+const ANON = { user_id: '', tenant_id: null, role: null };
+
+const PRODUCT_UUID = '11111111-2222-3333-4444-555555555555';
+
+type QResult = { data: unknown; error: { message: string } | null };
+
+function makeSb(queues: Record<string, QResult[]> = {}) {
+  const log: Array<{ table: string; method: string; args: unknown[] }> = [];
+  const from = jest.fn((table: string) => {
+    const q = queues[table];
+    const result: QResult = q && q.length > 0 ? q.shift()! : { data: [], error: null };
+    const builder: Record<string, unknown> = {};
+    for (const m of [
+      'select', 'eq', 'neq', 'in', 'is', 'or', 'ilike', 'gte', 'lte', 'lt',
+      'order', 'limit', 'contains', 'update', 'insert', 'upsert', 'delete', 'not', 'textSearch',
+    ]) {
+      builder[m] = jest.fn((...args: unknown[]) => {
+        log.push({ table, method: m, args });
+        return builder;
+      });
+    }
+    builder.maybeSingle = jest.fn(async () => result);
+    builder.single = jest.fn(async () => result);
+    (builder as { then: unknown }).then = (
+      resolve: (v: QResult) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => Promise.resolve(result).then(resolve, reject);
+    return builder;
+  });
+  return { sb: { from } as unknown as SupabaseClient, from, log };
+}
+
+const guideStateRow = (state: Record<string, unknown>): QResult => ({
+  data: [{ id: 'mi-1', content_json: { type: 'marketplace_guide_state', ...state } }],
+  error: null,
+});
+
+const productRow = (over: Record<string, unknown> = {}): QResult => ({
+  data: {
+    id: PRODUCT_UUID,
+    title: 'Sleep Tea',
+    description: 'A calming evening tea.',
+    brand: 'Maxina',
+    category: 'supplements',
+    subcategory: null,
+    price_cents: 1999,
+    currency: 'EUR',
+    compare_at_price_cents: null,
+    rating: 4.6,
+    review_count: 12,
+    availability: 'in_stock',
+    dietary_tags: ['vegan'],
+    health_goals: null,
+    ingredients_primary: null,
+    contains_allergens: null,
+    ships_to_countries: null,
+    dosage: 'one cup before bed',
+    serving_size: null,
+    servings_per_container: 20,
+    safety_notes: 'Not for pregnancy.',
+    ...over,
+  },
+  error: null,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (writeFact as jest.Mock).mockResolvedValue({ ok: true, fact_id: 'f-1' });
+});
+
+describe('marketplace guide tools — exports', () => {
+  const NAMES = [
+    'start_marketplace_discover_assistant',
+    'build_personalized_shopping_guide',
+    'refine_marketplace_recommendations',
+    'explain_marketplace_recommendation',
+    'complete_marketplace_selection',
+    'capture_shopping_goal',
+    'clarify_shopping_need',
+    'classify_marketplace_intent',
+    'save_marketplace_preferences',
+    'get_marketplace_preferences',
+    'reset_marketplace_preferences',
+    'get_marketplace_context',
+    'dismiss_marketplace_recommendation',
+  ];
+
+  it('exposes all 13 tools with matching declarations', () => {
+    expect(Object.keys(MARKETPLACE_GUIDE_TOOL_HANDLERS).sort()).toEqual([...NAMES].sort());
+    const declNames = MARKETPLACE_GUIDE_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of NAMES) expect(declNames).toContain(n);
+    expect(declNames).toHaveLength(NAMES.length);
+  });
+
+  it.each(Object.keys(MARKETPLACE_GUIDE_TOOL_HANDLERS))('%s denies unauthenticated callers', async (name) => {
+    const r = await MARKETPLACE_GUIDE_TOOL_HANDLERS[name]({}, ANON, makeSb().sb);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('classifyIntent', () => {
+  it('routes diagnostic vocabulary to diagnostic_test', () => {
+    expect(classifyIntent('I want a blood test for my energy').intent).toBe('diagnostic_test');
+  });
+  it('routes practitioner vocabulary to practitioner', () => {
+    expect(classifyIntent('find me a sleep coach').intent).toBe('practitioner');
+  });
+  it('defaults to product', () => {
+    expect(classifyIntent('something for better sleep').intent).toBe('product');
+  });
+  it('mixed diagnostic + practitioner → combination', () => {
+    expect(classifyIntent('a blood test and a doctor to explain it').intent).toBe('combination');
+  });
+});
+
+describe('capture_shopping_goal', () => {
+  it('requires a goal', async () => {
+    const r = await tool_capture_shopping_goal({}, IDENT, makeSb().sb);
+    expect(r.ok).toBe(false);
+  });
+
+  it('records the goal with classified intent and clears stale picks', async () => {
+    const { sb, log } = makeSb({
+      // loadGuideState (existing state with old picks) → save: load again + update
+      memory_items: [
+        guideStateRow({ goal: 'old', picks: [{ kind: 'product', id: 'x', title: 'Old', price_cents: 1, currency: 'EUR', rationale: 'r' }] }),
+        guideStateRow({ goal: 'old' }),
+        { data: null, error: null },
+      ],
+    });
+    const r = await tool_capture_shopping_goal({ goal: 'improve my sleep', budget_max_amount: 100 }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('improve my sleep');
+    const update = log.find((l) => l.table === 'memory_items' && l.method === 'update');
+    expect(update).toBeDefined();
+    const payload = (update!.args[0] as { content_json: { picks: unknown[]; criteria: { budget_max_cents: number } } }).content_json;
+    expect(payload.picks).toEqual([]);
+    expect(payload.criteria.budget_max_cents).toBe(10000);
+  });
+});
+
+describe('classify_marketplace_intent', () => {
+  it('classifies an explicit need without touching state', async () => {
+    const r = await tool_classify_marketplace_intent({ need: 'metabolomics panel' }, IDENT, makeSb().sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { intent: string } }).result.intent).toBe('diagnostic_test');
+  });
+
+  it('fails honestly when no need and no recorded goal', async () => {
+    const r = await tool_classify_marketplace_intent({}, IDENT, makeSb().sb);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('clarify_shopping_need', () => {
+  it('asks for the goal first when none is recorded', async () => {
+    const r = await tool_clarify_shopping_need({}, IDENT, makeSb().sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { has_goal: boolean } }).result.has_goal).toBe(false);
+  });
+
+  it('lists missing criteria for a recorded goal', async () => {
+    const { sb } = makeSb({ memory_items: [guideStateRow({ goal: 'better sleep', criteria: {} })] });
+    const r = await tool_clarify_shopping_need({}, IDENT, sb);
+    expect(r.ok).toBe(true);
+    const missing = (r as { result: { missing_criteria: string[] } }).result.missing_criteria;
+    expect(missing).toContain('budget');
+  });
+});
+
+describe('save_marketplace_preferences', () => {
+  it('requires at least one preference field', async () => {
+    const r = await tool_save_marketplace_preferences({}, IDENT, makeSb().sb);
+    expect(r.ok).toBe(false);
+  });
+
+  it('writes each stated preference as a marketplace_pref_* fact', async () => {
+    const r = await tool_save_marketplace_preferences(
+      { dietary: 'vegan, gluten-free', budget_monthly_amount: 150 },
+      IDENT,
+      makeSb().sb,
+    );
+    expect(r.ok).toBe(true);
+    const keys = (writeFact as jest.Mock).mock.calls.map((c) => c[0].fact_key);
+    expect(keys).toContain('marketplace_pref_dietary');
+    expect(keys).toContain('marketplace_pref_budget_monthly_cents');
+    const budgetCall = (writeFact as jest.Mock).mock.calls.find((c) => c[0].fact_key === 'marketplace_pref_budget_monthly_cents');
+    expect(budgetCall[0].fact_value).toBe('15000');
+    expect(budgetCall[0].provenance_source).toBe('user_stated');
+  });
+});
+
+describe('get_marketplace_preferences', () => {
+  it('reads current facts into a speakable summary', async () => {
+    const { sb } = makeSb({
+      memory_facts: [{ data: [{ fact_key: 'marketplace_pref_dietary', fact_value: 'vegan' }], error: null }],
+    });
+    const r = await tool_get_marketplace_preferences({}, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('vegan');
+  });
+});
+
+describe('reset_marketplace_preferences', () => {
+  const factsQueue = (): QResult[] => [
+    { data: [{ fact_key: 'marketplace_pref_dietary', fact_value: 'vegan' }], error: null },
+  ];
+
+  it('is a no-op when nothing is saved', async () => {
+    const r = await tool_reset_marketplace_preferences({}, IDENT, makeSb().sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { reset: boolean } }).result.reset).toBe(false);
+    expect(writeFact).not.toHaveBeenCalled();
+  });
+
+  it('reads back what would be cleared before confirm', async () => {
+    const { sb } = makeSb({ memory_facts: factsQueue() });
+    const r = await tool_reset_marketplace_preferences({}, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { needs_confirmation: boolean } }).result.needs_confirmation).toBe(true);
+    expect(writeFact).not.toHaveBeenCalled();
+  });
+
+  it('clears via empty-value supersession with confirm:true', async () => {
+    const { sb } = makeSb({ memory_facts: factsQueue() });
+    const r = await tool_reset_marketplace_preferences({ confirm: true }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { reset: boolean } }).result.reset).toBe(true);
+    expect(writeFact).toHaveBeenCalledWith(expect.objectContaining({ fact_key: 'marketplace_pref_dietary', fact_value: '' }));
+  });
+});
+
+describe('complete_marketplace_selection (two-step confirm)', () => {
+  const stateWithPick = () =>
+    guideStateRow({
+      goal: 'better sleep',
+      picks: [{ kind: 'product', id: PRODUCT_UUID, title: 'Sleep Tea', price_cents: 1999, currency: 'EUR', rationale: 'fits the sleep goal' }],
+    });
+
+  it('errors when there is nothing selected', async () => {
+    const r = await tool_complete_marketplace_selection({}, IDENT, makeSb().sb);
+    expect(r.ok).toBe(false);
+  });
+
+  it('reads back name + price and does NOT touch the cart without confirm', async () => {
+    const { sb, log } = makeSb({
+      memory_items: [stateWithPick(), stateWithPick(), { data: null, error: null }],
+      products: [productRow()],
+    });
+    const r = await tool_complete_marketplace_selection({ position: 1 }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { needs_confirmation: boolean } }).result.needs_confirmation).toBe(true);
+    expect((r as { text: string }).text).toContain('Sleep Tea');
+    expect(log.filter((l) => l.table === 'universal_cart_items')).toHaveLength(0);
+    expect(emitCartEvent).not.toHaveBeenCalled();
+  });
+
+  it('stages the cart (with audit event) only with confirm:true — never payment', async () => {
+    const { sb, log } = makeSb({
+      memory_items: [stateWithPick(), stateWithPick(), { data: null, error: null }],
+      products: [productRow()],
+      universal_carts: [
+        { data: null, error: null },
+        { data: { id: 'cart-1' }, error: null },
+      ],
+      universal_cart_items: [{ data: { id: 'item-1' }, error: null }],
+    });
+    const r = await tool_complete_marketplace_selection({ position: 1, confirm: true }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { added: boolean } }).result.added).toBe(true);
+    const insert = log.find((l) => l.table === 'universal_cart_items' && l.method === 'insert');
+    expect(insert).toBeDefined();
+    const payload = insert!.args[0] as { source_surface: string; metadata: { origin: string } };
+    expect(payload.source_surface).toBe('voice');
+    expect(payload.metadata.origin).toBe('discover_assistant');
+    expect(emitCartEvent).toHaveBeenCalledWith(expect.objectContaining({ event_type: 'item.added' }));
+    expect((r as { text: string }).text).toContain('nothing has been charged');
+  });
+});

--- a/services/gateway/test/orb-tools/marketplace-journey-tools.test.ts
+++ b/services/gateway/test/orb-tools/marketplace-journey-tools.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Marketplace Voice Assistant — journey tools (Wave MVA-1, plan sections
+ * A20–A29) — unit tests.
+ *
+ * Same mock discipline as marketplace-guide-tools.test.ts: cross-module
+ * backings mocked, table access through the chainable FIFO SupabaseClient
+ * fake. Covered: exports/declarations parity, unauthenticated gates,
+ * need-driven search with saved-preference exclusions, propose-only picks
+ * (runPropose degraded → deterministic fallback, nothing staged), path
+ * recommendation, shortlist CRUD on shop_saved_products, suitability
+ * honesty (conflicts vs could-not-verify), budget review, and the two-step
+ * confirm on add_selected_option_to_cart.
+ */
+
+jest.mock('../../src/routes/universal-cart', () => ({
+  emitCartEvent: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../src/services/memory-facts-service', () => ({
+  writeFact: jest.fn().mockResolvedValue({ ok: true, fact_id: 'f-1' }),
+}));
+jest.mock('../../src/services/user-health-context', () => ({
+  getUserHealthContext: jest.fn().mockResolvedValue({
+    stale: true,
+    active_goals: [],
+    active_conditions: [],
+    allergies: [],
+    dietary_restrictions: [],
+    current_medications: [],
+    currency: 'EUR',
+  }),
+}));
+jest.mock('../../src/services/budget/spend-service', () => ({
+  getMonthlySpend: jest.fn().mockResolvedValue(5000),
+}));
+jest.mock('../../src/services/shopping-agent/agent-core', () => ({
+  runPropose: jest.fn().mockResolvedValue({ ok: false, error: 'llm_unavailable' }),
+}));
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { emitCartEvent } from '../../src/routes/universal-cart';
+import { runPropose } from '../../src/services/shopping-agent/agent-core';
+import {
+  MARKETPLACE_JOURNEY_TOOL_HANDLERS,
+  MARKETPLACE_JOURNEY_TOOL_DECLARATIONS,
+  tool_discover_marketplace_options,
+  tool_search_products_by_need,
+  tool_search_marketplace_by_values,
+  tool_generate_top_marketplace_picks,
+  tool_recommend_marketplace_path,
+  tool_shortlist_marketplace_options,
+  tool_view_marketplace_shortlist,
+  tool_remove_from_marketplace_shortlist,
+  tool_check_product_suitability,
+  tool_review_shopping_budget,
+  tool_add_selected_option_to_cart,
+  tool_explain_why_recommended,
+} from '../../src/services/orb-tools/marketplace-journey-tools';
+
+const IDENT = { user_id: 'u-1', tenant_id: 't-1', role: 'community' };
+const ANON = { user_id: '', tenant_id: null, role: null };
+
+const PRODUCT_UUID = '11111111-2222-3333-4444-555555555555';
+
+type QResult = { data: unknown; error: { message: string } | null };
+
+function makeSb(queues: Record<string, QResult[]> = {}) {
+  const log: Array<{ table: string; method: string; args: unknown[] }> = [];
+  const from = jest.fn((table: string) => {
+    const q = queues[table];
+    const result: QResult = q && q.length > 0 ? q.shift()! : { data: [], error: null };
+    const builder: Record<string, unknown> = {};
+    for (const m of [
+      'select', 'eq', 'neq', 'in', 'is', 'or', 'ilike', 'gte', 'lte', 'lt',
+      'order', 'limit', 'contains', 'update', 'insert', 'upsert', 'delete', 'not', 'textSearch',
+    ]) {
+      builder[m] = jest.fn((...args: unknown[]) => {
+        log.push({ table, method: m, args });
+        return builder;
+      });
+    }
+    builder.maybeSingle = jest.fn(async () => result);
+    builder.single = jest.fn(async () => result);
+    (builder as { then: unknown }).then = (
+      resolve: (v: QResult) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => Promise.resolve(result).then(resolve, reject);
+    return builder;
+  });
+  return { sb: { from } as unknown as SupabaseClient, from, log };
+}
+
+const product = (over: Record<string, unknown> = {}) => ({
+  id: PRODUCT_UUID,
+  title: 'Sleep Tea',
+  description: 'A calming evening tea.',
+  brand: 'Maxina',
+  category: 'supplements',
+  subcategory: null,
+  price_cents: 1999,
+  currency: 'EUR',
+  compare_at_price_cents: null,
+  rating: 4.6,
+  review_count: 12,
+  availability: 'in_stock',
+  dietary_tags: ['vegan'],
+  health_goals: null,
+  ingredients_primary: null,
+  contains_allergens: null,
+  ships_to_countries: null,
+  dosage: 'one cup before bed',
+  serving_size: null,
+  servings_per_container: 20,
+  safety_notes: 'Not for pregnancy.',
+  ...over,
+});
+
+const guideStateRow = (state: Record<string, unknown>): QResult => ({
+  data: [{ id: 'mi-1', content_json: { type: 'marketplace_guide_state', ...state } }],
+  error: null,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (runPropose as jest.Mock).mockResolvedValue({ ok: false, error: 'llm_unavailable' });
+});
+
+describe('marketplace journey tools — exports', () => {
+  const NAMES = [
+    'discover_marketplace_options',
+    'search_products_by_need',
+    'search_services_by_need',
+    'search_marketplace_by_values',
+    'search_marketplace_alternatives',
+    'generate_top_marketplace_picks',
+    'recommend_marketplace_path',
+    'recommend_lower_cost_option',
+    'explain_why_recommended',
+    'summarize_product_for_user',
+    'get_key_product_facts',
+    'compare_marketplace_options',
+    'shortlist_marketplace_options',
+    'view_marketplace_shortlist',
+    'remove_from_marketplace_shortlist',
+    'check_product_suitability',
+    'check_cart_duplication',
+    'review_shopping_budget',
+    'confirm_marketplace_selection',
+    'add_selected_option_to_cart',
+    'review_cart_suitability',
+    'explain_cart_item',
+  ];
+
+  it('exposes all 22 tools with matching declarations', () => {
+    expect(Object.keys(MARKETPLACE_JOURNEY_TOOL_HANDLERS).sort()).toEqual([...NAMES].sort());
+    const declNames = MARKETPLACE_JOURNEY_TOOL_DECLARATIONS.map((d) => d.name);
+    for (const n of NAMES) expect(declNames).toContain(n);
+    expect(declNames).toHaveLength(NAMES.length);
+  });
+
+  it.each(Object.keys(MARKETPLACE_JOURNEY_TOOL_HANDLERS))('%s denies unauthenticated callers', async (name) => {
+    const r = await MARKETPLACE_JOURNEY_TOOL_HANDLERS[name]({}, ANON, makeSb().sb);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('discover_marketplace_options', () => {
+  it('requires a need', async () => {
+    const r = await tool_discover_marketplace_options({}, IDENT, makeSb().sb);
+    expect(r.ok).toBe(false);
+  });
+
+  it('merges products and services into one option list', async () => {
+    const { sb } = makeSb({
+      products: [{ data: [product()], error: null }],
+      services_catalog: [
+        { data: [{ id: 's-1', name: 'Sleep Coaching', service_type: 'coach', provider_name: 'Dr. A', topic_keys: null, metadata: null }], error: null },
+      ],
+    });
+    const r = await tool_discover_marketplace_options({ need: 'better sleep' }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    const options = (r as { result: { options: Array<{ kind: string }> } }).result.options;
+    expect(options.some((o) => o.kind === 'product')).toBe(true);
+    expect(options.some((o) => o.kind === 'service')).toBe(true);
+  });
+
+  it('is honest when nothing matches', async () => {
+    const { sb } = makeSb({ products: [{ data: [], error: null }, { data: [], error: null }] });
+    const r = await tool_discover_marketplace_options({ need: 'xyzzy' }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('honestly');
+  });
+});
+
+describe('search_products_by_need — saved exclusions apply', () => {
+  it('filters excluded brands and reports the drop', async () => {
+    const { sb } = makeSb({
+      memory_facts: [
+        { data: [{ fact_key: 'marketplace_pref_excluded_brands', fact_value: 'Maxina' }], error: null },
+      ],
+      products: [{ data: [product()], error: null }, { data: [product()], error: null }],
+    });
+    const r = await tool_search_products_by_need({ need: 'sleep tea' }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    const res = r as { result: { items: unknown[]; dropped: Array<{ reason: string }> } };
+    expect(res.result.items).toHaveLength(0);
+    expect(res.result.dropped[0].reason).toContain('Maxina');
+  });
+});
+
+describe('search_marketplace_by_values', () => {
+  it('requires a dietary tag or certification', async () => {
+    const r = await tool_search_marketplace_by_values({ need: 'sleep' }, IDENT, makeSb().sb);
+    expect(r.ok).toBe(false);
+  });
+
+  it('returns declared matches only', async () => {
+    const { sb } = makeSb({ products: [{ data: [product()], error: null }] });
+    const r = await tool_search_marketplace_by_values({ dietary_tags: 'vegan' }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('Sleep Tea');
+  });
+});
+
+describe('generate_top_marketplace_picks (propose-only)', () => {
+  it('falls back to deterministic search when the agent LLM is unavailable and stages nothing', async () => {
+    const { sb, log } = makeSb({
+      products: [{ data: [product()], error: null }],
+      memory_items: [{ data: [], error: null }, { data: [], error: null }],
+    });
+    const r = await tool_generate_top_marketplace_picks({ prompt: 'better sleep' }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    const picks = (r as { result: { picks: Array<{ title: string }> } }).result.picks;
+    expect(picks[0].title).toBe('Sleep Tea');
+    expect((r as { text: string }).text).toContain('nothing added to the cart');
+    expect(log.filter((l) => l.table === 'universal_cart_items')).toHaveLength(0);
+    expect(emitCartEvent).not.toHaveBeenCalled();
+  });
+
+  it('uses collect-only picks from runPropose when the agent is available', async () => {
+    (runPropose as jest.Mock).mockImplementation(async ({ insertPick }) => {
+      await insertPick(
+        {
+          product_id: PRODUCT_UUID,
+          title: 'Agent Pick',
+          rationale: 'matches the stated goal',
+          safety_flags: [],
+          confidence: 0.8,
+          item_type: 'supplement',
+          unit_price_cents_snapshot: 999,
+          currency_snapshot: 'EUR',
+        },
+        'run-1',
+        new Date().toISOString(),
+      );
+      return { ok: true, run_id: 'run-1', proposed: [], advisory: [] };
+    });
+    const { sb, log } = makeSb({ memory_items: [{ data: [], error: null }, { data: [], error: null }] });
+    const r = await tool_generate_top_marketplace_picks({ prompt: 'better sleep' }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    const picks = (r as { result: { picks: Array<{ title: string; rationale: string }> } }).result.picks;
+    expect(picks[0].title).toBe('Agent Pick');
+    expect(picks[0].rationale).toBe('matches the stated goal');
+    expect(log.filter((l) => l.table === 'universal_cart_items')).toHaveLength(0);
+  });
+});
+
+describe('recommend_marketplace_path', () => {
+  it('recommends assessment-first for understanding-type goals with the health boundary', async () => {
+    const r = await tool_recommend_marketplace_path({ goal: 'I want to understand why I am always tired' }, IDENT, makeSb().sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { path: string } }).result.path).toBe('assessment_first');
+    expect((r as { text: string }).text).toContain('does not diagnose');
+  });
+
+  it('recommends product-first for plain product goals', async () => {
+    const r = await tool_recommend_marketplace_path({ goal: 'a good vitamin d supplement' }, IDENT, makeSb().sb);
+    expect((r as { result: { path: string } }).result.path).toBe('product_first');
+  });
+});
+
+describe('shortlist (shop_saved_products)', () => {
+  it('saves a resolved product once', async () => {
+    const { sb, log } = makeSb({
+      memory_items: [{ data: [], error: null }],
+      products: [{ data: product(), error: null }],
+      shop_saved_products: [
+        { data: null, error: null },
+        { data: { id: 'sp-1' }, error: null },
+      ],
+    });
+    const r = await tool_shortlist_marketplace_options({ product_id: PRODUCT_UUID }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    const insert = log.find((l) => l.table === 'shop_saved_products' && l.method === 'insert');
+    expect(insert!.args[0]).toEqual({ user_id: 'u-1', product_id: PRODUCT_UUID });
+  });
+
+  it('reads the shortlist with product titles', async () => {
+    const { sb } = makeSb({
+      shop_saved_products: [{ data: [{ product_id: PRODUCT_UUID }], error: null }],
+      products: [{ data: [product()], error: null }],
+    });
+    const r = await tool_view_marketplace_shortlist({}, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('Sleep Tea');
+  });
+
+  it('reports honestly when removing something that was not shortlisted', async () => {
+    const { sb } = makeSb({
+      memory_items: [{ data: [], error: null }],
+      products: [{ data: product(), error: null }],
+      shop_saved_products: [{ data: [], error: null }],
+    });
+    const r = await tool_remove_from_marketplace_shortlist({ product_id: PRODUCT_UUID }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { removed: boolean } }).result.removed).toBe(false);
+  });
+});
+
+describe('check_product_suitability — declared data only', () => {
+  it('reports conflicts against saved exclusions', async () => {
+    const { sb } = makeSb({
+      memory_items: [{ data: [], error: null }],
+      products: [{ data: product(), error: null }],
+      memory_facts: [
+        { data: [{ fact_key: 'marketplace_pref_excluded_brands', fact_value: 'Maxina' }], error: null },
+      ],
+    });
+    const r = await tool_check_product_suitability({ product_id: PRODUCT_UUID }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { verdict: string } }).result.verdict).toBe('conflicts_found');
+  });
+
+  it('says what could NOT be verified instead of guessing', async () => {
+    const { sb } = makeSb({
+      memory_items: [{ data: [], error: null }],
+      products: [{ data: product({ dietary_tags: null }), error: null }],
+      memory_facts: [{ data: [{ fact_key: 'marketplace_pref_dietary', fact_value: 'vegan' }], error: null }],
+    });
+    const r = await tool_check_product_suitability({ product_id: PRODUCT_UUID }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    const res = r as { result: { unchecked: string[] }; text: string };
+    expect(res.result.unchecked.length).toBeGreaterThan(0);
+    expect(res.text).toContain('Could NOT verify');
+  });
+});
+
+describe('review_shopping_budget', () => {
+  it('reports cap, spend, remaining and cart total', async () => {
+    const { sb } = makeSb({
+      user_limitations: [{ data: { budget_monthly_cap_cents: 20000 }, error: null }],
+      universal_carts: [{ data: { id: 'cart-1' }, error: null }],
+      universal_cart_items: [
+        { data: [{ id: 'i1', product_id: PRODUCT_UUID, item_type: 'supplement', quantity: 2, status: 'active', unit_price_cents_snapshot: 1999, currency_snapshot: 'EUR', metadata: {} }], error: null },
+      ],
+    });
+    const r = await tool_review_shopping_budget({}, IDENT, sb);
+    expect(r.ok).toBe(true);
+    const res = (r as { result: { remaining_cents: number; cart_total_cents: number } }).result;
+    expect(res.remaining_cents).toBe(15000);
+    expect(res.cart_total_cents).toBe(3998);
+  });
+});
+
+describe('add_selected_option_to_cart (two-step confirm)', () => {
+  it('reads back and does not stage without confirm', async () => {
+    const { sb, log } = makeSb({
+      memory_items: [{ data: [], error: null }],
+      products: [{ data: product(), error: null }],
+    });
+    const r = await tool_add_selected_option_to_cart({ product_id: PRODUCT_UUID }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { needs_confirmation: boolean } }).result.needs_confirmation).toBe(true);
+    expect(log.filter((l) => l.table === 'universal_cart_items')).toHaveLength(0);
+  });
+
+  it('stages with confirm:true and hands payment off to the screen', async () => {
+    const { sb } = makeSb({
+      memory_items: [{ data: [], error: null }],
+      products: [{ data: product(), error: null }],
+      universal_carts: [
+        { data: null, error: null },
+        { data: { id: 'cart-1' }, error: null },
+      ],
+      universal_cart_items: [{ data: { id: 'item-1' }, error: null }],
+    });
+    const r = await tool_add_selected_option_to_cart({ product_id: PRODUCT_UUID, confirm: true }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { added: boolean } }).result.added).toBe(true);
+    expect(emitCartEvent).toHaveBeenCalledWith(expect.objectContaining({ event_type: 'item.added' }));
+    expect((r as { text: string }).text).toContain('nothing has been charged');
+  });
+});
+
+describe('explain_why_recommended — recorded rationale only', () => {
+  it('cites the recorded pick rationale', async () => {
+    const { sb } = makeSb({
+      memory_items: [
+        guideStateRow({
+          goal: 'sleep',
+          picks: [{ kind: 'product', id: PRODUCT_UUID, title: 'Sleep Tea', price_cents: 1999, currency: 'EUR', rationale: 'you asked for a non-pill option' }],
+        }),
+      ],
+      products: [{ data: product(), error: null }],
+    });
+    const r = await tool_explain_why_recommended({ position: 1 }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { text: string }).text).toContain('you asked for a non-pill option');
+  });
+
+  it('refuses to invent a rationale for items it never recommended', async () => {
+    const { sb } = makeSb({
+      memory_items: [{ data: [], error: null }],
+      products: [{ data: product(), error: null }],
+      universal_carts: [{ data: null, error: null }],
+    });
+    const r = await tool_explain_why_recommended({ product_id: PRODUCT_UUID }, IDENT, sb);
+    expect(r.ok).toBe(true);
+    expect((r as { result: { has_recorded_rationale: boolean } }).result.has_recorded_rationale).toBe(false);
+    expect((r as { text: string }).text).toContain('do not invent');
+  });
+});

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -2916,7 +2916,208 @@ Your achieved milestones.
 Spoken summary of a community member's public profile.
 
 ### update_service_offerings
-Replace the service offerings shown on your profile. TWO-STEP confirm."
+Replace the service offerings shown on your profile. TWO-STEP confirm.
+
+### start_marketplace_discover_assistant
+Start a guided marketplace conversation for a product, service,
+practitioner or diagnostic need. CALL WHEN the user asks for shopping
+guidance rather than a specific item: "I want a full shopping guide",
+"help me find something for my energy", "ich brauche eine Einkaufsberatung".
+Then follow the returned next step. Never read long specifications aloud.
+
+### build_personalized_shopping_guide
+Build a concise personalized recommendation set (max 3 options with
+short rationales) for the recorded shopping goal, across products and
+services. Nothing is added to the cart. CALL WHEN the goal (and the most
+important criteria) are known. Present each option in ONE sentence.
+
+### refine_marketplace_recommendations
+Update the current recommendations from conversational feedback.
+CALL WHEN the user reacts to picks: "cheaper", "nothing with pills",
+"I prefer something for home", "etwas Günstigeres bitte".
+
+### explain_marketplace_recommendation
+Explain one current pick: what it is, why it was chosen for this user,
+practical use, and relevant limitations. CALL WHEN the user asks "why
+this one?", "tell me more about the second option", "warum empfiehlst du
+mir das?". Answer concisely — what/why/limits, never the full spec.
+
+### complete_marketplace_selection
+Confirm the chosen option and stage it into the basket (NEVER charges;
+payment stays on screen). ALWAYS call once WITHOUT confirm first — it
+returns a read-back of name and price; after the user says yes, call
+again with confirm:true. CALL WHEN the user picks an option: "take the
+second one", "add it to my basket", "nimm das erste".
+
+### capture_shopping_goal
+Record what the user wants to achieve, solve, explore or purchase.
+CALL WHEN the user states a shopping goal in a guided conversation:
+"I want to improve my sleep", "ich will meine Energie verbessern".
+
+### clarify_shopping_need
+Get the smallest set of still-missing criteria (budget, format,
+exclusions, urgency) for the recorded goal so you ask only the most
+important follow-up question. CALL BEFORE building the guide when the
+request was vague. Ask ONE question at a time, never a questionnaire.
+
+### classify_marketplace_intent
+Determine whether a need maps to a product, service, diagnostic test,
+practitioner or combination, with the suggested next tool. CALL WHEN
+unsure which direction a marketplace request should take.
+
+### save_marketplace_preferences
+Save reusable shopping preferences the user explicitly stated: budget,
+dietary needs, values, exclusions, excluded brands/categories, preferred
+format. CALL ONLY after the user stated the preference or agreed to save
+it: "remember that I'm vegan", "merk dir, dass ich keine Kapseln will".
+
+### get_marketplace_preferences
+Read the user's saved marketplace preferences. CALL WHEN the user asks
+"what do you know about my shopping preferences?" or before explaining
+why a recommendation was personalized.
+
+### reset_marketplace_preferences
+Clear all saved marketplace preferences. ALWAYS call once WITHOUT
+confirm first — it reads back what would be cleared; after the user says
+yes, call again with confirm:true. CALL WHEN the user asks to forget or
+reset their shopping preferences.
+
+### get_marketplace_context
+Get the minimum relevant context for a shopping request: saved
+preferences, shopping budget and spend, recent orders, active goal.
+CALL at the start of a guided shopping conversation, or when the user
+asks "why are you recommending this to me?" — then answer citing their
+stated preferences in plain language, never an algorithm score.
+
+### dismiss_marketplace_recommendation
+Dismiss a recommended product so it is not proposed again. CALL WHEN
+the user rejects a recommendation: "not that one", "don't show me this
+again", "das interessiert mich nicht".
+
+### discover_marketplace_options
+Unified marketplace search across products AND services for one stated
+need. CALL WHEN the user describes a need without saying whether they
+want a product or a service: "something for my back pain", "etwas für
+besseren Schlaf". Mention at most 3 options, one sentence each.
+
+### search_products_by_need
+Search products by PURPOSE rather than product name, filtered against
+saved preferences (exclusions, budget). CALL WHEN the user describes
+what they want to achieve: "something that helps me focus", "etwas
+gegen Müdigkeit".
+
+### search_services_by_need
+Search marketplace services (wellness, nutrition, therapy, labs) by the
+desired outcome. CALL WHEN the user wants help through a service rather
+than a product: "a sleep consultation", "eine Ernährungsberatung".
+
+### search_marketplace_by_values
+Filter products by declared dietary tags and certifications (vegan,
+gluten-free, organic, …). CALL WHEN values/dietary constraints are the
+point of the request: "only vegan options", "nur vegane Produkte".
+Only DECLARED product data counts — say so if nothing declares the tag.
+
+### search_marketplace_alternatives
+Find alternatives to a product the user dislikes or cannot use, in the
+same category. CALL WHEN the user says "what else is there like this",
+"not this brand", "gibt es Alternativen dazu?".
+
+### generate_top_marketplace_picks
+Return up to 3 best-fit product picks with short rationales — WITHOUT
+adding anything to the cart (unlike get_ai_product_picks, which stages
+the cart). CALL WHEN the user wants recommendations to hear first:
+"what would you recommend for ...", "was würdest du mir empfehlen?".
+
+### recommend_marketplace_path
+Recommend whether to start with a product, a service/assessment, a
+practitioner, or a combination for the stated goal. CALL WHEN the user
+is unsure what kind of help they need: "I don't know whether I need
+supplements or a blood test", "ich weiß nicht, was ich brauche".
+
+### recommend_lower_cost_option
+Find a suitable cheaper alternative to a current pick or named product.
+CALL WHEN the user says "too expensive", "something cheaper", "zu teuer,
+gibt es was Günstigeres?". Mention the saving and any trade-off.
+
+### explain_why_recommended
+Explain why an option was recommended, from the RECORDED rationale.
+CALL WHEN the user asks "why are you recommending this?", "warum
+empfiehlst du mir das?". Cite stated preferences and the recorded
+reason in plain language — never an algorithm score. If there is no
+recorded reason, say so honestly.
+
+### summarize_product_for_user
+Personalized SHORT product summary: what it is, what it is for, why it
+may fit this user, one relevant limitation. CALL instead of reading a
+product description aloud. 2–3 spoken sentences maximum.
+
+### get_key_product_facts
+Only the most important product facts: price, dosage/serving, declared
+allergens, safety notes, availability. CALL WHEN the user asks a
+factual detail: "how many servings?", "what's the dosage?", "welche
+Allergene enthält es?". Read only what was asked.
+
+### compare_marketplace_options
+Compare up to 3 options on price, rating, availability, dietary fit —
+speaking only the differences that matter to this user. CALL WHEN the
+user asks to compare: "compare the first two", "was ist der
+Unterschied?". Defaults to the current picks.
+
+### shortlist_marketplace_options
+Save one product (or all current picks) to the user's shortlist for
+later. CALL WHEN the user says "save that one", "put it on my list",
+"merk dir das". Products only — services cannot be shortlisted yet.
+
+### view_marketplace_shortlist
+Read the user's saved shortlist. CALL WHEN the user asks "what's on my
+shortlist?", "zeig mir meine Merkliste".
+
+### remove_from_marketplace_shortlist
+Remove one product from the shortlist. CALL WHEN the user says "remove
+... from my list", "nimm das von meiner Merkliste".
+
+### check_product_suitability
+Check one product against the user's saved preferences (dietary,
+exclusions, brands, budget) using only DECLARED product data. CALL WHEN
+the user asks "is this suitable for me?", "ist das für mich geeignet?".
+Report what could NOT be verified instead of guessing. Never a medical
+judgement.
+
+### check_cart_duplication
+Detect repeated or overlapping products in the basket. CALL before
+checkout or WHEN the user asks "is anything doubled in my basket?",
+"habe ich etwas doppelt im Warenkorb?".
+
+### review_shopping_budget
+Read the monthly shopping budget, spend so far, remaining headroom, and
+whether the current basket would exceed it. CALL WHEN the user asks
+about their budget or before an expensive addition: "how is my shopping
+budget?", "wie steht mein Einkaufsbudget?".
+
+### confirm_marketplace_selection
+Read back the exact selected option (name, price, availability) and ask
+for explicit confirmation BEFORE any cart action. CALL WHEN the user
+picks an option in conversation. On the user's yes, follow with
+add_selected_option_to_cart confirm:true. Never skip this read-back.
+
+### add_selected_option_to_cart
+Stage the confirmed selection into the universal basket. NEVER charges —
+payment is a screen handoff. ALWAYS run the confirm_marketplace_selection
+read-back (or call once without confirm) first; pass confirm:true only
+after the user said yes. CALL WHEN the user confirms adding the chosen
+item: "yes, add it", "ja, in den Warenkorb".
+
+### review_cart_suitability
+Check the whole basket for duplicates, conflicts with saved preferences,
+declared allergens and availability problems before checkout. CALL WHEN
+the user says "check my basket", "is everything in my cart okay?",
+"prüf meinen Warenkorb".
+
+### explain_cart_item
+Explain why a specific basket item is there (added by the user, the
+shopping agent, a reorder — with the recorded rationale). CALL WHEN the
+user asks "why is this in my basket?", "warum ist das in meinem
+Warenkorb?"."
 `;
 
 exports[`A0.1 characterization: buildLiveSystemInstruction renders a stable system instruction for persona "day-180-veteran-reconnect": persona:day-180-veteran-reconnect 1`] = `
@@ -5577,5 +5778,206 @@ Your achieved milestones.
 Spoken summary of a community member's public profile.
 
 ### update_service_offerings
-Replace the service offerings shown on your profile. TWO-STEP confirm."
+Replace the service offerings shown on your profile. TWO-STEP confirm.
+
+### start_marketplace_discover_assistant
+Start a guided marketplace conversation for a product, service,
+practitioner or diagnostic need. CALL WHEN the user asks for shopping
+guidance rather than a specific item: "I want a full shopping guide",
+"help me find something for my energy", "ich brauche eine Einkaufsberatung".
+Then follow the returned next step. Never read long specifications aloud.
+
+### build_personalized_shopping_guide
+Build a concise personalized recommendation set (max 3 options with
+short rationales) for the recorded shopping goal, across products and
+services. Nothing is added to the cart. CALL WHEN the goal (and the most
+important criteria) are known. Present each option in ONE sentence.
+
+### refine_marketplace_recommendations
+Update the current recommendations from conversational feedback.
+CALL WHEN the user reacts to picks: "cheaper", "nothing with pills",
+"I prefer something for home", "etwas Günstigeres bitte".
+
+### explain_marketplace_recommendation
+Explain one current pick: what it is, why it was chosen for this user,
+practical use, and relevant limitations. CALL WHEN the user asks "why
+this one?", "tell me more about the second option", "warum empfiehlst du
+mir das?". Answer concisely — what/why/limits, never the full spec.
+
+### complete_marketplace_selection
+Confirm the chosen option and stage it into the basket (NEVER charges;
+payment stays on screen). ALWAYS call once WITHOUT confirm first — it
+returns a read-back of name and price; after the user says yes, call
+again with confirm:true. CALL WHEN the user picks an option: "take the
+second one", "add it to my basket", "nimm das erste".
+
+### capture_shopping_goal
+Record what the user wants to achieve, solve, explore or purchase.
+CALL WHEN the user states a shopping goal in a guided conversation:
+"I want to improve my sleep", "ich will meine Energie verbessern".
+
+### clarify_shopping_need
+Get the smallest set of still-missing criteria (budget, format,
+exclusions, urgency) for the recorded goal so you ask only the most
+important follow-up question. CALL BEFORE building the guide when the
+request was vague. Ask ONE question at a time, never a questionnaire.
+
+### classify_marketplace_intent
+Determine whether a need maps to a product, service, diagnostic test,
+practitioner or combination, with the suggested next tool. CALL WHEN
+unsure which direction a marketplace request should take.
+
+### save_marketplace_preferences
+Save reusable shopping preferences the user explicitly stated: budget,
+dietary needs, values, exclusions, excluded brands/categories, preferred
+format. CALL ONLY after the user stated the preference or agreed to save
+it: "remember that I'm vegan", "merk dir, dass ich keine Kapseln will".
+
+### get_marketplace_preferences
+Read the user's saved marketplace preferences. CALL WHEN the user asks
+"what do you know about my shopping preferences?" or before explaining
+why a recommendation was personalized.
+
+### reset_marketplace_preferences
+Clear all saved marketplace preferences. ALWAYS call once WITHOUT
+confirm first — it reads back what would be cleared; after the user says
+yes, call again with confirm:true. CALL WHEN the user asks to forget or
+reset their shopping preferences.
+
+### get_marketplace_context
+Get the minimum relevant context for a shopping request: saved
+preferences, shopping budget and spend, recent orders, active goal.
+CALL at the start of a guided shopping conversation, or when the user
+asks "why are you recommending this to me?" — then answer citing their
+stated preferences in plain language, never an algorithm score.
+
+### dismiss_marketplace_recommendation
+Dismiss a recommended product so it is not proposed again. CALL WHEN
+the user rejects a recommendation: "not that one", "don't show me this
+again", "das interessiert mich nicht".
+
+### discover_marketplace_options
+Unified marketplace search across products AND services for one stated
+need. CALL WHEN the user describes a need without saying whether they
+want a product or a service: "something for my back pain", "etwas für
+besseren Schlaf". Mention at most 3 options, one sentence each.
+
+### search_products_by_need
+Search products by PURPOSE rather than product name, filtered against
+saved preferences (exclusions, budget). CALL WHEN the user describes
+what they want to achieve: "something that helps me focus", "etwas
+gegen Müdigkeit".
+
+### search_services_by_need
+Search marketplace services (wellness, nutrition, therapy, labs) by the
+desired outcome. CALL WHEN the user wants help through a service rather
+than a product: "a sleep consultation", "eine Ernährungsberatung".
+
+### search_marketplace_by_values
+Filter products by declared dietary tags and certifications (vegan,
+gluten-free, organic, …). CALL WHEN values/dietary constraints are the
+point of the request: "only vegan options", "nur vegane Produkte".
+Only DECLARED product data counts — say so if nothing declares the tag.
+
+### search_marketplace_alternatives
+Find alternatives to a product the user dislikes or cannot use, in the
+same category. CALL WHEN the user says "what else is there like this",
+"not this brand", "gibt es Alternativen dazu?".
+
+### generate_top_marketplace_picks
+Return up to 3 best-fit product picks with short rationales — WITHOUT
+adding anything to the cart (unlike get_ai_product_picks, which stages
+the cart). CALL WHEN the user wants recommendations to hear first:
+"what would you recommend for ...", "was würdest du mir empfehlen?".
+
+### recommend_marketplace_path
+Recommend whether to start with a product, a service/assessment, a
+practitioner, or a combination for the stated goal. CALL WHEN the user
+is unsure what kind of help they need: "I don't know whether I need
+supplements or a blood test", "ich weiß nicht, was ich brauche".
+
+### recommend_lower_cost_option
+Find a suitable cheaper alternative to a current pick or named product.
+CALL WHEN the user says "too expensive", "something cheaper", "zu teuer,
+gibt es was Günstigeres?". Mention the saving and any trade-off.
+
+### explain_why_recommended
+Explain why an option was recommended, from the RECORDED rationale.
+CALL WHEN the user asks "why are you recommending this?", "warum
+empfiehlst du mir das?". Cite stated preferences and the recorded
+reason in plain language — never an algorithm score. If there is no
+recorded reason, say so honestly.
+
+### summarize_product_for_user
+Personalized SHORT product summary: what it is, what it is for, why it
+may fit this user, one relevant limitation. CALL instead of reading a
+product description aloud. 2–3 spoken sentences maximum.
+
+### get_key_product_facts
+Only the most important product facts: price, dosage/serving, declared
+allergens, safety notes, availability. CALL WHEN the user asks a
+factual detail: "how many servings?", "what's the dosage?", "welche
+Allergene enthält es?". Read only what was asked.
+
+### compare_marketplace_options
+Compare up to 3 options on price, rating, availability, dietary fit —
+speaking only the differences that matter to this user. CALL WHEN the
+user asks to compare: "compare the first two", "was ist der
+Unterschied?". Defaults to the current picks.
+
+### shortlist_marketplace_options
+Save one product (or all current picks) to the user's shortlist for
+later. CALL WHEN the user says "save that one", "put it on my list",
+"merk dir das". Products only — services cannot be shortlisted yet.
+
+### view_marketplace_shortlist
+Read the user's saved shortlist. CALL WHEN the user asks "what's on my
+shortlist?", "zeig mir meine Merkliste".
+
+### remove_from_marketplace_shortlist
+Remove one product from the shortlist. CALL WHEN the user says "remove
+... from my list", "nimm das von meiner Merkliste".
+
+### check_product_suitability
+Check one product against the user's saved preferences (dietary,
+exclusions, brands, budget) using only DECLARED product data. CALL WHEN
+the user asks "is this suitable for me?", "ist das für mich geeignet?".
+Report what could NOT be verified instead of guessing. Never a medical
+judgement.
+
+### check_cart_duplication
+Detect repeated or overlapping products in the basket. CALL before
+checkout or WHEN the user asks "is anything doubled in my basket?",
+"habe ich etwas doppelt im Warenkorb?".
+
+### review_shopping_budget
+Read the monthly shopping budget, spend so far, remaining headroom, and
+whether the current basket would exceed it. CALL WHEN the user asks
+about their budget or before an expensive addition: "how is my shopping
+budget?", "wie steht mein Einkaufsbudget?".
+
+### confirm_marketplace_selection
+Read back the exact selected option (name, price, availability) and ask
+for explicit confirmation BEFORE any cart action. CALL WHEN the user
+picks an option in conversation. On the user's yes, follow with
+add_selected_option_to_cart confirm:true. Never skip this read-back.
+
+### add_selected_option_to_cart
+Stage the confirmed selection into the universal basket. NEVER charges —
+payment is a screen handoff. ALWAYS run the confirm_marketplace_selection
+read-back (or call once without confirm) first; pass confirm:true only
+after the user said yes. CALL WHEN the user confirms adding the chosen
+item: "yes, add it", "ja, in den Warenkorb".
+
+### review_cart_suitability
+Check the whole basket for duplicates, conflicts with saved preferences,
+declared allergens and availability problems before checkout. CALL WHEN
+the user says "check my basket", "is everything in my cart okay?",
+"prüf meinen Warenkorb".
+
+### explain_cart_item
+Explain why a specific basket item is there (added by the user, the
+shopping agent, a reorder — with the recorded rationale). CALL WHEN the
+user asks "why is this in my basket?", "warum ist das in meinem
+Warenkorb?"."
 `;

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -6719,6 +6719,804 @@ CALL WHEN the user says: "connect my Oura ring", "pair my device",
         },
       },
       {
+        "description": "Start a guided marketplace conversation for a product, service,
+practitioner or diagnostic need. CALL WHEN the user asks for shopping
+guidance rather than a specific item: "I want a full shopping guide",
+"help me find something for my energy", "ich brauche eine Einkaufsberatung".
+Then follow the returned next step. Never read long specifications aloud.",
+        "name": "start_marketplace_discover_assistant",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling in whole currency units (e.g. 150).",
+              "type": "number",
+            },
+            "exclusions": {
+              "description": "Comma-separated things to avoid (e.g. "pills").",
+              "type": "string",
+            },
+            "goal": {
+              "description": "The stated goal/need, if the user already said it.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Build a concise personalized recommendation set (max 3 options with
+short rationales) for the recorded shopping goal, across products and
+services. Nothing is added to the cart. CALL WHEN the goal (and the most
+important criteria) are known. Present each option in ONE sentence.",
+        "name": "build_personalized_shopping_guide",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling in whole currency units.",
+              "type": "number",
+            },
+            "goal": {
+              "description": "Override goal (otherwise the recorded one is used).",
+              "type": "string",
+            },
+            "max_items": {
+              "description": "Max options (default 3).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Update the current recommendations from conversational feedback.
+CALL WHEN the user reacts to picks: "cheaper", "nothing with pills",
+"I prefer something for home", "etwas Günstigeres bitte".",
+        "name": "refine_marketplace_recommendations",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "New budget ceiling in whole currency units.",
+              "type": "number",
+            },
+            "exclude": {
+              "description": "Comma-separated new exclusions from the feedback.",
+              "type": "string",
+            },
+            "prefer": {
+              "description": "What the user now prefers (e.g. "tea", "home test").",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Explain one current pick: what it is, why it was chosen for this user,
+practical use, and relevant limitations. CALL WHEN the user asks "why
+this one?", "tell me more about the second option", "warum empfiehlst du
+mir das?". Answer concisely — what/why/limits, never the full spec.",
+        "name": "explain_marketplace_recommendation",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position of the pick ("the second one" → 2).",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Exact product UUID when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the pick.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Confirm the chosen option and stage it into the basket (NEVER charges;
+payment stays on screen). ALWAYS call once WITHOUT confirm first — it
+returns a read-back of name and price; after the user says yes, call
+again with confirm:true. CALL WHEN the user picks an option: "take the
+second one", "add it to my basket", "nimm das erste".",
+        "name": "complete_marketplace_selection",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the read-back.",
+              "type": "boolean",
+            },
+            "position": {
+              "description": "1-based position of the chosen pick.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Exact product UUID when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the chosen pick.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Record what the user wants to achieve, solve, explore or purchase.
+CALL WHEN the user states a shopping goal in a guided conversation:
+"I want to improve my sleep", "ich will meine Energie verbessern".",
+        "name": "capture_shopping_goal",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling if stated.",
+              "type": "number",
+            },
+            "exclusions": {
+              "description": "Comma-separated exclusions if stated (e.g. "pills").",
+              "type": "string",
+            },
+            "goal": {
+              "description": "The goal in the user's words.",
+              "type": "string",
+            },
+            "urgency": {
+              "description": "Urgency if stated (e.g. "this week").",
+              "type": "string",
+            },
+          },
+          "required": [
+            "goal",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the smallest set of still-missing criteria (budget, format,
+exclusions, urgency) for the recorded goal so you ask only the most
+important follow-up question. CALL BEFORE building the guide when the
+request was vague. Ask ONE question at a time, never a questionnaire.",
+        "name": "clarify_shopping_need",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Determine whether a need maps to a product, service, diagnostic test,
+practitioner or combination, with the suggested next tool. CALL WHEN
+unsure which direction a marketplace request should take.",
+        "name": "classify_marketplace_intent",
+        "parameters": {
+          "properties": {
+            "need": {
+              "description": "The stated need (defaults to the recorded goal).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Save reusable shopping preferences the user explicitly stated: budget,
+dietary needs, values, exclusions, excluded brands/categories, preferred
+format. CALL ONLY after the user stated the preference or agreed to save
+it: "remember that I'm vegan", "merk dir, dass ich keine Kapseln will".",
+        "name": "save_marketplace_preferences",
+        "parameters": {
+          "properties": {
+            "budget_monthly_amount": {
+              "description": "Monthly budget in whole currency units.",
+              "type": "number",
+            },
+            "dietary": {
+              "description": "Comma-separated dietary needs (e.g. "vegan, gluten-free").",
+              "type": "string",
+            },
+            "excluded_brands": {
+              "description": "Comma-separated brands to exclude.",
+              "type": "string",
+            },
+            "excluded_categories": {
+              "description": "Comma-separated categories to exclude.",
+              "type": "string",
+            },
+            "exclusions": {
+              "description": "Comma-separated things to avoid (e.g. "pills").",
+              "type": "string",
+            },
+            "format": {
+              "description": "Preferred formats (e.g. "home, online").",
+              "type": "string",
+            },
+            "values": {
+              "description": "Comma-separated values (e.g. "sustainable, local").",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's saved marketplace preferences. CALL WHEN the user asks
+"what do you know about my shopping preferences?" or before explaining
+why a recommendation was personalized.",
+        "name": "get_marketplace_preferences",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Clear all saved marketplace preferences. ALWAYS call once WITHOUT
+confirm first — it reads back what would be cleared; after the user says
+yes, call again with confirm:true. CALL WHEN the user asks to forget or
+reset their shopping preferences.",
+        "name": "reset_marketplace_preferences",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed.",
+              "type": "boolean",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the minimum relevant context for a shopping request: saved
+preferences, shopping budget and spend, recent orders, active goal.
+CALL at the start of a guided shopping conversation, or when the user
+asks "why are you recommending this to me?" — then answer citing their
+stated preferences in plain language, never an algorithm score.",
+        "name": "get_marketplace_context",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Dismiss a recommended product so it is not proposed again. CALL WHEN
+the user rejects a recommendation: "not that one", "don't show me this
+again", "das interessiert mich nicht".",
+        "name": "dismiss_marketplace_recommendation",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position of the pick to dismiss.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Exact product UUID when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the item to dismiss.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Unified marketplace search across products AND services for one stated
+need. CALL WHEN the user describes a need without saying whether they
+want a product or a service: "something for my back pain", "etwas für
+besseren Schlaf". Mention at most 3 options, one sentence each.",
+        "name": "discover_marketplace_options",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling in whole currency units.",
+              "type": "number",
+            },
+            "limit": {
+              "description": "Max options (default 4, max 6).",
+              "type": "number",
+            },
+            "need": {
+              "description": "The stated need or desired outcome.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "need",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Search products by PURPOSE rather than product name, filtered against
+saved preferences (exclusions, budget). CALL WHEN the user describes
+what they want to achieve: "something that helps me focus", "etwas
+gegen Müdigkeit".",
+        "name": "search_products_by_need",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling in whole currency units.",
+              "type": "number",
+            },
+            "limit": {
+              "description": "Max results (default 5, max 8).",
+              "type": "number",
+            },
+            "need": {
+              "description": "The purpose/need to search for.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "need",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Search marketplace services (wellness, nutrition, therapy, labs) by the
+desired outcome. CALL WHEN the user wants help through a service rather
+than a product: "a sleep consultation", "eine Ernährungsberatung".",
+        "name": "search_services_by_need",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 5, max 8).",
+              "type": "number",
+            },
+            "need": {
+              "description": "The desired outcome.",
+              "type": "string",
+            },
+            "service_types": {
+              "description": "Optional comma-separated types: coach, doctor, lab, wellness, nutrition, fitness, therapy.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "need",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Filter products by declared dietary tags and certifications (vegan,
+gluten-free, organic, …). CALL WHEN values/dietary constraints are the
+point of the request: "only vegan options", "nur vegane Produkte".
+Only DECLARED product data counts — say so if nothing declares the tag.",
+        "name": "search_marketplace_by_values",
+        "parameters": {
+          "properties": {
+            "certifications": {
+              "description": "Comma-separated certifications (e.g. "organic").",
+              "type": "string",
+            },
+            "dietary_tags": {
+              "description": "Comma-separated dietary tags (e.g. "vegan, gluten-free").",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max results (default 5, max 8).",
+              "type": "number",
+            },
+            "need": {
+              "description": "Optional need to combine with the filter.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Find alternatives to a product the user dislikes or cannot use, in the
+same category. CALL WHEN the user says "what else is there like this",
+"not this brand", "gibt es Alternativen dazu?".",
+        "name": "search_marketplace_alternatives",
+        "parameters": {
+          "properties": {
+            "different_brand": {
+              "description": "True if the user wants a different brand.",
+              "type": "boolean",
+            },
+            "limit": {
+              "description": "Max alternatives (default 3, max 6).",
+              "type": "number",
+            },
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "UUID of the product to replace, when known.",
+              "type": "string",
+            },
+            "reason": {
+              "description": "Why the user wants an alternative (improves the search).",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the product to replace.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Return up to 3 best-fit product picks with short rationales — WITHOUT
+adding anything to the cart (unlike get_ai_product_picks, which stages
+the cart). CALL WHEN the user wants recommendations to hear first:
+"what would you recommend for ...", "was würdest du mir empfehlen?".",
+        "name": "generate_top_marketplace_picks",
+        "parameters": {
+          "properties": {
+            "max_items": {
+              "description": "Max picks (default 3).",
+              "type": "number",
+            },
+            "prompt": {
+              "description": "What the user is looking for.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "prompt",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Recommend whether to start with a product, a service/assessment, a
+practitioner, or a combination for the stated goal. CALL WHEN the user
+is unsure what kind of help they need: "I don't know whether I need
+supplements or a blood test", "ich weiß nicht, was ich brauche".",
+        "name": "recommend_marketplace_path",
+        "parameters": {
+          "properties": {
+            "goal": {
+              "description": "The goal (defaults to the recorded one).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Find a suitable cheaper alternative to a current pick or named product.
+CALL WHEN the user says "too expensive", "something cheaper", "zu teuer,
+gibt es was Günstigeres?". Mention the saving and any trade-off.",
+        "name": "recommend_lower_cost_option",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "UUID of the too-expensive product, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the product.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Explain why an option was recommended, from the RECORDED rationale.
+CALL WHEN the user asks "why are you recommending this?", "warum
+empfiehlst du mir das?". Cite stated preferences and the recorded
+reason in plain language — never an algorithm score. If there is no
+recorded reason, say so honestly.",
+        "name": "explain_why_recommended",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "UUID of the recommended product, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Personalized SHORT product summary: what it is, what it is for, why it
+may fit this user, one relevant limitation. CALL instead of reading a
+product description aloud. 2–3 spoken sentences maximum.",
+        "name": "summarize_product_for_user",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Only the most important product facts: price, dosage/serving, declared
+allergens, safety notes, availability. CALL WHEN the user asks a
+factual detail: "how many servings?", "what's the dosage?", "welche
+Allergene enthält es?". Read only what was asked.",
+        "name": "get_key_product_facts",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Compare up to 3 options on price, rating, availability, dietary fit —
+speaking only the differences that matter to this user. CALL WHEN the
+user asks to compare: "compare the first two", "was ist der
+Unterschied?". Defaults to the current picks.",
+        "name": "compare_marketplace_options",
+        "parameters": {
+          "properties": {
+            "product_ids": {
+              "description": "Comma-separated product UUIDs, when known.",
+              "type": "string",
+            },
+            "titles": {
+              "description": "Comma-separated spoken product names.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Save one product (or all current picks) to the user's shortlist for
+later. CALL WHEN the user says "save that one", "put it on my list",
+"merk dir das". Products only — services cannot be shortlisted yet.",
+        "name": "shortlist_marketplace_options",
+        "parameters": {
+          "properties": {
+            "all_picks": {
+              "description": "True to shortlist all current picks.",
+              "type": "boolean",
+            },
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's saved shortlist. CALL WHEN the user asks "what's on my
+shortlist?", "zeig mir meine Merkliste".",
+        "name": "view_marketplace_shortlist",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max items (default 10, max 20).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Remove one product from the shortlist. CALL WHEN the user says "remove
+... from my list", "nimm das von meiner Merkliste".",
+        "name": "remove_from_marketplace_shortlist",
+        "parameters": {
+          "properties": {
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check one product against the user's saved preferences (dietary,
+exclusions, brands, budget) using only DECLARED product data. CALL WHEN
+the user asks "is this suitable for me?", "ist das für mich geeignet?".
+Report what could NOT be verified instead of guessing. Never a medical
+judgement.",
+        "name": "check_product_suitability",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Detect repeated or overlapping products in the basket. CALL before
+checkout or WHEN the user asks "is anything doubled in my basket?",
+"habe ich etwas doppelt im Warenkorb?".",
+        "name": "check_cart_duplication",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the monthly shopping budget, spend so far, remaining headroom, and
+whether the current basket would exceed it. CALL WHEN the user asks
+about their budget or before an expensive addition: "how is my shopping
+budget?", "wie steht mein Einkaufsbudget?".",
+        "name": "review_shopping_budget",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read back the exact selected option (name, price, availability) and ask
+for explicit confirmation BEFORE any cart action. CALL WHEN the user
+picks an option in conversation. On the user's yes, follow with
+add_selected_option_to_cart confirm:true. Never skip this read-back.",
+        "name": "confirm_marketplace_selection",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Stage the confirmed selection into the universal basket. NEVER charges —
+payment is a screen handoff. ALWAYS run the confirm_marketplace_selection
+read-back (or call once without confirm) first; pass confirm:true only
+after the user said yes. CALL WHEN the user confirms adding the chosen
+item: "yes, add it", "ja, in den Warenkorb".",
+        "name": "add_selected_option_to_cart",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the read-back.",
+              "type": "boolean",
+            },
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check the whole basket for duplicates, conflicts with saved preferences,
+declared allergens and availability problems before checkout. CALL WHEN
+the user says "check my basket", "is everything in my cart okay?",
+"prüf meinen Warenkorb".",
+        "name": "review_cart_suitability",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Explain why a specific basket item is there (added by the user, the
+shopping agent, a reorder — with the recorded rationale). CALL WHEN the
+user asks "why is this in my basket?", "warum ist das in meinem
+Warenkorb?".",
+        "name": "explain_cart_item",
+        "parameters": {
+          "properties": {
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
         "description": "Return the top open admin_insights for this tenant, ranked by severity × confidence. Call this AT THE START of every admin orb session to know what needs attention. The bootstrap context already includes the briefing on session-open; only call again if the admin asks "what else?", "anything new?", or "give me the briefing again".",
         "name": "admin_briefing",
         "parameters": {
@@ -18653,6 +19451,804 @@ CALL WHEN the user says: "connect my Oura ring", "pair my device",
           "required": [
             "offers",
           ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Start a guided marketplace conversation for a product, service,
+practitioner or diagnostic need. CALL WHEN the user asks for shopping
+guidance rather than a specific item: "I want a full shopping guide",
+"help me find something for my energy", "ich brauche eine Einkaufsberatung".
+Then follow the returned next step. Never read long specifications aloud.",
+        "name": "start_marketplace_discover_assistant",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling in whole currency units (e.g. 150).",
+              "type": "number",
+            },
+            "exclusions": {
+              "description": "Comma-separated things to avoid (e.g. "pills").",
+              "type": "string",
+            },
+            "goal": {
+              "description": "The stated goal/need, if the user already said it.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Build a concise personalized recommendation set (max 3 options with
+short rationales) for the recorded shopping goal, across products and
+services. Nothing is added to the cart. CALL WHEN the goal (and the most
+important criteria) are known. Present each option in ONE sentence.",
+        "name": "build_personalized_shopping_guide",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling in whole currency units.",
+              "type": "number",
+            },
+            "goal": {
+              "description": "Override goal (otherwise the recorded one is used).",
+              "type": "string",
+            },
+            "max_items": {
+              "description": "Max options (default 3).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Update the current recommendations from conversational feedback.
+CALL WHEN the user reacts to picks: "cheaper", "nothing with pills",
+"I prefer something for home", "etwas Günstigeres bitte".",
+        "name": "refine_marketplace_recommendations",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "New budget ceiling in whole currency units.",
+              "type": "number",
+            },
+            "exclude": {
+              "description": "Comma-separated new exclusions from the feedback.",
+              "type": "string",
+            },
+            "prefer": {
+              "description": "What the user now prefers (e.g. "tea", "home test").",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Explain one current pick: what it is, why it was chosen for this user,
+practical use, and relevant limitations. CALL WHEN the user asks "why
+this one?", "tell me more about the second option", "warum empfiehlst du
+mir das?". Answer concisely — what/why/limits, never the full spec.",
+        "name": "explain_marketplace_recommendation",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position of the pick ("the second one" → 2).",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Exact product UUID when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the pick.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Confirm the chosen option and stage it into the basket (NEVER charges;
+payment stays on screen). ALWAYS call once WITHOUT confirm first — it
+returns a read-back of name and price; after the user says yes, call
+again with confirm:true. CALL WHEN the user picks an option: "take the
+second one", "add it to my basket", "nimm das erste".",
+        "name": "complete_marketplace_selection",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the read-back.",
+              "type": "boolean",
+            },
+            "position": {
+              "description": "1-based position of the chosen pick.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Exact product UUID when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the chosen pick.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Record what the user wants to achieve, solve, explore or purchase.
+CALL WHEN the user states a shopping goal in a guided conversation:
+"I want to improve my sleep", "ich will meine Energie verbessern".",
+        "name": "capture_shopping_goal",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling if stated.",
+              "type": "number",
+            },
+            "exclusions": {
+              "description": "Comma-separated exclusions if stated (e.g. "pills").",
+              "type": "string",
+            },
+            "goal": {
+              "description": "The goal in the user's words.",
+              "type": "string",
+            },
+            "urgency": {
+              "description": "Urgency if stated (e.g. "this week").",
+              "type": "string",
+            },
+          },
+          "required": [
+            "goal",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the smallest set of still-missing criteria (budget, format,
+exclusions, urgency) for the recorded goal so you ask only the most
+important follow-up question. CALL BEFORE building the guide when the
+request was vague. Ask ONE question at a time, never a questionnaire.",
+        "name": "clarify_shopping_need",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Determine whether a need maps to a product, service, diagnostic test,
+practitioner or combination, with the suggested next tool. CALL WHEN
+unsure which direction a marketplace request should take.",
+        "name": "classify_marketplace_intent",
+        "parameters": {
+          "properties": {
+            "need": {
+              "description": "The stated need (defaults to the recorded goal).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Save reusable shopping preferences the user explicitly stated: budget,
+dietary needs, values, exclusions, excluded brands/categories, preferred
+format. CALL ONLY after the user stated the preference or agreed to save
+it: "remember that I'm vegan", "merk dir, dass ich keine Kapseln will".",
+        "name": "save_marketplace_preferences",
+        "parameters": {
+          "properties": {
+            "budget_monthly_amount": {
+              "description": "Monthly budget in whole currency units.",
+              "type": "number",
+            },
+            "dietary": {
+              "description": "Comma-separated dietary needs (e.g. "vegan, gluten-free").",
+              "type": "string",
+            },
+            "excluded_brands": {
+              "description": "Comma-separated brands to exclude.",
+              "type": "string",
+            },
+            "excluded_categories": {
+              "description": "Comma-separated categories to exclude.",
+              "type": "string",
+            },
+            "exclusions": {
+              "description": "Comma-separated things to avoid (e.g. "pills").",
+              "type": "string",
+            },
+            "format": {
+              "description": "Preferred formats (e.g. "home, online").",
+              "type": "string",
+            },
+            "values": {
+              "description": "Comma-separated values (e.g. "sustainable, local").",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's saved marketplace preferences. CALL WHEN the user asks
+"what do you know about my shopping preferences?" or before explaining
+why a recommendation was personalized.",
+        "name": "get_marketplace_preferences",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Clear all saved marketplace preferences. ALWAYS call once WITHOUT
+confirm first — it reads back what would be cleared; after the user says
+yes, call again with confirm:true. CALL WHEN the user asks to forget or
+reset their shopping preferences.",
+        "name": "reset_marketplace_preferences",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed.",
+              "type": "boolean",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Get the minimum relevant context for a shopping request: saved
+preferences, shopping budget and spend, recent orders, active goal.
+CALL at the start of a guided shopping conversation, or when the user
+asks "why are you recommending this to me?" — then answer citing their
+stated preferences in plain language, never an algorithm score.",
+        "name": "get_marketplace_context",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Dismiss a recommended product so it is not proposed again. CALL WHEN
+the user rejects a recommendation: "not that one", "don't show me this
+again", "das interessiert mich nicht".",
+        "name": "dismiss_marketplace_recommendation",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position of the pick to dismiss.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Exact product UUID when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the item to dismiss.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Unified marketplace search across products AND services for one stated
+need. CALL WHEN the user describes a need without saying whether they
+want a product or a service: "something for my back pain", "etwas für
+besseren Schlaf". Mention at most 3 options, one sentence each.",
+        "name": "discover_marketplace_options",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling in whole currency units.",
+              "type": "number",
+            },
+            "limit": {
+              "description": "Max options (default 4, max 6).",
+              "type": "number",
+            },
+            "need": {
+              "description": "The stated need or desired outcome.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "need",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Search products by PURPOSE rather than product name, filtered against
+saved preferences (exclusions, budget). CALL WHEN the user describes
+what they want to achieve: "something that helps me focus", "etwas
+gegen Müdigkeit".",
+        "name": "search_products_by_need",
+        "parameters": {
+          "properties": {
+            "budget_max_amount": {
+              "description": "Budget ceiling in whole currency units.",
+              "type": "number",
+            },
+            "limit": {
+              "description": "Max results (default 5, max 8).",
+              "type": "number",
+            },
+            "need": {
+              "description": "The purpose/need to search for.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "need",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Search marketplace services (wellness, nutrition, therapy, labs) by the
+desired outcome. CALL WHEN the user wants help through a service rather
+than a product: "a sleep consultation", "eine Ernährungsberatung".",
+        "name": "search_services_by_need",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max results (default 5, max 8).",
+              "type": "number",
+            },
+            "need": {
+              "description": "The desired outcome.",
+              "type": "string",
+            },
+            "service_types": {
+              "description": "Optional comma-separated types: coach, doctor, lab, wellness, nutrition, fitness, therapy.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "need",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Filter products by declared dietary tags and certifications (vegan,
+gluten-free, organic, …). CALL WHEN values/dietary constraints are the
+point of the request: "only vegan options", "nur vegane Produkte".
+Only DECLARED product data counts — say so if nothing declares the tag.",
+        "name": "search_marketplace_by_values",
+        "parameters": {
+          "properties": {
+            "certifications": {
+              "description": "Comma-separated certifications (e.g. "organic").",
+              "type": "string",
+            },
+            "dietary_tags": {
+              "description": "Comma-separated dietary tags (e.g. "vegan, gluten-free").",
+              "type": "string",
+            },
+            "limit": {
+              "description": "Max results (default 5, max 8).",
+              "type": "number",
+            },
+            "need": {
+              "description": "Optional need to combine with the filter.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Find alternatives to a product the user dislikes or cannot use, in the
+same category. CALL WHEN the user says "what else is there like this",
+"not this brand", "gibt es Alternativen dazu?".",
+        "name": "search_marketplace_alternatives",
+        "parameters": {
+          "properties": {
+            "different_brand": {
+              "description": "True if the user wants a different brand.",
+              "type": "boolean",
+            },
+            "limit": {
+              "description": "Max alternatives (default 3, max 6).",
+              "type": "number",
+            },
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "UUID of the product to replace, when known.",
+              "type": "string",
+            },
+            "reason": {
+              "description": "Why the user wants an alternative (improves the search).",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the product to replace.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Return up to 3 best-fit product picks with short rationales — WITHOUT
+adding anything to the cart (unlike get_ai_product_picks, which stages
+the cart). CALL WHEN the user wants recommendations to hear first:
+"what would you recommend for ...", "was würdest du mir empfehlen?".",
+        "name": "generate_top_marketplace_picks",
+        "parameters": {
+          "properties": {
+            "max_items": {
+              "description": "Max picks (default 3).",
+              "type": "number",
+            },
+            "prompt": {
+              "description": "What the user is looking for.",
+              "type": "string",
+            },
+          },
+          "required": [
+            "prompt",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Recommend whether to start with a product, a service/assessment, a
+practitioner, or a combination for the stated goal. CALL WHEN the user
+is unsure what kind of help they need: "I don't know whether I need
+supplements or a blood test", "ich weiß nicht, was ich brauche".",
+        "name": "recommend_marketplace_path",
+        "parameters": {
+          "properties": {
+            "goal": {
+              "description": "The goal (defaults to the recorded one).",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Find a suitable cheaper alternative to a current pick or named product.
+CALL WHEN the user says "too expensive", "something cheaper", "zu teuer,
+gibt es was Günstigeres?". Mention the saving and any trade-off.",
+        "name": "recommend_lower_cost_option",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "UUID of the too-expensive product, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name of the product.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Explain why an option was recommended, from the RECORDED rationale.
+CALL WHEN the user asks "why are you recommending this?", "warum
+empfiehlst du mir das?". Cite stated preferences and the recorded
+reason in plain language — never an algorithm score. If there is no
+recorded reason, say so honestly.",
+        "name": "explain_why_recommended",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "UUID of the recommended product, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Personalized SHORT product summary: what it is, what it is for, why it
+may fit this user, one relevant limitation. CALL instead of reading a
+product description aloud. 2–3 spoken sentences maximum.",
+        "name": "summarize_product_for_user",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Only the most important product facts: price, dosage/serving, declared
+allergens, safety notes, availability. CALL WHEN the user asks a
+factual detail: "how many servings?", "what's the dosage?", "welche
+Allergene enthält es?". Read only what was asked.",
+        "name": "get_key_product_facts",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Compare up to 3 options on price, rating, availability, dietary fit —
+speaking only the differences that matter to this user. CALL WHEN the
+user asks to compare: "compare the first two", "was ist der
+Unterschied?". Defaults to the current picks.",
+        "name": "compare_marketplace_options",
+        "parameters": {
+          "properties": {
+            "product_ids": {
+              "description": "Comma-separated product UUIDs, when known.",
+              "type": "string",
+            },
+            "titles": {
+              "description": "Comma-separated spoken product names.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Save one product (or all current picks) to the user's shortlist for
+later. CALL WHEN the user says "save that one", "put it on my list",
+"merk dir das". Products only — services cannot be shortlisted yet.",
+        "name": "shortlist_marketplace_options",
+        "parameters": {
+          "properties": {
+            "all_picks": {
+              "description": "True to shortlist all current picks.",
+              "type": "boolean",
+            },
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the user's saved shortlist. CALL WHEN the user asks "what's on my
+shortlist?", "zeig mir meine Merkliste".",
+        "name": "view_marketplace_shortlist",
+        "parameters": {
+          "properties": {
+            "limit": {
+              "description": "Max items (default 10, max 20).",
+              "type": "number",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Remove one product from the shortlist. CALL WHEN the user says "remove
+... from my list", "nimm das von meiner Merkliste".",
+        "name": "remove_from_marketplace_shortlist",
+        "parameters": {
+          "properties": {
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check one product against the user's saved preferences (dietary,
+exclusions, brands, budget) using only DECLARED product data. CALL WHEN
+the user asks "is this suitable for me?", "ist das für mich geeignet?".
+Report what could NOT be verified instead of guessing. Never a medical
+judgement.",
+        "name": "check_product_suitability",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Detect repeated or overlapping products in the basket. CALL before
+checkout or WHEN the user asks "is anything doubled in my basket?",
+"habe ich etwas doppelt im Warenkorb?".",
+        "name": "check_cart_duplication",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read the monthly shopping budget, spend so far, remaining headroom, and
+whether the current basket would exceed it. CALL WHEN the user asks
+about their budget or before an expensive addition: "how is my shopping
+budget?", "wie steht mein Einkaufsbudget?".",
+        "name": "review_shopping_budget",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Read back the exact selected option (name, price, availability) and ask
+for explicit confirmation BEFORE any cart action. CALL WHEN the user
+picks an option in conversation. On the user's yes, follow with
+add_selected_option_to_cart confirm:true. Never skip this read-back.",
+        "name": "confirm_marketplace_selection",
+        "parameters": {
+          "properties": {
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Stage the confirmed selection into the universal basket. NEVER charges —
+payment is a screen handoff. ALWAYS run the confirm_marketplace_selection
+read-back (or call once without confirm) first; pass confirm:true only
+after the user said yes. CALL WHEN the user confirms adding the chosen
+item: "yes, add it", "ja, in den Warenkorb".",
+        "name": "add_selected_option_to_cart",
+        "parameters": {
+          "properties": {
+            "confirm": {
+              "description": "Pass true ONLY after the user confirmed the read-back.",
+              "type": "boolean",
+            },
+            "position": {
+              "description": "1-based position among the current picks.",
+              "type": "number",
+            },
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Check the whole basket for duplicates, conflicts with saved preferences,
+declared allergens and availability problems before checkout. CALL WHEN
+the user says "check my basket", "is everything in my cart okay?",
+"prüf meinen Warenkorb".",
+        "name": "review_cart_suitability",
+        "parameters": {
+          "properties": {},
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Explain why a specific basket item is there (added by the user, the
+shopping agent, a reorder — with the recorded rationale). CALL WHEN the
+user asks "why is this in my basket?", "warum ist das in meinem
+Warenkorb?".",
+        "name": "explain_cart_item",
+        "parameters": {
+          "properties": {
+            "product_id": {
+              "description": "Product UUID, when known.",
+              "type": "string",
+            },
+            "title": {
+              "description": "Spoken product name.",
+              "type": "string",
+            },
+          },
+          "required": [],
           "type": "object",
         },
       },


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-MARKETPLACE-VOICE-ASSISTANT` _(bootstrap tag — no ledger VTID allocated for this owner-requested expansion)_

**Layer:** AGTL (voice tools) + APIL (gateway)

**Priority:** P0

---

## 📋 Summary

Turns Vitana into a **Marketplace Discover Assistant**: a complete conversational shopping journey — understand the need → clarify → discover options → explain relevance concisely → compare → choose → confirmed add-to-basket — across products, services, practitioners, and health diagnostics (blood tests, metabolomics, microbiome, genomics).

Adds **89 curated voice tools** (14 new plan sections A17–A30) to the Voice Tools Catalog on the Command Hub (`/command-hub/conversation/tool-catalog/`, surface **Marketplace**), and ships **Wave MVA-1: 35 of them live** — every live tool backed exclusively by systems that already exist (`products`, `services_catalog`, universal cart, shopping-agent `runPropose`, `memory_facts`, `memory_items`, `shop_saved_products`, `user_offers_memory`). The remaining 54 seed as honest `planned` roadmap entries until their backends exist (diagnostic-test catalog with biomarkers, practitioner booking/availability, bundles, returns). No new DB tables.

---

## ✅ Changes

- [x] `docs/VOICE_TOOLS_EXPANSION_PLAN.md` — new "Marketplace Voice Assistant — expansion v3" part, sections A17–A30 (89 tools) in the seed-script-parsable table format, incl. the health-domain boundary and the Wave MVA-1 build slice
- [x] `scripts/voice-tools-plan-seed.mjs` — `SECTION_SURFACE` A17–A30 → Marketplace, `plan: marketplace-va-v3` tag, idempotent re-run (skips names already in the manifest, per the script's own header contract)
- [x] **New** `orb-tools/marketplace-va-shared.ts` — shared helpers: guide state in `memory_items` (`content_json.type='marketplace_guide_state'`), `marketplace_pref_*` loader, declared-data exclusion filter, cart staging via `emitCartEvent`
- [x] **New** `orb-tools/marketplace-guide-tools.ts` (13 live) — the 5 Discover Assistant orchestrators (`start_marketplace_discover_assistant`, `build_personalized_shopping_guide`, `refine_marketplace_recommendations`, `explain_marketplace_recommendation`, `complete_marketplace_selection` ⚠️ two-step) + goal capture/clarify/classify, save/get/reset preferences (via `writeFact`; reset = empty-value supersession, history preserved), marketplace context, dismissals (`user_offers_memory` `state='dismissed'`)
- [x] **New** `orb-tools/marketplace-journey-tools.ts` (22 live) — unified/need/values/alternatives discovery, propose-only picks (`runPropose` with a collect-only `insertPick` — nothing staged at recommendation time; deterministic fallback when no LLM), path recommendation, concise explanation from **recorded** rationales only, compare, shortlist (`shop_saved_products`), suitability checks limited to declared product data, budget review, two-step-confirm cart actions
- [x] `orb-tools-shared.ts` — registry + community declaration-bucket spreads (generic Vertex dispatch; **zero `orb-live.ts` changes**)
- [x] `orb-agent/tools.py` — 35 `@function_tool` wrappers + `all_tool_names()` entries (LiveKit pipeline)
- [x] `tool-manifest.json` — regenerated via seed + reconcile `--apply`: 683 tools total, 89 new, 35 `planned→live` with `wired_in: [vertex, livekit]`

**Safety semantics:** payment is never taken by voice (cart staging + `/cart` screen handoff only); every cart write is a two-step confirm; diagnostics/health-adjacent answers carry an explicit no-diagnosis boundary note; suitability checks report "could not verify" instead of guessing; `explain_why_recommended` refuses to invent rationales for items it never recommended.

---

## 🧪 Testing

- [ ] Manual testing completed _(voice smoke on staging pending merge — see notes)_
- [x] Automated tests added/updated
- [ ] Verified in staging/dev environment _(post-merge: staging auto-deploy)_

Ran locally:
- 2 new Jest suites, **76 tests** (`test/orb-tools/marketplace-{guide,journey}-tools.test.ts`): exports/declarations parity, unauthenticated gates, preference save/read/reset semantics, propose-only guarantee (no cart writes at recommendation time), suitability honesty, both two-step confirm flows
- Full gateway suite green: **458 suites / 8096 tests**; `tool-catalog` + `system-instruction` characterization snapshots regenerated (drift = the 35 new declarations, as expected)
- `voice-tools-manifest-reconcile.mjs --check` → ✅ in sync (572 Vertex / 550 LiveKit / 545 shared registry)
- `orb-tools-lift-scanner.mjs` → ✅ no drift; voice-pipeline-spec `validate-spec` + `extract:ts` + `extract:py` + `diff` → no new tool drift
- `npm run build` (gateway) → clean

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] No workflow files touched

### File Names
- [x] All new files follow **kebab-case** convention (`marketplace-guide-tools.ts`, `marketplace-journey-tools.ts`, `marketplace-va-shared.ts`)
- [x] No files violate naming canon

### Code Standards
- [x] Event types use **snake_case** (`item.added`, `cart.created` — existing taxonomy)
- [x] Status values lowercase (`planned`, `live`, `active`, `dismissed`)

### Cloud Run Deployments
- [x] N/A — no deployment config changes (ships with the normal gateway staging deploy)

### Documentation
- [x] Tag in commit message (`BOOTSTRAP-MARKETPLACE-VOICE-ASSISTANT`)
- [x] Plan doc updated (the catalog's source of truth)

---

## 🔗 Links

- **Documentation:** `docs/VOICE_TOOLS_EXPANSION_PLAN.md` → "Marketplace Voice Assistant (Discover) — expansion v3"
- **Related:** Voice Tools Expansion Plan v2 waves 1–6 (#2860s–#2881 series) — same architecture and rollout pattern

---

## 🚨 Breaking Changes

None — additive only. Existing marketplace/cart tools (`search_marketplace`, `get_ai_product_picks`, `add_to_cart`, `start_checkout`, `find_perfect_product`, …) are unchanged; the new layer complements them.

---

## 📸 Screenshots (if applicable)

After merge, the new tools appear on `/command-hub/conversation/tool-catalog/` filtered by surface **Marketplace** (26 existing + 89 new; 61 live / 54 planned on that surface).

---

## 📌 Additional Notes

- **Post-merge verification (staging-first):** merge auto-deploys **staging only**. Check `https://preview-gateway.vitanaland.com/api/v1/voice-tools/catalog?surface=Marketplace&limit=200` (expect 115 entries) and the Command Hub catalog page; optional REST smoke via `/api/v1/orb/tool` with `get_marketplace_preferences` and the `confirm_marketplace_selection` → `add_selected_option_to_cart` confirm flow. Prod ships via the Command Hub PUBLISH button.
- The seed script previously hard-failed on re-run when plan names already existed in the manifest, contradicting its own "idempotent" header contract — fixed to skip-and-log so future waves can re-seed safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8asyxacyzSFfwYCH5eT83

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8asyxacyzSFfwYCH5eT83)_