### PR TITLE
Add flag-gated AWS dual-publish to Command Hub PUBLISH button (VTID-03407)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,7 @@ service without its own VTID.
 | Database | RDS Aurora PostgreSQL `vitana-aurora-prod` (writer/reader), same Supabase project as GCP prod (`inmkhvwdcuyhnxkgfvsb`) |
 | Redis | ElastiCache `vitana-redis-prod` |
 | Deploy workflow | `.github/workflows/AWS-PROD-DEPLOY-GATEWAY.yml` — **`workflow_dispatch`-only, required `reason`, never on push** |
+| Command Hub PUBLISH dual-publish | `AWS_DUAL_PUBLISH_ENABLED=true` (gateway env var, default off) makes the PUBLISH button best-effort dispatch `AWS-PROD-DEPLOY-GATEWAY.yml` alongside the GCP `EXEC-DEPLOY.yml` dispatch — see `services/gateway/src/routes/operator.ts` `POST /publish` step 7b |
 
 **Full build record, exact commands, and pre-existing-state findings:**
 `docs/AWS-PRODUCTION-BUILD-LOG.md`.
@@ -334,7 +335,10 @@ service without its own VTID.
   (§16): AWS staging (`vitana-gateway`) auto-deploys on push; AWS prod
   (`vitana-gateway-awsdr`) is a deliberate manual dispatch with a
   recorded reason, same spirit as the GCP PUBLISH button /
-  `publish-to-prod.sh` escape hatch.
+  `publish-to-prod.sh` escape hatch. The Command Hub PUBLISH button MAY
+  also dispatch it (via `workflow_dispatch`, never push) when
+  `AWS_DUAL_PUBLISH_ENABLED=true` — that is still a deliberate dispatch
+  triggered by an admin's PUBLISH click, not an automatic push trigger.
 - **Never** confuse `vitana-gateway` (AWS staging) with
   `vitana-gateway-awsdr` (AWS DR prod) — same ECS cluster, similarly
   named. The `vitana-alb-prod` ALB's target group named
@@ -585,6 +589,15 @@ NODE_ENV=production|development|test
 # frontend_promote.ok=false with a "token not set" detail (deploy frontend manually).
 FRONTEND_DEPLOY_TOKEN=<PAT with actions:write on exafyltd/vitana-v1>
 FRONTEND_DEPLOY_REPO=exafyltd/vitana-v1
+# AWS dual-publish (VTID-03398): when 'true', the Command Hub PUBLISH button
+# also best-effort dispatches AWS-PROD-DEPLOY-GATEWAY.yml with the same
+# commit, after the GCP EXEC-DEPLOY dispatch. Default OFF — AWS-PROD-DEPLOY-
+# GATEWAY.yml was deliberately built workflow_dispatch-only with a required
+# human-entered reason so AWS prod deploys stay a deliberate action; this
+# flag trades that off for one-click dual-publish. GCP remains canonical
+# regardless of this flag — see §1b. Failure on the AWS leg never fails the
+# publish (response reports aws_promote.ok=false with detail).
+AWS_DUAL_PUBLISH_ENABLED=true|false
 GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1
 GCP_PROJECT=lovable-vitana-vers1
 VERTEX_LOCATION=us-central1

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -64,6 +64,14 @@ AUTOPILOT_REGEN_COOLDOWN_MS=180000
 FRONTEND_DEPLOY_TOKEN=
 FRONTEND_DEPLOY_REPO=exafyltd/vitana-v1
 
+# AWS dual-publish (VTID-03407, on top of VTID-03398's AWS Production DR).
+# AWS_DUAL_PUBLISH_ENABLED: when 'true', PUBLISH ALSO best-effort dispatches
+#   AWS-PROD-DEPLOY-GATEWAY.yml with the same commit as the GCP publish.
+#   OPTIONAL — defaults to off (any value other than the literal string
+#   'true', including unset, leaves AWS un-promoted; response reports
+#   aws_promote.ok=false with detail). GCP remains canonical regardless.
+AWS_DUAL_PUBLISH_ENABLED=false
+
 # BOOTSTRAP-PRODUCT-ANALYTICS: daily rollup + retention purge for
 # product_analytics_events (default on; set to "false" to disable)
 PRODUCT_ANALYTICS_ROLLUP_ENABLED=true

