### PR TITLE
BOOTSTRAP-TEST-COVERAGE Phase 1: repair & un-quarantine all 11 gateway suites + oasis-projector

### DIFF
--- a/.github/workflows/TEST-SUITE.yml
+++ b/.github/workflows/TEST-SUITE.yml
@@ -11,8 +11,6 @@ name: TEST-SUITE
 #   - manual dispatch
 #
 # Scope & exclusions are documented in docs/TEST_COVERAGE_PLAN.md.
-# oasis-projector is intentionally absent until its stale suite is repaired
-# (Phase 1 of the plan).
 
 run-name: 'Test Suite (${{ github.event_name }} on ${{ github.ref_name }})'
 
@@ -76,6 +74,10 @@ jobs:
             test: npx jest --silent
             runner: jest
           - service: worker-runner
+            install: npm ci --no-audit --no-fund
+            test: npx jest --silent
+            runner: jest
+          - service: oasis-projector
             install: npm ci --no-audit --no-fund
             test: npx jest --silent
             runner: jest

--- a/docs/TEST_COVERAGE_PLAN.md
+++ b/docs/TEST_COVERAGE_PLAN.md
@@ -109,7 +109,7 @@ depends on. Paths are real; use them as the work list.
 
 **P1 — Governance**:
 - `src/controllers/governance-controller.ts`, `src/routes/governance-controls.ts`
-- remaining quarantined suites: `test/llm-router.test.ts`, `test/services/action-executors.test.ts`, `test/routes/health.test.ts`, `test/routes/wearables-waitlist.test.ts`, `test/routes/admin-notification-categories.test.ts`, `test/services/recommendation-engine/analyzers/codebase-analyzer.test.ts`
+- ~~remaining quarantined suites~~ — all un-quarantined and green as of Phase 1 (2026-07-22)
 
 ### 2.2 Sibling services & packages (vitana-platform)
 
@@ -139,7 +139,7 @@ phase at pickup. Order is by risk: tenancy → memory → autopilot → brain/vo
 | Phase | Repo | Deliverable | Target | Status |
 |---|---|---|---|---|
 | **0. Enforcement baseline** | both | CI actually runs all existing tests (this branch: `TEST-SUITE.yml` + `UNIT-TESTS.yml`, Jest ESM fix, Vitest bootstrap) | 2026-07-13 | ✅ this PR |
-| **1. Un-quarantine sweep** | platform | Fix the 11 quarantined gateway suites (memory, admin-autopilot, action-executors, llm-router, cognee, intelligence-e2e, health, wearables, notification-categories, codebase-analyzer, dev-autopilot-synthesis); remove `testPathIgnorePatterns` entries. Also repair `services/oasis-projector/test/ledger-writer.test.ts`: it had unresolved merge-conflict markers committed on `main` (fixed on this branch), and now that it parses, 27/35 tests fail from drift against the current `LedgerWriter` (mocked `Database.getInstance` path no longer populates the ledger store). It is excluded from the `TEST-SUITE.yml` matrix until green — add it back when fixed. | +1 week | ☐ |
+| **1. Un-quarantine sweep** | platform | DONE 2026-07-22: all 11 quarantined gateway suites repaired (45 failing tests fixed — drifted mocks/assertions vs tenant-scoped autopilot tables, memory-broker refactor, Bedrock provider, VTID-01007 format, auth-middleware migration; `wearables-waitlist` had broken import paths and never ran). One genuine src bug found & fixed: `classifyCategory()` in `routes/memory.ts` matched the substring `'pr'`, misclassifying any content containing "pr" ("prefer", "espresso") as dev tasks — now word-boundary matched. `testPathIgnorePatterns` quarantine list removed. `oasis-projector/test/ledger-writer.test.ts` repaired (35/35 green; fixture VTIDs updated to canonical VTID-01007 format) and oasis-projector added to the `TEST-SUITE.yml` matrix. Open observation for the team (documented in that test): an all-error batch emits no `ledger_sync` event and still advances the projection offset (no retry) — by design or not? | 2026-07-22 | ✅ |
 | **2. Tenancy & RBAC (P0)** | platform | Tests for all 6 middleware files, `tenant-admin/*` routes, `admin-tenants`, RBAC orb-tools; assert cross-tenant denial paths | +2 weeks | ☐ |
 | **3. Frontend auth/roles/tenancy (P0)** | vitana-v1 | `AuthProvider`, `ProtectedRoute`, `AdminGuard`, `useRole`, `usePermissions`, `useTenant`, `TenantDetector`, guest-auth, oauthErrors | +2 weeks | ☐ |
 | **4. Memory stack (P0)** | platform | retrieval-router rule table, context-pack-builder, orb-memory-bridge, memory-facts-service (write_fact semantics), social-memory/*, memory routes | +3 weeks | ☐ |
@@ -201,4 +201,5 @@ file's schedule table.
 
 | Date | Change |
 |---|---|
+| 2026-07-22 | Phase 1 complete: all 11 quarantined gateway suites + oasis-projector ledger-writer repaired and un-quarantined; `'pr'` substring memory-classification bug fixed in `routes/memory.ts`; oasis-projector added to TEST-SUITE matrix (BOOTSTRAP-TEST-COVERAGE Phase 1) |
 | 2026-07-13 | Initial inventory, schedule, TEST-SUITE.yml + UNIT-TESTS.yml routines, Jest ESM fix, frontend Vitest bootstrap (BOOTSTRAP-TEST-COVERAGE) |

--- a/services/gateway/jest.config.js
+++ b/services/gateway/jest.config.js
@@ -3,29 +3,12 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/test'],
   testMatch: ['**/*.test.ts'],
