### PR TITLE
perf(voice): Bedrock connection warm + keep-warm loop for Nova 2 Sonic latency (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/docs/NOVA-SONIC-CANARY-RUNBOOK.md
+++ b/docs/NOVA-SONIC-CANARY-RUNBOOK.md
@@ -107,6 +107,28 @@ playback queue clears on every interruption; usage telemetry
 (`orb.live.upstream.usage`) on every completed session; no raw
 audio/transcripts/credentials/SigV4 in CloudWatch/OASIS.
 
+## 5b. Latency posture (what keeps Nova fast)
+
+Three mechanisms remove connection setup from the session critical path —
+verify all three from CloudWatch logs after enabling Nova:
+
+1. **Boot prewarm** — `[BOOTSTRAP-NOVA-SONIC-VOICE] Bedrock prewarm complete`
+   at task start: SDK loaded, task-role credentials resolved, and the
+   TLS/HTTP/2 path to `bedrock-runtime.eu-north-1` established via a
+   zero-cost warm request (a signed `InvokeModel` against the
+   `vitana.connection-warmup` marker id — rejected 4xx before inference,
+   never billed).
+2. **Shared HTTP/2 client** — all Nova sessions reuse one pooled client;
+   no per-session TCP/TLS/H2 setup.
+3. **Keep-warm loop** — `bedrock keep-warm ok ms=<n>` every
+   `NOVA_SONIC_KEEPWARM_MS` (default 240 s, safely under the handler's
+   480 s idle drop; `0` disables). This keeps the pool warm through quiet
+   periods so the first user after a lull still gets the warm path.
+
+Measure the effect with the Test Bench's live probes (`connect_ms` should
+sit at roughly one eu-central-1→eu-north-1 round-trip once warm) and the
+`latency_comparison` check against the Vertex baseline.
+
 ## 6. Expand (AWS staging only)
 
 One internal tenant → observe one working day → intended test cohort.

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -359,6 +359,10 @@ NOVA_SONIC_CANARY_TENANT_IDS=
 NOVA_SONIC_CONNECT_TIMEOUT_MS=15000
 # 435000 ms = 7m15s — rotate 45s before Bedrock's 8-minute stream cap.
 NOVA_SONIC_ROTATION_AFTER_MS=435000
+# Bedrock connection keep-warm ping interval (keeps the pooled HTTP/2 session
+# + task-role credentials hot between voice sessions; must stay under the
+# handler's 480s idle timeout). 0 disables.
+NOVA_SONIC_KEEPWARM_MS=240000
 # Unlock for a GLOBAL nova_sonic active-provider flip (still requires runtime
 # readiness; the canary rides the per-identity allowlists, never this).
 NOVA_SONIC_ALLOW_GLOBAL_FLIP=false

--- a/services/gateway/.env.template
+++ b/services/gateway/.env.template
@@ -104,4 +104,8 @@ NOVA_SONIC_CANARY_TENANT_IDS=
 NOVA_SONIC_CONNECT_TIMEOUT_MS=15000
 # 435000 ms = 7m15s — rotate 45s before Bedrock's 8-minute stream cap.
 NOVA_SONIC_ROTATION_AFTER_MS=435000
+# Bedrock connection keep-warm ping interval (keeps the pooled HTTP/2 session
+# + task-role credentials hot between voice sessions; must stay under the
+# handler's 480s idle timeout). 0 disables.
+NOVA_SONIC_KEEPWARM_MS=240000
 NOVA_SONIC_ALLOW_GLOBAL_FLIP=false

--- a/services/gateway/src/orb/live/upstream/nova-sonic-config.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-config.ts
@@ -26,6 +26,9 @@ export type NovaSonicLanguage = (typeof NOVA_SONIC_SUPPORTED_LANGUAGES)[number];
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
 /** 7m15s — rotate 45s before Bedrock's 8-minute bidirectional stream cap. */
 const DEFAULT_ROTATION_AFTER_MS = 435_000;
