### PR TITLE
feat(voice-lab): parameterized Nova payload probes + system-instruction chunking (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -368,7 +368,22 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     this.queue.push(buildSessionStart());
     this.queue.push(buildPromptStart({ promptName: this.promptName, voiceId: this.deps.voiceId, tools }));
     this.queue.push(buildTextContentStart({ promptName: this.promptName, contentName: systemContentName, role: 'SYSTEM' }));
-    this.queue.push(buildTextInput({ promptName: this.promptName, contentName: systemContentName, content: options.systemInstruction }));
+    // Chunk oversized system instructions into multiple textInput events
+    // within the single SYSTEM block — Nova rejects a single large textInput
+    // with nova_validation, but streams many bounded events fine (same
+    // pattern as audioInput frames).
+    const chunkBytes = options.systemInstructionChunkBytes;
+    if (chunkBytes && chunkBytes > 0 && options.systemInstruction.length > chunkBytes) {
+      for (let i = 0; i < options.systemInstruction.length; i += chunkBytes) {
+        this.queue.push(buildTextInput({
+          promptName: this.promptName,
+          contentName: systemContentName,
+          content: options.systemInstruction.slice(i, i + chunkBytes),
+        }));
+      }
+    } else {
+      this.queue.push(buildTextInput({ promptName: this.promptName, contentName: systemContentName, content: options.systemInstruction }));
+    }
     this.queue.push(buildContentEnd({ promptName: this.promptName, contentName: systemContentName }));
     // Long-lived USER audio block — stays open for the whole stream; Nova's
     // server-side turn detection segments utterances.

--- a/services/gateway/src/orb/live/upstream/types.ts
+++ b/services/gateway/src/orb/live/upstream/types.ts
@@ -73,6 +73,14 @@ export interface UpstreamConnectOptions {
   vadSilenceMs: number;
   /** System instruction (already-composed prompt text). */
   systemInstruction: string;
+  /**
+   * BOOTSTRAP-NOVA-SONIC-VOICE: when set, providers that support it split
+   * the system instruction into multiple sequential textInput events of at
+   * most this many bytes inside the single SYSTEM content block (audio-frame
+   * style). Nova rejects single oversized textInput events (nova_validation);
+   * chunking preserves the full instruction. Ignored by Vertex/Gemini.
+   */
+  systemInstructionChunkBytes?: number;
   /** Tool function declarations (provider passes through as-is). */
   tools?: ReadonlyArray<Record<string, unknown>>;
   /** Enable input audio transcription stream. Vertex default: true. */

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -325,6 +325,16 @@ const NOVA_TESTS_VTID = 'BOOTSTRAP-NOVA-SONIC-VOICE';
 const NovaRunPostSchema = z.object({
   live: z.boolean().optional(),
   trigger: z.string().max(64).optional(),
+  // Remote payload bisect (BOOTSTRAP-NOVA-SONIC-VOICE): bounded probe shapes
+  // so the exact Nova limits can be measured without a redeploy per guess.
+  payload_probes: z.array(z.object({
+    key: z.string().min(1).max(48),
+    text_kb: z.number().int().min(0).max(128).optional(),
+    chunk_kb: z.number().int().min(0).max(64).optional(),
+    dummy_tools: z.number().int().min(0).max(300).optional(),
+    real_catalog: z.boolean().optional(),
+    truncate_descriptions: z.number().int().min(0).max(2000).optional(),
+  })).max(10).optional(),
 });
 
 router.post(
@@ -344,6 +354,7 @@ router.post(
       const summary = await runNovaSonicTestSuite({
         live: parsed.data.live === true,
         trigger: parsed.data.trigger ?? 'command-hub',
+        payloadProbes: parsed.data.payload_probes,
       });
       return res.status(200).json({ ok: true, vtid: NOVA_TESTS_VTID, summary });
     } catch (err) {

--- a/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
@@ -207,9 +207,24 @@ function formatProbeMetrics(m: LiveProbeMetrics): string {
  * catalog — the minimal health probe passing while real sessions fail means
  * one of those dimensions trips a Bedrock/Nova limit; this finds which.
  */
+/** Request-supplied probe shape for remote bisecting (bounded by the route). */
+export interface NovaPayloadProbeSpec {
+  key: string;
+  /** System-instruction size in KB (filler text). 0/absent = tiny prompt. */
+  text_kb?: number;
+  /** Chunk the instruction into textInput events of this many KB. */
+  chunk_kb?: number;
+  /** Number of small synthetic tools to declare. */
+  dummy_tools?: number;
+  /** Use the REAL buildLiveApiTools('authenticated') catalog. */
+  real_catalog?: boolean;
+  /** Truncate each tool description to this many chars (real catalog only). */
+  truncate_descriptions?: number;
+}
+
 async function probeNovaPayload(
   cfg: ReturnType<typeof getNovaSonicConfig>,
-  shape: { systemInstruction: string; tools?: ReadonlyArray<Record<string, unknown>>; observeMs?: number },
+  shape: { systemInstruction: string; tools?: ReadonlyArray<Record<string, unknown>>; observeMs?: number; chunkBytes?: number },
 ): Promise<{ ok: boolean; detail: string }> {
   const client = new NovaSonicLiveClient({ config: cfg, voiceId: 'tiffany' });
   const errorCodes: string[] = [];
@@ -224,6 +239,7 @@ async function probeNovaPayload(
       responseModalities: ['audio'],
       vadSilenceMs: 2000,
       systemInstruction: shape.systemInstruction,
+      systemInstructionChunkBytes: shape.chunkBytes,
       tools: shape.tools,
       connectTimeoutMs: cfg.connectTimeoutMs,
     });
@@ -267,9 +283,39 @@ const NOVA_ALL_PASS = {
 };
 const PROBE_IDENTITY = { userId: 'probe-user', tenantId: 'probe-tenant' };
 
+function payloadSpecToShape(spec: NovaPayloadProbeSpec): {
+  systemInstruction: string;
+  tools?: ReadonlyArray<Record<string, unknown>>;
+  chunkBytes?: number;
+} {
+  const systemInstruction = spec.text_kb && spec.text_kb > 0
+    ? 'You are a bench probe. Context: ' + 'x'.repeat(spec.text_kb * 1024)
+    : PROBE_SYSTEM_INSTRUCTION;
+  let tools: ReadonlyArray<Record<string, unknown>> | undefined;
+  if (spec.real_catalog) {
+    let catalog = buildLiveApiTools('authenticated') as Array<Record<string, unknown>>;
+    if (spec.truncate_descriptions && spec.truncate_descriptions > 0) {
+      catalog = catalog.map((t) => ({
+        ...t,
+        description: String(t.description ?? '').slice(0, spec.truncate_descriptions),
+      }));
+    }
+    tools = catalog;
+  } else if (spec.dummy_tools && spec.dummy_tools > 0) {
+    tools = buildDummyTools(spec.dummy_tools);
+  }
+  return {
+    systemInstruction,
+    tools,
+    chunkBytes: spec.chunk_kb && spec.chunk_kb > 0 ? spec.chunk_kb * 1024 : undefined,
+  };
+}
+
 export async function runNovaSonicTestSuite(options: {
   live?: boolean;
   trigger?: string;
+  /** Remote bisect: replaces the default payload probes when provided. */
+  payloadProbes?: NovaPayloadProbeSpec[];
 } = {}): Promise<NovaTestRunSummary> {
   const startedAt = Date.now();
   const checks: NovaTestCheck[] = [];
@@ -420,7 +466,14 @@ export async function runNovaSonicTestSuite(options: {
   // Payload-limit bisect — pinpoints why a REAL ORB session (large system
   // instruction + full live tool catalog) can fail while the minimal probe
   // passes. Only runs when the baseline Nova probe produced metrics.
-  const payloadShapes: Array<{ key: string; label: string; shape: Parameters<typeof probeNovaPayload>[1] }> = [
+  const payloadShapes: Array<{ key: string; label: string; shape: Parameters<typeof probeNovaPayload>[1] }> =
+    options.payloadProbes && options.payloadProbes.length > 0
+      ? options.payloadProbes.map((spec) => ({
+          key: spec.key,
+          label: `Payload probe: ${spec.key}`,
+          shape: payloadSpecToShape(spec),
+        }))
+      : [
     {
       key: 'payload_text_32k',
       label: 'Payload: 32KB system instruction, no tools',
@@ -449,6 +502,7 @@ export async function runNovaSonicTestSuite(options: {
     },
   ];
   for (const p of payloadShapes) {
+    // (loop body below runs identically for default and request-supplied shapes)
     checks.push(await runCheck(p.key, p.label, async () => {
       if (!options.live) return { status: 'skip', detail: 'live probe not requested' };
       if (!novaMetrics) return { status: 'skip', detail: 'baseline nova probe did not pass' };


### PR DESCRIPTION
## Why

The payload bisect on AWS staging named the root cause of real Nova sessions failing while the minimal probe passes — **both** envelope dimensions exceed Nova limits:

| Probe | Result |
|---|---|
| minimal baseline | PASS (first event 642 ms) |
| 32 KB system instruction | `nova_validation` |
| 100 small tools | `nova_validation` |
| real live tool catalog | stream error at connect |

Pinning the exact thresholds (and validating the loss-free mitigation) shouldn't cost a 15-minute deploy per guess.

## What

1. **Remote bisect**: `POST /api/v1/voice-lab/nova/tests/run` accepts a bounded `payload_probes[]` (`key`, `text_kb ≤128`, `chunk_kb ≤64`, `dummy_tools ≤300`, `real_catalog`, `truncate_descriptions ≤2000`, max 10 probes) that replaces the default bisect shapes for that run.
2. **Instruction chunking**: `UpstreamConnectOptions.systemInstructionChunkBytes` — the Nova client splits the system instruction into multiple sequential `textInput` events inside the single SYSTEM content block (audio-frame style). If Nova accepts chunked text, the eventual session fix preserves the **full** personalized instruction with zero truncation. Vertex/Gemini ignore the option.

## Testing

- Full gateway suite green locally (485 suites).
- Existing Nova suites cover the unchanged default path; chunking is inert unless the new option is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_