### PR TITLE
Tag confusingly-named ALB target groups; flag Terraform ownership (VTID-03412)

### DIFF
--- a/docs/AWS-CUTOVER-RUNBOOK.md
+++ b/docs/AWS-CUTOVER-RUNBOOK.md
@@ -49,7 +49,7 @@ CLI + Cloudflare DNS audit performed under this VTID.
 | Database sync | RDS Aurora `vitana-aurora-prod` via DMS task `vitana-supabase-to-aurora` (full-load-and-cdc): 494/495 tables under live CDC from the same Supabase project GCP prod uses. **One table, `autopilot_recommendations`, has its own dedicated CDC task (`vitana-autopilot-cdc`) which was in `FATAL_ERROR` for ~26h as of this audit** — see §5, tracked/being fixed under this same session outside this VTID's scope. |
 | Secrets | `vitana/supabase/prod/*` (4 secrets) current as of 2026-07-14/21; RDS-managed master credential rotates automatically. |
 | Alarms | 47 `vitana-*` CloudWatch alarms, all `OK`/`INSUFFICIENT_DATA`. `community-app-awsdr` and `oasis-operator-awsdr` now have the same 4-alarm set (cpu-high, memory-high, target-5xx, unhealthy-hosts) gateway-awsdr already had — closed 2026-07-24. A `vitana-dms-task-failure` EventBridge rule (source `aws.dms` → SNS topic `vitana-alarms-prod`) was also added the same day so a future DMS task failure isn't silent for 26+ hours again like `vitana-autopilot-cdc` was. **New gap found while wiring this up: the `vitana-alarms-prod` SNS topic has zero subscribers** — no email, Slack, or PagerDuty endpoint is attached, so none of the 47 alarms or the new DMS rule currently notify anyone. All of this alerting infrastructure is presently inert until a real subscriber is added; this needs a decision on where alerts should actually go. |
-| ALB naming | `vitana-tg-gateway-prod` / `vitana-tg-community-prod` are pre-existing naming leftovers that **actually serve AWS staging traffic**, not prod — confirmed live via `/api/v1/admin/health` returning `env:"staging"` through those target groups. A real cutover must not confuse these with the `-awsdr` target groups. |
+| ALB naming | `vitana-tg-gateway-prod` / `vitana-tg-community-prod` **actually serve AWS staging traffic**, not prod — confirmed live via `/api/v1/admin/health` returning `env:"staging"` through those target groups. Both are `ManagedBy=terraform`-tagged (Terraform state not found in this repo) — not a stray hand-created leftover, part of some external IaC. Tagged 2026-07-24 with `ActualEnvironment=staging` to reduce confusion; not renamed (immutable name, rename requires recreation + ALB rule reattachment, risks a traffic blip). A real cutover must not confuse these with the `-awsdr` target groups. |
 | Legacy/mystery services | ~22 of the 29 (now 31) ECS services in `Vitana-ECS-Cluster` from the 2026-07-09 bulk-provisioning event remain unexplained — flagged, not investigated. Out of scope for cutover unless one turns out to be load-bearing. |
 | Cutover/rollback docs | **Did not exist before this VTID.** No DNS-repoint runbook, no rollback/TTL plan, no GCP decommission checklist. |
 | Governance | **No execution VTID exists yet for a full cutover.** Every AWS VTID this week is scoped to one service's DR build. |
@@ -96,10 +96,21 @@ objective — each item has a clear done/not-done state.
       `oasis-operator-awsdr`** — done 2026-07-24, same 4-alarm pattern as
       `gateway-awsdr` (cpu-high, memory-high, target-5xx, unhealthy-hosts).
       *(Same SNS-subscriber caveat as the DMS alerting item above applies.)*
