### PR TITLE
fix(nova): silence keepalive must run THROUGH model speech — breaks the END_TURN deadlock (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-keepalive.ts
+++ b/services/gateway/src/orb/live/session/upstream-keepalive.ts
@@ -42,6 +42,16 @@ export interface KeepaliveDeps {
   sendAudioToLiveAPI: (ws: WebSocket, audioB64: string, mimeType?: string) => boolean;
   /** Override the 25s ping cadence (tests). */
   pingIntervalMs?: number;
+  /**
+   * Nova: keep feeding silence even while `isModelSpeaking`. Vertex skips
+   * silence during model speech (it glitches Gemini VAD), but Nova expects
+   * a CONTINUOUS audio-input cadence and may not emit END_TURN until input
+   * flows — with the Vertex gate, a greeting whose turn-complete is pending
+   * starves the stream and Bedrock kills it ~15s later ("Premature close",
+   * staging session live-f1135350). Real mic audio still suppresses silence
+   * via the lastAudioForwardedTime idle threshold.
+   */
+  ignoreModelSpeaking?: boolean;
 }
 
 const DEFAULT_PING_INTERVAL_MS = 25_000;
@@ -91,7 +101,7 @@ export function armUpstreamKeepalive(
   }
   session.silenceKeepaliveInterval = setInterval(() => {
     if (ws.readyState !== WebSocket.OPEN || !session.active) return;
-    if (session.isModelSpeaking) return;
+    if (session.isModelSpeaking && !deps.ignoreModelSpeaking) return;
     const idleMs = Date.now() - (session.lastAudioForwardedTime ?? 0);
     if (idleMs >= getSilenceIdleThresholdMs()) {
       try {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7331,7 +7331,10 @@ async function connectToLiveAPI(
         // bidirectional stream that goes ~15s without audio-frame input, so
         // quiet pauses (mic gated, user thinking) need synthetic silence.
         // ping() is a no-op on the facade; the silence leg does the work.
-        armUpstreamKeepalive(novaFacade, session, { sendAudioToLiveAPI });
+        // ignoreModelSpeaking: Nova may not emit END_TURN until input audio
+        // flows, so silence must continue THROUGH model speech or the flag
+        // deadlocks the stream into the 15s idle kill.
+        armUpstreamKeepalive(novaFacade, session, { sendAudioToLiveAPI, ignoreModelSpeaking: true });
         resolve(novaFacade);
         return;
       } catch (err) {


### PR DESCRIPTION
## Verification of #2963 got 90% of the way

Zero-mic 90s session on staging (`live-f1135350…`): Nova connected and spoke the **full personalized greeting** — 6 transcript segments, 450 audio chunks ("Good morning, E2E… Today marks your 62nd day with Vitana… Your Vitana Index is holding steady at 126…"). The maxTokens fix works.

But the stream still died ~16s after speech ended. The remaining deadlock:

- Nova never emitted END_TURN for the greeting turn → `isModelSpeaking` stayed `true`
- `armUpstreamKeepalive`'s silence leg **skips while the model is speaking** (a Vertex-VAD protection)
- → zero input flowed → Bedrock's 15s idle kill → "Premature close" → the reconnect/Vertex-bounce mess the user experienced

## Fix

`KeepaliveDeps.ignoreModelSpeaking` (Nova passes `true`): silence frames continue through model speech, Nova's server VAD sees the continuous input cadence it requires, the turn can conclude, and the stream stays alive. Vertex behavior unchanged; real mic audio still suppresses synthetic silence via the `lastAudioForwardedTime` idle threshold.

## Testing

`tsc` clean; session suites pass. After deploy: repeat the zero-mic 90s session — expect greeting + stream alive the full window with no `Premature close`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_