### PR TITLE
feat(ci): add AWS-PROD-DEPLOY-ORB-AGENT.yml deploy pipeline

### DIFF
--- a/.github/workflows/AWS-PROD-DEPLOY-ORB-AGENT.yml
+++ b/.github/workflows/AWS-PROD-DEPLOY-ORB-AGENT.yml
@@ -1,0 +1,148 @@
+# AWS-PROD-DEPLOY-ORB-AGENT — build orb-agent, push to ECR, and roll the
+# AWS ECS service (VTID-03414, full-parity pass ahead of the GCP->AWS
+# cutover).
+#
+# orb-agent is the LiveKit voice worker (standby alternative to the
+# Vertex Live pipeline, services/gateway/src/routes/orb-live.ts). It
+# connects OUTBOUND to LiveKit Cloud and exposes only a health/readiness
+# probe on $PORT — like worker-runner/oasis-projector, it has NO public
+# ALB/DNS endpoint. Verification relies on the ECS-level container
+# healthCheck (added under this same VTID, hits GET /alive internally)
+# and `aws ecs wait services-stable`.
+#
+# The ECS service + task definition (family `vitana-orb-agent`, already
+# wired to the correct prod secrets: LiveKit creds, Supabase prod,
+# Aurora) predate this workflow — they were part of the unexplained
+# 2026-07-09 bulk-provisioning event, not this week's deliberate AWS-DR
+# builds. This workflow is the missing piece: an actual deploy pipeline,
+# so the running service doesn't silently drift from `main` the way the
+# runbook's "Legacy/mystery services" section warned about.
+#
+# workflow_dispatch ONLY, required `reason`, never on push.
+
+name: AWS Prod Deploy Orb Agent (ECS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for this AWS orb-agent deploy — required'
+        required: true
+      aws_region:
+        description: 'AWS region'
+        required: false
+        default: 'eu-central-1'
+      ecr_repository:
+        description: 'ECR repository name'
+        required: false
+        default: 'vitana/orb-agent'
+      ecs_cluster:
+        description: 'ECS cluster name'
+        required: false
+        default: 'Vitana-ECS-Cluster'
+      ecs_service:
+        description: 'ECS service name'
+        required: false
+        default: 'vitana-orb-agent'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: aws-prod-deploy-orb-agent
+  cancel-in-progress: false
+
+jobs:
+  build-push-deploy:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_AWS_REGION: ${{ inputs.aws_region }}
+      ECR_REPOSITORY: ${{ inputs.ecr_repository }}
+      ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+      ECS_SERVICE: ${{ inputs.ecs_service }}
+      DEPLOY_REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve commit metadata
+        id: commit
+        run: echo "short=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (GitHub OIDC — no static keys)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_ARN }}
+          aws-region: ${{ env.TARGET_AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Preflight
+        run: |
+          set -e
+          if ! aws ecr describe-repositories --repository-names "${{ env.ECR_REPOSITORY }}" >/dev/null 2>&1; then
+            echo "::error::ECR repository '${{ env.ECR_REPOSITORY }}' not found."
+            exit 1
+          fi
+          if ! aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+               --query 'services[0].status' --output text 2>/dev/null | grep -q ACTIVE; then
+            echo "::error::ECS service '${{ env.ECS_SERVICE }}' not ACTIVE."
+            exit 1
+          fi
+
+      - name: Build and push image
+        id: build
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -e
+          IMAGE="$REGISTRY/${{ env.ECR_REPOSITORY }}:${{ steps.commit.outputs.short }}"
+          docker build -t "$IMAGE" -t "$REGISTRY/${{ env.ECR_REPOSITORY }}:latest" services/agents/orb-agent
+          docker push "$IMAGE"
+          docker push "$REGISTRY/${{ env.ECR_REPOSITORY }}:latest"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Register task-definition revision + roll the service
+        run: |
+          set -e
+          IMAGE="${{ steps.build.outputs.image }}"
+          TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' --output text)
+          NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
+            | jq --arg IMG "$IMAGE" '
+                .containerDefinitions[0].image = $IMG
+                | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                      .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "Registered $NEW_ARN"
+          aws ecs update-service --cluster "${{ env.ECS_CLUSTER }}" --service "${{ env.ECS_SERVICE }}" --task-definition "$NEW_ARN" >/dev/null
+          aws ecs wait services-stable --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}"
+          echo "Service stable on $NEW_ARN"
+
+      - name: Verify — task health (no public endpoint to curl; internal-only service)
+        run: |
+          set -e
+          for i in 1 2 3 4 5 6; do
+            TASK_ARN=$(aws ecs list-tasks --cluster "${{ env.ECS_CLUSTER }}" --service-name "${{ env.ECS_SERVICE }}" --query "taskArns[0]" --output text)
+            HEALTH=$(aws ecs describe-tasks --cluster "${{ env.ECS_CLUSTER }}" --tasks "$TASK_ARN" --query "tasks[0].healthStatus" --output text)
+            if [ "$HEALTH" = "HEALTHY" ]; then
+              echo "✓ Task healthy (container healthCheck hit /alive)"
+              exit 0
+            fi
+            echo "Attempt $i: healthStatus='$HEALTH' — retry in 15s"
+            sleep 15
+          done
+          echo "::error::Task did not report HEALTHY after deploy"
+          exit 1
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## orb-agent deploy"
+            echo "- Image: \`${{ steps.build.outputs.image }}\`"
+            echo "- Reason: ${{ env.DEPLOY_REASON }}"
+            echo "- VTID: VTID-03414"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03414` (AWS Production (DR) — orb-agent)

**Layer:** INFRA / CICDL

**Priority:** P1 — closes a real gap ahead of the planned Monday GCP→AWS cutover.

---

## 📋 Summary

`orb-agent`'s ECS service/task-definition already existed in AWS (from the unexplained 2026-07-09 bulk-provisioning event — correctly wired to prod LiveKit/Supabase/Aurora secrets, `ACTIVE` and steady-state), but had **no deploy pipeline**, **no ECS-level health check**, and **no CloudWatch alarms** — exactly the "silent drift" risk `docs/AWS-CUTOVER-RUNBOOK.md`'s "Legacy/mystery services" section flagged.

This PR adds the missing deploy workflow, mirroring `AWS-PROD-DEPLOY-WORKER-RUNNER.yml` (VTID-03411) — same no-public-ALB pattern (orb-agent connects *outbound* to LiveKit Cloud and only exposes a health probe, so verification is via ECS task `healthStatus`, not an HTTP smoke test).

## ✅ Changes

- [x] Added `.github/workflows/AWS-PROD-DEPLOY-ORB-AGENT.yml` (workflow_dispatch-only, required `reason`, never on push)

## Also done directly via aws-cli under this VTID (not in this diff, infra-only)

- Added an ECS-level container `healthCheck` to `vitana-orb-agent` (python3 `urllib` against `/alive`, since the `python:3.11-slim` base has no `wget`) — rolled out and verified stable (task-def rev 8→9).
- Added 3 CloudWatch alarms (`cpu-high`, `memory-high`, `running-count-low`), same thresholds/pattern as the other no-ALB services, pointed at `vitana-alarms-prod` (which now has a confirmed subscriber).
- Extended `vitana-gateway-awsdr-deploy-role`'s inline policy to cover `vitana/orb-agent` and `vitana/autopilot-executor` ECR repos (the latter for the VTID-03415 follow-up), plus `ecs:RunTask` for the same follow-up.

## 🧪 Testing

- [x] ECS-level health check verified live — task reports `healthStatus: HEALTHY` post-rollout.
- [ ] Will dispatch this workflow once merged and confirm a full build→push→register→roll cycle succeeds end-to-end.

## 🚨 Breaking Changes

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_