### PR TITLE
fix(nova): silence keepalive + 4096 maxTokens — stops the 15s idle stream death (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -363,6 +363,9 @@ NOVA_SONIC_ROTATION_AFTER_MS=435000
 # + task-role credentials hot between voice sessions; must stay under the
 # handler's 480s idle timeout). 0 disables.
 NOVA_SONIC_KEEPWARM_MS=240000
+# Per-turn output budget (sessionStart maxTokens). The sample default of 1024
+# starves real ORB turns (greeting + tool rounds) into silent turn-ends.
+NOVA_SONIC_MAX_TOKENS=4096
 # Unlock for a GLOBAL nova_sonic active-provider flip (still requires runtime
 # readiness; the canary rides the per-identity allowlists, never this).
 NOVA_SONIC_ALLOW_GLOBAL_FLIP=false

--- a/services/gateway/.env.template
+++ b/services/gateway/.env.template
@@ -108,4 +108,7 @@ NOVA_SONIC_ROTATION_AFTER_MS=435000
 # + task-role credentials hot between voice sessions; must stay under the
 # handler's 480s idle timeout). 0 disables.
 NOVA_SONIC_KEEPWARM_MS=240000
+# Per-turn output budget (sessionStart maxTokens). The sample default of 1024
+# starves real ORB turns (greeting + tool rounds) into silent turn-ends.
+NOVA_SONIC_MAX_TOKENS=4096
 NOVA_SONIC_ALLOW_GLOBAL_FLIP=false

--- a/services/gateway/src/orb/live/upstream/nova-sonic-config.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-config.ts
@@ -29,6 +29,10 @@ const DEFAULT_ROTATION_AFTER_MS = 435_000;
 // Under NodeHttp2Handler's 480s idle sessionTimeout so the pooled HTTP/2
 // session never expires between pings.
 const DEFAULT_KEEPWARM_MS = 240_000;
+// Per-turn output budget. The Nova sample's 1024 starves real ORB turns —
+// the greeting turn alone (16KB wake prompt + tool rounds) exhausted it and
+// ended with no speech (staging session live-dedf85d5).
+const DEFAULT_MAX_TOKENS = 4096;
 
 export type NovaSonicConfigIssue =
   | 'nova_region_invalid'
@@ -37,7 +41,8 @@ export type NovaSonicConfigIssue =
   | 'nova_canary_tenant_ids_invalid'
   | 'nova_connect_timeout_invalid'
   | 'nova_rotation_after_invalid'
-  | 'nova_keepwarm_invalid';
+  | 'nova_keepwarm_invalid'
+  | 'nova_max_tokens_invalid';
 
 export interface NovaSonicConfig {
   enabled: boolean;
@@ -53,6 +58,8 @@ export interface NovaSonicConfig {
    * NodeHttp2Handler drops idle sessions after 8 min). 0 disables.
    */
   keepWarmMs: number;
+  /** sessionStart inferenceConfiguration.maxTokens (per-turn output budget). */
+  maxTokens: number;
   /**
    * Typed configuration problems. Non-empty issues force `ready` false —
    * misconfiguration is never silently corrected into live traffic.
@@ -142,6 +149,9 @@ export function getNovaSonicConfig(env: NodeJS.ProcessEnv): NovaSonicConfig {
   );
   if (keepWarmMs === null) issues.push('nova_keepwarm_invalid');
 
+  const maxTokens = parsePositiveInt(env.NOVA_SONIC_MAX_TOKENS, DEFAULT_MAX_TOKENS);
+  if (maxTokens === null) issues.push('nova_max_tokens_invalid');
+
   return {
     enabled,
     region: NOVA_SONIC_REGION,
@@ -151,6 +161,7 @@ export function getNovaSonicConfig(env: NodeJS.ProcessEnv): NovaSonicConfig {
     connectTimeoutMs: connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
     rotationAfterMs: rotationAfterMs ?? DEFAULT_ROTATION_AFTER_MS,
     keepWarmMs: keepWarmMs ?? DEFAULT_KEEPWARM_MS,
+    maxTokens: maxTokens ?? DEFAULT_MAX_TOKENS,
     issues,
     ready: enabled && issues.length === 0,
   };

--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -382,7 +382,7 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     // Queue the full initialization sequence BEFORE opening the stream so
     // the request body replays it in order the moment Bedrock connects.
     const systemContentName = randomUUID();
-    this.queue.push(buildSessionStart());
+    this.queue.push(buildSessionStart({ maxTokens: this.deps.config.maxTokens }));
     this.queue.push(buildPromptStart({ promptName: this.promptName, voiceId: this.deps.voiceId, tools }));
     // interactive:false — the documented shape for SYSTEM prompts (the
     // interactive:true form is the cross-modal USER text path, which may

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1343,7 +1343,7 @@ import { classifyUpstreamClose } from '../orb/live/session/upstream-close-classi
 // VTID-03234 (report finding #3): restore the upstream ping + silence
 // keepalive that the VertexLiveClient refactor left unreachable (it lived in
 // the now-dead setup_complete branch of the message handler).
-import { armUpstreamKeepalive } from '../orb/live/session/upstream-keepalive';
+import { armUpstreamKeepalive, clearUpstreamKeepalive } from '../orb/live/session/upstream-keepalive';
 // VTID-03126 (Phase D.3): Live API voice resolver — externalizes the
 // LIVE_API_VOICES Record + adds telemetry on silent fallbacks.
 import { getLiveApiVoice } from '../orb/live/voice/live-api-voice';
@@ -7219,9 +7219,14 @@ async function connectToLiveAPI(
             markVoiceLatency,
             finalizeVoiceTurnLatency,
           },
-          // Nova needs no synthetic PCM keepalive — server-side turn
-          // detection keeps its stream alive; rotation handles the 8-min cap.
-          options: { enableSilenceKeepalive: false },
+          // Nova NEEDS the synthetic PCM keepalive just like Vertex: Bedrock
+          // expects continuous audio-frame cadence and terminates an idle
+          // bidirectional stream after ~15s ("Premature close" — measured on
+          // staging session live-dedf85d5, exactly +15.0s after the last
+          // response event, with the widget's mic gated). The earlier
+          // assumption that server-side turn detection keeps the stream
+          // alive without input was wrong.
+          options: { enableSilenceKeepalive: true },
         });
 
         // Close policy: diag always; on an unexpected close of an active,
@@ -7233,6 +7238,9 @@ async function connectToLiveAPI(
             reason: closeEvent.reason ?? null,
             initiated_locally: closeEvent.initiatedLocally,
           });
+          // Stop feeding silence into a dead stream (mirrors the Vertex ws
+          // close handler's interval cleanup).
+          clearUpstreamKeepalive(session);
           if (session.upstreamClient === novaClient) {
             session.upstreamClient = null;
           }
@@ -7318,7 +7326,13 @@ async function connectToLiveAPI(
 
         // The ws-shaped facade lets every legacy upstreamWs call site
         // (greeting engine, nudges, input handlers, stop path) drive Nova.
-        resolve(createNovaWsFacade(novaClient) as unknown as WebSocket);
+        const novaFacade = createNovaWsFacade(novaClient) as unknown as WebSocket;
+        // Same keepalive the Vertex path arms after connect: Bedrock kills a
+        // bidirectional stream that goes ~15s without audio-frame input, so
+        // quiet pauses (mic gated, user thinking) need synthetic silence.
+        // ping() is a no-op on the facade; the silence leg does the work.
+        armUpstreamKeepalive(novaFacade, session, { sendAudioToLiveAPI });
+        resolve(novaFacade);
         return;
       } catch (err) {
         clearTimeout(connectionTimeout);

--- a/services/gateway/test/orb/live/upstream/nova-sonic-config.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-config.test.ts
@@ -25,9 +25,22 @@ describe('getNovaSonicConfig', () => {
         connectTimeoutMs: 15000,
         rotationAfterMs: 435000,
         keepWarmMs: 240000,
+        maxTokens: 4096,
         issues: [],
       }),
     );
+  });
+
+  it('maxTokens is env-tunable and invalid values are a typed issue', () => {
+    expect(
+      getNovaSonicConfig({ NOVA_SONIC_MAX_TOKENS: '8192' } as NodeJS.ProcessEnv).maxTokens,
+    ).toBe(8192);
+    const bad = getNovaSonicConfig({
+      NOVA_SONIC_ENABLED: 'true',
+      NOVA_SONIC_MAX_TOKENS: '0',
+    } as NodeJS.ProcessEnv);
+    expect(bad.issues).toContain('nova_max_tokens_invalid');
+    expect(bad.ready).toBe(false);
   });
 
   it('is ready when enabled with a clean environment', () => {


### PR DESCRIPTION
## From the user's first real voice test (session `live-dedf85d5…`)

Symptoms: no Nova audio, "connection issue → reconnect", bounced to Vertex, Vertex also cut off mid-speech. The persisted diagnostics show two defects:

1. **`audio_in: 0` for the entire session, and Bedrock killed the stream with `Premature close` at exactly +15.0s after the last response event.** Same +15.0s signature on every failed session tonight; the session with continuous tool traffic survived 60s+. Nova requires a continuous audio-frame cadence — the widget gates its mic client-side, and the Nova path had the synthetic-silence keepalive **explicitly disabled** (my wrong assumption in Task 6 that server-side turn detection kept the stream alive). The Nova path now arms the exact same `armUpstreamKeepalive` the Vertex path uses (3s silence cadence through the ws-shaped facade) and clears it on upstream close.

2. **The greeting turn ended with almost no speech** (`audio_out: 1`). `sessionStart.maxTokens` was the AWS sample's 1024 — starved by a 16KB wake prompt plus tool rounds. Now wired through config: `NOVA_SONIC_MAX_TOKENS` (default **4096**, typed `nova_max_tokens_invalid` on bad values), documented in both env templates.

The reconnect-bounce-to-Vertex mess is a downstream consequence of the stream dying; with the stream stable it should not trigger.

## Testing

- 211/211 across all Nova/voice-lab suites (new: maxTokens default/env/invalid).
- `tsc` clean.
- After deploy: rerun the browser-sim (mic silence only, 60s+) — expect NO `Premature close`; then user retests Connect &amp; Talk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_