### PR TITLE
fix(nova): record upstream diagnostic on orb.live.connection_failed (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -13065,6 +13065,11 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
       emitLiveSessionEvent('orb.live.connection_failed', {
         session_id: sessionId,
         error: err.message,
+        // BOOTSTRAP-NOVA-SONIC-VOICE: bounded upstream detail attached by the
+        // Nova client's connect catch — operator surface only. Null on Vertex.
+        upstream_diagnostic: (err as { diagnostic?: string })?.diagnostic ?? null,
+        upstream_instruction_chars: (session as any)._novaInstructionChars ?? null,
+        upstream_tool_entry_count: (session as any)._novaToolEntryCount ?? null,
         vertex_project_id: VERTEX_PROJECT_ID || 'EMPTY',
       }, 'error').catch(() => {});
       // VTID-01959: voice self-healing dispatch (mode-gated; off by default).


### PR DESCRIPTION
## Why

PR #2955 attached the AWS rejection detail to `orb.upstream.nova.connect_failed` — but that event type turns out not to persist to `oasis_events` (verified against live session `live-061079d1…`: the diag and `orb.live.connection_failed` rows land, the nova-topic ones never do). So the diagnostic is still unreadable.

## What

Attach `upstream_diagnostic`, `upstream_instruction_chars`, and `upstream_tool_entry_count` to the `orb.live.connection_failed` session event — a topic that demonstrably persists. Values are null on the Vertex path.

## Testing

`tsc` clean; no behavior change beyond event payload fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_