### PR TITLE
fix(voice): drop redundant AVAILABLE TOOLS prose on Vertex Live transport — prod ORB hotfix (BOOTSTRAP-ORB-INSTRUCTION-BUDGET)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -413,9 +413,12 @@ export function buildLiveSystemInstruction(
   // heavy-tool-catalog user (250+ tools) it alone can run well past 100 KB,
   // which is what pushed the aggregate system_instruction over AI Studio's
   // real context budget and caused a code=1007 "invalid argument" close on
-  // the very first client_content send (setup itself is accepted). Passed
-  // true only for the AI Studio transport for now — Vertex keeps existing
-  // behavior unchanged pending a decision to trim it there too.
+  // the very first client_content send (setup itself is accepted).
+  // BOOTSTRAP-ORB-INSTRUCTION-BUDGET: now passed true for BOTH raw-WS
+  // transports (Vertex included) — after the Wave-MVA-1 catalog growth the
+  // authenticated Vertex instruction hit ~49k tokens and Gemini Live closed
+  // every authenticated prod session with the same code=1007. Only LiveKit
+  // (which genuinely needs the prose) leaves this unset.
   omitToolsProse?: boolean,
 ): string {
   const languageNames: Record<string, string> = {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6902,11 +6902,22 @@ async function connectToLiveAPI(
                         session.identity?.vitana_id ?? null,
                         undefined, // omitGreetingPolicy — unchanged (Vertex/AI Studio still need it)
                         undefined, // surface — unchanged (route-based heuristic)
-                        // BOOTSTRAP-AWS-STAGING-VALIDATION: drop the redundant
-                        // `## AVAILABLE TOOLS` prose block on the AI Studio
-                        // transport only — see buildLiveSystemInstruction's
-                        // omitToolsProse param comment. Vertex keeps it.
-                        GEMINI_LIVE_USE_API_KEY,
+                        // BOOTSTRAP-ORB-INSTRUCTION-BUDGET: drop the redundant
+                        // `## AVAILABLE TOOLS` prose block on BOTH raw-WS
+                        // transports (Vertex and AI Studio). The prose is
+                        // generated from the exact same buildLiveApiTools()
+                        // declarations this envelope already carries
+                        // structurally (renderAvailableToolsSection), so it is
+                        // redundant by construction here; it exists only for
+                        // LiveKit, whose call site does NOT set this flag.
+                        // #2905 dropped it for AI Studio when it blew that
+                        // transport's budget; the Wave-MVA-1 catalog growth
+                        // (+35 tools, PR #2895) then pushed the authenticated
+                        // Vertex instruction to ~49k tokens → Gemini Live
+                        // closed every authenticated session with code 1007
+                        // ("user system instruction has 48787 tokens") —
+                        // prod ORB stuck at "Verbinden…". Always omit here.
+                        true,
                       ))) as string
             }]
           },

--- a/services/gateway/test/orb/live/instruction/omit-tools-prose.test.ts
+++ b/services/gateway/test/orb/live/instruction/omit-tools-prose.test.ts
@@ -53,3 +53,38 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: omitToolsProse', () => {
     expect(withBlock.length).toBeGreaterThan(withoutBlock.length);
   });
 });
