### PR TITLE
fix(gateway): admin-feature-announcements never verified the JWT

### DIFF
--- a/services/gateway/src/routes/admin-feature-announcements.ts
+++ b/services/gateway/src/routes/admin-feature-announcements.ts
@@ -29,13 +29,17 @@ import { getSupabase } from '../lib/supabase';
 import { notifyUsersAsync, NotificationPayload } from '../services/notification-service';
 import { bulkGetUserLocales } from '../i18n/server-locale';
 import { tt, type GatewayLocale } from '../i18n/catalog';
-import { requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { requireAuth, requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 import { emitOasisEvent } from '../services/oasis-event-service';
 
 const router = Router();
 const VTID = 'ADMIN-FEATURE-ANNOUNCEMENTS';
 
-router.use(requireExafyAdmin);
+// requireExafyAdmin only CHECKS req.identity — it must run after requireAuth,
+// which actually verifies the JWT and populates req.identity. admin-notifications.ts
+// (the file this route was modeled on) is missing requireAuth too — same bug,
+// out of scope to fix here, but worth flagging separately.
+router.use(requireAuth, requireExafyAdmin);
 
 interface LocalizedText {
   en: string;

--- a/services/gateway/test/admin-feature-announcements.test.ts
+++ b/services/gateway/test/admin-feature-announcements.test.ts
@@ -19,17 +19,29 @@ let mockSupabase: any;
 const notifyUsersAsyncMock = jest.fn();
 const bulkGetUserLocalesMock = jest.fn();
 
+// Mirrors the real two-stage contract: requireAuth verifies the token and
+// sets req.identity; requireExafyAdmin only checks it (must run after).
 jest.mock('../src/middleware/auth-supabase-jwt', () => ({
-  requireExafyAdmin: (req: any, res: any, next: any) => {
+  requireAuth: (req: any, res: any, next: any) => {
     const h = req.headers.authorization;
     if (h === 'Bearer admin') {
       req.identity = { user_id: 'admin-1', email: 'admin@exafy.io', exafy_admin: true };
       return next();
     }
     if (h === 'Bearer user') {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+      req.identity = { user_id: 'user-1', email: 'user@example.com', exafy_admin: false };
+      return next();
     }
     return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  },
+  requireExafyAdmin: (req: any, res: any, next: any) => {
+    if (!req.identity) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (!req.identity.exafy_admin) {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    return next();
   },
 }));
 


### PR DESCRIPTION
## Summary

Root cause of why the test-send in #2922's follow-up couldn't authenticate, on both staging and production: `requireExafyAdmin` only *checks* `req.identity` — it must run **after** `requireAuth`, which actually verifies the JWT and populates `req.identity` (its own doc comment says so). `admin-feature-announcements.ts` only had `router.use(requireExafyAdmin)`, so `req.identity` was never set and every call failed `401 UNAUTHENTICATED` — including with a freshly issued, non-expired token carrying `app_metadata.exafy_admin=true`, tested directly against the live production endpoint.

`wallet-admin.ts` has the correct reference pattern: `router.use(path, requireAuth, requireExafyAdmin)`. This PR applies the same fix here.

**Also flagged, not fixed here:** `admin-notifications.ts` (the file this route was modeled on) has the identical gap — worth a follow-up.

## Changes

- `services/gateway/src/routes/admin-feature-announcements.ts`: `router.use(requireExafyAdmin)` → `router.use(requireAuth, requireExafyAdmin)`.

## Test plan

- [x] Confirmed the failure mode directly against production (`gateway.vitanaland.com`) with a real, valid, non-expired admin token before this fix.
- [ ] Will re-verify the same call succeeds once this deploys.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhBPkg9U1DJyo8ojognubd)_