### PR TITLE
fix(nova): emit turnComplete on ASSISTANT contentEnd END_TURN — completionEnd never arrives in-turn (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-keepalive.ts
+++ b/services/gateway/src/orb/live/session/upstream-keepalive.ts
@@ -52,6 +52,24 @@ export interface KeepaliveDeps {
    * via the lastAudioForwardedTime idle threshold.
    */
   ignoreModelSpeaking?: boolean;
+  /**
+   * Nova: override the silence cadence to REAL-TIME streaming. The Vertex
+   * default (one 250ms frame every 3s, ~8% duty cycle) is an anti-idle
+   * heartbeat — but Nova's endpointer needs a continuous audio-input stream
+   * to conclude turns at all. With sparse input Nova never emits END_TURN
+   * after the greeting, `isModelSpeaking` stays true, and the gateway's own
+   * 20s audio-stall watchdog terminates a healthy session (staging session
+   * live-bc3ac313: 108 greeting chunks → silence → stall_detected →
+   * locally-initiated upstream close). Nova passes 250 so each tick ships
+   * exactly one frame-duration of silence — a gapless real-time stream,
+   * matching how the AWS samples continuously stream mic audio including
+   * ambient silence. Vertex omits it and keeps the 3s heartbeat.
+   */
+  silenceIntervalMs?: number;
+  /** Override the idle threshold before silence kicks in (pairs with
+   * silenceIntervalMs — Nova uses a sub-second threshold so the real-time
+   * stream resumes almost immediately after real audio stops). */
+  idleThresholdMs?: number;
 }
 
 const DEFAULT_PING_INTERVAL_MS = 25_000;
@@ -103,7 +121,7 @@ export function armUpstreamKeepalive(
     if (ws.readyState !== WebSocket.OPEN || !session.active) return;
     if (session.isModelSpeaking && !deps.ignoreModelSpeaking) return;
     const idleMs = Date.now() - (session.lastAudioForwardedTime ?? 0);
-    if (idleMs >= getSilenceIdleThresholdMs()) {
+    if (idleMs >= (deps.idleThresholdMs ?? getSilenceIdleThresholdMs())) {
       try {
         deps.sendAudioToLiveAPI(ws, SILENCE_AUDIO_B64, 'audio/pcm;rate=16000');
         // Don't update lastAudioForwardedTime — silence isn't real audio.
@@ -111,5 +129,5 @@ export function armUpstreamKeepalive(
         /* socket closing — ignore */
       }
     }
-  }, getSilenceKeepaliveIntervalMs());
+  }, deps.silenceIntervalMs ?? getSilenceKeepaliveIntervalMs());
 }

--- a/services/gateway/src/orb/live/upstream/nova-sonic-protocol.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-protocol.ts
@@ -349,6 +349,13 @@ export class NovaOutputNormalizer {
     name: string;
     argsJson: string;
   } | null = null;
+  /**
+   * Dedupe guard for turnComplete: a turn's end can be signalled by BOTH the
+   * final ASSISTANT `contentEnd` (stopReason END_TURN) and a later
+   * `completionEnd` — emit exactly one turnComplete per turn. Reset when the
+   * next content block starts (new generation activity).
+   */
+  private turnCompleteEmitted = false;
 
   normalize(raw: unknown): NovaNormalizedEvent[] {
     const eventObj = (raw as { event?: Record<string, unknown> })?.event;
@@ -378,6 +385,9 @@ export class NovaOutputNormalizer {
         }
       }
       if (contentId) this.contentMeta.set(contentId, meta);
+      // New content block = new generation activity → the next END_TURN /
+      // completionEnd is a fresh turn boundary again.
+      this.turnCompleteEmitted = false;
       out.push({ kind: 'ignored', eventName: 'contentStart' });
     }
 
@@ -442,6 +452,23 @@ export class NovaOutputNormalizer {
         this.pendingToolUse = null;
       } else if (stopReason === 'INTERRUPTED') {
         out.push({ kind: 'interrupted' });
+      } else if (stopReason === 'END_TURN') {
+        // Nova signals end-of-turn on the FINAL output content block's
+        // contentEnd — completionEnd may not arrive until much later (or at
+        // teardown). Waiting only for completionEnd left isModelSpeaking
+        // stuck true after the greeting finished, so the gateway's 20s
+        // audio-stall watchdog killed healthy sessions (staging session
+        // live-3650deea: 1695 greeting chunks → stall_detected → local
+        // terminate). Scope to ASSISTANT blocks: USER (ASR) content blocks
+        // also carry END_TURN and must NOT complete the model's turn.
+        const ceId = (contentEnd.contentId as string) ?? (contentEnd.contentName as string) ?? '';
+        const ceMeta = this.contentMeta.get(ceId);
+        if (ceMeta?.role === 'ASSISTANT' && !this.turnCompleteEmitted) {
+          this.turnCompleteEmitted = true;
+          out.push({ kind: 'turnComplete' });
+        } else {
+          out.push({ kind: 'ignored', eventName: 'contentEnd' });
+        }
       } else {
         out.push({ kind: 'ignored', eventName: 'contentEnd' });
       }