+
+describe('BOOTSTRAP-ORB-INSTRUCTION-BUDGET: raw-WS transports always omit the prose', () => {
+  // Prod incident lock: with the full catalog (683 manifest / 500+ live
+  // tools), the prose block alone pushes an authenticated instruction to
+  // ~49k tokens — Gemini Live closes the session with code=1007 ("user
+  // system instruction has 48787 tokens") and the ORB freezes at
+  // "Verbinden…". The single Vertex/AI-Studio call site in routes/orb-live.ts
+  // must therefore pass omitToolsProse=true UNCONDITIONALLY (it was
+  // GEMINI_LIVE_USE_API_KEY-gated, which left Vertex prod exposed). The
+  // structured function_declarations in the same setup envelope keep every
+  // tool callable — the prose is redundant by construction on these
+  // transports (renderAvailableToolsSection reads the same declarations).
+  it('routes/orb-live.ts passes omitToolsProse=true unconditionally at the raw-WS call site', () => {
+    const fs = require('fs') as typeof import('fs');
+    const path = require('path') as typeof import('path');
+    const src = fs
+      .readFileSync(path.join(__dirname, '../../../../src/routes/orb-live.ts'), 'utf8')
+      .replace(/\r\n/g, '\n');
+    // The omitGreetingPolicy/surface/omitToolsProse positional tail of the
+    // buildLiveSystemInstruction call. A revert to the transport-gated flag
+    // (GEMINI_LIVE_USE_API_KEY) or to `undefined` re-opens the prod outage.
+    const tail = /omitGreetingPolicy[^]*?surface — unchanged[^]*?\n\s*(true|GEMINI_LIVE_USE_API_KEY|undefined|false),\n\s*\)\)\) as string/;
+    const m = src.match(tail);
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe('true');
+  });
+
+  it('the prose drop reclaims the bulk of the authenticated instruction budget', () => {
+    const withBlock = build(false);
+    const withoutBlock = build(true);
+    // The block is the dominant cost: dropping it must reclaim well over
+    // half of the assembled instruction on a full-catalog community build.
+    expect(withoutBlock.length).toBeLessThan(withBlock.length / 2);
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-ORB-INSTRUCTION-BUDGET` _(production hotfix)_

**Layer:** AGTL (voice) / APIL (gateway)

**Priority:** P0 — **prod ORB voice is down for all authenticated users**

---

## 📋 Summary

After the Wave-MVA-1 catalog growth (#2895, +35 live tools) shipped to prod, **every authenticated ORB voice session dies ~3s after `session_started`**: Gemini Live closes the upstream with **code 1007** — *"the system instruction has 94 tokens, user system instruction has 48787 tokens…"*. The mobile ORB freezes at "Verbinden…". Anonymous sessions (smaller instruction) kept working, which is why post-deploy smoke passed.

Root cause: the `## AVAILABLE TOOLS` prose directory in the system instruction. It is generated from the **exact same `buildLiveApiTools()` declarations** the raw-WS setup envelope already carries structurally (`renderAvailableToolsSection`) — redundant by construction on Vertex and AI Studio. #2905 already dropped it for the AI Studio transport when it blew that budget, explicitly leaving Vertex *"pending a decision to trim it there too."* The MVA growth forced that decision.

---

## ✅ Changes

- [x] `routes/orb-live.ts` — pass `omitToolsProse=true` unconditionally at the single raw-WS call site (was: only when `GEMINI_LIVE_USE_API_KEY`). LiveKit call sites untouched — that transport genuinely needs the prose.
- [x] `orb/live/instruction/live-system-instruction.ts` — param doc updated to the new reality.

Tool calling is unaffected: the structured `function_declarations` still go up in the same envelope.

---

## 🧪 Testing

- [x] Automated tests added/updated — existing `omit-tools-prose.test.ts` covers the flag; full gateway suite green (458 suites / 8096 tests, snapshots unchanged — call-site-only change)
- [x] Manual testing — **reproduced the outage via authenticated WS probe against prod** (e2e test user): `connect → start → session_started → live_api_disconnected code=1007` with the 48,787-token instruction error. Anonymous probe streams greeting audio fine on both prod and staging.
- [ ] Verified in staging/dev environment — post-merge: will re-run the authenticated probe against staging before publishing prod

---

## 📝 Phase 2B Naming Compliance Checklist

- [x] No workflow files touched; no new files; existing naming untouched
- [x] Tag in commit message (`BOOTSTRAP-ORB-INSTRUCTION-BUDGET`)

---

## 🔗 Links

- **Precedent:** #2905 (same fix for the AI Studio transport)
- **Trigger:** #2895 (Wave MVA-1 catalog growth)

---

## 🚨 Breaking Changes

None. The Vertex model loses only a duplicate text listing of tools it already receives as structured declarations.

---

## 📌 Additional Notes

Publish plan: merge → staging auto-deploy → authenticated WS probe on `preview-gateway.vitanaland.com` must show `session_started` **without** the code-1007 close → EXEC-DEPLOY dispatch to prod → same probe on `gateway.vitanaland.com` → user retest on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8asyxacyzSFfwYCH5eT83

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8asyxacyzSFfwYCH5eT83)_