### PR TITLE
fix(nova): capture upstream validation detail + docs-conformant SYSTEM block (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -87,6 +87,17 @@ export function classifyNovaError(err: unknown): NovaFailureCode {
 }
 
 /**
+ * Extract a bounded upstream error detail for the `diagnostic` field on
+ * UpstreamErrorEvent — operator/bench surfaces only, never end-user UI.
+ * Truncated so a pathological message can't bloat logs or events.
+ */
+export function extractNovaDiagnostic(err: unknown): string | undefined {
+  const message = (err as { message?: unknown })?.message;
+  if (typeof message !== 'string' || message.trim() === '') return undefined;
+  return message.length > 400 ? `${message.slice(0, 400)}…` : message;
+}
+
+/**
  * Bounded async input queue implementing the AsyncIterable the Bedrock
  * command consumes. Order-preserving. `push` (control/tool events) always
  * enqueues; `pushAudio` refuses beyond the high-water mark so a stalled
@@ -358,7 +369,11 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
         : [];
     } catch (err) {
       this.state = 'error';
-      this.emitError({ code: 'nova_validation', message: 'Nova tool catalog rejected before stream open' });
+      this.emitError({
+        code: 'nova_validation',
+        message: 'Nova tool catalog rejected before stream open',
+        diagnostic: extractNovaDiagnostic(err),
+      });
       throw err;
     }
 
@@ -367,7 +382,15 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     const systemContentName = randomUUID();
     this.queue.push(buildSessionStart());
     this.queue.push(buildPromptStart({ promptName: this.promptName, voiceId: this.deps.voiceId, tools }));
-    this.queue.push(buildTextContentStart({ promptName: this.promptName, contentName: systemContentName, role: 'SYSTEM' }));
+    // interactive:false — the documented shape for SYSTEM prompts (the
+    // interactive:true form is the cross-modal USER text path, which may
+    // carry different validation limits).
+    this.queue.push(buildTextContentStart({
+      promptName: this.promptName,
+      contentName: systemContentName,
+      role: 'SYSTEM',
+      interactive: false,
+    }));
     // Chunk oversized system instructions into multiple textInput events
     // within the single SYSTEM block — Nova rejects a single large textInput
     // with nova_validation, but streams many bounded events fine (same
@@ -420,7 +443,7 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     } catch (err) {
       const code = classifyNovaError(err);
       this.state = 'error';
-      this.emitError({ code, message: `Nova connect failed (${code})`, cause: err });
+      this.emitError({ code, message: `Nova connect failed (${code})`, cause: err, diagnostic: extractNovaDiagnostic(err) });
       this.finalizeClose({ initiatedLocally: false, reason: code });
       throw new Error(`nova_connect_failed: ${code}`);
     }
@@ -456,7 +479,11 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
           if (exceptionMember) {
             const code = classifyNovaError({ name: exceptionMember.replace(/^./, (c) => c.toUpperCase()) });
             this.state = 'error';
-            this.emitError({ code, message: `Nova stream exception event (${code}: ${exceptionMember})` });
+            this.emitError({
+              code,
+              message: `Nova stream exception event (${code}: ${exceptionMember})`,
+              diagnostic: extractNovaDiagnostic((item as Record<string, unknown>)[exceptionMember]),
+            });
             this.finalizeClose({ initiatedLocally: false, reason: code });
             return;
           }
@@ -480,7 +507,7 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       if (this.closeEmitted) return;
       const code = classifyNovaError(err);
       this.state = 'error';
-      this.emitError({ code, message: `Nova stream failed (${code})`, cause: err });
+      this.emitError({ code, message: `Nova stream failed (${code})`, cause: err, diagnostic: extractNovaDiagnostic(err) });
       this.finalizeClose({ initiatedLocally: false, reason: code });
     }
   }

--- a/services/gateway/src/orb/live/upstream/types.ts
+++ b/services/gateway/src/orb/live/upstream/types.ts
@@ -268,6 +268,12 @@ export interface UpstreamErrorEvent {
   message: string;
   /** Underlying error object, when known. */
   cause?: unknown;
+  /**
+   * Truncated upstream error detail (e.g. the AWS validationException
+   * message) for OPERATOR/DIAGNOSTIC surfaces only — the voice-lab bench
+   * and server logs. Never forward this to end-user UI.
+   */
+  diagnostic?: string;
 }
 
 /**

--- a/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
@@ -228,8 +228,12 @@ async function probeNovaPayload(
 ): Promise<{ ok: boolean; detail: string }> {
   const client = new NovaSonicLiveClient({ config: cfg, voiceId: 'tiffany' });
   const errorCodes: string[] = [];
+  const diagnostics: string[] = [];
   let closeReason: string | undefined;
-  client.onError((e) => { errorCodes.push(e.code); });
+  client.onError((e) => {
+    errorCodes.push(e.code);
+    if (e.diagnostic) diagnostics.push(e.diagnostic);
+  });
   client.onClose((e) => { closeReason = e.reason; });
   const t0 = Date.now();
   try {
@@ -244,7 +248,8 @@ async function probeNovaPayload(
       connectTimeoutMs: cfg.connectTimeoutMs,
     });
   } catch (err) {
-    return { ok: false, detail: `connect rejected: ${classifyNovaError(err)}` };
+    const upstream = diagnostics.length > 0 ? ` upstream="${diagnostics.join(' | ')}"` : '';
+    return { ok: false, detail: `connect rejected: ${classifyNovaError(err)}${upstream}` };
   }
   const connectMs = Date.now() - t0;
   // Async rejections (validation on promptStart/textInput) arrive on the
@@ -255,7 +260,8 @@ async function probeNovaPayload(
   });
   await client.close('nova_payload_probe').catch(() => { /* idempotent */ });
   if (errorCodes.length > 0) {
-    return { ok: false, detail: `stream rejected after connect (${connectMs}ms): ${errorCodes.join('|')} close=${closeReason ?? 'n/a'}` };
+    const upstream = diagnostics.length > 0 ? ` upstream="${diagnostics.join(' | ')}"` : '';
+    return { ok: false, detail: `stream rejected after connect (${connectMs}ms): ${errorCodes.join('|')} close=${closeReason ?? 'n/a'}${upstream}` };
   }
   return { ok: true, detail: `accepted (connect_ms=${connectMs}, no rejection within ${shape.observeMs ?? 3000}ms)` };
 }