+// Under NodeHttp2Handler's 480s idle sessionTimeout so the pooled HTTP/2
+// session never expires between pings.
+const DEFAULT_KEEPWARM_MS = 240_000;
 
 export type NovaSonicConfigIssue =
   | 'nova_region_invalid'
@@ -33,7 +36,8 @@ export type NovaSonicConfigIssue =
   | 'nova_canary_user_ids_invalid'
   | 'nova_canary_tenant_ids_invalid'
   | 'nova_connect_timeout_invalid'
-  | 'nova_rotation_after_invalid';
+  | 'nova_rotation_after_invalid'
+  | 'nova_keepwarm_invalid';
 
 export interface NovaSonicConfig {
   enabled: boolean;
@@ -43,6 +47,12 @@ export interface NovaSonicConfig {
   canaryTenantIds: ReadonlySet<string>;
   connectTimeoutMs: number;
   rotationAfterMs: number;
+  /**
+   * Interval for the Bedrock connection keep-warm ping (latency: keeps the
+   * pooled HTTP/2 session + resolved credentials hot between real sessions;
+   * NodeHttp2Handler drops idle sessions after 8 min). 0 disables.
+   */
+  keepWarmMs: number;
   /**
    * Typed configuration problems. Non-empty issues force `ready` false —
    * misconfiguration is never silently corrected into live traffic.
@@ -86,6 +96,14 @@ function parsePositiveInt(raw: string | undefined, fallback: number): number | n
   return n;
 }
 
+/** Like parsePositiveInt but 0 is legal ("explicitly disabled"). */
+function parseNonNegativeInt(raw: string | undefined, fallback: number): number | null {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) return null;
+  return n;
+}
+
 /** Parse Nova configuration from an environment bag. Pure — never throws. */
 export function getNovaSonicConfig(env: NodeJS.ProcessEnv): NovaSonicConfig {
   const issues: NovaSonicConfigIssue[] = [];
@@ -118,6 +136,12 @@ export function getNovaSonicConfig(env: NodeJS.ProcessEnv): NovaSonicConfig {
   );
   if (rotationAfterMs === null) issues.push('nova_rotation_after_invalid');
 
+  const keepWarmMs = parseNonNegativeInt(
+    env.NOVA_SONIC_KEEPWARM_MS,
+    DEFAULT_KEEPWARM_MS,
+  );
+  if (keepWarmMs === null) issues.push('nova_keepwarm_invalid');
+
   return {
     enabled,
     region: NOVA_SONIC_REGION,
@@ -126,6 +150,7 @@ export function getNovaSonicConfig(env: NodeJS.ProcessEnv): NovaSonicConfig {
     canaryTenantIds: canaryTenantIds ?? new Set(),
     connectTimeoutMs: connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
     rotationAfterMs: rotationAfterMs ?? DEFAULT_ROTATION_AFTER_MS,
+    keepWarmMs: keepWarmMs ?? DEFAULT_KEEPWARM_MS,
     issues,
     ready: enabled && issues.length === 0,
   };

--- a/services/gateway/src/orb/live/upstream/nova-sonic-keepwarm.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-keepwarm.ts
@@ -1,0 +1,77 @@
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE (latency): Bedrock connection keep-warm loop.
+ *
+ * Why: NodeHttp2Handler pools the HTTP/2 session to the Bedrock endpoint but
+ * drops it after 8 idle minutes (sessionTimeout 480s), and STS/task-role
+ * credentials also age out of cache. In low-traffic periods that means the
+ * NEXT real voice session pays DNS + TCP + TLS + HTTP/2 setup (~100-300ms
+ * from eu-central-1 to eu-north-1) before Nova hears any audio. This loop
+ * re-fires the zero-cost warm request (see warmNovaSonicConnection — a
+ * signed request Bedrock rejects with a fast 4xx before inference) every
+ * `keepWarmMs` so the path stays permanently hot.
+ *
+ * Telemetry discipline: this is a keep-alive, NOT progress — it must never
+ * emit OASIS events (CLAUDE.md: "Never mark polling or heartbeats as OASIS
+ * events"). One console line per ping, typed outcomes only, no AWS text.
+ */
+
+import type { NovaSonicConfig } from './nova-sonic-config';
+import { warmNovaSonicConnection } from './nova-sonic-live-client';
+
+export interface NovaKeepWarmDeps {
+  /** Injectable warm fn for tests; defaults to warmNovaSonicConnection. */
+  warm?: (config: NovaSonicConfig) => Promise<number | null>;
+  /** Injectable logger for tests; defaults to console. */
+  log?: (line: string) => void;
+}
+
+let keepWarmTimer: NodeJS.Timeout | null = null;
+
+export function isNovaKeepWarmRunning(): boolean {
+  return keepWarmTimer !== null;
+}
+
+/**
+ * Start the keep-warm loop. Idempotent — a second start is a no-op while a
+ * loop is running. Returns true when a loop is (now) running, false when
+ * disabled (keepWarmMs === 0). The timer is unref'd: it never keeps the
+ * process alive, and each tick is fully awaited before the next is armed so
+ * pings can never pile up behind a slow endpoint.
+ */
+export function startNovaSonicKeepWarm(config: NovaSonicConfig, deps: NovaKeepWarmDeps = {}): boolean {
+  if (keepWarmTimer) return true;
+  if (config.keepWarmMs <= 0) return false;
+  const warm = deps.warm ?? warmNovaSonicConnection;
+  const log = deps.log ?? ((line: string) => console.log(line));
+
+  const arm = () => {
+    keepWarmTimer = setTimeout(async () => {
+      try {
+        const ms = await warm(config);
+        if (ms === null) {
+          log('[BOOTSTRAP-NOVA-SONIC-VOICE] bedrock keep-warm transport failure (will retry next interval)');
+        } else {
+          log(`[BOOTSTRAP-NOVA-SONIC-VOICE] bedrock keep-warm ok ms=${ms}`);
+        }
+      } catch {
+        /* warm() never throws by contract; belt-and-braces only */
+      }
+      // Re-arm only if not stopped while the ping was in flight.
+      if (keepWarmTimer) {
+        keepWarmTimer = null;
+        arm();
+      }
+    }, config.keepWarmMs);
+    keepWarmTimer.unref?.();
+  };
+
+  arm();
+  return true;
+}
+
+export function stopNovaSonicKeepWarm(): void {
+  if (keepWarmTimer) {
+    clearTimeout(keepWarmTimer);
+    keepWarmTimer = null;
+  }
+}

--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -214,9 +214,56 @@ async function defaultBedrockFactory(config: NovaSonicConfig): Promise<NovaBedro
 }
 
 /**
- * Boot-time prewarm: build the shared client and resolve the credential
- * chain (ECS task-role fetch) off the session critical path. Best-effort —
- * a failure falls back to lazy construction on first connect.
+ * Marker model id for the zero-cost connection warm-up. Bedrock rejects it
+ * with a fast 4xx BEFORE any inference (no charge, no stream), but the
+ * signed request rides — and therefore establishes — the pooled DNS + TCP +
+ * TLS + HTTP/2 path a real session will reuse.
+ */
+const NOVA_WARMUP_MARKER_MODEL_ID = 'vitana.connection-warmup';
+
+/**
+ * Fire one zero-cost signed request through the shared client to establish
+ * (or refresh) the pooled HTTP/2 session and keep resolved credentials hot.
+ * The expected outcome is a typed 4xx — that still means the connection is
+ * warm. Returns latency ms on success-shaped outcomes, null on transport
+ * failure. Never logs or returns raw AWS error text.
+ */
+export async function warmNovaSonicConnection(config: NovaSonicConfig): Promise<number | null> {
+  try {
+    const client = await defaultBedrockFactory(config);
+    const { InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime');
+    const t0 = Date.now();
+    try {
+      await Promise.race([
+        client.send(new InvokeModelCommand({
+          modelId: NOVA_WARMUP_MARKER_MODEL_ID,
+          contentType: 'application/json',
+          body: new Uint8Array(0),
+        })),
+        new Promise((_, reject) => {
+          const t = setTimeout(() => reject(Object.assign(new Error('warmup timeout'), { name: 'TimeoutError' })), 10_000);
+          (t as NodeJS.Timeout).unref?.();
+        }),
+      ]);
+      return Date.now() - t0;
+    } catch (err) {
+      const code = classifyNovaError(err);
+      // 4xx categories mean the request reached Bedrock — connection is warm.
+      if (code === 'nova_validation' || code === 'nova_model_not_found' || code === 'nova_access_denied') {
+        return Date.now() - t0;
+      }
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Boot-time prewarm: build the shared client, resolve the credential chain
+ * (ECS task-role fetch), and establish the TLS/HTTP/2 path — all off the
+ * session critical path. Best-effort — a failure falls back to lazy
+ * construction on first connect.
  */
 export async function prewarmNovaSonicBedrock(config: NovaSonicConfig): Promise<boolean> {
   try {
@@ -234,6 +281,8 @@ export async function prewarmNovaSonicBedrock(config: NovaSonicConfig): Promise<
         }),
       ]);
     }
+    // Establish the actual network path, not just the credentials.
+    await warmNovaSonicConnection(config);
     return true;
   } catch {
     return false;

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1390,6 +1390,7 @@ import {
 } from '../orb/live/upstream/nova-sonic-config';
 import { resolveNovaSonicVoice } from '../orb/live/voice/nova-sonic-voice';
 import { prewarmNovaSonicBedrock } from '../orb/live/upstream/nova-sonic-live-client';
+import { startNovaSonicKeepWarm } from '../orb/live/upstream/nova-sonic-keepwarm';
 import { createUpstreamClient } from '../orb/live/upstream/upstream-client-factory';
 import { bindUpstreamSessionHandlers } from '../orb/live/session/upstream-message-handler';
 import { createNovaWsFacade } from '../orb/live/upstream/nova-ws-facade';
@@ -1591,6 +1592,11 @@ if (googleAuth && VERTEX_PROJECT_ID) {
   if (novaBootCfg.ready) {
     void prewarmNovaSonicBedrock(novaBootCfg).then((ok) =>
       console.log(`[BOOTSTRAP-NOVA-SONIC-VOICE] Bedrock prewarm ${ok ? 'complete' : 'failed (lazy fallback on first connect)'}`));
+    // Keep the pooled HTTP/2 session + credentials hot between real
+    // sessions (NodeHttp2Handler drops idle sessions after 8 min, which
+    // would put TLS/H2 setup back on the next user's critical path).
+    const keepWarm = startNovaSonicKeepWarm(novaBootCfg);
+    console.log(`[BOOTSTRAP-NOVA-SONIC-VOICE] Bedrock keep-warm ${keepWarm ? `enabled (every ${novaBootCfg.keepWarmMs}ms)` : 'disabled'}`);
   }
 }
 

--- a/services/gateway/test/orb/live/upstream/nova-sonic-config.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-config.test.ts
@@ -24,6 +24,7 @@ describe('getNovaSonicConfig', () => {
         modelId: 'amazon.nova-2-sonic-v1:0',
         connectTimeoutMs: 15000,
         rotationAfterMs: 435000,
+        keepWarmMs: 240000,
         issues: [],
       }),
     );
@@ -71,11 +72,26 @@ describe('getNovaSonicConfig', () => {
       NOVA_SONIC_ENABLED: 'true',
       NOVA_SONIC_CONNECT_TIMEOUT_MS: 'soon',
       NOVA_SONIC_ROTATION_AFTER_MS: '-5',
+      NOVA_SONIC_KEEPWARM_MS: 'often',
     } as NodeJS.ProcessEnv);
     expect(cfg.ready).toBe(false);
     expect(cfg.issues).toEqual(
-      expect.arrayContaining(['nova_connect_timeout_invalid', 'nova_rotation_after_invalid']),
+      expect.arrayContaining([
+        'nova_connect_timeout_invalid',
+        'nova_rotation_after_invalid',
+        'nova_keepwarm_invalid',
+      ]),
     );
+  });
+
+  it('keep-warm accepts 0 as an explicit disable (no issue)', () => {
+    const cfg = getNovaSonicConfig({
+      NOVA_SONIC_ENABLED: 'true',
+      NOVA_SONIC_KEEPWARM_MS: '0',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.keepWarmMs).toBe(0);
+    expect(cfg.ready).toBe(true);
+    expect(cfg.issues).toEqual([]);
   });
 });
 

