### PR TITLE
Close 3 cutover checklist items; flag SNS alerting gap (VTID-03412)

### DIFF
--- a/docs/AWS-CUTOVER-RUNBOOK.md
+++ b/docs/AWS-CUTOVER-RUNBOOK.md
@@ -43,12 +43,12 @@ CLI + Cloudflare DNS audit performed under this VTID.
 | gateway | AWS-DR built (VTID-03398), autoscaled, alarmed, dual-publish wired. Healthy. |
 | community-app | AWS-DR built (VTID-03409). **Bakes the GCP `gateway.vitanaland.com` URL into its static Vite bundle at build time, by design** — it was built as a same-backend hot-standby, not a fully independent stack. Will break if GCP disappears without either repointing `gateway.vitanaland.com` to AWS or rebuilding against `dr-gateway.vitanaland.com`. See open decision §4.1. |
 | oasis-operator | AWS-DR built (VTID-03410) from a 9-month-old dead backup (`main.py.backup-20251101-111126`) with zero prior AWS production traffic history. No burn-in yet. |
-| oasis-projector / worker-runner / verification-engine | Bug-fixed + ECS health-checked + alarmed (VTID-03411). Deliberately **not** autoscaled or made public — `oasis-projector`'s ledger writer has no cross-instance locking (CLAUDE.md: "Never run parallel VTID executions"); `worker-runner`'s N>1 safety is plausible but unreviewed. |
+| oasis-projector / worker-runner / verification-engine | Bug-fixed + ECS health-checked + alarmed (VTID-03411). Deliberately **not** autoscaled or made public — `oasis-projector`'s ledger writer has no cross-instance locking (CLAUDE.md: "Never run parallel VTID executions"). **`worker-runner` has since been reviewed (2026-07-24) and found CONDITIONALLY SAFE for N>1**: its claim mechanism is a genuine server-side compare-and-swap (`SELECT ... FOR UPDATE` + conditional `UPDATE` inside one Postgres transaction, `claim_vtid_task` RPC in `supabase/migrations/20260413000000_fix_claim_accepts_scheduled.sql`), not a client-side read-then-write race, and no other shared mutable state exists between instances. The one real N>1-specific risk: an idle sibling instance will legitimately re-claim a VTID whose 60-minute claim lease expired due to sustained heartbeat failure on the active instance, causing double execution — condition for safety is that heartbeats reliably survive transient network hiccups; recommend alerting on sustained heartbeat failure before actually enabling autoscaling. Autoscaling itself has **not** been enabled — this is a documentation finding only, pending a decision on whether to act on it. |
 | orb-agent | **No AWS deploy path at all.** Named directly in CLAUDE.md §16 IF-THEN rule 24 alongside worker-runner as something needing prod updates. |
 | autopilot job (Cloud Run Job) | **No AWS deploy path at all.** |
 | Database sync | RDS Aurora `vitana-aurora-prod` via DMS task `vitana-supabase-to-aurora` (full-load-and-cdc): 494/495 tables under live CDC from the same Supabase project GCP prod uses. **One table, `autopilot_recommendations`, has its own dedicated CDC task (`vitana-autopilot-cdc`) which was in `FATAL_ERROR` for ~26h as of this audit** — see §5, tracked/being fixed under this same session outside this VTID's scope. |
 | Secrets | `vitana/supabase/prod/*` (4 secrets) current as of 2026-07-14/21; RDS-managed master credential rotates automatically. |
-| Alarms | 39 `vitana-*` CloudWatch alarms, all `OK`. **Gap:** no dedicated alarm set yet for `community-app-awsdr` or `oasis-operator-awsdr` (only gateway has the full 4-alarm set). |
+| Alarms | 47 `vitana-*` CloudWatch alarms, all `OK`/`INSUFFICIENT_DATA`. `community-app-awsdr` and `oasis-operator-awsdr` now have the same 4-alarm set (cpu-high, memory-high, target-5xx, unhealthy-hosts) gateway-awsdr already had — closed 2026-07-24. A `vitana-dms-task-failure` EventBridge rule (source `aws.dms` → SNS topic `vitana-alarms-prod`) was also added the same day so a future DMS task failure isn't silent for 26+ hours again like `vitana-autopilot-cdc` was. **New gap found while wiring this up: the `vitana-alarms-prod` SNS topic has zero subscribers** — no email, Slack, or PagerDuty endpoint is attached, so none of the 47 alarms or the new DMS rule currently notify anyone. All of this alerting infrastructure is presently inert until a real subscriber is added; this needs a decision on where alerts should actually go. |
 | ALB naming | `vitana-tg-gateway-prod` / `vitana-tg-community-prod` are pre-existing naming leftovers that **actually serve AWS staging traffic**, not prod — confirmed live via `/api/v1/admin/health` returning `env:"staging"` through those target groups. A real cutover must not confuse these with the `-awsdr` target groups. |
 | Legacy/mystery services | ~22 of the 29 (now 31) ECS services in `Vitana-ECS-Cluster` from the 2026-07-09 bulk-provisioning event remain unexplained — flagged, not investigated. Out of scope for cutover unless one turns out to be load-bearing. |
 | Cutover/rollback docs | **Did not exist before this VTID.** No DNS-repoint runbook, no rollback/TTL plan, no GCP decommission checklist. |
