### PR TITLE
fix(nova): skip Vertex builtin tools + omit empty-audio contentEnd — unblocks real ORB sessions (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -87,6 +87,17 @@ export function classifyNovaError(err: unknown): NovaFailureCode {
 }
 
 /**
+ * Extract a bounded upstream error detail for the `diagnostic` field on
+ * UpstreamErrorEvent — operator/bench surfaces only, never end-user UI.
+ * Truncated so a pathological message can't bloat logs or events.
+ */
+export function extractNovaDiagnostic(err: unknown): string | undefined {
+  const message = (err as { message?: unknown })?.message;
+  if (typeof message !== 'string' || message.trim() === '') return undefined;
+  return message.length > 400 ? `${message.slice(0, 400)}…` : message;
+}
+
+/**
  * Bounded async input queue implementing the AsyncIterable the Bedrock
  * command consumes. Order-preserving. `push` (control/tool events) always
  * enqueues; `pushAudio` refuses beyond the high-water mark so a stalled
@@ -358,7 +369,11 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
         : [];
     } catch (err) {
       this.state = 'error';
-      this.emitError({ code: 'nova_validation', message: 'Nova tool catalog rejected before stream open' });
+      this.emitError({
+        code: 'nova_validation',
+        message: 'Nova tool catalog rejected before stream open',
+        diagnostic: extractNovaDiagnostic(err),
+      });
       throw err;
     }
 
@@ -367,7 +382,15 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     const systemContentName = randomUUID();
     this.queue.push(buildSessionStart());
     this.queue.push(buildPromptStart({ promptName: this.promptName, voiceId: this.deps.voiceId, tools }));
-    this.queue.push(buildTextContentStart({ promptName: this.promptName, contentName: systemContentName, role: 'SYSTEM' }));
+    // interactive:false — the documented shape for SYSTEM prompts (the
+    // interactive:true form is the cross-modal USER text path, which may
+    // carry different validation limits).
+    this.queue.push(buildTextContentStart({
+      promptName: this.promptName,
+      contentName: systemContentName,
+      role: 'SYSTEM',
+      interactive: false,
+    }));
     // Chunk oversized system instructions into multiple textInput events
     // within the single SYSTEM block — Nova rejects a single large textInput
     // with nova_validation, but streams many bounded events fine (same
@@ -420,7 +443,7 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     } catch (err) {
       const code = classifyNovaError(err);
       this.state = 'error';
-      this.emitError({ code, message: `Nova connect failed (${code})`, cause: err });
+      this.emitError({ code, message: `Nova connect failed (${code})`, cause: err, diagnostic: extractNovaDiagnostic(err) });
       this.finalizeClose({ initiatedLocally: false, reason: code });
       throw new Error(`nova_connect_failed: ${code}`);
     }
@@ -456,7 +479,11 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
           if (exceptionMember) {
             const code = classifyNovaError({ name: exceptionMember.replace(/^./, (c) => c.toUpperCase()) });
             this.state = 'error';
-            this.emitError({ code, message: `Nova stream exception event (${code}: ${exceptionMember})` });
+            this.emitError({
+              code,
+              message: `Nova stream exception event (${code}: ${exceptionMember})`,
+              diagnostic: extractNovaDiagnostic((item as Record<string, unknown>)[exceptionMember]),
+            });
             this.finalizeClose({ initiatedLocally: false, reason: code });
             return;
           }
@@ -480,7 +507,7 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       if (this.closeEmitted) return;
       const code = classifyNovaError(err);
       this.state = 'error';
-      this.emitError({ code, message: `Nova stream failed (${code})`, cause: err });
+      this.emitError({ code, message: `Nova stream failed (${code})`, cause: err, diagnostic: extractNovaDiagnostic(err) });
       this.finalizeClose({ initiatedLocally: false, reason: code });
     }
   }

--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -319,6 +319,8 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
   private rotationTimer: NodeJS.Timeout | null = null;
   private rotationFired = false;
   private closeEmitted = false;
+  /** Frames actually queued — gates the audio contentEnd on teardown. */
+  private audioFramesSent = 0;
   private errorEmitted = false;
   private localCloseReason: string | undefined;
   private responseLoopDone: Promise<void> | null = null;
@@ -554,6 +556,8 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     );
     if (!accepted) {
       this.emitError({ code: 'nova_backpressure', message: 'Nova input queue high-water mark reached; audio chunk dropped' });
+    } else {
+      this.audioFramesSent++;
     }
     return accepted;
   }
