### PR TITLE
Migrate Tier A gateway LLM call sites from Gemini 2.5 to Claude Sonnet 4.6

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -309,3 +309,11 @@ GEMINI_LIVE_TRANSPORT=vertex
 # (gemini-live-2.5-flash-native-audio) nor gemini-2.0-flash-live-001 exist
 # in this catalog. Override if Google's catalog changes.
 AI_STUDIO_LIVE_MODEL=gemini-2.5-flash-native-audio-latest
+
+# VOICE_INVESTIGATOR_MODEL: model used by the Architecture Investigator
+# (services/voice-architecture-investigator.ts) that Recurrence Sentinel /
+# Spec Memory Gate spawns to diagnose recurring voice-pipeline failures.
+# OPTIONAL — unset defaults to claude-sonnet-4-6 (BOOTSTRAP-GEMINI-TO-CLAUDE;
+# was gemini-2.5-pro via Vertex before this migration). Intentionally
+# unbound in deploy config; only set to pin a different Claude model.
+# VOICE_INVESTIGATOR_MODEL=claude-sonnet-4-6

--- a/services/gateway/.env.template
+++ b/services/gateway/.env.template
@@ -86,3 +86,9 @@ AUTOPILOT_RETRY_CONFIDENCE_VERIFICATION=0.5
 
 # BOOTSTRAP-MATCHMAKING-INDEX: gate match-journey context derivation; OFF→historical {journeyStage:'none'} stub; dev/validation only
 # FEATURE_MATCH_JOURNEY_CONTEXT=false
+
+# VOICE_INVESTIGATOR_MODEL: model used by the Architecture Investigator
+# (services/voice-architecture-investigator.ts). OPTIONAL — unset defaults
+# to claude-sonnet-4-6 (BOOTSTRAP-GEMINI-TO-CLAUDE). Intentionally unbound
+# in deploy config; only set to pin a different Claude model.
+# VOICE_INVESTIGATOR_MODEL=claude-sonnet-4-6

