### PR TITLE
Fix wrong default GATEWAY_URL in setup-cloud-scheduler.sh

### DIFF
--- a/scripts/setup-cloud-scheduler.sh
+++ b/scripts/setup-cloud-scheduler.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 # ── Config ────────────────────────────────────────────────────
 PROJECT="${GCP_PROJECT_ID:-lovable-vitana-vers1}"
 REGION="${GCP_REGION:-us-central1}"
-GATEWAY_URL="${GATEWAY_URL:-https://vitana-gateway-q74ibpv6ia-uc.a.run.app}"
+GATEWAY_URL="${GATEWAY_URL:-https://gateway-q74ibpv6ia-uc.a.run.app}"
 TENANT_ID="${DEFAULT_TENANT_ID:-}"
 DELETE=false
 DRY_RUN=false


### PR DESCRIPTION
## Summary

- Confirmed live: `gcloud run services describe gateway` returns `https://gateway-q74ibpv6ia-uc.a.run.app` — **no** `vitana-` prefix.
- `scripts/setup-cloud-scheduler.sh`'s hardcoded default had an extra `vitana-` prefix (`vitana-gateway-q74ibpv6ia-uc.a.run.app`), a hostname that returns Google's generic infrastructure 404 (the request never reaches the gateway container).
- Root-caused via the newly-created `gateway-daily-feature-tip` job: `gcloud scheduler jobs describe` showed `status: {code: 5}` (gRPC `NOT_FOUND`) despite firing daily since creation, and a direct `curl` to the same URL reproduced the identical 404.

## Impact

This means **every** job this script creates has likely been silently 404ing via Cloud Scheduler since the script was written — not just the new `daily-feature-tip` job, but `morning-briefing`, `diary-reminder`, `daily-pace-notifications`, `daily-recompute`, and the reminder ticks too. Anyone who already ran the script needs to re-run it (or pass `--gateway https://gateway-q74ibpv6ia-uc.a.run.app` explicitly) to recreate the existing jobs with the corrected host — done live during this session's testing, confirmed the corrected URL creates/updates all jobs successfully.

## Test plan

- [x] Live re-verification: `bash scripts/setup-cloud-scheduler.sh --gateway https://gateway-q74ibpv6ia-uc.a.run.app` recreated all jobs against the confirmed-correct host
- [ ] Confirm `did_you_know_state` gets a row and a real `did-you-know-feature` announcement appears after the next 17:00 UTC firing

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhBPkg9U1DJyo8ojognubd)_