### PR TITLE
DoctorBox: per-product affiliate deep links + 11 new catalog products (VTID-02000)

### DIFF
--- a/supabase/migrations/20260723000000_vtid_02000_doctorbox_per_product_deeplinks.sql
+++ b/supabase/migrations/20260723000000_vtid_02000_doctorbox_per_product_deeplinks.sql
@@ -1,0 +1,91 @@
+-- VTID-02000 (Discover marketplace) — DoctorBox per-product affiliate deep links.
+--
+-- Replaces the single shared affiliate_url ('https://shop.doctorbox.de/VITANALAND',
+-- used for all 53 products since the initial seed) with 53 individual Shopify
+-- Collabs deep links (https://collabs.shop/xxxxxx), one per product. This was
+-- already flagged as a future option in the original seed migration's header
+-- comment (per-product deep-linking confirmed supported and tested there).
+--
+-- Why: with one shared link, DoctorBox purchases can never be attributed back
+-- to a specific product or a specific Vitana user's click/recommendation —
+-- Awin's automated order sync works because each click gets a unique clickref
+-- token; a shared link can't support that even in principle. Per-product deep
+-- links are a prerequisite for any future order/attribution sync (still
+-- blocked separately on DoctorBox granting Shopify Admin API order-read
+-- access — see conversation history, not a code change). This migration only
+-- fixes the Vitana-side half of that gap.
+--
+-- Links gathered manually from the Shopify Collabs "DoctorBox Heimtests
+-- products" grid (same dashboard used to source the real product photos in
+-- 20260721000000_..._doctorbox_real_photos.sql) — the storefront itself
+-- remains bot-protected (403 to automated fetch), so this required the same
+-- manual-copy method. All 53 links tap-tested by the source of the original
+-- catalog; 1 (AntePC / "Prostatakrebs Risiko Test") was inferred from the
+-- naming pattern shared by 5 other confirmed Ante*-branded renames rather
+-- than visually re-confirmed — flagging here in case it needs a follow-up
+-- correction.
+--
+-- No gateway/frontend code change required: click-redirect.ts already reads
+-- `products.affiliate_url` per row (not a merchant-level field), and
+-- stampAffiliateUrl() is host-agnostic — confirmed via direct code read.
+--
+-- impact-allow-solo-migration: intentional data-only migration, no gateway/
+-- worker code touch needed.
+
+BEGIN;
+
+UPDATE products SET affiliate_url = 'https://collabs.shop/7iepsg', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000001';
+UPDATE products SET affiliate_url = 'https://collabs.shop/kq8gl4', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000002';
+UPDATE products SET affiliate_url = 'https://collabs.shop/8qalyh', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000003';
+UPDATE products SET affiliate_url = 'https://collabs.shop/krdijy', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000004';
+UPDATE products SET affiliate_url = 'https://collabs.shop/nfob8g', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000005';
+UPDATE products SET affiliate_url = 'https://collabs.shop/pcomtf', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000006';
+UPDATE products SET affiliate_url = 'https://collabs.shop/cvjftp', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000007';
+UPDATE products SET affiliate_url = 'https://collabs.shop/wotexb', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000008';
+UPDATE products SET affiliate_url = 'https://collabs.shop/alh1rr', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000009';
+UPDATE products SET affiliate_url = 'https://collabs.shop/2uxi1q', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000000a';
+UPDATE products SET affiliate_url = 'https://collabs.shop/hccam9', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000000b';
+UPDATE products SET affiliate_url = 'https://collabs.shop/4aj95i', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000000c';
+UPDATE products SET affiliate_url = 'https://collabs.shop/guv9fd', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000000d';
+UPDATE products SET affiliate_url = 'https://collabs.shop/uqfhwp', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000000e';
+UPDATE products SET affiliate_url = 'https://collabs.shop/zncv4v', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000000f';
+UPDATE products SET affiliate_url = 'https://collabs.shop/pvcmc8', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000010';
+UPDATE products SET affiliate_url = 'https://collabs.shop/ztu8m1', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000011';
+UPDATE products SET affiliate_url = 'https://collabs.shop/qckyvl', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000012';
+UPDATE products SET affiliate_url = 'https://collabs.shop/qay7od', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000013';
+UPDATE products SET affiliate_url = 'https://collabs.shop/gxgqp9', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000014';
+UPDATE products SET affiliate_url = 'https://collabs.shop/gozsnt', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000015';
+UPDATE products SET affiliate_url = 'https://collabs.shop/zzkxgn', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000016';
+UPDATE products SET affiliate_url = 'https://collabs.shop/uxh78t', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000017';
+UPDATE products SET affiliate_url = 'https://collabs.shop/o11dkt', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000018';
+UPDATE products SET affiliate_url = 'https://collabs.shop/glub7a', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000019';
+UPDATE products SET affiliate_url = 'https://collabs.shop/jzerrc', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000001a';
+UPDATE products SET affiliate_url = 'https://collabs.shop/pnecwc', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000001b';
+UPDATE products SET affiliate_url = 'https://collabs.shop/mkrwdt', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000001c';
+UPDATE products SET affiliate_url = 'https://collabs.shop/jrml1j', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000001d';
+UPDATE products SET affiliate_url = 'https://collabs.shop/jtvmu2', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000001e';
+UPDATE products SET affiliate_url = 'https://collabs.shop/ydcrue', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000001f';
+UPDATE products SET affiliate_url = 'https://collabs.shop/m4bvkv', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000020';
+UPDATE products SET affiliate_url = 'https://collabs.shop/7pmfw9', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000021';
+UPDATE products SET affiliate_url = 'https://collabs.shop/qezwvt', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000022';
+UPDATE products SET affiliate_url = 'https://collabs.shop/lxbekg', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000023';
+UPDATE products SET affiliate_url = 'https://collabs.shop/fpoaz7', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000024';
+UPDATE products SET affiliate_url = 'https://collabs.shop/qbmfn5', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000025';
+UPDATE products SET affiliate_url = 'https://collabs.shop/ritqd6', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000026';
+UPDATE products SET affiliate_url = 'https://collabs.shop/zp9b3p', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000027';
+UPDATE products SET affiliate_url = 'https://collabs.shop/gjvper', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000028';
+UPDATE products SET affiliate_url = 'https://collabs.shop/eafhdl', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000029';
+UPDATE products SET affiliate_url = 'https://collabs.shop/ksp7zd', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000002a';
+UPDATE products SET affiliate_url = 'https://collabs.shop/2hwtkc', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000002b';
+UPDATE products SET affiliate_url = 'https://collabs.shop/rwxt4z', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000002c';
+UPDATE products SET affiliate_url = 'https://collabs.shop/5gby0v', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000002d';
+UPDATE products SET affiliate_url = 'https://collabs.shop/bjvejk', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000002e';
+UPDATE products SET affiliate_url = 'https://collabs.shop/dfric2', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-00000000002f';
+UPDATE products SET affiliate_url = 'https://collabs.shop/rzvejj', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000030';
+UPDATE products SET affiliate_url = 'https://collabs.shop/xvwqlb', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000031';
+UPDATE products SET affiliate_url = 'https://collabs.shop/h69eau', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000032';
+UPDATE products SET affiliate_url = 'https://collabs.shop/jaobuw', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000033';
+UPDATE products SET affiliate_url = 'https://collabs.shop/yxvlz9', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000034';
+UPDATE products SET affiliate_url = 'https://collabs.shop/3wqcvh', updated_at = now() WHERE id = 'd0c70000-0000-4000-8000-000000000035';
+
+COMMIT;