--- a/services/gateway/src/routes/llm.ts
+++ b/services/gateway/src/routes/llm.ts
@@ -408,7 +408,10 @@ router.get('/models', async (req: Request, res: Response) => {
     cost_per_1k: string;
     usage: string;
   }> = [
-    // Vertex AI (voice/live pipeline only — chat/spec routes migrated to Claude, see below)
+    // Vertex AI (Operator Chat NOT yet migrated — routes/operator.ts still
+    // calls processWithGemini/gemini-operator.ts, default gemini-2.5-pro —
+    // plus voice/live pipeline)
+    { provider: 'vertex-ai', model_id: 'gemini-2.5-pro', status: 'active', avg_latency: 850, cost_per_1k: '0.0035', usage: 'Operator Chat (not yet migrated — see gemini-operator.ts)' },
     { provider: 'vertex-ai', model_id: 'gemini-2.0-flash', status: 'active', avg_latency: 320, cost_per_1k: '0.00015', usage: 'Fact extraction, fast queries' },
     { provider: 'vertex-ai', model_id: 'gemini-1.5-pro', status: 'active', avg_latency: 920, cost_per_1k: '0.0035', usage: 'Fallback routing, long context' },
     // Gemini API
@@ -419,10 +422,11 @@ router.get('/models', async (req: Request, res: Response) => {
     { provider: 'openai', model_id: 'gpt-4o', status: 'active', avg_latency: 900, cost_per_1k: '0.0050', usage: 'ChatGPT (user-supplied key)' },
     { provider: 'openai', model_id: 'gpt-4o-mini', status: 'active', avg_latency: 400, cost_per_1k: '0.00015', usage: 'ChatGPT fast (user-supplied key)' },
     // Anthropic
-    // BOOTSTRAP-GEMINI-TO-CLAUDE: Operator Chat, spec generation, intent
-    // classify/extract, matchmaker, and the architecture investigator now
-    // call Claude Sonnet 4.6 directly (server-side key, not user-supplied).
-    { provider: 'anthropic', model_id: 'claude-sonnet-4-6', status: 'active', avg_latency: 700, cost_per_1k: '0.003', usage: 'Operator Chat, spec generation, intent classify/extract, matchmaker, architecture investigator' },
+    // BOOTSTRAP-GEMINI-TO-CLAUDE: spec generation, intent classify/extract,
+    // matchmaker, and the architecture investigator now call Claude Sonnet
+    // 4.6 directly (server-side key, not user-supplied). Operator Chat
+    // itself is NOT included — that's the still-Gemini row above.
+    { provider: 'anthropic', model_id: 'claude-sonnet-4-6', status: 'active', avg_latency: 700, cost_per_1k: '0.003', usage: 'Spec generation, intent classify/extract, matchmaker, architecture investigator' },
     { provider: 'anthropic', model_id: 'claude-sonnet-4-6', status: 'active', avg_latency: 700, cost_per_1k: '0.003', usage: 'Claude default (user-supplied key)' },
     { provider: 'anthropic', model_id: 'claude-haiku-4-5-20251001', status: 'active', avg_latency: 350, cost_per_1k: '0.0008', usage: 'Claude fast (user-supplied key)' },
     { provider: 'anthropic', model_id: 'claude-opus-4-7', status: 'configured', avg_latency: 1200, cost_per_1k: '0.015', usage: 'Claude premium (user-supplied key)' },

--- a/services/gateway/src/routes/llm.ts
+++ b/services/gateway/src/routes/llm.ts
@@ -408,20 +408,21 @@ router.get('/models', async (req: Request, res: Response) => {
     cost_per_1k: string;
     usage: string;
   }> = [
-    // Vertex AI
-    { provider: 'vertex-ai', model_id: 'gemini-2.5-pro', status: 'active', avg_latency: 850, cost_per_1k: '0.0035', usage: 'Operator Chat, spec quality' },
+    // Vertex AI (voice/live pipeline only — chat/spec routes migrated to Claude, see below)
     { provider: 'vertex-ai', model_id: 'gemini-2.0-flash', status: 'active', avg_latency: 320, cost_per_1k: '0.00015', usage: 'Fact extraction, fast queries' },
     { provider: 'vertex-ai', model_id: 'gemini-1.5-pro', status: 'active', avg_latency: 920, cost_per_1k: '0.0035', usage: 'Fallback routing, long context' },
     // Gemini API
     { provider: 'gemini-api', model_id: 'gemini-3-pro-preview', status: 'active', avg_latency: 1100, cost_per_1k: '0.0040', usage: 'ORB Assistant (Q&A)' },
     { provider: 'gemini-api', model_id: 'gemini-2.0-flash-exp', status: 'active', avg_latency: 280, cost_per_1k: '0.00015', usage: 'Command parsing' },
-    { provider: 'gemini-api', model_id: 'gemini-2.5-pro', status: 'active', avg_latency: 880, cost_per_1k: '0.0035', usage: 'General assistance' },
     // OpenAI (embeddings + user-keyed chat)
     { provider: 'openai', model_id: 'text-embedding-3-small', status: 'active', avg_latency: 120, cost_per_1k: '0.00002', usage: 'Semantic memory embeddings' },
     { provider: 'openai', model_id: 'gpt-4o', status: 'active', avg_latency: 900, cost_per_1k: '0.0050', usage: 'ChatGPT (user-supplied key)' },
     { provider: 'openai', model_id: 'gpt-4o-mini', status: 'active', avg_latency: 400, cost_per_1k: '0.00015', usage: 'ChatGPT fast (user-supplied key)' },
-    // Anthropic (user-keyed chat)
-    // BOOTSTRAP-AI-VERIFY-MODEL: refreshed to current Claude 4.x lineup.
+    // Anthropic
+    // BOOTSTRAP-GEMINI-TO-CLAUDE: Operator Chat, spec generation, intent
+    // classify/extract, matchmaker, and the architecture investigator now
+    // call Claude Sonnet 4.6 directly (server-side key, not user-supplied).
+    { provider: 'anthropic', model_id: 'claude-sonnet-4-6', status: 'active', avg_latency: 700, cost_per_1k: '0.003', usage: 'Operator Chat, spec generation, intent classify/extract, matchmaker, architecture investigator' },
     { provider: 'anthropic', model_id: 'claude-sonnet-4-6', status: 'active', avg_latency: 700, cost_per_1k: '0.003', usage: 'Claude default (user-supplied key)' },
     { provider: 'anthropic', model_id: 'claude-haiku-4-5-20251001', status: 'active', avg_latency: 350, cost_per_1k: '0.0008', usage: 'Claude fast (user-supplied key)' },
     { provider: 'anthropic', model_id: 'claude-opus-4-7', status: 'configured', avg_latency: 1200, cost_per_1k: '0.015', usage: 'Claude premium (user-supplied key)' },

--- a/services/gateway/src/routes/specs.ts
+++ b/services/gateway/src/routes/specs.ts
@@ -12,32 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { createHash } from 'crypto';
-import { VertexAI } from '@google-cloud/vertexai';
-import { GoogleAuth } from 'google-auth-library';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import { runFullQualityCheck } from '../services/spec-quality-agent';
+import { callClaudeText, CLAUDE_SONNET_4_6 } from '../services/claude-text-client';
 
 const router = Router();
 
 // ===========================================================================
-// Vertex AI for LLM-powered spec generation
+// Claude Sonnet 4.6 for LLM-powered spec generation (BOOTSTRAP-GEMINI-TO-CLAUDE:
+// migrated off Gemini 3.1 Pro / 2.5 Pro — see claude-text-client.ts)
 // ===========================================================================
-const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
-
-// Primary: Gemini 3.1 Pro via REST (requires global endpoint)
-const SPEC_GEN_MODEL_PRIMARY = 'gemini-3.1-pro-preview';
-// Fallback: Gemini 2.5 Pro via SDK (us-central1)
-const SPEC_GEN_MODEL_FALLBACK = 'gemini-2.5-pro';
-
-let googleAuth: GoogleAuth | null = null;
-let vertexAI: VertexAI | null = null;
-try {
-  googleAuth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/cloud-platform'] });
-  vertexAI = new VertexAI({ project: VERTEX_PROJECT, location: 'us-central1' });
-  console.log(`[VTID-01188] Spec gen initialized: primary=${SPEC_GEN_MODEL_PRIMARY} (global), fallback=${SPEC_GEN_MODEL_FALLBACK} (us-central1)`);
-} catch (err: any) {
-  console.warn(`[VTID-01188] Failed to init spec gen: ${err.message}`);
-}
+const SPEC_GEN_MODEL = CLAUDE_SONNET_4_6;
 
 // ===========================================================================
 // VTID-01188: Spec Template (Mandatory Output Format)
@@ -272,58 +257,8 @@ async function gatherSystemContext(vtid: string, title: string): Promise<string>
 }
 
 /**
- * Call Gemini via Vertex AI REST API (supports global endpoint for 3.1 Pro).
- */
-async function callGeminiREST(
-  model: string,
-  location: string,
-  systemPrompt: string,
-  userPrompt: string,
-  config: { temperature: number; maxOutputTokens: number; topP: number }
-): Promise<string | null> {
-  if (!googleAuth) return null;
-
-  const accessToken = await googleAuth.getAccessToken();
-  if (!accessToken) throw new Error('Failed to get access token');
-
-  // Global endpoint has no region prefix; regional endpoints use {region}-aiplatform...
-  const baseUrl = location === 'global'
-    ? 'https://aiplatform.googleapis.com'
-    : `https://${location}-aiplatform.googleapis.com`;
-
-  const url = `${baseUrl}/v1/projects/${VERTEX_PROJECT}/locations/${location}/publishers/google/models/${model}:generateContent`;
-
-  const body = {
-    contents: [{ role: 'user', parts: [{ text: userPrompt }] }],
-    systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] },
-    generationConfig: {
-      temperature: config.temperature,
-      maxOutputTokens: config.maxOutputTokens,
-      topP: config.topP,
-    },
-  };
-
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
-  });
-
-  if (!resp.ok) {
-    const errText = await resp.text().catch(() => 'unknown');
-    throw new Error(`Vertex REST ${resp.status}: ${errText.substring(0, 300)}`);
-  }
-
-  const data = await resp.json() as any;
-  return data?.candidates?.[0]?.content?.parts?.[0]?.text || null;
-}
-
-/**
- * Generate a spec using Gemini 3.1 Pro (primary) or 2.5 Pro (fallback).
- * Falls back to a minimal template if all LLMs are unavailable.
+ * Generate a spec using Claude Sonnet 4.6.
+ * Falls back to a minimal template if the LLM is unavailable.
  */
 async function generateSpecWithLLM(vtid: string, title: string, summary: string, seedNotes: string, source: string): Promise<string> {
   const systemContext = await gatherSystemContext(vtid, title);
@@ -349,46 +284,22 @@ async function generateSpecWithLLM(vtid: string, title: string, summary: string,
     `- NEVER use placeholder text like "TBD", "to be determined", or "None identified"`,
   ].filter(Boolean).join('\n');
 
-  const genConfig = { temperature: 0.3, maxOutputTokens: 16384, topP: 0.9 };
-
-  // === Primary: Gemini 3.1 Pro via REST (global endpoint) ===
   try {
-    console.log(`[VTID-01188] Trying ${SPEC_GEN_MODEL_PRIMARY} (global) for ${vtid}: "${title}" (context: ${systemContext.length} chars)`);
-    const text = await callGeminiREST(SPEC_GEN_MODEL_PRIMARY, 'global', SPEC_GEN_SYSTEM_PROMPT, promptParts, genConfig);
+    console.log(`[VTID-01188] Trying ${SPEC_GEN_MODEL} for ${vtid}: "${title}" (context: ${systemContext.length} chars)`);
+    const text = await callClaudeText({
+      model: SPEC_GEN_MODEL,
+      system: SPEC_GEN_SYSTEM_PROMPT,
+      prompt: promptParts,
+      maxTokens: 16384,
+      temperature: 0.3,
+    });
     if (text && text.length > 200) {
-      console.log(`[VTID-01188] ${SPEC_GEN_MODEL_PRIMARY} spec generated for ${vtid}: ${text.length} chars`);
+      console.log(`[VTID-01188] ${SPEC_GEN_MODEL} spec generated for ${vtid}: ${text.length} chars`);
       return text;
     }
-    console.warn(`[VTID-01188] ${SPEC_GEN_MODEL_PRIMARY} returned insufficient content (${text?.length || 0} chars)`);
+    console.warn(`[VTID-01188] ${SPEC_GEN_MODEL} returned insufficient content (${text?.length || 0} chars)`);
   } catch (err: any) {
-    console.warn(`[VTID-01188] ${SPEC_GEN_MODEL_PRIMARY} failed for ${vtid}: ${err.message}`);
-  }
-
-  // === Fallback: Gemini 2.5 Pro via SDK (us-central1) ===
-  if (vertexAI) {
-    try {
-      console.log(`[VTID-01188] Falling back to ${SPEC_GEN_MODEL_FALLBACK} (us-central1) for ${vtid}`);
-      const model = vertexAI.getGenerativeModel({
-        model: SPEC_GEN_MODEL_FALLBACK,
-        generationConfig: genConfig,
-        systemInstruction: { role: 'system', parts: [{ text: SPEC_GEN_SYSTEM_PROMPT }] },
-      });
-
-      const response = await model.generateContent({
-        contents: [{ role: 'user', parts: [{ text: promptParts }] }],
-      });
-
-      const candidate = response.response?.candidates?.[0];
-      const text = candidate?.content?.parts?.[0]?.text;
-
-      if (text && text.length > 200) {
-        console.log(`[VTID-01188] ${SPEC_GEN_MODEL_FALLBACK} spec generated for ${vtid}: ${text.length} chars`);
-        return text;
-      }
-      console.warn(`[VTID-01188] ${SPEC_GEN_MODEL_FALLBACK} returned insufficient content (${text?.length || 0} chars)`);
-    } catch (err: any) {
-      console.error(`[VTID-01188] ${SPEC_GEN_MODEL_FALLBACK} failed for ${vtid}: ${err.message}`);
-    }
+    console.error(`[VTID-01188] ${SPEC_GEN_MODEL} failed for ${vtid}: ${err.message}`);
   }
 
   // Fallback: minimal template (clearly marked as needing manual editing)

--- a/services/gateway/src/services/claude-text-client.ts
+++ b/services/gateway/src/services/claude-text-client.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared direct-API Claude client for gateway services migrated off Gemini/Vertex.
+ *
+ * Single choke point so the transport (direct Anthropic API today, Bedrock
+ * once AWS IAM + model access are provisioned) can change in one place
+ * without touching every call site.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+
+export const CLAUDE_SONNET_4_6 = 'claude-sonnet-4-6';
+
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+
+let client: Anthropic | null = null;
+try {
+  if (ANTHROPIC_API_KEY) {
+    client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
+  }
+} catch {
+  client = null;
+}
+
+export interface ClaudeTextCallOptions {
+  model?: string;
+  system: string;
+  prompt: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+/**
+ * Single-turn text completion. Returns null (not throw) when the client
+ * isn't configured or the response has no text — callers already have
+ * deterministic fallbacks for a null result.
+ */
+export async function callClaudeText(opts: ClaudeTextCallOptions): Promise<string | null> {
+  if (!client) return null;
+
+  const msg = await client.messages.create({
+    model: opts.model ?? CLAUDE_SONNET_4_6,
+    max_tokens: opts.maxTokens ?? 4096,
+    temperature: opts.temperature ?? 0.3,
+    system: opts.system,
+    messages: [{ role: 'user', content: opts.prompt }],
+  });
+
+  const text = msg.content
+    .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+    .map((block) => block.text)
+    .join('');
+
+  return text || null;
+}

--- a/services/gateway/src/services/intent-classifier.ts
+++ b/services/gateway/src/services/intent-classifier.ts
@@ -1,51 +1,23 @@
 /**
  * VTID-01973: Intent kind classifier for the Vitana Intent Engine (P2-A).
  *
- * First-stage Gemini call that maps a free-form utterance to one of the
+ * First-stage LLM call that maps a free-form utterance to one of the
  * registered intent_kinds + a confidence score. The dispatcher hands off
  * to the kind-specific extractor only when confidence ≥ 0.7; below that,
  * ORB asks a clarifying question.
  *
- * BOOTSTRAP-FIND-MATCH-CLASSIFY-FIX: the original Vertex call used
- * gemini-2.0-flash with NO responseMimeType and a system-role
- * systemInstruction, and its only fallback was gated on
- * GOOGLE_GEMINI_API_KEY — an env var that is NOT configured on the gateway
- * (see index.ts). In production that combination returned confidence 0 for
- * EVERY utterance (verified against textbook examples), so the ORB
- * "find a match / post an activity" voice flow could never classify an
- * intent and bailed with "I can't do that right now" before posting.
- *
- * This now mirrors the proven-working matchmaker call shape: JSON mode
- * (responseMimeType), the prompt folded into the user turn (no
- * system-role systemInstruction), a model fallback chain that ends in the
- * known-good gemini-2.5-pro, and withGeminiLog telemetry so any future
- * regression is visible in gemini_call_log instead of silent.
+ * BOOTSTRAP-GEMINI-TO-CLAUDE: migrated off the Vertex Gemini fallback chain
+ * (gemini-2.5-flash → gemini-2.5-pro, plus a GOOGLE_GEMINI_API_KEY REST
+ * fallback that was never actually configured on the gateway) to Claude
+ * Sonnet 4.6 via the direct Anthropic API. withGeminiLog telemetry is kept
+ * (logs to the existing gemini_call_log table by feature+model) so any
+ * regression is still visible in the same dashboard.
  */
 
-import { VertexAI } from '@google-cloud/vertexai';
 import { withGeminiLog } from './gemini-call-log';
+import { callClaudeText, CLAUDE_SONNET_4_6 } from './claude-text-client';
 
-// Accept either name — CLAUDE.md documents GEMINI_API_KEY, older code used GOOGLE_GEMINI_API_KEY.
-const GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY || process.env.GEMINI_API_KEY;
-const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
-const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
-// Use the model family proven to work on this Vertex project. The matchmaker
-// succeeds on gemini-2.5-pro; gemini-2.0-flash is never actually exercised
-// there (no fallback rows) and returned empty/errored for the classifier, so
-// we lead with 2.5-flash and fall back to the proven 2.5-pro. Both are
-// "thinking" models, so maxOutputTokens must leave room for reasoning BEFORE
-// the JSON (a 256-token budget made 2.5-pro emit an empty candidate).
-const CLASSIFY_MODELS = ['gemini-2.5-flash', 'gemini-2.5-pro'];
 const CLASSIFY_MAX_OUTPUT_TOKENS = 2048;
-
-let vertexAI: VertexAI | null = null;
-try {
-  if (VERTEX_PROJECT && VERTEX_LOCATION) {
-    vertexAI = new VertexAI({ project: VERTEX_PROJECT, location: VERTEX_LOCATION });
-  }
-} catch {
-  vertexAI = null;
-}
 
 export type IntentKind =
   | 'commercial_buy'
@@ -134,78 +106,42 @@ function parseClassifierResponse(raw: string): IntentClassification {
 }
 
 /**
- * Vertex call with JSON mode + model fallback. Returns the raw JSON text, or
- * '' when every model failed. Each attempt is recorded in gemini_call_log
- * (success / error / fallback) so silent breakage like the original
- * confidence-0 bug surfaces in telemetry.
+ * Claude call, JSON requested via prompt instructions (parsed leniently by
+ * extractJsonObject/parseClassifierResponse). Recorded in gemini_call_log
+ * (success/error) so silent breakage like the original confidence-0 bug
+ * surfaces in telemetry.
  */
-async function runVertexClassify(userText: string): Promise<string> {
-  if (!vertexAI) return '';
-  for (let i = 0; i < CLASSIFY_MODELS.length; i++) {
-    const modelName = CLASSIFY_MODELS[i];
-    try {
-      const raw = await withGeminiLog(
-        { feature: 'classifier', model: modelName },
-        async () => {
-          const model = vertexAI!.getGenerativeModel({
-            model: modelName,
-            generationConfig: { temperature: 0.1, maxOutputTokens: CLASSIFY_MAX_OUTPUT_TOKENS, topP: 0.8, responseMimeType: 'application/json' },
-          });
-          const response = await model.generateContent({
-            contents: [{ role: 'user', parts: [{ text: `${CLASSIFIER_SYSTEM_PROMPT}\n\nUtterance to classify:\n${userText}` }] }],
-          });
-          const candidate = response.response?.candidates?.[0];
-          const textPart = candidate?.content?.parts?.find((p: any) => 'text' in p);
-          const text = textPart ? (textPart as any).text : '';
-          if (!text) throw new Error(`empty Vertex response (finishReason=${candidate?.finishReason ?? 'unknown'})`);
-          return text as string;
-        },
-      );
-      if (raw) {
-        if (i > 0) console.warn(`[VTID-01973] classifier fell back to ${modelName}`);
-        return raw;
-      }
-    } catch (err: any) {
-      console.warn(`[VTID-01973] Vertex classifier model ${modelName} failed: ${err?.message}`);
-      // try the next model in the chain
-    }
+async function runClaudeClassify(userText: string): Promise<string> {
+  try {
+    const raw = await withGeminiLog(
+      { feature: 'classifier', model: CLAUDE_SONNET_4_6 },
+      async () => {
+        const text = await callClaudeText({
+          model: CLAUDE_SONNET_4_6,
+          system: CLASSIFIER_SYSTEM_PROMPT,
+          prompt: `Utterance to classify:\n${userText}`,
+          maxTokens: CLASSIFY_MAX_OUTPUT_TOKENS,
+          temperature: 0.1,
+        });
+        if (!text) throw new Error('empty Claude response');
+        return text;
+      },
+    );
+    return raw ?? '';
+  } catch (err: any) {
+    console.warn(`[VTID-01973] Claude classifier failed: ${err?.message}`);
+    return '';
   }
-  return '';
 }
 
 export async function classifyIntentKind(utterance: string): Promise<IntentClassification> {
   const trimmed = (utterance || '').trim();
   if (!trimmed) return { intent_kind: null, confidence: 0 };
 
-  // Primary: Vertex AI (JSON mode + model fallback chain).
-  const raw = await runVertexClassify(trimmed);
+  const raw = await runClaudeClassify(trimmed);
   if (raw) {
     const parsed = parseClassifierResponse(raw);
     if (parsed.intent_kind || parsed.confidence > 0) return parsed;
-  }
-
-  // Fallback: Gemini API key (only when configured — usually not on the gateway).
-  if (GEMINI_API_KEY) {
-    try {
-      const response = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            contents: [{ parts: [{ text: `${CLASSIFIER_SYSTEM_PROMPT}\n\nUtterance to classify:\n${trimmed}` }] }],
-            generationConfig: { temperature: 0.1, maxOutputTokens: CLASSIFY_MAX_OUTPUT_TOKENS, responseMimeType: 'application/json' },
-          }),
-        }
-      );
-      if (response.ok) {
-        const data = await response.json() as any;
-        const rawApi = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
-        if (rawApi) return parseClassifierResponse(rawApi);
-      }
-    } catch (err: any) {
-      console.warn(`[VTID-01973] Gemini API classifier failed: ${err.message}`);
-    }
   }
 
   // No backend available — return null kind so callers fall back to clarification.

--- a/services/gateway/src/services/intent-extractor.ts
+++ b/services/gateway/src/services/intent-extractor.ts
@@ -1,43 +1,24 @@
 /**
  * VTID-01973: Per-kind intent extractor (P2-A).
  *
- * Strategy pattern over five Gemini-driven extractors. After
+ * Strategy pattern over five LLM-driven extractors. After
  * intent-classifier.ts identifies the kind, this module produces the
  * kind-specific structured payload (kind_payload JSONB on user_intents).
  *
- * Same Vertex+Gemini fallback pattern as inline-fact-extractor.ts. JSON
- * mode, temp 0.1, low token budget.
+ * BOOTSTRAP-GEMINI-TO-CLAUDE: migrated off the Vertex Gemini fallback chain
+ * (gemini-2.5-flash → gemini-2.5-pro, plus an unconfigured Gemini API-key
+ * fallback) to Claude Sonnet 4.6 via the direct Anthropic API. JSON
+ * requested via prompt instructions, temp 0.1, low token budget.
  *
  * Returns { fields, confidence, missing_critical } so the dispatcher knows
  * whether to fire single-shot or fall back to multi-turn slot-fill.
  */
 
-import { VertexAI } from '@google-cloud/vertexai';
 import type { IntentKind } from './intent-classifier';
 import { withGeminiLog } from './gemini-call-log';
+import { callClaudeText, CLAUDE_SONNET_4_6 } from './claude-text-client';
 
-// Accept either name — CLAUDE.md documents GEMINI_API_KEY, older code used GOOGLE_GEMINI_API_KEY.
-const GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY || process.env.GEMINI_API_KEY;
-const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
-const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
-// BOOTSTRAP-FIND-MATCH-CLASSIFY-FIX: same failure mode as the classifier — the
-// bare gemini-2.0-flash call (no JSON mode) returned empty/unparseable output on
-// the gateway and the only fallback was gated on an unset env var. Use JSON mode
-// + the model family proven to work on this Vertex project (2.5-flash → the
-// matchmaker-proven 2.5-pro), and log each attempt so silent breakage surfaces
-// in gemini_call_log. Both are "thinking" models, so the token budget must leave
-// room for reasoning before the JSON payload.
-const EXTRACT_MODELS = ['gemini-2.5-flash', 'gemini-2.5-pro'];
 const EXTRACT_MAX_OUTPUT_TOKENS = 2048;
-
-let vertexAI: VertexAI | null = null;
-try {
-  if (VERTEX_PROJECT && VERTEX_LOCATION) {
-    vertexAI = new VertexAI({ project: VERTEX_PROJECT, location: VERTEX_LOCATION });
-  }
-} catch {
-  vertexAI = null;
-}
 
 export interface ExtractedIntent {
   intent_kind: IntentKind;
@@ -239,63 +220,26 @@ export async function extractIntent(utterance: string, kind: IntentKind): Promis
   }
 
   const systemPrompt = SYSTEM_PROMPT_BY_KIND[kind];
-  const prompt = `${systemPrompt}\n\nUtterance to extract from:\n${trimmed}`;
+  const prompt = `Utterance to extract from:\n${trimmed}`;
 
-  // Primary: Vertex AI with JSON mode + model fallback chain.
-  if (vertexAI) {
-    for (let i = 0; i < EXTRACT_MODELS.length; i++) {
-      const modelName = EXTRACT_MODELS[i];
-      try {
-        const raw = await withGeminiLog(
-          { feature: 'extractor', model: modelName },
-          async () => {
-            const model = vertexAI!.getGenerativeModel({
-              model: modelName,
-              generationConfig: { temperature: 0.1, maxOutputTokens: EXTRACT_MAX_OUTPUT_TOKENS, topP: 0.8, responseMimeType: 'application/json' },
-            });
-            const response = await model.generateContent({
-              contents: [{ role: 'user', parts: [{ text: prompt }] }],
-            });
-            const candidate = response.response?.candidates?.[0];
-            const textPart = candidate?.content?.parts?.find((p: any) => 'text' in p);
-            const text = textPart ? (textPart as any).text : '';
-            if (!text) throw new Error(`empty Vertex response (finishReason=${candidate?.finishReason ?? 'unknown'})`);
-            return text as string;
-          },
-        );
-        if (raw) {
-          if (i > 0) console.warn(`[VTID-01973] extractor fell back to ${modelName} (kind=${kind})`);
-          return parseExtractorResponse(raw, kind);
-        }
-      } catch (err: any) {
-        console.warn(`[VTID-01973] Vertex extractor model ${modelName} failed (kind=${kind}): ${err?.message}`);
-        // try the next model in the chain
-      }
-    }
-  }
-
-  // Fallback: Gemini API key (only when configured — usually not on the gateway).
-  if (GEMINI_API_KEY) {
-    try {
-      const response = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            contents: [{ parts: [{ text: prompt }] }],
-            generationConfig: { temperature: 0.1, maxOutputTokens: EXTRACT_MAX_OUTPUT_TOKENS, responseMimeType: 'application/json' },
-          }),
-        }
-      );
-      if (response.ok) {
-        const data = await response.json() as any;
-        const raw = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
-        if (raw) return parseExtractorResponse(raw, kind);
-      }
-    } catch (err: any) {
-      console.warn(`[VTID-01973] Gemini API extractor failed (kind=${kind}): ${err.message}`);
-    }
+  try {
+    const raw = await withGeminiLog(
+      { feature: 'extractor', model: CLAUDE_SONNET_4_6 },
+      async () => {
+        const text = await callClaudeText({
+          model: CLAUDE_SONNET_4_6,
+          system: systemPrompt,
+          prompt,
+          maxTokens: EXTRACT_MAX_OUTPUT_TOKENS,
+          temperature: 0.1,
+        });
+        if (!text) throw new Error('empty Claude response');
+        return text;
+      },
+    );
+    if (raw) return parseExtractorResponse(raw, kind);
+  } catch (err: any) {
+    console.warn(`[VTID-01973] Claude extractor failed (kind=${kind}): ${err?.message}`);
   }
 
   return {

--- a/services/gateway/src/services/matchmaker-agent.ts
+++ b/services/gateway/src/services/matchmaker-agent.ts
@@ -1,9 +1,9 @@
 /**
- * VTID-DANCE-D12: Matchmaker agent (Gemini 2.5 Pro).
+ * VTID-DANCE-D12: Matchmaker agent (Claude Sonnet 4.6).
  *
  * Layer 2 over the SQL matcher. Takes the top-K candidates from
- * compute_intent_matches() + the requester's full context, asks Gemini
- * 2.5 Pro to re-rank and explain, and returns a richer match list.
+ * compute_intent_matches() + the requester's full context, asks Claude
+ * Sonnet 4.6 to re-rank and explain, and returns a richer match list.
  *
  * Density-aware:
  *  - solo  (pool < 5)  → simpler prompt, focus on presentation + fallbacks
@@ -13,31 +13,18 @@
  * Sensitive kinds (`partner_seek`, paid services) get extended thinking on
  * by default. Other kinds use the default reasoning budget.
  *
- * During the credit window (now → 2026-07-01) every model selection
- * favours quality: 2.5 Pro for matchmaker, embeddings via gemini-embedding-001.
+ * BOOTSTRAP-GEMINI-TO-CLAUDE: migrated off Gemini 2.5 Pro/Vertex to Claude
+ * Sonnet 4.6 via the direct Anthropic API — see claude-text-client.ts.
  *
- * Falls back gracefully to SQL ranking if Gemini fails.
+ * Falls back gracefully to SQL ranking if Claude fails.
  */
 
-import { VertexAI } from '@google-cloud/vertexai';
 import { getSupabase } from '../lib/supabase';
 import { withGeminiLog } from './gemini-call-log';
+import { callClaudeText, CLAUDE_SONNET_4_6 } from './claude-text-client';
 import type { MatchRow } from './intent-matcher';
 
-const VERTEX_PROJECT =
-  process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
-const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
-const PRIMARY_MODEL = 'gemini-2.5-pro';
-const FALLBACK_MODEL = 'gemini-2.0-flash';
-
-let vertexAI: VertexAI | null = null;
-try {
-  if (VERTEX_PROJECT && VERTEX_LOCATION) {
-    vertexAI = new VertexAI({ project: VERTEX_PROJECT, location: VERTEX_LOCATION });
-  }
-} catch {
-  vertexAI = null;
-}
+const PRIMARY_MODEL = CLAUDE_SONNET_4_6;
 
 export interface MatchmakerCandidateOut {
   match_id: string | null;            // null when this came purely from profile fallback
@@ -101,8 +88,6 @@ interface ProfileFallbackCandidate {
   city: string | null;
   dance_preferences: Record<string, any> | null;
 }
-
-const SENSITIVE_KINDS = new Set(['partner_seek']);
 
 /**
  * D12 async wrapper: kick off matchmaker as fire-and-forget. The synchronous
@@ -282,14 +267,13 @@ export async function runMatchmakerForIntent(intentId: string): Promise<Matchmak
     sqlCandidates, profileFallback,
   });
 
-  const isSensitive = SENSITIVE_KINDS.has(source.intent_kind);
-  const model = isSensitive || mode === 'growth' ? PRIMARY_MODEL : PRIMARY_MODEL; // always Pro during credit window
+  const model = PRIMARY_MODEL;
 
   const agentResponse = await callAgent({
     prompt, model, source, requester, intentId,
   });
 
-  // If Gemini failed, fall back to a deterministic shape from SQL only.
+  // If Claude failed, fall back to a deterministic shape from SQL only.
   if (!agentResponse) {
     return buildSqlOnlyResult({ source, mode, poolSize, sqlCandidates });
   }
@@ -598,7 +582,6 @@ async function callAgent(args: {
   voice_readback: string;
   reasoning_summary: string;
 } | null> {
-  if (!vertexAI) return null;
   const { prompt, model, source, requester, intentId } = args;
 
   try {
@@ -611,20 +594,14 @@ async function callAgent(args: {
         intent_id: intentId,
       },
       async () => {
-        const genModel = vertexAI!.getGenerativeModel({
+        const raw = await callClaudeText({
           model,
-          generationConfig: {
-            temperature: 0.2,
-            maxOutputTokens: 4096,
-            topP: 0.9,
-            responseMimeType: 'application/json',
-          },
+          system: 'Return ONLY valid JSON matching the schema described in the prompt — no markdown, no prose.',
+          prompt,
+          maxTokens: 4096,
+          temperature: 0.2,
         });
-        const resp = await genModel.generateContent({
-          contents: [{ role: 'user', parts: [{ text: prompt }] }],
-        });
-        const part = resp.response?.candidates?.[0]?.content?.parts?.find((p: any) => 'text' in p);
-        const raw = part ? (part as any).text : '';
+        if (!raw) throw new Error('empty Claude response');
         return raw;
       }
     );

--- a/services/gateway/src/services/self-healing-spec-service.ts
+++ b/services/gateway/src/services/self-healing-spec-service.ts
@@ -3,33 +3,22 @@
  *
  * Generates fix specifications for the Vitana self-healing system.
  * Takes a Diagnosis and produces a spec following the VTID-01188 template format.
- * Uses Gemini AI with deterministic fallback when AI is unavailable.
+ * Uses Claude Sonnet 4.6 with deterministic fallback when AI is unavailable.
+ * (BOOTSTRAP-GEMINI-TO-CLAUDE: migrated off Gemini 2.5 Pro/Vertex.)
  */
 
 import { createHash } from 'crypto';
-import { VertexAI } from '@google-cloud/vertexai';
-import { GoogleAuth } from 'google-auth-library';
 import { Diagnosis, FailureClass } from '../types/self-healing';
 import { emitOasisEvent } from './oasis-event-service';
 import { runFullQualityCheck } from './spec-quality-agent';
 import { createVtidSpec } from './vtid-spec-service';
 import { getVoiceSpecHint, parseVoiceClassFromEndpoint } from './voice-spec-hints';
+import { callClaudeText, CLAUDE_SONNET_4_6 } from './claude-text-client';
 
-const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
 
-const SPEC_MODEL_PRIMARY = 'gemini-2.5-pro';
-
-let googleAuth: GoogleAuth | null = null;
-let vertexAI: VertexAI | null = null;
-try {
-  googleAuth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/cloud-platform'] });
-  vertexAI = new VertexAI({ project: VERTEX_PROJECT, location: 'us-central1' });
-  console.log(`[SelfHealingSpec] Vertex AI initialized: model=${SPEC_MODEL_PRIMARY}, project=${VERTEX_PROJECT}`);
-} catch (err: any) {
-  console.warn(`[SelfHealingSpec] Failed to init Vertex AI: ${err.message}`);
-}
+const SPEC_MODEL_PRIMARY = CLAUDE_SONNET_4_6;
 
 const REQUIRED_SECTIONS = [
   'Goal',
@@ -168,31 +157,21 @@ ${context}
 Produce the spec in markdown with a title line "# Fix: ${diagnosis.root_cause}" and VTID "${diagnosis.vtid}".
 Include ALL 9 required sections with real, actionable content. Every curl verification step must use the actual endpoint.`;
 
-  if (vertexAI) {
-    try {
-      const model = vertexAI.getGenerativeModel({
-        model: SPEC_MODEL_PRIMARY,
-        generationConfig: {
-          temperature: 0.3,
-          maxOutputTokens: 8192,
-          topP: 0.9,
-        },
-        systemInstruction: { role: 'system', parts: [{ text: SYSTEM_PROMPT }] },
-      });
-
-      const result = await model.generateContent({
-        contents: [{ role: 'user', parts: [{ text: userPrompt }] }],
-      });
-
-      const text = result.response?.candidates?.[0]?.content?.parts?.[0]?.text;
-      if (text && text.length > 200) {
-        console.log(`[SelfHealingSpec] AI spec generated (${text.length} chars) for ${diagnosis.vtid}`);
-        return text;
-      }
-      console.warn(`[SelfHealingSpec] AI returned empty/short response for ${diagnosis.vtid}, using fallback`);
-    } catch (err: any) {
-      console.warn(`[SelfHealingSpec] AI generation failed for ${diagnosis.vtid}: ${err.message}, using fallback`);
+  try {
+    const text = await callClaudeText({
+      model: SPEC_MODEL_PRIMARY,
+      system: SYSTEM_PROMPT,
+      prompt: userPrompt,
+      maxTokens: 8192,
+      temperature: 0.3,
+    });
+    if (text && text.length > 200) {
+      console.log(`[SelfHealingSpec] AI spec generated (${text.length} chars) for ${diagnosis.vtid}`);
+      return text;
     }
+    console.warn(`[SelfHealingSpec] AI returned empty/short response for ${diagnosis.vtid}, using fallback`);
+  } catch (err: any) {
+    console.warn(`[SelfHealingSpec] AI generation failed for ${diagnosis.vtid}: ${err.message}, using fallback`);
   }
 
   return buildDeterministicSpec(diagnosis);

--- a/services/gateway/src/services/voice-architecture-investigator.ts
+++ b/services/gateway/src/services/voice-architecture-investigator.ts
@@ -11,47 +11,38 @@
  *   - Recent oasis_events for the session/class
  *   - Deterministic spec body if available (voice-spec-hints)
  *
- * Calls Vertex Gemini with a strict structured-output schema. The schema
- * requires per-hypothesis confidence, top-3 disconfirming data points,
- * and ≥ 3 alternative architectures with pros/cons/links — designed to
- * make polished hallucination harder. Persists the report to
- * voice_architecture_reports and emits voice.healing.investigation.completed.
+ * Calls Claude Sonnet 4.6 with a strict schema described in the prompt
+ * (Claude Sonnet 4.6 doesn't support native structured-output enforcement —
+ * see claude-text-client.ts / model-migration notes). The schema requires
+ * per-hypothesis confidence, top-3 disconfirming data points, and ≥ 3
+ * alternative architectures with pros/cons/links — designed to make
+ * polished hallucination harder — and validateReport() below is the
+ * enforcement backstop since the provider can't guarantee the shape.
+ * Persists the report to voice_architecture_reports and emits
+ * voice.healing.investigation.completed.
  *
  * The recommendation is NEVER auto-executed. Architectural pivots remain
  * a human decision (review in Healing dashboard, PR #8).
  *
- * v2 (post-canary): swap the Vertex call for Claude Managed Agents with
- * web_search and web_fetch tools — see Incident Triage Agent in memory.
+ * BOOTSTRAP-GEMINI-TO-CLAUDE: migrated off Vertex Gemini to Claude Sonnet
+ * 4.6 via the direct Anthropic API. Note: the INVESTIGATED SYSTEM (the ORB
+ * voice pipeline itself) still runs on Vertex Gemini Live — only the model
+ * doing the investigating changed.
+ *
+ * v2 (post-canary): swap for Claude Managed Agents with web_search and
+ * web_fetch tools — see Incident Triage Agent in memory.
  *
  * Plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md
  */
 
-import { VertexAI } from '@google-cloud/vertexai';
-import { GoogleAuth } from 'google-auth-library';
 import { emitOasisEvent } from './oasis-event-service';
 import { getVoiceSpecHint } from './voice-spec-hints';
 import { notifyGChat } from './self-healing-snapshot-service';
+import { callClaudeText, CLAUDE_SONNET_4_6 } from './claude-text-client';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
-const VERTEX_PROJECT =
-  process.env.GOOGLE_CLOUD_PROJECT ||
-  process.env.GCP_PROJECT ||
-  'lovable-vitana-vers1';
-const INVESTIGATOR_MODEL = process.env.VOICE_INVESTIGATOR_MODEL || 'gemini-2.5-pro';
-
-// =============================================================================
-// Vertex client (lazy init — same pattern as self-healing-spec-service)
-// =============================================================================
-
-let vertexAI: VertexAI | null = null;
-let googleAuth: GoogleAuth | null = null;
-try {
-  googleAuth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/cloud-platform'] });
-  vertexAI = new VertexAI({ project: VERTEX_PROJECT, location: 'us-central1' });
-} catch (err: any) {
-  console.warn(`[voice-architecture-investigator] Vertex init failed: ${err.message}`);
-}
+const INVESTIGATOR_MODEL = process.env.VOICE_INVESTIGATOR_MODEL || CLAUDE_SONNET_4_6;
 
 // =============================================================================
 // Pre-vetted alternative architectures (v1 — agent picks the relevant subset
@@ -500,63 +491,55 @@ const RESPONSE_SCHEMA = {
 };
 
 /**
- * BOOTSTRAP-LLM-ROUTER (Phase G): the investigator now routes through the
- * provider router instead of calling Vertex directly. Operator picks the
- * provider per `classifier` stage from the Command Hub dropdown. We use
- * the router's tool-use mode (forceTool) to get structured output across
- * any provider — Anthropic, OpenAI, Vertex/Gemini, DeepSeek all support
- * function calling. The report shape is unchanged; we just parse from
- * `toolCall.arguments` instead of from a JSON-mode text response.
+ * BOOTSTRAP-GEMINI-TO-CLAUDE: calls Claude Sonnet 4.6 directly via
+ * claude-text-client.ts. Claude Sonnet 4.6 has no native structured-output
+ * enforcement, so the schema is embedded as a textual instruction in the
+ * prompt and validateReport() below is the real enforcement backstop.
+ * (VTID-02002 history: this previously went through a multi-provider router
+ * whose fallback model didn't exist, silently failing every automatic
+ * investigator spawn — bypassing the router in favor of a direct call is
+ * what fixed that, and this migration keeps the direct-call shape.)
  */
-interface VertexInvestigatorResult {
+interface ClaudeInvestigatorResult {
   report: InvestigatorReport | null;
   error: string | null;
   raw_text?: string;
 }
 
-async function callVertexInvestigator(prompt: string): Promise<VertexInvestigatorResult> {
-  // VTID-02002: was using callViaRouter('classifier', ...) — but that router's
-  // primary (deepseek-reasoner) doesn't support forced tool_choice and its
-  // fallback was pointing at a non-existent model name (gemini-3-pro-preview),
-  // so 100% of automatic investigator spawns failed silently into stub reports.
-  // Bypass the router and call Vertex directly with the same pattern
-  // self-healing-spec-service.ts uses successfully in production today
-  // (vertexAI.getGenerativeModel + gemini-2.5-pro + responseSchema).
-  if (!vertexAI) {
-    return { report: null, error: 'vertex_not_initialized' };
-  }
+/** Pull the first balanced JSON object out of a model response, tolerating fences/prose. */
+function extractJsonObject(raw: string): string {
+  const cleaned = raw.trim().replace(/^```(?:json)?/i, '').replace(/```$/, '').trim();
+  if (cleaned.startsWith('{')) return cleaned;
+  const start = cleaned.indexOf('{');
+  const end = cleaned.lastIndexOf('}');
+  return start >= 0 && end > start ? cleaned.slice(start, end + 1) : cleaned;
+}
+
+async function callClaudeInvestigator(prompt: string): Promise<ClaudeInvestigatorResult> {
   try {
-    const model = vertexAI.getGenerativeModel({
+    const text = await callClaudeText({
       model: INVESTIGATOR_MODEL,
-      generationConfig: {
-        temperature: 0.4,
-        maxOutputTokens: 8192,
-        topP: 0.9,
-        responseMimeType: 'application/json',
-        responseSchema: RESPONSE_SCHEMA as any,
-      },
+      system:
+        'Return ONE JSON object only — no markdown fences, no prose before or after — ' +
+        `conforming exactly to this JSON Schema:\n${JSON.stringify(RESPONSE_SCHEMA)}`,
+      prompt,
+      maxTokens: 8192,
+      temperature: 0.4,
     });
-    const result = await model.generateContent({
-      contents: [{ role: 'user', parts: [{ text: prompt }] }],
-    });
-    const text = result.response?.candidates?.[0]?.content?.parts?.[0]?.text;
     if (!text) {
-      return {
-        report: null,
-        error: `vertex_no_text_in_response: candidates=${result.response?.candidates?.length ?? 0}`,
-      };
+      return { report: null, error: 'claude_no_text_in_response' };
     }
     try {
-      return { report: JSON.parse(text) as InvestigatorReport, error: null, raw_text: text };
+      return { report: JSON.parse(extractJsonObject(text)) as InvestigatorReport, error: null, raw_text: text };
     } catch (parseErr: any) {
       return {
         report: null,
-        error: `vertex_json_parse_failed: ${parseErr?.message ?? 'unknown'}`,
+        error: `claude_json_parse_failed: ${parseErr?.message ?? 'unknown'}`,
         raw_text: text.slice(0, 4000),
       };
     }
   } catch (err: any) {
-    const detail = `vertex_threw: ${err?.message ?? String(err)}`;
+    const detail = `claude_threw: ${err?.message ?? String(err)}`;
     console.warn(`[voice-architecture-investigator] ${detail}`);
     return { report: null, error: detail };
   }
@@ -692,26 +675,8 @@ export async function spawnInvestigator(input: InvestigatorInput): Promise<Inves
   const ev = await gatherEvidence(input);
   const summary = summarizeEvidence(input, ev);
 
-  if (!vertexAI) {
-    // VTID-01996: persist stub even when client uninitialized so ops can see
-    // the failure pattern (currently only mode==test or env misconfig).
-    const stubId = await persistFailureStub(
-      input,
-      'vertex_unavailable',
-      'Vertex client not initialized at module load; investigator skipped.',
-      summary,
-    );
-    return {
-      ok: false,
-      report_id: stubId,
-      validation: { ok: false, reason: 'vertex_unavailable' },
-      vertex_responded: false,
-      detail: 'Vertex client not initialized; investigator skipped.',
-    };
-  }
-
   const prompt = buildPrompt(input, ev, summary);
-  const callResult = await callVertexInvestigator(prompt);
+  const callResult = await callClaudeInvestigator(prompt);
 
   if (!callResult.report) {
     // VTID-01996: persist a failure stub so ops sees WHY the investigator
@@ -719,16 +684,16 @@ export async function spawnInvestigator(input: InvestigatorInput): Promise<Inves
     // produced 0 visible rows and the gap was invisible.
     const stubId = await persistFailureStub(
       input,
-      'vertex_no_response',
-      callResult.error ?? 'Vertex returned no parseable JSON and no error captured.',
+      'claude_no_response',
+      callResult.error ?? 'Claude returned no parseable JSON and no error captured.',
       summary,
     );
     return {
       ok: false,
       report_id: stubId,
-      validation: { ok: false, reason: 'vertex_no_response' },
+      validation: { ok: false, reason: 'claude_no_response' },
       vertex_responded: false,
-      detail: `Vertex no usable response: ${callResult.error ?? 'unknown'}`,
+      detail: `Claude no usable response: ${callResult.error ?? 'unknown'}`,
     };
   }
 


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-GEMINI-TO-CLAUDE` _(no numbered VTID allocated — Gemini→Claude migration bootstrap work)_

**Layer:** AGTL (agents/LLM routing)

**Priority:** P2

---

## 📋 Summary

First slice of a broader Gemini 2.5 → Claude audit: swaps the gateway's
lowest-risk, non-voice, non-TTS, non-embedding LLM call sites ("Tier A")
from Vertex/Gemini 2.5 to Claude Sonnet 4.6, via the direct Anthropic
Messages API (not Bedrock — see Additional Notes).

---

## ✅ Changes

- [x] New `services/gateway/src/services/claude-text-client.ts` — single
      choke point for direct-API Claude calls, so the transport can move
      to Bedrock later without touching every call site
- [x] `routes/specs.ts` — Operator spec generation → Claude Sonnet 4.6
      (removed the Vertex REST + SDK dual-path and `callGeminiREST`)
- [x] `services/self-healing-spec-service.ts` — self-healing fix-spec
      generation → Claude Sonnet 4.6
- [x] `services/intent-classifier.ts` — intent classification → Claude
      Sonnet 4.6 (also dropped a dead Gemini-API-key REST fallback that
      was never configured on the gateway)
- [x] `services/intent-extractor.ts` — per-kind slot extraction → Claude
      Sonnet 4.6
- [x] `services/matchmaker-agent.ts` — dance-match re-ranking agent →
      Claude Sonnet 4.6
- [x] `services/voice-architecture-investigator.ts` — structured JSON
      incident reports → Claude Sonnet 4.6 (schema is now enforced via the
      existing `validateReport()` backstop, since Claude Sonnet 4.6 has no
      native structured-output constraint the way Vertex's `responseSchema`
      did)
- [x] `routes/llm.ts` — admin model-catalog display updated to match

---

## 🧪 Testing

- [x] `npm install && npm run build` in `services/gateway` — compiles clean, zero TypeScript errors
- [ ] Manual/staging verification — **not yet done**, see Additional Notes
- [ ] Automated tests added/updated — none added (no existing test coverage for these call sites)

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] N/A — no workflow files touched

### File Names
- [x] New file `claude-text-client.ts` follows kebab-case
- [x] No naming-canon violations introduced

### Code Standards
- [x] N/A — no new VTID/event-type/status constants introduced

### Cloud Run Deployments
- [x] N/A — no Cloud Run service/label changes in this PR

### Documentation
- [x] `BOOTSTRAP-GEMINI-TO-CLAUDE` referenced in the commit message
- [ ] Phase 2B compliance — N/A, no numbered VTID for this bootstrap slice

---

## 🚨 Breaking Changes

None to the external API contract. Internally, these six call sites no
longer fall back to Gemini/Vertex at all — if `ANTHROPIC_API_KEY` is ever
unset, each falls through to its existing deterministic/SQL-only fallback
(spec template, SQL-ranked matches, etc.) rather than to Gemini.

---

## 📌 Additional Notes

- **Not routed through Bedrock.** AWS Bedrock access for Claude is still
  unconfigured (no model-access grant, no IAM policy, `@aws-sdk/client-bedrock-runtime`
  not installed) — that's a separate, still-blocked workstream. This PR
  uses the direct Anthropic API, which already works today since
  `ANTHROPIC_API_KEY` is a provisioned GCP secret.
- **Not deployed or staging-verified yet** — per the staging-first CI/CD
  model, merging to `main` will auto-deploy to `gateway-staging`; verify
  `env=staging` there before considering this done.
- **Out of scope (by design):** ORB Live voice-to-voice (Gemini Live API),
  Gemini TTS, and embeddings are unchanged — Claude has no equivalent for
  any of those on any transport.
- **Also out of scope:** `gemini-operator.ts` / `conversation.ts` /
  `conversation-client.ts` (Operator Chat's full tool-calling bridge, ~3700
  lines of Gemini-specific function-calling infra) — a much larger
  migration than a model-string swap, tracked separately.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgQ1F5tPaPmvpBL1gWibj1)_