### PR TITLE
Fix ORB voice on AWS: API-key Gemini Live transport (AWS-only, no GCP credential needed)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -290,3 +290,12 @@ USER_CONTEXT_PROFILER_TIMEOUT_MS=3000
 #   lib/gcp-adc-bootstrap.ts from GCP_SERVICE_ACCOUNT_JSON — do not set this
 #   directly; setting it yourself skips the bootstrap (used as-is).
 GCP_SERVICE_ACCOUNT_JSON=
+
+# BOOTSTRAP-AWS-STAGING-VALIDATION: alternate ORB Live API transport for
+# environments where the Vertex ADC path above is not viable (e.g. no GCP
+# service-account key available yet). Set to `api_key` to switch
+# connectToLiveAPI from Vertex AI (OAuth) to Google AI Studio's Live API,
+# authenticated with GOOGLE_GEMINI_API_KEY instead of any GCP credential.
+# OPTIONAL — unset/'vertex' (default) keeps the existing Vertex path;
+# nothing to configure on GCP, where Vertex + ADC already works.
+GEMINI_LIVE_TRANSPORT=vertex

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -273,3 +273,20 @@ ORB_WS_BOOTSTRAP_STAGE_TIMEOUT_MS=4000
 # bootstrap indefinitely; this caps it and falls back to a safe default.
 # Default 3000.
 USER_CONTEXT_PROFILER_TIMEOUT_MS=3000
+
+# BOOTSTRAP-AWS-STAGING-VALIDATION: GCP Application Default Credentials on
+# non-GCP compute (AWS ECS Fargate, no GCP metadata server). Every
+# `new GoogleAuth()` call (Vertex Live API in orb-live.ts, TTS, spec
+# self-healing, cover-image outpaint) resolves ADC for free on Cloud Run via
+# its metadata server; on AWS it has nothing to resolve and fails with
+# "Could not load the default credentials" at first token fetch.
+# GCP_SERVICE_ACCOUNT_JSON: a GCP service-account key (raw JSON or
+#   base64-encoded JSON), scoped to roles/aiplatform.user on the Vertex
+#   project. On AWS this is sourced from AWS Secrets Manager
+#   (vitana/vertex-ai/service-account-key) via the task definition's
+#   `secrets` block. OPTIONAL — unset (GCP, or local dev with `gcloud auth
+#   application-default login`) is a no-op; ADC resolves normally.
+# GOOGLE_APPLICATION_CREDENTIALS: set automatically by
+#   lib/gcp-adc-bootstrap.ts from GCP_SERVICE_ACCOUNT_JSON — do not set this
+#   directly; setting it yourself skips the bootstrap (used as-is).
+GCP_SERVICE_ACCOUNT_JSON=

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1,3 +1,4 @@
+import './lib/gcp-adc-bootstrap'; // must run before any GoogleAuth()/Vertex client is constructed
 import express from 'express';
 import path from 'path';
 import fs from 'fs';

--- a/services/gateway/src/lib/gcp-adc-bootstrap.ts
+++ b/services/gateway/src/lib/gcp-adc-bootstrap.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// BOOTSTRAP-AWS-VERTEX-ADC: every `new GoogleAuth()` call in this service
+// (Vertex Live API in orb-live.ts, TTS, spec self-healing, cover-image
+// outpaint, etc.) relies on Application Default Credentials. On Cloud Run,
+// ADC resolves for free via the GCP metadata server tied to the service's
+// attached service account. AWS ECS Fargate has no GCP metadata server, so
+// ADC has nothing to resolve and every Vertex call fails at connect time
+// with "Could not load the default credentials" — this was the root cause
+// of ORB voice on AWS staging opening a session/SSE stream successfully
+// (pure bookkeeping) but never producing a greeting: the Gemini Live
+// upstream connection itself never established.
+//
+// GCP_SERVICE_ACCOUNT_JSON carries the key (raw JSON or base64-encoded JSON)
+// via AWS Secrets Manager; this writes it to a local file and points
+// GOOGLE_APPLICATION_CREDENTIALS at it so ADC resolves identically to Cloud
+// Run. No-op when unset (GCP, or any environment where ADC already works).
+const raw = process.env.GCP_SERVICE_ACCOUNT_JSON;
+if (raw && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  try {
+    const json = raw.trim().startsWith('{') ? raw : Buffer.from(raw, 'base64').toString('utf8');
+    JSON.parse(json); // fail fast on malformed key before writing/pointing ADC at it
+    const keyPath = path.join(os.tmpdir(), 'gcp-service-account.json');
+    fs.writeFileSync(keyPath, json, { mode: 0o600 });
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = keyPath;
+    console.log(`[GCP-ADC] Materialized GCP_SERVICE_ACCOUNT_JSON to ${keyPath} for ADC resolution`);
+  } catch (err: any) {
+    console.error('[GCP-ADC] GCP_SERVICE_ACCOUNT_JSON present but invalid — ADC will fail:', err.message);
+  }
+}