-- [ ] **ALB naming cleanup done or explicitly waived** — `vitana-tg-gateway-prod`
-      / `vitana-tg-community-prod` renamed to reflect that they serve
-      staging, or the cutover sequence explicitly calls out why the
-      confusion is safe to leave as-is.
+- [~] **ALB naming cleanup done or explicitly waived.** *(Partially
+      mitigated 2026-07-24: both target groups tagged
+      `ActualEnvironment=staging` + a `NamingWarning` explaining they
+      actually serve AWS staging traffic despite the `-prod` name — not
+      renamed, since target group names are immutable in AWS and a
+      rename requires recreating the resource + reattaching the ALB rule,
+      which risks a brief traffic blip and wasn't done without asking
+      first. **New finding:** both are tagged `ManagedBy=terraform`,
+      `Environment=prod`, `Phase=5-compute` — this naming is not a random
+      leftover, it's part of some Terraform-managed stack not present in
+      this repo (no matching `.tf` files found under `infra/` or
+      elsewhere in `vitana-platform`). A proper fix likely needs to go
+      through whatever external IaC actually owns these resources, not
+      hand-editing via aws-cli.)* Full rename or an explicit sign-off that
+      the tag-only mitigation is sufficient still needed before cutover.
 - [ ] **`orb-agent` / autopilot-job AWS-parity decision made** (§4.2) —
       either they get an AWS deploy path before cutover, or an explicit,
       documented decision that they stay GCP-only post-cutover (and what

--- a/docs/AWS-PRODUCTION-BUILD-LOG.md
+++ b/docs/AWS-PRODUCTION-BUILD-LOG.md
@@ -548,3 +548,34 @@ one record's UPDATE apply kept failing until the task exhausted 9 recovery
 attempts) but the actual fix (`dms:StartReplicationTask` with
 `resume-processing`, falling back to a clean restart if that hits the
 same record again) is still blocked on the same IAM grant.
+
+### ALB target-group tagging (same day, follow-up)
+
+Tagged (not renamed) `vitana-tg-gateway-prod` and `vitana-tg-community-prod`
+to reduce the confusion risk flagged in the pre-existing-state section
+above:
+
+```bash
+aws elbv2 add-tags --resource-arns <tg-arn> \
+  --tags Key=ActualEnvironment,Value=staging \
+         Key=NamingWarning,Value="tag-added-2026-07-24-name-says-prod-but-currently-serves-AWS-staging-traffic-verify-via-admin-health-env-field" \
+         Key=Vtid,Value=VTID-03412 \
+  --region eu-central-1
+```
+
+Renaming was deliberately not attempted — target group names are
+immutable in AWS; a real rename means creating a new target group,
+registering the same targets, and swapping the ALB listener rule to
+point at it, which risks a brief traffic blip on a resource actively
+serving staging traffic. Not worth the risk for a naming-only fix
+without asking first.
+
+**New finding while doing this:** `describe-tags` on both target groups
+showed pre-existing tags `ManagedBy=terraform`, `Environment=prod`,
+`Phase=5-compute` — this is not an ad-hoc leftover, it's part of some
+Terraform-managed stack. `find . -iname "*.tf"` across `vitana-platform`
+only turns up `infra/livekit/*.tf` — nothing matching this ALB/target-group
+setup. Whatever Terraform project actually owns this infrastructure is
+not in this repo. A real fix (rename, or understanding why a
+`Environment=prod`-tagged, Terraform-managed target group serves staging
+traffic) should go through that IaC, not further hand-edits via aws-cli.


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03412` (continuation — closing out another go/no-go checklist item within its already-approved scope)
**Layer:** `INFRA`
**spec_status:** `approved`

---

## 📋 Summary

Mitigated (not fully resolved) the "ALB naming cleanup" checklist item from `docs/AWS-CUTOVER-RUNBOOK.md`: tagged the two target groups whose `-prod` name is misleading (they actually serve AWS staging traffic) instead of renaming them.

---

## ✅ Changes

- [x] Tagged `vitana-tg-gateway-prod` and `vitana-tg-community-prod` with `ActualEnvironment=staging` + an explicit naming warning.
- [x] Updated `docs/AWS-CUTOVER-RUNBOOK.md` §1 and §2 checklist to reflect the mitigation.
- [x] `docs/AWS-PRODUCTION-BUILD-LOG.md` addendum with the exact command + reasoning.

---

## ⚠️ New finding

Both target groups carry pre-existing tags `ManagedBy=terraform`, `Environment=prod`, `Phase=5-compute` — this naming isn't a stray leftover, it's part of an external Terraform-managed stack not present in this repo (`find . -iname "*.tf"` only turns up `infra/livekit/*.tf`). A real fix should go through whatever IaC actually owns these resources.

---

## ⚠️ Explicitly NOT done

**No rename.** Target group names are immutable in AWS; a real rename means creating a new resource and reattaching the ALB listener rule, which risks a brief traffic blip on a resource actively serving staging traffic — not something to do without asking first.

---

## 🔗 Links

- **VTID:** VTID-03412
- **Related:** PR #2930 (runbook), PR #2931 (alarms + worker-runner review)

---

## 🚨 Breaking Changes

None — tags only, no routing or resource changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF)_