### PR TITLE
Add temporary AI Studio ListModels debug endpoint (BOOTSTRAP-AWS-STAGING-VALIDATION)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -329,6 +329,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const autonomyPulseRouter = require('./routes/autonomy-pulse').default;
   // Autonomy Trace — unified timeline of autonomous work-in-flight + history
   const autonomyTraceRouter = require('./routes/autonomy-trace').default;
+  // BOOTSTRAP-AWS-STAGING-VALIDATION: TEMPORARY — AI Studio ListModels debug proxy
+  const debugAiStudioModelsRouter = require('./routes/debug-ai-studio-models').default;
   // VTID-01250: Social Connect (AP-1305/AP-1306)
   const socialConnectRouter = require('./routes/social-connect').default;
   // Intelligent Calendar — Phase 1: Backend Calendar API
@@ -751,6 +753,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/dev-autopilot', devAutopilotRouter, { owner: 'dev-autopilot' });
   mountRouterSync(app, '/api/v1/autonomy', autonomyPulseRouter, { owner: 'autonomy-pulse' });
   mountRouterSync(app, '/api/v1/autonomy', autonomyTraceRouter, { owner: 'autonomy-trace' });
+
+  // BOOTSTRAP-AWS-STAGING-VALIDATION: TEMPORARY — remove once AI_STUDIO_LIVE_MODEL is confirmed
+  mountRouterSync(app, '/api/v1', debugAiStudioModelsRouter, { owner: 'debug-ai-studio-models' });
 
   // VTID-01250: Social Connect — OAuth, profile enrichment, auto-share (AP-1305/AP-1306)
   mountRouterSync(app, '/api/v1/social-accounts', socialConnectRouter, { owner: 'social-connect' });