@@ -602,8 +606,13 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       this.rotationTimer = null;
     }
     // Orderly teardown: close the audio block, end the prompt + session,
-    // then close the input queue so the request stream completes.
-    this.queue.push(buildContentEnd({ promptName: this.promptName, contentName: this.audioContentName }));
+    // then close the input queue so the request stream completes. Nova
+    // rejects a contentEnd for a content block that never received data
+    // ("no content data was received"), so the audio block is only ended
+    // when at least one audioInput frame actually went out.
+    if (this.audioFramesSent > 0) {
+      this.queue.push(buildContentEnd({ promptName: this.promptName, contentName: this.audioContentName }));
+    }
     this.queue.push(buildPromptEnd(this.promptName));
     this.queue.push(buildSessionEnd());
     this.queue.close();

--- a/services/gateway/src/orb/live/upstream/nova-sonic-protocol.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-protocol.ts
@@ -232,11 +232,31 @@ export function buildSessionEnd(): NovaInputEvent {
 // ---------------------------------------------------------------------------
 
 /**
+ * Vertex/Gemini catalog entries that are provider-builtin directives, not
+ * function declarations — Nova has no equivalent, so they are skipped
+ * (silently dropping them is correct: the alternative is failing every
+ * session over a capability Nova simply doesn't offer).
+ */
+const VERTEX_BUILTIN_TOOL_KEYS = new Set([
+  'google_search',
+  'googleSearch',
+  'google_search_retrieval',
+  'googleSearchRetrieval',
+  'url_context',
+  'urlContext',
+  'code_execution',
+  'codeExecution',
+  'retrieval',
+]);
+
+/**
  * Convert the gateway's Gemini-shaped tool declarations into Nova
  * `toolSpec`s. Accepts either a flat `{name, description, parameters}` list
- * or the Vertex `{function_declarations: [...]}` wrapper. Throws on
- * duplicate tool names or malformed entries — a broken catalog must fail
- * BEFORE a paid stream opens, not stall mid-session.
+ * or the Vertex `{function_declarations: [...]}` wrapper. Vertex builtin
+ * directives (e.g. `{ google_search: {} }`) are skipped — they are not
+ * function declarations. Throws on duplicate tool names or malformed
+ * entries — a broken catalog must fail BEFORE a paid stream opens, not
+ * stall mid-session.
  */
 export function convertToolsToNovaSpecs(
   tools: ReadonlyArray<Record<string, unknown>>,
@@ -247,9 +267,13 @@ export function convertToolsToNovaSpecs(
       ?? (entry as { functionDeclarations?: unknown }).functionDeclarations;
     if (Array.isArray(fnDecls)) {
       flat.push(...(fnDecls as Array<Record<string, unknown>>));
-    } else {
-      flat.push(entry);
+      continue;
     }
+    const keys = Object.keys(entry);
+    if (!('name' in entry) && keys.length > 0 && keys.every((k) => VERTEX_BUILTIN_TOOL_KEYS.has(k))) {
+      continue;
+    }
+    flat.push(entry);
   }
 
   const seen = new Set<string>();

--- a/services/gateway/src/orb/live/upstream/types.ts
+++ b/services/gateway/src/orb/live/upstream/types.ts
@@ -268,6 +268,12 @@ export interface UpstreamErrorEvent {
   message: string;
   /** Underlying error object, when known. */
   cause?: unknown;
+  /**
+   * Truncated upstream error detail (e.g. the AWS validationException
+   * message) for OPERATOR/DIAGNOSTIC surfaces only — the voice-lab bench
+   * and server logs. Never forward this to end-user UI.
+   */
+  diagnostic?: string;
 }
 
 /**

--- a/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
@@ -228,8 +228,12 @@ async function probeNovaPayload(
 ): Promise<{ ok: boolean; detail: string }> {
   const client = new NovaSonicLiveClient({ config: cfg, voiceId: 'tiffany' });
   const errorCodes: string[] = [];
+  const diagnostics: string[] = [];
   let closeReason: string | undefined;
-  client.onError((e) => { errorCodes.push(e.code); });
+  client.onError((e) => {
+    errorCodes.push(e.code);
+    if (e.diagnostic) diagnostics.push(e.diagnostic);
+  });
   client.onClose((e) => { closeReason = e.reason; });
   const t0 = Date.now();
   try {
@@ -244,7 +248,8 @@ async function probeNovaPayload(
       connectTimeoutMs: cfg.connectTimeoutMs,
     });
   } catch (err) {
-    return { ok: false, detail: `connect rejected: ${classifyNovaError(err)}` };
+    const upstream = diagnostics.length > 0 ? ` upstream="${diagnostics.join(' | ')}"` : '';
+    return { ok: false, detail: `connect rejected: ${classifyNovaError(err)}${upstream}` };
   }
   const connectMs = Date.now() - t0;
   // Async rejections (validation on promptStart/textInput) arrive on the
@@ -255,7 +260,8 @@ async function probeNovaPayload(
   });
   await client.close('nova_payload_probe').catch(() => { /* idempotent */ });
   if (errorCodes.length > 0) {
-    return { ok: false, detail: `stream rejected after connect (${connectMs}ms): ${errorCodes.join('|')} close=${closeReason ?? 'n/a'}` };
+    const upstream = diagnostics.length > 0 ? ` upstream="${diagnostics.join(' | ')}"` : '';
+    return { ok: false, detail: `stream rejected after connect (${connectMs}ms): ${errorCodes.join('|')} close=${closeReason ?? 'n/a'}${upstream}` };
   }
   return { ok: true, detail: `accepted (connect_ms=${connectMs}, no rejection within ${shape.observeMs ?? 3000}ms)` };
 }