--- a/supabase/migrations/20260723010000_vtid_02000_doctorbox_new_products.sql
+++ b/supabase/migrations/20260723010000_vtid_02000_doctorbox_new_products.sql
@@ -1,0 +1,199 @@
+-- VTID-02000 (Discover marketplace) — DoctorBox catalog: 11 new products
+-- discovered while gathering per-product deep links (see the sibling
+-- migration 20260723000000_..._doctorbox_per_product_deeplinks.sql).
+--
+-- While copying deep links from the Shopify Collabs grid, several cards
+-- didn't match any of the original 53 products by name/price/value-panel —
+-- confirmed as genuinely new SKUs added to DoctorBox's catalog since the
+-- initial seed (20260717120000), not renames (renames were cross-checked via
+-- price/branding and are covered by the sibling migration instead):
+--
+--   1. Cardio & Vital-Check (health-tests/cardio) — broader cardio/metabolic
+--      panel than Herz-Kreislauf Check, distinct price (EUR 110 vs EUR 89)
+--      and value panel (8 vs different values).
+--   2. Nierenfunktion (UACR Analyse) (health-tests/prevention) — urine-based
+--      albumin/creatinine ratio test, distinct from the existing Nieren
+--      Profil (blood-based, 5 values, EUR 69).
+--   3. OsteoTest für zu Hause (health-tests/prevention) — urine-based
+--      osteoporosis-risk screening (osteolabs brand), box marked "NEU".
+--   4. STI Standard – 4er Bundle (health-tests/sexual-health) — separate
+--      4-pack bundle SKU of the existing STI Standard test, distinctly
+--      priced/positioned ("für Gruppen und Paare").
+--   5. Burnout Stress Check (health-tests/general-health).
+--   6. Müdigkeits-Check (health-tests/general-health).
+--   7-9, 11. Vitamin D3 biomo® — 4 supplement SKUs (120/60-tablet, 90-capsule
+--      vegan, and drops), a different product TYPE entirely (nutritional
+--      supplement, not a diagnostic test) — seeded under category=
+--      'supplements', subcategory='vitamins' (existing, already wired into
+--      CategoryShopSections.tsx/CategoryProducts.tsx — confirmed via direct
+--      code read, no frontend change needed). Brand is the actual
+--      manufacturer ("biomo"), not DoctorBox itself.
+--  10. Notfallsticker — a QR-code emergency medical info sticker/card, not a
+--      test or supplement at all. No existing category fits cleanly
+--      (confirmed via querying distinct categories: supplements, skincare,
+--      health-tests, lifestyle, plus unrelated dropshipping categories) —
+--      seeded under category='lifestyle' as the closest available fit, no
+--      new subcategory taxonomy or frontend wiring added for it.
+--
+-- Real product photos (Shopify CDN) and per-product Shopify Collabs deep
+-- links were gathered directly for all 11 at creation time — none of these
+-- start on the Unsplash-placeholder/shared-link pattern the original 53 did.
+--
+-- Not fabricated: rating/review_count left NULL, same as every other
+-- DoctorBox product.
+--
+-- impact-allow-solo-migration: intentional data-only migration, no gateway/
+-- worker code touch needed.
+
+BEGIN;
+
+INSERT INTO products (
+  id, merchant_id, source_network, source_product_id, title, description, description_long,
+  brand, category, subcategory, price_cents, compare_at_price_cents, currency, images,
+  affiliate_url, availability, rating, review_count, origin_country, origin_region,
+  ships_to_countries, ships_to_regions, health_goals, dietary_tags, ingredients_primary,
+  topic_keys, reward_preview, is_active, requires_admin_review
+) VALUES
+
+  ('d0c70000-0000-4000-8000-000000000036', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-cardio-vital-check', 'Cardio & Vital-Check',
+   'Für alle, die ihre Gesundheit ganzheitlich überprüfen möchten – besonders bei Müdigkeit, unausgewogener Ernährung, erhöhtem Herz-Kreislauf-Risiko oder zur allgemeinen Vorsorge.',
+   'Der Cardio & Vital-Check analysiert 8 zentrale Blutwerte für Herz-Kreislauf- und Vitalgesundheit. 8 analysierte Werte, Probenart: Blut.',
+   'DoctorBox', 'health-tests', 'cardio', 11000, NULL, 'EUR',
+   ARRAY['https://cdn.shopify.com/s/files/1/0564/6991/3683/files/Tasso_ohne_text.jpg?v=1773752734&width=283&height=283&crop=center']::text[],
+   'https://collabs.shop/ir8pzz', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['cardio-health','longevity']::text[], ARRAY[]::text[], ARRAY[]::text[],
+   ARRAY['diagnostics','self-testing','cardio','cholesterol','lipids']::text[],
+   '{"points_estimate": 550, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-000000000037', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-nierenfunktion-uacr', 'Nierenfunktion (UACR Analyse)',
+   'Ermittelt das Eiweiß-Verhältnis im Urin, um beginnende Nierenschäden frühzeitig zu erkennen. Dient vor allem Menschen mit Diabetes oder Bluthochdruck zur einfachen und regelmäßigen Vorsorge.',
+   'Die UACR-Analyse misst Albumin, Kreatinin und den Urin-Albumin-Kreatinin-Quotienten. 3 analysierte Werte, Probenart: Urin.',
+   'DoctorBox', 'health-tests', 'prevention', 9900, NULL, 'EUR',
+   ARRAY['https://shop.doctorbox.de/cdn/shop/files/UACRTestShopify.png?v=1779955707&width=493']::text[],
+   'https://collabs.shop/hfhsod', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['kidney-health','prevention']::text[], ARRAY[]::text[], ARRAY[]::text[],
+   ARRAY['diagnostics','self-testing','kidney','urine-test']::text[],
+   '{"points_estimate": 495, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-000000000038', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-osteotest-zu-hause', 'OsteoTest für zu Hause',
+   'Frühe Risikobestimmung von Knochencalciumverlust – bequem von zu Hause aus, ohne Röntgen, ohne Praxisbesuch.',
+   'Der OsteoTest | home analysiert Calcium-Isotope im Urin mittels Massenspektrometer und erkennt Veränderungen des Knochenstoffwechsels, bevor sie im Röntgenbild sichtbar werden. 1 analysierter Wert, Probenart: Urin (morgens, nüchtern). Marke: osteolabs.',
+   'DoctorBox', 'health-tests', 'prevention', 9900, NULL, 'EUR',
+   ARRAY['https://shop.doctorbox.de/cdn/shop/files/OsteoTest_1.jpg?v=1767962596&width=493']::text[],
+   'https://collabs.shop/tva5ts', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['bone-health','prevention']::text[], ARRAY[]::text[], ARRAY[]::text[],
+   ARRAY['diagnostics','self-testing','osteoporosis','bone-health','urine-test']::text[],
+   '{"points_estimate": 495, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-000000000039', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-sti-standard-4er-bundle', 'STI Standard – 4er Bundle',
+   'STI Standard für Gruppen und Paare – überprüft auf die 5 häufigsten STIs, im praktischen 4er-Bundle.',
+   'Bundle aus 4 STI-Standard-Tests. Analysierte Werte: Chlamydien, Gonorrhö (Tripper), HIV, Syphilis, Hepatitis C. Probenart: Urin & Trockenblut.',
+   'DoctorBox', 'health-tests', 'sexual-health', 25600, 32000, 'EUR',
+   ARRAY['https://shop.doctorbox.de/cdn/shop/files/4erBundleSTIStandard.png?v=1769445301&width=600']::text[],
+   'https://collabs.shop/sbpgr7', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['sexual-health','group-testing']::text[], ARRAY[]::text[], ARRAY[]::text[],
+   ARRAY['diagnostics','self-testing','sti','sexual-health','bundle','group-testing']::text[],
+   '{"points_estimate": 1280, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-00000000003a', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-burnout-stress-check', 'Burnout Stress Check',
+   'Zeigt anhand zentraler Blutwerte dein Stressniveau und mögliche Nährstoffdefizite.',
+   'Der Burnout Stress Check analysiert Cortisol, TSH (sensitiv), Magnesium, Hämoglobin, Folsäure und Transcobalamin. 6 analysierte Werte, Probenart: Kapillarblut.',
+   'DoctorBox', 'health-tests', 'general-health', 12500, NULL, 'EUR',
+   ARRAY['https://shop.doctorbox.de/cdn/shop/files/Probenahme-Set-Deutsch.png?v=1774880217&width=600']::text[],
+   'https://collabs.shop/dw2it1', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['stress-reduction','burnout-recovery']::text[], ARRAY[]::text[], ARRAY[]::text[],
+   ARRAY['diagnostics','self-testing','stress','burnout','cortisol']::text[],
+   '{"points_estimate": 625, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-00000000003b', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-vitamin-d3-biomo-120-tabletten', 'Vitamin D3 biomo® 2.000 I.E. - 120 Tabletten',
+   'Nahrungsergänzungsmittel mit Vitamin D3. Unterstützt das Immunsystem und ist wichtig für den Erhalt normaler Knochen und Muskeln.',
+   'Vitamin D3 biomo® 2.000 I.E., 120 Tabletten. Unterstützt Immunsystem, Knochen, Muskelfunktion, Calcium-/Phosphor-Aufnahme und Zahngesundheit. Laktosefrei, glutenfrei. Dosierung: Erwachsene/Kinder ab 11 Jahren bis 2 Tabletten/Tag, unter 10 Jahren 1 Tablette/Tag.',
+   'biomo', 'supplements', 'vitamins', 1645, NULL, 'EUR',
+   ARRAY['https://shop.doctorbox.de/cdn/shop/files/VitaminD32.000I.E.TablettenNEM2048x2048.jpg?v=1729000330&width=600']::text[],
+   'https://collabs.shop/uasv5g', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['vitamin-d','immunity','bone-health']::text[], ARRAY[]::text[], ARRAY['Cholecalciferol (Vitamin D3)']::text[],
+   ARRAY['supplement','vitamin-d','immunity','bone-health']::text[],
+   '{"points_estimate": 82, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-00000000003c', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-vitamin-d3-biomo-vegan-90-kapseln', 'Vitamin D3 biomo® 2.000 I.E. (vegan) - 90 Kapseln',
+   'Nahrungsergänzungsmittel mit Vitamin D3, vegane Kapselvariante. Unterstützt das Immunsystem und ist wichtig für den Erhalt normaler Knochen und Muskeln.',
+   'Vitamin D3 biomo® 2.000 I.E., vegan, 90 Kapseln. Gleiches Wirkprofil wie die Tabletten-Variante (Immunsystem, Knochen, Muskeln).',
+   'biomo', 'supplements', 'vitamins', 1449, NULL, 'EUR',
+   ARRAY['https://shop.doctorbox.de/cdn/shop/files/VitaminD32.000I.E.KapselnNEM2048x2048.jpg?v=1729000167&width=600']::text[],
+   'https://collabs.shop/qp05gp', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['vitamin-d','immunity','bone-health']::text[], ARRAY['vegan']::text[], ARRAY['Cholecalciferol (Vitamin D3)']::text[],
+   ARRAY['supplement','vitamin-d','immunity','bone-health','vegan']::text[],
+   '{"points_estimate": 72, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-00000000003d', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-vitamin-d3-biomo-60-tabletten', 'Vitamin D3 biomo® 2.000 I.E. - 60 Tabletten',
+   'Nahrungsergänzungsmittel mit Vitamin D3. Unterstützt das Immunsystem und ist wichtig für den Erhalt normaler Knochen und Muskeln.',
+   'Vitamin D3 biomo® 2.000 I.E., 60 Tabletten (kleinere Packungsgröße der 120er-Variante).',
+   'biomo', 'supplements', 'vitamins', 895, NULL, 'EUR',
+   ARRAY['https://shop.doctorbox.de/cdn/shop/files/VitaminD32.000I.E.TablettenNEM2048x2048.jpg?v=1729000330&width=600']::text[],
+   'https://collabs.shop/gwnuqr', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['vitamin-d','immunity','bone-health']::text[], ARRAY[]::text[], ARRAY['Cholecalciferol (Vitamin D3)']::text[],
+   ARRAY['supplement','vitamin-d','immunity','bone-health']::text[],
+   '{"points_estimate": 45, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-00000000003e', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-muedigkeits-check', 'Müdigkeits-Check',
+   'Untersucht 6 wichtige Blutwerte, die Aufschluss über Energiehaushalt, Stressbelastung, Hormonbalance und mögliche Nährstoffdefizite geben.',
+   'Der Müdigkeits-Check misst 25-OH-Vitamin D3, Vitamin B12, SHBG, Cortisol, Harnsäure und Folsäure. 6 analysierte Werte, Probenart: Kapillarblut.',
+   'DoctorBox', 'health-tests', 'general-health', 9900, NULL, 'EUR',
+   ARRAY['https://shop.doctorbox.de/cdn/shop/files/Probenahme-Set-Deutsch.png?v=1774880217&width=600']::text[],
+   'https://collabs.shop/yyigx3', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['energy','fatigue-recovery']::text[], ARRAY[]::text[], ARRAY[]::text[],
+   ARRAY['diagnostics','self-testing','fatigue','energy','vitamins']::text[],
+   '{"points_estimate": 495, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-00000000003f', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-vitamin-d3-biomo-tropfen', 'Vitamin D3 biomo® Tropfen - Anpassbare Dosierung',
+   'Nahrungsergänzungsmittel mit Vitamin D3 in Tropfenform, individuell dosierbar.',
+   'Vitamin D3 biomo® Tropfen, 500 I.E. pro Tropfen, anpassbare Dosierung.',
+   'biomo', 'supplements', 'vitamins', 949, NULL, 'EUR',
+   ARRAY['https://shop.doctorbox.de/cdn/shop/files/VitaminD32.000I.E.TropfenNEM2048x2048.jpg?v=1729000488&width=600']::text[],
+   'https://collabs.shop/tmgc6g', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['vitamin-d','immunity','bone-health']::text[], ARRAY[]::text[], ARRAY['Cholecalciferol (Vitamin D3)']::text[],
+   ARRAY['supplement','vitamin-d','immunity','bone-health','drops']::text[],
+   '{"points_estimate": 47, "currency": "EUR"}'::jsonb, true, false),
+
+  ('d0c70000-0000-4000-8000-000000000040', 'd0c706b0-0000-4000-8000-000000000001', 'doctorbox',
+   'doctorbox-notfallsticker', 'Notfallsticker',
+   'QR-Code Notfallsticker für Smartphone & Geldbeutel – verlinkt auf deine digitale Notfall-Patientenakte.',
+   'Notfallsticker mit QR-Code für Smartphone und Karten für den Geldbeutel, verlinkt auf eine digitale Notfall-Patientenakte mit wichtigen medizinischen Informationen.',
+   'DoctorBox', 'lifestyle', 'safety', 999, NULL, 'EUR',
+   ARRAY['https://cdn.shopify.com/s/files/1/0564/6991/3683/files/MicrosoftTeams-image_169.png?v=1720451843&width=283&height=283&crop=center']::text[],
+   'https://collabs.shop/hjleke', 'in_stock', NULL, NULL, 'DE', 'EU',
+   ARRAY['DE','AT','CH','FR','IT','ES','NL','BE','PL','SE','DK','FI','GB','IE']::text[], ARRAY['EU','UK']::text[],
+   ARRAY['safety','emergency-preparedness']::text[], ARRAY[]::text[], ARRAY[]::text[],
+   ARRAY['safety','emergency','medical-id','qr-code']::text[],
+   '{"points_estimate": 50, "currency": "EUR"}'::jsonb, true, false)
+
+ON CONFLICT (source_network, source_product_id) DO UPDATE
+  SET title = EXCLUDED.title, description = EXCLUDED.description, description_long = EXCLUDED.description_long,
+      brand = EXCLUDED.brand, category = EXCLUDED.category, subcategory = EXCLUDED.subcategory,
+      price_cents = EXCLUDED.price_cents, compare_at_price_cents = EXCLUDED.compare_at_price_cents,
+      images = EXCLUDED.images, affiliate_url = EXCLUDED.affiliate_url,
+      health_goals = EXCLUDED.health_goals, dietary_tags = EXCLUDED.dietary_tags,
+      ingredients_primary = EXCLUDED.ingredients_primary, topic_keys = EXCLUDED.topic_keys,
+      reward_preview = EXCLUDED.reward_preview, is_active = true, updated_at = now();
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Replaces DoctorBox's single shared affiliate link (`https://shop.doctorbox.de/VITANALAND`, used for all 53 products) with individual Shopify Collabs deep links (`https://collabs.shop/xxxxxx`), one per product.
- Purely a data migration — no gateway/frontend code change needed. `click-redirect.ts` already reads `products.affiliate_url` per row, and `stampAffiliateUrl()` is host-agnostic, so it appends the same `sub1/sub2/sub3` tracking params regardless of host.
- Why: with one shared link, a purchase can never be attributed back to a specific product or a specific user's click/recommendation. Per-product links are a prerequisite for any future order/attribution sync (still separately blocked on DoctorBox granting Shopify Admin API order-read access — not a code change).
- **Second commit**: while gathering the 53 per-product links from the Shopify Collabs grid, found 11 products that didn't match any existing catalog row (confirmed new via price/value-panel mismatch, not renames — 6 renamed products were folded into the first commit's link mapping instead):
  - 6 new health-test SKUs: Cardio & Vital-Check, Nierenfunktion (UACR Analyse), OsteoTest für zu Hause, STI Standard – 4er Bundle, Burnout Stress Check, Müdigkeits-Check
  - 4 Vitamin D3 biomo® supplement variants (120/60-tablet, 90-capsule vegan, drops) — seeded under `category='supplements', subcategory='vitamins'` (existing, already wired into `CategoryShopSections.tsx`/`CategoryProducts.tsx`, no frontend change needed)
  - 1 lifestyle/safety item: Notfallsticker (QR-code emergency medical info sticker) — no existing category fit cleanly, seeded under `category='lifestyle'` as the closest available
  - All 11 have real product photos and their own per-product deep link gathered at creation time (never started on the placeholder/shared-link pattern the original 53 did)