--- a/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
@@ -139,6 +139,10 @@ describe('NovaSonicLiveClient', () => {
     expect(events[3].event.textInput.content).toBe('You are Vitana.');
     expect(events[5].event.contentStart.type).toBe('AUDIO');
     expect(events[1].event.promptStart.audioOutputConfiguration.voiceId).toBe('tina');
+    // SYSTEM prompts use the documented non-interactive shape; the
+    // interactive:true form is reserved for cross-modal USER text turns.
+    expect(events[2].event.contentStart.role).toBe('SYSTEM');
+    expect(events[2].event.contentStart.interactive).toBe(false);
   });
 
   it('rejects a broken tool catalog BEFORE opening the stream', async () => {
@@ -387,17 +391,21 @@ describe('named eventstream exception members', () => {
   it('a validationException union member becomes a typed error, never a silent skip', async () => {
     const { client, body } = makeClient();
     const errors: string[] = [];
+    const diagnostics: Array<string | undefined> = [];
     const closes: Array<string | undefined> = [];
-    client.onError((e) => errors.push(e.code));
+    client.onError((e) => { errors.push(e.code); diagnostics.push(e.diagnostic); });
     client.onClose((e) => closes.push(e.reason));
     await client.connect(baseOptions());
 
-    body.feedRaw({ validationException: { message: 'raw AWS text that must not leak' } } as any);
+    body.feedRaw({ validationException: { message: 'ValidationException: prompt exceeds limit' } } as any);
     await flush();
 
     expect(errors).toContain('nova_validation');
     expect(closes).toEqual(['nova_validation']);
     expect(client.getState()).toBe('closed');
+    // The upstream message is preserved on the diagnostic field (operator
+    // surfaces only) — the typed message itself stays generic.
+    expect(diagnostics).toContain('ValidationException: prompt exceeds limit');
   });
 });
 


### PR DESCRIPTION
## Why

The fine-grained payload bisect on AWS staging showed **every** non-minimal Nova probe failing `nova_validation` — even 1 KB of system text and a single tiny tool — while the minimal probe passes and beats Vertex by ~800 ms. That rules out a size limit; something structural in our session envelope is rejected, and the typed taxonomy alone can't say what.

## What

- `UpstreamErrorEvent` gains an optional bounded `diagnostic` field (≤400 chars) carrying the raw AWS exception message (`validationException` member message, connect/stream errors). It is for operator/bench surfaces and server logs only — never forwarded to end-user UI; the typed `message` stays generic.
- `NovaSonicLiveClient` populates `diagnostic` at all four failure sites (tool-catalog rejection, connect failure, named eventstream exception members, stream-loop errors) via a new `extractNovaDiagnostic()`.
- The voice-lab payload probes include the diagnostic in their check detail, so the next bisect run reports AWS's actual rejection reason per shape.
- The SYSTEM text block is now sent `interactive: false` — the documented shape for system prompts in the Nova 2 Sonic input-events reference. `interactive: true` remains on cross-modal USER text turns (`sendTextTurn`) per the cross-modal guide.

## Testing

- `nova-sonic-live-client.test.ts`: init-sequence test now asserts the SYSTEM block is `interactive:false`; the validationException test asserts the upstream message is preserved on `diagnostic` while the typed message stays generic. 35/35 pass.
- voice-lab suites: 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_