### PR TITLE
feat(voice-lab): Nova payload-limit bisect probes (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -37805,20 +37805,51 @@ function renderNovaSonicTestView() {
     // probe, and watch the session appear in the table below.
     manualPanel.querySelector('.nst-talk-btn').addEventListener('click', function () {
         var hint = manualPanel.querySelector('.nst-talk-hint');
+        hint.style.display = 'block';
         if (!window.VitanaOrb) {
-            hint.style.display = 'block';
             hint.textContent = 'ORB widget not loaded on this page — refresh and try again.';
             return;
         }
         var lang = manualPanel.querySelector('.nst-lang').value;
-        try { window.VitanaOrb.setLang(lang); } catch (_) { /* keep default */ }
-        hint.style.display = 'block';
-        hint.innerHTML = 'Voice session starting in <b>' + lang + '</b> — speak when the overlay shows '
-            + '<i>Listening</i>. Close the overlay (X) to end. Provider for YOUR identity: use '
-            + '<i>Probe my provider decision</i>; the session appears in the table below within ~5s.';
-        if (window.state && state.orb) { state.orb.overlayVisible = true; }
-        window.VitanaOrb.show();
-        loadSessions();
+        // HARD GATE: this is the NOVA bench — never open the mic on a session
+        // that would silently fall back to Vertex. Run the decision probe for
+        // the signed-in identity first and refuse loudly on any non-Nova
+        // answer, with the typed reason (wrong account on the allowlist,
+        // language fallback, Nova disabled on this host, …).
+        hint.style.borderLeftColor = '#f97316';
+        hint.textContent = 'Checking which provider YOUR identity gets…';
+        fetch('/api/v1/voice-lab/nova/decision?lang=' + encodeURIComponent(lang), { headers: buildContextHeaders() })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (disposed) return;
+                if (!data.ok) {
+                    hint.style.borderLeftColor = '#ef4444';
+                    hint.textContent = 'Decision probe failed (' + (data.error || 'unknown') + ') — refusing to start a session blind.';
+                    return;
+                }
+                var d = data.decision;
+                if (d.provider !== 'nova_sonic') {
+                    hint.style.borderLeftColor = '#ef4444';
+                    hint.innerHTML = '<b style="color:#ef4444;">NOT STARTING — your session would ride '
+                        + d.provider + '</b> (reason: <code>' + d.reason + '</code>'
+                        + (data.authenticated ? '' : ', not signed in')
+                        + ', runtime=' + data.runtime + '). '
+                        + 'This bench refuses to open a non-Nova session. Check that THIS login’s user id is on the canary allowlist and that Nova is enabled on this host.';
+                    return;
+                }
+                hint.style.borderLeftColor = '#22c55e';
+                hint.innerHTML = 'Decision: <b style="color:#22c55e;">nova_sonic</b> (' + d.reason + ') — starting Nova voice session in <b>' + lang + '</b>. '
+                    + 'Speak when the overlay shows <i>Listening</i>; close (X) to end. Session appears below within ~5s.';
+                try { window.VitanaOrb.setLang(lang); } catch (_) { /* keep default */ }
+                if (window.state && state.orb) { state.orb.overlayVisible = true; }
+                window.VitanaOrb.show();
+                loadSessions();
+            })
+            .catch(function (e) {
+                if (disposed) return;
+                hint.style.borderLeftColor = '#ef4444';
+                hint.textContent = 'Decision probe network error (' + (e.message || 'unknown') + ') — refusing to start a session blind.';
+            });
     });
 
     function loadSessions() {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260711-bg-watchdog"></script>
-  <script src="/command-hub/app.js?v=20260724-DEV-COMHU-0514-nova-connect-talk"></script>
+  <script src="/command-hub/app.js?v=20260724-DEV-COMHU-0514-nova-talk-gate"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
   <!-- Phase 0 staging build (P0.5): PUBLISH→staging-source card + CLOCK revert -->

--- a/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
@@ -49,6 +49,7 @@ import {
   VERTEX_PROJECT_ID,
 } from '../../orb/live/config';
 import { VERTEX_LIVE_MODEL } from '../../orb/live/protocol';
+import { buildLiveApiTools } from '../../orb/live/tools/live-tool-catalog';
 
 export interface NovaTestCheck {
   key: string;
@@ -197,6 +198,65 @@ async function probeLiveClient(
 
 function formatProbeMetrics(m: LiveProbeMetrics): string {
   return `connect_ms=${m.connect_ms} first_event_ms=${m.first_event_ms} first_audio_ms=${m.first_audio_ms < 0 ? 'n/a' : m.first_audio_ms}`;
+}
+
+/**
+ * Payload-limit bisect: open a Nova stream with a specific envelope shape
+ * (system-instruction size, tool set), observe for async rejection events,
+ * close. A real ORB session sends a large instruction + the full live tool
+ * catalog — the minimal health probe passing while real sessions fail means
+ * one of those dimensions trips a Bedrock/Nova limit; this finds which.
+ */
+async function probeNovaPayload(
+  cfg: ReturnType<typeof getNovaSonicConfig>,
+  shape: { systemInstruction: string; tools?: ReadonlyArray<Record<string, unknown>>; observeMs?: number },
+): Promise<{ ok: boolean; detail: string }> {
+  const client = new NovaSonicLiveClient({ config: cfg, voiceId: 'tiffany' });
+  const errorCodes: string[] = [];
+  let closeReason: string | undefined;
+  client.onError((e) => { errorCodes.push(e.code); });
+  client.onClose((e) => { closeReason = e.reason; });
+  const t0 = Date.now();
+  try {
+    await client.connect({
+      model: cfg.modelId,
+      voiceName: 'tiffany',
+      responseModalities: ['audio'],
+      vadSilenceMs: 2000,
+      systemInstruction: shape.systemInstruction,
+      tools: shape.tools,
+      connectTimeoutMs: cfg.connectTimeoutMs,
+    });
+  } catch (err) {
+    return { ok: false, detail: `connect rejected: ${classifyNovaError(err)}` };
+  }
+  const connectMs = Date.now() - t0;
+  // Async rejections (validation on promptStart/textInput) arrive on the
+  // response stream after connect resolves — observe before declaring pass.
+  await new Promise((resolve) => {
+    const t = setTimeout(resolve, shape.observeMs ?? 3_000);
+    (t as NodeJS.Timeout).unref?.();
+  });
+  await client.close('nova_payload_probe').catch(() => { /* idempotent */ });
+  if (errorCodes.length > 0) {
+    return { ok: false, detail: `stream rejected after connect (${connectMs}ms): ${errorCodes.join('|')} close=${closeReason ?? 'n/a'}` };
+  }
+  return { ok: true, detail: `accepted (connect_ms=${connectMs}, no rejection within ${shape.observeMs ?? 3000}ms)` };
+}
+
+function buildDummyTools(count: number): Array<Record<string, unknown>> {
+  const tools: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < count; i++) {
+    tools.push({
+      name: `bench_dummy_tool_${i}`,
+      description: `Synthetic bench tool #${i} — never called; exists to measure Nova toolConfiguration limits.`,
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string', description: 'test parameter' } },
+      },
+    });
+  }
+  return tools;
 }
 
 const NOVA_ALL_PASS = {
@@ -356,6 +416,46 @@ export async function runNovaSonicTestSuite(options: {
     novaMetrics = result.metrics!;
     return { status: 'pass', detail: formatProbeMetrics(result.metrics!), metrics: result.metrics };
   }));
+
+  // Payload-limit bisect — pinpoints why a REAL ORB session (large system
+  // instruction + full live tool catalog) can fail while the minimal probe
+  // passes. Only runs when the baseline Nova probe produced metrics.
+  const payloadShapes: Array<{ key: string; label: string; shape: Parameters<typeof probeNovaPayload>[1] }> = [
+    {
+      key: 'payload_text_32k',
+      label: 'Payload: 32KB system instruction, no tools',
+      shape: { systemInstruction: 'You are a bench probe. Context: ' + 'x'.repeat(32_000) },
+    },
+    {
+      key: 'payload_dummy_tools_100',
+      label: 'Payload: tiny instruction + 100 dummy tools',
+      shape: { systemInstruction: PROBE_SYSTEM_INSTRUCTION, tools: buildDummyTools(100) },
+    },
+    {
+      key: 'payload_real_catalog',
+      label: 'Payload: tiny instruction + REAL live tool catalog',
+      shape: {
+        systemInstruction: PROBE_SYSTEM_INSTRUCTION,
+        tools: buildLiveApiTools('authenticated') as ReadonlyArray<Record<string, unknown>>,
+      },
+    },
+    {
+      key: 'payload_real_catalog_plus_text',
+      label: 'Payload: 32KB instruction + REAL live tool catalog (session-shaped)',
+      shape: {
+        systemInstruction: 'You are a bench probe. Context: ' + 'x'.repeat(32_000),
+        tools: buildLiveApiTools('authenticated') as ReadonlyArray<Record<string, unknown>>,
+      },
+    },
+  ];
+  for (const p of payloadShapes) {
+    checks.push(await runCheck(p.key, p.label, async () => {
+      if (!options.live) return { status: 'skip', detail: 'live probe not requested' };
+      if (!novaMetrics) return { status: 'skip', detail: 'baseline nova probe did not pass' };
+      const result = await probeNovaPayload(cfg, p.shape);
+      return { status: result.ok ? 'pass' : 'fail', detail: result.detail };
+    }));
+  }
 
   checks.push(await runCheck('vertex_baseline_probe', 'Vertex baseline: connect + first-response latency', async () => {
     if (!options.live) {


### PR DESCRIPTION
## Why

A real ORB voice session on the AWS staging Nova canary fails with "Voice connection failed" (session `live-de6ae088…`, user allowlisted, decision `nova_sonic`) while the bench's minimal live probe passes with sub-second latency. The difference is the envelope: real sessions carry a large system instruction plus the full `buildLiveApiTools('authenticated')` catalog; the probe sent one sentence and zero tools. Nova/Bedrock rejects something in the real payload — asynchronously, on the response stream, after connect resolves.

## What

Four new live-tier bisect probes in the automated suite (run only when `live=true` **and** the baseline Nova probe passed):

| Check | Shape |
|---|---|
| `payload_text_32k` | 32 KB system instruction, no tools |
| `payload_dummy_tools_100` | tiny instruction + 100 synthetic tools |
| `payload_real_catalog` | tiny instruction + the REAL live tool catalog |
| `payload_real_catalog_plus_text` | 32 KB instruction + real catalog (session-shaped) |

Each opens a stream, observes 3 s for async rejection events, closes, and reports typed codes only (`nova_validation`, `nova_tool_schema_invalid`, …). One bench run now pinpoints which dimension breaks real sessions.

## Testing

- Runner unit tests green (offline tier unchanged; new checks type-skip without `live`).
- `tsc` clean on changed files (the `@aws-sdk/client-ecs` local resolution error is a stale local node_modules artifact from #2940's new dep, not this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_