--- a/services/gateway/src/routes/debug-ai-studio-models.ts
+++ b/services/gateway/src/routes/debug-ai-studio-models.ts
@@ -1,0 +1,75 @@
+/**
+ * BOOTSTRAP-AWS-STAGING-VALIDATION: TEMPORARY debug route.
+ *
+ * Diagnosing why GeminiApiKeyLiveClient's Live handshake gets rejected with
+ * "models/gemini-2.0-flash-live-001 is not found for API version v1beta,
+ * or is not supported for bidiGenerateContent" (also tried v1alpha — same
+ * result). The sandbox this investigation runs from cannot reach
+ * generativelanguage.googleapis.com directly (network policy blocks it),
+ * but the gateway itself can (every WS handshake attempt has proven that).
+ * This proxies Google's own ListModels so the real, current model catalog
+ * for GOOGLE_GEMINI_API_KEY can be read from the response instead of
+ * guessed at.
+ *
+ * REMOVE THIS FILE once the correct model id is confirmed and
+ * AI_STUDIO_LIVE_MODEL is set correctly (orb/live/config.ts).
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+async function requireDevRole(req: Request, res: Response, next: NextFunction): Promise<void> {
+  if (req.get('X-Gateway-Internal') === (process.env.GATEWAY_INTERNAL_TOKEN || '__dev__') &&
+      process.env.GATEWAY_INTERNAL_TOKEN) {
+    return next();
+  }
+  let authFailed = false;
+  await requireAuth(req as AuthenticatedRequest, res, () => {
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity) {
+      authFailed = true;
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+      return;
+    }
+    if (identity.exafy_admin === true) return next();
+    authFailed = true;
+    res.status(403).json({ ok: false, error: 'requires developer access (exafy_admin)' });
+  });
+  if (authFailed) return;
+}
+
+router.get('/debug/ai-studio-models', requireDevRole, async (req: Request, res: Response) => {
+  const apiKey = process.env.GOOGLE_GEMINI_API_KEY || '';
+  if (!apiKey) {
+    res.status(500).json({ ok: false, error: 'GOOGLE_GEMINI_API_KEY not configured' });
+    return;
+  }
+  const apiVersion = (req.query.version as string) || 'v1beta';
+  try {
+    const resp = await fetch(
+      `https://generativelanguage.googleapis.com/${encodeURIComponent(apiVersion)}/models?key=${encodeURIComponent(apiKey)}`,
+    );
+    const body = (await resp.json()) as { models?: Array<{ name: string; supportedGenerationMethods?: string[] }> };
+    if (!resp.ok) {
+      res.status(resp.status).json({ ok: false, api_version: apiVersion, google_error: body });
+      return;
+    }
+    const models = (body.models || []) as Array<{ name: string; supportedGenerationMethods?: string[] }>;
+    const liveCapable = models.filter((m) =>
+      (m.supportedGenerationMethods || []).some((mm) => mm.toLowerCase().includes('bidi')),
+    );
+    res.json({
+      ok: true,
+      api_version: apiVersion,
+      total_models: models.length,
+      live_capable: liveCapable.map((m) => ({ name: m.name, methods: m.supportedGenerationMethods })),
+      all_model_names: models.map((m) => m.name),
+    });
+  } catch (err: any) {
+    res.status(502).json({ ok: false, error: err?.message || String(err) });
+  }
+});
+
+export default router;

--- a/services/gateway/test/routes/debug-ai-studio-models.test.ts
+++ b/services/gateway/test/routes/debug-ai-studio-models.test.ts
@@ -1,0 +1,132 @@
+/**
+ * BOOTSTRAP-AWS-STAGING-VALIDATION: covers auth (internal bypass, admin JWT,
+ * non-admin JWT, unauthenticated) and the happy/error paths of the temporary
+ * AI Studio ListModels debug proxy.
+ */
+
+import request from 'supertest';
+import express, { Express } from 'express';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: jest.fn(),
+}));
+
+import debugAiStudioModelsRouter from '../../src/routes/debug-ai-studio-models';
+import { requireAuth } from '../../src/middleware/auth-supabase-jwt';
+
+describe('BOOTSTRAP-AWS-STAGING-VALIDATION: debug-ai-studio-models route', () => {
+  let app: Express;
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, GATEWAY_INTERNAL_TOKEN: 'test-internal-token', GOOGLE_GEMINI_API_KEY: 'test-api-key' };
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1', debugAiStudioModelsRouter);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  it('allows access via the internal bypass header, skipping JWT auth entirely', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ models: [{ name: 'models/gemini-2.0-flash-live-001', supportedGenerationMethods: ['bidiGenerateContent'] }] }),
+    }) as any;
+
+    const response = await request(app)
+      .get('/api/v1/debug/ai-studio-models')
+      .set('X-Gateway-Internal', 'test-internal-token');
+
+    expect(response.status).toBe(200);
+    expect(requireAuth).not.toHaveBeenCalled();
+    expect(response.body.ok).toBe(true);
+  });
+
+  it('rejects a mismatched internal bypass header and falls through to JWT auth (which is unauthenticated here)', async () => {
+    (requireAuth as jest.Mock).mockImplementation((_req, res: express.Response) => {
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    });
+
+    const response = await request(app)
+      .get('/api/v1/debug/ai-studio-models')
+      .set('X-Gateway-Internal', 'wrong-token');
+
+    expect(response.status).toBe(401);
+    expect(requireAuth).toHaveBeenCalled();
+  });
+
+  it('rejects an authenticated non-admin identity with 403', async () => {
+    (requireAuth as jest.Mock).mockImplementation((req: any, _res, next) => {
+      req.identity = { user_id: 'u1', email: 'u@test.com', tenant_id: 't1', exafy_admin: false, role: 'authenticated' };
+      next();
+    });
+
+    const response = await request(app).get('/api/v1/debug/ai-studio-models');
+
+    expect(response.status).toBe(403);
+  });
+
+  it('allows an authenticated exafy_admin identity and proxies ListModels, filtering to bidi-capable models', async () => {
+    (requireAuth as jest.Mock).mockImplementation((req: any, _res, next) => {
+      req.identity = { user_id: 'admin1', email: 'admin@test.com', tenant_id: 't1', exafy_admin: true, role: 'authenticated' };
+      next();
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: [
+          { name: 'models/gemini-2.0-flash-live-001', supportedGenerationMethods: ['bidiGenerateContent'] },
+          { name: 'models/gemini-2.0-flash-exp', supportedGenerationMethods: ['generateContent'] },
+        ],
+      }),
+    }) as any;
+
+    const response = await request(app).get('/api/v1/debug/ai-studio-models?version=v1alpha');
+
+    expect(response.status).toBe(200);
+    expect(response.body.api_version).toBe('v1alpha');
+    expect(response.body.total_models).toBe(2);
+    expect(response.body.live_capable).toEqual([
+      { name: 'models/gemini-2.0-flash-live-001', methods: ['bidiGenerateContent'] },
+    ]);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://generativelanguage.googleapis.com/v1alpha/models?key=test-api-key'),
+    );
+  });
+
+  it('returns 500 when GOOGLE_GEMINI_API_KEY is not configured', async () => {
+    delete process.env.GOOGLE_GEMINI_API_KEY;
+    (requireAuth as jest.Mock).mockImplementation((req: any, _res, next) => {
+      req.identity = { user_id: 'admin1', email: 'admin@test.com', tenant_id: 't1', exafy_admin: true, role: 'authenticated' };
+      next();
+    });
+
+    const response = await request(app).get('/api/v1/debug/ai-studio-models');
+
+    expect(response.status).toBe(500);
+    expect(response.body.ok).toBe(false);
+  });
+
+  it('passes through Google error responses with their status code', async () => {
+    (requireAuth as jest.Mock).mockImplementation((req: any, _res, next) => {
+      req.identity = { user_id: 'admin1', email: 'admin@test.com', tenant_id: 't1', exafy_admin: true, role: 'authenticated' };
+      next();
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'API key not valid' } }),
+    }) as any;
+
+    const response = await request(app).get('/api/v1/debug/ai-studio-models');
+
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.google_error).toEqual({ error: { message: 'API key not valid' } });
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION` _(continuation of #2898/#2899/#2900/#2901 — no formal VTID allocated for this diagnostic step)_

**Layer:** APIL

**Priority:** P1

---

## 📋 Summary

`GeminiApiKeyLiveClient`'s Live handshake (used for ORB voice on AWS staging, where Vertex ADC credentials aren't available) is rejected by Google with `models/gemini-2.0-flash-live-001 is not found for API version {v}, or is not supported for bidiGenerateContent` — under **both** `v1alpha` and `v1beta` — even though this exact model id is already used elsewhere in the Command Hub's own model picker.

The sandbox this investigation runs from cannot reach `generativelanguage.googleapis.com` directly (network policy blocks it), but the gateway itself can (every failed WS handshake attempt proves that). This PR adds a temporary, dev-gated route that proxies Google's own `ListModels` REST API through the gateway so the real, current model catalog for `GOOGLE_GEMINI_API_KEY` can be read instead of guessed at — three consecutive model/version guesses have already failed.

---

## ✅ Changes

- [x] New route `GET /api/v1/debug/ai-studio-models?version=v1alpha|v1beta`, gated by the same dev-only auth pattern used elsewhere in this codebase (internal bypass header + `GATEWAY_INTERNAL_TOKEN`, or `requireAuth` + `exafy_admin` identity)
- [x] Mounted in `index.ts` alongside the other `/api/v1/*` routers
- [x] No changes to any production code path — this only adds a new, isolated diagnostic endpoint

---

## 🧪 Testing

- [x] `npm run build` — compiles cleanly
- [x] `npx jest test/orb/live/upstream/` — 108/108 passing (unaffected by this change; included to confirm nothing else broke)
- [ ] Manual: call the endpoint against AWS staging once deployed, to retrieve Google's real model catalog

---

## 🚨 Breaking Changes

None. Temporary diagnostic-only addition.

---

## 📌 Additional Notes

This file is explicitly marked for removal in its own header comment once the correct `AI_STUDIO_LIVE_MODEL` / API version is confirmed (`services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts`, `services/gateway/src/orb/live/config.ts`). A follow-up PR will remove this route and apply the real fix based on what `ListModels` reports.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_