### PR TITLE
Harden 3 backend AWS services to governed CI (VTID-03411)

### DIFF
--- a/.github/workflows/AWS-PROD-DEPLOY-OASIS-PROJECTOR.yml
+++ b/.github/workflows/AWS-PROD-DEPLOY-OASIS-PROJECTOR.yml
@@ -1,0 +1,145 @@
+# AWS-PROD-DEPLOY-OASIS-PROJECTOR — build oasis-projector, push to ECR,
+# and roll the AWS ECS service (VTID-03411 hardening pass).
+#
+# oasis-projector is an internal-only singleton background worker (the
+# VTID Ledger Writer, VTID-0521) with NO public ALB/DNS endpoint — it has
+# no external callers, so unlike gateway/frontend/oasis-operator this
+# workflow cannot curl-verify a live URL after deploy. Instead it relies
+# on the ECS-level container healthCheck (added in this same pass, hits
+# GET /ready internally, which itself verifies the Aurora DB connection —
+# the exact dependency that was broken and fixed under VTID-03408) and
+# `aws ecs wait services-stable`, which incorporates that health check
+# into its stability determination.
+#
+# Deliberately NOT autoscaled: the ledger writer has no cross-instance
+# locking, so running N>1 replicas risks duplicate event processing.
+# desiredCount stays fixed at 1 — see docs/AWS-PRODUCTION-BUILD-LOG.md.
+#
+# workflow_dispatch ONLY, required `reason`, never on push — same model
+# as every other AWS-DR deploy workflow this session.
+
+name: AWS Prod Deploy Oasis Projector (ECS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for this AWS oasis-projector deploy — required'
+        required: true
+      aws_region:
+        description: 'AWS region'
+        required: false
+        default: 'eu-central-1'
+      ecr_repository:
+        description: 'ECR repository name'
+        required: false
+        default: 'vitana/oasis-projector'
+      ecs_cluster:
+        description: 'ECS cluster name'
+        required: false
+        default: 'Vitana-ECS-Cluster'
+      ecs_service:
+        description: 'ECS service name'
+        required: false
+        default: 'vitana-oasis-projector'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-prod-deploy-oasis-projector
+  cancel-in-progress: false
+
+jobs:
+  build-push-deploy:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_AWS_REGION: ${{ inputs.aws_region }}
+      ECR_REPOSITORY: ${{ inputs.ecr_repository }}
+      ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+      ECS_SERVICE: ${{ inputs.ecs_service }}
+      DEPLOY_REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve commit metadata
+        id: commit
+        run: echo "short=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (GitHub OIDC — no static keys)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_ARN }}
+          aws-region: ${{ env.TARGET_AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Preflight
+        run: |
+          set -e
+          if ! aws ecr describe-repositories --repository-names "${{ env.ECR_REPOSITORY }}" >/dev/null 2>&1; then
+            echo "::error::ECR repository '${{ env.ECR_REPOSITORY }}' not found."
+            exit 1
+          fi
+          if ! aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+               --query 'services[0].status' --output text 2>/dev/null | grep -q ACTIVE; then
+            echo "::error::ECS service '${{ env.ECS_SERVICE }}' not ACTIVE."
+            exit 1
+          fi
+
+      - name: Build and push image
+        id: build
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -e
+          IMAGE="$REGISTRY/${{ env.ECR_REPOSITORY }}:${{ steps.commit.outputs.short }}"
+          docker build -t "$IMAGE" -t "$REGISTRY/${{ env.ECR_REPOSITORY }}:latest" services/oasis-projector
+          docker push "$IMAGE"
+          docker push "$REGISTRY/${{ env.ECR_REPOSITORY }}:latest"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Register task-definition revision + roll the service (desiredCount stays as-is — no autoscaling)
+        run: |
+          set -e
+          IMAGE="${{ steps.build.outputs.image }}"
+          TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' --output text)
+          NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
+            | jq --arg IMG "$IMAGE" '
+                .containerDefinitions[0].image = $IMG
+                | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                      .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "Registered $NEW_ARN"
+          aws ecs update-service --cluster "${{ env.ECS_CLUSTER }}" --service "${{ env.ECS_SERVICE }}" --task-definition "$NEW_ARN" >/dev/null
+          aws ecs wait services-stable --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}"
+          echo "Service stable on $NEW_ARN"
+
+      - name: Verify — task health (no public endpoint to curl; internal-only service)
+        run: |
+          set -e
+          for i in 1 2 3 4 5 6; do
+            TASK_ARN=$(aws ecs list-tasks --cluster "${{ env.ECS_CLUSTER }}" --service-name "${{ env.ECS_SERVICE }}" --query "taskArns[0]" --output text)
+            HEALTH=$(aws ecs describe-tasks --cluster "${{ env.ECS_CLUSTER }}" --tasks "$TASK_ARN" --query "tasks[0].healthStatus" --output text)
+            if [ "$HEALTH" = "HEALTHY" ]; then
+              echo "✓ Task healthy (container healthCheck hit /ready, confirming DB connectivity)"
+              exit 0
+            fi
+            echo "Attempt $i: healthStatus='$HEALTH' — retry in 15s"
+            sleep 15
+          done
+          echo "::error::Task did not report HEALTHY after deploy"
+          exit 1
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## oasis-projector deploy"
+            echo "- Image: \`${{ steps.build.outputs.image }}\`"
+            echo "- Reason: ${{ env.DEPLOY_REASON }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/AWS-PROD-DEPLOY-VERIFICATION-ENGINE.yml
+++ b/.github/workflows/AWS-PROD-DEPLOY-VERIFICATION-ENGINE.yml
@@ -1,0 +1,143 @@
+# AWS-PROD-DEPLOY-VERIFICATION-ENGINE — build the verification engine
+# (services/agents/vitana-orchestrator), push to ECR, and roll the AWS
+# ECS service (VTID-03411 hardening pass).
+#
+# vitana-verification-engine is an internal-only service (VTID-01163
+# verification stage gate) with NO public ALB/DNS endpoint. Verification
+# relies on the ECS-level container healthCheck (added in this same pass,
+# hits GET /health internally via a python3 urllib one-liner — the
+# python:3.11-slim base image has no curl/wget) and
+# `aws ecs wait services-stable`.
+#
+# Deliberately NOT autoscaled: this service holds no per-request state
+# that's obviously unsafe to duplicate, but its agents-registry
+# self-registration (one heartbeat loop per process) hasn't been reviewed
+# for N>1 safety — kept at fixed desiredCount pending that review.
+#
+# workflow_dispatch ONLY, required `reason`, never on push.
+
+name: AWS Prod Deploy Verification Engine (ECS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for this AWS verification-engine deploy — required'
+        required: true
+      aws_region:
+        description: 'AWS region'
+        required: false
+        default: 'eu-central-1'
+      ecr_repository:
+        description: 'ECR repository name'
+        required: false
+        default: 'vitana/vitana-verification-engine'
+      ecs_cluster:
+        description: 'ECS cluster name'
+        required: false
+        default: 'Vitana-ECS-Cluster'
+      ecs_service:
+        description: 'ECS service name'
+        required: false
+        default: 'vitana-vitana-verification-engine'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-prod-deploy-verification-engine
+  cancel-in-progress: false
+
+jobs:
+  build-push-deploy:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_AWS_REGION: ${{ inputs.aws_region }}
+      ECR_REPOSITORY: ${{ inputs.ecr_repository }}
+      ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+      ECS_SERVICE: ${{ inputs.ecs_service }}
+      DEPLOY_REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve commit metadata
+        id: commit
+        run: echo "short=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (GitHub OIDC — no static keys)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_ARN }}
+          aws-region: ${{ env.TARGET_AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Preflight
+        run: |
+          set -e
+          if ! aws ecr describe-repositories --repository-names "${{ env.ECR_REPOSITORY }}" >/dev/null 2>&1; then
+            echo "::error::ECR repository '${{ env.ECR_REPOSITORY }}' not found."
+            exit 1
+          fi
+          if ! aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+               --query 'services[0].status' --output text 2>/dev/null | grep -q ACTIVE; then
+            echo "::error::ECS service '${{ env.ECS_SERVICE }}' not ACTIVE."
+            exit 1
+          fi
+
+      - name: Build and push image
+        id: build
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -e
+          IMAGE="$REGISTRY/${{ env.ECR_REPOSITORY }}:${{ steps.commit.outputs.short }}"
+          docker build -t "$IMAGE" -t "$REGISTRY/${{ env.ECR_REPOSITORY }}:latest" services/agents/vitana-orchestrator
+          docker push "$IMAGE"
+          docker push "$REGISTRY/${{ env.ECR_REPOSITORY }}:latest"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Register task-definition revision + roll the service
+        run: |
+          set -e
+          IMAGE="${{ steps.build.outputs.image }}"
+          TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' --output text)
+          NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
+            | jq --arg IMG "$IMAGE" '
+                .containerDefinitions[0].image = $IMG
+                | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                      .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "Registered $NEW_ARN"
+          aws ecs update-service --cluster "${{ env.ECS_CLUSTER }}" --service "${{ env.ECS_SERVICE }}" --task-definition "$NEW_ARN" >/dev/null
+          aws ecs wait services-stable --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}"
+          echo "Service stable on $NEW_ARN"
+
+      - name: Verify — task health (no public endpoint to curl; internal-only service)
+        run: |
+          set -e
+          for i in 1 2 3 4 5 6; do
+            TASK_ARN=$(aws ecs list-tasks --cluster "${{ env.ECS_CLUSTER }}" --service-name "${{ env.ECS_SERVICE }}" --query "taskArns[0]" --output text)
+            HEALTH=$(aws ecs describe-tasks --cluster "${{ env.ECS_CLUSTER }}" --tasks "$TASK_ARN" --query "tasks[0].healthStatus" --output text)
+            if [ "$HEALTH" = "HEALTHY" ]; then
+              echo "✓ Task healthy (container healthCheck hit /health)"
+              exit 0
+            fi
+            echo "Attempt $i: healthStatus='$HEALTH' — retry in 15s"
+            sleep 15
+          done
+          echo "::error::Task did not report HEALTHY after deploy"
+          exit 1
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## verification-engine deploy"
+            echo "- Image: \`${{ steps.build.outputs.image }}\`"
+            echo "- Reason: ${{ env.DEPLOY_REASON }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/AWS-PROD-DEPLOY-WORKER-RUNNER.yml
+++ b/.github/workflows/AWS-PROD-DEPLOY-WORKER-RUNNER.yml
@@ -1,0 +1,143 @@
+# AWS-PROD-DEPLOY-WORKER-RUNNER — build worker-runner, push to ECR, and
+# roll the AWS ECS service (VTID-03411 hardening pass).
+#
+# worker-runner is an internal-only background poller (VTID-01200,
+# autonomous VTID execution plane) with NO public ALB/DNS endpoint. Like
+# oasis-projector, verification relies on the ECS-level container
+# healthCheck (added in this same pass, hits GET /alive internally) and
+# `aws ecs wait services-stable`.
+#
+# Deliberately NOT autoscaled in this pass: worker-runner's claim-based
+# design (claimed_by/claim_expires_at, atomic claims via the gateway) is
+# plausibly safe for N>1 replicas, but that hasn't been explicitly
+# verified against CLAUDE.md's "Never run parallel VTID executions" rule
+# — kept at fixed desiredCount pending that review, not because it's
+# known-unsafe like oasis-projector.
+#
+# workflow_dispatch ONLY, required `reason`, never on push.
+
+name: AWS Prod Deploy Worker Runner (ECS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for this AWS worker-runner deploy — required'
+        required: true
+      aws_region:
+        description: 'AWS region'
+        required: false
+        default: 'eu-central-1'
+      ecr_repository:
+        description: 'ECR repository name'
+        required: false
+        default: 'vitana/worker-runner'
+      ecs_cluster:
+        description: 'ECS cluster name'
+        required: false
+        default: 'Vitana-ECS-Cluster'
+      ecs_service:
+        description: 'ECS service name'
+        required: false
+        default: 'vitana-worker-runner'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-prod-deploy-worker-runner
+  cancel-in-progress: false
+
+jobs:
+  build-push-deploy:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_AWS_REGION: ${{ inputs.aws_region }}
+      ECR_REPOSITORY: ${{ inputs.ecr_repository }}
+      ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+      ECS_SERVICE: ${{ inputs.ecs_service }}
+      DEPLOY_REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve commit metadata
+        id: commit
+        run: echo "short=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (GitHub OIDC — no static keys)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_ARN }}
+          aws-region: ${{ env.TARGET_AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Preflight
+        run: |
+          set -e
+          if ! aws ecr describe-repositories --repository-names "${{ env.ECR_REPOSITORY }}" >/dev/null 2>&1; then
+            echo "::error::ECR repository '${{ env.ECR_REPOSITORY }}' not found."
+            exit 1
+          fi
+          if ! aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+               --query 'services[0].status' --output text 2>/dev/null | grep -q ACTIVE; then
+            echo "::error::ECS service '${{ env.ECS_SERVICE }}' not ACTIVE."
+            exit 1
+          fi
+
+      - name: Build and push image
+        id: build
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -e
+          IMAGE="$REGISTRY/${{ env.ECR_REPOSITORY }}:${{ steps.commit.outputs.short }}"
+          docker build -t "$IMAGE" -t "$REGISTRY/${{ env.ECR_REPOSITORY }}:latest" services/worker-runner
+          docker push "$IMAGE"
+          docker push "$REGISTRY/${{ env.ECR_REPOSITORY }}:latest"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Register task-definition revision + roll the service
+        run: |
+          set -e
+          IMAGE="${{ steps.build.outputs.image }}"
+          TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' --output text)
+          NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
+            | jq --arg IMG "$IMAGE" '
+                .containerDefinitions[0].image = $IMG
+                | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                      .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "Registered $NEW_ARN"
+          aws ecs update-service --cluster "${{ env.ECS_CLUSTER }}" --service "${{ env.ECS_SERVICE }}" --task-definition "$NEW_ARN" >/dev/null
+          aws ecs wait services-stable --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}"
+          echo "Service stable on $NEW_ARN"
+
+      - name: Verify — task health (no public endpoint to curl; internal-only service)
+        run: |
+          set -e
+          for i in 1 2 3 4 5 6; do
+            TASK_ARN=$(aws ecs list-tasks --cluster "${{ env.ECS_CLUSTER }}" --service-name "${{ env.ECS_SERVICE }}" --query "taskArns[0]" --output text)
+            HEALTH=$(aws ecs describe-tasks --cluster "${{ env.ECS_CLUSTER }}" --tasks "$TASK_ARN" --query "tasks[0].healthStatus" --output text)
+            if [ "$HEALTH" = "HEALTHY" ]; then
+              echo "✓ Task healthy (container healthCheck hit /alive)"
+              exit 0
+            fi
+            echo "Attempt $i: healthStatus='$HEALTH' — retry in 15s"
+            sleep 15
+          done
+          echo "::error::Task did not report HEALTHY after deploy"
+          exit 1
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## worker-runner deploy"
+            echo "- Image: \`${{ steps.build.outputs.image }}\`"
+            echo "- Reason: ${{ env.DEPLOY_REASON }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/AWS-PRODUCTION-BUILD-LOG.md
+++ b/docs/AWS-PRODUCTION-BUILD-LOG.md
@@ -355,7 +355,7 @@ a placeholder so `create-service` doesn't fail on a missing image; the
 first real dispatch of `AWS-PROD-DEPLOY-OASIS-OPERATOR.yml` builds and
 ships the actual restored code under an `awsdr-<sha>` tag.
 
-### Verdict so far
+### Verdict at this point
 
 Gateway (VTID-03398), the 3 backend bug-fixes (VTID-03408), the frontend
 (VTID-03409), and oasis-operator (VTID-03410) now all have real AWS-DR
@@ -365,3 +365,88 @@ VTID-03398-grade rigor (dedicated ALB rule, autoscaling, alarms,
 dispatch-only CI, OIDC) of their own — they're bug-fixed, not yet built
 out to the same standard as gateway. A full GCP→AWS cutover is closer
 than it was, but still not a same-day undertaking.
+
+---
+
+## Addendum (2026-07-23 cont'd again): VTID-03411 harden the 3 backend services
+
+Extends `oasis-projector`, `worker-runner`, and `verification-engine`
+(fixed but not yet governed under VTID-03408) toward gateway-grade
+rigor — **without** autoscaling or public ALB/DNS, both deliberately
+excluded after review.
+
+### Why no autoscaling
+
+Read `services/oasis-projector/src/ledger-writer.ts`: the VTID Ledger
+Writer has no cross-instance locking (no advisory lock, no `SKIP
+LOCKED`, no leader election) — running N>1 replicas risks duplicate
+event processing. CLAUDE.md's own hard governance rule, "Never run
+parallel VTID executions," backs this up directly. `worker-runner`'s
+claim-based design (`claimed_by`/`claim_expires_at`, atomic claims via
+the gateway) is plausibly safe for N>1 but wasn't reviewed carefully
+enough to act on that assumption here — kept at fixed `desiredCount`
+alongside the other two rather than guessed into autoscaling.
+
+### Why no public ALB/DNS
+
+None of the three have any evidence of external HTTP callers (unlike
+gateway/frontend/oasis-operator, which are all directly called by
+browsers or each other over the public internet) — `worker-runner`
+polls outward to the gateway, `oasis-projector` reconciles the DB in a
+loop, `verification-engine` self-registers a heartbeat outward. Adding
+public endpoints for services that don't need them would be
+unjustified new attack surface.
+
+### What was actually added
+
+- **ECS-level container `healthCheck`** on all 3 task definitions.
+  Before this, `aws ecs describe-tasks` reported `healthStatus: UNKNOWN`
+  for all three — ECS Fargate does **not** automatically honor a Docker
+  image's own `HEALTHCHECK` instruction (confirmed directly:
+  `worker-runner`'s Dockerfile already has one, and it was still
+  reporting `UNKNOWN`); an explicit `healthCheck` field on the task
+  definition container is required regardless. Commands used per
+  container's available tooling: `wget --spider` for the two
+  node:20-alpine services (`oasis-projector` → `/ready`, which itself
+  verifies the Aurora connection that VTID-03408 fixed; `worker-runner`
+  → `/alive`), and a `python3 -c "import urllib.request; ..."`
+  one-liner for `verification-engine` (`/health`) since its
+  `python:3.11-slim` base has no curl/wget. All three now report
+  `healthStatus: HEALTHY` after a forced redeploy.
+- **3 new deploy workflows** — `AWS-PROD-DEPLOY-OASIS-PROJECTOR.yml`,
+  `AWS-PROD-DEPLOY-WORKER-RUNNER.yml`,
+  `AWS-PROD-DEPLOY-VERIFICATION-ENGINE.yml` —
+  `workflow_dispatch`-only, required `reason`, never on push, reusing
+  the VTID-03398 GitHub-OIDC deploy role (policy extended again to cover
+  these 3 ECR repos + `ecs:ListTasks`/`ecs:DescribeTasks`, needed since
+  there's no public URL to curl — verification reads the task's
+  `healthStatus` directly via the AWS API instead).
+- **9 CloudWatch alarms** (running-task-count-low, CPU-high,
+  memory-high × 3 services).
+- **Container Insights enabled on `Vitana-ECS-Cluster`** (cluster-wide)
+  — it was off, which would have left the running-task-count alarms
+  permanently starved of data (`ECS/ContainerInsights` namespace metrics
+  don't exist without it). This benefits every service on the shared
+  cluster, not just these three.
+
+### Commands run
+
+```bash
+# Add ECS-level health check (per service, tool varies by base image):
+# node:20-alpine -> wget --spider; python:3.11-slim -> python3 urllib
+# (patch task def JSON, then:)
+aws ecs register-task-definition --cli-input-json file://<patched>.json --region eu-central-1
+aws ecs update-service --cluster Vitana-ECS-Cluster --service <service> \
+  --task-definition <family>:<new-revision> --region eu-central-1
+
+# Enable Container Insights
+aws ecs update-cluster-settings --cluster Vitana-ECS-Cluster \
+  --settings name=containerInsights,value=enabled --region eu-central-1
+
+# Alarms (repeated per service, 3 alarms each)
+aws cloudwatch put-metric-alarm --alarm-name <service>-running-count-low \
+  --namespace ECS/ContainerInsights --metric-name RunningTaskCount \
+  --dimensions Name=ClusterName,Value=Vitana-ECS-Cluster Name=ServiceName,Value=<service> \
+  --statistic Minimum --period 300 --evaluation-periods 2 --threshold 1 \
+  --comparison-operator LessThanThreshold --treat-missing-data breaching --region eu-central-1
+```


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03411` — "Harden oasis-projector/worker-runner/verification-engine to governed CI"
**Layer:** `INFRA`
**spec_status:** `approved`

---

## 📋 Summary

Brings the 3 backend services fixed under VTID-03408 (`oasis-projector`, `worker-runner`, `verification-engine`) from "functionally correct but only manually patchable" toward gateway-grade (VTID-03398) governance — **minus autoscaling and public ALB/DNS, both deliberately excluded**.

---

## ✅ Changes

- [x] ECS-level container `healthCheck` on all 3 task definitions — previously all three reported `healthStatus: UNKNOWN` (confirmed ECS Fargate does **not** auto-honor a Docker image's own `HEALTHCHECK`, even where one already exists, like `worker-runner`'s). All three now confirmed `HEALTHY` after a forced redeploy.
- [x] 3 new deploy workflows (`AWS-PROD-DEPLOY-OASIS-PROJECTOR.yml`, `AWS-PROD-DEPLOY-WORKER-RUNNER.yml`, `AWS-PROD-DEPLOY-VERIFICATION-ENGINE.yml`) — `workflow_dispatch`-only, required `reason`, never on push, reusing the VTID-03398 OIDC role
- [x] 9 CloudWatch alarms (running-count-low, CPU-high, memory-high × 3 services)
- [x] Container Insights enabled on `Vitana-ECS-Cluster` (cluster-wide — was off, which would have starved the running-count alarms of data)
- [x] `docs/AWS-PRODUCTION-BUILD-LOG.md` addendum

---

## ⚠️ Deliberately NOT done, with reasoning

**No autoscaling.** Read `services/oasis-projector/src/ledger-writer.ts`: the VTID Ledger Writer has no cross-instance locking — running N>1 replicas risks duplicate event processing. CLAUDE.md's own hard rule, *"Never run parallel VTID executions,"* backs this directly. `worker-runner`'s claim-based design is plausibly N>1-safe but wasn't reviewed carefully enough here to act on that assumption — kept at fixed `desiredCount` alongside the other two rather than guessed into autoscaling.

**No public ALB/DNS.** None of the three have evidence of external HTTP callers (worker-runner polls outward, oasis-projector reconciles the DB internally, verification-engine self-registers a heartbeat outward) — adding public endpoints would be unjustified new attack surface.

---

## 🧪 Testing

- [x] All 3 services confirmed `healthStatus: HEALTHY` via `aws ecs describe-tasks` after redeploy
- [x] All 3 new workflow YAMLs validated: `workflow_dispatch` only, no `on: push`
- [x] `desiredCount` confirmed unchanged (still 1) for all 3

---

## 🔗 Links

- **VTID:** VTID-03411
- **Related:** VTID-03398 (PR #2919), VTID-03408 (PR #2926), VTID-03410 (PR #2927)

---

## 🚨 Breaking Changes

None — purely additive observability/CI. No application behavior change, no new network exposure, no autoscaling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF)_