### PR TITLE
fix(deploy): bind ANTHROPIC_API_KEY to gateway-staging (BOOTSTRAP-GEMINI-TO-CLAUDE)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -179,6 +179,18 @@ jobs:
             # no-op'd on preview-gateway.vitanaland.com.
             "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
             "DEEPSEEK_API_KEY=${{ secrets.DEEPSEEK_API_KEY }}"
+            # BOOTSTRAP-GEMINI-TO-CLAUDE: Claude Sonnet 4.6 direct-API key for
+            # the Tier A migrated call sites (spec generation, intent
+            # classify/extract, matchmaker, architecture investigator —
+            # services/gateway/src/services/claude-text-client.ts). Bound as
+            # a plain GitHub Actions secret, same pattern EXEC-DEPLOY.yml
+            # already uses for prod's gateway (no GCP Secret Manager entry
+            # for this key). Without it, callClaudeText() returns null and
+            # every migrated call site silently falls back to its
+            # deterministic default — this was previously unbound on
+            # gateway-staging, so live testing showed CLASSIFY_LOW_CONFIDENCE
+            # with confidence 0 instead of real Claude responses.
+            "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}"
           )
 
           # Comma-joined for --set-env-vars (replaces, not merges — we want the


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-GEMINI-TO-CLAUDE` _(bootstrap tag, no formal VTID exists yet)_

**Layer:** CICDL

**Priority:** P1

---

## 📋 Summary

Follow-up to #2914 (Tier A Gemini→Claude Sonnet 4.6 migration, merged). Live-testing the migrated services against `gateway-staging` with a real authenticated user showed `POST /api/v1/intents` returning `CLASSIFY_LOW_CONFIDENCE` / `confidence: 0` instead of a real classification.

**Root cause:** `STAGE-DEPLOY.yml` never bound `ANTHROPIC_API_KEY`. `callClaudeText()` (`services/gateway/src/services/claude-text-client.ts`) returns `null` when its client isn't configured, so on staging every migrated call site (classifier, extractor, matchmaker, spec generation, architecture investigator) silently falls through to its deterministic fallback instead of calling Claude. Production's `EXEC-DEPLOY.yml` already binds this exact secret for the gateway — staging just never picked it up, the same class of bug documented twice before in this file for `FEATURE_INTENT_ENGINE_A` and `OPENAI_API_KEY`/`DEEPSEEK_API_KEY` (`--set-env-vars`/`--set-secrets` replace, not merge).

---

## ✅ Changes

- [x] Add `ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}` to `STAGE-DEPLOY.yml`'s `ENV_VARS` array, mirroring the existing `OPENAI_API_KEY`/`DEEPSEEK_API_KEY` pattern (plain GitHub Actions secret, no GCP Secret Manager entry — same as prod's gateway binding in `EXEC-DEPLOY.yml`)

---

## 🧪 Testing

_How was this tested?_

- [ ] Manual testing completed
- [x] Verified in staging/dev environment (root-caused via live test against `gateway-staging` prior to this fix; will re-verify `POST /api/v1/intents` once this deploys)
- [x] YAML syntax validated locally (`yaml.safe_load`)

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] All workflow files use **UPPERCASE** names
- [x] No lowercase workflow names present

### File Names
- [x] No files violate naming canon (no new files added)

### Code Standards
- [x] N/A — single-line workflow config change, no new constants/events

### Cloud Run Deployments
- [x] N/A — no new Cloud Run service

### Documentation
- [x] BOOTSTRAP tag referenced in commit message

---

## 🚨 Breaking Changes

None.

---

## 📌 Additional Notes

Single-line functional change (plus explanatory comment). Once deployed, will re-run the live `POST /api/v1/intents` test with the e2e test user to confirm classify/extract/matchmaker now get real Claude Sonnet 4.6 responses.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgQ1F5tPaPmvpBL1gWibj1)_