### PR TITLE
fix(nova): real-time silence cadence — Nova's endpointer needs a gapless input stream (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-keepalive.ts
+++ b/services/gateway/src/orb/live/session/upstream-keepalive.ts
@@ -52,6 +52,24 @@ export interface KeepaliveDeps {
    * via the lastAudioForwardedTime idle threshold.
    */
   ignoreModelSpeaking?: boolean;
+  /**
+   * Nova: override the silence cadence to REAL-TIME streaming. The Vertex
+   * default (one 250ms frame every 3s, ~8% duty cycle) is an anti-idle
+   * heartbeat — but Nova's endpointer needs a continuous audio-input stream
+   * to conclude turns at all. With sparse input Nova never emits END_TURN
+   * after the greeting, `isModelSpeaking` stays true, and the gateway's own
+   * 20s audio-stall watchdog terminates a healthy session (staging session
+   * live-bc3ac313: 108 greeting chunks → silence → stall_detected →
+   * locally-initiated upstream close). Nova passes 250 so each tick ships
+   * exactly one frame-duration of silence — a gapless real-time stream,
+   * matching how the AWS samples continuously stream mic audio including
+   * ambient silence. Vertex omits it and keeps the 3s heartbeat.
+   */
+  silenceIntervalMs?: number;
+  /** Override the idle threshold before silence kicks in (pairs with
+   * silenceIntervalMs — Nova uses a sub-second threshold so the real-time
+   * stream resumes almost immediately after real audio stops). */
+  idleThresholdMs?: number;
 }
 
 const DEFAULT_PING_INTERVAL_MS = 25_000;
