### PR TITLE
Drop redundant AVAILABLE TOOLS prose block on AI Studio Live transport (BOOTSTRAP-AWS-STAGING-VALIDATION)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -402,6 +402,21 @@ export function buildLiveSystemInstruction(
   // wellness companion. Default (undefined or 'vitanaland') is unchanged
   // behavior — the existing community persona.
   surface?: string | null,
+  // BOOTSTRAP-AWS-STAGING-VALIDATION: drop the redundant `## AVAILABLE TOOLS`
+  // prose directory (see renderAvailableToolsSection call below) for callers
+  // whose transport already carries the structured function_declarations in
+  // the setup/session envelope AND doesn't need the LiveKit-only workaround
+  // this block exists for (reason #1 at the call site: livekit-plugins-google
+  // doesn't fully serialize @function_tool metadata onto the wire). Both the
+  // Vertex and AI Studio (API-key) raw-WebSocket paths always send structured
+  // declarations, so the prose block is genuinely redundant text there — on a
+  // heavy-tool-catalog user (250+ tools) it alone can run well past 100 KB,
+  // which is what pushed the aggregate system_instruction over AI Studio's
+  // real context budget and caused a code=1007 "invalid argument" close on
+  // the very first client_content send (setup itself is accepted). Passed
+  // true only for the AI Studio transport for now — Vertex keeps existing
+  // behavior unchanged pending a decision to trim it there too.
+  omitToolsProse?: boolean,
 ): string {
   const languageNames: Record<string, string> = {
     'en': 'English',
@@ -1363,7 +1378,7 @@ M. DIARY LOGGING IS A TOOL CALL, NOT A NAVIGATION. (VTID-01983)
     currentRoute ?? undefined,
     activeRole ?? undefined,
   );
-  if (toolsBlock) {
+  if (toolsBlock && !omitToolsProse) {
     instruction += `\n\n## AVAILABLE TOOLS\n\nYou have the following tools available. Call the matching tool immediately when the user asks about anything in its description — do NOT say "I don't have access" or "I can't do that". Tools you didn't see in your own function-declarations array but DO see described below are still callable; the runtime resolves the call through the shared dispatcher. Never invent a tool name not listed here.\n\n${toolsBlock}`;
   }
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -8108,14 +8108,21 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
       voiceWakeBriefReason: _voiceReasonSync,
     });
     if (_syncDecision.directive !== null) {
-      ws.send(
-        JSON.stringify({
-          client_content: {
-            turns: [{ role: 'user', parts: [{ text: _syncDecision.directive }] }],
-            turn_complete: true,
-          },
-        }),
+      const _greetingClientContentMsg = JSON.stringify({
+        client_content: {
+          turns: [{ role: 'user', parts: [{ text: _syncDecision.directive }] }],
+          turn_complete: true,
+        },
+      });
+      // BOOTSTRAP-AWS-STAGING-VALIDATION: diagnosing a code=1007 "Request
+      // contains an invalid argument" close from AI Studio's Live API right
+      // after this exact send (Vertex accepts it fine). Log size + a safe
+      // preview so the real payload is inspectable in CloudWatch instead of
+      // guessed at — remove once the AI-Studio-vs-Vertex divergence is found.
+      console.log(
+        `[BOOTSTRAP-AWS-STAGING-VALIDATION] Sending greeting client_content for session ${session.sessionId}: wakeOpener=${_syncDecision.wakeOpener} bytes=${Buffer.byteLength(_greetingClientContentMsg)} directive_chars=${_syncDecision.directive.length} preview=${JSON.stringify(_syncDecision.directive.slice(0, 200))}`,
       );
+      ws.send(_greetingClientContentMsg);
     }
     session.greetingSent = true;
     session.greetingTurnIndex = session.turn_count;

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6900,6 +6900,13 @@ async function connectToLiveAPI(
                         // VTID-01967: Canonical Vitana ID handle (already resolved
                         // by optionalAuth → resolveVitanaId on session start).
                         session.identity?.vitana_id ?? null,
+                        undefined, // omitGreetingPolicy — unchanged (Vertex/AI Studio still need it)
+                        undefined, // surface — unchanged (route-based heuristic)
+                        // BOOTSTRAP-AWS-STAGING-VALIDATION: drop the redundant
+                        // `## AVAILABLE TOOLS` prose block on the AI Studio
+                        // transport only — see buildLiveSystemInstruction's
+                        // omitToolsProse param comment. Vertex keeps it.
+                        GEMINI_LIVE_USE_API_KEY,
                       ))) as string
             }]
           },

