### PR TITLE
Route Tier A Claude call sites through Bedrock instead of direct API (BOOTSTRAP-GEMINI-TO-CLAUDE)

### DIFF
--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -179,18 +179,32 @@ jobs:
             # no-op'd on preview-gateway.vitanaland.com.
             "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
             "DEEPSEEK_API_KEY=${{ secrets.DEEPSEEK_API_KEY }}"
-            # BOOTSTRAP-GEMINI-TO-CLAUDE: Claude Sonnet 4.6 direct-API key for
-            # the Tier A migrated call sites (spec generation, intent
-            # classify/extract, matchmaker, architecture investigator —
-            # services/gateway/src/services/claude-text-client.ts). Bound as
-            # a plain GitHub Actions secret, same pattern EXEC-DEPLOY.yml
-            # already uses for prod's gateway (no GCP Secret Manager entry
-            # for this key). Without it, callClaudeText() returns null and
-            # every migrated call site silently falls back to its
-            # deterministic default — this was previously unbound on
-            # gateway-staging, so live testing showed CLASSIFY_LOW_CONFIDENCE
-            # with confidence 0 instead of real Claude responses.
+            # BOOTSTRAP-GEMINI-TO-CLAUDE: direct Anthropic API key. NOT used
+            # by claude-text-client.ts (Tier A call sites now run through
+            # Bedrock — see AWS_ACCESS_KEY_ID block below); still used by
+            # llm-router.ts's anthropicAdapter, orb/delegation, and the
+            # vision client. Bound as a plain GitHub Actions secret, same
+            # pattern EXEC-DEPLOY.yml uses for prod (no GCP Secret Manager
+            # entry for this key).
             "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}"
+            # BOOTSTRAP-GEMINI-TO-CLAUDE: Bedrock transport for the Tier A
+            # migrated call sites (spec generation, intent classify/extract,
+            # matchmaker, architecture investigator —
+            # services/gateway/src/services/claude-text-client.ts, via
+            # invokeBedrock() in providers/bedrock.ts). Static IAM user
+            # access key (vitana-gateway-bedrock, scoped to bedrock:InvokeModel
+            # on the Claude Sonnet 4.6 inference profile only) — bound as
+            # plain GitHub Actions secrets/env, same no-GCP-Secret-Manager
+            # pattern as OPENAI_API_KEY/DEEPSEEK_API_KEY above.
+            # BEDROCK_ROLE_ARN is only an activation gate today (invokeBedrock()
+            # checks it's non-empty; it does not yet assume the role via STS —
+            # actual auth comes from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
+            # via the AWS SDK's default credential chain).
+            "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}"
+            "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            "AWS_BEDROCK_REGION=${{ secrets.AWS_BEDROCK_REGION }}"
+            "BEDROCK_MODEL_ID=${{ secrets.BEDROCK_MODEL_ID }}"
+            "BEDROCK_ROLE_ARN=${{ secrets.BEDROCK_ROLE_ARN }}"
           )
 
           # Comma-joined for --set-env-vars (replaces, not merges — we want the

--- a/services/gateway/src/services/claude-text-client.ts
+++ b/services/gateway/src/services/claude-text-client.ts
@@ -1,25 +1,25 @@
 /**
- * Shared direct-API Claude client for gateway services migrated off Gemini/Vertex.
+ * Shared Claude client for gateway services migrated off Gemini/Vertex.
  *
- * Single choke point so the transport (direct Anthropic API today, Bedrock
- * once AWS IAM + model access are provisioned) can change in one place
- * without touching every call site.
+ * Single choke point so the transport can change in one place without
+ * touching every call site. BOOTSTRAP-GEMINI-TO-CLAUDE: transport is now
+ * Amazon Bedrock (`invokeBedrock()`, VTID-03403's `providers/bedrock.ts`) —
+ * the user requires these Tier A call sites to run through Bedrock, not the
+ * direct Anthropic API. Reuses the existing Bedrock adapter rather than
+ * building a second client (`invokeBedrock()` is also what
+ * `llm-router.ts`'s `bedrockAdapter` calls).
+ *
+ * `opts.model` (a bare model name like "claude-sonnet-4-6") is accepted for
+ * call-site compatibility but ignored for the actual invocation — Bedrock
+ * needs a resolved cross-region inference profile ID, read from
+ * `BEDROCK_MODEL_ID` instead.
  */
 
-import Anthropic from '@anthropic-ai/sdk';
+import { invokeBedrock } from '../providers/bedrock';
 
 export const CLAUDE_SONNET_4_6 = 'claude-sonnet-4-6';
 
