### PR TITLE
Wire Bedrock as an explicit LLM provider option (VTID-03403)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,47 @@ Located at: `config/service-path-map.json`
 
 ---
 
+## 2b. LLM ROUTING — BEDROCK PROVIDER (VTID-03403)
+
+The gateway's LLM dispatcher (`services/gateway/src/services/llm-router.ts`)
+selects a provider per-*stage* from the DB-backed `llm_routing_policy` table
+(editable via the Command Hub dropdown), via an `ADAPTERS: Record<LLMProvider,
+ProviderAdapter>` map. **Anthropic Claude via Amazon Bedrock (`'bedrock'`) is
+one of these adapters**, alongside `anthropic`, `openai`, `vertex`,
+`deepseek`, and `claude_subscription`.
+
+- **Region:** `eu-central-1` — the only region with any Vitana AWS
+  infrastructure for account `472838866351` (confirmed via
+  `scripts/aws-staging-validation/reports/aws-run-20260716/FINDINGS.md`).
+  Read from `AWS_BEDROCK_REGION` (falls back to `AWS_REGION`, then
+  `us-east-1`).
+- **Activation gate:** `BEDROCK_ROLE_ARN` env var. Unset → the adapter
+  reports itself unavailable (`not_configured`) and the router skips it like
+  any other provider with missing credentials. Setting it in
+  `gateway-staging` is a deliberate, separate action — not a byproduct of
+  deploying this code.
+- **Model selection:** `ADAPTERS.bedrock.call()` takes the model string
+  straight from whatever the active stage's `llm_routing_policy` row
+  specifies — for Bedrock this must be a resolved **cross-region inference
+  profile ID** (e.g. `eu.anthropic.claude-sonnet-4-6-v1:0`), not a bare
+  on-demand model ID. `PROVIDER_FLAGSHIPS.bedrock`
+  (`services/gateway/src/constants/llm-defaults.ts`) is only the Command Hub
+  dropdown's convenience default — read from `BEDROCK_MODEL_ID` if set.
+- **Not selected by default anywhere.** Adding the adapter does not change
+  any stage's routing — Bedrock only runs when an operator explicitly points
+  a stage at `'bedrock'`.
+- **Not yet supported:** vision (`image`/`images`) and tool calling
+  (`tools`/`forceTool`) — the adapter returns an explicit error for these
+  rather than silently dropping them or mis-serializing the request.
+- **Implementation:** `services/gateway/src/providers/bedrock.ts`
+  (`invokeBedrock()`) does the actual `BedrockRuntimeClient.send()` call;
+  `bedrockAdapter` in `llm-router.ts` adapts it to the router's
+  `ProviderAdapter` interface. Provider/model/latency logging comes for
+  free via the router's existing `startLLMCall`/`completeLLMCall`/
+  `failLLMCall` telemetry — no Bedrock-specific logging code needed.
+
+---
+
 ## 3. DATABASE (SUPABASE)
 
 ### Critical Rules

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -309,3 +309,25 @@ GEMINI_LIVE_TRANSPORT=vertex
 # (gemini-live-2.5-flash-native-audio) nor gemini-2.0-flash-live-001 exist
 # in this catalog. Override if Google's catalog changes.
 AI_STUDIO_LIVE_MODEL=gemini-2.5-flash-native-audio-latest
