### PR TITLE
fix(ci): use describe-task-definition in autopilot-executor preflight

### DIFF
--- a/.github/workflows/AWS-PROD-DEPLOY-AUTOPILOT-EXECUTOR.yml
+++ b/.github/workflows/AWS-PROD-DEPLOY-AUTOPILOT-EXECUTOR.yml
@@ -83,8 +83,8 @@ jobs:
             echo "::error::ECR repository '${{ env.ECR_REPOSITORY }}' not found."
             exit 1
           fi
-          if ! aws ecs list-task-definitions --family-prefix "${{ env.TASK_FAMILY }}" \
-               --query 'taskDefinitionArns[0]' --output text 2>/dev/null | grep -q "${{ env.TASK_FAMILY }}"; then
+          if ! aws ecs describe-task-definition --task-definition "${{ env.TASK_FAMILY }}" \
+               --query 'taskDefinition.taskDefinitionArn' --output text; then
             echo "::error::Task definition family '${{ env.TASK_FAMILY }}' not found."
             exit 1
           fi


### PR DESCRIPTION
## Summary

First real dispatch of `AWS-PROD-DEPLOY-AUTOPILOT-EXECUTOR.yml` (VTID-03415) failed at Preflight with a misleading `"Task definition family 'vitana-autopilot-executor' not found"`, even though the family definitely exists (registered revisions 1-4 earlier this session). Root cause: the check called `aws ecs list-task-definitions`, which needs `ecs:ListTaskDefinitions` — a permission `vitana-gateway-awsdr-deploy-role` doesn't have — and piped stderr to `/dev/null`, silently swallowing the resulting `AccessDenied` instead of surfacing it.

## Fix

Switch the check to `aws ecs describe-task-definition`, which needs only `ecs:DescribeTaskDefinition` (already granted), and is exactly what the later "Register new task-definition revision" step already uses successfully. Also drops the `2>/dev/null` so any future real failure is visible instead of masked.

## Testing

- [x] Will re-dispatch this workflow once merged and confirm Preflight passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9cc493QxtVQ3p2xAKCkqM)_