--- a/services/gateway/test/orb/live/instruction/omit-tools-prose.test.ts
+++ b/services/gateway/test/orb/live/instruction/omit-tools-prose.test.ts
@@ -1,0 +1,55 @@
+/**
+ * BOOTSTRAP-AWS-STAGING-VALIDATION: omitToolsProse locks down the new 15th
+ * positional param on buildLiveSystemInstruction.
+ *
+ * Context: the `## AVAILABLE TOOLS` prose directory duplicates every tool's
+ * description as text (see live-system-instruction.ts's toolsBlock comment).
+ * It exists ONLY for LiveKit (whose @function_tool decorators don't fully
+ * serialize onto the wire). Vertex and AI Studio both always carry the
+ * structured function_declarations, so the block is genuinely redundant on
+ * those transports — and on a heavy-tool-catalog authenticated user it can
+ * push the aggregate system_instruction well past 100 KB, which is what
+ * caused AI Studio's Live API to close the connection with a code=1007
+ * "invalid argument" on the first client_content send (setup itself is
+ * accepted; see orb-live.ts's GEMINI_LIVE_USE_API_KEY call site).
+ *
+ * These tests lock: the block renders by default (existing Vertex/LiveKit
+ * behavior, unchanged), and omitToolsProse=true removes ONLY that block while
+ * leaving the rest of the prompt (identity lock, tone rules, etc.) intact.
+ */
+
+import { buildLiveSystemInstruction } from '../../../../src/orb/live/instruction/live-system-instruction';
+
+const H_TOOLS = '## AVAILABLE TOOLS';
+const IDENTITY_LOCK = '=== IDENTITY LOCK ===';
+
+/** Authenticated community-role call so renderAvailableToolsSection is non-empty. */
+function build(omitToolsProse?: boolean): string {
+  return buildLiveSystemInstruction(
+    'en', 'conversational', '', 'community', '', '', false, null, '/', [], undefined, '@x',
+    undefined, // omitGreetingPolicy
+    undefined, // surface
+    omitToolsProse,
+  );
+}
+
+describe('BOOTSTRAP-AWS-STAGING-VALIDATION: omitToolsProse', () => {
+  it('defaults to including the AVAILABLE TOOLS prose block (existing behavior)', () => {
+    const out = build();
+    expect(out).toContain(H_TOOLS);
+  });
+
+  it('explicit false still includes the block', () => {
+    const out = build(false);
+    expect(out).toContain(H_TOOLS);
+  });
+
+  it('true drops ONLY the AVAILABLE TOOLS block', () => {
+    const withBlock = build(false);
+    const withoutBlock = build(true);
+    expect(withoutBlock).not.toContain(H_TOOLS);
+    // Everything else is unaffected — same prompt minus the tools section.
+    expect(withoutBlock).toContain(IDENTITY_LOCK);
+    expect(withBlock.length).toBeGreaterThan(withoutBlock.length);
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-AWS-STAGING-VALIDATION` _(continuation of #2902–#2904)_

**Layer:** APIL

**Priority:** P1

---

## 📋 Summary

This is the root-cause fix for the `code=1007 "Request contains an invalid argument"` close discovered while verifying #2904's diagnostic logging against AWS staging.

**What the diagnostic evidence showed:** setup now succeeds (the model-id fix from #2903 works), but the connection closes ~200ms after the gateway sends its first `client_content` (the injected greeting) — for a payload as small as 530 bytes, with completely different greeting templates across two separate test runs. That rules out the greeting message itself.

**What actually causes it:** the assembled `system_instruction` sent in `setup` already has its own known, documented budget guard (`BOOTSTRAP-ORB-R0-INSTRUCTION-CAP`, 30 KB) — and it's firing on every authenticated session, logging `stillOverBudget: true` at **~150 KB**, because the guard's largest section (the static "scaffold") is explicitly never trimmed, by design, when trimming everything else still isn't enough. The bulk of that scaffold turns out to be `## AVAILABLE TOOLS` — a full prose restatement of every tool's name + description, laid on top of the *already-sent* structured `function_declarations` in the same envelope. Its own code comment says exactly why it exists and that it's redundant elsewhere:

> "Vertex's own path always carries the structured `function_declarations` in the BidiGenerate setup message, so the prose block is redundant on Vertex but harmless — same description text Gemini already sees from the declarations, just rendered once more."

It exists *only* because LiveKit's `@function_tool` decorator chain doesn't fully serialize onto the wire. AI Studio uses the exact same envelope builder as Vertex (same structured declarations), so the same "redundant but harmless" reasoning applies — except on AI Studio it isn't harmless: for an authenticated user with a large tool catalog (250+ tools here), this single block is large enough to push the aggregate instruction well past whatever context budget AI Studio actually enforces at generation time (setup itself only checks frame validity, not context size — hence the failure surfaces on the *first* content-generation attempt, not at setup).

## ✅ Changes

- [x] `live-system-instruction.ts` — new `omitToolsProse?: boolean` param on `buildLiveSystemInstruction`, mirroring the existing `omitGreetingPolicy` flag already used for the same kind of LiveKit-only trim. When true, skips appending the `## AVAILABLE TOOLS` block.
- [x] `orb-live.ts` — the AI Studio Live call site now passes `omitToolsProse: GEMINI_LIVE_USE_API_KEY` (true only for that transport). The Vertex/GCP behavior is **completely unchanged** — it doesn't pass this flag, so it defaults to `false`.
- [x] `orb-livekit.ts` / `voice-lab/livekit-test-eval.ts` — untouched. LiveKit still needs (and gets) the prose block for its own documented reason.
- [x] New test: `test/orb/live/instruction/omit-tools-prose.test.ts` — locks default-on behavior, explicit-false behavior, and that `true` drops *only* that block (rest of the prompt, incl. `IDENTITY LOCK`, is untouched).

Tool-calling itself is unaffected on AI Studio — the structured `function_declarations` are still sent in full; only the duplicate text description is dropped.

## 🧪 Testing

- [x] `npm run build` — compiles cleanly
- [x] `npx jest` (full suite) — 460/460 suites, 8043/8043 tests passing (6 skipped, 6 todo — pre-existing)
- [x] New `omit-tools-prose.test.ts` — 3/3 passing
- [ ] Manual: once deployed, run another live ORB session against AWS staging and confirm the greeting completes without the `code=1007` close

## 🚨 Breaking Changes

None for Vertex/GCP or LiveKit. AI Studio Live sessions no longer receive the duplicate `## AVAILABLE TOOLS` text block in `system_instruction` — tools remain fully callable via the structured declarations.

## 📌 Additional Notes

Part of the same investigation thread as #2902–#2904. The temporary `GET /api/v1/debug/ai-studio-models` route from #2902 is still present pending full end-to-end confirmation that ORB voice works on AWS.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_