--- a/services/gateway/test/orb/live/upstream/nova-sonic-keepwarm.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-keepwarm.test.ts
@@ -1,0 +1,72 @@
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE (latency): keep-warm loop tests — the pooled
+ * Bedrock HTTP/2 session must be re-warmed on the configured interval,
+ * never pile up pings, and stop cleanly.
+ */
+
+import {
+  isNovaKeepWarmRunning,
+  startNovaSonicKeepWarm,
+  stopNovaSonicKeepWarm,
+} from '../../../../src/orb/live/upstream/nova-sonic-keepwarm';
+import { getNovaSonicConfig } from '../../../../src/orb/live/upstream/nova-sonic-config';
+
+const cfg = (keepWarmMs: string) =>
+  getNovaSonicConfig({
+    NOVA_SONIC_ENABLED: 'true',
+    NOVA_SONIC_KEEPWARM_MS: keepWarmMs,
+  } as NodeJS.ProcessEnv);
+
+describe('startNovaSonicKeepWarm', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    stopNovaSonicKeepWarm();
+    jest.useRealTimers();
+  });
+
+  it('keepWarmMs=0 disables the loop', () => {
+    expect(startNovaSonicKeepWarm(cfg('0'), { warm: jest.fn(), log: jest.fn() })).toBe(false);
+    expect(isNovaKeepWarmRunning()).toBe(false);
+  });
+
+  it('pings on the interval, re-arms, and logs typed outcomes only', async () => {
+    const warm = jest.fn().mockResolvedValue(42);
+    const log = jest.fn();
+    expect(startNovaSonicKeepWarm(cfg('1000'), { warm, log })).toBe(true);
+    expect(isNovaKeepWarmRunning()).toBe(true);
+    expect(warm).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(warm).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('keep-warm ok ms=42'));
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(warm).toHaveBeenCalledTimes(2);
+  });
+
+  it('transport failure logs a retry line and keeps the loop alive', async () => {
+    const warm = jest.fn().mockResolvedValue(null);
+    const log = jest.fn();
+    startNovaSonicKeepWarm(cfg('1000'), { warm, log });
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('transport failure'));
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(warm).toHaveBeenCalledTimes(2);
+  });
+
+  it('is idempotent while running and stops cleanly', async () => {
+    const warm = jest.fn().mockResolvedValue(10);
+    startNovaSonicKeepWarm(cfg('1000'), { warm, log: jest.fn() });
+    // Second start is a no-op — still one loop.
+    expect(startNovaSonicKeepWarm(cfg('1000'), { warm: jest.fn(), log: jest.fn() })).toBe(true);
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(warm).toHaveBeenCalledTimes(1);
+
+    stopNovaSonicKeepWarm();
+    expect(isNovaKeepWarmRunning()).toBe(false);
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(warm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
@@ -7,6 +7,7 @@ import {
   NovaSonicLiveClient,
   NovaInputQueue,
   classifyNovaError,
+  warmNovaSonicConnection,
   __setSharedBedrockClientForTests,
   type NovaBedrockLike,
 } from '../../../../src/orb/live/upstream/nova-sonic-live-client';
@@ -375,5 +376,33 @@ describe('shared Bedrock client (latency: HTTP/2 session reuse)', () => {
     await client.connect(baseOptions());
     await client.close('done');
     expect(owned.destroy).toHaveBeenCalled();
+  });
+});
+
+describe('warmNovaSonicConnection (zero-cost connection warm)', () => {
+  afterEach(() => {
+    __setSharedBedrockClientForTests(null);
+  });
+
+  it('a 4xx rejection means the path is warm — returns latency', async () => {
+    const shared: NovaBedrockLike = {
+      send: jest.fn(async () => {
+        throw Object.assign(new Error('raw AWS text must not leak'), { name: 'ValidationException' });
+      }),
+    };
+    __setSharedBedrockClientForTests(shared);
+    const ms = await warmNovaSonicConnection(config);
+    expect(typeof ms).toBe('number');
+    expect(shared.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('a transport-level failure returns null (typed, no throw)', async () => {
+    const shared: NovaBedrockLike = {
+      send: jest.fn(async () => {
+        throw Object.assign(new Error('socket hang up'), { name: 'ModelStreamErrorException' });
+      }),
+    };
+    __setSharedBedrockClientForTests(shared);
+    expect(await warmNovaSonicConnection(config)).toBeNull();
   });
 });


### PR DESCRIPTION
## Why

Vertex and LiveKit both disappointed on latency; Nova 2 Sonic is the shot at near-realtime — but only if nothing sits in front of the model on the session critical path. After PR #2923's shared-client prewarm, the remaining structural tax was **connection setup**: the boot prewarm resolved the SDK + task-role credentials, but the TLS/HTTP2 tunnel to `bedrock-runtime.eu-north-1` was still only established by the first real session, and `NodeHttp2Handler` drops the pooled session after **480s idle** — so after any quiet period the next user paid DNS + TCP + TLS + H2 setup (~100–300ms) before Nova heard a single audio frame.

## What

- **`warmNovaSonicConnection()`** (nova-sonic-live-client.ts): a zero-cost signed `InvokeModel` against the `vitana.connection-warmup` marker id. Bedrock rejects it with a fast 4xx **before any inference** (never billed, never opens a stream), but the request establishes the pooled DNS/TCP/TLS/HTTP2 path real sessions reuse. A 4xx outcome is warm-success; only transport failures return null. No raw AWS text anywhere.
- **Boot prewarm** now fires the connection warm too — the very first session after deploy already gets the warm path.
- **Keep-warm loop** (`nova-sonic-keepwarm.ts`): re-warms every `NOVA_SONIC_KEEPWARM_MS` (default **240s**, safely under the 480s idle drop; `0` disables; an invalid value is a typed `nova_keepwarm_invalid` readiness failure — misconfiguration never silently reaches traffic). Unref'd timer, each tick fully awaited before re-arming (no ping pile-up), one console line per ping, and **no OASIS events** (heartbeats are not events).
- Runbook §5b documents the latency posture and how to verify it in CloudWatch + the Test Bench live probes (`connect_ms` should sit at ~1 RTT once warm; `latency_comparison` gates Nova ≤ 1.15× Vertex).

## Testing

- Full gateway suite: **485 suites / 8,526 tests green** locally.
- New: keep-warm loop tests (interval firing, re-arm, transport-failure retry, idempotent start, clean stop — fake timers), `warmNovaSonicConnection` typed-outcome tests, config parsing tests (`0` = explicit disable, invalid → typed issue).
- `NOVA_SONIC_KEEPWARM_MS` documented in `.env.example` / `.env.template`.

Only active when Nova is ready (`NOVA_SONIC_ENABLED=true` + clean config) — zero behavior change on GCP and on AWS until the canary is switched on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_