-const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
-
-let client: Anthropic | null = null;
-try {
-  if (ANTHROPIC_API_KEY) {
-    client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
-  }
-} catch {
-  client = null;
-}
+const BEDROCK_MODEL_ID = process.env.BEDROCK_MODEL_ID || 'eu.anthropic.claude-sonnet-4-6';
 
 export interface ClaudeTextCallOptions {
   model?: string;
@@ -30,25 +30,27 @@ export interface ClaudeTextCallOptions {
 }
 
 /**
- * Single-turn text completion. Returns null (not throw) when the client
- * isn't configured or the response has no text — callers already have
- * deterministic fallbacks for a null result.
+ * Single-turn text completion via Bedrock. Returns null when Bedrock isn't
+ * configured (BEDROCK_ROLE_ARN unset) or the response has no text — callers
+ * already have deterministic fallbacks for a null result. Throws (rather
+ * than swallowing) when a configured call actually fails upstream, so the
+ * real error (auth, model access, throttling, etc.) surfaces in
+ * gemini_call_log via each caller's existing withGeminiLog wrapper instead
+ * of being misread as "not configured".
  */
 export async function callClaudeText(opts: ClaudeTextCallOptions): Promise<string | null> {
-  if (!client) return null;
-
-  const msg = await client.messages.create({
-    model: opts.model ?? CLAUDE_SONNET_4_6,
-    max_tokens: opts.maxTokens ?? 4096,
-    temperature: opts.temperature ?? 0.3,
+  const result = await invokeBedrock({
+    model: BEDROCK_MODEL_ID,
     system: opts.system,
     messages: [{ role: 'user', content: opts.prompt }],
+    max_tokens: opts.maxTokens ?? 4096,
+    temperature: opts.temperature ?? 0.3,
   });
 
-  const text = msg.content
-    .filter((block): block is Anthropic.TextBlock => block.type === 'text')
-    .map((block) => block.text)
-    .join('');
+  if (!result.ok) {
+    if (result.error === 'not_configured') return null;
+    throw new Error(`Bedrock call failed: ${result.message}`);
+  }
 
-  return text || null;
+  return result.text || null;
 }


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-GEMINI-TO-CLAUDE` _(bootstrap tag, no formal VTID exists yet; builds on VTID-03403's Bedrock adapter)_

**Layer:** APIL / CICDL

**Priority:** P1

---

## 📋 Summary

Requirement: the Tier A LLM call sites migrated from Gemini to Claude Sonnet 4.6 (#2914, #2918) must run through **Amazon Bedrock**, not the direct Anthropic API — even though the direct API was confirmed working end-to-end against `gateway-staging` (modulo an unrelated Anthropic-account credit-balance issue).

`services/gateway/src/services/claude-text-client.ts` now calls `invokeBedrock()` (`services/gateway/src/providers/bedrock.ts`, built under VTID-03403) instead of the `@anthropic-ai/sdk` client — reusing the existing Bedrock adapter rather than building a second Claude transport, same function `llm-router.ts`'s `bedrockAdapter` already calls.

`opts.model` is kept on the public interface for call-site compatibility (none of the 6 call sites needed changes), but the actual invocation uses `BEDROCK_MODEL_ID` — the resolved cross-region inference profile ID (`eu.anthropic.claude-sonnet-4-6`, confirmed live in the AWS console for account `472838866351` / `eu-central-1`) — since Bedrock doesn't accept a bare model name for cross-region models.

---

## ✅ Changes

- [x] `claude-text-client.ts`: replace direct Anthropic SDK call with `invokeBedrock()`. Preserves existing null-vs-throw semantics (`not_configured` → `null`, matching the old "client not configured" branch; real invocation failures → thrown, so the actual upstream error still surfaces in `gemini_call_log` via each caller's `withGeminiLog` wrapper, same as the credit-balance error we diagnosed there previously).
- [x] `STAGE-DEPLOY.yml`: bind new secrets for `gateway-staging` — `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (dedicated IAM user `vitana-gateway-bedrock`, scoped to `bedrock:InvokeModel` on the Claude Sonnet 4.6 inference profile only), `AWS_BEDROCK_REGION`, `BEDROCK_MODEL_ID`, `BEDROCK_ROLE_ARN`. All plain GitHub Actions secrets, same no-GCP-Secret-Manager pattern already used for `OPENAI_API_KEY`/`DEEPSEEK_API_KEY`.
- [x] `ANTHROPIC_API_KEY` stays bound — still used by `llm-router.ts`'s `anthropicAdapter`, `orb/delegation`, and the vision client. Only the Tier A transport changed.

---

## 🧪 Testing

- [x] `npm run build` (TypeScript compiles clean)
- [x] YAML syntax validated locally
- [ ] Manual/staging verification — pending this PR merging + `gateway-staging` redeploy, then re-running the live `POST /api/v1/intents` test to confirm a real Bedrock-backed classification (not `CLASSIFY_LOW_CONFIDENCE`/confidence 0)

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] All workflow files use **UPPERCASE** names
- [x] No lowercase workflow names present

### File Names
- [x] No new files added; existing files follow kebab-case/camelCase conventions already in place

### Code Standards
- [x] N/A — no new constants/events requiring naming review

### Cloud Run Deployments
- [x] N/A — no new Cloud Run service

### Documentation
- [x] BOOTSTRAP tag referenced in commit message

---

## 🚨 Breaking Changes

None to the public API. Internal transport change only — Tier A call sites' behavior is unchanged from the caller's perspective (same `callClaudeText()` signature, same null/throw semantics).

---

## 📌 Additional Notes

**Known limitation carried over from VTID-03403:** `invokeBedrock()` only checks `BEDROCK_ROLE_ARN` as a non-empty activation gate — it does not yet call STS to assume that role. Actual AWS authentication comes from `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` via the AWS SDK's default credential chain (a static-key IAM user, not federated). This is a known simplification for this iteration, not a regression introduced here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PgQ1F5tPaPmvpBL1gWibj1)_