### PR TITLE
feat(nova): content-filter bisect instruments — full-text brain debug + verbatim system_text probe (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -11848,6 +11848,10 @@ router.get('/debug/brain-instruction', requireAuthWithTenant, async (req: Authen
       has_social_context: instruction.includes('<social_context>'),
       has_self_check: instruction.includes('MANDATORY SELF-CHECK'),
       social_tool_declared: toolNames.includes('get_social_context'),
+      // BOOTSTRAP-NOVA-SONIC-VOICE: full=1 returns the instruction text
+      // itself (self-or-admin scoped above) so provider content-filter
+      // rejections (Nova RAI) can be bisected against the real text.
+      ...(req.query.full === '1' ? { instruction } : {}),
     });
   } catch (err: any) {
     return res.status(500).json({ ok: false, error: err.message });

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -330,6 +330,8 @@ const NovaRunPostSchema = z.object({
   payload_probes: z.array(z.object({
     key: z.string().min(1).max(48),
     text_kb: z.number().int().min(0).max(128).optional(),
+    // Verbatim instruction text for content-filter bisecting (Nova RAI).
+    system_text: z.string().max(65536).optional(),
     chunk_kb: z.number().int().min(0).max(64).optional(),
     dummy_tools: z.number().int().min(0).max(300).optional(),
     real_catalog: z.boolean().optional(),

--- a/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
@@ -212,6 +212,9 @@ export interface NovaPayloadProbeSpec {
   key: string;
   /** System-instruction size in KB (filler text). 0/absent = tiny prompt. */
   text_kb?: number;
+  /** Verbatim system-instruction text — takes precedence over text_kb.
+   *  Used to bisect provider content-filter rejections against real text. */
+  system_text?: string;
   /** Chunk the instruction into textInput events of this many KB. */
   chunk_kb?: number;
   /** Number of small synthetic tools to declare. */
@@ -300,9 +303,11 @@ function payloadSpecToShape(spec: NovaPayloadProbeSpec): {
   tools?: ReadonlyArray<Record<string, unknown>>;
   chunkBytes?: number;
 } {
-  const systemInstruction = spec.text_kb && spec.text_kb > 0
-    ? 'You are a bench probe. Context: ' + 'x'.repeat(spec.text_kb * 1024)
-    : PROBE_SYSTEM_INSTRUCTION;
+  const systemInstruction = spec.system_text && spec.system_text.length > 0
+    ? spec.system_text
+    : spec.text_kb && spec.text_kb > 0
+      ? 'You are a bench probe. Context: ' + 'x'.repeat(spec.text_kb * 1024)
+      : PROBE_SYSTEM_INSTRUCTION;
   let tools: ReadonlyArray<Record<string, unknown>> | undefined;
   if (spec.real_catalog) {
     let catalog = buildLiveApiTools('authenticated') as Array<Record<string, unknown>>;


### PR DESCRIPTION
## Root cause found (via PR #2956's persisted diagnostic)

Real ORB Nova sessions fail connect because AWS rejects the actual brain instruction (29,842 chars) with:

> `This request has been blocked by our content filters.`

That's Nova's built-in Responsible-AI moderation on the system prompt — not a size limit (32/48 KB filler passes), not the tool catalog (real catalog passes since #2954). To locate the tripping section, this PR adds bisect instruments:

## What

- `GET /orb/debug/brain-instruction?full=1` also returns the instruction text (same self-or-admin scope the endpoint already enforces).
- Voice-lab payload probes accept `system_text` (verbatim, ≤64 KB, Zod-capped) so slices of the real instruction can be replayed against a live Nova connect remotely.

## Next

Bisect the real text → identify the section Nova's filter blocks → rephrase or strip it on the Nova path only.

## Testing

`tsc` clean; voice-lab suites 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_