### PR TITLE
fix(automations): add missing AP-0906..AP-0913 Cloud Scheduler jobs

### DIFF
--- a/scripts/setup-cloud-scheduler.sh
+++ b/scripts/setup-cloud-scheduler.sh
@@ -65,6 +65,80 @@ JOBS=(
   "AP-0510|upcoming-events-today|0 8 * * *|Europe/Berlin"
 )
 
+# ──────────────────────────────────────────────────────────────
+# Memory & Intelligence automations (VTID-01250 / BOOTSTRAP-MEMORY-
+# DAILY-LEARNING) — AP-0906 through AP-0913.
+#
+# ROOT CAUSE: these automations were registered in
+# automation-registry.ts with triggerType: 'cron' and real cron
+# expressions, but were NEVER added to this script. A registry
+# cronExpression is just descriptive metadata — it does not create a
+# Cloud Scheduler job by itself. Every execution of these automations,
+# ever, has trigger_type='manual' in automation_runs (confirmed via
+# direct query) — meaning no scheduler has ever invoked them, including
+# AP-0907 (Daily Learning Digest — the "I learned something new about
+# you today" push), which has zero runs in its entire history. That is
+# why users never see daily learning surfaced: nothing has ever run it
+# on a schedule.
+#
+# Schedules below are copied verbatim from automation-registry.ts's
+# triggerConfig.cronExpression comments. UTC (not Europe/Berlin): these
+# are backend batch/analytics jobs over all users' data, not a
+# single-user local-time notification slot — same reasoning as the
+# daily-recompute / daily-pace-notifications jobs further down this
+# file, which are also UTC.
+# ──────────────────────────────────────────────────────────────
+MEMORY_INTELLIGENCE_JOBS=(
+  "AP-0906|memory-routine-pattern-extraction|30 3 * * *|UTC"
+  "AP-0909|memory-relationship-graph-projection|50 3 * * *|UTC"
+  "AP-0908|memory-behavior-preference-inference|40 4 * * *|UTC"
+  "AP-0912|memory-health-correlation-insights|55 4 * * *|UTC"
+  "AP-0911|memory-user-model-synthesis|5 5 * * *|UTC"
+  "AP-0913|memory-own-post-capture|15 * * * *|UTC"
+  "AP-0910|memory-embedding-backfill|25 * * * *|UTC"
+  "AP-0907|memory-daily-learning-digest|10 18 * * *|UTC"
+)
+
+for JOB in "${MEMORY_INTELLIGENCE_JOBS[@]}"; do
+  IFS='|' read -r AP_ID NAME SCHEDULE TIMEZONE <<< "$JOB"
+  JOB_NAME="autopilot-${NAME}"
+  TARGET_URL="${GATEWAY_URL}/api/v1/automations/cron/${AP_ID}"
+
+  if $DELETE; then
+    echo "Deleting: $JOB_NAME"
+    if ! $DRY_RUN; then
+      gcloud scheduler jobs delete "$JOB_NAME" \
+        --project="$PROJECT" \
+        --location="$REGION" \
+        --quiet 2>/dev/null || echo "  (not found, skipping)"
+    fi
+  else
+    echo "Creating: $JOB_NAME → $AP_ID ($SCHEDULE $TIMEZONE)"
+    if ! $DRY_RUN; then
+      gcloud scheduler jobs delete "$JOB_NAME" \
+        --project="$PROJECT" \
+        --location="$REGION" \
+        --quiet 2>/dev/null || true
+
+      gcloud scheduler jobs create http "$JOB_NAME" \
+        --project="$PROJECT" \
+        --location="$REGION" \
+        --schedule="$SCHEDULE" \
+        --time-zone="$TIMEZONE" \
+        --uri="$TARGET_URL" \
+        --http-method=POST \
+        --headers="Content-Type=application/json" \
+        --message-body="{\"tenant_id\":\"$TENANT_ID\"}" \
+        --attempt-deadline=300s \
+        --max-retry-attempts=1 \
+        --description="Autopilot $AP_ID: $NAME"
+    fi
+  fi
+done
+
+echo ""
+echo "Done. ${#MEMORY_INTELLIGENCE_JOBS[@]} memory-intelligence scheduler jobs processed."
+
 for JOB in "${JOBS[@]}"; do
   IFS='|' read -r AP_ID NAME SCHEDULE TIMEZONE <<< "$JOB"
   JOB_NAME="autopilot-${NAME}"


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-01250` (Autopilot Automations Engine) / `BOOTSTRAP-MEMORY-DAILY-LEARNING`

**Layer:** CICDL

**Priority:** P1

---

## 📋 Summary

Root-caused why users never see "Vitana learned something about you today" or any of the other memory-intelligence automation output: the AP-0906..AP-0913 automations are correctly registered in `automation-registry.ts` with `triggerType: 'cron'` and real cron expressions, but a registry `cronExpression` is only descriptive metadata — it never actually created a GCP Cloud Scheduler job. `scripts/setup-cloud-scheduler.sh` is the only script that provisions real recurring jobs, and it was written for an earlier automation wave; it was never updated when the AP-09xx memory-intelligence series was added.

Confirmed directly against production `automation_runs`: every execution of every AP-09xx automation, ever, has `trigger_type='manual', trigger_source='api'`. Not one has ever fired via a real scheduler. `AP-0907` (Daily Learning Digest — the "I learned something new about you today" push) has **zero runs in its entire history**.

---

## ✅ Changes

- [x] Added the 8 missing Cloud Scheduler job definitions to `scripts/setup-cloud-scheduler.sh` (AP-0906, AP-0907, AP-0908, AP-0909, AP-0910, AP-0911, AP-0912, AP-0913), using the exact cron expressions already declared in `automation-registry.ts`
- [x] Used UTC (not Europe/Berlin) for these jobs — they're backend batch/analytics jobs over all users' data, not single-user local-time notification slots, matching this file's existing UTC jobs (`daily-recompute`, `daily-pace-notifications`)

---

## 🧪 Testing

- [x] `bash -n` syntax-checked clean (the file has pre-existing CRLF line endings unrelated to this change; verified clean both as-is against a line-ending-normalized copy)
- [x] Diff reviewed to confirm purely additive — 74 insertions, 0 deletions, no existing job definitions touched, cleanly rebased onto current `main`
- [ ] Not yet run against GCP — this PR only adds the job *definitions* to the provisioning script. Actually creating the Cloud Scheduler jobs requires running this script with `gcloud` credentials against project `lovable-vitana-vers1`, which is a separate, deliberate step outside this session's access.

---

## 🚨 Breaking Changes

None. Purely additive to the job-definition list; no existing automation, route, or schedule is modified.

---

## 📌 Additional Notes

This PR does not itself fix the "no daily learning" symptom — it only prepares the missing scheduler wiring. The actual jobs still need to be created by running:

```bash
./scripts/setup-cloud-scheduler.sh --tenant <TENANT_ID>
```

against the `lovable-vitana-vers1` GCP project, by someone with `gcloud` credentials. (The script's default `GATEWAY_URL` already resolves correctly to the live production gateway — verified directly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nXnLyojrW5m8L9SegctxH