### PR TITLE
Fix vitana-autopilot-cdc DMS task; close DMS-health checklist item (VTID-03412)

### DIFF
--- a/docs/AWS-CUTOVER-RUNBOOK.md
+++ b/docs/AWS-CUTOVER-RUNBOOK.md
@@ -46,7 +46,7 @@ CLI + Cloudflare DNS audit performed under this VTID.
 | oasis-projector / worker-runner / verification-engine | Bug-fixed + ECS health-checked + alarmed (VTID-03411). Deliberately **not** autoscaled or made public — `oasis-projector`'s ledger writer has no cross-instance locking (CLAUDE.md: "Never run parallel VTID executions"). **`worker-runner` has since been reviewed (2026-07-24) and found CONDITIONALLY SAFE for N>1**: its claim mechanism is a genuine server-side compare-and-swap (`SELECT ... FOR UPDATE` + conditional `UPDATE` inside one Postgres transaction, `claim_vtid_task` RPC in `supabase/migrations/20260413000000_fix_claim_accepts_scheduled.sql`), not a client-side read-then-write race, and no other shared mutable state exists between instances. The one real N>1-specific risk: an idle sibling instance will legitimately re-claim a VTID whose 60-minute claim lease expired due to sustained heartbeat failure on the active instance, causing double execution — condition for safety is that heartbeats reliably survive transient network hiccups; recommend alerting on sustained heartbeat failure before actually enabling autoscaling. Autoscaling itself has **not** been enabled — this is a documentation finding only, pending a decision on whether to act on it. |
 | orb-agent | **No AWS deploy path at all.** Named directly in CLAUDE.md §16 IF-THEN rule 24 alongside worker-runner as something needing prod updates. |
 | autopilot job (Cloud Run Job) | **No AWS deploy path at all.** |
-| Database sync | RDS Aurora `vitana-aurora-prod` via DMS task `vitana-supabase-to-aurora` (full-load-and-cdc): 494/495 tables under live CDC from the same Supabase project GCP prod uses. **One table, `autopilot_recommendations`, has its own dedicated CDC task (`vitana-autopilot-cdc`) which was in `FATAL_ERROR` for ~26h as of this audit** — see §5, tracked/being fixed under this same session outside this VTID's scope. |
+| Database sync | RDS Aurora `vitana-aurora-prod` via DMS task `vitana-supabase-to-aurora` (full-load-and-cdc): 495/495 tables under live CDC from the same Supabase project GCP prod uses. `autopilot_recommendations`'s dedicated CDC task (`vitana-autopilot-cdc`), which was `FATAL_ERROR` for ~26h, was fixed 2026-07-24 via a clean restart — both tasks confirmed `running`. **Note:** the specific update that was stuck at the time of the original failure did not replicate (the fix restarts CDC capture from "now", not from the stale position) — a one-row historical drift, not an ongoing gap. |
 | Secrets | `vitana/supabase/prod/*` (4 secrets) current as of 2026-07-14/21; RDS-managed master credential rotates automatically. |
 | Alarms | 47 `vitana-*` CloudWatch alarms, all `OK`/`INSUFFICIENT_DATA`. `community-app-awsdr` and `oasis-operator-awsdr` now have the same 4-alarm set (cpu-high, memory-high, target-5xx, unhealthy-hosts) gateway-awsdr already had — closed 2026-07-24. A `vitana-dms-task-failure` EventBridge rule (source `aws.dms` → SNS topic `vitana-alarms-prod`) was also added the same day so a future DMS task failure isn't silent for 26+ hours again like `vitana-autopilot-cdc` was. **New gap found while wiring this up: the `vitana-alarms-prod` SNS topic has zero subscribers** — no email, Slack, or PagerDuty endpoint is attached, so none of the 47 alarms or the new DMS rule currently notify anyone. All of this alerting infrastructure is presently inert until a real subscriber is added; this needs a decision on where alerts should actually go. |
 | ALB naming | `vitana-tg-gateway-prod` / `vitana-tg-community-prod` **actually serve AWS staging traffic**, not prod — confirmed live via `/api/v1/admin/health` returning `env:"staging"` through those target groups. Both are `ManagedBy=terraform`-tagged (Terraform state not found in this repo) — not a stray hand-created leftover, part of some external IaC. Tagged 2026-07-24 with `ActualEnvironment=staging` to reduce confusion; not renamed (immutable name, rename requires recreation + ALB rule reattachment, risks a traffic blip). A real cutover must not confuse these with the `-awsdr` target groups. |
@@ -66,10 +66,19 @@ Every item must be checked before an execution VTID for the actual
 cutover can reach `spec_status=approved`. This list is deliberately
 objective — each item has a clear done/not-done state.
 
