### PR TITLE
fix(gateway): unshadow GET /session/continuity route

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -41,7 +41,7 @@
  * - CSP compliant: No inline scripts/styles
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
@@ -11204,8 +11204,15 @@ router.post('/session/finalize', async (req: Request, res: Response) => {
 /**
  * VTID-01039: GET /session/:orb_session_id - Get full transcript + summary
  */
-router.get('/session/:orb_session_id', (req: Request, res: Response) => {
+router.get('/session/:orb_session_id', (req: Request, res: Response, next: NextFunction) => {
   const { orb_session_id } = req.params;
+
+  // GET /session/continuity is a separate, more specific route registered
+  // later in this file — without this guard it's unreachable, since Express
+  // matches routes in registration order and this wildcard comes first.
+  if (orb_session_id === 'continuity') {
+    return next();
+  }
 
   if (!orb_session_id) {
     return res.status(400).json({

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -11204,6 +11204,9 @@ router.post('/session/finalize', async (req: Request, res: Response) => {
 /**
  * VTID-01039: GET /session/:orb_session_id - Get full transcript + summary
  */
+// public-route: pre-existing anonymous route (no auth wrapper on main before
+// this PR either); the session id itself is the access token, and this PR
+// only adds a passthrough guard for the /session/continuity path below.
 router.get('/session/:orb_session_id', (req: Request, res: Response, next: NextFunction) => {
   const { orb_session_id } = req.params;
 


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-VOICE-SESSION-CONTINUITY-ROUTE-SHADOW` _(no formal VTID exists yet for this fix, tracked under this BOOTSTRAP tag pending one — same pattern as the recent `BOOTSTRAP-PUBLIC-BUSINESS-PROFILE` entry)_

**Layer:** APIL (Gateway ORB Live routes)

**Priority:** P2

---

## 📋 Summary

`GET /session/:orb_session_id` was registered earlier in `orb-live.ts` than the dedicated `GET /session/continuity` handler. Express matches routes in registration order, so every `GET /session/continuity` request was being caught by the wildcard handler first, which looked up `"continuity"` as a session id in `orbTranscripts`, found nothing, and returned a 404 `{"ok":false,"error":"Session transcript not found"}`. The real continuity handler further down the file was unreachable dead code. Confirmed live via curl against `preview-gateway.vitanaland.com`.

Found while investigating a live ORB voice bug report (mic disconnecting right after the assistant's turn ends) — this particular route wasn't the root cause of that symptom (continuity is documented in the widget code as "an optimization — never block session start," so it fails soft), but it's a real, deployed bug worth fixing on its own. Companion fix in `exafyltd/vitana-v1` (same branch) addresses the actual root cause found for the mic-disconnect symptom (missing `allow="microphone"` on the admin device-preview iframe).

`POST`/`DELETE /session/continuity` were unaffected — no earlier wildcard route registered for those methods.

---

## ✅ Changes

- [x] Import `NextFunction` from `express`
- [x] Guard `GET /session/:orb_session_id` to call `next()` when the param is literally `"continuity"`, passing the request through to the real handler instead of treating it as a session id

---

## 🧪 Testing

- [x] Local build passes (`npm run build` in `services/gateway`)
- [x] Automated test added and run locally (not committed — a throwaway supertest check mounting the router directly): confirmed `GET /session/continuity` no longer returns the wildcard's `"Session transcript not found"` 404, and `GET /session/<real-id>` still 404s via the wildcard exactly as before
- [x] Verified in staging/dev environment — reproduced the pre-fix 404 live via curl against `preview-gateway.vitanaland.com` before writing the fix

---

## 📝 Phase 2B Naming Compliance Checklist

- [x] No new workflow files added
- [x] No new files added (single-file diff to an existing kebab-case file, `orb-live.ts`)
- [x] No new VTID constants, event types, or status values introduced
- [x] No Cloud Run deployment/label changes
- [x] N/A — no formal VTID exists yet; tracked under the BOOTSTRAP tag above per existing precedent

---

## 🚨 Breaking Changes

None. `GET /session/continuity` starts returning real data instead of a 404; no other route's behavior changes.

---

## 📌 Additional Notes

Minimal single-guard fix rather than reordering ~1,200 lines of route registrations between the two handlers, to avoid disturbing anything the intervening routes depend on.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBzE9eYF2276nW7P33nKj6)_