### PR TITLE
fix(nova): wrap non-object tool outputs — Nova kills the stream on unparseable toolResult (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -586,9 +586,22 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       this.emitError({ code: 'nova_protocol_error', message: 'Tool result missing callId — cannot correlate toolUse' });
       return false;
     }
-    const content = result.success
+    const raw = result.success
       ? result.output
       : JSON.stringify({ error: result.error ?? 'tool failed', output: result.output });
+    // Nova requires toolResult.content to parse as a JSON OBJECT — a plain
+    // text (or array/scalar JSON) payload kills the whole stream with
+    // "Tool Response parsing error" (measured live, 2026-07-27). Pass JSON
+    // objects through untouched; wrap everything else.
+    let content: string;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      content = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? raw
+        : JSON.stringify({ result: parsed });
+    } catch {
+      content = JSON.stringify({ result: raw });
+    }
     for (const event of buildToolResultEvents({
       promptName: this.promptName,
       contentName: randomUUID(),

--- a/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
@@ -240,6 +240,21 @@ describe('NovaSonicLiveClient', () => {
     expect(toolResult!.event.toolResult.content).toBe('{"ok":true}');
   });
 
+  it('sendToolResult wraps non-JSON-object outputs — Nova kills the stream on unparseable toolResult content', async () => {
+    const { client, body, sentEvents } = makeClient();
+    await client.connect(baseOptions());
+    body.feed({ event: { toolUse: { toolUseId: 'use-1', toolName: 't', content: '{}' } } });
+    await flush();
+    // Plain text output → wrapped in a JSON object.
+    client.sendToolResult({ callId: 'use-1', name: 't', success: true, output: 'All good, screen is Community.' });
+    // JSON array output → wrapped too (Nova wants an object).
+    client.sendToolResult({ callId: 'use-1', name: 't', success: true, output: '[1,2]' });
+    const events = await sentEvents();
+    const results = events.filter((e) => e.event.toolResult).map((e) => e.event.toolResult.content);
+    expect(JSON.parse(results[0])).toEqual({ result: 'All good, screen is Community.' });
+    expect(JSON.parse(results[1])).toEqual({ result: [1, 2] });
+  });
+
   it('sendToolResult without callId is a typed protocol error (no un-correlatable result)', async () => {
     const { client } = makeClient();
     const errors: any[] = [];


### PR DESCRIPTION
## Chain so far

After the identity-lock fix (#2958), a real ORB Nova session on staging speaks its greeting end-to-end. The next failure appears exactly at the model's first tool call (`save_diary_entry`, `thinking` at 6.5s, stream dead at 6.9s). The mid-stream diagnostic added in #2959 captured AWS's reason:

> `Tool Response parsing error` (`nova_validation`)

Nova requires `toolResult.content` to parse as a JSON **object** (the docs' `"{\"key\": \"value\"}"` shape). Our ORB tools often return plain prose or scalar/array JSON, which the Nova client passed through verbatim — one such tool result kills the entire bidirectional stream.

## Fix

`sendToolResult` now passes JSON-object outputs through untouched and wraps everything else (plain text, arrays, scalars) as `{"result": <value>}`. Failure results were already JSON objects. Vertex is unchanged — its `functionResponse` envelope accepts free-form output.

## Testing

- New test: plain-text and array outputs get wrapped; object outputs unchanged (existing correlation test still asserts pass-through of `{"ok":true}`). 21/21 client suite; `tsc` clean.
- After deploy: rerun the full browser-sim (SSE + mic silence) and confirm the session survives greeting → tool call → continued conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_