+
+# VTID-03403: Anthropic Claude via Amazon Bedrock, wired as an explicit
+# llm-router.ts provider ('bedrock') that no stage selects by default.
+# BEDROCK_ROLE_ARN: IAM role ARN with least-privilege bedrock:InvokeModel /
+#   bedrock:InvokeModelWithResponseStream, scoped to the resolved
+#   cross-region inference profile. OPTIONAL — unset means the adapter
+#   reports itself unavailable (not_configured); there is no sensible
+#   default for a role ARN, so no fallback is applied at the call site.
+#   Not yet provisioned — AWS console/CLI access blocked in the session
+#   that wrote this file (see VTID-03403).
+BEDROCK_ROLE_ARN=
+# AWS_BEDROCK_REGION: falls back to AWS_REGION, then 'us-east-1'. Confirmed
+# eu-central-1 for this account (472838866351) — see
+# scripts/aws-staging-validation/reports/aws-run-20260716/FINDINGS.md.
+AWS_BEDROCK_REGION=eu-central-1
+# BEDROCK_MODEL_ID: Command Hub dropdown convenience default only — must be
+# a resolved cross-region inference profile ID (e.g.
+# eu.anthropic.claude-sonnet-4-6-v1:0), NOT a bare on-demand model ID. Does
+# NOT affect ADAPTERS.bedrock.call(), which always uses the per-stage
+# llm_routing_policy model string. OPTIONAL — falls back to an unconfirmed
+# placeholder in code pending AWS resolution (VTID-03403).
+BEDROCK_MODEL_ID=

--- a/services/gateway/package-lock.json
+++ b/services/gateway/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.1091.0",
         "@google-cloud/text-to-speech": "^5.5.0",
         "@google-cloud/vertexai": "^1.9.2",
         "@google/generative-ai": "^0.24.1",
@@ -79,6 +80,347 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1091.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1091.0.tgz",
+      "integrity": "sha512-THeQe5ftFfJD0DdSanD3BjXjjbOWK5mhJX1pEzDUH9VgBRGB9KFCIDTfgWOj6hZ8HTMpZdjF2WjqopuESleEAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/eventstream-handler-node": "^3.972.29",
+        "@aws-sdk/middleware-eventstream": "^3.972.24",
+        "@aws-sdk/middleware-websocket": "^3.972.41",
+        "@aws-sdk/token-providers": "3.1091.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.29.tgz",
+      "integrity": "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.24.tgz",
+      "integrity": "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.41.tgz",
+      "integrity": "sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1091.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1091.0.tgz",
+      "integrity": "sha512-l+/H0KCTcUZzE4RVT+eW5E94BRKX4vsuvquWvldzIjiDkGonMJM0sOtdZYeW4z5hq953jY+wESFGpCxs0K62GQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2700,6 +3042,87 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.6.tgz",
+      "integrity": "sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.11.tgz",
+      "integrity": "sha512-6CUvZwS0tCcVCrcvh2TpwTXxmAkuY6JGNPeKODYRLjHtUUhFLGS3dNkNdRvT/ttJyqimqnhFMTS2nqp4pDZ7oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.8.tgz",
+      "integrity": "sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.8.tgz",
+      "integrity": "sha512-ArSSIN4t1wLutcIkHzaL6N11J7xpZK7W3T0pFz9cep9zIpEr9x5+lhJRcVUgObGI3OIMbnROq7w8bwzx+Nkf8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.7.tgz",
+      "integrity": "sha512-32PmEsuZV9lz7SZk3gJcm+EfIAoIVu83AJyEzgALpwmSqLvuacdAu0fvCVNMbDbegyk1S0lHUDrMWIfR47Micw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.80.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.80.0.tgz",
@@ -3796,6 +4219,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1091.0",
     "@google-cloud/text-to-speech": "^5.5.0",
     "@google-cloud/vertexai": "^1.9.2",
     "@google/generative-ai": "^0.24.1",

--- a/services/gateway/pnpm-lock.yaml
+++ b/services/gateway/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.90.0
         version: 0.90.0(zod@3.25.76)
+      '@aws-sdk/client-bedrock-runtime':
+        specifier: ^3.1091.0
+        version: 3.1091.0
       '@google-cloud/text-to-speech':
         specifier: ^5.5.0
         version: 5.8.1
@@ -73,7 +76,7 @@ importers:
         version: 3.3.2
       openai:
         specifier: ^6.34.0
-        version: 6.46.0(ws@8.18.3)(zod@3.25.76)
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.70)(@smithy/signature-v4@5.6.7)(ws@8.18.3)(zod@3.25.76)
       rss-parser:
         specifier: ^3.13.0
         version: 3.13.0
