### PR TITLE
fix(ci): capture psql stderr in welcome-greeting trigger health checks

### DIFF
--- a/.github/workflows/MORNING-SYSTEM-HEALTH-CHECK.yml
+++ b/.github/workflows/MORNING-SYSTEM-HEALTH-CHECK.yml
@@ -141,7 +141,7 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           set +e
-          OUT=$(psql "$SUPABASE_DB_URL" -t -A <<'EOF'
+          OUT=$(psql "$SUPABASE_DB_URL" -t -A <<'EOF' 2>&1
           SELECT
             CASE
               WHEN NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'welcome_chat_on_primary_membership')
@@ -162,7 +162,7 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           set +e
-          OUT=$(psql "$SUPABASE_DB_URL" -t -A -F '|' <<'EOF'
+          OUT=$(psql "$SUPABASE_DB_URL" -t -A -F '|' <<'EOF' 2>&1
           WITH w AS (SELECT now() - interval '24 hours' AS since)
           SELECT
             (SELECT COUNT(*) FROM public.app_users WHERE created_at >= (SELECT since FROM w) AND user_id <> '00000000-0000-0000-0000-000000000001'::uuid),


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-MORNING-HEALTH-STDERR` _(no VTID exists for this yet — small diagnostic fix, tracked under a BOOTSTRAP tag per existing repo convention, e.g. BOOTSTRAP-DAILY-FEATURE-TIP)_

**Layer:** CICDL

**Priority:** P3

---

## 📋 Summary

Triggered by this morning's Morning Health Check report showing 6/15 checks FAILED. Investigation (full job-log review across `MORNING-SYSTEM-HEALTH-CHECK.yml`, `CRON-AUTO-PROMOTER.yml`, `CRON-GRADUATION-RECOMMENDER.yml`, `ALERT-WELCOME-GREETING-HEALTH.yml`) found **two independent, unrelated root causes**, both requiring action outside this repo — plus one small, genuinely code-fixable bug, which is what this PR addresses.

**Root causes (not fixed by this PR — need a human with the right access):**
1. **Supabase pooler IP allowlist** (checks 5, 6, 7, 8, 9 + `ALERT-WELCOME-GREETING-HEALTH.yml`): the Supavisor pooler (port 6543) rejects connections whose source IP isn't in the project's `allow_list`. Confirmed from live job logs that GitHub-hosted runner egress IPs vary *even within a single job*, so a fixed-IP allowlist entry can't reliably fix this. Needs a human to relax/disable the Supabase Dashboard network restriction, or migrate these checks off direct `psql` onto the PostgREST HTTPS API.
2. **GCP Secret Manager IAM gap** (`CRON-AUTO-PROMOTER.yml`, `CRON-GRADUATION-RECOMMENDER.yml`): the WIF service account lacks `secretmanager.versions.access` on 4 secrets — a pre-existing, already-documented gap (`docs/FAILING-ROUTINES-ANALYSIS.md`) unrelated to issue #1. Needs someone with GCP IAM admin on `lovable-vitana-vers1` to run the `gcloud secrets add-iam-policy-binding` grants already staged in that doc.

**What this PR actually fixes:** checks 8 and 9 (`Welcome-greeting trigger — structural/behavioral`) pipe their heredoc `psql` invocation into `$OUT` without `2>&1`, so the connection error goes straight to the job log and never reaches `$OUT`/`$LINE` — the report table shows a blank detail (`FAIL |`, `query error: `) instead of the real error text. Checks 5/6/7 already redirect stderr correctly; this makes 8/9 consistent so future failures on this workflow are diagnosable from the report table alone, without having to open the raw job log.

---

## ✅ Changes

- [x] Add `2>&1` to the check-8 heredoc `psql` invocation (structural trigger check)
- [x] Add `2>&1` to the check-9 heredoc `psql` invocation (behavioral trigger check)

---

## 🧪 Testing

- [x] Read the full live job logs for the failing runs (via GitHub Actions API) to confirm the exact failure mode and that `2>&1` is the correct, minimal fix
- [ ] Automated tests added/updated — N/A, this is a 2-character diff in an ops workflow's error capture, not app logic
- [ ] Verified in staging/dev environment — N/A, this is a scheduled diagnostic workflow with no staging twin; next scheduled/dispatched run of `MORNING-SYSTEM-HEALTH-CHECK.yml` will exercise it

---

## 📝 Phase 2B Naming Compliance Checklist

N/A for this PR — no new workflow files, Cloud Run deployments, or renamed files; existing `MORNING-SYSTEM-HEALTH-CHECK.yml` already complies with naming conventions.

---

## 🔗 Links

- **Related docs:** `docs/FAILING-ROUTINES-ANALYSIS.md` (documents the GCP Secret Manager IAM gap for CRON-AUTO-PROMOTER/CRON-GRADUATION-RECOMMENDER)

---

## 🚨 Breaking Changes

None.

---

## 📌 Additional Notes

This PR does **not** resolve the 6 failing morning-health-check items — it only makes checks 8/9's failure detail visible instead of blank. The two real blockers (Supabase network restrictions, GCP IAM grant) require dashboard/IAM access this session does not have and are called out above for a human to action.

---
_Generated by [Claude Code](https://claude.ai/code/session_015myRdLZrGwuLu53fUiuyAm)_