@@ -70,9 +70,18 @@ objective — each item has a clear done/not-done state.
       `vitana-supabase-to-aurora`) both report `status=running` with no
       failed tasks, verified via `aws dms describe-replication-tasks`,
       not just "was fixed once."
-- [ ] **DMS alerting exists.** A CloudWatch alarm (or equivalent) fires
-      on any DMS task leaving `running` state — the ~26h silent gap this
-      audit found must not be repeatable.
+- [~] **DMS alerting exists.** *(Partially done 2026-07-24: EventBridge
+      rule `vitana-dms-task-failure` created, source `aws.dms` → SNS
+      topic `vitana-alarms-prod`. Still NOT actually alerting anyone —
+      that topic has zero subscribers. Not complete until a real
+      email/Slack/PagerDuty endpoint is subscribed.)* the ~26h silent
+      gap this audit found must not be repeatable.
+- [ ] **`vitana-alarms-prod` SNS topic has a real subscriber.** Found
+      2026-07-24 while wiring the DMS alerting rule: the topic all 47
+      CloudWatch alarms and the new EventBridge rule point at has zero
+      subscriptions. Every alarm in the account is currently silent
+      regardless of state. Needs an explicit decision on where alerts
+      should go (email/Slack/PagerDuty) — cannot be assumed or invented.
 - [ ] **Frontend gateway-URL decision made and implemented** (§4.1) —
       either `gateway.vitanaland.com` DNS is part of the cutover sequence
       itself, or `community-app-awsdr` has been rebuilt against
@@ -83,9 +92,10 @@ objective — each item has a clear done/not-done state.
 - [ ] **`community-app-awsdr` burn-in complete** — same 72h bar, verified
       via the AWS-PROD-DEPLOY-FRONTEND smoke checks passing on at least
       2 consecutive real deploys.
-- [ ] **CloudWatch alarms exist for `community-app-awsdr` and
-      `oasis-operator-awsdr`**, matching the pattern already in place for
-      `gateway-awsdr` (running-count, CPU, memory).
+- [x] **CloudWatch alarms exist for `community-app-awsdr` and
+      `oasis-operator-awsdr`** — done 2026-07-24, same 4-alarm pattern as
+      `gateway-awsdr` (cpu-high, memory-high, target-5xx, unhealthy-hosts).
+      *(Same SNS-subscriber caveat as the DMS alerting item above applies.)*
 - [ ] **ALB naming cleanup done or explicitly waived** — `vitana-tg-gateway-prod`
       / `vitana-tg-community-prod` renamed to reflect that they serve
       staging, or the cutover sequence explicitly calls out why the
@@ -94,9 +104,10 @@ objective — each item has a clear done/not-done state.
       either they get an AWS deploy path before cutover, or an explicit,
       documented decision that they stay GCP-only post-cutover (and what
       that means operationally).
-- [ ] **`worker-runner` N>1 safety reviewed** (or explicitly deferred) —
-      not a hard blocker for a single-instance cutover, but must be a
-      conscious decision, not silence.
+- [x] **`worker-runner` N>1 safety reviewed** — done 2026-07-24, verdict
+      CONDITIONALLY SAFE (see §1 table row for detail + code citations).
+      Autoscaling has **not** been enabled based on this finding — that
+      remains a separate decision, not automatically implied by "reviewed."
 - [ ] **Rollback plan rehearsed** — §3 below has been dry-run at least
       once (e.g., against a non-critical hostname) so the revert sequence
       isn't being executed for the first time under pressure.

