### PR TITLE
fix(voice-latency): stop mislabeling every provider as vertex in voice.latency.measured (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/latency-tracker.ts
+++ b/services/gateway/src/orb/live/latency-tracker.ts
@@ -84,6 +84,18 @@ export class LatencyTracker {
     return this.enabled;
   }
 
+  /**
+   * Correct the provider hint after construction. Upstream provider
+   * selection (Vertex vs Nova vs LiveKit) can resolve AFTER the tracker is
+   * created — e.g. the turn-0 establishment tracker is constructed before
+   * `connectToLiveAPI` picks an upstream — so the constructor's `provider`
+   * is a best-guess default, not a fact. Call this once the real provider
+   * is known, before `finalize()`.
+   */
+  setProvider(provider: string): void {
+    this.ctx.provider = provider;
+  }
+
   mark(phase: LatencyPhase, detail?: Record<string, unknown>): void {
     if (!this.enabled || this.finalized) return;
     this.marks.push({ phase, at_ms: Date.now(), detail });

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1387,6 +1387,7 @@ import {
   getNovaSonicConfig,
   isNovaSonicIdentityAllowed,
   isNovaSonicLanguageSupported,
+  NOVA_SONIC_MODEL_ID,
 } from '../orb/live/upstream/nova-sonic-config';
 import { resolveNovaSonicVoice } from '../orb/live/voice/nova-sonic-voice';
 import { prewarmNovaSonicBedrock } from '../orb/live/upstream/nova-sonic-live-client';
@@ -6474,6 +6475,13 @@ async function connectToLiveAPI(
       ` livekit_ready=${__upstreamDecision.livekitReady}` +
       ` canary=${__upstreamDecision.canary}`,
   );
+  // BOOTSTRAP-NOVA-SONIC-VOICE: record the resolved provider as soon as it's
+  // known, for every provider (not just Nova) — this is what the latency
+  // tracker correction sites and per-turn tracker construction read to
+  // attribute voice.latency.measured events correctly instead of assuming
+  // Vertex. (The later `session.upstreamProvider = 'nova_sonic'` deeper in
+  // the Nova branch is now redundant but harmless — left in place.)
+  session.upstreamProvider = __upstreamDecision.provider;
   // OASIS emission — every connect call emits a single `selected` event.
   // When the request was LiveKit but the path degraded (config invalid or
   // pinned_to_vertex_l1 or canary_not_allowlisted), also emit
@@ -9054,12 +9062,19 @@ async function emitOrbSessionEnded(orbSessionId: string, conversationId: string,
 function startVoiceTurnLatency(session: GeminiLiveSession): void {
   if (session.latencyTracker) return; // turn already in flight
   session.latencyTurnIndex = (session.latencyTurnIndex || 0) + 1;
+  // BOOTSTRAP-NOVA-SONIC-VOICE: unlike the turn-0 establishment tracker,
+  // upstream selection has always resolved by the time a per-turn tracker
+  // starts (turn 0 IS the connect), so session.upstreamProvider is trustworthy
+  // here at construction time — no setProvider() correction needed later.
+  const provider = session.upstreamProvider === 'nova_sonic'
+    ? `nova_sonic/${NOVA_SONIC_MODEL_ID}`
+    : `vertex/${GEMINI_MODEL}`;
   const tracker = new LatencyTracker({
     session_id: session.sessionId,
     surface: 'voice',
     actor_id: session.identity?.user_id,
     turn: session.latencyTurnIndex,
-    provider: `vertex/${GEMINI_MODEL}`,
+    provider,
     transport: session.clientWs ? 'websocket' : 'sse',
   });
   session.latencyTracker = tracker;
@@ -12996,6 +13011,14 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
         // The greeting has no preceding user turn, so the per-turn tracker never
         // fires for it; this is the only place that closes turn 0.
         if (session.establishLatency) {
+          // BOOTSTRAP-NOVA-SONIC-VOICE: the tracker was constructed with a
+          // Vertex default before upstream selection ran (session.upstreamProvider
+          // is only known once connectToLiveAPI resolves) — correct it now so
+          // voice.latency.measured attributes the timeline to the provider that
+          // actually generated this audio.
+          if (session.upstreamProvider === 'nova_sonic') {
+            session.establishLatency.setProvider(`nova_sonic/${NOVA_SONIC_MODEL_ID}`);
+          }
           session.establishLatency.mark('audio_out_first_chunk', { source: 'greeting' });
           void session.establishLatency.finalize('success');
           session.establishLatency = null;
@@ -14394,6 +14417,12 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
       // FIX: Send raw PCM for Web Audio API scheduled playback (eliminates gaps between chunks)
       (audioB64: string) => {
         if (liveSession.establishLatency) {
+          // BOOTSTRAP-NOVA-SONIC-VOICE: see the SSE audio handler's identical
+          // comment — the tracker's Vertex default needs correcting once
+          // upstream selection has actually resolved.
+          if (liveSession.upstreamProvider === 'nova_sonic') {
+            liveSession.establishLatency.setProvider(`nova_sonic/${NOVA_SONIC_MODEL_ID}`);
+          }
           liveSession.establishLatency.mark('audio_out_first_chunk', { source: 'greeting' });
           void liveSession.establishLatency.finalize('success');
           liveSession.establishLatency = null;

--- a/services/gateway/test/orb/live/latency-tracker.test.ts
+++ b/services/gateway/test/orb/live/latency-tracker.test.ts
@@ -1,0 +1,64 @@
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE: LatencyTracker.setProvider() — corrects the
+ * `provider` label on voice.latency.measured after upstream selection
+ * resolves (construction happens before Nova/Vertex is known for the
+ * turn-0 establishment tracker).
+ */
+
+import { isFeatureLive } from '../../../src/services/feature-flags';
+import { emitOasisEvent } from '../../../src/services/oasis-event-service';
+
+jest.mock('../../../src/services/feature-flags', () => ({
+  isFeatureLive: jest.fn(),
+}));
+jest.mock('../../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+const mockIsFeatureLive = isFeatureLive as jest.MockedFunction<typeof isFeatureLive>;
+const mockEmitOasisEvent = emitOasisEvent as jest.MockedFunction<typeof emitOasisEvent>;
+
+import { LatencyTracker } from '../../../src/orb/live/latency-tracker';
+
+describe('LatencyTracker.setProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsFeatureLive.mockReturnValue(true);
+  });
+
+  it('emits the constructor-time provider when setProvider is never called', async () => {
+    const t = new LatencyTracker({ session_id: 's1', surface: 'voice', provider: 'vertex/gemini-live' });
+    t.mark('audio_out_first_chunk');
+    await t.finalize('success');
+    expect(mockEmitOasisEvent).toHaveBeenCalledTimes(1);
+    const payload = mockEmitOasisEvent.mock.calls[0][0].payload as Record<string, unknown>;
+    expect(payload.provider).toBe('vertex/gemini-live');
+  });
+
+  it('overrides the provider label before finalize — the Nova-vs-Vertex mislabel fix', async () => {
+    const t = new LatencyTracker({ session_id: 's2', surface: 'voice', provider: 'vertex/gemini-live' });
+    t.mark('upstream_connected');
+    t.setProvider('nova_sonic/amazon.nova-2-sonic-v1:0');
+    t.mark('audio_out_first_chunk');
+    await t.finalize('success');
+    const payload = mockEmitOasisEvent.mock.calls[0][0].payload as Record<string, unknown>;
+    expect(payload.provider).toBe('nova_sonic/amazon.nova-2-sonic-v1:0');
+  });
+
+  it('setProvider after finalize is a no-op — the emitted event is already sent', async () => {
+    const t = new LatencyTracker({ session_id: 's3', surface: 'voice', provider: 'vertex/gemini-live' });
+    await t.finalize('success');
+    t.setProvider('nova_sonic/amazon.nova-2-sonic-v1:0'); // too late, event already emitted
+    expect(mockEmitOasisEvent).toHaveBeenCalledTimes(1);
+    const payload = mockEmitOasisEvent.mock.calls[0][0].payload as Record<string, unknown>;
+    expect(payload.provider).toBe('vertex/gemini-live');
+  });
+
+  it('feature-flag off: setProvider is harmless and finalize never emits', async () => {
+    mockIsFeatureLive.mockReturnValue(false);
+    const t = new LatencyTracker({ session_id: 's4', surface: 'voice', provider: 'vertex/gemini-live' });
+    t.setProvider('nova_sonic/amazon.nova-2-sonic-v1:0');
+    await t.finalize('success');
+    expect(mockEmitOasisEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

`voice.latency.measured` has hardcoded `provider: \`vertex/${MODEL}\`` at every `LatencyTracker` construction site — a leftover from before Nova existed. Every Nova session's latency telemetry currently reads `vertex/gemini-live-2.5-flash-native-audio`, making the two providers indistinguishable in the data.

- `LatencyTracker` gains `setProvider(provider: string)` to correct the label after construction (the turn-0 establishment tracker is built *before* upstream selection resolves).
- `connectToLiveAPI` now stamps `session.upstreamProvider` as soon as `selectUpstreamProvider()` returns — uniformly for `vertex` / `livekit` / `nova_sonic`, not just the prior Nova-only assignment deep in the Nova branch.
- Both the SSE and WS greeting audio handlers call `setProvider()` right before finalizing the turn-0 tracker.
- The per-turn tracker (`startVoiceTurnLatency`) reads `session.upstreamProvider` at construction — always resolved by then, since turn 0 *is* the connect.

## Why

Found while investigating a user report that Nova's greeting takes 7-8s vs Vertex's remembered ~2s. Pulling `voice.latency.measured` history showed the whole system's median time-to-first-audio has climbed from ~2s (Jul 20) to ~7.7s (Jul 28) — but I couldn't tell how much of that is Nova-specific vs a shared regression (larger system instruction / tool catalog) because every session in the data is labeled `vertex`, Nova included. This is a prerequisite for getting a real answer.

## Tests

- 4 new tests: default label preserved when `setProvider` isn't called, override before `finalize`, no-op after `finalize`, no-op with telemetry feature-flag off.
- Full `test/orb/live` suite: 866/866 pass.
- `tsc --noEmit` clean.

## After deploy

Next: run a controlled paired comparison now that the label is trustworthy, and look at trimming the greeting-turn prompt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_