-  // VTID-02696: Quarantine pre-existing broken test suites that have been
-  // red on every main commit since at least 2026-05-02 (50+ consecutive
-  // failures). They block autonomous-pipeline merges (autopilot rightfully
-  // refuses to ship into a red CI). Each has its own bug — broken mock
-  // chains, stale RPC signatures, drifted assertions — and none touch the
-  // feedback-pipeline or persona-registry code paths exercised by the
-  // current smoke test.
-  //
-  // TODO(post-smoke-test): un-quarantine each one. They're real coverage
-  // we shouldn't lose. File issues by suite and fix in a follow-up sweep.
+  // The VTID-02696 quarantine list is gone: all 11 suites were repaired in
+  // the Phase 1 sweep of docs/TEST_COVERAGE_PLAN.md (drifted mocks/assertions
+  // updated to current behavior; one genuine src bug fixed in routes/memory.ts).
+  // Do not re-add suites here without an entry in the plan's schedule table.
   testPathIgnorePatterns: [
     '/node_modules/',
-    'test/memory.test.ts',
-    'test/routes/health.test.ts',
-    'test/intelligence-stack-e2e.test.ts',
-    'test/routes/admin-autopilot.test.ts',
-    'test/services/action-executors.test.ts',
-    'test/llm-router.test.ts',
-    'test/routes/wearables-waitlist.test.ts',
-    'test/dev-autopilot-synthesis.test.ts',
-    'test/services/recommendation-engine/analyzers/codebase-analyzer.test.ts',
-    'test/cognee-extractor-client.test.ts',
-    'test/routes/admin-notification-categories.test.ts',
   ],
   setupFilesAfterEnv: ['<rootDir>/test/__mocks__/setup-tests.ts'],
   collectCoverageFrom: [

--- a/services/gateway/src/routes/memory.ts
+++ b/services/gateway/src/routes/memory.ts
@@ -600,13 +600,18 @@ export function classifyCategory(content: string): CategoryKey {
   // Tasks keywords (dev/work-related)
   const tasksKeywords = [
     'task', 'vtid', 'spec', 'deploy', 'gateway', 'oasis', 'bug', 'fix',
-    'implement', 'feature', 'ticket', 'issue', 'pr', 'pull request',
+    'implement', 'feature', 'ticket', 'issue', 'pull request',
     'merge', 'commit', 'code', 'test', 'debug', 'review'
   ];
   for (const keyword of tasksKeywords) {
     if (lowerContent.includes(keyword)) {
       return 'tasks';
     }
+  }
+  // 'pr' must match as a whole word only — as a substring it would misroute
+  // common words like "prefer", "price", or "espresso" into tasks.
+  if (/\bpr\b/.test(lowerContent)) {
+    return 'tasks';
   }
 
   // Goals keywords

--- a/services/gateway/test/cognee-extractor-client.test.ts
+++ b/services/gateway/test/cognee-extractor-client.test.ts
@@ -25,6 +25,18 @@ jest.mock('../src/services/oasis-event-service', () => ({
   emitOasisEvent: mockEmitOasisEvent,
 }));
 
+// VTID-02632 Phase 8: extractAsync() is gated behind the runtime flag
+// `cognee_extraction_enabled` (strict opt-in, default OFF for the Cognee
+// deprecation phase). Enable it here so the persistence pipeline under test
+// actually runs.
+jest.mock('../src/services/system-controls-service', () => ({
+  getSystemControl: jest.fn().mockResolvedValue({
+    key: 'cognee_extraction_enabled',
+    enabled: true,
+    expires_at: null,
+  }),
+}));
+
 // Mock global fetch
 const mockFetch = jest.fn();
 global.fetch = mockFetch as any;

--- a/services/gateway/test/dev-autopilot-synthesis.test.ts
+++ b/services/gateway/test/dev-autopilot-synthesis.test.ts
@@ -69,10 +69,16 @@ describe('scoreSignal', () => {
     expect(s.auto_exec_eligible).toBe(false);
   });
 
-  it('marks medium-risk types eligible for auto-exec', () => {
+  it('marks medium-risk types ineligible for auto-exec (human review required)', () => {
     const s = scoreSignal(signal({ type: 'missing_tests' }));
     expect(s.risk_class).toBe('medium');
-    expect(s.auto_exec_eligible).toBe(true);
+    expect(s.auto_exec_eligible).toBe(false);
+  });
+
+  it('marks low-risk but trivial-impact signals ineligible for auto-exec', () => {
+    const s = scoreSignal(signal({ type: 'dead_code', severity: 'low' }));
+    expect(s.risk_class).toBe('low');
+    expect(s.auto_exec_eligible).toBe(false);
   });
 });
 

--- a/services/gateway/test/intelligence-stack-e2e.test.ts
+++ b/services/gateway/test/intelligence-stack-e2e.test.ts
@@ -22,135 +22,204 @@ process.env.PERPLEXITY_API_KEY = 'test-perplexity-key';
 // Track all fetch calls to verify correct tables are queried
 const fetchCalls: Array<{ url: string; method: string; body?: string }> = [];
 
+/**
+ * Build a Response-like object that satisfies both raw-fetch callers and
+ * supabase-js (postgrest-js reads status/statusText/headers/text()).
+ */
+function restResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : String(status),
+    headers: new Headers(),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+// Structured facts as stored in memory_facts (REST list + get_current_facts RPC)
+const FACT_ROWS = [
+  {
+    id: 'fact-1',
+    fact_key: 'user_name',
+    fact_value: 'Dragan Alexander',
+    fact_value_type: 'text',
+    entity: 'self',
+    provenance_confidence: 0.95,
+    provenance_source: 'assistant_inferred',
+    extracted_at: new Date().toISOString(),
+  },
+  {
+    id: 'fact-2',
+    fact_key: 'fiancee_name',
+    fact_value: 'Mariia Maksina',
+    fact_value_type: 'text',
+    entity: 'disclosed',
+    provenance_confidence: 0.92,
+    provenance_source: 'assistant_inferred',
+    extracted_at: new Date().toISOString(),
+  },
+  {
+    id: 'fact-3',
+    fact_key: 'work_location',
+    fact_value: 'Exafy, Santa Monica',
+    fact_value_type: 'text',
+    entity: 'self',
+    provenance_confidence: 0.88,
+    provenance_source: 'assistant_inferred',
+    extracted_at: new Date().toISOString(),
+  },
+];
+
+// Legacy episodic rows in memory_items — the memory-broker's EPISODIC block
+// falls back to these when mem_episodes is empty (VTID-03156 ladder step 4).
+const MEMORY_ITEM_ROWS = [
+  {
+    id: 'mem-1',
+    category_key: 'personal',
+    content: 'User: My name is Dragan\nAssistant: Nice to meet you, Dragan!',
+    importance: 90,
+    occurred_at: new Date().toISOString(),
+    source: 'orb_text',
+  },
+  {
+    id: 'mem-2',
+    category_key: 'relationships',
+    content: 'User mentioned fiancée Mariia Maksina',
+    importance: 85,
+    occurred_at: new Date().toISOString(),
+    source: 'cognee_extraction',
+  },
+];
+
+// Relationship graph in the AP-0909 shape the broker's NETWORK block reads:
+// edges are user-centric (source_id = user), targets resolve via
+// relationship_nodes (display column is `title`).
+const RELATIONSHIP_EDGE_ROWS = [
+  {
+    source_type: 'person',
+    source_id: 'test-user',
+    target_type: 'person',
+    target_id: 'node-2',
+    edge_type: 'fiancée',
+    strength: 95,
+    last_interaction_at: new Date().toISOString(),
+  },
+  {
+    source_type: 'person',
+    source_id: 'test-user',
+    target_type: 'person',
+    target_id: 'node-3',
+    edge_type: 'works_at',
+    strength: 60,
+    last_interaction_at: new Date().toISOString(),
+  },
+];
+
+const RELATIONSHIP_NODE_ROWS = [
+  { id: 'node-2', title: 'Mariia Maksina', node_type: 'person' },
+  { id: 'node-3', title: 'Exafy', node_type: 'organization' },
+];
+
 // Mock global fetch
 const mockFetch = jest.fn().mockImplementation(async (url: string, options?: RequestInit) => {
   const method = options?.method || 'GET';
   fetchCalls.push({ url, method, body: options?.body as string });
 
-  // Mock responses based on URL
+  // ---- system_controls: enable ONLY the memory broker (VTID-02026 gate).
+  // Everything else (tier0 redis, cognee, …) stays off so the test exercises
+  // the canonical broker read path without side quests.
+  if (url.includes('/rest/v1/system_controls')) {
+    const keyMatch = url.match(/key=eq\.([^&]+)/);
+    const key = keyMatch ? decodeURIComponent(keyMatch[1]) : '';
+    return restResponse([
+      { key, enabled: key === 'memory_broker_enabled', scope: {}, reason: 'test', expires_at: null },
+    ]);
+  }
+
+  // ---- RPCs (check before plain table names — URLs overlap) ----
+  if (url.includes('/rpc/get_current_facts')) {
+    return restResponse(FACT_ROWS);
+  }
+  if (url.includes('/rpc/memory_facts_semantic_search')) {
+    return restResponse([]);
+  }
+  if (url.includes('/rpc/mem_episodes_semantic_search') || url.includes('/rpc/memory_semantic_search')) {
+    return restResponse([]);
+  }
+  if (url.includes('/rpc/write_fact')) {
+    return restResponse('fact-new-id');
+  }
+  if (url.includes('/rest/v1/rpc/')) {
+    return restResponse([]);
+  }
+
+  // ---- Tables ----
+  if (url.includes('/rest/v1/mem_episodes')) {
+    // Empty → broker EPISODIC ladder falls through to legacy memory_items.
+    return restResponse([]);
+  }
+
   if (url.includes('/rest/v1/memory_items')) {
     if (method === 'GET') {
-      return {
-        ok: true,
-        json: async () => [
-          {
-            id: 'mem-1',
-            category_key: 'personal',
-            content: 'User: My name is Dragan\nAssistant: Nice to meet you, Dragan!',
-            importance: 90,
-            occurred_at: new Date().toISOString(),
-            source: 'orb_text',
-          },
-          {
-            id: 'mem-2',
-            category_key: 'relationships',
-            content: 'User mentioned fiancée Mariia Maksina',
-            importance: 85,
-            occurred_at: new Date().toISOString(),
-            source: 'cognee_extraction',
-          },
-        ],
-      };
+      return restResponse(MEMORY_ITEM_ROWS);
     }
-    // POST (write)
-    return { ok: true, json: async () => ({ id: 'new-mem-id' }), text: async () => '' };
+    return restResponse({ id: 'new-mem-id' }, 201);
   }
 
   if (url.includes('/rest/v1/memory_facts')) {
     if (method === 'GET') {
-      return {
-        ok: true,
-        json: async () => [
-          {
-            id: 'fact-1',
-            fact_key: 'user_name',
-            fact_value: 'Dragan Alexander',
-            entity: 'self',
-            provenance_confidence: 0.95,
-            provenance_source: 'assistant_inferred',
-          },
-          {
-            id: 'fact-2',
-            fact_key: 'fiancee_name',
-            fact_value: 'Mariia Maksina',
-            entity: 'disclosed',
-            provenance_confidence: 0.92,
-            provenance_source: 'assistant_inferred',
-          },
-          {
-            id: 'fact-3',
-            fact_key: 'work_location',
-            fact_value: 'Exafy, Santa Monica',
-            entity: 'self',
-            provenance_confidence: 0.88,
-            provenance_source: 'assistant_inferred',
-          },
-        ],
-      };
+      return restResponse(FACT_ROWS);
     }
+  }
+
+  if (url.includes('/rest/v1/memory_diary_entries')) {
+    return restResponse([]);
   }
 
   if (url.includes('/rest/v1/relationship_nodes')) {
     if (method === 'GET') {
-      return {
-        ok: true,
-        json: async () => [
-          { id: 'node-1', title: 'Dragan Alexander', node_type: 'person', domain: 'personal', metadata: {} },
-          { id: 'node-2', title: 'Mariia Maksina', node_type: 'person', domain: 'personal', metadata: {} },
-          { id: 'node-3', title: 'Exafy', node_type: 'organization', domain: 'work', metadata: {} },
-        ],
-      };
+      return restResponse(RELATIONSHIP_NODE_ROWS);
     }
-    // POST (write)
-    return { ok: true, json: async () => [{ id: 'new-node-id' }], text: async () => '' };
+    return restResponse([{ id: 'new-node-id' }], 201);
   }
 
   if (url.includes('/rest/v1/relationship_edges')) {
     if (method === 'GET') {
-      return {
-        ok: true,
-        json: async () => [
-          { from_node_id: 'node-1', to_node_id: 'node-2', relationship_type: 'fiancée', strength: 0.95 },
-          { from_node_id: 'node-1', to_node_id: 'node-3', relationship_type: 'works_at', strength: 0.90 },
-        ],
-      };
+      return restResponse(RELATIONSHIP_EDGE_ROWS);
     }
-    // POST (write)
-    return { ok: true, json: async () => ({ id: 'new-edge-id' }), text: async () => '' };
+    return restResponse({ id: 'new-edge-id' }, 201);
   }
 
   if (url.includes('/rest/v1/relationship_signals')) {
-    return { ok: true, json: async () => ({}), text: async () => '' };
-  }
-
-  if (url.includes('/rest/v1/rpc/write_fact')) {
-    return { ok: true, json: async () => 'fact-new-id', text: async () => '' };
+    return restResponse([]);
   }
 
   if (url.includes('/rest/v1/vtid_ledger')) {
-    return { ok: true, json: async () => [] };
+    return restResponse([]);
   }
 
   if (url.includes('/rest/v1/oasis_events')) {
-    return { ok: true, json: async () => ({ id: 'evt-1' }) };
+    return restResponse([{ id: 'evt-1' }], 201);
   }
 
   if (url.includes('/rest/v1/knowledge_base') || url.includes('/rest/v1/knowledge_hub')) {
-    return { ok: true, json: async () => [] };
+    return restResponse([]);
   }
 
   if (url.includes('perplexity.ai')) {
-    return {
-      ok: true,
-      json: async () => ({
-        choices: [{ message: { content: 'Web search result about Dragan.' } }],
-        citations: ['https://example.com'],
-      }),
-    };
+    return restResponse({
+      choices: [{ message: { content: 'Web search result about Dragan.' } }],
+      citations: ['https://example.com'],
+    });
   }
 
-  // Default: return empty success
-  return { ok: true, json: async () => ({}), text: async () => '' };
+  // Default: any other PostgREST read returns an empty row set; anything
+  // else gets an empty object.
+  if (url.includes('/rest/v1/')) {
+    return restResponse([]);
+  }
+  return restResponse({});
 });
 
 global.fetch = mockFetch as any;
@@ -272,13 +341,16 @@ describe('VTID-01225: Intelligence & Memory Stack E2E', () => {
         active_role: 'community',
       });
 
-      const routerDecision = computeRetrievalRouterDecision('Tell me about myself', {
+      // NOTE: "Tell me about myself" would match the teach_intent router rule
+      // (BOOTSTRAP-TEACH-BEFORE-REDIRECT, "tell me about" → knowledge_hub only,
+      // no memory_garden), so use a personal-recall phrasing instead.
+      const routerDecision = computeRetrievalRouterDecision('What do you remember about me?', {
         channel: 'orb',
       });
 
       const input: BuildContextPackInput = {
         lens,
-        query: 'Tell me about myself',
+        query: 'What do you remember about me?',
         channel: 'orb',
         thread_id: 'test-thread',
         turn_number: 1,
@@ -289,7 +361,8 @@ describe('VTID-01225: Intelligence & Memory Stack E2E', () => {
 
       const pack = await buildContextPack(input);
 
-      // Verify memory_items was also queried
+      // Verify memory_items was also queried (the memory-broker's EPISODIC
+      // ladder falls back to legacy memory_items when mem_episodes is empty)
       const itemsQueries = fetchCalls.filter(c => c.url.includes('memory_items') && c.method === 'GET');
       expect(itemsQueries.length).toBeGreaterThanOrEqual(1);
     });
@@ -355,9 +428,10 @@ describe('VTID-01225: Intelligence & Memory Stack E2E', () => {
       const pack = await buildContextPack(input);
       const llmContext = formatContextPackForLLM(pack);
 
-      // The LLM context should contain relationship graph
+      // The LLM context should contain the relationship graph. Since
+      // VTID-03145 the strings are user-centric ("User <edge>: <name> (<type>)")
+      // — the user's own name is not repeated, only the other side of each edge.
       expect(llmContext).toContain('<relationship_graph>');
-      expect(llmContext).toContain('Dragan Alexander');
       expect(llmContext).toContain('Mariia Maksina');
       expect(llmContext).toContain('fiancée');
     });
@@ -497,10 +571,13 @@ describe('VTID-01225: Intelligence & Memory Stack E2E', () => {
       expect(pack.relationship_context).toBeDefined();
       expect(pack.relationship_context!.length).toBeGreaterThan(0);
 
-      // Should contain human-readable relationship strings
+      // Should contain human-readable, user-centric relationship strings
+      // ("User <edge>: <name> (<type>)" — the broker's NETWORK block resolves
+      // the other side of each edge; the user's own name is not repeated).
       const relStrings = pack.relationship_context!.join(' ');
-      expect(relStrings).toContain('Dragan Alexander');
       expect(relStrings).toContain('Mariia Maksina');
+      expect(relStrings).toContain('Exafy');
+      expect(relStrings).toContain('fiancée');
     });
   });
 
@@ -515,13 +592,16 @@ describe('VTID-01225: Intelligence & Memory Stack E2E', () => {
         active_role: 'community',
       });
 
-      const routerDecision = computeRetrievalRouterDecision('Tell me about myself', {
+      // Personal-recall phrasing so the router includes memory_garden and the
+      // token count actually covers facts + relationships (teach-intent
+      // phrasings like "tell me about X" skip memory entirely).
+      const routerDecision = computeRetrievalRouterDecision('What do you remember about me?', {
         channel: 'orb',
       });
 
       const input: BuildContextPackInput = {
         lens,
-        query: 'Tell me about myself',
+        query: 'What do you remember about me?',
         channel: 'orb',
         thread_id: 'test-thread',
         turn_number: 1,

--- a/services/gateway/test/llm-router.test.ts
+++ b/services/gateway/test/llm-router.test.ts
@@ -15,6 +15,7 @@ import {
   LLM_SAFE_DEFAULTS,
   PROVIDER_FLAGSHIPS,
   VALID_STAGES,
+  VALID_PROVIDERS,
   type LLMStage,
 } from '../src/constants/llm-defaults';
 
@@ -60,19 +61,28 @@ describe('BOOTSTRAP-LLM-ROUTER constants', () => {
       expect(LLM_SAFE_DEFAULTS.classifier.primary_model).toBe('deepseek-reasoner');
     });
 
-    test('vision stage primary is vertex with gemini-3.1-pro', () => {
+    test('vision stage primary is vertex with gemini-3.1-pro-preview', () => {
+      // VTID-02690: the Gemini 3.1 flagship is only exposed as a preview
+      // model id — the router special-cases preview ids, so the safe default
+      // deliberately uses the `-preview` suffix.
       expect(LLM_SAFE_DEFAULTS.vision.primary_provider).toBe('vertex');
-      expect(LLM_SAFE_DEFAULTS.vision.primary_model).toBe('gemini-3.1-pro');
+      expect(LLM_SAFE_DEFAULTS.vision.primary_model).toBe('gemini-3.1-pro-preview');
     });
   });
 
   describe('PROVIDER_FLAGSHIPS table', () => {
     test('contains an entry for every supported provider', () => {
+      for (const provider of VALID_PROVIDERS) {
+        expect(PROVIDER_FLAGSHIPS[provider]).toBeTruthy();
+      }
       expect(PROVIDER_FLAGSHIPS.anthropic).toBe('claude-opus-4-7');
       expect(PROVIDER_FLAGSHIPS.openai).toBe('gpt-5');
-      expect(PROVIDER_FLAGSHIPS.vertex).toBe('gemini-3.1-pro');
+      expect(PROVIDER_FLAGSHIPS.vertex).toBe('gemini-3.1-pro-preview');
       expect(PROVIDER_FLAGSHIPS.deepseek).toBe('deepseek-reasoner');
       expect(PROVIDER_FLAGSHIPS.claude_subscription).toBe('claude-opus-4-7');
+      // VTID-03403: Bedrock's flagship is a cross-region inference profile id,
+      // overridable via BEDROCK_MODEL_ID (unset in the test environment).
+      expect(PROVIDER_FLAGSHIPS.bedrock).toBe('eu.anthropic.claude-sonnet-4-6');
     });
   });
 });

--- a/services/gateway/test/memory.test.ts
+++ b/services/gateway/test/memory.test.ts
@@ -147,7 +147,9 @@ describe('classifyCategory — unit', () => {
   });
 
   it('returns tasks for deploy keyword', () => {
-    expect(classifyCategory('need to deploy the gateway service')).toBe('tasks');
+    // NOTE: avoid the word "service" here — products_services is checked
+    // before tasks, so "service" would win over "deploy".
+    expect(classifyCategory('need to deploy the gateway')).toBe('tasks');
   });
 
   it('returns goals for goal keyword', () => {
@@ -236,7 +238,9 @@ describe('writeMemoryItem — unit', () => {
       data: { id: 'mem-123' },
       error: null,
     });
-    const result = await writeMemoryItem('token', { source: 'orb_text', content: 'test content' });
+    // NOTE: content must not contain any classifier keyword ("test" is a
+    // tasks keyword) so auto-classification lands on 'conversation'.
+    const result = await writeMemoryItem('token', { source: 'orb_text', content: 'hello world' });
     expect(result.ok).toBe(true);
     expect(result.id).toBe('mem-123');
     expect(result.category_key).toBe('conversation');

--- a/services/gateway/test/routes/admin-autopilot.test.ts
+++ b/services/gateway/test/routes/admin-autopilot.test.ts
@@ -41,12 +41,20 @@ jest.mock('../../src/services/automation-registry', () => ({
 }));
 
 jest.mock('../../src/services/wave-defaults', () => ({
-  DEFAULT_WAVE_CONFIG: {
-    waveId: 'default-wave',
-    name: 'Default Wave',
-    description: 'Automatically created wave',
-    schedule: '0 0 * * *',
-  },
+  DEFAULT_WAVE_CONFIG: [
+    {
+      id: 'default-wave',
+      name: 'Default Wave',
+      description: 'Automatically created wave',
+      icon: 'rocket',
+      enabled: true,
+      order: 1,
+      is_initiative: false,
+      timeline: { start_day: 0, end_day: 7 },
+      automation_ids: ['auto-1', 'auto-2'],
+      recommendation_templates: ['template-1'],
+    },
+  ],
 }));
 
 // --------------------------------------------------------------------------
@@ -162,19 +170,19 @@ describe('Authorization', () => {
 
 describe('GET /api/v1/admin/autopilot/settings', () => {
   it('returns settings when they exist', async () => {
-    mockSupabase.__setMockData([{ tenant_id: 'tenant-001', wave_enabled: true }]);
+    mockSupabase.__setMockData({ tenant_id: 'tenant-001', enabled: true });
 
     const res = await request(app).get('/api/v1/admin/autopilot/settings');
     expect(res.status).toBe(200);
-    expect(mockSupabase.from).toHaveBeenCalledWith('autopilot_settings');
+    expect(mockSupabase.from).toHaveBeenCalledWith('tenant_autopilot_settings');
     expect(mockSupabase.mockQuery.eq).toHaveBeenCalledWith('tenant_id', 'tenant-001');
   });
 
   it('auto-creates settings when none found and returns them', async () => {
-    // 1st query: select (returns empty)
-    mockSupabase.__addQueueData([]);
+    // 1st query: select (no row found)
+    mockSupabase.__addQueueData(null);
     // 2nd query: insert (returns new row)
-    mockSupabase.__addQueueData([{ tenant_id: 'tenant-001', wave_enabled: false }]);
+    mockSupabase.__addQueueData({ tenant_id: 'tenant-001', enabled: true });
 
     const res = await request(app).get('/api/v1/admin/autopilot/settings');
     expect(res.status).toBe(200);
@@ -191,11 +199,11 @@ describe('GET /api/v1/admin/autopilot/settings', () => {
 
 describe('PATCH /api/v1/admin/autopilot/settings', () => {
   it('updates settings successfully', async () => {
-    mockSupabase.__setMockData([{ tenant_id: 'tenant-001', wave_enabled: false }]);
+    mockSupabase.__setMockData({ tenant_id: 'tenant-001', enabled: false });
 
     const res = await request(app)
       .patch('/api/v1/admin/autopilot/settings')
-      .send({ wave_enabled: false });
+      .send({ enabled: false });
 
     expect(res.status).toBe(200);
     expect(mockSupabase.mockQuery.update).toHaveBeenCalled();
@@ -215,7 +223,7 @@ describe('PATCH /api/v1/admin/autopilot/settings', () => {
     mockSupabase.__setMockError(new Error('Update failed'));
     const res = await request(app)
       .patch('/api/v1/admin/autopilot/settings')
-      .send({ wave_enabled: true });
+      .send({ enabled: true });
     expect(res.status).toBe(500);
   });
 });
@@ -227,58 +235,72 @@ describe('GET /api/v1/admin/autopilot/bindings', () => {
 
     const res = await request(app).get('/api/v1/admin/autopilot/bindings');
     expect(res.status).toBe(200);
-    expect(mockSupabase.from).toHaveBeenCalledWith('autopilot_bindings');
+    expect(mockSupabase.from).toHaveBeenCalledWith('tenant_autopilot_bindings');
     expect(mockSupabase.mockQuery.eq).toHaveBeenCalledWith('tenant_id', 'tenant-001');
   });
 
   it('filters by enabled query parameter', async () => {
     mockSupabase.__setMockData([]);
     await request(app).get('/api/v1/admin/autopilot/bindings?enabled=true');
-    expect(mockSupabase.mockQuery.eq).toHaveBeenCalledWith('enabled', 'true');
+    expect(mockSupabase.mockQuery.eq).toHaveBeenCalledWith('enabled', true);
   });
 });
 
 describe('POST /api/v1/admin/autopilot/bindings', () => {
-  it('creates a new binding', async () => {
-    mockSupabase.__setMockData([{ id: 'b-new', automation_id: 'auto-2', tenant_id: 'tenant-001' }]);
+  it('creates a new binding (upsert)', async () => {
+    mockSupabase.__setMockData({ id: 'b-new', automation_id: 'auto-2', tenant_id: 'tenant-001' });
 
     const res = await request(app)
       .post('/api/v1/admin/autopilot/bindings')
-      .send({ automation_id: 'auto-2', config: {} });
+      .send({ automation_id: 'auto-2', enabled: true });
 
     expect(res.status).toBeLessThan(300);
-    expect(mockSupabase.mockQuery.insert).toHaveBeenCalled();
+    expect(mockSupabase.mockQuery.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ tenant_id: 'tenant-001', automation_id: 'auto-2', enabled: true }),
+      { onConflict: 'tenant_id,automation_id' },
+    );
   });
 
-  it('returns error when required fields are missing', async () => {
+  it('returns 400 when automation_id is missing', async () => {
     const res = await request(app)
       .post('/api/v1/admin/autopilot/bindings')
-      .send({ config: {} }); // missing automation_id
+      .send({ enabled: true }); // missing automation_id
 
-    expect([400, 500]).toContain(res.status);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('MISSING_AUTOMATION_ID');
   });
 });
 
 describe('PATCH /api/v1/admin/autopilot/bindings/:id', () => {
   it('updates a binding', async () => {
-    mockSupabase.__setMockData([{ id: 'b1', config: { new: true } }]);
+    mockSupabase.__setMockData({ id: 'b1', enabled: false });
 
     const res = await request(app)
       .patch('/api/v1/admin/autopilot/bindings/b1')
-      .send({ config: { new: true } });
+      .send({ enabled: false });
 
     expect(res.status).toBe(200);
     expect(mockSupabase.mockQuery.eq).toHaveBeenCalledWith('id', 'b1');
+    expect(mockSupabase.mockQuery.eq).toHaveBeenCalledWith('tenant_id', 'tenant-001');
     expect(mockSupabase.mockQuery.update).toHaveBeenCalled();
   });
 
+  it('returns 400 when no valid fields are supplied', async () => {
+    const res = await request(app)
+      .patch('/api/v1/admin/autopilot/bindings/b1')
+      .send({ config: {} }); // config is not an updatable field
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('NO_CHANGES');
+  });
+
   it('handles 404 when binding is missing', async () => {
-    mockSupabase.__setMockData([]);
+    mockSupabase.__setMockData(null);
     const res = await request(app)
       .patch('/api/v1/admin/autopilot/bindings/nonexistent')
-      .send({ config: {} });
-    
-    expect([200, 404]).toContain(res.status);
+      .send({ enabled: true });
+
+    expect(res.status).toBe(404);
   });
 });
 
@@ -295,9 +317,10 @@ describe('GET /api/v1/admin/autopilot/runs', () => {
   it('returns paginated runs', async () => {
     mockSupabase.__setMockData([{ id: 'r1', status: 'success' }], 1);
 
-    const res = await request(app).get('/api/v1/admin/autopilot/runs?page=1&limit=10');
+    const res = await request(app).get('/api/v1/admin/autopilot/runs?offset=0&limit=10');
     expect(res.status).toBe(200);
-    expect(mockSupabase.from).toHaveBeenCalledWith('autopilot_runs');
+    expect(mockSupabase.from).toHaveBeenCalledWith('tenant_autopilot_runs');
+    expect(res.body.total).toBe(1);
   });
 
   it('filters by status and automation_id', async () => {
@@ -311,9 +334,23 @@ describe('GET /api/v1/admin/autopilot/runs', () => {
 
 describe('GET /api/v1/admin/autopilot/runs/stats', () => {
   it('returns aggregated stats', async () => {
-    mockSupabase.__setMockData({ total: 10, successful: 7, failed: 3 });
+    mockSupabase.__setMockData([
+      { status: 'completed', duration_ms: 1000, started_at: '2026-07-01T10:00:00Z', automation_id: 'auto-1' },
+      { status: 'completed', duration_ms: 2000, started_at: '2026-07-01T11:00:00Z', automation_id: 'auto-1' },
+      { status: 'failed', duration_ms: null, started_at: '2026-07-02T10:00:00Z', automation_id: 'auto-2' },
+    ]);
     const res = await request(app).get('/api/v1/admin/autopilot/runs/stats');
     expect(res.status).toBe(200);
+    expect(mockSupabase.from).toHaveBeenCalledWith('tenant_autopilot_runs');
+    expect(res.body.data.total_runs).toBe(3);
+    expect(res.body.data.completed).toBe(2);
+    expect(res.body.data.failed).toBe(1);
+    expect(res.body.data.success_rate).toBe(67);
+    expect(res.body.data.by_automation['auto-1'].avg_duration_ms).toBe(1500);
+    expect(res.body.data.daily_trend).toEqual([
+      { date: '2026-07-01', count: 2 },
+      { date: '2026-07-02', count: 1 },
+    ]);
   });
 
   it('handles empty stats or aggregation error', async () => {
@@ -325,61 +362,122 @@ describe('GET /api/v1/admin/autopilot/runs/stats', () => {
 
 describe('GET /api/v1/admin/autopilot/recommendations', () => {
   it('returns tenant-specific recommendations', async () => {
-    // 1st query: autopilot_settings checks (if route implements them before querying recs)
-    mockSupabase.__addQueueData([{ tenant_id: 'tenant-001', wave_enabled: true }]);
+    // 1st query: tenant_autopilot_settings check
+    mockSupabase.__addQueueData({ tenant_id: 'tenant-001', enabled: true });
     // 2nd query: actual recommendations
-    mockSupabase.__addQueueData([{ id: 'rec-1', domain: 'perf' }]);
+    mockSupabase.__addQueueData([{ id: 'rec-1', domain: 'health' }], 1);
 
     const res = await request(app).get('/api/v1/admin/autopilot/recommendations');
     expect(res.status).toBe(200);
+    expect(res.body.autopilot_enabled).toBe(true);
+    expect(res.body.data).toEqual([{ id: 'rec-1', domain: 'health' }]);
+    expect(mockSupabase.from).toHaveBeenCalledWith('autopilot_recommendations');
   });
 
-  it('returns safely if autopilot disabled', async () => {
-    // 1st query: autopilot_settings shows disabled
-    mockSupabase.__addQueueData([{ tenant_id: 'tenant-001', wave_enabled: false }]);
-    // Fallback if it still proceeds to query
-    mockSupabase.__addQueueData([]);
+  it('returns empty if autopilot disabled for the tenant', async () => {
+    // 1st query: tenant_autopilot_settings shows disabled
+    mockSupabase.__addQueueData({ tenant_id: 'tenant-001', enabled: false });
 
     const res = await request(app).get('/api/v1/admin/autopilot/recommendations');
     expect(res.status).toBe(200);
+    expect(res.body.autopilot_enabled).toBe(false);
+    expect(res.body.data).toEqual([]);
   });
 
-  it('filters by domain and risk', async () => {
-    mockSupabase.__addQueueData([{ tenant_id: 'tenant-001', wave_enabled: true }]);
-    mockSupabase.__addQueueData([{ id: 'rec-2', domain: 'security', risk_level: 'high' }]);
+  it('filters by domain and risk_level', async () => {
+    mockSupabase.__addQueueData({ tenant_id: 'tenant-001', enabled: true });
+    mockSupabase.__addQueueData([{ id: 'rec-2', domain: 'health', risk_level: 'medium' }], 1);
 
-    const res = await request(app).get('/api/v1/admin/autopilot/recommendations?domain=security&risk=high');
+    const res = await request(app).get('/api/v1/admin/autopilot/recommendations?domain=health&risk_level=medium');
     expect(res.status).toBe(200);
+    expect(mockSupabase.mockQuery.eq).toHaveBeenCalledWith('domain', 'health');
+    expect(mockSupabase.mockQuery.eq).toHaveBeenCalledWith('risk_level', 'medium');
   });
 });
 
 describe('GET /api/v1/admin/autopilot/recommendations/summary', () => {
   it('returns summary counts', async () => {
-    mockSupabase.__setMockData([{ domain: 'security', count: 5 }]);
+    // 1st query: tenant settings
+    mockSupabase.__addQueueData({ tenant_id: 'tenant-001', enabled: true });
+    // 2nd query: recommendation statuses
+    mockSupabase.__addQueueData([
+      { status: 'new' }, { status: 'new' }, { status: 'activated' },
+      { status: 'rejected' }, { status: 'snoozed' },
+    ]);
+
     const res = await request(app).get('/api/v1/admin/autopilot/recommendations/summary');
     expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ new: 2, activated: 1, rejected: 1, snoozed: 1, total: 5 });
   });
 });
 
 describe('GET /api/v1/admin/autopilot/waves', () => {
   it('returns enriched wave data', async () => {
-    mockSupabase.__setMockData([{ wave_id: 'default-wave', enabled: true }]);
-    
+    // 1st query: tenant settings (wave_config overrides)
+    mockSupabase.__addQueueData({ wave_config: {} });
+    // 2nd query: tenant bindings
+    mockSupabase.__addQueueData([{ automation_id: 'auto-1', enabled: true }]);
+
     const res = await request(app).get('/api/v1/admin/autopilot/waves');
     expect(res.status).toBe(200);
-    expect(mockSupabase.from).toHaveBeenCalledWith('autopilot_waves');
+    expect(mockSupabase.from).toHaveBeenCalledWith('tenant_autopilot_settings');
+    expect(mockSupabase.from).toHaveBeenCalledWith('tenant_autopilot_bindings');
+
+    expect(res.body.data).toHaveLength(1);
+    const wave = res.body.data[0];
+    expect(wave.id).toBe('default-wave');
+    expect(wave.total_automations).toBe(2);
+    expect(wave.enabled_automations).toBe(1);
+    expect(wave.total_templates).toBe(1);
+    expect(wave.automations).toEqual([
+      expect.objectContaining({ id: 'auto-1', name: 'Auto One', enabled: true }),
+      expect.objectContaining({ id: 'auto-2', name: 'Auto Two', enabled: false }),
+    ]);
   });
 });
 
 describe('PATCH /api/v1/admin/autopilot/waves/:waveId', () => {
   it('enables/disables a wave and handles binding batch updates', async () => {
-    mockSupabase.__setMockData([{ wave_id: 'wave-1', enabled: false }]);
-    
+    // 1st query: tenant settings (existing row with wave_config)
+    mockSupabase.__addQueueData({ wave_config: {} });
+
     const res = await request(app)
-      .patch('/api/v1/admin/autopilot/waves/wave-1')
-      .send({ enabled: false, bindings: [{ automation_id: 'auto-1' }] });
-    
+      .patch('/api/v1/admin/autopilot/waves/default-wave')
+      .send({ enabled: false });
+
     expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ wave_id: 'default-wave', enabled: false });
+    // wave_config saved on settings
+    expect(mockSupabase.mockQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({ wave_config: { 'default-wave': { enabled: false } } }),
+    );
+    // one upsert per automation in the wave
+    expect(mockSupabase.mockQuery.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ automation_id: 'auto-1', enabled: false, tenant_id: 'tenant-001' }),
+      { onConflict: 'tenant_id,automation_id' },
+    );
+    expect(mockSupabase.mockQuery.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ automation_id: 'auto-2', enabled: false, tenant_id: 'tenant-001' }),
+      { onConflict: 'tenant_id,automation_id' },
+    );
+  });
+
+  it('returns 404 for an unknown wave', async () => {
+    const res = await request(app)
+      .patch('/api/v1/admin/autopilot/waves/no-such-wave')
+      .send({ enabled: true });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('WAVE_NOT_FOUND');
+  });
+
+  it('returns 400 when enabled flag is missing', async () => {
+    const res = await request(app)
+      .patch('/api/v1/admin/autopilot/waves/default-wave')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('MISSING_ENABLED');
   });
 });
 
@@ -390,14 +488,20 @@ describe('GET /api/v1/admin/autopilot/catalog', () => {
 
     const res = await request(app).get('/api/v1/admin/autopilot/catalog');
     expect(res.status).toBe(200);
-    expect(mockSupabase.from).toHaveBeenCalledWith('autopilot_bindings');
-    
+    expect(mockSupabase.from).toHaveBeenCalledWith('tenant_autopilot_bindings');
+
     // Assert the shape contains elements mixed from registry
     const payloadData = res.body.data ?? res.body;
     expect(Array.isArray(payloadData)).toBe(true);
-    
-    // Verify auto-1 overlay
-    const auto1 = payloadData.find((a: any) => a.id === 'auto-1' || a.automation_id === 'auto-1');
+    expect(payloadData).toHaveLength(2); // one per AUTOMATION_REGISTRY entry
+
+    // Verify auto-1 has its tenant binding overlaid; auto-2 has none
+    const auto1 = payloadData.find((a: any) => a.id === 'auto-1');
     expect(auto1).toBeDefined();
+    expect(auto1.binding).toEqual({ automation_id: 'auto-1', id: 'b1' });
+
+    const auto2 = payloadData.find((a: any) => a.id === 'auto-2');
+    expect(auto2.binding).toBeNull();
+    expect(auto2.enabled).toBe(false);
   });
 });

--- a/services/gateway/test/routes/admin-notification-categories.test.ts
+++ b/services/gateway/test/routes/admin-notification-categories.test.ts
@@ -1,45 +1,112 @@
 import request from 'supertest';
 import express from 'express';
-import router from '../../src/routes/admin-notification-categories';
-import { createUserSupabaseClient } from '../../src/lib/supabase-user';
-import { createClient } from '@supabase/supabase-js';
+import * as jose from 'jose';
 
-// Mock dependencies
-jest.mock('../../src/lib/supabase-user');
-jest.mock('@supabase/supabase-js');
+// ---------------------------------------------------------------------------
+// Mocks — the router auths via requireAuth/requireExafyAdmin middleware
+// (auth-supabase-jwt), which verifies the JWT with jose against
+// SUPABASE_JWT_SECRET and uses getSupabase() for all DB access.
+// ---------------------------------------------------------------------------
+
+// Per-table thenable query-chain mock for the service-role client
+const createChain = () => {
+  const responseQueue: any[] = [];
+  let defaultData: any = { data: null, error: null };
+
+  const chain: any = {
+    select: jest.fn(() => chain),
+    insert: jest.fn(() => chain),
+    update: jest.fn(() => chain),
+    delete: jest.fn(() => chain),
+    order: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    or: jest.fn(() => chain),
+    is: jest.fn(() => chain),
+    limit: jest.fn(() => chain),
+    single: jest.fn(() => chain),
+    maybeSingle: jest.fn(() => chain),
+    then: jest.fn((resolve: (v: any) => any) => {
+      const value = responseQueue.length > 0 ? responseQueue.shift() : defaultData;
+      return Promise.resolve(value).then(resolve);
+    }),
+    mockResolvedValue(v: any) {
+      defaultData = v;
+      return chain;
+    },
+    mockResolvedValueOnce(v: any) {
+      responseQueue.push(v);
+      return chain;
+    },
+    mockReset() {
+      responseQueue.length = 0;
+      defaultData = { data: null, error: null };
+    },
+  };
+
+  return chain;
+};
+
+const tableChains: Record<string, ReturnType<typeof createChain>> = {};
+const chainFor = (table: string) => (tableChains[table] ??= createChain());
+
+const mockSupabase = { from: jest.fn((table: string) => chainFor(table)) };
+const mockGetSupabase = jest.fn(() => mockSupabase as any);
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => mockGetSupabase(),
+}));
+
+jest.mock('jose');
+
+// Fire-and-forget active-day tracker invoked by requireAuth — keep it inert
+jest.mock('../../src/services/guide/active-usage', () => ({
+  upsertActiveDay: jest.fn().mockResolvedValue(undefined),
+  countActiveUsageDays: jest.fn().mockResolvedValue(0),
+}));
+
 jest.mock('../../src/services/notification-service', () => ({
   notifyUser: jest.fn().mockResolvedValue({ ok: true }),
 }));
 
-
-const mockCreateUserSupabaseClient = createUserSupabaseClient as jest.Mock;
-const mockCreateSupabaseClient = createClient as jest.Mock;
+import router from '../../src/routes/admin-notification-categories';
 
 const app = express();
 app.use(express.json());
 app.use('/', router);
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_CLAIMS = {
+  sub: 'admin-123',
+  email: 'admin@example.com',
+  app_metadata: { exafy_admin: true },
+};
+
+const NON_ADMIN_CLAIMS = {
+  sub: 'user-123',
+  email: 'test@example.com',
+  app_metadata: { exafy_admin: false },
+};
+
+function mockVerifiedJwt(payload: object) {
+  (jose.jwtVerify as jest.Mock).mockResolvedValue({ payload });
+}
+
+function mockInvalidJwt() {
+  (jose.jwtVerify as jest.Mock).mockRejectedValue(new Error('signature verification failed'));
+}
+
 describe('Admin Notification Categories Routes', () => {
-  let mockSupabase: any;
-  
   beforeEach(() => {
     jest.clearAllMocks();
-
-    // Default mock for the service role client
-    mockSupabase = {
-      from: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      insert: jest.fn().mockReturnThis(),
-      update: jest.fn().mockReturnThis(),
-      delete: jest.fn().mockReturnThis(),
-      order: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      or: jest.fn().mockReturnThis(),
-      is: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      single: jest.fn().mockResolvedValue({ data: { id: '123' }, error: null }),
-    };
-    mockCreateSupabaseClient.mockReturnValue(mockSupabase);
+    process.env.SUPABASE_JWT_SECRET = 'test-jwt-secret';
+    delete process.env.SUPABASE_AUTH_JWKS_URL;
+    for (const chain of Object.values(tableChains)) chain.mockReset();
+    mockGetSupabase.mockReturnValue(mockSupabase as any);
+    // Default: unverifiable token
+    mockInvalidJwt();
   });
 
   // --- Auth Middleware Tests ---
@@ -51,32 +118,15 @@ describe('Admin Notification Categories Routes', () => {
   });
 
   it('should return 401 if the token is invalid', async () => {
-    mockCreateUserSupabaseClient.mockReturnValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: { message: 'Invalid token' } }),
-      },
-    });
+    mockInvalidJwt();
 
     const response = await request(app).get('/').set('Authorization', 'Bearer invalid-token');
     expect(response.status).toBe(401);
-    expect(response.body.error).toBe('INVALID_TOKEN');
+    expect(response.body.error).toBe('UNAUTHENTICATED');
   });
 
   it('should return 403 if the user is not an exafy_admin', async () => {
-    mockCreateUserSupabaseClient.mockReturnValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({
-          data: {
-            user: {
-              id: 'user-123',
-              email: 'test@example.com',
-              app_metadata: { exafy_admin: false },
-            },
-          },
-          error: null,
-        }),
-      },
-    });
+    mockVerifiedJwt(NON_ADMIN_CLAIMS);
 
     const response = await request(app).get('/').set('Authorization', 'Bearer valid-non-admin-token');
     expect(response.status).toBe(403);
@@ -84,51 +134,44 @@ describe('Admin Notification Categories Routes', () => {
   });
 
   it('should allow access if the user is an exafy_admin', async () => {
-    // Mock user client for auth
-    mockCreateUserSupabaseClient.mockReturnValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({
-          data: {
-            user: {
-              id: 'admin-123',
-              email: 'admin@example.com',
-              app_metadata: { exafy_admin: true },
-            },
-          },
-          error: null,
-        }),
-      },
-    });
-
-    // Mock service client for the handler logic
-    mockSupabase.select.mockResolvedValue({ data: [], error: null });
+    mockVerifiedJwt(ADMIN_CLAIMS);
+    chainFor('notification_categories').mockResolvedValue({ data: [], error: null });
 
     const response = await request(app).get('/').set('Authorization', 'Bearer valid-admin-token');
-    
+
     expect(response.status).toBe(200);
     expect(response.body.ok).toBe(true);
     expect(response.body.data).toEqual({ chat: [], calendar: [], community: [] }); // Check handler response
-    expect(mockCreateUserSupabaseClient).toHaveBeenCalledWith('valid-admin-token');
+    // Middleware verified the exact token from the Authorization header
+    expect(jose.jwtVerify).toHaveBeenCalledWith(
+      'valid-admin-token',
+      expect.anything(),
+      expect.objectContaining({ algorithms: ['HS256'] })
+    );
+  });
+
+  it('GET / groups categories by type', async () => {
+    mockVerifiedJwt(ADMIN_CLAIMS);
+    const rows = [
+      { id: '1', type: 'chat', slug: 'mentions' },
+      { id: '2', type: 'calendar', slug: 'reminders' },
+      { id: '3', type: 'chat', slug: 'replies' },
+    ];
+    chainFor('notification_categories').mockResolvedValue({ data: rows, error: null });
+
+    const response = await request(app).get('/').set('Authorization', 'Bearer valid-admin-token');
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(3);
+    expect(response.body.data.chat).toHaveLength(2);
+    expect(response.body.data.calendar).toHaveLength(1);
+    expect(response.body.data.community).toHaveLength(0);
   });
 
   // --- Example handler test to confirm passthrough ---
 
   it('POST / should create a category for an admin user', async () => {
-     // Mock user client for auth
-    mockCreateUserSupabaseClient.mockReturnValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({
-          data: {
-            user: {
-              id: 'admin-user-id',
-              email: 'admin@example.com',
-              app_metadata: { exafy_admin: true },
-            },
-          },
-          error: null,
-        }),
-      },
-    });
+    mockVerifiedJwt({ ...ADMIN_CLAIMS, sub: 'admin-user-id' });
 
     const newCategory = {
       type: 'chat',
@@ -148,7 +191,8 @@ describe('Admin Notification Categories Routes', () => {
       tenant_id: null,
     };
 
-    mockSupabase.single.mockResolvedValue({ data: createdCategory, error: null });
+    const categoriesChain = chainFor('notification_categories');
+    categoriesChain.mockResolvedValueOnce({ data: createdCategory, error: null });
 
     const response = await request(app)
       .post('/')
@@ -158,10 +202,38 @@ describe('Admin Notification Categories Routes', () => {
     expect(response.status).toBe(201);
     expect(response.body.ok).toBe(true);
     expect(response.body.data).toMatchObject(newCategory);
-    expect(mockSupabase.insert).toHaveBeenCalledWith(expect.objectContaining({
-        ...newCategory,
-        slug: 'new_test_category',
-        created_by: 'admin-user-id' // confirms user is passed from middleware
+    expect(categoriesChain.insert).toHaveBeenCalledWith(expect.objectContaining({
+      ...newCategory,
+      slug: 'new_test_category',
+      created_by: 'admin-user-id', // confirms user is passed from middleware
     }));
+  });
+
+  it('POST / should return 400 for a missing display_name', async () => {
+    mockVerifiedJwt(ADMIN_CLAIMS);
+
+    const response = await request(app)
+      .post('/')
+      .set('Authorization', 'Bearer valid-admin-token')
+      .send({ type: 'chat' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('INVALID_INPUT');
+  });
+
+  it('POST / should return 409 on slug conflict', async () => {
+    mockVerifiedJwt(ADMIN_CLAIMS);
+    chainFor('notification_categories').mockResolvedValueOnce({
+      data: null,
+      error: { code: '23505', message: 'duplicate key value violates unique constraint' },
+    });
+
+    const response = await request(app)
+      .post('/')
+      .set('Authorization', 'Bearer valid-admin-token')
+      .send({ type: 'chat', display_name: 'Mentions' });
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toBe('SLUG_CONFLICT');
   });
 });

--- a/services/gateway/test/routes/health.test.ts
+++ b/services/gateway/test/routes/health.test.ts
@@ -2,13 +2,16 @@ import request from 'supertest';
 import express from 'express';
 
 jest.mock('../../src/lib/supabase-user');
+jest.mock('../../src/lib/supabase');
 jest.mock('../../src/services/oasis-event-service');
 
 import healthRouter from '../../src/routes/health';
 import { createUserSupabaseClient } from '../../src/lib/supabase-user';
+import { getSupabase } from '../../src/lib/supabase';
 import { emitOasisEvent } from '../../src/services/oasis-event-service';
 
 const mockCreateUserSupabaseClient = createUserSupabaseClient as jest.MockedFunction<typeof createUserSupabaseClient>;
+const mockGetSupabase = getSupabase as jest.MockedFunction<typeof getSupabase>;
 const mockEmitOasisEvent = emitOasisEvent as jest.MockedFunction<typeof emitOasisEvent>;
 
 const TOKEN = 'test-jwt-token';
@@ -20,6 +23,7 @@ function makeFromChain() {
   const chain: any = {};
   chain.select = jest.fn().mockReturnValue(chain);
   chain.eq = jest.fn().mockReturnValue(chain);
+  chain.limit = jest.fn().mockReturnValue(chain);
   chain.order = jest.fn().mockResolvedValue({ data: [], error: null });
   chain.upsert = jest.fn().mockResolvedValue({ data: null, error: null });
   chain.single = jest.fn().mockResolvedValue({ data: null, error: null });
@@ -32,6 +36,9 @@ function makeSupabaseMock() {
   const mock: any = {
     rpc: jest.fn(),
     from: jest.fn().mockReturnValue(fromChain),
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }),
+    },
     _fromChain: fromChain,
   };
   return mock;
@@ -43,11 +50,14 @@ testApp.use('/', healthRouter);
 
 describe('Health Router', () => {
   let supabaseMock: ReturnType<typeof makeSupabaseMock>;
+  let adminMock: ReturnType<typeof makeSupabaseMock>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     supabaseMock = makeSupabaseMock();
+    adminMock = makeSupabaseMock();
     mockCreateUserSupabaseClient.mockReturnValue(supabaseMock as any);
+    mockGetSupabase.mockReturnValue(adminMock as any);
     mockEmitOasisEvent.mockResolvedValue(undefined as any);
     global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 } as any);
     process.env.SUPABASE_URL = 'http://localhost:54321';
@@ -450,42 +460,61 @@ describe('Health Router', () => {
       expect(res.body.error).toBe('INVALID_RATING');
     });
 
-    it('returns 401 when me_context fails', async () => {
-      supabaseMock.rpc.mockResolvedValueOnce({
-        data: null,
-        error: { message: 'JWT error' },
+    it('returns 401 when the Supabase user lookup fails', async () => {
+      supabaseMock.auth.getUser.mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: 'Invalid token' },
       });
       const res = await request(testApp)
         .post('/baseline-survey')
         .set('Authorization', AUTH_HEADER)
         .send({ physical: 3, mental: 3, nutritional: 3 });
       expect(res.status).toBe(401);
-      expect(res.body.error).toBe('NO_CONTEXT');
+      expect(res.body.error).toBe('UNAUTHENTICATED');
     });
 
-    it('returns 400 when the compute RPC fails', async () => {
-      supabaseMock.rpc
-        .mockResolvedValueOnce({ data: { user_id: 'u1', tenant_id: 't1' }, error: null })
-        .mockResolvedValueOnce({ data: null, error: { message: 'compute failed' } });
+    it('returns 400 when the survey upsert fails', async () => {
+      supabaseMock.rpc.mockResolvedValueOnce({ data: { tenant_id: 't1' }, error: null });
+      supabaseMock._fromChain.upsert.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'upsert failed' },
+      });
       const res = await request(testApp)
         .post('/baseline-survey')
         .set('Authorization', AUTH_HEADER)
         .send({ physical: 3, mental: 3, nutritional: 3 });
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe('COMPUTE_FAILED');
+      expect(res.body.error).toBe('SURVEY_WRITE_FAILED');
     });
 
     it('returns 200 with ok:true and index.score_total on success', async () => {
-      supabaseMock.rpc
-        .mockResolvedValueOnce({ data: { user_id: 'u1', tenant_id: 't1' }, error: null })
-        .mockResolvedValueOnce({ data: { ok: true, score_total: 65 }, error: null });
+      // Legacy 3-question payload maps to 5 pillars (hydration/sleep default to 3).
+      // Baseline curve: rating 3 → 25 per pillar; 5 pillars × 25 × weight 1.0 = 125.
+      supabaseMock.rpc.mockResolvedValueOnce({ data: { tenant_id: 't1' }, error: null });
       const res = await request(testApp)
         .post('/baseline-survey')
         .set('Authorization', AUTH_HEADER)
         .send({ physical: 3, mental: 3, nutritional: 3 });
       expect(res.status).toBe(200);
       expect(res.body.ok).toBe(true);
-      expect(res.body.index.score_total).toBe(65);
+      expect(res.body.index.score_total).toBe(125);
+      expect(res.body.index.model_version).toBe('baseline-survey-v3-5pillar');
+      // Survey row is written via the user client; the Day-0 score via the admin client
+      expect(supabaseMock.from).toHaveBeenCalledWith('vitana_index_baseline_survey');
+      expect(adminMock.from).toHaveBeenCalledWith('vitana_index_scores');
+    });
+
+    it('returns 200 and honors an explicit 5-pillar payload', async () => {
+      // Curve: 1→10, 2→20, 3→25, 4→32, 5→40 → total 10+20+25+32+40 = 127
+      supabaseMock.rpc.mockResolvedValueOnce({ data: { tenant_id: 't1' }, error: null });
+      const res = await request(testApp)
+        .post('/baseline-survey')
+        .set('Authorization', AUTH_HEADER)
+        .send({ nutrition: 1, hydration: 2, exercise: 3, sleep: 4, mental: 5 });
+      expect(res.status).toBe(200);
+      expect(res.body.index.score_total).toBe(127);
+      expect(res.body.index.score_nutrition).toBe(10);
+      expect(res.body.index.score_mental).toBe(40);
     });
   });
 
@@ -496,6 +525,18 @@ describe('Health Router', () => {
     it('returns 401 when Authorization header is absent', async () => {
       const res = await request(testApp).get('/baseline-survey/status');
       expect(res.status).toBe(401);
+    });
+
+    it('returns 401 when the Supabase user lookup fails', async () => {
+      supabaseMock.auth.getUser.mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: 'Invalid token' },
+      });
+      const res = await request(testApp)
+        .get('/baseline-survey/status')
+        .set('Authorization', AUTH_HEADER);
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('UNAUTHENTICATED');
     });
 
     it('returns 400 on DB error', async () => {
@@ -509,9 +550,15 @@ describe('Health Router', () => {
       expect(res.status).toBe(400);
     });
 
-    it('returns completed:true with completed_at when survey row exists', async () => {
+    it('returns completed:true when both survey row and score row exist', async () => {
+      // User client: survey row
       supabaseMock._fromChain.maybeSingle.mockResolvedValueOnce({
         data: { completed_at: '2026-01-01T00:00:00Z' },
+        error: null,
+      });
+      // Admin client: vitana_index_scores row
+      adminMock._fromChain.maybeSingle.mockResolvedValueOnce({
+        data: { id: 'score-1' },
         error: null,
       });
       const res = await request(testApp)
@@ -519,7 +566,24 @@ describe('Health Router', () => {
         .set('Authorization', AUTH_HEADER);
       expect(res.status).toBe(200);
       expect(res.body.completed).toBe(true);
+      expect(res.body.has_survey).toBe(true);
+      expect(res.body.has_score).toBe(true);
       expect(res.body.completed_at).toBe('2026-01-01T00:00:00Z');
+    });
+
+    it('returns completed:false when the survey exists but no score was written', async () => {
+      supabaseMock._fromChain.maybeSingle.mockResolvedValueOnce({
+        data: { completed_at: '2026-01-01T00:00:00Z' },
+        error: null,
+      });
+      // Admin score lookup finds nothing (default maybeSingle → { data: null })
+      const res = await request(testApp)
+        .get('/baseline-survey/status')
+        .set('Authorization', AUTH_HEADER);
+      expect(res.status).toBe(200);
+      expect(res.body.completed).toBe(false);
+      expect(res.body.has_survey).toBe(true);
+      expect(res.body.has_score).toBe(false);
     });
 
     it('returns completed:false when no survey row exists', async () => {

--- a/services/gateway/test/routes/wearables-waitlist.test.ts
+++ b/services/gateway/test/routes/wearables-waitlist.test.ts
@@ -43,7 +43,7 @@ const createChain = () => {
 const mockChain = createChain();
 const mockGetSupabase = jest.fn(() => mockChain as any);
 
-jest.mock('../src/lib/supabase', () => ({
+jest.mock('../../src/lib/supabase', () => ({
   getSupabase: mockGetSupabase,
 }));
 
@@ -53,7 +53,7 @@ jest.mock('jose');
 // App setup — mount the router under the same prefix used in production
 // ---------------------------------------------------------------------------
 
-import router from '../src/routes/wearables-waitlist';
+import router from '../../src/routes/wearables-waitlist';
 
 const app = express();
 app.use(express.json());

--- a/services/gateway/test/services/action-executors.test.ts
+++ b/services/gateway/test/services/action-executors.test.ts
@@ -79,6 +79,10 @@ describe('registerAllActionExecutors', () => {
   // ---- boot ----------------------------------------------------------------
   describe('boot', () => {
     it('registers exactly 5 executors', () => {
+      // beforeEach's clearAllMocks wipes the beforeAll call history, so
+      // re-register here (idempotent — same keys are overwritten) to assert
+      // on the registration calls themselves.
+      registerAllActionExecutors();
       expect(mockRegister).toHaveBeenCalledTimes(5);
       expect(Object.keys(executors)).toHaveLength(5);
       expect(Object.keys(executors).sort()).toEqual([

--- a/services/gateway/test/services/recommendation-engine/analyzers/codebase-analyzer.test.ts
+++ b/services/gateway/test/services/recommendation-engine/analyzers/codebase-analyzer.test.ts
@@ -20,13 +20,17 @@ describe('codebase-analyzer severity mapping', () => {
     ['HACK', 'high'],
     ['XXX', 'medium'],
   ])('should assign severity %s for type %s', async (type: string, expectedSeverity: string) => {
-    // Create a single file with one comment of the given type
+    // Create a single file with one comment of the given type.
+    // Use a subdirectory scan path (like the production defaults `services/`
+    // etc.) — the analyzer strips `basePath/` off grep output, so paths are
+    // reported relative to basePath, prefixed by the scan path.
     const fileContent = `// ${type}: test comment`;
-    const filePath = path.join(tmpDir, 'test.ts');
+    fs.mkdirSync(path.join(tmpDir, 'src'));
+    const filePath = path.join(tmpDir, 'src', 'test.ts');
     fs.writeFileSync(filePath, fileContent, 'utf-8');
 
     const result = await analyzeCodebase(tmpDir, {
-      scan_paths: ['.'],
+      scan_paths: ['src/'],
       exclude_paths: [],
       file_size_threshold_lines: 1000,
     });
@@ -36,7 +40,7 @@ describe('codebase-analyzer severity mapping', () => {
     const signal = result.signals[0];
     expect(signal.type).toBe('todo');
     expect(signal.severity).toBe(expectedSeverity);
-    expect(signal.file_path).toBe('test.ts');
+    expect(signal.file_path).toBe('src/test.ts');
   });
 
   it('should handle all four types simultaneously', async () => {

--- a/services/oasis-projector/test/ledger-writer.test.ts
+++ b/services/oasis-projector/test/ledger-writer.test.ts
@@ -6,6 +6,12 @@
  * - Maps event types/statuses to ledger statuses
  * - Creates and updates vtid_ledger entries
  * - Emits ledger_sync events
+ *
+ * NOTE (VTID-01007): isValidVtid() only accepts canonical 4-5 digit VTIDs
+ * (`VTID-0521`, `VTID-01006`, optionally with a numeric suffix like
+ * `VTID-0522-1`) or legacy `PREFIX-NAME-123` identifiers (`DEV-OASIS-0010`).
+ * Fixture VTIDs in this file must match one of those shapes or the writer
+ * (correctly) skips the event.
  */
 
 import { LedgerWriter, LedgerWriterResult } from '../src/ledger-writer';
@@ -203,7 +209,8 @@ describe('LedgerWriter (VTID-0521)', () => {
       async ({ eventType, expectedStatus }) => {
         mockOasisEventStore.push({
           id: `event-${eventType}`,
-          vtid: `VTID-${eventType}`,
+          // Must be a canonical VTID (VTID-01007) or the event is skipped
+          vtid: 'VTID-0521',
           topic: eventType,
           service: 'test',
           status: 'info',
@@ -219,7 +226,7 @@ describe('LedgerWriter (VTID-0521)', () => {
     it('should fallback to event.status when event type is not mapped', async () => {
       mockOasisEventStore.push({
         id: 'event-fallback',
-        vtid: 'VTID-FALLBACK',
+        vtid: 'VTID-0600',
         event: 'unknown.event',
         service: 'test',
         status: 'success',
@@ -263,7 +270,7 @@ describe('LedgerWriter (VTID-0521)', () => {
       // Pre-populate with existing entry
       mockVtidLedgerStore.push({
         id: 'existing-1',
-        vtid: 'VTID-EXISTING',
+        vtid: 'VTID-0601',
         status: 'active',
         service: 'gateway',
         taskFamily: 'deployment',
@@ -277,7 +284,7 @@ describe('LedgerWriter (VTID-0521)', () => {
 
       mockOasisEventStore.push({
         id: 'event-update',
-        vtid: 'VTID-EXISTING',
+        vtid: 'VTID-0601',
         topic: 'task_completed',
         service: 'ci-cd',
         status: 'success',
@@ -294,7 +301,7 @@ describe('LedgerWriter (VTID-0521)', () => {
     it('should not downgrade status from complete to active', async () => {
       mockVtidLedgerStore.push({
         id: 'completed-1',
-        vtid: 'VTID-COMPLETED',
+        vtid: 'VTID-0602',
         status: 'complete',
         service: 'gateway',
         taskFamily: 'deployment',
@@ -308,7 +315,7 @@ describe('LedgerWriter (VTID-0521)', () => {
 
       mockOasisEventStore.push({
         id: 'event-downgrade',
-        vtid: 'VTID-COMPLETED',
+        vtid: 'VTID-0602',
         topic: 'deployment_started',
         service: 'ci-cd',
         status: 'start',
@@ -324,7 +331,7 @@ describe('LedgerWriter (VTID-0521)', () => {
     it('should update last_event_id and last_event_at', async () => {
       mockOasisEventStore.push({
         id: 'event-tracking',
-        vtid: 'VTID-TRACKING',
+        vtid: 'VTID-0603',
         topic: 'task_started',
         service: 'gateway',
         status: 'start',
@@ -390,7 +397,7 @@ describe('LedgerWriter (VTID-0521)', () => {
     it('should update projection offset after batch', async () => {
       mockOasisEventStore.push({
         id: 'event-offset',
-        vtid: 'VTID-OFFSET',
+        vtid: 'VTID-0604',
         topic: 'task_started',
         service: 'gateway',
         status: 'start',
@@ -414,7 +421,7 @@ describe('LedgerWriter (VTID-0521)', () => {
     it('should emit ledger_sync event after successful batch', async () => {
       mockOasisEventStore.push({
         id: 'event-sync',
-        vtid: 'VTID-SYNC',
+        vtid: 'VTID-0605',
         topic: 'task_created',
         service: 'gateway',
         status: 'info',
@@ -435,17 +442,30 @@ describe('LedgerWriter (VTID-0521)', () => {
     });
 
     it('should emit warning status when there are errors', async () => {
-      // Create an event that will cause an error during processing
-      mockOasisEventStore.push({
-        id: 'event-error',
-        vtid: 'VTID-ERROR',
-        topic: 'task_created',
-        service: 'gateway',
-        status: 'info',
-        createdAt: new Date(),
-      });
+      // First event errors during processing; second succeeds. Note: a
+      // failed event does NOT count as processed, and syncNow() only emits
+      // a sync event when processed > 0 — so the batch needs at least one
+      // successful event for the warning to be observable.
+      mockOasisEventStore.push(
+        {
+          id: 'event-error',
+          vtid: 'VTID-0606',
+          topic: 'task_created',
+          service: 'gateway',
+          status: 'info',
+          createdAt: new Date(Date.now() - 1000),
+        },
+        {
+          id: 'event-ok',
+          vtid: 'VTID-0607',
+          topic: 'task_created',
+          service: 'gateway',
+          status: 'info',
+          createdAt: new Date(),
+        }
+      );
 
-      // Make the create throw an error
+      // Make the first create throw an error
       mockDb.vtidLedger.create.mockRejectedValueOnce(new Error('DB Error'));
 
       await ledgerWriter.syncNow();
@@ -464,7 +484,7 @@ describe('LedgerWriter (VTID-0521)', () => {
       for (let i = 0; i < 5; i++) {
         mockOasisEventStore.push({
           id: `event-${i}`,
-          vtid: `VTID-${i}`,
+          vtid: `VTID-100${i}`,
           topic: 'task_created',
           service: 'gateway',
           status: 'info',
@@ -484,7 +504,7 @@ describe('LedgerWriter (VTID-0521)', () => {
     it('should populate layer, module, title, summary columns on create', async () => {
       mockOasisEventStore.push({
         id: 'event-columns',
-        vtid: 'VTID-0522-TEST-001',
+        vtid: 'VTID-0522-1',
         topic: 'deployment_succeeded',
         service: 'gateway',
         status: 'success',
@@ -501,7 +521,7 @@ describe('LedgerWriter (VTID-0521)', () => {
       await ledgerWriter.processBatch();
 
       const entry = mockVtidLedgerStore[0];
-      expect(entry.vtid).toBe('VTID-0522-TEST-001');
+      expect(entry.vtid).toBe('VTID-0522-1');
       expect(entry.layer).toBe('OASIS');
       expect(entry.module).toBe('projector');
       expect(entry.title).toBe('Test Deployment');
@@ -511,7 +531,7 @@ describe('LedgerWriter (VTID-0521)', () => {
     it('should derive layer from taskFamily if not provided', async () => {
       mockOasisEventStore.push({
         id: 'event-derive-layer',
-        vtid: 'VTID-0522-TEST-002',
+        vtid: 'VTID-0522-2',
         topic: 'task_started',
         service: 'gateway',
         status: 'start',
@@ -530,7 +550,7 @@ describe('LedgerWriter (VTID-0521)', () => {
     it('should derive module from topic if not provided', async () => {
       mockOasisEventStore.push({
         id: 'event-derive-module',
-        vtid: 'VTID-0522-TEST-003',
+        vtid: 'VTID-0522-3',
         topic: 'build_succeeded',
         service: 'ci-cd',
         status: 'success',
@@ -546,7 +566,7 @@ describe('LedgerWriter (VTID-0521)', () => {
     it('should use vtid as title if not provided', async () => {
       mockOasisEventStore.push({
         id: 'event-derive-title',
-        vtid: 'VTID-0522-TEST-004',
+        vtid: 'VTID-0522-4',
         topic: 'task_created',
         service: 'gateway',
         status: 'info',
@@ -556,13 +576,13 @@ describe('LedgerWriter (VTID-0521)', () => {
       await ledgerWriter.processBatch();
 
       const entry = mockVtidLedgerStore[0];
-      expect(entry.title).toBe('VTID-0522-TEST-004');
+      expect(entry.title).toBe('VTID-0522-4');
     });
 
     it('should derive summary from message if not provided', async () => {
       mockOasisEventStore.push({
         id: 'event-derive-summary',
-        vtid: 'VTID-0522-TEST-005',
+        vtid: 'VTID-0522-5',
         topic: 'task_completed',
         service: 'gateway',
         status: 'success',
@@ -580,7 +600,7 @@ describe('LedgerWriter (VTID-0521)', () => {
       // Pre-populate with existing entry that has tasks API columns
       mockVtidLedgerStore.push({
         id: 'existing-with-columns',
-        vtid: 'VTID-0522-UPDATE',
+        vtid: 'VTID-0522-6',
         status: 'active',
         service: 'gateway',
         taskFamily: 'deployment',
@@ -599,7 +619,7 @@ describe('LedgerWriter (VTID-0521)', () => {
       // Update event without tasks API columns in metadata
       mockOasisEventStore.push({
         id: 'event-update-preserve',
-        vtid: 'VTID-0522-UPDATE',
+        vtid: 'VTID-0522-6',
         topic: 'deployment_succeeded',
         service: 'ci-cd',
         status: 'success',
@@ -610,11 +630,15 @@ describe('LedgerWriter (VTID-0521)', () => {
 
       const entry = mockVtidLedgerStore[0];
       expect(entry.status).toBe('complete');
-      // Tasks API columns should be preserved
+      // layer, title, summary have no event-derived fallback here, so the
+      // existing values are preserved on update.
       expect(entry.layer).toBe('DEPLOYMENT');
-      expect(entry.module).toBe('ci-cd');
       expect(entry.title).toBe('Original Title');
       expect(entry.summary).toBe('Original summary');
+      // module intentionally tracks the latest event: extractMetadata()
+      // derives module from the event topic when no explicit module/taskType
+      // metadata is present, and the update path prefers that derived value.
+      expect(entry.module).toBe('deployment_succeeded');
     });
   });
 });


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-TEST-COVERAGE` (Phase 1 of `docs/TEST_COVERAGE_PLAN.md`)

**Layer:** CICDL

**Priority:** P0

---

## 📋 Summary

Phase 1 of the test-coverage plan: every suite in the VTID-02696 quarantine list (red on main since 2026-05-02) has been repaired, plus the drift-broken oasis-projector `ledger-writer` suite. The quarantine list is deleted from `jest.config.js` and oasis-projector rejoins the `TEST-SUITE.yml` CI matrix. **Full gateway suite is now 474 suites / 8,398 tests, all green** (was 437 suites / 7,492 running, 11 suites skipped).

---

## ✅ Changes

- [x] 11 quarantined gateway suites repaired (45 failing tests fixed) — root causes were drift against: tenant-scoped autopilot tables, the memory-broker read path (VTID-02026/03145/03156), the Bedrock provider (VTID-03403), `gemini-3.1-pro-preview` flagship (VTID-02690), the cognee opt-in gate (VTID-02632), jose-JWT auth middleware, and the rewritten baseline-survey pipeline; `wearables-waitlist` had broken import paths and never registered a single test
- [x] **Genuine src bug fixed** — `classifyCategory()` in `services/gateway/src/routes/memory.ts` matched the substring `'pr'`, so any memory containing those letters ("**pr**efer", "es**pr**esso") was misclassified as a dev `tasks` memory; now word-boundary matched
- [x] `services/oasis-projector/test/ledger-writer.test.ts` — 35/35 green (fixture VTIDs updated to canonical VTID-01007 format; intentional module-refresh-on-update behavior asserted)
- [x] `services/gateway/jest.config.js` — quarantine list removed; suites can no longer silently rot
- [x] `.github/workflows/TEST-SUITE.yml` — oasis-projector added to the matrix
- [x] `docs/TEST_COVERAGE_PLAN.md` — Phase 1 marked complete

---

## 🧪 Testing

- [x] Manual testing completed — every repaired suite verified individually, then the **full gateway suite run clean-room: 474 suites / 8,398 tests green (exit 0)**; oasis-projector verified independently (35/35)
- [x] Automated tests added/updated — net +10 tests beyond the repairs (strengthened accidental-pass tests, added missing edge cases)
- [ ] Verified in staging/dev environment — n/a, tests/CI only; the PR's own TEST-SUITE run is the verification

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] All workflow files use **UPPERCASE** names
- [x] All workflows include `run-name`
- [x] No lowercase workflow names present

### File Names
- [x] All new files follow **kebab-case** convention (no new files besides test edits)
- [x] Directory names use **kebab-case**
- [x] No files violate naming canon

### Code Standards
- [x] Event types/kinds use **snake_case**
- [x] Status values use **lowercase**
- [x] VTID references in comments follow canonical format

### Cloud Run Deployments
- [x] n/a — no deployment changes

### Documentation
- [x] BOOTSTRAP reference in commit message
- [x] Phase 2B compliance verified
- [x] No non-compliant files introduced

---

## 🔗 Links

- **Documentation:** `docs/TEST_COVERAGE_PLAN.md` (Phase 1 row + change log)
- **Related PRs:** #2876 (Phase 0 — CI enforcement baseline)

---

## 🚨 Breaking Changes

None. One behavioral src change: the memory classifier no longer misroutes content containing the letters "pr" — strictly a correctness fix.

---

## 📌 Additional Notes

One open design question surfaced for the team (documented as a comment in the ledger-writer test): a batch in which **every** event errors emits no `ledger_sync` event and still advances the projection offset (no retry). Worth a deliberate decision; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzaoWroFJgiACJ6N5b2Ceb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzaoWroFJgiACJ6N5b2Ceb)_