### PR TITLE
fix(nova): persist mid-stream upstream error diagnostic as diag event (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -1813,6 +1813,12 @@ export function handleUpstreamError(
   event: UpstreamClientErrorEvent,
 ): void {
   console.error(`[BOOTSTRAP-NOVA-SONIC-VOICE] Upstream error for session ${ctx.session.sessionId}: code=${event.code} message=${event.message}`);
+  // Persist the bounded upstream detail (e.g. Nova's RAI/stream message) as
+  // a diag event — operator surface only; the user-facing error stays typed.
+  ctx.deps.emitDiag(ctx.session, 'upstream_error', {
+    code: event.code,
+    diagnostic: (event as { diagnostic?: string }).diagnostic ?? null,
+  });
   ctx.callbacks.onError(new Error(`${event.code}: ${event.message}`));
 }
 


### PR DESCRIPTION
## Status after the identity-lock fix (PR #2958)

Real ORB Nova session on staging now gets a **spoken greeting end-to-end**: `live_api_ready` → greeting prompt (16.7KB) → `output_transcript` ("I see we were just talking about Vitanaland. I'd suggest we start your longevity journey now…") → 97 audio chunks. The connect-path blocker is gone.

Remaining defect: ~15s after the greeting finishes, the stream dies with `nova_stream_error` (not locally initiated). The AWS message for mid-stream errors is captured on the client's error event but never persisted — only connect failures are.

## What

`handleUpstreamError` now emits an `upstream_error` diag event carrying the error code and the bounded upstream diagnostic, so mid-stream Nova failures are diagnosable from OASIS the same way connect failures became in PRs #2955/#2956. User-facing errors stay typed.

## Testing

`tsc` clean; session-handler suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_