--- a/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
@@ -254,10 +254,16 @@ async function probeNovaPayload(
   const connectMs = Date.now() - t0;
   // Async rejections (validation on promptStart/textInput) arrive on the
   // response stream after connect resolves — observe before declaring pass.
+  // Stream silence during the window so the session looks like a real one
+  // (a probe that never sends audio would otherwise manufacture teardown
+  // validation errors unrelated to the payload under test).
+  const silenceTimer = setInterval(() => { client.sendAudioChunk(SILENCE_FRAME_B64); }, 32);
+  (silenceTimer as NodeJS.Timeout).unref?.();
   await new Promise((resolve) => {
     const t = setTimeout(resolve, shape.observeMs ?? 3_000);
     (t as NodeJS.Timeout).unref?.();
   });
+  clearInterval(silenceTimer);
   await client.close('nova_payload_probe').catch(() => { /* idempotent */ });
   if (errorCodes.length > 0) {
     const upstream = diagnostics.length > 0 ? ` upstream="${diagnostics.join(' | ')}"` : '';

--- a/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
@@ -139,6 +139,10 @@ describe('NovaSonicLiveClient', () => {
     expect(events[3].event.textInput.content).toBe('You are Vitana.');
     expect(events[5].event.contentStart.type).toBe('AUDIO');
     expect(events[1].event.promptStart.audioOutputConfiguration.voiceId).toBe('tina');
+    // SYSTEM prompts use the documented non-interactive shape; the
+    // interactive:true form is reserved for cross-modal USER text turns.
+    expect(events[2].event.contentStart.role).toBe('SYSTEM');
+    expect(events[2].event.contentStart.interactive).toBe(false);
   });
 
   it('rejects a broken tool catalog BEFORE opening the stream', async () => {
@@ -387,17 +391,21 @@ describe('named eventstream exception members', () => {
   it('a validationException union member becomes a typed error, never a silent skip', async () => {
     const { client, body } = makeClient();
     const errors: string[] = [];
+    const diagnostics: Array<string | undefined> = [];
     const closes: Array<string | undefined> = [];
-    client.onError((e) => errors.push(e.code));
+    client.onError((e) => { errors.push(e.code); diagnostics.push(e.diagnostic); });
     client.onClose((e) => closes.push(e.reason));
     await client.connect(baseOptions());
 
-    body.feedRaw({ validationException: { message: 'raw AWS text that must not leak' } } as any);
+    body.feedRaw({ validationException: { message: 'ValidationException: prompt exceeds limit' } } as any);
     await flush();
 
     expect(errors).toContain('nova_validation');
     expect(closes).toEqual(['nova_validation']);
     expect(client.getState()).toBe('closed');
+    // The upstream message is preserved on the diagnostic field (operator
+    // surfaces only) — the typed message itself stays generic.
+    expect(diagnostics).toContain('ValidationException: prompt exceeds limit');
   });
 });
 

--- a/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
@@ -254,18 +254,29 @@ describe('NovaSonicLiveClient', () => {
     const closes: any[] = [];
     client.onClose((e) => closes.push(e));
     await client.connect(baseOptions());
+    client.sendAudioChunk('AAAA');
     body.end();
     await client.close('persona_swap');
     await client.close('persona_swap');
     const events = await sentEvents();
     const names = events.map(firstEventName);
-    expect(names.slice(-3)).toEqual(['promptEnd', 'sessionEnd'].length === 2
-      ? [names.at(-3)!, 'promptEnd', 'sessionEnd']
-      : names.slice(-3));
-    expect(names).toEqual(expect.arrayContaining(['promptEnd', 'sessionEnd']));
+    // Audio flowed, so teardown ends the audio block before prompt/session.
+    expect(names.slice(-3)).toEqual(['contentEnd', 'promptEnd', 'sessionEnd']);
     expect(closes).toHaveLength(1);
     expect(closes[0]).toEqual(expect.objectContaining({ initiatedLocally: true, reason: 'persona_swap' }));
     expect(client.getState()).toBe('closed');
+  });
+
+  it('close of a session that never sent audio omits the audio contentEnd (Nova rejects ending an empty block)', async () => {
+    const { client, body, sentEvents } = makeClient();
+    await client.connect(baseOptions());
+    body.end();
+    await client.close('done');
+    const events = await sentEvents();
+    const names = events.map(firstEventName);
+    expect(names.slice(-2)).toEqual(['promptEnd', 'sessionEnd']);
+    // The only contentEnd is the system text block's — none for audio.
+    expect(names.filter((n) => n === 'contentEnd')).toHaveLength(1);
   });
 
   it('SDK send failure maps to a typed error + single onClose; no raw AWS text in the thrown error', async () => {

--- a/services/gateway/test/orb/live/upstream/nova-sonic-protocol.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-protocol.test.ts
@@ -161,6 +161,17 @@ describe('convertToolsToNovaSpecs', () => {
     expect(specs.map((s) => s.toolSpec.name)).toEqual(['a', 'b']);
   });
 
+  it('skips Vertex builtin directives (google_search etc.) — Nova has no equivalent', () => {
+    const specs = convertToolsToNovaSpecs([
+      { google_search: {} },
+      { function_declarations: [{ name: 'a', description: '', parameters: { type: 'object' } }] },
+      { googleSearch: {} },
+      { url_context: {} },
+      { code_execution: {} },
+    ]);
+    expect(specs.map((s) => s.toolSpec.name)).toEqual(['a']);
+  });
+
   it('rejects duplicate tool names and malformed schemas BEFORE a paid stream', () => {
     expect(() =>
       convertToolsToNovaSpecs([


### PR DESCRIPTION
## Root causes (from the diagnostics build, PR #2953)

The new `diagnostic` field surfaced AWS's actual rejection reasons, and they disprove the payload-limit theory entirely:

1. **Real ORB sessions failed at connect** ("Voice connection failed") because the live tool catalog contains `{ google_search: {} }` (`live-tool-catalog.ts:2514`) — a Vertex grounding directive, not a function declaration. `convertToolsToNovaSpecs` treated it as malformed and threw before the stream opened.
2. **Every payload probe's `nova_validation` was a probe artifact.** AWS's message: `Cannot end content [...] as no content data was received`. The payload probes never send audio, and `close()` unconditionally ended the never-fed AUDIO block. The rejection was about teardown, not about the system-instruction or tool payload under test — which is why 1 KB of text and a single tiny tool "failed" identically to 32 KB and 100 tools.

## Changes

- `convertToolsToNovaSpecs` now skips Vertex builtin directives (`google_search`, `googleSearch`, `google_search_retrieval`, `url_context`, `code_execution`, `retrieval`, camelCase variants) — Nova has no grounding equivalent. Genuinely malformed function declarations (missing name, bad schema, duplicates) still throw before a paid stream opens.
- `NovaSonicLiveClient.close()` ends the audio content block only when at least one `audioInput` frame was actually sent (tracked via `audioFramesSent`).
- `probeNovaPayload` streams 32 ms silence frames during its observe window so probes measure payload acceptance, not teardown behavior.

## Testing

- New: converter skips builtin directives while keeping real declarations; close-without-audio omits the audio `contentEnd` (single `contentEnd` = system text block); close-with-audio still ends `contentEnd → promptEnd → sessionEnd`.
- 43/43 across the Nova client/protocol/voice-lab suites; `tsc` clean.

After deploy: rerun the payload probes (expect real catalog to pass now) and re-test Connect &amp; Talk voice-to-voice on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_