--- a/docs/AWS-PRODUCTION-BUILD-LOG.md
+++ b/docs/AWS-PRODUCTION-BUILD-LOG.md
@@ -450,3 +450,101 @@ aws cloudwatch put-metric-alarm --alarm-name <service>-running-count-low \
   --statistic Minimum --period 300 --evaluation-periods 2 --threshold 1 \
   --comparison-operator LessThanThreshold --treat-missing-data breaching --region eu-central-1
 ```
+
+## Addendum (2026-07-24): VTID-03412 cutover runbook + go/no-go checklist progress
+
+`docs/AWS-CUTOVER-RUNBOOK.md` was added under VTID-03412 (see that doc for
+the full go/no-go checklist, DNS repoint sequence, rollback plan, and open
+decisions). While the DMS write-permission grant was pending (blocked on
+`dms:StartReplicationTask` — the `claude-staging-validation` IAM user only
+has DMS read access), the following checklist items were closed out with
+permissions already available (`AmazonECS_FullAccess`,
+`ElasticLoadBalancingFullAccess`, plus incidental CloudWatch/EventBridge
+write access — see below):
+
+### CloudWatch alarms for `community-app-awsdr` / `oasis-operator-awsdr`
+
+Mirrored the existing `gateway-awsdr` 4-alarm set (cpu-high, memory-high,
+target-5xx, unhealthy-hosts) exactly — same thresholds (CPU/memory >90%
+for 3×5min periods, target 5xx >10 in 5×1min periods, any unhealthy host).
+8 new alarms total, all confirmed created via `describe-alarms`.
+
+```bash
+# cpu-high / memory-high (per service)
+aws cloudwatch put-metric-alarm --alarm-name vitana-<service>-cpu-high \
+  --namespace AWS/ECS --metric-name CPUUtilization --statistic Average \
+  --period 300 --evaluation-periods 3 --threshold 90 \
+  --comparison-operator GreaterThanThreshold --treat-missing-data notBreaching \
+  --dimensions Name=ClusterName,Value=Vitana-ECS-Cluster Name=ServiceName,Value=vitana-<service> \
+  --region eu-central-1
+# (memory-high identical, MetricName=MemoryUtilization)
+
+# target-5xx / unhealthy-hosts (per service, needs the service's target group ARN)
+aws cloudwatch put-metric-alarm --alarm-name vitana-<service>-target-5xx \
+  --namespace AWS/ApplicationELB --metric-name HTTPCode_Target_5XX_Count --statistic Sum \
+  --period 60 --evaluation-periods 5 --threshold 10 \
+  --comparison-operator GreaterThanThreshold --treat-missing-data notBreaching \
+  --dimensions Name=TargetGroup,Value=targetgroup/<tg-name>/<id> Name=LoadBalancer,Value=app/vitana-alb-prod/3d60b7c377e63d95 \
+  --region eu-central-1
+# (unhealthy-hosts identical, MetricName=UnHealthyHostCount, Statistic=Maximum, threshold=0)
+```
+
+### DMS failure alerting (`vitana-dms-task-failure` EventBridge rule)
+
+`dms:CreateEventSubscription` (the DMS-native notification mechanism) was
+tested and confirmed blocked by IAM — same wall as `StartReplicationTask`.
+`events:PutRule`/`events:PutTargets` were **not** blocked, so alerting was
+built via EventBridge instead: AWS DMS emits events to the default event
+bus under `source: "aws.dms"` without needing any DMS-side subscription
+API call. Rule pattern deliberately left broad (source-only, no
+`detail-type` filter) since the exact DMS EventBridge detail-type schema
+wasn't confirmed against a live event — better to over-notify than miss a
+future failure the way `vitana-autopilot-cdc`'s ~26h silent gap happened.
+
+```bash
+aws events put-rule --name vitana-dms-task-failure \
+  --event-pattern '{"source":["aws.dms"]}' --state ENABLED --region eu-central-1
+aws events put-targets --rule vitana-dms-task-failure \
+  --targets '[{"Id":"vitana-alarms-sns","Arn":"arn:aws:sns:eu-central-1:472838866351:vitana-alarms-prod"}]' \
+  --region eu-central-1
+```
+
+**Important caveat found while wiring this up, not yet resolved:** the
+`vitana-alarms-prod` SNS topic — the one target for all 47 CloudWatch
+alarms in the account plus this new rule — has **zero subscribers**
+(confirmed via `aws sns list-subscriptions-by-topic`). `sns:Subscribe`/
+`sns:AddPermission` are also blocked for this IAM user. Every alarm in
+the account is currently inert: they'll transition state correctly but
+nothing receives a notification. This needs an explicit decision from
+the user on where alerts should actually go (email/Slack/PagerDuty) —
+not something to invent or guess an endpoint for. Tracked as its own
+go/no-go checklist item in `docs/AWS-CUTOVER-RUNBOOK.md` §2.
+
+### `worker-runner` N>1 safety review
+
+Reviewed the actual claim mechanism end-to-end (not just the service's
+own code): `services/worker-runner/src/services/runner-service.ts`
+`doPoll()` never processes more than one VTID per instance; the claim
+itself goes through the gateway's `POST /api/v1/worker/orchestrator/
+tasks/:vtid/claim` → `claim_vtid_task` RPC (`supabase/migrations/
+20260413000000_fix_claim_accepts_scheduled.sql`), which does
+`SELECT ... FOR UPDATE` + a conditional `UPDATE`, all inside one Postgres
+transaction — a genuine server-side compare-and-swap, not a client-side
+read-then-write race. **Verdict: CONDITIONALLY SAFE for N>1.** The one
+real risk unique to N>1: an idle sibling instance will legitimately
+re-claim a VTID whose 60-minute claim lease expired because the active
+instance's heartbeats failed for that long, causing double execution —
+acceptable if heartbeats reliably survive transient network hiccups.
+
+**Autoscaling was NOT enabled based on this finding** — reviewing safety
+and acting on it are kept as separate decisions; enabling autoscaling
+changes live production behavior and wasn't asked for.
+
+### Still blocked, unchanged
+
+`vitana-autopilot-cdc`'s `FATAL_ERROR` state itself is untouched — root
+cause diagnosed (full load completed cleanly, 17/18 CDC updates applied,
+one record's UPDATE apply kept failing until the task exhausted 9 recovery
+attempts) but the actual fix (`dms:StartReplicationTask` with
+`resume-processing`, falling back to a clean restart if that hits the
+same record again) is still blocked on the same IAM grant.


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03412` (continuation — same runbook/checklist deliverable, still governance/observability-only)
**Layer:** `INFRA`
**spec_status:** `approved` (VTID-03412 spec already approved; this closes checklist items within its already-approved scope, no new spec needed)

