### PR TITLE
Decouple feature_announcement push tap target from the card's CTA

### DIFF
--- a/services/gateway/src/routes/admin-feature-announcements.ts
+++ b/services/gateway/src/routes/admin-feature-announcements.ts
@@ -22,6 +22,13 @@
  * the notification title wraps the resolved feature name in the gateway's
  * generic `notif.feature_announcement.title` catalog key, the body IS the
  * per-locale description directly (one-off editorial copy, not a catalog key).
+ *
+ * `deep_link` vs. the push's own deep link: `deep_link` is the CARD's own
+ * "Try it yourself" in-app button target (e.g. /home/compose) — it is NOT
+ * reused for the push notification. Tapping the push always lands on
+ * /home (the News Feed, where the card itself is pinned near the top) so
+ * the user sees the card before deciding to act on its CTA, rather than
+ * being skipped straight into the CTA's action.
  */
 
 import { Router, Request, Response } from 'express';
@@ -174,7 +181,12 @@ router.post('/', async (req: AuthenticatedRequest, res: Response) => {
       const payload: NotificationPayload = {
         title: tt('notif.feature_announcement.title', locale, { feature: pickLocale(feature_title, locale) }),
         body: pickLocale(description, locale),
-        data: { url: deep_link, entity_id: announcementId },
+        // Push tap lands on the News Feed (where the card itself lives) —
+        // deliberately NOT `deep_link`, which is the card's own "Try it
+        // yourself" in-app button target (e.g. /home/compose). Tapping the
+        // push should show the card first, not skip straight past it into
+        // whatever action the card's CTA performs.
+        data: { url: '/home', entity_id: announcementId },
       };
       notifyUsersAsync(userIds, tenant_id, 'feature_announcement', payload, supabase);
     }


### PR DESCRIPTION
## Summary

- `POST /api/v1/admin/feature-announcements` was reusing `deep_link` (the card's own "Try it yourself" in-app button target, e.g. `/home/compose`) as the push notification's tap destination too.
- Confirmed via a live single-user test: tapping the push notification skipped straight into the post composer without ever showing the card in the News Feed — the wrong experience for a notification tap, which should show the relevant content first.
- Push `data.url` is now hardcoded to `/home` (the News Feed, where the card is pinned near the top) for both variants. `deep_link` remains exclusively the card's own CTA target, unaffected.

## Test plan

- [x] Confirmed via `Jest` suite (`test/admin-feature-announcements.test.ts`) — no assertions target `data.url`'s value, so no test changes needed; existing auth/validation/fan-out coverage still passes
- [ ] Live re-verification: re-run the single-user test send once deployed, confirm the push notification now lands on the News Feed card instead of the composer

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhBPkg9U1DJyo8ojognubd)_