@@ -103,7 +121,7 @@ export function armUpstreamKeepalive(
     if (ws.readyState !== WebSocket.OPEN || !session.active) return;
     if (session.isModelSpeaking && !deps.ignoreModelSpeaking) return;
     const idleMs = Date.now() - (session.lastAudioForwardedTime ?? 0);
-    if (idleMs >= getSilenceIdleThresholdMs()) {
+    if (idleMs >= (deps.idleThresholdMs ?? getSilenceIdleThresholdMs())) {
       try {
         deps.sendAudioToLiveAPI(ws, SILENCE_AUDIO_B64, 'audio/pcm;rate=16000');
         // Don't update lastAudioForwardedTime — silence isn't real audio.
@@ -111,5 +129,5 @@ export function armUpstreamKeepalive(
         /* socket closing — ignore */
       }
     }
-  }, getSilenceKeepaliveIntervalMs());
+  }, deps.silenceIntervalMs ?? getSilenceKeepaliveIntervalMs());
 }

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7334,7 +7334,19 @@ async function connectToLiveAPI(
         // ignoreModelSpeaking: Nova may not emit END_TURN until input audio
         // flows, so silence must continue THROUGH model speech or the flag
         // deadlocks the stream into the 15s idle kill.
-        armUpstreamKeepalive(novaFacade, session, { sendAudioToLiveAPI, ignoreModelSpeaking: true });
+        // silenceIntervalMs 250 + idleThresholdMs 750: Nova's endpointer needs
+        // a CONTINUOUS real-time input stream — one 250ms frame per 250ms tick
+        // is gapless silence, exactly like a live mic streaming ambient quiet.
+        // The Vertex heartbeat cadence (250ms frame / 3s ≈ 8% duty) kept
+        // Bedrock from idle-killing but Nova still never concluded the
+        // greeting turn, so the gateway's own 20s audio-stall watchdog
+        // terminated healthy sessions (staging session live-bc3ac313).
+        armUpstreamKeepalive(novaFacade, session, {
+          sendAudioToLiveAPI,
+          ignoreModelSpeaking: true,
+          silenceIntervalMs: 250,
+          idleThresholdMs: 750,
+        });
         resolve(novaFacade);
         return;
       } catch (err) {

--- a/services/gateway/test/orb/live/session/upstream-keepalive.test.ts
+++ b/services/gateway/test/orb/live/session/upstream-keepalive.test.ts
@@ -67,6 +67,45 @@ describe('armUpstreamKeepalive', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('ignoreModelSpeaking feeds silence THROUGH model speech (Nova END_TURN deadlock)', () => {
+    const ws = makeWs();
+    const send = jest.fn(() => true);
+    const session = makeSession({ lastAudioForwardedTime: Date.now() - 10_000, isModelSpeaking: true });
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: send, ignoreModelSpeaking: true });
+    jest.advanceTimersByTime(3_000);
+    expect(send).toHaveBeenCalled();
+  });
+
+  it('silenceIntervalMs/idleThresholdMs overrides give Nova a real-time gapless cadence', () => {
+    const ws = makeWs();
+    const send = jest.fn(() => true);
+    const session = makeSession({ lastAudioForwardedTime: Date.now() - 1_000, isModelSpeaking: true });
+    armUpstreamKeepalive(ws, session, {
+      sendAudioToLiveAPI: send,
+      ignoreModelSpeaking: true,
+      silenceIntervalMs: 250,
+      idleThresholdMs: 750,
+    });
+    // 1s of ticks at 250ms → 4 frames of 250ms silence = gapless real time.
+    jest.advanceTimersByTime(1_000);
+    expect(send).toHaveBeenCalledTimes(4);
+  });
+
+  it('idleThresholdMs override suppresses silence while real audio is fresh', () => {
+    const ws = makeWs();
+    const send = jest.fn(() => true);
+    const session = makeSession({ lastAudioForwardedTime: Date.now(), isModelSpeaking: false });
+    armUpstreamKeepalive(ws, session, {
+      sendAudioToLiveAPI: send,
+      silenceIntervalMs: 250,
+      idleThresholdMs: 750,
+    });
+    jest.advanceTimersByTime(500); // idle only 500ms < 750ms threshold
+    expect(send).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(500); // now idle ≥ 750ms
+    expect(send).toHaveBeenCalled();
+  });
+
   it('does NOT ping or feed silence once the socket is closed', () => {
     const ws = makeWs(3 /* CLOSED */);
     const send = jest.fn(() => true);


### PR DESCRIPTION
## What

Nova-only change to the upstream silence keepalive: `KeepaliveDeps` gains `silenceIntervalMs` + `idleThresholdMs` overrides, and the Nova arm site in `orb-live.ts` passes `250 / 750` so each 250ms tick ships exactly one 250ms silence frame — a **gapless real-time input stream**, matching how a live mic streams ambient quiet. Vertex passes neither override and keeps its 3s heartbeat byte-identically.

## Why

The through-model-speech keepalive (#2964) fixed Bedrock's 15s idle kill — verified: staging session `live-bc3ac313` survived the full 90s observation window with zero stream errors. But the next layer of the same deadlock surfaced:

- Nova spoke the full greeting (108 audio chunks) and then **never emitted END_TURN**.
- The Vertex heartbeat cadence (one 250ms frame every 3s ≈ 8% duty cycle) is an anti-idle ping, not a continuous stream — and Nova's endpointer needs a continuous stream to conclude turns at all. The bench probes where Nova *did* end turns streamed silence at real-time cadence.
- With `isModelSpeaking` stuck true and no further audio, the gateway's **own 20s audio-stall watchdog** terminated the healthy session: `orb.live.stall_detected reason=audio_stall` → `upstream_closed reason=terminated initiated_locally=true`. That local kill is what cascades into the reconnect/Vertex-bounce mess seen in real Connect &amp; Talk sessions.

## Evidence

OASIS, session `live-bc3ac313-d96a-4f2a-a24a-3798591bc385` (post-#2964 build):
- 12:16:40.6 `model_start_speaking`, audio_out ramps 1→108 chunks
- 12:16:42.1 last audio chunk; `is_model_speaking` remains `true`, no END_TURN
- 12:17:02.1 `stall_detected reason=audio_stall timeout_ms=20000` → `upstream_closed initiated_locally=true`

## Tests

- 3 new keepalive tests: silence-through-model-speech, 250ms gapless cadence (4 frames/s), idle-threshold suppression while real audio is fresh. Suite 10/10.
- `tsc --noEmit` clean.

## After deploy

Repeat the zero-mic 90s session — expect greeting + END_TURN (`turn_complete` diag with `is_model_speaking=false` and no stall) + stream alive the full window. Then hand back for the manual voice retest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_