### PR TITLE
Fix AI Studio Live model id using ListModels ground truth (BOOTSTRAP-AWS-STAGING-VALIDATION)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -301,10 +301,11 @@ GCP_SERVICE_ACCOUNT_JSON=
 GEMINI_LIVE_TRANSPORT=vertex
 
 # AI_STUDIO_LIVE_MODEL: model id used ONLY by the api_key transport above.
-# Vertex AI and Google AI Studio have SEPARATE Live model catalogs — Vertex's
-# own Live model (gemini-live-2.5-flash-native-audio) is confirmed NOT
-# reachable through AI Studio's public v1alpha bidiGenerateContent endpoint
-# (handshake closes with code 1008: "... is not found for API version
-# v1alpha, or is not supported for bidiGenerateContent"). Defaults to AI
-# Studio's own documented Live model; override if Google's catalog changes.
-AI_STUDIO_LIVE_MODEL=gemini-2.0-flash-live-001
+# Vertex AI and Google AI Studio have SEPARATE Live model catalogs. Confirmed
+# via GET /api/v1/debug/ai-studio-models (ListModels ground truth) that of
+# ~50 models visible to GOOGLE_GEMINI_API_KEY, exactly one supports
+# bidiGenerateContent under both v1alpha and v1beta:
+# gemini-2.5-flash-native-audio-latest. Neither Vertex's own Live model
+# (gemini-live-2.5-flash-native-audio) nor gemini-2.0-flash-live-001 exist
+# in this catalog. Override if Google's catalog changes.
+AI_STUDIO_LIVE_MODEL=gemini-2.5-flash-native-audio-latest

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -329,6 +329,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const autonomyPulseRouter = require('./routes/autonomy-pulse').default;
   // Autonomy Trace — unified timeline of autonomous work-in-flight + history
   const autonomyTraceRouter = require('./routes/autonomy-trace').default;
+  // BOOTSTRAP-AWS-STAGING-VALIDATION: TEMPORARY — AI Studio ListModels debug proxy
+  const debugAiStudioModelsRouter = require('./routes/debug-ai-studio-models').default;
   // VTID-01250: Social Connect (AP-1305/AP-1306)
   const socialConnectRouter = require('./routes/social-connect').default;
   // Intelligent Calendar — Phase 1: Backend Calendar API
@@ -751,6 +753,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/dev-autopilot', devAutopilotRouter, { owner: 'dev-autopilot' });
   mountRouterSync(app, '/api/v1/autonomy', autonomyPulseRouter, { owner: 'autonomy-pulse' });
   mountRouterSync(app, '/api/v1/autonomy', autonomyTraceRouter, { owner: 'autonomy-trace' });
+
+  // BOOTSTRAP-AWS-STAGING-VALIDATION: TEMPORARY — remove once AI_STUDIO_LIVE_MODEL is confirmed
+  mountRouterSync(app, '/api/v1', debugAiStudioModelsRouter, { owner: 'debug-ai-studio-models' });
 
   // VTID-01250: Social Connect — OAuth, profile enrichment, auto-share (AP-1305/AP-1306)
   mountRouterSync(app, '/api/v1/social-accounts', socialConnectRouter, { owner: 'social-connect' });

--- a/services/gateway/src/orb/live/config.ts
+++ b/services/gateway/src/orb/live/config.ts
@@ -44,17 +44,17 @@ export const GEMINI_LIVE_USE_API_KEY =
 
 /**
  * BOOTSTRAP-AWS-STAGING-VALIDATION: model id for the api_key (AI Studio)
- * transport. Confirmed empirically on AWS staging that Vertex's own Live
- * model (gemini-live-2.5-flash-native-audio) is NOT reachable through
- * Google's public v1alpha bidiGenerateContent endpoint — the handshake
- * closes with code 1008 and the reason text "models/gemini-live-2.5-flash-
- * native-audio is not found for API version v1alpha, or is not supported
- * for bidiGenerateContent." Vertex AI and AI Studio Live have separate
- * model catalogs; this is AI Studio's publicly documented Live model.
+ * transport. Neither Vertex's Live model (gemini-live-2.5-flash-native-audio)
+ * nor the commonly-referenced gemini-2.0-flash-live-001 are reachable through
+ * this key's AI Studio catalog (confirmed via GET /api/v1/debug/ai-studio-models,
+ * a temporary ListModels proxy — see routes/debug-ai-studio-models.ts). Of the
+ * ~50 models GOOGLE_GEMINI_API_KEY can see under both v1alpha and v1beta,
+ * exactly one supports bidiGenerateContent: gemini-2.5-flash-native-audio-latest.
+ * Vertex AI and AI Studio Live have separate model catalogs.
  * Override via env var if Google's catalog changes without a redeploy.
  */
 export const AI_STUDIO_LIVE_MODEL =