--- a/services/gateway/src/orb/live/config.ts
+++ b/services/gateway/src/orb/live/config.ts
@@ -29,6 +29,20 @@ export const VERTEX_PROJECT_ID =
 export const VERTEX_LOCATION = process.env.VERTEX_AI_LOCATION || 'us-central1';
 
 /**
+ * BOOTSTRAP-AWS-STAGING-VALIDATION: ORB's Live API upstream normally
+ * authenticates to Vertex AI via OAuth Application Default Credentials,
+ * which resolve for free on Cloud Run (GCP metadata server) but have
+ * nothing to resolve from on non-GCP compute (AWS ECS has no metadata
+ * server — see lib/gcp-adc-bootstrap.ts for the same problem on the REST
+ * side). Setting GEMINI_LIVE_TRANSPORT=api_key switches `connectToLiveAPI`
+ * to `GeminiApiKeyLiveClient`, which talks to the Google AI Studio Live API
+ * using a plain Gemini API key (GOOGLE_GEMINI_API_KEY) — no GCP credential
+ * needed at all. Unset (default 'vertex') on GCP, where ADC already works.
+ */
+export const GEMINI_LIVE_USE_API_KEY =
+  (process.env.GEMINI_LIVE_TRANSPORT || 'vertex').toLowerCase() === 'api_key';
+
+/**
  * Live (ORB voice) session timeout. After 30 minutes of inactivity the
  * periodic session sweep purges the entry from `liveSessions`. SSE/WS
  * cleanup handlers handle the happy path; this is the safety net.

--- a/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
@@ -1,0 +1,443 @@
+/**
+ * BOOTSTRAP-AWS-STAGING-VALIDATION: Google AI Studio (Gemini API key) Live
+ * API implementation of `UpstreamLiveClient`.
+ *
+ * Sibling to `VertexLiveClient` (vertex-live-client.ts), not a subclass of
+ * it — kept fully self-contained so the existing, production-proven Vertex
+ * path is untouched by this addition.
+ *
+ * Why this exists: `VertexLiveClient` authenticates via OAuth Application
+ * Default Credentials, which resolve for free on Cloud Run (GCP metadata
+ * server) but have nothing to resolve from on non-GCP compute (AWS ECS —
+ * see gcp-adc-bootstrap.ts). The Gemini Live API is also reachable through
+ * Google AI Studio's public endpoint using a plain API key — no ADC, no GCP
+ * service-account credential, no metadata server required. This client
+ * targets that endpoint so AWS can run ORB voice without a GCP credential
+ * at all.
+ *
+ * Wire-protocol parity with VertexLiveClient: same `setup` /
+ * `realtime_input` / `client_content` snake_case envelope shapes and the
+ * same `server_content` / `tool_call` response dispatch — Vertex AI Live
+ * and the AI Studio Live API share the same underlying BidiGenerateContent
+ * proto definitions. The two concrete differences are:
+ *   1. Auth: API key (`?key=`) instead of an OAuth `Authorization: Bearer`.
+ *   2. Model id format: bare `models/{model}` instead of Vertex's
+ *      `projects/{p}/locations/{l}/publishers/google/models/{model}` — the
+ *      setup envelope built by callers (orb-live.ts's `customSetupMessage`)
+ *      is Vertex-shaped, so this client rewrites just the `model` field
+ *      after building it, rather than forking the (large) envelope-builder.
+ *
+ * UNVERIFIED IN PRODUCTION: this path has not yet been exercised against a
+ * live ORB session. Confirm in AWS CloudWatch logs (`/vitana/gateway`) that
+ * a real session reaches `setup_complete` (this client's `connect()`
+ * resolving) rather than an auth/handshake error before treating AWS ORB
+ * voice as fixed.
+ */
+
+import WebSocket from 'ws';
+import type {
+  AudioOutputEvent,
+  GoAwayEvent,
+  InterruptedEvent,
+  SessionResumptionEvent,
+  ToolCallEvent,
+  TranscriptEvent,
+  TurnCompleteEvent,
+  UpstreamCloseEvent,
+  UpstreamConnectOptions,
+  UpstreamConnectionState,
+  UpstreamErrorEvent,
+  UpstreamLiveClient,
+} from './types';
+import { AUDIO_OUT_RATE_HZ } from '../protocol';
+import { buildSetupMessage, parseDurationMs } from './vertex-live-client';
+import type { VertexWebSocketLike } from './vertex-live-client';
+
+export interface GeminiApiKeyLiveClientDeps {
+  /** Factory for the underlying socket. Defaults to a real `ws` connection. */
+  createSocket?: (url: string, headers: Record<string, string>) => VertexWebSocketLike;
+}
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
+const DEFAULT_INPUT_MIME = 'audio/pcm;rate=16000';
+const DEFAULT_OUTPUT_MIME = `audio/pcm;rate=${AUDIO_OUT_RATE_HZ}`;
+const AI_STUDIO_LIVE_WS_BASE =
+  'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent';
+
+/** Build the AI Studio Live API WebSocket URL. Exposed for tests. */
+export function buildAiStudioBidiGenerateContentUrl(apiKey: string): string {
+  return `${AI_STUDIO_LIVE_WS_BASE}?key=${encodeURIComponent(apiKey)}`;
+}
+
+/**
+ * Rewrite a Vertex-shaped `setup.model` (`projects/.../models/{name}`) to
+ * the bare AI Studio form (`models/{name}`). Already-bare values pass
+ * through unchanged.
+ */
+export function toAiStudioModelId(vertexModelId: string): string {
+  const name = vertexModelId.split('/').pop() || vertexModelId;
+  return `models/${name}`;
+}
+
+/**
+ * AI Studio (API-key auth) Live API client. See file header for why this
+ * exists and what it shares with `VertexLiveClient`.
+ */
+export class GeminiApiKeyLiveClient implements UpstreamLiveClient {
+  private state: UpstreamConnectionState = 'idle';
+  private ws: VertexWebSocketLike | null = null;
+  private readonly createSocket: NonNullable<GeminiApiKeyLiveClientDeps['createSocket']>;
+
+  private audioOutputHandler: ((e: AudioOutputEvent) => void) | null = null;
+  private transcriptHandler: ((e: TranscriptEvent) => void) | null = null;
+  private toolCallHandler: ((e: ToolCallEvent) => void) | null = null;
+  private turnCompleteHandler: ((e: TurnCompleteEvent) => void) | null = null;
+  private interruptedHandler: ((e: InterruptedEvent) => void) | null = null;
+  private sessionResumptionHandler: ((e: SessionResumptionEvent) => void) | null = null;
+  private goAwayHandler: ((e: GoAwayEvent) => void) | null = null;
+  private errorHandler: ((e: UpstreamErrorEvent) => void) | null = null;
+  private closeHandler: ((e: UpstreamCloseEvent) => void) | null = null;
+
+  private closeEmitted = false;
+  private connectTimeout: NodeJS.Timeout | null = null;
+  private localCloseRequested = false;
+
+  constructor(deps: GeminiApiKeyLiveClientDeps = {}) {
+    this.createSocket =
+      deps.createSocket ??
+      ((url, headers) =>
+        new WebSocket(url, { headers }) as unknown as VertexWebSocketLike);
+  }
+
+  getState(): UpstreamConnectionState {
+    return this.state;
+  }
+
+  getSocket(): WebSocket | null {
+    return this.ws as unknown as WebSocket | null;
+  }
+
+  onAudioOutput(handler: (event: AudioOutputEvent) => void): void {
+    this.audioOutputHandler = handler;
+  }
+
+  onTranscript(handler: (event: TranscriptEvent) => void): void {
+    this.transcriptHandler = handler;
+  }
+
+  onToolCall(handler: (event: ToolCallEvent) => void): void {
+    this.toolCallHandler = handler;
+  }
+
+  onTurnComplete(handler: (event: TurnCompleteEvent) => void): void {
+    this.turnCompleteHandler = handler;
+  }
+
+  onInterrupted(handler: (event: InterruptedEvent) => void): void {
+    this.interruptedHandler = handler;
+  }
+
+  onSessionResumption(handler: (event: SessionResumptionEvent) => void): void {
+    this.sessionResumptionHandler = handler;
+  }
+
+  onGoAway(handler: (event: GoAwayEvent) => void): void {
+    this.goAwayHandler = handler;
+  }
+
+  onError(handler: (event: UpstreamErrorEvent) => void): void {
+    this.errorHandler = handler;
+  }
+
+  onClose(handler: (event: UpstreamCloseEvent) => void): void {
+    this.closeHandler = handler;
+  }
+
+  async connect(options: UpstreamConnectOptions): Promise<void> {
+    if (this.state !== 'idle') {
+      throw new Error(`invalid_state: cannot connect from state '${this.state}'`);
+    }
+
+    this.state = 'connecting';
+
+    // Reuses the provider-neutral credential hook per its own contract
+    // ("Other providers may use it for API keys / JWTs" — types.ts) — the
+    // caller passes a function returning the raw Gemini API key here
+    // instead of an OAuth token fetcher.
+    const apiKey = await options.getAccessToken();
+    const url = buildAiStudioBidiGenerateContentUrl(apiKey);
+    const ws = this.createSocket(url, { 'Content-Type': 'application/json' });
+    this.ws = ws;
+
+    const timeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      this.connectTimeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        this.transitionToError({
+          code: 'timeout',
+          message: `Live API connection timeout after ${timeoutMs}ms`,
+        });
+        try {
+          ws.close();
+        } catch {
+          /* ignore */
+        }
+        reject(new Error('Live API connection timeout'));
+      }, timeoutMs);
+
+      ws.on('open', async () => {
+        try {
+          const envelope = options.customSetupMessage
+            ? await Promise.resolve(options.customSetupMessage())
+            : buildSetupMessage(options);
+          const setup = (envelope as { setup?: Record<string, unknown> }).setup;
+          if (setup && typeof setup.model === 'string') {
+            setup.model = toAiStudioModelId(setup.model);
+          }
+          ws.send(JSON.stringify(envelope));
+        } catch (err) {
+          if (settled) return;
+          settled = true;
+          this.clearConnectTimeout();
+          this.transitionToError({
+            code: 'setup_send_failed',
+            message: (err as Error).message,
+            cause: err,
+          });
+          reject(err);
+        }
+      });
+
+      ws.on('message', (data: WebSocket.Data) => {
+        let parsed: any;
+        try {
+          parsed = JSON.parse(data.toString());
+        } catch {
+          this.emitError({ code: 'parse_error', message: 'Non-JSON message from upstream' });
+          return;
+        }
+
+        if (parsed.setup_complete || parsed.setupComplete) {
+          if (!settled) {
+            settled = true;
+            this.clearConnectTimeout();
+            this.state = 'open';
+            resolve();
+          }
+          return;
+        }
+
+        if (this.state === 'open') {
+          this.dispatchServerMessage(parsed);
+        }
+      });
+
+      ws.on('error', (err: Error) => {
+        if (!settled) {
+          settled = true;
+          this.clearConnectTimeout();
+          this.transitionToError({
+            code: 'transport_error',
+            message: err.message,
+            cause: err,
+          });
+          reject(err);
+          return;
+        }
+        this.emitError({
+          code: 'transport_error',
+          message: err.message,
+          cause: err,
+        });
+      });
+
+      ws.on('close', (code: number, reason: Buffer) => {
+        this.handleSocketClose(code, reason);
+        if (!settled) {
+          settled = true;
+          this.clearConnectTimeout();
+          reject(new Error(`Live API closed during handshake (code=${code})`));
+        }
+      });
+    });
+  }
+
+  sendAudioChunk(audioB64: string, mimeType: string = DEFAULT_INPUT_MIME): boolean {
+    if (this.state !== 'open' || !this.ws) return false;
+    if (this.ws.readyState !== WebSocket.OPEN) return false;
+
+    const message = {
+      realtime_input: {
+        media_chunks: [{ mime_type: mimeType, data: audioB64 }],
+      },
+    };
+
+    try {
+      this.ws.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  sendTextTurn(text: string, turnComplete: boolean = true): boolean {
+    if (this.state !== 'open' || !this.ws) return false;
+    if (this.ws.readyState !== WebSocket.OPEN) return false;
+
+    const message = {
+      client_content: {
+        turns: [{ role: 'user', parts: [{ text }] }],
+        turn_complete: turnComplete,
+      },
+    };
+
+    try {
+      this.ws.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  sendEndOfTurn(): boolean {
+    if (this.state !== 'open' || !this.ws) return false;
+    if (this.ws.readyState !== WebSocket.OPEN) return false;
+
+    const message = { client_content: { turn_complete: true } };
+
+    try {
+      this.ws.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.state === 'closed' || this.state === 'closing') return;
+    this.localCloseRequested = true;
+    this.state = 'closing';
+    this.clearConnectTimeout();
+    try {
+      this.ws?.close();
+    } catch {
+      /* ignore */
+    }
+    if (!this.closeEmitted) {
+      this.finalizeClose({ initiatedLocally: true });
+    }
+  }
+
+  private dispatchServerMessage(message: any): void {
+    const serverContent = message.server_content || message.serverContent;
+    if (serverContent) {
+      const interrupted =
+        serverContent.interrupted ||
+        serverContent.grounding_metadata?.interrupted ||
+        serverContent.groundingMetadata?.interrupted;
+      if (interrupted) {
+        this.interruptedHandler?.({});
+      }
+
+      const modelTurn = serverContent.model_turn || serverContent.modelTurn;
+      const parts: any[] = modelTurn?.parts || [];
+      for (const part of parts) {
+        const inlineData = part.inline_data || part.inlineData;
+        if (inlineData?.data) {
+          this.audioOutputHandler?.({
+            dataB64: inlineData.data,
+            mimeType: inlineData.mime_type || inlineData.mimeType || DEFAULT_OUTPUT_MIME,
+          });
+        }
+      }
+
+      const inputTransObj = serverContent.input_transcription || serverContent.inputTranscription;
+      const outputTransObj = serverContent.output_transcription || serverContent.outputTranscription;
+
+      const inputText = typeof inputTransObj === 'string' ? inputTransObj : inputTransObj?.text;
+      const outputText = typeof outputTransObj === 'string' ? outputTransObj : outputTransObj?.text;
+
+      if (inputText) {
+        this.transcriptHandler?.({ direction: 'input', text: inputText });
+      }
+      if (outputText) {
+        this.transcriptHandler?.({ direction: 'output', text: outputText });
+      }
+
+      if (serverContent.turn_complete || serverContent.turnComplete) {
+        this.turnCompleteHandler?.({});
+      }
+    }
+
+    const toolCall = message.tool_call || message.toolCall;
+    if (toolCall) {
+      const fnCalls = toolCall.function_calls || toolCall.functionCalls || [];
+      const calls = fnCalls.map((fc: any) => ({
+        name: fc.name,
+        args: fc.args || {},
+        id: fc.id,
+      }));
+      if (calls.length > 0) {
+        this.toolCallHandler?.({ calls });
+      }
+    }
+
+    const resumption =
+      message.session_resumption_update || message.sessionResumptionUpdate;
+    if (resumption) {
+      this.sessionResumptionHandler?.({
+        handle: resumption.new_handle || resumption.newHandle || null,
+        resumable: resumption.resumable === true,
+      });
+    }
+
+    const goAway = message.go_away || message.goAway;
+    if (goAway) {
+      this.goAwayHandler?.({ timeLeftMs: parseDurationMs(goAway.time_left ?? goAway.timeLeft) });
+    }
+  }
+
+  private handleSocketClose(code: number, reason: Buffer): void {
+    if (this.closeEmitted) return;
+    this.finalizeClose({
+      code,
+      reason: reason?.toString?.() || undefined,
+      initiatedLocally: this.localCloseRequested,
+    });
+  }
+
+  private finalizeClose(event: UpstreamCloseEvent): void {
+    this.closeEmitted = true;
+    this.state = 'closed';
+    this.clearConnectTimeout();
+    try {
+      this.closeHandler?.(event);
+    } catch {
+      /* swallow handler exceptions */
+    }
+  }
+
+  private transitionToError(err: UpstreamErrorEvent): void {
+    this.state = 'error';
+    this.emitError(err);
+  }
+
+  private emitError(err: UpstreamErrorEvent): void {
+    try {
+      this.errorHandler?.(err);
+    } catch {
+      /* swallow handler exceptions */
+    }
+  }
+
+  private clearConnectTimeout(): void {
+    if (this.connectTimeout) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
+  }
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1275,7 +1275,7 @@ function terminateExistingSessionsForUser(userId: string, excludeSessionId?: str
 // Cloud Run does NOT auto-set GOOGLE_CLOUD_PROJECT env var.
 // Fallback to hardcoded project ID for Cloud Run deployments.
 // A2 (orb-live-refactor): VERTEX_PROJECT_ID + VERTEX_LOCATION lifted to orb/live/config.ts.
-import { VERTEX_PROJECT_ID, VERTEX_LOCATION } from '../orb/live/config';
+import { VERTEX_PROJECT_ID, VERTEX_LOCATION, GEMINI_LIVE_USE_API_KEY } from '../orb/live/config';
 // A1 (orb-live-refactor): VERTEX_LIVE_MODEL + VERTEX_TTS_MODEL lifted to
 // orb/live/protocol.ts. Same values, same callers; the constants now live
 // in a shared module so A3/A7/A9 don't have to re-declare them.
@@ -1355,6 +1355,10 @@ import {
 // A8.3b.2 will rename / remove this adapter; for now it remains the active
 // call path so frontends + transparent reconnect see no behavior change.
 import { VertexLiveClient } from '../orb/live/upstream/vertex-live-client';
+// BOOTSTRAP-AWS-STAGING-VALIDATION: alternate upstream for non-GCP compute
+// (AWS) where Vertex OAuth ADC has no metadata server to resolve from. See
+// GEMINI_LIVE_USE_API_KEY (orb/live/config.ts) for the selection switch.
+import { GeminiApiKeyLiveClient } from '../orb/live/upstream/gemini-api-key-live-client';
 // L1 (VTID-02976): provider-selection plumbing for the upstream live client.
 // Pure selector — `connectToLiveAPI` reads env + voice.active_provider, then
 // asks the selector which provider to use, then emits OASIS events for the
@@ -6344,6 +6348,11 @@ async function connectToLiveAPI(
   if (!VERTEX_PROJECT_ID || !VERTEX_LOCATION) {
     throw new Error('Missing VERTEX_PROJECT_ID or VERTEX_LOCATION');
   }
+  // BOOTSTRAP-AWS-STAGING-VALIDATION: fail fast if the api_key transport is
+  // selected but no key is configured — same shape as the ADC check above.
+  if (GEMINI_LIVE_USE_API_KEY && !GEMINI_API_KEY) {
+    throw new Error('GEMINI_LIVE_TRANSPORT=api_key but GOOGLE_GEMINI_API_KEY is missing');
+  }
 
   // L1 (VTID-02976) / L2.1 (VTID-02980): consult the upstream provider
   // selector. The selector is a pure function — it never reads env / DB /
@@ -6475,6 +6484,7 @@ async function connectToLiveAPI(
   // to log what we're about to ask it to do.
   console.log(`[VTID-01219] Using model: ${VERTEX_LIVE_MODEL}`);
   console.log(`[VTID-01219] Project: ${VERTEX_PROJECT_ID}, Location: ${VERTEX_LOCATION}`);
+  console.log(`[BOOTSTRAP-AWS-STAGING-VALIDATION] Live API transport: ${GEMINI_LIVE_USE_API_KEY ? 'api_key (AI Studio)' : 'vertex (OAuth/ADC)'}`);
 
   // A8.3b.1 (VTID-02971): the WS lifecycle now flows through the A7
   // UpstreamLiveClient boundary via VertexLiveClient. The orb-specific
@@ -6515,7 +6525,13 @@ async function connectToLiveAPI(
   );
 
   return new Promise<WebSocket>(async (resolve, reject) => {
-    const vertex = new VertexLiveClient();
+    // BOOTSTRAP-AWS-STAGING-VALIDATION: both classes implement the same
+    // UpstreamLiveClient surface (see gemini-api-key-live-client.ts header
+    // for why a sibling class rather than a subclass) — every `vertex.*`
+    // call below works unchanged regardless of which one is selected.
+    const vertex: VertexLiveClient | GeminiApiKeyLiveClient = GEMINI_LIVE_USE_API_KEY
+      ? new GeminiApiKeyLiveClient()
+      : new VertexLiveClient();
 
     // VTID-03273 Pillar B — capture the rolling native session-resumption handle.
     // Stored on the session (the durable Conversation), replayed in the next
@@ -7006,7 +7022,11 @@ async function connectToLiveAPI(
         vadSilenceMs: session.vadSilenceMs,
         systemInstruction: 'overridden',
         // A8.3b.2: VertexLiveClient.connect() invokes this directly.
-        getAccessToken,
+        // BOOTSTRAP-AWS-STAGING-VALIDATION: api_key transport reuses this
+        // same provider-neutral credential hook (types.ts documents it as
+        // "Other providers may use it for API keys / JWTs") to hand back
+        // the raw Gemini API key instead of an OAuth token.
+        getAccessToken: GEMINI_LIVE_USE_API_KEY ? async () => GEMINI_API_KEY : getAccessToken,
         connectTimeoutMs: 15000,
         customSetupMessage: buildOrbVertexSetupEnvelope,
       });

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -420,6 +420,14 @@ const ALLOWED_ORIGINS = [
   // prod returned 200 + a session for its own origin.
   'https://preview.vitanaland.com',          // Staging community-app (community-app-staging)
   'https://preview-gateway.vitanaland.com',  // Staging gateway custom domain (command-hub orb)
+  // BOOTSTRAP-AWS-STAGING-VALIDATION: AWS staging origins (ECS stack behind
+  // vitana-alb-prod, Cloudflare-proxied). Same failure mode as the GCP
+  // staging entries above: without these, POST /orb/live/session/start
+  // returns 403 "Origin not allowed" and the orb hangs on "Connecting…" on
+  // preview-aws.* — confirmed in the browser console 2026-07-20 while the
+  // direct-API smoke (no Origin header) passed.
+  'https://preview-aws.vitanaland.com',          // AWS staging community-app
+  'https://preview-aws-gateway.vitanaland.com',  // AWS staging gateway (command-hub orb)
   'http://localhost:8080',
   'http://localhost:8081',  // VTID-01225: Mobile dev server
   'http://localhost:3000',

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6353,6 +6353,12 @@ async function connectToLiveAPI(
   if (GEMINI_LIVE_USE_API_KEY && !GEMINI_API_KEY) {
     throw new Error('GEMINI_LIVE_TRANSPORT=api_key but GOOGLE_GEMINI_API_KEY is missing');
   }
+  // flow-test-exempt: this touches connectToLiveAPI's transport selection
+  // only (which upstream client + credential to use), not any conversation-
+  // flow decision (greeting, persona routing, turn handling, tool dispatch —
+  // all unchanged and still driven by buildOrbVertexSetupEnvelope below).
+  // The new logic itself (URL/key building, model-id rewrite) has a
+  // dedicated same-PR test suite: test/orb/live/upstream/gemini-api-key-live-client.test.ts.
 
   // L1 (VTID-02976) / L2.1 (VTID-02980): consult the upstream provider
   // selector. The selector is a pure function — it never reads env / DB /

--- a/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
@@ -1,0 +1,207 @@
+/**
+ * BOOTSTRAP-AWS-STAGING-VALIDATION: Characterization tests for
+ * `GeminiApiKeyLiveClient` — the AI Studio (API-key auth) sibling of
+ * `VertexLiveClient`, added so ORB voice can run on AWS without a GCP
+ * service-account credential (see file header in
+ * gemini-api-key-live-client.ts for the full rationale).
+ *
+ * Focuses on what's actually NEW relative to VertexLiveClient (URL/auth,
+ * model-id rewrite) plus a basic connect/dispatch/close smoke pass to
+ * confirm the duplicated lifecycle logic behaves identically. Uses the
+ * same hand-rolled WebSocket mock pattern as vertex-live-client.test.ts —
+ * no real network access.
+ */
+
+import {
+  GeminiApiKeyLiveClient,
+  buildAiStudioBidiGenerateContentUrl,
+  toAiStudioModelId,
+} from '../../../../src/orb/live/upstream/gemini-api-key-live-client';
+import type { VertexWebSocketLike } from '../../../../src/orb/live/upstream/vertex-live-client';
+import type { UpstreamConnectOptions } from '../../../../src/orb/live/upstream/types';
+
+const WS_OPEN = 1;
+const WS_CLOSED = 3;
+
+class MockSocket implements VertexWebSocketLike {
+  readyState = WS_OPEN;
+  sent: string[] = [];
+
+  private openListeners: Array<() => void> = [];
+  private messageListeners: Array<(data: any) => void> = [];
+  private errorListeners: Array<(err: Error) => void> = [];
+  private closeListeners: Array<(code: number, reason: Buffer) => void> = [];
+
+  on(event: 'open', listener: () => void): void;
+  on(event: 'message', listener: (data: any) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+  on(event: 'close', listener: (code: number, reason: Buffer) => void): void;
+  on(event: string, listener: (...args: any[]) => void): void {
+    if (event === 'open') this.openListeners.push(listener as () => void);
+    else if (event === 'message') this.messageListeners.push(listener as (d: any) => void);
+    else if (event === 'error') this.errorListeners.push(listener as (e: Error) => void);
+    else if (event === 'close')
+      this.closeListeners.push(listener as (c: number, r: Buffer) => void);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = WS_CLOSED;
+  }
+
+  fireOpen(): void {
+    this.openListeners.forEach((l) => l());
+  }
+
+  fireMessage(payload: unknown): void {
+    const str = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    this.messageListeners.forEach((l) => l(Buffer.from(str)));
+  }
+
+  fireClose(code: number = 1000, reason: string = 'normal'): void {
+    this.readyState = WS_CLOSED;
+    this.closeListeners.forEach((l) => l(code, Buffer.from(reason)));
+  }
+}
+
+function baseOptions(overrides: Partial<UpstreamConnectOptions> = {}): UpstreamConnectOptions {
+  return {
+    model: 'gemini-live-2.5-flash-native-audio',
+    projectId: 'lovable-vitana-vers1',
+    location: 'us-central1',
+    voiceName: 'Aoede',
+    responseModalities: ['audio'],
+    vadSilenceMs: 2000,
+    systemInstruction: 'You are Vitana.',
+    getAccessToken: async () => 'test-api-key',
+    connectTimeoutMs: 1000,
+    ...overrides,
+  };
+}
+
+async function connectClient(
+  client: GeminiApiKeyLiveClient,
+  socket: MockSocket,
+  options: UpstreamConnectOptions = baseOptions(),
+): Promise<void> {
+  const connectPromise = client.connect(options);
+  await new Promise((resolve) => setImmediate(resolve));
+  socket.fireOpen();
+  await new Promise((resolve) => setImmediate(resolve));
+  socket.fireMessage({ setup_complete: {} });
+  await connectPromise;
+}
+
+describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
+  describe('URL + model-id rewrite (the actual new behavior)', () => {
+    it('builds the AI Studio BidiGenerateContent URL with the key as a query param', () => {
+      expect(buildAiStudioBidiGenerateContentUrl('my-key')).toBe(
+        'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent?key=my-key',
+      );
+    });
+
+    it('URL-encodes special characters in the key', () => {
+      expect(buildAiStudioBidiGenerateContentUrl('a/b+c')).toBe(
+        'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent?key=a%2Fb%2Bc',
+      );
+    });
+
+    it('rewrites a Vertex-shaped model id to the bare AI Studio form', () => {
+      expect(
+        toAiStudioModelId(
+          'projects/lovable-vitana-vers1/locations/us-central1/publishers/google/models/gemini-live-2.5-flash-native-audio',
+        ),
+      ).toBe('models/gemini-live-2.5-flash-native-audio');
+    });
+
+    it('passes through an already-bare model id unchanged (idempotent)', () => {
+      expect(toAiStudioModelId('models/gemini-live-2.5-flash-native-audio')).toBe(
+        'models/gemini-live-2.5-flash-native-audio',
+      );
+    });
+  });
+
+  describe('connect() sends the rewritten envelope', () => {
+    it('rewrites setup.model from the default builder before sending', async () => {
+      const socket = new MockSocket();
+      const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });
+      await connectClient(client, socket);
+
+      expect(client.getState()).toBe('open');
+      const sentSetup = JSON.parse(socket.sent[0]);
+      expect(sentSetup.setup.model).toBe('models/gemini-live-2.5-flash-native-audio');
+      // Rest of the envelope is untouched — same builder as Vertex.
+      expect(sentSetup.setup.generation_config.response_modalities).toEqual(['AUDIO']);
+    });
+
+    it('rewrites setup.model from a customSetupMessage override too', async () => {
+      const socket = new MockSocket();
+      const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });
+      const options = baseOptions({
+        customSetupMessage: () => ({
+          setup: {
+            model:
+              'projects/lovable-vitana-vers1/locations/us-central1/publishers/google/models/gemini-live-2.5-flash-native-audio',
+            system_instruction: { parts: [{ text: 'persona override' }] },
+          },
+        }),
+      });
+      await connectClient(client, socket, options);
+
+      const sentSetup = JSON.parse(socket.sent[0]);
+      expect(sentSetup.setup.model).toBe('models/gemini-live-2.5-flash-native-audio');
+      expect(sentSetup.setup.system_instruction.parts[0].text).toBe('persona override');
+    });
+
+    it('does not attach an Authorization header (auth travels via the URL key param)', async () => {
+      const socket = new MockSocket();
+      let capturedHeaders: Record<string, string> | undefined;
+      const client = new GeminiApiKeyLiveClient({
+        createSocket: (_url, headers) => {
+          capturedHeaders = headers;
+          return socket;
+        },
+      });
+      await connectClient(client, socket);
+      expect(capturedHeaders?.Authorization).toBeUndefined();
+    });
+  });
+
+  describe('dispatch + close parity with VertexLiveClient', () => {
+    it('forwards audio output and tool calls after connect', async () => {
+      const socket = new MockSocket();
+      const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });
+      const audioEvents: unknown[] = [];
+      const toolEvents: unknown[] = [];
+      client.onAudioOutput((e) => audioEvents.push(e));
+      client.onToolCall((e) => toolEvents.push(e));
+      await connectClient(client, socket);
+
+      socket.fireMessage({
+        server_content: {
+          model_turn: { parts: [{ inline_data: { data: 'QUJD', mime_type: 'audio/pcm;rate=24000' } }] },
+        },
+      });
+      socket.fireMessage({ tool_call: { function_calls: [{ name: 'navigate', args: {}, id: '1' }] } });
+
+      expect(audioEvents).toEqual([{ dataB64: 'QUJD', mimeType: 'audio/pcm;rate=24000' }]);
+      expect(toolEvents).toEqual([{ calls: [{ name: 'navigate', args: {}, id: '1' }] }]);
+    });
+
+    it('close() is idempotent and emits onClose exactly once', async () => {
+      const socket = new MockSocket();
+      const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });
+      let closeCount = 0;
+      client.onClose(() => { closeCount += 1; });
+      await connectClient(client, socket);
+
+      await client.close();
+      await client.close();
+      expect(closeCount).toBe(1);
+      expect(client.getState()).toBe('closed');
+    });
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION`

**Layer:** APIL

**Priority:** P0

---

## 📋 Summary

ORB voice on AWS staging (`preview-aws.vitanaland.com`) opens a session and SSE stream successfully but never produces a greeting or audio — a failure invisible to the browser because it happens entirely server-side. Gateway CloudWatch logs (`/vitana/gateway`) pinpoint it exactly:

```
[VTID-01219] Failed to connect Live API for session live-...:
  Could not load the default credentials.
```

Every Vertex AI call site (`orb-live.ts`'s `connectToLiveAPI`) authenticates via OAuth Application Default Credentials. Cloud Run resolves ADC for free via its metadata server; AWS ECS Fargate has none, so ADC has nothing to fall back to.

**This PR's history:** the first commits added a `GOOGLE_APPLICATION_CREDENTIALS` bootstrap (`lib/gcp-adc-bootstrap.ts`) to restore ADC on AWS from a GCP service-account key. While wiring that up, the AWS Secrets Manager secret meant to hold that key (`vitana/vertex-ai/service-account-key`) turned out to be an empty shell — provisioned during migration but never populated, and I don't have GCP IAM/`gcloud` access in this sandbox to create a real one. Rather than block on that, this PR adds a **second, AWS-only path that needs no GCP credential at all**.

---

## ✅ Changes

- [x] `services/gateway/src/lib/gcp-adc-bootstrap.ts` — ADC bootstrap for when a GCP service-account key *is* available (kept; not yet usable until the secret above is populated)
- [x] `services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts` — **new**: `GeminiApiKeyLiveClient`, a self-contained sibling of `VertexLiveClient` (not a subclass — the production-proven Vertex path is untouched) implementing the same `UpstreamLiveClient` interface against Google AI Studio's public Live API (`wss://generativelanguage.googleapis.com/.../BidiGenerateContent`), authenticated with a plain API key instead of an OAuth/ADC token. Vertex AI Live and AI Studio Live share the same wire protocol; the only two differences (auth, model-id format) are handled without forking the existing (large) Vertex-shaped setup-envelope builder.
- [x] `services/gateway/src/orb/live/config.ts` — `GEMINI_LIVE_USE_API_KEY` switch, driven by `GEMINI_LIVE_TRANSPORT=api_key` (default `vertex`, i.e. **no behavior change on GCP**)
- [x] `services/gateway/src/routes/orb-live.ts` — `connectToLiveAPI` selects between `VertexLiveClient` and `GeminiApiKeyLiveClient` based on the switch; fail-fast if `api_key` mode is selected without `GOOGLE_GEMINI_API_KEY`
- [x] `services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts` — 9 new tests (URL/key building, model-id rewrite, no-Authorization-header, dispatch/close parity)
- [x] `.env.example` — documents both `GCP_SERVICE_ACCOUNT_JSON`/`GOOGLE_APPLICATION_CREDENTIALS` and `GEMINI_LIVE_TRANSPORT`

---

## 🧪 Testing

- [x] `npm run build` passes (tsc clean)
- [x] Full existing `vertex-live-client.test.ts` suite (55 tests) passes unchanged — confirms the untouched Vertex path
- [x] 9 new tests for `GeminiApiKeyLiveClient` pass
- [ ] **UNVERIFIED IN PRODUCTION** — this path has never been exercised against Google's real Live API endpoint. `GOOGLE_GEMINI_API_KEY` is already bound on the AWS gateway task definition, so once this merges and mirror-mode redeploys AWS, flipping `GEMINI_LIVE_TRANSPORT=api_key` on the task def and re-testing ORB voice on `preview-aws.vitanaland.com` — with a CloudWatch log check for `setup_complete` rather than an auth/handshake error — is required before calling this fixed.

---

## 🚨 Breaking Changes

None — `GEMINI_LIVE_TRANSPORT` defaults to `vertex` everywhere; GCP behavior is byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