--- a/services/gateway/src/routes/operator.ts
+++ b/services/gateway/src/routes/operator.ts
@@ -1285,11 +1285,19 @@ const STAGING_PUBLISH_BAKE_MS = (() => {
  *   5. Allocate a VTID via the canonical allocator (EXEC-DEPLOY gate needs it
  *      in vtid_ledger).
  *   6. Call deployOrchestrator.executeDeploy({ service:'gateway',
- *      environment:'production', source:'api' }) — this dispatches EXEC-DEPLOY.
- *   7. Insert software_versions row with source_revision=<staging revision short
+ *      environment:'production', source:'api' }) — this dispatches EXEC-DEPLOY
+ *      (GCP, canonical production).
+ *   7a. Best-effort: cross-dispatch vitana-v1's DEPLOY.yml to promote the
+ *       frontend alongside gateway (requires FRONTEND_DEPLOY_TOKEN).
+ *   7b. Best-effort, gated by AWS_DUAL_PUBLISH_ENABLED (default off): also
+ *       dispatch AWS-PROD-DEPLOY-GATEWAY.yml (VTID-03398) to ship the same
+ *       commit to AWS Production (DR) — additive DR capacity per CLAUDE.md
+ *       §1b, GCP remains canonical. Failure here never fails the publish.
+ *   8. Insert software_versions row with source_revision=<staging revision short
  *      name>, initiator_id=<admin uuid>, deploy_type='normal'. cloud_run_revision
  *      stays NULL — EXEC-DEPLOY's post-deploy step backfills it.
- *   8. Emit production.publish.requested + production.publish.completed events.
+ *   9. Emit production.publish.requested + production.publish.completed events
+ *      (payload includes frontend_promote + aws_promote outcomes).
  */
 router.post('/publish', requireAdminAuth, async (req: Request, res: Response) => {
   const requestId = randomUUID();
@@ -1489,6 +1497,40 @@ router.post('/publish', requireAdminAuth, async (req: Request, res: Response) =>
       frontendPromote = { ok: false, detail: e instanceof Error ? e.message : 'frontend_dispatch_failed' };
     }
 
+    // Step 7c: AWS Production (DR) dual-publish (VTID-03398) — also ship the
+    // SAME commit to vitana-gateway-awsdr on AWS, alongside the GCP publish
+    // above. Best-effort, same shape as the frontend promote: a failure here
+    // does NOT fail the overall publish (GCP is still canonical; AWS is
+    // additive DR capacity per CLAUDE.md §1b, not the other way around).
+    //
+    // Gated behind AWS_DUAL_PUBLISH_ENABLED (default off) rather than firing
+    // unconditionally: AWS-PROD-DEPLOY-GATEWAY.yml was deliberately built
+    // workflow_dispatch-only with a required human-entered `reason` so AWS
+    // prod deploys stay a deliberate action, not an automatic side effect of
+    // every GCP publish. Flip the env var on only once that tradeoff has
+    // been explicitly accepted.
+    let awsPromote: { ok: boolean; detail?: string; source_commit?: string | null } = {
+      ok: false,
+      detail: 'not_attempted',
+    };
+    if (process.env.AWS_DUAL_PUBLISH_ENABLED === 'true') {
+      try {
+        await triggerWorkflow(
+          'exafyltd/vitana-platform',
+          'AWS-PROD-DEPLOY-GATEWAY.yml',
+          'main',
+          {
+            reason: `dual-publish via Command Hub (${vtid}, gateway ${stagingCommit.slice(0, 7)})`,
+          },
+        );
+        awsPromote = { ok: true, source_commit: stagingCommit };
+      } catch (e) {
+        awsPromote = { ok: false, detail: e instanceof Error ? e.message : 'aws_dispatch_failed' };
+      }
+    } else {
+      awsPromote = { ok: false, detail: 'AWS_DUAL_PUBLISH_ENABLED not set to true — AWS DR NOT promoted.' };
+    }
+
     // Step 8: record the publish row in software_versions. cloud_run_revision
     // stays null — STAGE/EXEC-DEPLOY post-deploy step (P0.7) is responsible
     // for backfilling it once the new prod revision is healthy.
@@ -1534,6 +1576,7 @@ router.post('/publish', requireAdminAuth, async (req: Request, res: Response) =>
         workflow_run_id: deployResult.workflow_run_id,
         workflow_url: deployResult.workflow_url,
         frontend_promote: frontendPromote,
+        aws_promote: awsPromote,
       },
     });
 
