### PR TITLE
Log the greeting client_content payload for AI-Studio-vs-Vertex diagnosis (BOOTSTRAP-AWS-STAGING-VALIDATION)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -8108,14 +8108,21 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
       voiceWakeBriefReason: _voiceReasonSync,
     });
     if (_syncDecision.directive !== null) {
-      ws.send(
-        JSON.stringify({
-          client_content: {
-            turns: [{ role: 'user', parts: [{ text: _syncDecision.directive }] }],
-            turn_complete: true,
-          },
-        }),
+      const _greetingClientContentMsg = JSON.stringify({
+        client_content: {
+          turns: [{ role: 'user', parts: [{ text: _syncDecision.directive }] }],
+          turn_complete: true,
+        },
+      });
+      // BOOTSTRAP-AWS-STAGING-VALIDATION: diagnosing a code=1007 "Request
+      // contains an invalid argument" close from AI Studio's Live API right
+      // after this exact send (Vertex accepts it fine). Log size + a safe
+      // preview so the real payload is inspectable in CloudWatch instead of
+      // guessed at — remove once the AI-Studio-vs-Vertex divergence is found.
+      console.log(
+        `[BOOTSTRAP-AWS-STAGING-VALIDATION] Sending greeting client_content for session ${session.sessionId}: wakeOpener=${_syncDecision.wakeOpener} bytes=${Buffer.byteLength(_greetingClientContentMsg)} directive_chars=${_syncDecision.directive.length} preview=${JSON.stringify(_syncDecision.directive.slice(0, 200))}`,
       );
+      ws.send(_greetingClientContentMsg);
     }
     session.greetingSent = true;
     session.greetingTurnIndex = session.turn_count;


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION` _(continuation of #2898–#2903 — no formal VTID allocated for this diagnostic thread)_

**Layer:** APIL

**Priority:** P1

---

## 📋 Summary

With the model-id fix from #2903 live, a real end-to-end ORB voice session against AWS staging now gets **past** the handshake — `setup_complete` arrives and the WebSocket stays open. But ~200ms later, right after the gateway sends its injected "greeting" text turn (`client_content`) over the raw upstream WebSocket, Google closes the connection with code `1007`: `"Request contains an invalid argument."` Vertex accepts the exact same send shape without issue on GCP staging.

The error text carries no field name, so two plausible causes have already been ruled out by evidence:
- **Voice name** — confirmed via web search that both `Aoede` and `Callirrhoe` are in the documented voice catalog for `gemini-2.5-flash-native-audio-latest`.
- **JSON field casing** — `setup` itself uses the same snake_case (`system_instruction`, `generation_config`, `response_modalities`, `speech_config`, ...) and was accepted, so AI Studio isn't strictly camelCase-only.

This PR adds a diagnostic-only log line immediately before that `ws.send()` call, capturing the exact byte size, directive character count, and a 200-char preview of the greeting payload — so the next live test gives real evidence (actual payload shape/size) instead of another guess.

---

## ✅ Changes

- [x] `services/gateway/src/routes/orb-live.ts` (`sendGreetingPromptToLiveAPI`) — logs `wakeOpener`, payload byte size, directive char count, and a preview right before the greeting `client_content` send. No behavior change — pure diagnostic logging.

---

## 🧪 Testing

- [x] `npm run build` — compiles cleanly
- [x] `npx jest test/orb/live/` — 707/707 passing
- [ ] Manual: once deployed, run another live ORB session against AWS staging and read the new log line in CloudWatch to see the actual payload that Google is rejecting

---

## 🚨 Breaking Changes

None. Adds a `console.log` only.

---

## 📌 Additional Notes

Part of the same investigation thread as #2902/#2903. The temporary `GET /api/v1/debug/ai-studio-models` route is still present (not yet removed) since ORB voice on AWS is not fully working end-to-end yet.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_