### PR TITLE
fix(nova): Nova-safe identity lock — unblocks real ORB voice sessions (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/upstream/nova-instruction-sanitizer.ts
+++ b/services/gateway/src/orb/live/upstream/nova-instruction-sanitizer.ts
@@ -1,0 +1,67 @@
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE: Nova-safe system-instruction sanitizer.
+ *
+ * Amazon Nova's built-in Responsible-AI content filter rejects the whole
+ * bidirectional stream ("This request has been blocked by our content
+ * filters") when the system prompt contains the IDENTITY LOCK block's
+ * persona-impersonation denial list — measured by live bisect on staging
+ * (2026-07-27): the block's "You NEVER: … mimic another persona's tone,
+ * signature phrases, or voice …" list alone trips the filter, while the
+ * rest of the ~30KB instruction (brain context, RULE 0, journey blocks,
+ * real tool catalog) passes.
+ *
+ * This sanitizer swaps ONLY that marker-delimited block for a semantically
+ * equivalent phrasing proven to pass Nova's filter (same bisect run,
+ * verified inside the full assembled instruction). The Vertex path is
+ * untouched — parity of intent, not of exact wording, on this one block.
+ */
+
+const LOCK_START = '=== IDENTITY LOCK ===';
+const LOCK_END = '=== END IDENTITY LOCK ===';
+
+/** Fallback role line when the original block's line can't be recovered. */
+const DEFAULT_ROLE_LINE = "the user's life companion and instruction manual";
+
+function buildNovaSafeIdentityLock(roleLine: string): string {
+  return `${LOCK_START}
+YOU ARE Vitana.
+Your role is ${roleLine}.
+
+You speak exclusively as Vitana, always in your own voice. The conversation
+transcript may show OTHER personas (Devon — our tech-support colleague, the
+only specialist currently enabled) speaking earlier; those lines belong to
+them — read them as third-party context only, and always answer as yourself.
+
+If you ever notice yourself drifting toward another persona's identity,
+stop and re-anchor: "I'm Vitana." Then continue.
+${LOCK_END}`;
+}
+
+export interface NovaInstructionSanitizeResult {
+  text: string;
+  /** True when an IDENTITY LOCK block was found and replaced. */
+  replaced: boolean;
+}
+
+/**
+ * Replace the IDENTITY LOCK block with the Nova-safe equivalent. The
+ * per-surface role line ("Your role is …") from the original block is
+ * preserved so the Command Hub dev-co-pilot variant keeps its role text.
+ * No-op (replaced=false) when the block is absent.
+ */
+export function sanitizeInstructionForNova(instruction: string): NovaInstructionSanitizeResult {
+  const start = instruction.indexOf(LOCK_START);
+  if (start === -1) return { text: instruction, replaced: false };
+  const endIdx = instruction.indexOf(LOCK_END, start);
+  if (endIdx === -1) return { text: instruction, replaced: false };
+  const end = endIdx + LOCK_END.length;
+
+  const original = instruction.slice(start, end);
+  const roleMatch = /Your role is ([^\n]+?)\.?\n/.exec(original);
+  const roleLine = roleMatch?.[1]?.trim() || DEFAULT_ROLE_LINE;
+
+  return {
+    text: instruction.slice(0, start) + buildNovaSafeIdentityLock(roleLine) + instruction.slice(end),
+    replaced: true,
+  };
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1390,6 +1390,7 @@ import {
 } from '../orb/live/upstream/nova-sonic-config';
 import { resolveNovaSonicVoice } from '../orb/live/voice/nova-sonic-voice';
 import { prewarmNovaSonicBedrock } from '../orb/live/upstream/nova-sonic-live-client';
+import { sanitizeInstructionForNova } from '../orb/live/upstream/nova-instruction-sanitizer';
 import { startNovaSonicKeepWarm } from '../orb/live/upstream/nova-sonic-keepwarm';
 import { createUpstreamClient } from '../orb/live/upstream/upstream-client-factory';
 import { bindUpstreamSessionHandlers } from '../orb/live/session/upstream-message-handler';
@@ -7113,8 +7114,14 @@ async function connectToLiveAPI(
         const novaCfg = getNovaSonicConfig(process.env);
         const envelope = (await buildOrbVertexSetupEnvelope()) as { setup?: Record<string, any> };
         const setup = envelope.setup ?? {};
-        const novaSystemInstruction: string =
-          setup.system_instruction?.parts?.[0]?.text ?? '';
+        // Nova's RAI content filter rejects the stream over the IDENTITY
+        // LOCK block's impersonation-denial list (measured via bisect) —
+        // swap it for the Nova-safe equivalent. Vertex is untouched.
+        const { text: novaSystemInstruction, replaced: novaLockReplaced } =
+          sanitizeInstructionForNova(setup.system_instruction?.parts?.[0]?.text ?? '');
+        if (novaLockReplaced) {
+          emitDiag(session, 'nova_instruction_sanitized', { provider: 'nova_sonic', block: 'identity_lock' });
+        }
         const novaTools: Array<Record<string, unknown>> = Array.isArray(setup.tools)
           ? (setup.tools as Array<Record<string, unknown>>)
           : [];

--- a/services/gateway/test/orb/live/upstream/nova-instruction-sanitizer.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-instruction-sanitizer.test.ts
@@ -1,0 +1,62 @@
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE: Nova-safe identity-lock sanitizer.
+ */
+import { sanitizeInstructionForNova } from '../../../../src/orb/live/upstream/nova-instruction-sanitizer';
+
+const VERTEX_LOCK = `=== IDENTITY LOCK ===
+YOU ARE Vitana.
+Your role is the user's life companion and instruction manual.
+
+You speak EXCLUSIVELY as Vitana. You NEVER:
+  - introduce yourself as another persona ("Hi, this is Devon" — only Devon ever says that)
+  - continue another persona's sentence as if it were your own
+  - mimic another persona's tone, signature phrases, or voice
+  - acknowledge another persona's words as if YOU said them
+  - name yourself as anyone other than Vitana
+
+If you ever notice yourself drifting toward another persona's identity,
+stop and re-anchor: "I'm Vitana." Then continue.
+=== END IDENTITY LOCK ===`;
+
+describe('sanitizeInstructionForNova', () => {
+  it('replaces the identity-lock block and drops the filter-tripping denial list', () => {
+    const instruction = `PREAMBLE\n${VERTEX_LOCK}\nPOSTAMBLE`;
+    const { text, replaced } = sanitizeInstructionForNova(instruction);
+    expect(replaced).toBe(true);
+    // The measured Nova RAI trigger must be gone.
+    expect(text).not.toContain('mimic another persona');
+    expect(text).not.toContain('You NEVER:');
+    // Markers and identity intent stay so downstream section decomposition
+    // and the persona anchor keep working.
+    expect(text).toContain('=== IDENTITY LOCK ===');
+    expect(text).toContain('=== END IDENTITY LOCK ===');
+    expect(text).toContain('YOU ARE Vitana.');
+    expect(text).toContain('re-anchor: "I\'m Vitana."');
+    // Surrounding content untouched.
+    expect(text.startsWith('PREAMBLE\n')).toBe(true);
+    expect(text.endsWith('\nPOSTAMBLE')).toBe(true);
+  });
+
+  it('preserves the per-surface role line (Command Hub dev co-pilot variant)', () => {
+    const devLock = VERTEX_LOCK.replace(
+      "the user's life companion and instruction manual",
+      'the engineering co-pilot for the Vitana platform',
+    );
+    const { text, replaced } = sanitizeInstructionForNova(devLock);
+    expect(replaced).toBe(true);
+    expect(text).toContain('Your role is the engineering co-pilot for the Vitana platform.');
+  });
+
+  it('no-ops when no identity-lock block is present', () => {
+    const { text, replaced } = sanitizeInstructionForNova('You are a bench probe.');
+    expect(replaced).toBe(false);
+    expect(text).toBe('You are a bench probe.');
+  });
+
+  it('no-ops on an unterminated block rather than corrupting the prompt', () => {
+    const broken = 'X\n=== IDENTITY LOCK ===\nYOU ARE Vitana.';
+    const { text, replaced } = sanitizeInstructionForNova(broken);
+    expect(replaced).toBe(false);
+    expect(text).toBe(broken);
+  });
+});


### PR DESCRIPTION
## The root cause, finally measured

Live content bisect (PR #2957's `system_text` probes) against Nova on staging:

| Probe | Result |
|---|---|
| Full 27KB real brain instruction | ✅ pass |
| Real tool catalog (+16-48KB filler) | ✅ pass |
| Brain + catalog combined | ✅ pass |
| Scaffold blocks: role header, Vitana-ID header, RULE 0, journey | ✅ pass |
| **IDENTITY LOCK block alone** | ❌ `This request has been blocked by our content filters` |
| Lock sub-part: `You NEVER: … mimic another persona's tone, signature phrases, or voice …` | ❌ **the minimal trigger** |
| Nova-safe rephrasing, alone and inside the full assembly + real catalog | ✅ pass |

Nova's built-in Responsible-AI filter reads the impersonation-denial list as a persona-hijack prompt and rejects the whole stream — which is why every real ORB session died with "Voice connection failed" while bench probes (innocuous filler text) passed.

## Fix

- New `nova-instruction-sanitizer.ts`: `sanitizeInstructionForNova()` swaps only the marker-delimited IDENTITY LOCK block for a semantically equivalent phrasing proven to pass Nova's filter, preserving the per-surface role line (Command Hub dev co-pilot variant keeps its role text). No-op when the block is absent or unterminated.
- Applied in orb-live's **Nova branch only** — Vertex keeps its battle-tested wording. Emits a `nova_instruction_sanitized` diag when the swap happens.

## Testing

- 4/4 new sanitizer tests (replacement, role-line preservation, no-op paths); `tsc` clean.
- The exact replacement text was verified against **live Nova** inside the full assembled instruction + real catalog before writing this code.
- After deploy: real-session repro via the session API — expect `ready` + greeting audio instead of `connection_issue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_