-  process.env.AI_STUDIO_LIVE_MODEL || 'gemini-2.0-flash-live-001';
+  process.env.AI_STUDIO_LIVE_MODEL || 'gemini-2.5-flash-native-audio-latest';
 
 /**
  * Live (ORB voice) session timeout. After 30 minutes of inactivity the

--- a/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
@@ -21,22 +21,24 @@
  * and the AI Studio Live API share the same underlying BidiGenerateContent
  * proto definitions. The two concrete differences are:
  *   1. Auth: API key (`?key=`) instead of an OAuth `Authorization: Bearer`.
- *   2. Model: Vertex and AI Studio have SEPARATE model catalogs — Vertex's
- *      Live model (gemini-live-2.5-flash-native-audio) is not reachable
- *      through AI Studio's public endpoint at all (confirmed empirically:
- *      code 1008, "models/gemini-live-2.5-flash-native-audio is not found
- *      for API version v1alpha, or is not supported for bidiGenerateContent").
- *      The setup envelope built by callers (orb-live.ts's
- *      `customSetupMessage`) is Vertex-shaped, so this client always
- *      overrides `setup.model` to AI_STUDIO_LIVE_MODEL after building it,
- *      rather than forking the (large) envelope-builder.
+ *   2. Model: Vertex and AI Studio have SEPARATE model catalogs. Neither
+ *      Vertex's Live model (gemini-live-2.5-flash-native-audio) nor the
+ *      commonly-referenced gemini-2.0-flash-live-001 exist in this key's AI
+ *      Studio catalog — confirmed via GET /api/v1/debug/ai-studio-models
+ *      (a temporary ListModels proxy, routes/debug-ai-studio-models.ts),
+ *      which showed exactly one bidiGenerateContent-capable model out of
+ *      ~50: gemini-2.5-flash-native-audio-latest. The setup envelope built
+ *      by callers (orb-live.ts's `customSetupMessage`) is Vertex-shaped, so
+ *      this client always overrides `setup.model` to AI_STUDIO_LIVE_MODEL
+ *      after building it, rather than forking the (large) envelope-builder.
  *
  * CONFIRMED on AWS staging (2026-07-20): a real ORB session reaches a
  * genuine WebSocket handshake with Google's AI Studio Live API — the ADC
- * blocker is gone. The model catalog mismatch above was the next blocker
- * found via that same live test; AI_STUDIO_LIVE_MODEL is the fix, NOT yet
- * re-verified end-to-end (audio/setup_complete) — confirm in CloudWatch
- * logs before treating AWS ORB voice as fixed.
+ * blocker is gone. Two more model-name guesses failed after that (both
+ * v1alpha and v1beta rejected them); ListModels ground truth resolved it.
+ * AI_STUDIO_LIVE_MODEL = gemini-2.5-flash-native-audio-latest is the fix,
+ * NOT yet re-verified end-to-end (audio/setup_complete) — confirm in
+ * CloudWatch logs before treating AWS ORB voice as fixed.
  */
 
 import WebSocket from 'ws';
