### PR TITLE
Log WebSocket close-reason text on Live API handshake failures

### DIFF
--- a/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
@@ -260,7 +260,16 @@ export class GeminiApiKeyLiveClient implements UpstreamLiveClient {
         if (!settled) {
           settled = true;
           this.clearConnectTimeout();
-          reject(new Error(`Live API closed during handshake (code=${code})`));
+          // Include the close reason text (when the server sent one) so a
+          // handshake failure is diagnosable from the rejected error message
+          // alone — this is a NEW, unverified provider integration, so
+          // guessing at causes from a bare close code is not good enough.
+          const reasonText = reason?.toString?.();
+          reject(
+            new Error(
+              `Live API closed during handshake (code=${code})${reasonText ? `: ${reasonText}` : ''}`,
+            ),
+          );
         }
       });
     });

--- a/services/gateway/src/orb/live/upstream/vertex-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/vertex-live-client.ts
@@ -303,7 +303,16 @@ export class VertexLiveClient implements UpstreamLiveClient {
             );
             return;
           }
-          reject(new Error(`Live API closed during handshake (code=${code})`));
+          // BOOTSTRAP-AWS-STAGING-VALIDATION: include the close reason text
+          // (when the server sent one) so a handshake failure other than
+          // the 1007/1009 size case above is diagnosable from the rejected
+          // error message alone, instead of just a bare code.
+          const reasonText = reason?.toString?.();
+          reject(
+            new Error(
+              `Live API closed during handshake (code=${code})${reasonText ? `: ${reasonText}` : ''}`,
+            ),
+          );
         }
       });
     });

--- a/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
@@ -170,6 +170,21 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
     });
   });
 
+  describe('handshake-close diagnostics', () => {
+    it('rejects with the close reason text when the server closes before setup_complete', async () => {
+      const socket = new MockSocket();
+      const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });
+      const connectPromise = client.connect(baseOptions());
+      await new Promise((resolve) => setImmediate(resolve));
+      socket.fireOpen();
+      await new Promise((resolve) => setImmediate(resolve));
+      socket.fireClose(1008, 'invalid_argument: setup.model unsupported');
+      await expect(connectPromise).rejects.toThrow(
+        'Live API closed during handshake (code=1008): invalid_argument: setup.model unsupported',
+      );
+    });
+  });
+
   describe('dispatch + close parity with VertexLiveClient', () => {
     it('forwards audio output and tool calls after connect', async () => {
       const socket = new MockSocket();


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION`

**Layer:** APIL

**Priority:** P1

---

## 📋 Summary

Follow-up to #2898 (merged). Live-tested the new API-key Live transport on AWS staging right after it deployed:

- **Confirmed fixed:** the ADC/credentials blocker is gone. `GEMINI_LIVE_TRANSPORT=api_key` is active (verified via the new startup log line), and the AWS gateway now reaches a real WebSocket handshake with Google's AI Studio Live API instead of failing immediately on "Could not load the default credentials."
- **New failure surfaced:** the handshake now closes with code **1008 (Policy Violation)** before `setup_complete`. Neither `VertexLiveClient`'s generic fallback path nor the new `GeminiApiKeyLiveClient` logged the close *reason* text — only the bare code — so the actual cause isn't diagnosable from logs alone.

One suspect already visible in the same session's logs: the setup envelope is **150KB** even after trimming, still flagged `"stillOverBudget":true` against the existing 30KB guard built for Vertex's own message-too-big case. Plausible AI Studio's endpoint has a tighter tolerance than Vertex, but not confirmed — that's exactly what this PR's logging will settle on the next test.

---

## ✅ Changes

- [x] `services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts` — handshake-close rejection now includes the reason text when the server sends one
- [x] `services/gateway/src/orb/live/upstream/vertex-live-client.ts` — same fix applied to the generic (non-1007/1009) close path, so this benefits the existing Vertex path too
- [x] `services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts` — new test pinning the reason-text-included rejection message

---

## 🧪 Testing

- [x] `npm run build` passes (tsc clean)
- [x] Full `test/orb/live/upstream/` suite (107 tests) passes, including 1 new test for this change
- [ ] Next: redeploy to AWS, retrigger an ORB session, and read the actual close reason from CloudWatch to confirm (or rule out) the setup-envelope-size theory

---

## 🚨 Breaking Changes

None — purely additive logging; behavior on both success and failure paths is unchanged, only the error message text gains detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_