### PR TITLE
fix(command-hub): DEV-COMHU-0514 Connect & Talk refuses non-Nova sessions with the typed reason (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -37805,20 +37805,51 @@ function renderNovaSonicTestView() {
     // probe, and watch the session appear in the table below.
     manualPanel.querySelector('.nst-talk-btn').addEventListener('click', function () {
         var hint = manualPanel.querySelector('.nst-talk-hint');
+        hint.style.display = 'block';
         if (!window.VitanaOrb) {
-            hint.style.display = 'block';
             hint.textContent = 'ORB widget not loaded on this page — refresh and try again.';
             return;
         }
         var lang = manualPanel.querySelector('.nst-lang').value;
-        try { window.VitanaOrb.setLang(lang); } catch (_) { /* keep default */ }
-        hint.style.display = 'block';
-        hint.innerHTML = 'Voice session starting in <b>' + lang + '</b> — speak when the overlay shows '
-            + '<i>Listening</i>. Close the overlay (X) to end. Provider for YOUR identity: use '
-            + '<i>Probe my provider decision</i>; the session appears in the table below within ~5s.';
-        if (window.state && state.orb) { state.orb.overlayVisible = true; }
-        window.VitanaOrb.show();
-        loadSessions();
+        // HARD GATE: this is the NOVA bench — never open the mic on a session
+        // that would silently fall back to Vertex. Run the decision probe for
+        // the signed-in identity first and refuse loudly on any non-Nova
+        // answer, with the typed reason (wrong account on the allowlist,
+        // language fallback, Nova disabled on this host, …).
+        hint.style.borderLeftColor = '#f97316';
+        hint.textContent = 'Checking which provider YOUR identity gets…';
+        fetch('/api/v1/voice-lab/nova/decision?lang=' + encodeURIComponent(lang), { headers: buildContextHeaders() })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (disposed) return;
+                if (!data.ok) {
+                    hint.style.borderLeftColor = '#ef4444';
+                    hint.textContent = 'Decision probe failed (' + (data.error || 'unknown') + ') — refusing to start a session blind.';
+                    return;
+                }
+                var d = data.decision;
+                if (d.provider !== 'nova_sonic') {
+                    hint.style.borderLeftColor = '#ef4444';
+                    hint.innerHTML = '<b style="color:#ef4444;">NOT STARTING — your session would ride '
+                        + d.provider + '</b> (reason: <code>' + d.reason + '</code>'
+                        + (data.authenticated ? '' : ', not signed in')
+                        + ', runtime=' + data.runtime + '). '
+                        + 'This bench refuses to open a non-Nova session. Check that THIS login’s user id is on the canary allowlist and that Nova is enabled on this host.';
+                    return;
+                }
+                hint.style.borderLeftColor = '#22c55e';
+                hint.innerHTML = 'Decision: <b style="color:#22c55e;">nova_sonic</b> (' + d.reason + ') — starting Nova voice session in <b>' + lang + '</b>. '
+                    + 'Speak when the overlay shows <i>Listening</i>; close (X) to end. Session appears below within ~5s.';
+                try { window.VitanaOrb.setLang(lang); } catch (_) { /* keep default */ }
+                if (window.state && state.orb) { state.orb.overlayVisible = true; }
+                window.VitanaOrb.show();
+                loadSessions();
+            })
+            .catch(function (e) {
+                if (disposed) return;
+                hint.style.borderLeftColor = '#ef4444';
+                hint.textContent = 'Decision probe network error (' + (e.message || 'unknown') + ') — refusing to start a session blind.';
+            });
     });
 
     function loadSessions() {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260711-bg-watchdog"></script>
-  <script src="/command-hub/app.js?v=20260724-DEV-COMHU-0514-nova-connect-talk"></script>
+  <script src="/command-hub/app.js?v=20260724-DEV-COMHU-0514-nova-talk-gate"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
   <!-- Phase 0 staging build (P0.5): PUBLISH→staging-source card + CLOCK revert -->


### PR DESCRIPTION
## Why

The operator pressed Connect & Talk on the Nova bench and unknowingly spoke to **Vertex** — their Command Hub login is a different account (`dstevanovic@outlook.com` / `@hotmail.com` / `d.stevanovic@exafy.io` are three separate users) than the one on the canary allowlist. The canary's silent Vertex fallback is correct production safety, but on the **Nova test bench** it reads as a bait-and-switch: the screen implies you're testing Nova while the selector quietly routed you to Vertex.

## What

Connect & Talk now runs the per-identity decision probe (`GET /api/v1/voice-lab/nova/decision`) **before** opening the mic:

- Decision ≠ `nova_sonic` → **refuses to start**, red banner naming the provider it would have used and the typed reason (`nova_identity_not_allowlisted`, language fallback, Nova disabled on host, not signed in, runtime).
- Decision = `nova_sonic` → green verdict with the reason, then the ORB overlay opens. If the mic opens from this button, the session is Nova.
- Probe failure/network error → refuses to start a session blind.

Cache-bust bumped to `20260724-DEV-COMHU-0514-nova-talk-gate`.

(Operationally, all three of the operator's user ids are also being added to the staging canary allowlist via workflow dispatch, so their test passes the gate regardless of which account the hub session uses.)

## Testing

- `node --check` on app.js.
- Endpoint contract unchanged — same decision probe the adjacent button already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_