### PR TITLE
Stand up AWS Production (DR) for gateway service (VTID-03398)

### DIFF
--- a/.github/workflows/AWS-PROD-DEPLOY-GATEWAY.yml
+++ b/.github/workflows/AWS-PROD-DEPLOY-GATEWAY.yml
@@ -1,0 +1,237 @@
+# AWS-PROD-DEPLOY-GATEWAY — build the gateway, push to ECR, and roll the
+# AWS Production (DR) ECS service (VTID-03398).
+#
+# AWS twin of AWS-STAGE-DEPLOY-GATEWAY.yml, but for the parallel/DR
+# production stack (`vitana-gateway-awsdr`), not the staging one
+# (`vitana-gateway`). GCP Cloud Run remains the canonical production —
+# this workflow ships to the AWS DR target only, and NEVER on push.
+#
+# Design choices:
+# - workflow_dispatch ONLY, with a REQUIRED `reason` input. There is no
+#   `on: push` trigger of any kind — mirrors how GCP prod is gated
+#   post-cutover (CLAUDE.md §16: auto = staging, prod = deliberate manual
+#   action with a recorded reason). This is the single most important
+#   property of this file; do not add a push trigger.
+# - The existing `vitana-gateway-awsdr` task definition is PRESERVED: only
+#   the container image and the commit-stamp env vars (GIT_COMMIT_SHA /
+#   COMMIT_SHA / BUILD_INFO_MARKER) are replaced, same pattern as staging.
+# - Smoke gate mirrors AWS-STAGE-DEPLOY-GATEWAY.yml: /api/v1/admin/health
+#   must report env=production AND /api/v1/admin/build-info must report
+#   the deployed commit — otherwise the job fails loudly (CLAUDE.md §15).
+# - OASIS event + software_versions row are emitted best-effort via
+#   Supabase REST when SUPABASE_URL / SUPABASE_SERVICE_ROLE repo secrets
+#   exist, so the Command Hub CLOCK history sees AWS-DR prod deploys.
+#
+# Required repository secrets:
+#   AWS_PROD_ROLE_ARN — GitHub OIDC deploy role (see scripts/aws/README.md
+#   for the federation pattern; a dedicated role/trust-policy for this
+#   workflow still needs to be created by an operator with IAM admin
+#   rights — see docs/AWS-PRODUCTION-BUILD-LOG.md for the exact one-time
+#   setup commands. Deliberately NOT a static-key IAM user.)
+# Optional repository secrets (for OASIS/CLOCK visibility):
+#   SUPABASE_URL / SUPABASE_SERVICE_ROLE
+
+name: AWS Prod Deploy Gateway (ECS, DR)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for this AWS production (DR) gateway deploy — required'
+        required: true
+      gateway_url:
+        description: 'Public gateway URL for post-deploy verification'
+        required: false
+        default: 'https://dr-gateway.vitanaland.com'
+      aws_region:
+        description: 'AWS region'
+        required: false
+        default: 'eu-central-1'
+      ecr_repository:
+        description: 'ECR repository name for the gateway image'
+        required: false
+        default: 'vitana/gateway'
+      ecs_cluster:
+        description: 'ECS cluster name'
+        required: false
+        default: 'Vitana-ECS-Cluster'
+      ecs_service:
+        description: 'ECS service name'
+        required: false
+        default: 'vitana-gateway-awsdr'
+
+permissions:
+  contents: read
+  id-token: write # required for aws-actions/configure-aws-credentials OIDC
+
+concurrency:
+  group: aws-prod-deploy-gateway
+  cancel-in-progress: false
+
+jobs:
+  build-push-deploy:
+    runs-on: ubuntu-latest
+    env:
+      GATEWAY_URL: ${{ inputs.gateway_url }}
+      TARGET_AWS_REGION: ${{ inputs.aws_region }}
+      ECR_REPOSITORY: ${{ inputs.ecr_repository }}
+      ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+      ECS_SERVICE: ${{ inputs.ecs_service }}
+      DEPLOY_REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve commit metadata + refresh BUILD_INFO
+        id: commit
+        run: |
+          SHORT="$(git rev-parse --short=12 HEAD)"
+          {
+            echo "sha=$GITHUB_SHA"
+            echo "short=$SHORT"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "$GITHUB_SHA"
+            echo "Build: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } > services/gateway/BUILD_INFO
+
+      - name: Configure AWS credentials (GitHub OIDC — no static keys)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_ARN }}
+          aws-region: ${{ env.TARGET_AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Preflight — verify ECR repo + ECS service exist
+        run: |
+          set -e
+          if ! aws ecr describe-repositories --repository-names "${{ env.ECR_REPOSITORY }}" >/dev/null 2>&1; then
+            echo "::error::ECR repository '${{ env.ECR_REPOSITORY }}' not found."
+            exit 1
+          fi
+          if ! aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+               --query 'services[0].status' --output text 2>/dev/null | grep -q ACTIVE; then
+            echo "::error::ECS service '${{ env.ECS_SERVICE }}' not ACTIVE in cluster '${{ env.ECS_CLUSTER }}'. Services:"
+            aws ecs list-services --cluster "${{ env.ECS_CLUSTER }}" --output table
+            exit 1
+          fi
+          # Guardrail: this workflow must only ever touch the AWS-DR prod
+          # service, never the staging one. Refuse to run against
+          # 'vitana-gateway' (staging) even if someone passes it as an input.
+          if [ "${{ env.ECS_SERVICE }}" = "vitana-gateway" ]; then
+            echo "::error::Refusing to deploy — 'vitana-gateway' is the AWS STAGING service. This workflow targets 'vitana-gateway-awsdr' (prod DR) only."
+            exit 1
+          fi
+
+      - name: Build and push image
+        id: build
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -e
+          IMAGE="$REGISTRY/${{ env.ECR_REPOSITORY }}:${{ steps.commit.outputs.short }}"
+          docker build -t "$IMAGE" -t "$REGISTRY/${{ env.ECR_REPOSITORY }}:awsdr-latest" services/gateway
+          docker push "$IMAGE"
+          docker push "$REGISTRY/${{ env.ECR_REPOSITORY }}:awsdr-latest"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "Pushed $IMAGE"
+
+      - name: Register task-definition revision + roll the service
+        run: |
+          set -e
+          IMAGE="${{ steps.build.outputs.image }}"
+          SHA="${{ steps.commit.outputs.sha }}"
+          SHORT="${{ steps.commit.outputs.short }}"
+          TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' --output text)
+          echo "Current task definition: $TD_ARN"
+          NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
+            | jq --arg IMG "$IMAGE" --arg SHA "$SHA" --arg SHORT "$SHORT" '
+                .containerDefinitions[0].image = $IMG
+                | .containerDefinitions[0].environment |=
+                    ( [ .[] | select(.name | IN("GIT_COMMIT_SHA","COMMIT_SHA","BUILD_INFO_MARKER") | not) ]
+                      + [ {name:"GIT_COMMIT_SHA", value:$SHA},
+                          {name:"COMMIT_SHA", value:$SHA},
+                          {name:"BUILD_INFO_MARKER", value:$SHORT} ] )
+                | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                      .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "Registered $NEW_ARN"
+          aws ecs update-service --cluster "${{ env.ECS_CLUSTER }}" --service "${{ env.ECS_SERVICE }}" \
+            --task-definition "$NEW_ARN" >/dev/null
+          echo "Waiting for service to stabilize (up to ~10 min)…"
+          aws ecs wait services-stable --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}"
+          echo "Service stable on $NEW_ARN"
+
+      - name: Smoke — env=production + deployed commit live
+        run: |
+          set -e
+          URL="${{ env.GATEWAY_URL }}"
+          SHA="${{ steps.commit.outputs.sha }}"
+          for i in 1 2 3 4 5 6; do
+            HEALTH=$(curl -fsS "$URL/api/v1/admin/health" 2>/dev/null || echo '')
+            BUILD=$(curl -fsS "$URL/api/v1/admin/build-info" 2>/dev/null || echo '')
+            ALIVE=$(curl -fsS -o /dev/null -w "%{http_code}" "$URL/alive" 2>/dev/null || echo '')
+            ENV=$(echo "$HEALTH" | jq -r '.env // empty')
+            COMMIT=$(echo "$BUILD" | jq -r '.git_commit // empty')
+            if [ "$ENV" = "production" ] && [ "$COMMIT" = "$SHA" ] && [ "$ALIVE" = "200" ]; then
+              echo "✓ env=production, git_commit=$COMMIT, /alive=200"
+              exit 0
+            fi
+            echo "Attempt $i: env='$ENV' commit='$COMMIT' alive='$ALIVE' (want production/$SHA/200) — retry in 15s"
+            sleep 15
+          done
+          echo "::error::Smoke failed — health/build-info/alive did not report env=production with the deployed commit"
+          exit 1
+
+      - name: Emit OASIS event + software_versions row (best-effort)
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SVC: ${{ secrets.SUPABASE_SERVICE_ROLE }}
+          SHA: ${{ steps.commit.outputs.sha }}
+          SHORT: ${{ steps.commit.outputs.short }}
+          OUTCOME: ${{ job.status }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          set +e
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SVC" ]; then
+            echo "::notice::SUPABASE_URL / SUPABASE_SERVICE_ROLE repo secrets not set — skipping OASIS/CLOCK emission (deploy itself unaffected)."
+            exit 0
+          fi
+          STATUS=$([ "$OUTCOME" = "success" ] && echo success || echo error)
+          TOPIC=$([ "$OUTCOME" = "success" ] && echo prod.deploy.completed || echo prod.deploy.failed)
+          curl -fsS -X POST "$SUPABASE_URL/rest/v1/software_versions" \
+            -H "Content-Type: application/json" -H "apikey: $SUPABASE_SVC" \
+            -H "Authorization: Bearer $SUPABASE_SVC" -H "Prefer: return=minimal" \
+            -d "$(jq -nc --arg sha "$SHA" --arg st "$STATUS" \
+              '{service:"vitana-gateway-aws-dr", git_commit:$sha, deploy_type:"normal", initiator:"agent", status:$st, environment:"production"}')" \
+            || echo "::warning::software_versions insert failed; continuing."
+          curl -fsS -X POST "$SUPABASE_URL/rest/v1/oasis_events" \
+            -H "Content-Type: application/json" -H "apikey: $SUPABASE_SVC" \
+            -H "Authorization: Bearer $SUPABASE_SVC" -H "Prefer: return=minimal" \
+            -d "$(jq -nc --arg sha "$SHA" --arg short "$SHORT" --arg st "$STATUS" --arg topic "$TOPIC" --arg reason "$REASON" '{
+              vtid: "VTID-03398",
+              topic: $topic,
+              service: "vitana-gateway-aws-dr",
+              role: "CICD",
+              model: "aws-prod-deploy",
+              status: $st,
+              message: ("AWS-PROD-DEPLOY-GATEWAY: " + $short + " (" + $reason + ")"),
+              metadata: { env: "production", platform: "aws-ecs-dr", git_commit: $sha, workflow: "AWS-PROD-DEPLOY-GATEWAY.yml", reason: $reason }
+            }')" || echo "::warning::oasis_events insert failed; continuing."
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## AWS Production (DR) gateway deploy"
+            echo "- Image: \`${{ steps.build.outputs.image }}\`"
+            echo "- Commit: \`${{ steps.commit.outputs.sha }}\`"
+            echo "- Verified live at: ${{ env.GATEWAY_URL }}"
+            echo "- Reason: ${{ env.DEPLOY_REASON }}"
+            echo "- VTID: VTID-03398"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,10 @@ Claude must **never** do the following:
 
 ### Architecture & Logic
 
-1. **Never invent new projects, environments, or services.**
+1. **Never invent new projects, environments, or services.** (Exception:
+   the AWS parallel/DR environment for the `gateway` service, sanctioned
+   under **VTID-03398** — see §1b. GCP remains canonical production; AWS
+   is additive DR capacity for gateway only, not a new canonical target.)
 2. **Never bypass governance gates.**
 3. **Never execute without a VTID.**
 4. **Never deploy without OASIS approval.**
@@ -298,6 +301,59 @@ gcloud run deploy <service> \
   --region us-central1 \
   --project lovable-vitana-vers1
 ```
+
+---
+
+## 1b. AWS PRODUCTION (DR) — GATEWAY (VTID-03398)
+
+GCP (`lovable-vitana-vers1`) remains the **canonical** production for every
+service. AWS hosts a **parallel/DR production for the `gateway` service
+only** — additive capacity, not a migration, and not a general "use AWS
+too" precedent for other services. Do not extend this pattern to another
+service without its own VTID.
+
+| Item | Value |
+|---|---|
+| AWS account / region | `472838866351` / `eu-central-1` |
+| ECS cluster | `Vitana-ECS-Cluster` (shared with AWS staging) |
+| ECS service (AWS-DR prod) | `vitana-gateway-awsdr` — **distinct from** `vitana-gateway` (AWS staging) |
+| Task definition family | `vitana-gateway-awsdr` |
+| Public URL | `https://dr-gateway.vitanaland.com` |
+| Target group | `vitana-tg-gateway-awsdr` (on the existing `vitana-alb-prod` ALB) |
+| Database | RDS Aurora PostgreSQL `vitana-aurora-prod` (writer/reader), same Supabase project as GCP prod (`inmkhvwdcuyhnxkgfvsb`) |
+| Redis | ElastiCache `vitana-redis-prod` |
+| Deploy workflow | `.github/workflows/AWS-PROD-DEPLOY-GATEWAY.yml` — **`workflow_dispatch`-only, required `reason`, never on push** |
+
+**Full build record, exact commands, and pre-existing-state findings:**
+`docs/AWS-PRODUCTION-BUILD-LOG.md`.
+
+### Hard rules specific to AWS-DR prod
+
+- **Never** deploy to AWS-DR prod on push — `AWS-PROD-DEPLOY-GATEWAY.yml`
+  has no `on: push` trigger. It mirrors the GCP staging-first model
+  (§16): AWS staging (`vitana-gateway`) auto-deploys on push; AWS prod
+  (`vitana-gateway-awsdr`) is a deliberate manual dispatch with a
+  recorded reason, same spirit as the GCP PUBLISH button /
+  `publish-to-prod.sh` escape hatch.
+- **Never** confuse `vitana-gateway` (AWS staging) with
+  `vitana-gateway-awsdr` (AWS DR prod) — same ECS cluster, similarly
+  named. The `vitana-alb-prod` ALB's target group named
+  `vitana-tg-gateway-prod` is a **pre-existing naming leftover that
+  actually serves staging traffic**, not AWS-DR prod — verify via
+  `/api/v1/admin/health`'s `env` field before trusting a resource name.
+- **IF** adding another host-header listener rule to `vitana-alb-prod` →
+  **THEN** give it priority < 10 — the ALB's existing path-based rules
+  (`/api/*`, `/ws/*` at priority 10) match before higher-numbered
+  host-header rules regardless of `Host`, and will silently route to
+  staging otherwise (see the build log's "ALB listener-rule priority"
+  section for how this bit the initial build).
+- **Never** extend AWS-DR to `oasis-operator`, `oasis-projector`,
+  `worker-runner`, `vitana-verification-engine`, or the frontend without
+  a new VTID — gateway-only is the deliberate first slice.
+- GitHub OIDC federation (no static AWS keys) is required for the prod
+  deploy role, mirroring `scripts/aws/README.md`'s pattern — **never**
+  add a static-key IAM user for AWS-DR prod deploys the way AWS staging
+  did (`claude-staging-validation`; a known shortcut, not to be repeated).
 
 ---
 
@@ -1066,6 +1122,7 @@ Use these PATs with the GitHub REST API (`api.github.com`) for all PR and deploy
 
 | Date | Change | VTID |
 |------|--------|------|
+| 2026-07-23 | Stood up AWS Production (DR) for the gateway service only — parallel to canonical GCP prod, not a migration: ECS service `vitana-gateway-awsdr`, dedicated target group + host-header ALB rule (`dr-gateway.vitanaland.com`), autoscaling + CloudWatch alarms, `AWS-PROD-DEPLOY-GATEWAY.yml` (dispatch-only, required reason, never on push). Added §1b governance section + Never-rule exception. GitHub OIDC deploy-role wiring left for an operator with IAM admin rights (session's AWS IAM user has zero IAM write permissions) — see `docs/AWS-PRODUCTION-BUILD-LOG.md`. | VTID-03398 |
 | 2026-07-21 | Public "Business" tab: profile visitors can now see another user's active product recommendations (storefront card, buy-through with commission attributed to the profile owner via the existing VTID-02950 `?rec=`/`rec_id` flow). New public endpoint `GET /api/v1/discover/recommendations/:vitanaId` (`discover-recommendations-public.ts`), auth-required (any logged-in viewer, not owner-only), never returns click/conversion/commission fields. No formal VTID existed for this extension; tracked under this BOOTSTRAP tag pending one. | BOOTSTRAP-PUBLIC-BUSINESS-PROFILE |
 | 2026-07-13 | Integrated lycorp-jp/sim-use device-testing layer: `e2e/mobile-sim/` driver + smoke flow (iOS Simulator / Android), `MOBILE-DEVICE-E2E.yml` macOS-runner workflow, vendored sim-use agent skill + `vitana-mobile-testing` glue skill, `docs/MOBILE_DEVICE_TESTING.md` | BOOTSTRAP-SIM-USE-DEVICE-TESTING |
 | 2026-06-04 | Staging-first cutover (time-gated, effective Mon 8 Jun 2026 10:00 Europe/Berlin): added a `cutover_gate` job to every auto-to-prod workflow (`AUTO-DEPLOY`, `DEPLOY-ORB-AGENT`, `DEPLOY-AUTOPILOT-JOB`, `VTID-02409-BOOTSTRAP`) that freezes the push path post-cutover while leaving manual dispatch open; added manual escape hatch `scripts/deploy/publish-to-prod.sh`; rewrote §15/§16 + IF-THEN CI/CD rules. Before cutover all paths still reach prod; after, auto = staging, prod = PUBLISH button / manual exception. Frontend (`vitana-v1`) gated in parallel. | BOOTSTRAP-STAGING-FIRST-CUTOVER |

--- a/docs/AWS-PRODUCTION-BUILD-LOG.md
+++ b/docs/AWS-PRODUCTION-BUILD-LOG.md
@@ -1,0 +1,250 @@
+# AWS Production (DR) — Gateway: Build Log
+
+**VTID:** VTID-03398 · **Built:** 2026-07-23 · **Branch:** `claude/aws-production-build`
+
+Supersedes `docs/AWS-PRODUCTION-HANDOVER.md` as the current-state reference
+for the AWS DR gateway. That doc's "what's not built yet" list undercounted
+what already existed in this AWS account (see "Pre-existing state found"
+below) — this log records what's real as of this build.
+
+No IaC exists in this repo (same as staging) — everything below was
+provisioned by hand via `aws-cli`. Commands are captured verbatim so this is
+reproducible/auditable even without Terraform/CDK.
+
+---
+
+## Scope confirmed with the user
+
+Parallel/DR production for the `gateway` service only, alongside GCP prod
+(canonical) and the existing AWS staging (`vitana-gateway`, unaffected by
+this build). AWS prod shares GCP prod's Supabase project
+(`inmkhvwdcuyhnxkgfvsb`) — confirmed via the pre-existing
+`vitana/supabase/prod/*` Secrets Manager entries. The AWS production Aurora
+database (in sync with Supabase) was already provisioned by the user ahead
+of this session.
+
+## Pre-existing state found (important — read before assuming "not built yet")
+
+Before provisioning anything, read-only investigation (`aws elbv2
+describe-target-groups` / `describe-load-balancers` / `describe-listeners`,
+`aws ecs list-services`) found:
+
+- `vitana-alb-prod` — a fully-built internet-facing ALB (created
+  2026-07-10) with a real ACM cert for `vitanaland.com` / `*.vitanaland.com`,
+  serving `preview-aws-gateway.vitanaland.com` / `preview-aws.vitanaland.com`
+  via Cloudflare CNAME. Its `vitana-tg-gateway-prod` / `vitana-tg-community-prod`
+  target groups are misleadingly named — they actually carry **staging**
+  traffic (`vitana-gateway` / `vitana-community-app` ECS services). This is
+  a naming leftover, not a hidden second prod build — confirmed by checking
+  `env` in `/api/v1/admin/health` responses through that ALB (`staging`).
+- **29 ECS services** in `Vitana-ECS-Cluster`, all created within the same
+  3-second window (2026-07-09T13:25:05 UTC) — a single scripted
+  bulk-provisioning event predating this session. Includes
+  `vitana-community-app`, `vitana-oasis-operator`, `vitana-oasis-projector`,
+  `vitana-worker-runner`, `vitana-vitana-verification-engine`, plus ~17
+  services with no counterpart in CLAUDE.md or GCP. **None of these were
+  touched by this build** — gateway-only scope was strictly honored. Their
+  origin/purpose is outside this VTID's scope; flagged to the user, who
+  confirmed the AWS prod DB layer (Aurora, in sync with Supabase) is
+  intentional and authorized proceeding.
+- Data layer already provisioned for prod: RDS Aurora PostgreSQL cluster
+  `vitana-aurora-prod` (writer + reader endpoints), ElastiCache Redis
+  `vitana-redis-prod`, and Secrets Manager entries
+  `vitana/supabase/prod/{url,anon-key,service-role-key,jwt-secret}` and
+  `vitana/aurora/prod/{master-password,database-url}`.
+
+## What this build added (all new, additively named `*-awsdr` / `dr-*`)
+
+| Resource | Name / value |
+|---|---|
+| CloudWatch log group | `/vitana/gateway-awsdr` |
+| ECS task definition family | `vitana-gateway-awsdr` (revision 1, cloned from `vitana-gateway`'s live staging task def, prod values swapped in) |
+| ECS service | `vitana-gateway-awsdr` in `Vitana-ECS-Cluster`, Fargate, desiredCount=1 (autoscaling 1–4, see below) |
+| ELBv2 target group | `vitana-tg-gateway-awsdr` (port 8080, health check `/alive`) |
+| ALB listener rule | Host-header `dr-gateway.vitanaland.com` → `vitana-tg-gateway-awsdr`, **priority 5** on `vitana-alb-prod`'s existing HTTPS listener (443) |
+| DNS | Cloudflare CNAME `dr-gateway.vitanaland.com` → `vitana-alb-prod-1579322953.eu-central-1.elb.amazonaws.com` (proxied, same pattern as staging's `preview-aws-gateway`) |
+| TLS | Reused the ALB's existing `*.vitanaland.com` ACM cert — no new certificate needed |
+| Autoscaling | Target-tracking, `ECSServiceAverageCPUUtilization` @ 65%, min 1 / max 4 |
+| CloudWatch alarms | `vitana-gateway-awsdr-target-5xx`, `-unhealthy-hosts`, `-cpu-high`, `-memory-high` |
+| Deploy workflow | `.github/workflows/AWS-PROD-DEPLOY-GATEWAY.yml` — `workflow_dispatch`-only, required `reason`, never on push |
+
+No new Secrets Manager entries were needed — the task definition's
+`secrets` block reuses the pre-existing prod-scoped secrets above, plus the
+existing RDS-managed master credential
+(`rds!cluster-eba8a4f2-3caa-4f11-88f0-c3102c3c176a`) for `DB_PASSWORD`. One
+security improvement made over the staging task def: `SUPABASE_JWT_SECRET`,
+`SUPABASE_ANON_KEY`, and `GATEWAY_SERVICE_TOKEN` are wired as Secrets
+Manager references in the prod task def (staging has them as plaintext env
+vars, and `GATEWAY_SERVICE_TOKEN` in staging is literally a placeholder
+string, not a working token — not fixed here since it's out of this VTID's
+gateway-DR scope, but worth a follow-up VTID against staging).
+
+### ALB listener-rule priority — read this before adding another host-header rule
+
+`vitana-alb-prod` has **path-based** rules at priority 10 (`/api/*`,
+`/ws/*` → the staging gateway TG) and 20 (`/community*` → staging
+community TG), evaluated before any higher-numbered rule regardless of
+`Host` header. The DR rule was created at priority 15 first — API calls to
+`dr-gateway.vitanaland.com/api/*` were silently served by the **staging**
+gateway (path-based rule 10 matched before the host-based rule 15 was
+evaluated). Caught by `/api/v1/admin/health` returning `env: staging`
+against `dr-gateway.vitanaland.com`. Fixed by moving the rule to
+**priority 5**. Any future host-header rule added to this ALB must sit
+below (numerically lower priority than) 10, or it will silently lose to
+the path-based staging rules.
+
+## Commands run (chronological, redacted of secret values)
+
+```bash
+# Log group
+aws logs create-log-group --log-group-name /vitana/gateway-awsdr --region eu-central-1
+
+# Task definition — registered from a JSON built by cloning
+# `aws ecs describe-task-definition --task-definition vitana-gateway` (rev 38)
+# and swapping: VITANA_ENV/ENVIRONMENT/ENV -> production, GATEWAY_URL ->
+# https://dr-gateway.vitanaland.com, DB_HOST/DB_READER_HOST -> Aurora prod
+# writer/reader endpoints, REDIS_HOST -> vitana-redis-prod, log group ->
+# /vitana/gateway-awsdr, and secrets -> the vitana/supabase/prod/* +
+# rds!cluster-eba8a4f2... ARNs.
+aws ecs register-task-definition --cli-input-json file://gateway-awsdr-taskdef-register.json --region eu-central-1
+
+# Target group
+aws elbv2 create-target-group --name vitana-tg-gateway-awsdr --protocol HTTP --port 8080 \
+  --vpc-id vpc-05958f035e596fe64 --target-type ip --health-check-protocol HTTP \
+  --health-check-path /alive --health-check-interval-seconds 15 --health-check-timeout-seconds 5 \
+  --healthy-threshold-count 2 --unhealthy-threshold-count 3 --matcher HttpCode=200 --region eu-central-1
+
+# Listener rule (host-header, dr-gateway.vitanaland.com)
+aws elbv2 create-rule \
+  --listener-arn arn:aws:elasticloadbalancing:eu-central-1:472838866351:listener/app/vitana-alb-prod/3d60b7c377e63d95/48eba68d49c39439 \
+  --priority 15 \
+  --conditions Field=host-header,HostHeaderConfig={Values=[dr-gateway.vitanaland.com]} \
+  --actions Type=forward,TargetGroupArn=arn:aws:elasticloadbalancing:eu-central-1:472838866351:targetgroup/vitana-tg-gateway-awsdr/a2b0e810877c12e7 \
+  --region eu-central-1
+# ... then fixed the priority (see "ALB listener-rule priority" above):
+aws elbv2 set-rule-priorities \
+  --rule-priorities RuleArn=<rule-arn>,Priority=5 --region eu-central-1
+
+# ECS service
+aws ecs create-service --cluster Vitana-ECS-Cluster --service-name vitana-gateway-awsdr \
+  --task-definition vitana-gateway-awsdr --desired-count 1 --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-0ff45a2051c5e5482,subnet-0c786864a28a5a821],securityGroups=[sg-0fbcf7b59b1f0d685],assignPublicIp=DISABLED}" \
+  --load-balancers "targetGroupArn=arn:...targetgroup/vitana-tg-gateway-awsdr/...,containerName=gateway,containerPort=8080" \
+  --region eu-central-1
+
+# DNS (Cloudflare API, zone 859c786db63e634e0ee36065e8a06e20)
+curl -X POST "https://api.cloudflare.com/client/v4/zones/859c786db63e634e0ee36065e8a06e20/dns_records" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H "Content-Type: application/json" \
+  -d '{"type":"CNAME","name":"dr-gateway.vitanaland.com","content":"vitana-alb-prod-1579322953.eu-central-1.elb.amazonaws.com","proxied":true,"ttl":1}'
+
+# Autoscaling
+aws application-autoscaling register-scalable-target --service-namespace ecs \
+  --resource-id service/Vitana-ECS-Cluster/vitana-gateway-awsdr --scalable-dimension ecs:service:DesiredCount \
+  --min-capacity 1 --max-capacity 4 --region eu-central-1
+aws application-autoscaling put-scaling-policy --service-namespace ecs \
+  --resource-id service/Vitana-ECS-Cluster/vitana-gateway-awsdr --scalable-dimension ecs:service:DesiredCount \
+  --policy-name vitana-gateway-awsdr-cpu-target-tracking --policy-type TargetTrackingScaling \
+  --target-tracking-scaling-policy-configuration '{"TargetValue":65.0,"PredefinedMetricSpecification":{"PredefinedMetricType":"ECSServiceAverageCPUUtilization"},"ScaleInCooldown":120,"ScaleOutCooldown":60}' \
+  --region eu-central-1
+
+# Alarms (repeat put-metric-alarm for target-5xx, unhealthy-hosts, cpu-high, memory-high — see workflow/task list for exact params)
+```
+
+## Verification performed
+
+- `GET /alive` → `200 {"status":"ok","service":"gateway",...}`
+- `GET /api/v1/admin/health` → `200 {"ok":true,"env":"production","supabase_host":"inmkhvwdcuyhnxkgfvsb.supabase.co",...}`
+- `GET /api/v1/admin/build-info` → commit matches the running task's image (`bf1f1add2398...`, same proven commit as AWS staging)
+- Live ORB voice session: `POST /api/v1/orb/live/session/start` (test user `a27552a3-0257-4305-8ed0-351a80fd3701`) then `GET /api/v1/orb/live/stream`. First attempt closed with `code=1011 Internal error encountered` after a ~14s stall between transcript fragments (not the previously-fixed `1007` payload-size bug); second attempt completed cleanly — 404 audio chunks, 37 `output_transcript` fragments, ending in `turn_complete`, no error close. Treated as a one-off upstream Gemini Live hiccup, not a deployment defect — logs confirm correct transport (`api_key`/AI Studio), correct budget-trim behavior (no repeat of the fixed 30KB overflow bug), and matching `env=production`/Supabase project.
+- Regression check: AWS staging (`preview-aws-gateway.vitanaland.com`) still reports `env: staging` with its original (unchanged) boot time — confirmed untouched by this build.
+
+## Not completed — requires IAM-admin AWS credentials this session does not have
+
+The session's AWS IAM user (`claude-staging-validation`) has
+`AmazonECS_FullAccess`, `AmazonEC2ContainerRegistryFullAccess`,
+`ElasticLoadBalancingFullAccess`, and `ReadOnlyAccess` — **no IAM write
+permissions at all**. Confirmed directly: both
+`iam:CreateOpenIDConnectProvider` and `iam:CreateRole` returned
+`AccessDenied`. `AWS-PROD-DEPLOY-GATEWAY.yml` is written and ready, but it
+references `secrets.AWS_PROD_ROLE_ARN`, which does not exist yet — the
+workflow cannot be dispatched until an operator with IAM admin rights runs
+the one-time setup below (mirrors `scripts/aws/README.md`'s existing OIDC
+pattern for the S3-mirror role).
+
+### One-time setup (run once, by a human/session with IAM admin rights)
+
+```bash
+# 1. Create the GitHub OIDC provider for this AWS account (skip if
+#    scripts/aws/README.md's provider already exists — check first with
+#    `aws iam list-open-id-connect-providers`).
+aws iam create-open-id-connect-provider \
+  --url "https://token.actions.githubusercontent.com" \
+  --client-id-list "sts.amazonaws.com" \
+  --thumbprint-list "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
+
+# 2. Create the deploy role, trust-scoped to this repo's main branch only
+#    (tighter than the mirror role's `repo:exafyltd/vitana-platform:*` —
+#    this role can deploy production, so it's restricted to workflow runs
+#    triggered against `main`).
+cat > /tmp/trust-policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "arn:aws:iam::472838866351:oidc-provider/token.actions.githubusercontent.com" },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": { "token.actions.githubusercontent.com:aud": "sts.amazonaws.com" },
+      "StringLike": { "token.actions.githubusercontent.com:sub": "repo:exafyltd/vitana-platform:ref:refs/heads/main" }
+    }
+  }]
+}
+EOF
+aws iam create-role --role-name vitana-gateway-awsdr-deploy-role \
+  --assume-role-policy-document file:///tmp/trust-policy.json
+
+# 3. Attach a policy scoped to exactly what the deploy workflow needs:
+#    ECR push/pull on vitana/gateway, and ECS register/describe/update on
+#    the awsdr service + its task definition family, plus PassRole for the
+#    two roles the task definition already uses.
+cat > /tmp/deploy-policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow", "Action": ["ecr:GetAuthorizationToken"], "Resource": "*" },
+    { "Effect": "Allow", "Action": ["ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage","ecr:PutImage","ecr:InitiateLayerUpload","ecr:UploadLayerPart","ecr:CompleteLayerUpload","ecr:DescribeRepositories"],
+      "Resource": "arn:aws:ecr:eu-central-1:472838866351:repository/vitana/gateway" },
+    { "Effect": "Allow", "Action": ["ecs:DescribeServices","ecs:UpdateService","ecs:DescribeTaskDefinition","ecs:RegisterTaskDefinition","ecs:ListServices"],
+      "Resource": "*" },
+    { "Effect": "Allow", "Action": "iam:PassRole",
+      "Resource": ["arn:aws:iam::472838866351:role/vitana-ecs-task-execution-role", "arn:aws:iam::472838866351:role/vitana-ecs-task-role"] }
+  ]
+}
+EOF
+aws iam put-role-policy --role-name vitana-gateway-awsdr-deploy-role \
+  --policy-name deploy-permissions --policy-document file:///tmp/deploy-policy.json
+
+# 4. Wire the role ARN into the repo secret.
+gh secret set AWS_PROD_ROLE_ARN --repo exafyltd/vitana-platform \
+  --body "arn:aws:iam::472838866351:role/vitana-gateway-awsdr-deploy-role"
+
+# 5. Prove it: dispatch the workflow once.
+gh workflow run AWS-PROD-DEPLOY-GATEWAY.yml --ref main -f reason="initial OIDC wiring smoke test"
+```
+
+## Natural next steps (not built — out of scope for this VTID)
+
+- Extend the same DR pattern to `oasis-operator`, `oasis-projector`,
+  `worker-runner`, `vitana-verification-engine`, and the frontend
+  (`community-app`) — explicitly deferred per the agreed gateway-only
+  first slice.
+- Fix the `GATEWAY_SERVICE_TOKEN` placeholder-string bug on **AWS
+  staging** (`vitana-gateway` task def) — discovered as a side effect of
+  building this prod task def correctly; not fixed on staging since it's
+  outside this VTID's scope.
+- Investigate/document the other ~27 pre-existing ECS services found
+  during this build (see "Pre-existing state found" above) — separate
+  from gateway DR, flagged for the user's awareness, not investigated
+  further here.
+- CloudWatch dashboard (alarms exist; a consolidated dashboard view does
+  not yet).


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03398` — "AWS Production (DR) — Gateway"
**Layer:** `INFRA` (exclusive target role per VTID-01010)
**spec_status:** `approved` (generated → validated → quality-checked → approved via the gateway's `/api/v1/specs/*` pipeline before any infra was touched)

---

## 📋 Summary

Builds a second, independent, parallel/DR production environment on AWS
(ECS/Fargate) for the `gateway` service only, alongside the existing
canonical GCP Cloud Run production. This is **additive DR capacity, not a
migration** — GCP stays canonical. Extends the already-validated AWS
staging pattern (`BOOTSTRAP-AWS-STAGING-VALIDATION`) one tier up, per
`docs/AWS-PRODUCTION-HANDOVER.md`'s suggested execution order.

---

## ✅ Changes

- [x] New ECS service `vitana-gateway-awsdr` (Fargate, `Vitana-ECS-Cluster`) — distinct from AWS staging's `vitana-gateway`
- [x] Task definition `vitana-gateway-awsdr` cloned from staging's live revision, prod-scoped values swapped in (Aurora prod DB, Redis prod, existing `vitana/supabase/prod/*` secrets — no new secrets needed)
- [x] New target group `vitana-tg-gateway-awsdr` + host-header ALB rule on the existing `vitana-alb-prod` load balancer, reusing its `*.vitanaland.com` ACM cert (no new cert needed)
- [x] Cloudflare CNAME `dr-gateway.vitanaland.com` → the ALB
- [x] Target-tracking autoscaling (1–4 tasks, CPU 65%) + 4 CloudWatch alarms (5xx, unhealthy hosts, CPU, memory)
- [x] `.github/workflows/AWS-PROD-DEPLOY-GATEWAY.yml` — **`workflow_dispatch`-only, required `reason` input, no `on: push` trigger**
- [x] `CLAUDE.md` §1b governance section + Never-rule exception documenting the AWS DR pattern
- [x] `docs/AWS-PRODUCTION-BUILD-LOG.md` — full command record + pre-existing-AWS-state findings (no IaC exists in this repo, matching the staging precedent)
- [ ] GitHub OIDC deploy-role wiring — **blocked**, see below

---

## 🧪 Testing

- [x] `GET /alive` → `200`
- [x] `GET /api/v1/admin/health` → `env: "production"`, correct Supabase host
- [x] `GET /api/v1/admin/build-info` → commit matches the deployed image
- [x] Live ORB voice session end-to-end: `POST /api/v1/orb/live/session/start` + SSE stream on `dr-gateway.vitanaland.com`, using the test user (`a27552a3-0257-4305-8ed0-351a80fd3701`). First attempt hit a generic upstream `1011` after a stall; second attempt completed cleanly (404 audio chunks, 37 transcript fragments, `turn_complete`, no error close) — logs confirm this wasn't the previously-fixed `1007` payload-size bug.
- [x] Regression check: AWS staging (`preview-aws-gateway.vitanaland.com`) still reports `env: staging` with its original boot time — confirmed untouched.
- [ ] `AWS-PROD-DEPLOY-GATEWAY.yml` itself has **not** been dispatched/tested yet — it needs `secrets.AWS_PROD_ROLE_ARN`, which doesn't exist until the OIDC setup below is run.

---

## ⚠️ Important — read before merging

**Pre-existing AWS state found during this build (see `docs/AWS-PRODUCTION-BUILD-LOG.md` for full detail):** the AWS account already had a fully-built `vitana-alb-prod` ALB and **29 ECS services** (created in one scripted batch on 2026-07-09) well beyond what `docs/AWS-PRODUCTION-HANDOVER.md` described — including a frontend and services with no GCP/CLAUDE.md counterpart. This was flagged to the user mid-session; they confirmed the AWS production database layer (Aurora, in sync with Supabase) is intentional and authorized proceeding with the gateway-only build. None of those pre-existing/unrelated services were touched. Worth a separate follow-up to document what they are.

**GitHub OIDC federation is not wired up yet.** This session's AWS IAM user (`claude-staging-validation`) has zero IAM write permissions — confirmed directly (`iam:CreateOpenIDConnectProvider` and `iam:CreateRole` both `AccessDenied`). The deploy workflow is written and ready but references `secrets.AWS_PROD_ROLE_ARN`, which doesn't exist. An operator with IAM admin rights needs to run the one-time setup in `docs/AWS-PRODUCTION-BUILD-LOG.md` (create the OIDC provider + a repo-and-branch-scoped deploy role + set the repo secret) before this workflow can be dispatched.

**A routing bug was caught and fixed during the build:** `vitana-alb-prod` evaluates path-based rules (`/api/*`, `/ws/*` at priority 10, forwarding to the *staging* target group) before host-header rules. The DR listener rule was initially created at priority 15 and was silently losing to the staging path rule for all `/api/*` traffic — caught via `env: staging` in the health response, fixed by moving it to priority 5. Documented in the build log so it isn't repeated.

---

## 🔗 Links

- **VTID:** VTID-03398
- **Handover doc this session executed against:** `docs/AWS-PRODUCTION-HANDOVER.md` (PR #2906)
- **Build record:** `docs/AWS-PRODUCTION-BUILD-LOG.md`

---

## 🚨 Breaking Changes

None. Purely additive AWS infrastructure; no application code changed; AWS staging and GCP production are both unaffected (verified).

---

## 📌 Additional Notes

Natural next steps (explicitly not built here, gateway-only was the agreed first slice): extending the same DR pattern to `oasis-operator`, `oasis-projector`, `worker-runner`, `vitana-verification-engine`, and the frontend; fixing a pre-existing `GATEWAY_SERVICE_TOKEN` placeholder-string bug found on AWS *staging*'s task definition (not touched here, out of scope); a CloudWatch dashboard on top of the alarms already created.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF)_