-- [ ] **DMS replication healthy.** `vitana-autopilot-cdc` (and
-      `vitana-supabase-to-aurora`) both report `status=running` with no
-      failed tasks, verified via `aws dms describe-replication-tasks`,
-      not just "was fixed once."
+- [x] **DMS replication healthy.** Fixed 2026-07-24. `vitana-autopilot-cdc`
+      was stuck `FATAL_ERROR`; `resume-processing` from its stale checkpoint
+      hit a *different* failure (`An internal WAL conversational protocol
+      error`, likely from the 2-day-old checkpoint's LSN position no
+      longer being valid on the source), so a clean restart
+      (`start-replication-task-type=start-replication`) was used instead —
+      accepts losing the one historical row's update in exchange for
+      restored currency. Confirmed stable `running` for 5+ minutes
+      post-restart with zero new failure events, both `vitana-autopilot-cdc`
+      and `vitana-supabase-to-aurora` `running`. This checklist item is
+      about *current* health, not a point-in-time fix — re-verify via
+      `aws dms describe-replication-tasks` before actually cutting over,
+      don't assume this stays true.
 - [~] **DMS alerting exists.** *(Partially done 2026-07-24: EventBridge
       rule `vitana-dms-task-failure` created, source `aws.dms` → SNS
       topic `vitana-alarms-prod`. Still NOT actually alerting anyone —

--- a/docs/AWS-PRODUCTION-BUILD-LOG.md
+++ b/docs/AWS-PRODUCTION-BUILD-LOG.md
@@ -579,3 +579,55 @@ setup. Whatever Terraform project actually owns this infrastructure is
 not in this repo. A real fix (rename, or understanding why a
 `Environment=prod`-tagged, Terraform-managed target group serves staging
 traffic) should go through that IaC, not further hand-edits via aws-cli.
+
+### `vitana-autopilot-cdc` DMS task fixed (same day, after IAM grant)
+
+The user attached a scoped temporary inline policy
+(`vitana-dms-autopilot-fix-temp`, `dms:StartReplicationTask`/
+`StopReplicationTask` on the specific task ARN only) to
+`claude-staging-validation`, unblocking the fix diagnosed earlier the
+same day (§ above, "Root cause diagnosed").
+
+```bash
+aws dms start-replication-task \
+  --replication-task-arn arn:aws:dms:eu-central-1:472838866351:task:PASTVC7U6BBWJPD4YFTFDRLNCU \
+  --start-replication-task-type resume-processing --region eu-central-1
+```
+
+`resume-processing` reached `running` briefly (~60s) then failed again —
+**a different error than before**: `An internal WAL conversational
+protocol error has occurred`, not the original "Postgres apply or data
+error." Given the task's `RecoveryCheckpoint` dated back to 2026-07-22
+(the task had been dead ~2 days) and this same task had a prior "Slot
+does not exist" failure in its history (see the original diagnosis
+above), the working theory is the checkpoint's LSN position was no
+longer valid against the source's current replication slot state.
+
+Fell back to the documented plan: a clean restart, accepting loss of the
+one specific historical row update in exchange for restored currency.
+
+```bash
+aws dms start-replication-task \
+  --replication-task-arn arn:aws:dms:eu-central-1:472838866351:task:PASTVC7U6BBWJPD4YFTFDRLNCU \
+  --start-replication-task-type start-replication --region eu-central-1
+```
+
+Confirmed stable: `status=running`, zero new failure events, for 5+
+minutes post-restart (`aws dms describe-events --start-time
+<restart-timestamp>` returning only the "started" state-change event, no
+"failed" events). `aws dms describe-table-statistics` showed a fresh
+full-load pass completing cleanly (`TableState: Table completed`) as
+part of the restart. Both `vitana-autopilot-cdc` and
+`vitana-supabase-to-aurora` confirmed `running` with `LastFailureMessage:
+null`.
+
+**Residual gap, accepted not fixed:** the specific UPDATE that was stuck
+at the time of the original 2026-07-22 failure never replicated — CDC
+capture restarted from "now," not from the old position. This is a
+one-row historical drift on a DR replica, not an ongoing sync gap.
+
+Attempted to self-remove `vitana-dms-autopilot-fix-temp` after the fix
+(`iam:DeleteUserPolicy`) — blocked, same as the earlier
+`vitana-awsdr-oidc-setup-temp` self-revoke attempt. Both temporary
+policies are still attached to `claude-staging-validation` pending
+manual removal by an operator with IAM write access.


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03412` (continuation — closing the last open go/no-go checklist item this session can close alone)
**Layer:** `INFRA`
**spec_status:** `approved`

---

## 📋 Summary

Fixes the `vitana-autopilot-cdc` DMS replication task that had been `FATAL_ERROR` since 2026-07-22 (root cause diagnosed in an earlier commit under this same VTID), now unblocked by a scoped temporary IAM grant.

---

## ✅ Changes

- [x] `resume-processing` attempted first (least data loss) — hit a *different* failure than the original one (WAL protocol error, likely a stale checkpoint LSN after ~2 days down).
- [x] Fell back to a clean restart (`start-replication`) per the documented plan — confirmed `running` for 5+ minutes with zero new failures.
- [x] `docs/AWS-CUTOVER-RUNBOOK.md` — closed the "DMS replication healthy" checklist item, updated the current-state table.
- [x] `docs/AWS-PRODUCTION-BUILD-LOG.md` addendum with exact commands + reasoning.

---

## ⚠️ Residual gap, accepted not fixed

The specific UPDATE that was stuck at the time of the original failure never replicated — a one-row historical drift on a DR replica, not an ongoing gap. Both tasks are current going forward.

---

## ⚠️ Explicitly NOT done

Could not self-remove the temporary IAM policy (`vitana-dms-autopilot-fix-temp`) after the fix — `iam:DeleteUserPolicy` is blocked, same as the earlier OIDC-setup temp policy. Both remain attached to `claude-staging-validation` pending manual cleanup.

---

## 🔗 Links

- **VTID:** VTID-03412
- **Related:** PR #2930 (runbook), #2931 (alarms + worker-runner review), #2932 (ALB tagging)

---

## 🚨 Breaking Changes

None — fixes a broken DR-replica data pipeline, no application code or infra topology change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF)_