- 3 Italian-language Collabs listings ("IST HIV/Sifilide/Epatite C", "IST Base", "IST Pro") were found to 404 on DoctorBox's live storefront — confirmed dead, not used anywhere in this migration.
- One link (`AntePC` / "Prostatakrebs Risiko Test") was inferred from the naming pattern shared by 5 other confirmed Ante*-branded renames rather than visually re-confirmed on the page — flagged in the migration comment in case it needs a follow-up correction.

## Test plan

- [x] Both migrations applied to live DB via Supabase MCP, `success: true`
- [x] Verified via SQL: 53/53 original products on distinct `collabs.shop` URLs (0 on the old shared link); 11 new products live with correct category/subcategory/price/affiliate_url; DoctorBox total now 64 products, all 64 on distinct deep links
- [x] Spot-checked `GET /r/d0c70000-0000-4000-8000-000000000011` (Herz-Kreislauf Check) → 302 to `https://collabs.shop/ztu8m1?sub1=...&sub2=...&sub3=...`
- [ ] No gateway/frontend code touched — confirmed unnecessary via direct code read of `click-redirect.ts` and `CategoryShopSections.tsx`/`CategoryProducts.tsx`


---
_Generated by [Claude Code](https://claude.ai/code/session_011JdP3fAJvzaKsd5FF2xHB1)_