@@ -158,6 +161,86 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@aws-sdk/client-bedrock-runtime@3.1091.0':
+    resolution: {integrity: sha512-THeQe5ftFfJD0DdSanD3BjXjjbOWK5mhJX1pEzDUH9VgBRGB9KFCIDTfgWOj6hZ8HTMpZdjF2WjqopuESleEAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.975.3':
+    resolution: {integrity: sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.59':
+    resolution: {integrity: sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.61':
+    resolution: {integrity: sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.4':
+    resolution: {integrity: sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.66':
+    resolution: {integrity: sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.70':
+    resolution: {integrity: sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.59':
+    resolution: {integrity: sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    resolution: {integrity: sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    resolution: {integrity: sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.29':
+    resolution: {integrity: sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.24':
+    resolution: {integrity: sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.41':
+    resolution: {integrity: sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.33':
+    resolution: {integrity: sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1088.0':
+    resolution: {integrity: sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1091.0':
+    resolution: {integrity: sha512-l+/H0KCTcUZzE4RVT+eW5E94BRKX4vsuvquWvldzIjiDkGonMJM0sOtdZYeW4z5hq953jY+wESFGpCxs0K62GQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.36':
+    resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -908,6 +991,30 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@smithy/core@3.29.6':
+    resolution: {integrity: sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.11':
+    resolution: {integrity: sha512-6CUvZwS0tCcVCrcvh2TpwTXxmAkuY6JGNPeKODYRLjHtUUhFLGS3dNkNdRvT/ttJyqimqnhFMTS2nqp4pDZ7oQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.8':
+    resolution: {integrity: sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.8':
+    resolution: {integrity: sha512-ArSSIN4t1wLutcIkHzaL6N11J7xpZK7W3T0pFz9cep9zIpEr9x5+lhJRcVUgObGI3OIMbnROq7w8bwzx+Nkf8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.7':
+    resolution: {integrity: sha512-32PmEsuZV9lz7SZk3gJcm+EfIAoIVu83AJyEzgALpwmSqLvuacdAu0fvCVNMbDbegyk1S0lHUDrMWIfR47Micw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@supabase/auth-js@2.87.1':
     resolution: {integrity: sha512-6RDeOf5TVoaXFtEstN188ykp3pXLZaU9qoAWfx8dc50FFAAqt+kcFJ96V0IvSmcpb4mDAWcpTJ7BegmVDn/WIw==}
     engines: {node: '>=20.0.0'}
@@ -1240,6 +1347,9 @@ packages:
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -3128,6 +3238,188 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
+  '@aws-sdk/client-bedrock-runtime@3.1091.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-node': 3.972.70
+      '@aws-sdk/eventstream-handler-node': 3.972.29
+      '@aws-sdk/middleware-eventstream': 3.972.24
+      '@aws-sdk/middleware-websocket': 3.972.41
+      '@aws-sdk/token-providers': 3.1091.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/node-http-handler': 4.9.8
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.975.3':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.36
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.6
+      '@smithy/signature-v4': 5.6.7
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/node-http-handler': 4.9.8
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.4':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-login': 3.972.66
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/credential-provider-imds': 4.4.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.66':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.70':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-ini': 3.973.4
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/credential-provider-imds': 4.4.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/token-providers': 3.1088.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.29':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.24':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/signature-v4': 5.6.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.33':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/node-http-handler': 4.9.8
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1088.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1091.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.36':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -3924,6 +4216,39 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@smithy/core@3.29.6':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.11':
+    dependencies:
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.8':
+    dependencies:
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.8':
+    dependencies:
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.7':
+    dependencies:
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@supabase/auth-js@2.87.1':
     dependencies:
       tslib: 2.8.1
@@ -4356,6 +4681,8 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -5872,8 +6199,10 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@6.46.0(ws@8.18.3)(zod@3.25.76):
+  openai@6.46.0(@aws-sdk/credential-provider-node@3.972.70)(@smithy/signature-v4@5.6.7)(ws@8.18.3)(zod@3.25.76):
     optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.70
+      '@smithy/signature-v4': 5.6.7
       ws: 8.18.3
       zod: 3.25.76
 

--- a/services/gateway/src/constants/llm-defaults.ts
+++ b/services/gateway/src/constants/llm-defaults.ts
@@ -212,12 +212,14 @@ export const VALID_PROVIDERS: LLMProvider[] = [
  * on a mid-tier or light option.
  *
  * `bedrock`'s value is NOT a plain model ID — Bedrock cross-region inference
- * requires the resolved inference profile ID (e.g. `eu.anthropic.claude-*`),
- * which is still blocked on AWS console/CLI access (VTID-03403). Read from
- * BEDROCK_MODEL_ID once that's resolved; the literal fallback below is an
- * unconfirmed placeholder for the dropdown default only — it does not affect
- * `ADAPTERS.bedrock.call()`, which always uses the per-stage DB policy's
- * configured model string, never this constant.
+ * requires the resolved inference profile ID. Confirmed via
+ * `aws bedrock list-inference-profiles` (VTID-03403): the Claude Sonnet 4.6
+ * cross-region profile in `eu-central-1` is `eu.anthropic.claude-sonnet-4-6`
+ * (no `-v1:0` suffix — that was an earlier unconfirmed guess). Read from
+ * BEDROCK_MODEL_ID if set; the literal below is only the dropdown's
+ * convenience default — it does not affect `ADAPTERS.bedrock.call()`, which
+ * always uses the per-stage DB policy's configured model string, never this
+ * constant.
  */
 export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
   anthropic: 'claude-opus-4-7',
@@ -225,7 +227,7 @@ export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
   openai: 'gpt-5',
   deepseek: 'deepseek-reasoner',
   claude_subscription: 'claude-opus-4-7',
-  bedrock: process.env.BEDROCK_MODEL_ID || 'eu.anthropic.claude-sonnet-4-6-v1:0',
+  bedrock: process.env.BEDROCK_MODEL_ID || 'eu.anthropic.claude-sonnet-4-6',
 };
 
 /**

--- a/services/gateway/src/constants/llm-defaults.ts
+++ b/services/gateway/src/constants/llm-defaults.ts
@@ -43,7 +43,8 @@ export type LLMProvider =
   | 'vertex'
   | 'openai'
   | 'deepseek'
-  | 'claude_subscription';
+  | 'claude_subscription'
+  | 'bedrock';
 
 /**
  * Stage routing configuration
@@ -202,12 +203,21 @@ export const VALID_PROVIDERS: LLMProvider[] = [
   'openai',
   'deepseek',
   'claude_subscription',
+  'bedrock',
 ];
 
 /**
  * Per-provider flagship — looked up by the Command Hub dropdown so flipping
  * providers always lands on the strongest model from the new provider, never
  * on a mid-tier or light option.
+ *
+ * `bedrock`'s value is NOT a plain model ID — Bedrock cross-region inference
+ * requires the resolved inference profile ID (e.g. `eu.anthropic.claude-*`),
+ * which is still blocked on AWS console/CLI access (VTID-03403). Read from
+ * BEDROCK_MODEL_ID once that's resolved; the literal fallback below is an
+ * unconfirmed placeholder for the dropdown default only — it does not affect
+ * `ADAPTERS.bedrock.call()`, which always uses the per-stage DB policy's
+ * configured model string, never this constant.
  */
 export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
   anthropic: 'claude-opus-4-7',
@@ -215,6 +225,7 @@ export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
   openai: 'gpt-5',
   deepseek: 'deepseek-reasoner',
   claude_subscription: 'claude-opus-4-7',
+  bedrock: process.env.BEDROCK_MODEL_ID || 'eu.anthropic.claude-sonnet-4-6-v1:0',
 };
 
 /**

--- a/services/gateway/src/providers/bedrock.ts
+++ b/services/gateway/src/providers/bedrock.ts
@@ -1,23 +1,28 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+
 /**
- * Anthropic-via-Bedrock provider — Phase 1 W1 (VTID-03181 VOICE-LAT).
+ * Anthropic-via-Bedrock provider (VTID-03181 VOICE-LAT W1; wired in
+ * VTID-03403 W3/W4, reopened from VTID-03402 after an autopilot false
+ * completion — see VTID-03402/03403 spec history).
  *
- * DORMANT in W1. Activates in W3+ once an AWS account is provisioned and
- * BEDROCK_ROLE_ARN env var is set. The runtime check below early-returns
- * a typed error so callers can fall back to Vertex/Anthropic seamlessly.
+ * Still dormant until BEDROCK_ROLE_ARN is set on a real deployment (AWS
+ * IAM/model-access provisioning is tracked separately in VTID-03403 and
+ * requires AWS console/CLI access). The runtime check below early-returns
+ * a typed error so callers can fall back to another provider seamlessly.
  *
- * The @aws-sdk/client-bedrock-runtime dep is NOT added in W1 — we use a
- * dynamic require() inside the function so the build stays green without
- * the install. When BEDROCK_ROLE_ARN is set in W3, the corresponding PR
- * also runs `npm i @aws-sdk/client-bedrock-runtime` in the same commit.
- *
- * Wire path: conversation-router.ts (W4 migration) reads
- * preferred_provider='bedrock' and routes here. Until then, this module
- * is unreferenced — included only so the import surface is fixed.
+ * Wire path: services/gateway/src/services/llm-router.ts registers a
+ * `bedrockAdapter` in its `ADAPTERS` map, calling `invokeBedrock()` below.
+ * There is no `conversation-router.ts` and no `preferred_provider` field —
+ * that mechanism never existed; the real dispatch is per-stage via the
+ * DB-backed `llm_routing_policy`, same as every other provider.
  */
 
 export interface BedrockInvokeRequest {
   model: string;
-  messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>;
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+  /** Top-level system prompt, matching Anthropic's Messages API shape
+   *  (including via Bedrock) — NOT a role:'system' entry in `messages`. */
+  system?: string;
   max_tokens?: number;
   temperature?: number;
   tools?: unknown[];
@@ -33,7 +38,7 @@ export interface BedrockInvokeResponse {
 
 export interface BedrockInvokeError {
   ok: false;
-  error: 'not_configured' | 'sdk_missing' | 'invoke_failed';
+  error: 'not_configured' | 'invoke_failed';
   message: string;
 }
 
@@ -47,44 +52,27 @@ export async function invokeBedrock(
     return {
       ok: false,
       error: 'not_configured',
-      message: 'BEDROCK_ROLE_ARN env var not set; Bedrock is dormant until W3 AWS provisioning lands',
-    };
-  }
-
-  let BedrockRuntimeClient: unknown;
-  let InvokeModelCommand: unknown;
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = require('@aws-sdk/client-bedrock-runtime');
-    BedrockRuntimeClient = mod.BedrockRuntimeClient;
-    InvokeModelCommand = mod.InvokeModelCommand;
-  } catch {
-    return {
-      ok: false,
-      error: 'sdk_missing',
-      message: '@aws-sdk/client-bedrock-runtime not installed; run `npm i @aws-sdk/client-bedrock-runtime` then redeploy',
+      message: 'BEDROCK_ROLE_ARN env var not set; Bedrock is dormant until AWS provisioning lands (VTID-03403)',
     };
   }
 
   const start = Date.now();
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const client = new (BedrockRuntimeClient as any)({ region: BEDROCK_REGION });
+    const client = new BedrockRuntimeClient({ region: BEDROCK_REGION });
     const body = JSON.stringify({
       anthropic_version: 'bedrock-2023-05-31',
       max_tokens: req.max_tokens ?? 2048,
       temperature: req.temperature ?? 0.5,
+      ...(req.system ? { system: req.system } : {}),
       messages: req.messages,
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const command = new (InvokeModelCommand as any)({
+    const command = new InvokeModelCommand({
       modelId: req.model,
       contentType: 'application/json',
       accept: 'application/json',
       body,
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const resp = await (client as any).send(command);
+    const resp = await client.send(command);
     const payload = JSON.parse(new TextDecoder().decode(resp.body));
     const text = Array.isArray(payload.content) && payload.content[0]?.text ? payload.content[0].text : '';
     return {

--- a/services/gateway/src/services/llm-router.ts
+++ b/services/gateway/src/services/llm-router.ts
@@ -35,6 +35,7 @@
 
 import { getActivePolicy } from './llm-routing-policy-service';
 import { startLLMCall, completeLLMCall, failLLMCall } from './llm-telemetry-service';
+import { invokeBedrock } from '../providers/bedrock';
 import {
   LLM_SAFE_DEFAULTS,
   type LLMRoutingPolicy,
@@ -677,12 +678,47 @@ const claudeSubscriptionAdapter: ProviderAdapter = {
   },
 };
 
+/**
+ * Anthropic Claude via Amazon Bedrock — dormant until BEDROCK_ROLE_ARN is
+ * set on a real deployment (VTID-03403; AWS IAM/model-access provisioning
+ * requires AWS console/CLI access outside this codebase). Vision and tool
+ * calling are not yet supported — see `call()` below.
+ */
+const bedrockAdapter: ProviderAdapter = {
+  isAvailable: () => Boolean(process.env.BEDROCK_ROLE_ARN),
+  async call({ prompt, model, systemPrompt, maxTokens, image, images, tools }): Promise<AdapterResult> {
+    if ((images && images.length > 0) || image || (tools && tools.length > 0)) {
+      return { ok: false, error: 'Bedrock adapter does not support images/tools yet (VTID-03403)' };
+    }
+
+    const result = await invokeBedrock({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      system: systemPrompt,
+      max_tokens: maxTokens,
+    });
+
+    if (!result.ok) {
+      return { ok: false, error: `Bedrock ${result.error}: ${result.message}` };
+    }
+    return {
+      ok: true,
+      text: result.text,
+      usage: {
+        inputTokens: result.usage?.input_tokens ?? 0,
+        outputTokens: result.usage?.output_tokens ?? 0,
+      },
+    };
+  },
+};
+
 const ADAPTERS: Record<LLMProvider, ProviderAdapter> = {
   anthropic: anthropicAdapter,
   openai: openaiAdapter,
   vertex: vertexAdapter,
   deepseek: deepseekAdapter,
   claude_subscription: claudeSubscriptionAdapter,
+  bedrock: bedrockAdapter,
 };
 
 // =============================================================================


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03403` (reopen of `VTID-03402`, parent lineage `VTID-03181` → `VTID-03402` → `VTID-03403`)

**Layer:** `DEV` / **Module:** `GATEWAY` (per `vtid_ledger`)

**Priority:** not formally assigned. Automated spec quality-check flagged `risk_level: CRITICAL`, but `overall_score: 100` and `overall_result: pass` — CRITICAL is a false positive from a keyword/filename scanner counting explicitly out-of-scope and cited-reference files as "files modified" (true count ~6, not the 17 it reported); see spec v1 §9 for the human risk assessment (LOW-MEDIUM).

---

## 📋 Summary

Adds Anthropic-via-Bedrock as a selectable provider adapter in the gateway's `llm-router.ts` `ADAPTERS` map, alongside `anthropic`/`openai`/`vertex`/`deepseek`/`claude_subscription`. Bedrock is reachable but **not selected anywhere by default** — an operator must explicitly point a stage's `llm_routing_policy` at `'bedrock'` for it to run.

---

## ✅ Changes

- [x] `services/gateway/src/providers/bedrock.ts` — static import of `@aws-sdk/client-bedrock-runtime`; top-level `system` field in the request body (Anthropic's Messages API requires it as a distinct field, not a `role:'system'` message)
- [x] `services/gateway/src/constants/llm-defaults.ts` — `'bedrock'` added to `LLMProvider`, `VALID_PROVIDERS`, `PROVIDER_FLAGSHIPS` (pointed at the confirmed real inference profile ID `eu.anthropic.claude-sonnet-4-6`)
- [x] `services/gateway/src/services/llm-router.ts` — new `bedrockAdapter` (gated on `BEDROCK_ROLE_ARN`; images/tools explicitly rejected, not silently dropped) registered in `ADAPTERS`
- [x] `CLAUDE.md` — new §2b documenting the provider
- [x] `@aws-sdk/client-bedrock-runtime` added to `package.json`/`pnpm-lock.yaml`
- [x] AWS: confirmed Claude Sonnet 4.6 model access in `eu-central-1`
- [x] AWS: least-privilege IAM policy + `BEDROCK_ROLE_ARN`-equivalent credentials scoped to the resolved inference profile ARN and its underlying regional foundation-model ARNs, wired into `gateway-staging` via GCP Secret Manager
- [x] Resolved exact cross-region inference profile ID (`aws bedrock list-inference-profiles`) — `eu.anthropic.claude-sonnet-4-6`
- [ ] End-to-end verification call through `ADAPTERS.bedrock.call()` from deployed `gateway-staging` — pending post-merge deploy (raw AWS CLI `invoke-model` already proven working)

---

## 🧪 Testing

- [x] `pnpm run build` succeeds (tsc + copy-frontend + copy-data)
- [x] Raw AWS CLI `invoke-model` against the resolved inference profile succeeds end-to-end
- [ ] Automated tests added/updated — none added; no existing tests reference these files
- [ ] Full adapter call verified against deployed staging — next step after merge/deploy

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- N/A — no workflow files added or changed by this PR.

### File Names
- [x] No new files added; all modified files already kebab-case (`bedrock.ts`, `llm-defaults.ts`, `llm-router.ts`).

### Code Standards
- N/A — no new VTID constants, OASIS event types, or status enums added in code by this PR.

### Cloud Run Deployments
- N/A — no Cloud Run service/deploy config changes in this PR. (Secrets wiring into `gateway-staging` was done directly via `gcloud`/Secret Manager, outside this diff.)

### Documentation
- [x] VTID (`VTID-03403`) is in the commit message.
- [x] No non-compliant files introduced.

---

## 🔗 Links

- **VTID lineage:** `VTID-03181` (W1 dormant stub) → `VTID-03402` (falsely completed by autopilot, see notes) → `VTID-03403` (this PR)
- **Documentation:** `CLAUDE.md` §2b (added in this PR)
- **Related PRs:** none

---

## 🚨 Breaking Changes

None. Purely additive — no existing provider, adapter, or routing policy is touched; nothing selects `'bedrock'` as a result of this change.

---

## 📸 Screenshots (if applicable)

N/A — backend-only change, no UI surface.

---

## 📌 Additional Notes

**Why this VTID number looks unusual:** this is a reopen. `VTID-03402`'s spec was approved, and the autopilot `worker-runner` pipeline auto-claimed it 5 seconds later, ran it through an LLM "worker" chain that **hallucinated** a file-change narrative referencing nonexistent paths (e.g. `services/agents/src/providers/bedrock-provider.ts`) and fabricated model IDs (`anthropic.claude-v3/v4`), hit a real verification error (`400 Invalid domain: infra`) that got misclassified as non-blocking advisory, then transitioned to `completed`/`success` with a mislabeled `trigger: verification_passed` despite the prior failure — **with zero real code changes landing** (confirmed via clean `git status` at the time). Since `VTID-03402` is now `is_terminal=true`, it can't be modified further per this repo's own governance rules, so the real, corrected plan was carried forward under `VTID-03403`, pre-claimed under a non-autopilot `worker_id` before spec approval to prevent the same race. This is worth someone investigating as a platform bug independent of this PR.

**Known unrelated CI anomaly:** `VALIDATOR-CHECK.yml` shows a failing "push"-triggered run on every commit to this branch, including the very first one before any of this PR's changes existed. That workflow only declares `on: pull_request` triggers but is also force-evaluated on raw pushes (likely via an org-level required-workflow ruleset), where it can't run (0 jobs, instant fail) since it depends on PR-only context. Pre-existing repo/ruleset misconfiguration, not introduced by or fixable within this PR; `mergeable_state` is `clean` so it is not gating merge.

Full spec: `vtid_specs` table, `vtid='VTID-03403'`, version 1 (region resolution, scope, acceptance criteria, rollback plan).

---
_Generated by [Claude Code](https://claude.ai/code/session_013B3WFRSjtHQ4dKAVu6bMyC)_