### PR TITLE
fix(gateway): allow AWS production DR origins in CORS allowlist

### DIFF
--- a/services/gateway/src/middleware/cors.ts
+++ b/services/gateway/src/middleware/cors.ts
@@ -29,6 +29,13 @@ const ALLOWED_ORIGINS = [
   // above for the GCP staging domains).
   "https://preview-aws.vitanaland.com",                        // AWS staging frontend
   "https://preview-aws-gateway.vitanaland.com",                // AWS staging gateway (Command Hub)
+  // VTID-03398: AWS production (DR) stack. Same reasoning as the AWS
+  // staging entries above — without these, the cors callback errors and
+  // Express answers with an HTML 500 instead of a JSON response, which
+  // breaks login (this exact failure mode already happened twice before:
+  // GCP staging, then AWS staging).
+  "https://dr-app.vitanaland.com",                             // AWS production DR frontend (community-app-awsdr)
+  "https://dr-gateway.vitanaland.com",                         // AWS production DR gateway (Command Hub same-origin POSTs)
 ];
 
 // VTID-01226: Dynamic origin patterns for Lovable-hosted frontends


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03398` (AWS Production DR — Gateway)

**Layer:** INFRA / CICDL

**Priority:** P0 — blocks any real browser traffic against the AWS DR stack, and per `docs/AWS-CUTOVER-RUNBOOK.md` this is directly on the path to Monday's planned cutover.

---

## 📋 Summary

`dr-app.vitanaland.com` and `dr-gateway.vitanaland.com` (the AWS production DR frontend/gateway pair) were missing from the gateway's CORS `ALLOWED_ORIGINS`. Any authenticated browser request from either origin crashes the `cors` callback into an unhandled Express 500 (`text/html`, not JSON) instead of a clean response — confirmed live: `curl` with `Authorization: Bearer <valid-token>` and `Origin: https://dr-app.vitanaland.com` against `https://dr-gateway.vitanaland.com/api/v1/auth/me` returns `500 Internal Server Error`; the same call with no `Origin` header returns `200` with the full identity payload.

This is the exact same failure mode already hit twice before (GCP staging, then AWS staging) — both are already documented inline in `cors.ts` right above this fix, with the identical root cause: "without these entries the cors callback errors and Express answers with an HTML 500, which broke login."

## ✅ Changes

- [x] Added `https://dr-app.vitanaland.com` and `https://dr-gateway.vitanaland.com` to `ALLOWED_ORIGINS` in `services/gateway/src/middleware/cors.ts`

## 🧪 Testing

- [x] `npx tsc --noEmit` clean (after a fresh `npm ci` — pre-existing unrelated `@aws-sdk/client-bedrock-runtime` type errors were a stale-`node_modules` artifact, not caused by this change)
- [x] Reproduced the bug live pre-fix (500 with a valid token + the DR origin) — will re-verify post-deploy that the same call returns 200

## 🚨 Breaking Changes

None — purely additive to an allowlist.

## 📌 Additional Notes

Once merged, this needs a manual dispatch of `AWS-PROD-DEPLOY-GATEWAY.yml` (workflow_dispatch-only by design, per CLAUDE.md §1b) to actually roll out to the live `vitana-gateway-awsdr` ECS service — merging to `main` alone will not fix production DR, only AWS staging (auto-deploy) and GCP (staging-first, per §16).


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_