### PR TITLE
Allow AWS staging origins for ORB live sessions

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -420,6 +420,14 @@ const ALLOWED_ORIGINS = [
   // prod returned 200 + a session for its own origin.
   'https://preview.vitanaland.com',          // Staging community-app (community-app-staging)
   'https://preview-gateway.vitanaland.com',  // Staging gateway custom domain (command-hub orb)
+  // BOOTSTRAP-AWS-STAGING-VALIDATION: AWS staging origins (ECS stack behind
+  // vitana-alb-prod, Cloudflare-proxied). Same failure mode as the GCP
+  // staging entries above: without these, POST /orb/live/session/start
+  // returns 403 "Origin not allowed" and the orb hangs on "Connecting…" on
+  // preview-aws.* — confirmed in the browser console 2026-07-20 while the
+  // direct-API smoke (no Origin header) passed.
+  'https://preview-aws.vitanaland.com',          // AWS staging community-app
+  'https://preview-aws-gateway.vitanaland.com',  // AWS staging gateway (command-hub orb)
   'http://localhost:8080',
   'http://localhost:8081',  // VTID-01225: Mobile dev server
   'http://localhost:3000',


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION`

**Layer:** APIL

**Priority:** P1

---

## 📋 Summary

ORB voice on AWS staging (`preview-aws.vitanaland.com`) fails with `[VTOrb] Failed to start session: Origin not allowed` — the widget dies at the gateway's ORB-specific origin gate (`validateOrigin` / `ALLOWED_ORIGINS` in `orb-live.ts`), before any Gemini Live call. This list already carries the GCP staging origins, added for the *identical* failure on `preview.vitanaland.com` (`BOOTSTRAP-ORB-STAGING-ORIGIN`); this PR adds the two AWS staging hostnames the same way. The general CORS middleware already allows both (PR #2888) — the ORB has its own separate check, which is why API-level smoke tests (no browser Origin header) passed while the real browser failed.

---

## ✅ Changes

- [x] `services/gateway/src/routes/orb-live.ts` — add `https://preview-aws.vitanaland.com` + `https://preview-aws-gateway.vitanaland.com` to `ALLOWED_ORIGINS` (used by all ORB session routes via the injected `validateOrigin`)

---

## 🧪 Testing

- [x] Manual testing completed — failure reproduced in the browser console on preview-aws (2026-07-20); direct-API ORB session start (no Origin header) returns 200, isolating the origin gate as the only blocker
- [ ] Automated tests added/updated (n/a — allowlist entry)
- [ ] Verified in staging/dev environment — merge auto-deploys BOTH stagings (mirror-mode); verify by opening the ORB on preview-aws.vitanaland.com after rollout

---

## 📝 Phase 2B Naming Compliance Checklist

- [x] No workflows/files added; BOOTSTRAP tag in commit message; no naming-canon violations

---

## 🚨 Breaking Changes

None — additive allowlist entries; GCP staging and prod behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_