### PR TITLE
fix(voice): AI Studio transport needs no GCP identity for the default setup envelope (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/gemini-api-key-live-client.ts
@@ -228,9 +228,17 @@ export class GeminiApiKeyLiveClient implements UpstreamLiveClient {
 
       ws.on('open', async () => {
         try {
+          // The Vertex-shaped model path buildSetupMessage composes from
+          // projectId/location is discarded below (setup.model is overridden
+          // to the AI Studio catalog id), so satisfy its fail-loud guard with
+          // placeholders instead of requiring GCP identity on this transport.
           const envelope = options.customSetupMessage
             ? await Promise.resolve(options.customSetupMessage())
-            : buildSetupMessage(options);
+            : buildSetupMessage({
+                ...options,
+                projectId: options.projectId ?? 'ai-studio',
+                location: options.location ?? 'global',
+              });
           // Always override to AI Studio's own model catalog — the
           // envelope's model field is Vertex-shaped and Vertex's Live
           // model is not reachable through this endpoint (see file header).

--- a/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/gemini-api-key-live-client.test.ts
@@ -138,6 +138,18 @@ describe('BOOTSTRAP-AWS-STAGING-VALIDATION: GeminiApiKeyLiveClient', () => {
       expect(sentSetup.setup.generation_config.response_modalities).toEqual(['AUDIO']);
     });
 
+    it('default builder works WITHOUT GCP projectId/location — AI Studio needs no GCP identity', async () => {
+      const socket = new MockSocket();
+      const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });
+      await connectClient(client, socket, baseOptions({ projectId: undefined, location: undefined }));
+
+      expect(client.getState()).toBe('open');
+      const sentSetup = JSON.parse(socket.sent[0]);
+      // The Vertex-shaped path from placeholders is discarded — the AI Studio
+      // catalog id must be what actually goes on the wire.
+      expect(sentSetup.setup.model).toBe('models/gemini-2.5-flash-native-audio-latest');
+    });
+
     it('overrides the model from a customSetupMessage override too', async () => {
       const socket = new MockSocket();
       const client = new GeminiApiKeyLiveClient({ createSocket: () => socket });


### PR DESCRIPTION
## Why

With the Nova canary live on AWS staging, the Test Bench's **Nova live probe now passes** (`connect_ms=290 first_event_ms=798 first_audio_ms=910`) — but the **Vertex baseline probe** failed with `vertex_config_missing`, blocking the Nova-vs-Vertex latency comparison.

## Root cause

`GeminiApiKeyLiveClient` (the AI Studio transport AWS staging uses for Vertex-class sessions) builds its default setup envelope via the shared `buildSetupMessage()`, whose fail-loud guard — added in the provider-neutral credential migration — requires `projectId`/`location` to compose the Vertex model path. This transport discards that path immediately (`setup.model` is overridden to the AI Studio catalog id), so the guard rejected a request that never needed GCP identity.

## What

One call site: satisfy the guard with placeholder `projectId`/`location` in the API-key client's default-envelope path (with a comment explaining why that's sound). Real ORB Vertex sessions are unaffected — orb-live.ts always supplies `customSetupMessage`, which bypasses the default builder entirely.

## Testing

- New test: default builder connects **without** projectId/location and the AI Studio catalog model is what goes on the wire.
- Full gateway suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_