### PR TITLE
fix(voice): surface Nova eventstream exceptions + probe diagnostics + VAD config (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/.github/workflows/AWS-STAGE-DEPLOY-GATEWAY.yml
+++ b/.github/workflows/AWS-STAGE-DEPLOY-GATEWAY.yml
@@ -43,6 +43,21 @@ on:
         description: 'Public gateway URL for post-deploy verification'
         required: false
         default: 'https://preview-aws-gateway.vitanaland.com'
+      # BOOTSTRAP-NOVA-SONIC-VOICE: per-dispatch canary overrides. Empty =
+      # fall back to the AWS_STAGE_NOVA_SONIC_* repository variables, so the
+      # push-triggered deploys keep reading the durable vars config.
+      nova_sonic_enabled:
+        description: 'Override NOVA_SONIC_ENABLED for this deploy (true/false; empty = use repo var)'
+        required: false
+        default: ''
+      nova_canary_user_ids:
+        description: 'Override Nova canary user UUID allowlist (comma-separated; empty = use repo var)'
+        required: false
+        default: ''
+      nova_canary_tenant_ids:
+        description: 'Override Nova canary tenant UUID allowlist (comma-separated; empty = use repo var)'
+        required: false
+        default: ''
       aws_region:
         description: 'AWS region'
         required: false
@@ -145,9 +160,9 @@ jobs:
           # is secret; credentials are the ECS task role). Defaults keep Nova
           # disabled with an empty canary. Model + region are FIXED here, not
           # variables — changing them is a code decision, not a knob.
-          NOVA_SONIC_ENABLED: ${{ vars.AWS_STAGE_NOVA_SONIC_ENABLED || 'false' }}
-          NOVA_SONIC_CANARY_USER_IDS: ${{ vars.AWS_STAGE_NOVA_SONIC_CANARY_USER_IDS || '' }}
-          NOVA_SONIC_CANARY_TENANT_IDS: ${{ vars.AWS_STAGE_NOVA_SONIC_CANARY_TENANT_IDS || '' }}
+          NOVA_SONIC_ENABLED: ${{ inputs.nova_sonic_enabled || vars.AWS_STAGE_NOVA_SONIC_ENABLED || 'false' }}
+          NOVA_SONIC_CANARY_USER_IDS: ${{ inputs.nova_canary_user_ids || vars.AWS_STAGE_NOVA_SONIC_CANARY_USER_IDS || '' }}
+          NOVA_SONIC_CANARY_TENANT_IDS: ${{ inputs.nova_canary_tenant_ids || vars.AWS_STAGE_NOVA_SONIC_CANARY_TENANT_IDS || '' }}
         run: |
           set -e
           IMAGE="${{ steps.build.outputs.image }}"

--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -432,7 +432,21 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       for await (const item of body) {
         if (this.state !== 'open' && this.state !== 'closing') break;
         const bytes = item?.chunk?.bytes;
-        if (!bytes) continue;
+        if (!bytes) {
+          // Bedrock delivers service errors as NAMED eventstream union
+          // members (validationException, modelStreamErrorException, …) —
+          // never let one pass silently or the session dies with no trace.
+          const exceptionMember = Object.keys(item ?? {}).find((k) =>
+            /exception/i.test(k));
+          if (exceptionMember) {
+            const code = classifyNovaError({ name: exceptionMember.replace(/^./, (c) => c.toUpperCase()) });
+            this.state = 'error';
+            this.emitError({ code, message: `Nova stream exception event (${code}: ${exceptionMember})` });
+            this.finalizeClose({ initiatedLocally: false, reason: code });
+            return;
+          }
+          continue;
+        }
         let decoded: unknown;
         try {
           decoded = JSON.parse(new TextDecoder().decode(bytes));

--- a/services/gateway/src/orb/live/upstream/nova-sonic-protocol.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-protocol.ts
@@ -26,6 +26,8 @@ export interface NovaSessionStartOptions {
   maxTokens?: number;
   topP?: number;
   temperature?: number;
+  /** Server-side VAD sensitivity; AWS-recommended default MEDIUM. */
+  endpointingSensitivity?: 'HIGH' | 'MEDIUM' | 'LOW';
 }
 
 export function buildSessionStart(options: NovaSessionStartOptions = {}): NovaInputEvent {
@@ -36,6 +38,11 @@ export function buildSessionStart(options: NovaSessionStartOptions = {}): NovaIn
           maxTokens: options.maxTokens ?? 1024,
           topP: options.topP ?? 0.9,
           temperature: options.temperature ?? 0.7,
+        },
+        // Documented server-side VAD sensitivity (Nova 2 Sonic input-events
+        // reference); MEDIUM is AWS's recommended conversational default.
+        turnDetectionConfiguration: {
+          endpointingSensitivity: options.endpointingSensitivity ?? 'MEDIUM',
         },
       },
     },

--- a/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
@@ -122,6 +122,9 @@ interface LiveProbeResult {
  * text turn, and measure connect / first-event / first-audio latency. Used
  * identically for Nova and the Vertex baseline so the comparison is fair.
  */
+/** 32ms of 16 kHz / 16-bit / mono PCM silence, base64 — one mic frame. */
+const SILENCE_FRAME_B64 = Buffer.alloc(1024).toString('base64');
+
 async function probeLiveClient(
   client: UpstreamLiveClient,
   connect: () => Promise<void>,
@@ -132,35 +135,55 @@ async function probeLiveClient(
   let connectMs = -1;
   let firstEventMs = -1;
   let firstAudioMs = -1;
+  let transcriptCount = 0;
+  let audioCount = 0;
+  const errorCodes: string[] = [];
+  let upstreamCloseReason: string | undefined;
 
+  let settled = false;
   const done = new Promise<void>((resolve) => {
-    let settled = false;
     const finish = () => { if (!settled) { settled = true; resolve(); } };
     const timer = setTimeout(finish, PROBE_TIMEOUT_MS);
     (timer as NodeJS.Timeout).unref?.();
     client.onTranscript(() => {
+      transcriptCount++;
       if (firstEventMs < 0) firstEventMs = Date.now() - t0;
     });
     client.onAudioOutput(() => {
+      audioCount++;
       if (firstAudioMs < 0) firstAudioMs = Date.now() - t0;
       if (firstEventMs < 0) firstEventMs = Date.now() - t0;
     });
     client.onTurnComplete(() => { clearTimeout(timer); finish(); });
-    client.onError(() => { clearTimeout(timer); finish(); });
-    client.onClose(() => { clearTimeout(timer); finish(); });
+    client.onError((e) => { errorCodes.push(e.code); clearTimeout(timer); finish(); });
+    client.onClose((e) => { upstreamCloseReason = e.reason; clearTimeout(timer); finish(); });
   });
 
   try {
     await connect();
     connectMs = Date.now() - t0;
     client.sendTextTurn('Say OK.');
+    // Stream mic-cadence silence alongside the text turn — production
+    // sessions always have the audio pipe flowing, and Nova's server-side
+    // turn detection expects it. 32ms frames, real-time pace.
+    const silenceTimer = setInterval(() => {
+      if (settled || client.getState() !== 'open') { clearInterval(silenceTimer); return; }
+      client.sendAudioChunk(SILENCE_FRAME_B64);
+    }, 32);
+    (silenceTimer as NodeJS.Timeout).unref?.();
     await done;
+    clearInterval(silenceTimer);
     await client.close(closeReason);
     if (firstEventMs < 0) {
-      return {
-        ok: false,
-        failDetail: `stream opened (connect_ms=${connectMs}) but no model response within ${PROBE_TIMEOUT_MS / 1000}s`,
-      };
+      const elapsed = Date.now() - t0;
+      const diag = [
+        `connect_ms=${connectMs}`,
+        `waited_ms=${elapsed - connectMs}`,
+        errorCodes.length ? `errors=${errorCodes.join('|')}` : 'errors=none',
+        `close_reason=${upstreamCloseReason ?? 'n/a'}`,
+        `transcripts=${transcriptCount} audio_chunks=${audioCount}`,
+      ].join(' ');
+      return { ok: false, failDetail: `stream opened but no model response — ${diag}` };
     }
     return {
       ok: true,

--- a/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
@@ -37,7 +37,11 @@ class FakeResponseBody implements AsyncIterable<{ chunk?: { bytes?: Uint8Array }
   private done = false;
 
   feed(event: Record<string, unknown>): void {
-    const item = { chunk: { bytes: new TextEncoder().encode(JSON.stringify(event)) } };
+    this.feedRaw({ chunk: { bytes: new TextEncoder().encode(JSON.stringify(event)) } });
+  }
+
+  /** Push a raw stream item (e.g. a named exception union member). */
+  feedRaw(item: { chunk?: { bytes?: Uint8Array } }): void {
     const w = this.waiting.shift();
     if (w) w({ value: item, done: false });
     else this.buffer.push(item);
@@ -376,6 +380,24 @@ describe('shared Bedrock client (latency: HTTP/2 session reuse)', () => {
     await client.connect(baseOptions());
     await client.close('done');
     expect(owned.destroy).toHaveBeenCalled();
+  });
+});
+
+describe('named eventstream exception members', () => {
+  it('a validationException union member becomes a typed error, never a silent skip', async () => {
+    const { client, body } = makeClient();
+    const errors: string[] = [];
+    const closes: Array<string | undefined> = [];
+    client.onError((e) => errors.push(e.code));
+    client.onClose((e) => closes.push(e.reason));
+    await client.connect(baseOptions());
+
+    body.feedRaw({ validationException: { message: 'raw AWS text that must not leak' } } as any);
+    await flush();
+
+    expect(errors).toContain('nova_validation');
+    expect(closes).toEqual(['nova_validation']);
+    expect(client.getState()).toBe('closed');
   });
 });
 

--- a/services/gateway/test/orb/live/upstream/nova-sonic-protocol.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-protocol.test.ts
@@ -19,14 +19,19 @@ import {
 } from '../../../../src/orb/live/upstream/nova-sonic-protocol';
 
 describe('input event builders — exact envelopes', () => {
-  it('sessionStart carries inference configuration', () => {
+  it('sessionStart carries inference + turn-detection configuration', () => {
     expect(buildSessionStart({ maxTokens: 2048, topP: 0.8, temperature: 0.5 })).toEqual({
       event: {
         sessionStart: {
           inferenceConfiguration: { maxTokens: 2048, topP: 0.8, temperature: 0.5 },
+          turnDetectionConfiguration: { endpointingSensitivity: 'MEDIUM' },
         },
       },
     });
+    expect(
+      (buildSessionStart({ endpointingSensitivity: 'LOW' }).event.sessionStart as Record<string, any>)
+        .turnDetectionConfiguration.endpointingSensitivity,
+    ).toBe('LOW');
   });
 
   it('promptStart configures 24kHz LPCM output + tools', () => {


### PR DESCRIPTION
## Why

The first live Nova canary probe on AWS staging **opened the Bedrock bidirectional stream successfully** (`connect_ms=157` — the task role already has Bedrock access) but got no model response within 20s, and the probe couldn't say why. Three gaps made the failure undiagnosable; this fixes all three per the [Nova 2 Sonic input-events reference](https://docs.aws.amazon.com/nova/latest/nova2-userguide/sonic-input-events.html).

## What

1. **Silent eventstream exceptions** — the response loop treated any stream item without `chunk.bytes` as skippable, but Bedrock delivers service rejections as **named union members** (`validationException`, `modelStreamErrorException`, …). A protocol rejection therefore vanished with no trace. They now route through `classifyNovaError` into a typed error + typed close (raw AWS text never leaks). New client test covers it.
2. **Missing turn-detection config** — `sessionStart` now carries the documented `turnDetectionConfiguration.endpointingSensitivity` (MEDIUM, AWS's recommended conversational default).
3. **Unrealistic probe** — the live probe streamed no audio at all; production sessions always have the mic pipe flowing and Nova's server-side VAD expects it. The probe now streams 32ms frames of 16 kHz silence at mic cadence alongside the cross-modal text turn, and on failure reports full typed diagnostics: error codes seen, upstream close reason, wait time, transcript/audio event counts.

## Testing

- Full gateway suite green locally: 485 suites / 8,527 tests.
- New: named-exception-member → typed error test; sessionStart envelope test updated for the turn-detection block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_