### PR TITLE
fix(nova): thread connect-failure diagnostic into the connect_failed OASIS event (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -444,10 +444,13 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       this.responseLoopDone = this.runResponseLoop(response.body);
     } catch (err) {
       const code = classifyNovaError(err);
+      const diagnostic = extractNovaDiagnostic(err);
       this.state = 'error';
-      this.emitError({ code, message: `Nova connect failed (${code})`, cause: err, diagnostic: extractNovaDiagnostic(err) });
+      this.emitError({ code, message: `Nova connect failed (${code})`, cause: err, diagnostic });
       this.finalizeClose({ initiatedLocally: false, reason: code });
-      throw new Error(`nova_connect_failed: ${code}`);
+      // The typed message stays generic; the bounded upstream detail rides a
+      // non-message property for operator surfaces (OASIS events, bench).
+      throw Object.assign(new Error(`nova_connect_failed: ${code}`), { diagnostic });
     }
   }
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7121,6 +7121,10 @@ async function connectToLiveAPI(
         const novaPersona = ((session as any).activePersona as string) || 'vitana';
         const novaVoice =
           resolveNovaSonicVoice({ language: session.lang || 'en', persona: novaPersona }) ?? 'tiffany';
+        // Stashed for the connect_failed OASIS payload — makes a rejected
+        // envelope diagnosable without server-log access.
+        (session as any)._novaInstructionChars = novaSystemInstruction.length;
+        (session as any)._novaToolEntryCount = novaTools.length;
 
         // Rotation (Bedrock caps a bidirectional stream at 8 minutes): open
         // the REPLACEMENT stream first (same connect path → same context/
@@ -7319,6 +7323,11 @@ async function connectToLiveAPI(
             session_id: session.sessionId,
             provider: 'nova_sonic',
             error: (err as Error).message,
+            // Bounded upstream detail (operator surface) + envelope shape so
+            // a failure is diagnosable without CloudWatch access.
+            diagnostic: (err as { diagnostic?: string })?.diagnostic ?? null,
+            instruction_chars: (session as any)._novaInstructionChars ?? null,
+            tool_entry_count: (session as any)._novaToolEntryCount ?? null,
             status: 'error',
           } as any,
         } as any).catch(() => { /* best-effort */ });


### PR DESCRIPTION
## Why

After PR #2954 every payload probe passes (real catalog, 24/32/48 KB instructions), yet a real ORB session on staging still dies at connect with `nova_connect_failed: nova_validation` (reproduced via the session API; OASIS `orb.live.connection_failed` for `live-949fa332…`). The difference must be in the exact session envelope — and the AWS error text is currently dropped on the connect path, with no CloudWatch access to recover it.

## What

- `NovaSonicLiveClient.connect()`'s catch now attaches the bounded upstream diagnostic (≤400 chars) to the thrown `nova_connect_failed` error as a non-message property — the typed message stays generic.
- orb-live's Nova connect catch records `diagnostic`, `instruction_chars`, and `tool_entry_count` on the `orb.upstream.nova.connect_failed` OASIS payload, so a rejected envelope is diagnosable from the operator surface.

## Testing

- Nova client suite 20/20; `tsc` clean.
- After deploy: re-run the real-session repro and read the exact AWS rejection reason from the OASIS event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_