---

## 📋 Summary

While the `dms:StartReplicationTask` IAM grant needed to actually fix the failed `vitana-autopilot-cdc` task is pending, closed out 3 items from the `docs/AWS-CUTOVER-RUNBOOK.md` go/no-go checklist using AWS permissions already available to this session, and surfaced one new gap.

---

## ✅ Changes

- [x] **CloudWatch alarms** for `community-app-awsdr` + `oasis-operator-awsdr` — 8 new alarms, mirroring `gateway-awsdr`'s existing 4-alarm pattern exactly.
- [x] **DMS failure alerting** — new `vitana-dms-task-failure` EventBridge rule (`source: aws.dms` → SNS `vitana-alarms-prod`), since the native `dms:CreateEventSubscription` path is IAM-blocked the same way `StartReplicationTask` is.
- [x] **`worker-runner` N>1 safety review** — read the actual claim mechanism end-to-end (not just the service code): the `claim_vtid_task` RPC does `SELECT ... FOR UPDATE` + conditional `UPDATE` in one transaction — a genuine atomic compare-and-swap. **Verdict: CONDITIONALLY SAFE for N>1**, with one documented lease-expiry edge case. Full citation trail in the runbook + build log addendum.
- [x] `docs/AWS-PRODUCTION-BUILD-LOG.md` addendum recording exact commands + findings.

---

## ⚠️ New finding, not yet resolved

**`vitana-alarms-prod` SNS topic has zero subscribers.** All 47 CloudWatch alarms in the account, plus the new DMS rule, publish to a topic nobody's listening to. `sns:Subscribe`/`sns:AddPermission` are also IAM-blocked for this session. Added as its own checklist item — needs an explicit decision on where alerts should go (email/Slack/PagerDuty), not something to guess at.

---

## ⚠️ Explicitly NOT done

**Autoscaling was not enabled for `worker-runner`** despite the CONDITIONALLY SAFE finding — reviewing safety and acting on it are different decisions, and enabling autoscaling changes live production behavior, which wasn't asked for. `vitana-autopilot-cdc` itself is still `FATAL_ERROR` — that fix remains blocked on the IAM grant.

---

## 🔗 Links

- **VTID:** VTID-03412
- **Related:** VTID-03412 runbook (PR #2930)

---

## 🚨 Breaking Changes

None — new CloudWatch alarms and an EventBridge rule (both currently unwired to any real notification channel per the SNS gap above), plus documentation. No application behavior change, no autoscaling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF)_