### PR TITLE
Fix Bedrock NGHTTP2_PROTOCOL_ERROR — force HTTP/1.1 (VTID-03403)

### DIFF
--- a/services/gateway/src/providers/bedrock.ts
+++ b/services/gateway/src/providers/bedrock.ts
@@ -1,4 +1,5 @@
 import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
 
 /**
  * Anthropic-via-Bedrock provider (VTID-03181 VOICE-LAT W1; wired in
@@ -58,7 +59,14 @@ export async function invokeBedrock(
 
   const start = Date.now();
   try {
-    const client = new BedrockRuntimeClient({ region: BEDROCK_REGION });
+    // Force HTTP/1.1: the SDK's default handler can negotiate HTTP/2 against
+    // Bedrock Runtime's regional endpoint, which breaks inside Cloud Run's
+    // sandboxed network stack (NGHTTP2_PROTOCOL_ERROR — confirmed via a real
+    // staging call in VTID-03403). NodeHttpHandler forces HTTP/1.1.
+    const client = new BedrockRuntimeClient({
+      region: BEDROCK_REGION,
+      requestHandler: new NodeHttpHandler(),
+    });
     const body = JSON.stringify({
       anthropic_version: 'bedrock-2023-05-31',
       max_tokens: req.max_tokens ?? 2048,


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03403` (same VTID as #2910, which this follows up on — lineage `VTID-03181` → `VTID-03402` → `VTID-03403`)

## 📋 Summary

Follow-up to #2910. That PR wired Bedrock into the gateway's `ADAPTERS` map and deployed it to `gateway-staging` with real AWS credentials bound via Secret Manager. End-to-end verification (a real call through `ADAPTERS.bedrock.call()` via the `triage` stage on staging) got past the credentials gate but failed on the actual AWS call:

```
Bedrock invoke_failed: Stream closed with error code NGHTTP2_PROTOCOL_ERROR
```

This is a known class of issue: the AWS SDK v3 default request handler can negotiate HTTP/2 against Bedrock Runtime's regional endpoint, which breaks inside Cloud Run's sandboxed network stack.

## ✅ Changes

- [x] `services/gateway/src/providers/bedrock.ts` — explicitly pass `requestHandler: new NodeHttpHandler()` to `BedrockRuntimeClient` to force HTTP/1.1. No new dependency — `@smithy/node-http-handler` is already a transitive dependency of `@aws-sdk/client-bedrock-runtime` (confirmed present in `package-lock.json`).

## 🧪 Testing

- [ ] Manual verification pending this PR's merge + staging redeploy: will re-run the same live test (temporarily point `triage` stage at `bedrock` via `llm_routing_policy`, call `POST /api/v1/agents/triage/investigate`, read the result via the stream endpoint, then revert the policy).
- [ ] Automated tests — none added; no existing tests cover this file.

## 🚨 Breaking Changes

None. Purely a request-handler configuration change to an adapter that isn't selected by default anywhere.

## 📌 Additional Notes

Also found and fixed during this verification pass (separate from this PR, already applied directly): `gateway-staging` was missing the AWS credential env bindings (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_BEDROCK_REGION`/`BEDROCK_ROLE_ARN`) despite the secrets existing in Secret Manager (`gateway-aws-access-key-id`, `gateway-aws-secret-access-key`) — they were never bound to the Cloud Run service. That's now fixed via `gcloud run services update --update-secrets` (revision `gateway-staging-00491-s7z`), unblocking the credentials gate and surfacing this HTTP/2 issue as the next real blocker.

---
_Generated by [Claude Code](https://claude.ai/code/session_013B3WFRSjtHQ4dKAVu6bMyC)_