@@ -450,7 +477,8 @@ export class NovaOutputNormalizer {
     const completionEnd = eventObj.completionEnd as Record<string, unknown> | undefined;
     if (completionEnd) {
       const stopReason = completionEnd.stopReason as string | undefined;
-      if (!stopReason || stopReason === 'END_TURN') {
+      if ((!stopReason || stopReason === 'END_TURN') && !this.turnCompleteEmitted) {
+        this.turnCompleteEmitted = true;
         out.push({ kind: 'turnComplete' });
       } else {
         out.push({ kind: 'ignored', eventName: 'completionEnd' });

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7334,7 +7334,19 @@ async function connectToLiveAPI(
         // ignoreModelSpeaking: Nova may not emit END_TURN until input audio
         // flows, so silence must continue THROUGH model speech or the flag
         // deadlocks the stream into the 15s idle kill.
-        armUpstreamKeepalive(novaFacade, session, { sendAudioToLiveAPI, ignoreModelSpeaking: true });
+        // silenceIntervalMs 250 + idleThresholdMs 750: Nova's endpointer needs
+        // a CONTINUOUS real-time input stream — one 250ms frame per 250ms tick
+        // is gapless silence, exactly like a live mic streaming ambient quiet.
+        // The Vertex heartbeat cadence (250ms frame / 3s ≈ 8% duty) kept
+        // Bedrock from idle-killing but Nova still never concluded the
+        // greeting turn, so the gateway's own 20s audio-stall watchdog
+        // terminated healthy sessions (staging session live-bc3ac313).
+        armUpstreamKeepalive(novaFacade, session, {
+          sendAudioToLiveAPI,
+          ignoreModelSpeaking: true,
+          silenceIntervalMs: 250,
+          idleThresholdMs: 750,
+        });
         resolve(novaFacade);
         return;
       } catch (err) {

--- a/services/gateway/test/orb/live/session/upstream-keepalive.test.ts
+++ b/services/gateway/test/orb/live/session/upstream-keepalive.test.ts
@@ -67,6 +67,45 @@ describe('armUpstreamKeepalive', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('ignoreModelSpeaking feeds silence THROUGH model speech (Nova END_TURN deadlock)', () => {
+    const ws = makeWs();
+    const send = jest.fn(() => true);
+    const session = makeSession({ lastAudioForwardedTime: Date.now() - 10_000, isModelSpeaking: true });
+    armUpstreamKeepalive(ws, session, { sendAudioToLiveAPI: send, ignoreModelSpeaking: true });
+    jest.advanceTimersByTime(3_000);
+    expect(send).toHaveBeenCalled();
+  });
+
+  it('silenceIntervalMs/idleThresholdMs overrides give Nova a real-time gapless cadence', () => {
+    const ws = makeWs();
+    const send = jest.fn(() => true);
+    const session = makeSession({ lastAudioForwardedTime: Date.now() - 1_000, isModelSpeaking: true });
+    armUpstreamKeepalive(ws, session, {
+      sendAudioToLiveAPI: send,
+      ignoreModelSpeaking: true,
+      silenceIntervalMs: 250,
+      idleThresholdMs: 750,
+    });
+    // 1s of ticks at 250ms → 4 frames of 250ms silence = gapless real time.
+    jest.advanceTimersByTime(1_000);
+    expect(send).toHaveBeenCalledTimes(4);
+  });
+
+  it('idleThresholdMs override suppresses silence while real audio is fresh', () => {
+    const ws = makeWs();
+    const send = jest.fn(() => true);
+    const session = makeSession({ lastAudioForwardedTime: Date.now(), isModelSpeaking: false });
+    armUpstreamKeepalive(ws, session, {
+      sendAudioToLiveAPI: send,
+      silenceIntervalMs: 250,
+      idleThresholdMs: 750,
+    });
+    jest.advanceTimersByTime(500); // idle only 500ms < 750ms threshold
+    expect(send).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(500); // now idle ≥ 750ms
+    expect(send).toHaveBeenCalled();
+  });
+
   it('does NOT ping or feed silence once the socket is closed', () => {
     const ws = makeWs(3 /* CLOSED */);
     const send = jest.fn(() => true);

--- a/services/gateway/test/orb/live/upstream/nova-sonic-protocol.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-protocol.test.ts
@@ -264,6 +264,31 @@ describe('NovaOutputNormalizer', () => {
     ]);
   });
 
+  it('ASSISTANT contentEnd END_TURN → turnComplete without waiting for completionEnd', () => {
+    const n = new NovaOutputNormalizer();
+    n.normalize({ event: { contentStart: { contentId: 'a1', type: 'AUDIO', role: 'ASSISTANT' } } });
+    expect(
+      n.normalize({ event: { contentEnd: { contentId: 'a1', type: 'AUDIO', stopReason: 'END_TURN' } } }),
+    ).toEqual([{ kind: 'turnComplete' }]);
+    // A trailing completionEnd for the SAME turn is deduped — one turnComplete per turn.
+    expect(n.normalize({ event: { completionEnd: { stopReason: 'END_TURN' } } })).toEqual([
+      { kind: 'ignored', eventName: 'completionEnd' },
+    ]);
+    // Next turn's content resets the guard: its END_TURN fires again.
+    n.normalize({ event: { contentStart: { contentId: 'a2', type: 'AUDIO', role: 'ASSISTANT' } } });
+    expect(
+      n.normalize({ event: { contentEnd: { contentId: 'a2', type: 'AUDIO', stopReason: 'END_TURN' } } }),
+    ).toEqual([{ kind: 'turnComplete' }]);
+  });
+
+  it('USER (ASR) contentEnd END_TURN does NOT complete the model turn', () => {
+    const n = new NovaOutputNormalizer();
+    n.normalize({ event: { contentStart: { contentId: 'u1', type: 'TEXT', role: 'USER' } } });
+    expect(
+      n.normalize({ event: { contentEnd: { contentId: 'u1', type: 'TEXT', stopReason: 'END_TURN' } } }),
+    ).toEqual([{ kind: 'ignored', eventName: 'contentEnd' }]);
+  });
+
   it('usageEvent.details.total → usage totals', () => {
     const n = new NovaOutputNormalizer();
     expect(


### PR DESCRIPTION
## What

`NovaOutputNormalizer` now emits `turnComplete` when an **ASSISTANT** content block's `contentEnd` carries `stopReason: "END_TURN"` — deduped against a later `completionEnd` via a per-turn guard that resets on the next `contentStart`. USER (ASR) content blocks also carry `END_TURN` and are explicitly excluded: a user finishing speaking must never complete the *model's* turn.

## Why

Third and (evidence says) final layer of the END_TURN deadlock:

1. #2963 fixed Bedrock's 15s idle kill (keepalive + maxTokens).
2. #2965 gave Nova the gapless real-time silence cadence its endpointer needs.
3. With both live, staging session `live-3650deea` spoke the **full** greeting (1695 audio chunks, 24 transcript segments) — and the 20s audio-stall watchdog *still* terminated the session at 12:49:53, because the normalizer only mapped `completionEnd` → turnComplete and explicitly **ignored** every non-TOOL `contentEnd`. Nova signals end-of-turn on the final ASSISTANT block's `contentEnd`; `completionEnd` may not arrive until much later. `isModelSpeaking` stayed true → watchdog kill → the local terminate behind the reconnect/Vertex-bounce mess.

## Evidence

OASIS, `live-3650deea-cc33-4a75-8780-6b912f7f7afe`:
- 12:49:07 `model_start_speaking` → 1695 chunks stream cleanly
- 12:49:53 `stall_detected reason=audio_stall` with `is_model_speaking=true` (no END_TURN mapped)
- 12:49:53 `turn_complete` + `upstream_closed reason=terminated` — both from the stall-recovery path, not Nova

## Tests

- 2 new normalizer tests: ASSISTANT `contentEnd END_TURN` → exactly one `turnComplete` (deduped vs `completionEnd`, guard resets per turn); USER ASR `contentEnd END_TURN` → ignored. Protocol + client suites 40/40.
- `tsc --noEmit` clean.

## After deploy

Zero-mic 90s session must show `turn_complete` with `is_model_speaking=false` **without** any `stall_detected`, and the stream stays alive the full window. Then hand back for the manual voice retest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_