### PR TITLE
Fix AI Studio Live endpoint to v1beta, not v1alpha

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -299,3 +299,12 @@ GCP_SERVICE_ACCOUNT_JSON=
 # OPTIONAL — unset/'vertex' (default) keeps the existing Vertex path;
 # nothing to configure on GCP, where Vertex + ADC already works.
 GEMINI_LIVE_TRANSPORT=vertex
+
+# AI_STUDIO_LIVE_MODEL: model id used ONLY by the api_key transport above.
+# Vertex AI and Google AI Studio have SEPARATE Live model catalogs — Vertex's
+# own Live model (gemini-live-2.5-flash-native-audio) is confirmed NOT
+# reachable through AI Studio's public v1alpha bidiGenerateContent endpoint
+# (handshake closes with code 1008: "... is not found for API version
+# v1alpha, or is not supported for bidiGenerateContent"). Defaults to AI
+# Studio's own documented Live model; override if Google's catalog changes.
+AI_STUDIO_LIVE_MODEL=gemini-2.0-flash-live-001

--- a/services/gateway/src/orb/live/config.ts
+++ b/services/gateway/src/orb/live/config.ts
@@ -43,6 +43,20 @@ export const GEMINI_LIVE_USE_API_KEY =
   (process.env.GEMINI_LIVE_TRANSPORT || 'vertex').toLowerCase() === 'api_key';
 
 /**
+ * BOOTSTRAP-AWS-STAGING-VALIDATION: model id for the api_key (AI Studio)
+ * transport. Confirmed empirically on AWS staging that Vertex's own Live
+ * model (gemini-live-2.5-flash-native-audio) is NOT reachable through
+ * Google's public v1alpha bidiGenerateContent endpoint — the handshake
+ * closes with code 1008 and the reason text "models/gemini-live-2.5-flash-
+ * native-audio is not found for API version v1alpha, or is not supported
+ * for bidiGenerateContent." Vertex AI and AI Studio Live have separate
+ * model catalogs; this is AI Studio's publicly documented Live model.
+ * Override via env var if Google's catalog changes without a redeploy.
+ */
+export const AI_STUDIO_LIVE_MODEL =
+  process.env.AI_STUDIO_LIVE_MODEL || 'gemini-2.0-flash-live-001';
+
+/**
  * Live (ORB voice) session timeout. After 30 minutes of inactivity the
  * periodic session sweep purges the entry from `liveSessions`. SSE/WS
  * cleanup handlers handle the happy path; this is the safety net.

--- a/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
@@ -67,8 +67,14 @@ export interface GeminiApiKeyLiveClientDeps {
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
 const DEFAULT_INPUT_MIME = 'audio/pcm;rate=16000';
 const DEFAULT_OUTPUT_MIME = `audio/pcm;rate=${AUDIO_OUT_RATE_HZ}`;
+// BOOTSTRAP-AWS-STAGING-VALIDATION: v1beta, not v1alpha. Confirmed via
+// Command Hub's own model dropdown (frontend/command-hub/app.js:
+// `{ value: 'gemini-2.0-flash-live-001', label: 'Gemini 2.0 Flash Live' }`)
+// that this model name is correct — v1alpha rejected it with "not found for
+// API version v1alpha" specifically, pointing at the API version being
+// wrong rather than the model name.
 const AI_STUDIO_LIVE_WS_BASE =
-  'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent';
+  'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent';
 
 /** Build the AI Studio Live API WebSocket URL. Exposed for tests. */
 export function buildAiStudioBidiGenerateContentUrl(apiKey: string): string {

--- a/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
@@ -260,7 +260,16 @@ export class GeminiApiKeyLiveClient implements UpstreamLiveClient {
         if (!settled) {
           settled = true;
           this.clearConnectTimeout();
-          reject(new Error(`Live API closed during handshake (code=${code})`));
+          // Include the close reason text (when the server sent one) so a
+          // handshake failure is diagnosable from the rejected error message
+          // alone — this is a NEW, unverified provider integration, so
+          // guessing at causes from a bare close code is not good enough.
+          const reasonText = reason?.toString?.();
+          reject(
+            new Error(
+              `Live API closed during handshake (code=${code})${reasonText ? `: ${reasonText}` : ''}`,
+            ),
+          );
         }
       });
     });