@@ -1546,6 +1589,7 @@ router.post('/publish', requireAdminAuth, async (req: Request, res: Response) =>
       workflow_run_id: deployResult.workflow_run_id,
       workflow_url: deployResult.workflow_url,
       frontend_promote: frontendPromote,
+      aws_promote: awsPromote,
     });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03407` — "Command Hub PUBLISH dual-deploy to GCP + AWS (gateway)"
**Layer:** `INFRA`
**spec_status:** `approved` (generated → hand-written → validated → quality-checked → approved via the gateway's `/api/v1/specs/*` pipeline)

---

## 📋 Summary

Extends the Command Hub PUBLISH button (`POST /operator/publish`) to optionally also ship the gateway to AWS Production (DR) — built in VTID-03398 — alongside its existing GCP `EXEC-DEPLOY.yml` publish, using the same resolved commit. **GCP stays canonical**; this is purely additive redundancy, gateway-only, and off by default.

Requested as prep toward a possible full GCP→AWS cutover targeted for Monday July 27. That larger goal is **explicitly not addressed by this PR** — see "Important" below.

---

## ✅ Changes

- [x] `services/gateway/src/routes/operator.ts` — new best-effort step 7b in `/publish`: dispatches `AWS-PROD-DEPLOY-GATEWAY.yml` with the same commit SHA already resolved for GCP, mirroring the existing frontend cross-dispatch pattern
- [x] Gated behind `AWS_DUAL_PUBLISH_ENABLED` env var (default off/unset)
- [x] Response + OASIS event payload gains `aws_promote: { ok, detail?, source_commit? }`
- [x] `CLAUDE.md` §1b + §8 updated to document the flag

---

## 🧪 Testing

- [x] `npm run typecheck` (gateway) — clean, no new errors
- [ ] Not yet exercised against a live admin session (no UI change, behavior verified by code review of the existing, already-proven `frontend_promote` pattern this mirrors)

---

## ⚠️ Important — scope boundary, please read

This PR does **not** prepare AWS for a full production cutover. It only lets gateway publish to both targets at once, when explicitly enabled. Turning off GCP and making AWS exclusive by Monday would additionally require:

- Real, verified AWS prod infra for `oasis-operator`, `oasis-projector`, `worker-runner`, `vitana-verification-engine`, and the frontend — **none exist today**. (There are unexplained pre-existing ECS services with these exact names in the AWS account from a 2026-07-09 bulk-provisioning batch; currently under separate investigation to determine if they're viable.)
- Load-testing AWS at full production traffic (current autoscaling was sized for DR/failover, not full load)
- A DNS cutover plan for the real production hostname with a rollback path
- Its own VTID/spec given the governance implications of decommissioning canonical production

`AWS_DUAL_PUBLISH_ENABLED` should **not** be flipped to `true` in any live environment until that broader plan is worked out — this PR just makes the capability available in code, still opt-in.

---

## 🔗 Links

- **VTID:** VTID-03407
- **Depends on:** VTID-03398 / PR #2919 (AWS Production DR build, merged)

---

## 🚨 Breaking Changes

None. Default behavior of `/publish` is unchanged (flag off).

---

## 📌 Additional Notes

`AWS-PROD-DEPLOY-GATEWAY.yml` itself is unchanged — still `workflow_dispatch`-only, still requires a `reason`, never triggers on push. The PUBLISH button dispatching it (when the flag is on) is still a `workflow_dispatch` call triggered by an admin's click, not a push trigger.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF)_