@@ -67,12 +69,10 @@ export interface GeminiApiKeyLiveClientDeps {
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
 const DEFAULT_INPUT_MIME = 'audio/pcm;rate=16000';
 const DEFAULT_OUTPUT_MIME = `audio/pcm;rate=${AUDIO_OUT_RATE_HZ}`;
-// BOOTSTRAP-AWS-STAGING-VALIDATION: v1beta, not v1alpha. Confirmed via
-// Command Hub's own model dropdown (frontend/command-hub/app.js:
-// `{ value: 'gemini-2.0-flash-live-001', label: 'Gemini 2.0 Flash Live' }`)
-// that this model name is correct — v1alpha rejected it with "not found for
-// API version v1alpha" specifically, pointing at the API version being
-// wrong rather than the model name.
+// BOOTSTRAP-AWS-STAGING-VALIDATION: v1beta. ListModels ground truth (see
+// file header) confirmed the same bidiGenerateContent-capable model shows
+// up identically under v1alpha and v1beta for this key — v1beta chosen as
+// AI Studio's documented, non-alpha surface.
 const AI_STUDIO_LIVE_WS_BASE =
   'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent';
 

--- a/services/gateway/src/routes/debug-ai-studio-models.ts
+++ b/services/gateway/src/routes/debug-ai-studio-models.ts
@@ -1,0 +1,75 @@
+/**
+ * BOOTSTRAP-AWS-STAGING-VALIDATION: TEMPORARY debug route.
+ *
+ * Diagnosing why GeminiApiKeyLiveClient's Live handshake gets rejected with
+ * "models/gemini-2.0-flash-live-001 is not found for API version v1beta,
+ * or is not supported for bidiGenerateContent" (also tried v1alpha — same
+ * result). The sandbox this investigation runs from cannot reach
+ * generativelanguage.googleapis.com directly (network policy blocks it),
+ * but the gateway itself can (every WS handshake attempt has proven that).
+ * This proxies Google's own ListModels so the real, current model catalog
+ * for GOOGLE_GEMINI_API_KEY can be read from the response instead of
+ * guessed at.
+ *
+ * REMOVE THIS FILE once the correct model id is confirmed and
+ * AI_STUDIO_LIVE_MODEL is set correctly (orb/live/config.ts).
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+async function requireDevRole(req: Request, res: Response, next: NextFunction): Promise<void> {
+  if (req.get('X-Gateway-Internal') === (process.env.GATEWAY_INTERNAL_TOKEN || '__dev__') &&
+      process.env.GATEWAY_INTERNAL_TOKEN) {
+    return next();
+  }
+  let authFailed = false;
+  await requireAuth(req as AuthenticatedRequest, res, () => {
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity) {
+      authFailed = true;
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+      return;
+    }
+    if (identity.exafy_admin === true) return next();
+    authFailed = true;
+    res.status(403).json({ ok: false, error: 'requires developer access (exafy_admin)' });
+  });
+  if (authFailed) return;
+}
+
+router.get('/debug/ai-studio-models', requireDevRole, async (req: Request, res: Response) => {
+  const apiKey = process.env.GOOGLE_GEMINI_API_KEY || '';
+  if (!apiKey) {
+    res.status(500).json({ ok: false, error: 'GOOGLE_GEMINI_API_KEY not configured' });
+    return;
+  }
+  const apiVersion = (req.query.version as string) || 'v1beta';
+  try {
+    const resp = await fetch(
+      `https://generativelanguage.googleapis.com/${encodeURIComponent(apiVersion)}/models?key=${encodeURIComponent(apiKey)}`,
+    );
+    const body = (await resp.json()) as { models?: Array<{ name: string; supportedGenerationMethods?: string[] }> };
+    if (!resp.ok) {
+      res.status(resp.status).json({ ok: false, api_version: apiVersion, google_error: body });
+      return;
+    }
+    const models = (body.models || []) as Array<{ name: string; supportedGenerationMethods?: string[] }>;
+    const liveCapable = models.filter((m) =>
+      (m.supportedGenerationMethods || []).some((mm) => mm.toLowerCase().includes('bidi')),
+    );
+    res.json({
+      ok: true,
+      api_version: apiVersion,
+      total_models: models.length,
+      live_capable: liveCapable.map((m) => ({ name: m.name, methods: m.supportedGenerationMethods })),
+      all_model_names: models.map((m) => m.name),
+    });
+  } catch (err: any) {
+    res.status(502).json({ ok: false, error: err?.message || String(err) });
+  }
+});
+
+export default router;

--- a/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
@@ -110,14 +110,14 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
     });
 
     it('adds the models/ prefix to a bare model id', () => {
-      expect(toAiStudioModelId('gemini-2.0-flash-live-001')).toBe(
-        'models/gemini-2.0-flash-live-001',
+      expect(toAiStudioModelId('gemini-2.5-flash-native-audio-latest')).toBe(
+        'models/gemini-2.5-flash-native-audio-latest',
       );
     });
 
     it('passes through an already-prefixed model id unchanged (idempotent)', () => {
-      expect(toAiStudioModelId('models/gemini-2.0-flash-live-001')).toBe(
-        'models/gemini-2.0-flash-live-001',
+      expect(toAiStudioModelId('models/gemini-2.5-flash-native-audio-latest')).toBe(
+        'models/gemini-2.5-flash-native-audio-latest',
       );
     });
   });
@@ -133,7 +133,7 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
       // baseOptions() sets model to a Vertex-catalog id (gemini-live-2.5-...) —
       // confirmed unreachable via AI Studio's endpoint (code 1008). The client
       // must always substitute its own AI_STUDIO_LIVE_MODEL, not derive from it.
-      expect(sentSetup.setup.model).toBe('models/gemini-2.0-flash-live-001');
+      expect(sentSetup.setup.model).toBe('models/gemini-2.5-flash-native-audio-latest');
       // Rest of the envelope is untouched — same builder as Vertex.
       expect(sentSetup.setup.generation_config.response_modalities).toEqual(['AUDIO']);
     });
@@ -153,7 +153,7 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
       await connectClient(client, socket, options);
 
       const sentSetup = JSON.parse(socket.sent[0]);
-      expect(sentSetup.setup.model).toBe('models/gemini-2.0-flash-live-001');
+      expect(sentSetup.setup.model).toBe('models/gemini-2.5-flash-native-audio-latest');
       expect(sentSetup.setup.system_instruction.parts[0].text).toBe('persona override');
     });
 

--- a/services/gateway/test/routes/debug-ai-studio-models.test.ts
+++ b/services/gateway/test/routes/debug-ai-studio-models.test.ts
@@ -1,0 +1,132 @@
+/**
+ * BOOTSTRAP-AWS-STAGING-VALIDATION: covers auth (internal bypass, admin JWT,
+ * non-admin JWT, unauthenticated) and the happy/error paths of the temporary
+ * AI Studio ListModels debug proxy.
+ */
+
+import request from 'supertest';
+import express, { Express } from 'express';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: jest.fn(),
+}));
+
+import debugAiStudioModelsRouter from '../../src/routes/debug-ai-studio-models';
+import { requireAuth } from '../../src/middleware/auth-supabase-jwt';
+
+describe('BOOTSTRAP-AWS-STAGING-VALIDATION: debug-ai-studio-models route', () => {
+  let app: Express;
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, GATEWAY_INTERNAL_TOKEN: 'test-internal-token', GOOGLE_GEMINI_API_KEY: 'test-api-key' };
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1', debugAiStudioModelsRouter);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  it('allows access via the internal bypass header, skipping JWT auth entirely', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ models: [{ name: 'models/gemini-2.0-flash-live-001', supportedGenerationMethods: ['bidiGenerateContent'] }] }),
+    }) as any;
+
+    const response = await request(app)
+      .get('/api/v1/debug/ai-studio-models')
+      .set('X-Gateway-Internal', 'test-internal-token');
+
+    expect(response.status).toBe(200);
+    expect(requireAuth).not.toHaveBeenCalled();
+    expect(response.body.ok).toBe(true);
+  });
+
+  it('rejects a mismatched internal bypass header and falls through to JWT auth (which is unauthenticated here)', async () => {
+    (requireAuth as jest.Mock).mockImplementation((_req, res: express.Response) => {
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    });
+
+    const response = await request(app)
+      .get('/api/v1/debug/ai-studio-models')
+      .set('X-Gateway-Internal', 'wrong-token');
+
+    expect(response.status).toBe(401);
+    expect(requireAuth).toHaveBeenCalled();
+  });
+
+  it('rejects an authenticated non-admin identity with 403', async () => {
+    (requireAuth as jest.Mock).mockImplementation((req: any, _res, next) => {
+      req.identity = { user_id: 'u1', email: 'u@test.com', tenant_id: 't1', exafy_admin: false, role: 'authenticated' };
+      next();
+    });
+
+    const response = await request(app).get('/api/v1/debug/ai-studio-models');
+
+    expect(response.status).toBe(403);
+  });
+
+  it('allows an authenticated exafy_admin identity and proxies ListModels, filtering to bidi-capable models', async () => {
+    (requireAuth as jest.Mock).mockImplementation((req: any, _res, next) => {
+      req.identity = { user_id: 'admin1', email: 'admin@test.com', tenant_id: 't1', exafy_admin: true, role: 'authenticated' };
+      next();
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: [
+          { name: 'models/gemini-2.0-flash-live-001', supportedGenerationMethods: ['bidiGenerateContent'] },
+          { name: 'models/gemini-2.0-flash-exp', supportedGenerationMethods: ['generateContent'] },
+        ],
+      }),
+    }) as any;
+
+    const response = await request(app).get('/api/v1/debug/ai-studio-models?version=v1alpha');
+
+    expect(response.status).toBe(200);
+    expect(response.body.api_version).toBe('v1alpha');
+    expect(response.body.total_models).toBe(2);
+    expect(response.body.live_capable).toEqual([
+      { name: 'models/gemini-2.0-flash-live-001', methods: ['bidiGenerateContent'] },
+    ]);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://generativelanguage.googleapis.com/v1alpha/models?key=test-api-key'),
+    );
+  });
+
+  it('returns 500 when GOOGLE_GEMINI_API_KEY is not configured', async () => {
+    delete process.env.GOOGLE_GEMINI_API_KEY;
+    (requireAuth as jest.Mock).mockImplementation((req: any, _res, next) => {
+      req.identity = { user_id: 'admin1', email: 'admin@test.com', tenant_id: 't1', exafy_admin: true, role: 'authenticated' };
+      next();
+    });
+
+    const response = await request(app).get('/api/v1/debug/ai-studio-models');
+
+    expect(response.status).toBe(500);
+    expect(response.body.ok).toBe(false);
+  });
+
+  it('passes through Google error responses with their status code', async () => {
+    (requireAuth as jest.Mock).mockImplementation((req: any, _res, next) => {
+      req.identity = { user_id: 'admin1', email: 'admin@test.com', tenant_id: 't1', exafy_admin: true, role: 'authenticated' };
+      next();
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'API key not valid' } }),
+    }) as any;
+
+    const response = await request(app).get('/api/v1/debug/ai-studio-models');
+
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.google_error).toEqual({ error: { message: 'API key not valid' } });
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION` _(continuation of #2898–#2902 — no formal VTID allocated for this diagnostic thread)_

**Layer:** APIL

**Priority:** P1

---

## 📋 Summary

`GET /api/v1/debug/ai-studio-models` (merged in #2902) was called against AWS staging with a real admin session and returned Google's actual model catalog for `GOOGLE_GEMINI_API_KEY`. Of ~50 models visible under **both** `v1alpha` and `v1beta`, exactly **one** supports `bidiGenerateContent`: `gemini-2.5-flash-native-audio-latest`.

Neither of the two model ids tried previously exist in this catalog at all:
- Vertex's own Live model (`gemini-live-2.5-flash-native-audio`) — Vertex and AI Studio have separate catalogs, as suspected.
- `gemini-2.0-flash-live-001` — present in the Command Hub's model dropdown (for a different purpose/surface), but not actually reachable via this key's AI Studio `bidiGenerateContent` endpoint.

This sets `AI_STUDIO_LIVE_MODEL`'s default to the confirmed working model id, and updates the file-header/`.env.example` documentation and tests to match.

---

## ✅ Changes

- [x] `services/gateway/src/orb/live/config.ts` — `AI_STUDIO_LIVE_MODEL` default → `gemini-2.5-flash-native-audio-latest`
- [x] `services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts` — updated header comments to reflect the ListModels ground truth (no behavior change beyond the config default)
- [x] `services/gateway/.env.example` — updated documented default + rationale
- [x] `services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts` — updated assertions to the new default model id

---

## 🧪 Testing

- [x] `npm run build` — compiles cleanly
- [x] `npx jest test/orb/live/upstream/ test/routes/debug-ai-studio-models.test.ts` — 114/114 passing
- [ ] Manual: once deployed to AWS staging, open a real ORB voice session and confirm `setup_complete` / audio flow in CloudWatch logs (this is the end-to-end verification step — not yet done)

---

## 🚨 Breaking Changes

None. Behind the AWS-only `GEMINI_LIVE_TRANSPORT=api_key` path; GCP staging (Vertex transport) is unaffected.

---

## 📌 Additional Notes

The temporary `GET /api/v1/debug/ai-studio-models` route from #2902 is intentionally still present — keeping it until this fix is verified end-to-end against a real ORB session, per its own header comment. A follow-up PR will remove it once that verification lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_