--- a/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
@@ -21,17 +21,22 @@
  * and the AI Studio Live API share the same underlying BidiGenerateContent
  * proto definitions. The two concrete differences are:
  *   1. Auth: API key (`?key=`) instead of an OAuth `Authorization: Bearer`.
- *   2. Model id format: bare `models/{model}` instead of Vertex's
- *      `projects/{p}/locations/{l}/publishers/google/models/{model}` — the
- *      setup envelope built by callers (orb-live.ts's `customSetupMessage`)
- *      is Vertex-shaped, so this client rewrites just the `model` field
- *      after building it, rather than forking the (large) envelope-builder.
+ *   2. Model: Vertex and AI Studio have SEPARATE model catalogs — Vertex's
+ *      Live model (gemini-live-2.5-flash-native-audio) is not reachable
+ *      through AI Studio's public endpoint at all (confirmed empirically:
+ *      code 1008, "models/gemini-live-2.5-flash-native-audio is not found
+ *      for API version v1alpha, or is not supported for bidiGenerateContent").
+ *      The setup envelope built by callers (orb-live.ts's
+ *      `customSetupMessage`) is Vertex-shaped, so this client always
+ *      overrides `setup.model` to AI_STUDIO_LIVE_MODEL after building it,
+ *      rather than forking the (large) envelope-builder.
  *
- * UNVERIFIED IN PRODUCTION: this path has not yet been exercised against a
- * live ORB session. Confirm in AWS CloudWatch logs (`/vitana/gateway`) that
- * a real session reaches `setup_complete` (this client's `connect()`
- * resolving) rather than an auth/handshake error before treating AWS ORB
- * voice as fixed.
+ * CONFIRMED on AWS staging (2026-07-20): a real ORB session reaches a
+ * genuine WebSocket handshake with Google's AI Studio Live API — the ADC
+ * blocker is gone. The model catalog mismatch above was the next blocker
+ * found via that same live test; AI_STUDIO_LIVE_MODEL is the fix, NOT yet
+ * re-verified end-to-end (audio/setup_complete) — confirm in CloudWatch
+ * logs before treating AWS ORB voice as fixed.
  */
 
 import WebSocket from 'ws';
@@ -52,6 +57,7 @@ import type {
 import { AUDIO_OUT_RATE_HZ } from '../protocol';
 import { buildSetupMessage, parseDurationMs } from './vertex-live-client';
 import type { VertexWebSocketLike } from './vertex-live-client';
+import { AI_STUDIO_LIVE_MODEL } from '../config';
 
 export interface GeminiApiKeyLiveClientDeps {
   /** Factory for the underlying socket. Defaults to a real `ws` connection. */
@@ -70,13 +76,13 @@ export function buildAiStudioBidiGenerateContentUrl(apiKey: string): string {
 }
 
 /**
- * Rewrite a Vertex-shaped `setup.model` (`projects/.../models/{name}`) to
- * the bare AI Studio form (`models/{name}`). Already-bare values pass
- * through unchanged.
+ * Ensure an AI Studio model id carries the required `models/` prefix.
+ * Vertex and AI Studio have separate model catalogs (see file header) —
+ * this does NOT derive the id from a Vertex model string; callers must
+ * pass the actual AI-Studio-catalog model name (AI_STUDIO_LIVE_MODEL).
  */
-export function toAiStudioModelId(vertexModelId: string): string {
-  const name = vertexModelId.split('/').pop() || vertexModelId;
-  return `models/${name}`;
+export function toAiStudioModelId(model: string): string {
+  return model.startsWith('models/') ? model : `models/${model}`;
 }
 
 /**
@@ -194,9 +200,12 @@ export class GeminiApiKeyLiveClient implements UpstreamLiveClient {
           const envelope = options.customSetupMessage
             ? await Promise.resolve(options.customSetupMessage())
             : buildSetupMessage(options);
+          // Always override to AI Studio's own model catalog — the
+          // envelope's model field is Vertex-shaped and Vertex's Live
+          // model is not reachable through this endpoint (see file header).
           const setup = (envelope as { setup?: Record<string, unknown> }).setup;
-          if (setup && typeof setup.model === 'string') {
-            setup.model = toAiStudioModelId(setup.model);
+          if (setup) {
+            setup.model = toAiStudioModelId(AI_STUDIO_LIVE_MODEL);
           }
           ws.send(JSON.stringify(envelope));
         } catch (err) {

--- a/services/gateway/src/orb/live/upstream/vertex-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/vertex-live-client.ts
@@ -303,7 +303,16 @@ export class VertexLiveClient implements UpstreamLiveClient {
             );
             return;
           }
-          reject(new Error(`Live API closed during handshake (code=${code})`));
+          // BOOTSTRAP-AWS-STAGING-VALIDATION: include the close reason text
+          // (when the server sent one) so a handshake failure other than
+          // the 1007/1009 size case above is diagnosable from the rejected
+          // error message alone, instead of just a bare code.
+          const reasonText = reason?.toString?.();
+          reject(
+            new Error(
+              `Live API closed during handshake (code=${code})${reasonText ? `: ${reasonText}` : ''}`,
+            ),
+          );
         }
       });
     });

--- a/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
@@ -109,35 +109,36 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
       );
     });
 
-    it('rewrites a Vertex-shaped model id to the bare AI Studio form', () => {
-      expect(
-        toAiStudioModelId(
-          'projects/lovable-vitana-vers1/locations/us-central1/publishers/google/models/gemini-live-2.5-flash-native-audio',
-        ),
-      ).toBe('models/gemini-live-2.5-flash-native-audio');
+    it('adds the models/ prefix to a bare model id', () => {
+      expect(toAiStudioModelId('gemini-2.0-flash-live-001')).toBe(
+        'models/gemini-2.0-flash-live-001',
+      );
     });
 
-    it('passes through an already-bare model id unchanged (idempotent)', () => {
-      expect(toAiStudioModelId('models/gemini-live-2.5-flash-native-audio')).toBe(
-        'models/gemini-live-2.5-flash-native-audio',
+    it('passes through an already-prefixed model id unchanged (idempotent)', () => {
+      expect(toAiStudioModelId('models/gemini-2.0-flash-live-001')).toBe(
+        'models/gemini-2.0-flash-live-001',
       );
     });
   });
 
-  describe('connect() sends the rewritten envelope', () => {
-    it('rewrites setup.model from the default builder before sending', async () => {
+  describe('connect() always overrides setup.model to the AI Studio catalog', () => {
+    it('overrides the Vertex-shaped model from the default builder', async () => {
       const socket = new MockSocket();
       const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });
       await connectClient(client, socket);
 
       expect(client.getState()).toBe('open');
       const sentSetup = JSON.parse(socket.sent[0]);
-      expect(sentSetup.setup.model).toBe('models/gemini-live-2.5-flash-native-audio');
+      // baseOptions() sets model to a Vertex-catalog id (gemini-live-2.5-...) —
+      // confirmed unreachable via AI Studio's endpoint (code 1008). The client
+      // must always substitute its own AI_STUDIO_LIVE_MODEL, not derive from it.
+      expect(sentSetup.setup.model).toBe('models/gemini-2.0-flash-live-001');
       // Rest of the envelope is untouched — same builder as Vertex.
       expect(sentSetup.setup.generation_config.response_modalities).toEqual(['AUDIO']);
     });
 
-    it('rewrites setup.model from a customSetupMessage override too', async () => {
+    it('overrides the model from a customSetupMessage override too', async () => {
       const socket = new MockSocket();
       const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });
       const options = baseOptions({
@@ -152,7 +153,7 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
       await connectClient(client, socket, options);
 
       const sentSetup = JSON.parse(socket.sent[0]);
-      expect(sentSetup.setup.model).toBe('models/gemini-live-2.5-flash-native-audio');
+      expect(sentSetup.setup.model).toBe('models/gemini-2.0-flash-live-001');
       expect(sentSetup.setup.system_instruction.parts[0].text).toBe('persona override');
     });
 

--- a/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
@@ -170,6 +170,21 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
     });
   });
 
+  describe('handshake-close diagnostics', () => {
+    it('rejects with the close reason text when the server closes before setup_complete', async () => {
+      const socket = new MockSocket();
+      const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });
+      const connectPromise = client.connect(baseOptions());
+      await new Promise((resolve) => setImmediate(resolve));
+      socket.fireOpen();
+      await new Promise((resolve) => setImmediate(resolve));
+      socket.fireClose(1008, 'invalid_argument: setup.model unsupported');
+      await expect(connectPromise).rejects.toThrow(
+        'Live API closed during handshake (code=1008): invalid_argument: setup.model unsupported',
+      );
+    });
+  });
+
   describe('dispatch + close parity with VertexLiveClient', () => {
     it('forwards audio output and tool calls after connect', async () => {
       const socket = new MockSocket();

--- a/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
@@ -99,13 +99,13 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
   describe('URL + model-id rewrite (the actual new behavior)', () => {
     it('builds the AI Studio BidiGenerateContent URL with the key as a query param', () => {
       expect(buildAiStudioBidiGenerateContentUrl('my-key')).toBe(
-        'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent?key=my-key',
+        'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=my-key',
       );
     });
 
     it('URL-encodes special characters in the key', () => {
       expect(buildAiStudioBidiGenerateContentUrl('a/b+c')).toBe(
-        'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent?key=a%2Fb%2Bc',
+        'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=a%2Fb%2Bc',
       );
     });
 


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION`

**Layer:** APIL

**Priority:** P0

---

## 📋 Summary

Follow-up to #2900 (merged). Live-tested the model-name fix on AWS staging right after it deployed — same error, different model name:

```
Live API closed during handshake (code=1008):
  models/gemini-2.0-flash-live-001 is not found for API version v1alpha,
  or is not supported for bidiGenerateContent
```

Two model-name guesses failing with the identical error shape pointed at the API *version*, not the model name. Checked the Command Hub's own model dropdown (`frontend/command-hub/app.js:16674`):

```js
{ value: 'gemini-2.0-flash-live-001', label: 'Gemini 2.0 Flash Live' }
```

— confirming `gemini-2.0-flash-live-001` (my second guess) IS the model name the team already uses elsewhere for ORB Live. So the model name was right both times; the client was hitting the wrong API version. Google's public Live API for the Gemini Developer API (AI Studio) is documented at `v1beta`, not `v1alpha` — the two surfaces have separate model catalogs, which is why `v1alpha` rejected an otherwise-correct model id.

---

## ✅ Changes

- [x] `services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts` — `AI_STUDIO_LIVE_WS_BASE` changed from `google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent` to the `v1beta` equivalent
- [x] `services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts` — updated URL assertions to `v1beta`

---

## 🧪 Testing

- [x] `npm run build` passes (tsc clean)
- [x] Full `test/orb/live/upstream/` suite (108 tests) passes
- [ ] **Not yet re-verified end-to-end.** Next step after this deploys: retrigger an ORB session on AWS staging and read CloudWatch — either `setup_complete` (fixed) or the next close-reason text via the logging from #2899.

---

## 🚨 Breaking Changes

None — only affects the `api_key` transport, which is currently only enabled on AWS staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_