### PR TITLE
Bind Bedrock AWS credentials durably in STAGE-DEPLOY.yml (VTID-03403)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -179,6 +179,16 @@ jobs:
             # no-op'd on preview-gateway.vitanaland.com.
             "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
             "DEEPSEEK_API_KEY=${{ secrets.DEEPSEEK_API_KEY }}"
+            # VTID-03403: Bedrock activation gate + region. Not a secret — the
+            # SDK auth comes from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY below,
+            # this is just the presence flag invokeBedrock() checks. Bake into
+            # this workflow (not a one-off gcloud call) for the same reason as
+            # every other entry above: --set-env-vars REPLACES the whole env on
+            # every STAGE-DEPLOY run, so anything set out-of-band gets wiped on
+            # the next push (confirmed live: it wiped a manual binding of this
+            # exact var).
+            "AWS_BEDROCK_REGION=eu-central-1"
+            "BEDROCK_ROLE_ARN=gateway-staging-static-iam-user"
           )
 
           # Comma-joined for --set-env-vars (replaces, not merges — we want the
@@ -201,6 +211,12 @@ jobs:
             "SUPABASE_ANON_KEY=SUPABASE_ANON_KEY:latest"
             "SUPABASE_JWT_SECRET=SUPABASE_JWT_SECRET:latest"
             "GOOGLE_GEMINI_API_KEY=GOOGLE_GEMINI_API_KEY:latest"
+            # VTID-03403: static IAM user credentials for the Bedrock adapter.
+            # --set-secrets REPLACES too — same trap as ENV_VARS above, this is
+            # the durable fix (was previously bound via a one-off
+            # gcloud run services update that this workflow wiped on redeploy).
+            "AWS_ACCESS_KEY_ID=gateway-aws-access-key-id:latest"
+            "AWS_SECRET_ACCESS_KEY=gateway-aws-secret-access-key:latest"
           )
           SECRETS_JOINED=$(IFS=, ; echo "${SECRETS[*]}")
 


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03403` (follows up on #2910 and #2912 — lineage `VTID-03181` → `VTID-03402` → `VTID-03403`)

## 📋 Summary

Second follow-up to #2910/#2912. After #2912 fixed the `NGHTTP2_PROTOCOL_ERROR`, re-running the same live end-to-end test on the freshly redeployed `gateway-staging` regressed back to `"Provider 'bedrock' has no credentials configured"` — even though the AWS credentials had already been confirmed bound via a manual `gcloud run services update --update-secrets` just before that deploy ran.

Root cause: `STAGE-DEPLOY.yml` deploys with `--set-env-vars`/`--set-secrets`, which **replace** the entire env/secret config on every run rather than merge. This exact trap is already documented in this file's own comments for `GATEWAY_SERVICE_TOKEN`, `FEATURE_INTENT_ENGINE_A`, and the ORB fast-start flags — each had to be baked into the workflow's own `ENV_VARS`/`SECRETS` arrays after a one-off `gcloud` binding got silently wiped by the next auto-deploy. The Bedrock AWS credentials fell into the same trap.

## ✅ Changes

- [x] `.github/workflows/STAGE-DEPLOY.yml` — added to `SECRETS`: `AWS_ACCESS_KEY_ID=gateway-aws-access-key-id:latest`, `AWS_SECRET_ACCESS_KEY=gateway-aws-secret-access-key:latest`. Added to `ENV_VARS`: `AWS_BEDROCK_REGION=eu-central-1`, `BEDROCK_ROLE_ARN=gateway-staging-static-iam-user`.

The two Secret Manager secrets already exist (created earlier in this VTID's work) — this PR only binds them durably to the deploy workflow.

## 🧪 Testing

- [ ] Manual verification pending this PR's merge + staging redeploy: same live test as #2910/#2912 (temporarily point `triage` stage at `bedrock`, call `POST /api/v1/agents/triage/investigate`, read the result via the stream endpoint, revert the policy).

## 🚨 Breaking Changes

None. Adds two new env vars and two new secret bindings to a staging-only deploy workflow; nothing existing changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_013B3WFRSjtHQ4dKAVu6bMyC)_