### PR TITLE
feat(publish): AWS staging→prod promotion — Command Hub PUBLISH parity for the ECS-served gateway (VTID-03420)

### DIFF
--- a/.github/workflows/AWS-PROD-DEPLOY-GATEWAY.yml
+++ b/.github/workflows/AWS-PROD-DEPLOY-GATEWAY.yml
@@ -1,10 +1,23 @@
-# AWS-PROD-DEPLOY-GATEWAY — build the gateway, push to ECR, and roll the
-# AWS Production (DR) ECS service (VTID-03398).
+# AWS-PROD-DEPLOY-GATEWAY — promote the gateway to the AWS Production ECS
+# service `vitana-gateway-awsdr` (VTID-03398, promotion mode VTID-03420).
 #
-# AWS twin of AWS-STAGE-DEPLOY-GATEWAY.yml, but for the parallel/DR
-# production stack (`vitana-gateway-awsdr`), not the staging one
-# (`vitana-gateway`). GCP Cloud Run remains the canonical production —
-# this workflow ships to the AWS DR target only, and NEVER on push.
+# Since the VTID-03419 cutover, `gateway.vitanaland.com` is served by this
+# AWS stack — it is the canonical production for the gateway. This workflow
+# is the ONLY path that updates it, and it NEVER runs on push.
+#
+# Two modes (`deploy_mode` input):
+# - promote-staging (DEFAULT, VTID-03420): ship the EXACT ECR image the AWS
+#   staging service (`vitana-gateway`) is currently running — no rebuild.
+#   Staging and prod share the `vitana/gateway` ECR repo, so promotion is
+#   just re-registering staging's image on the awsdr task definition. The
+#   run verifies staging actually SERVES that commit over HTTP first
+#   (build-info — never ECS status fields), and the optional
+#   `expected_commit` input pins the promotion to the commit an operator
+#   was shown (the Command Hub PUBLISH button always sets it): if staging
+#   moved in between, the run fails before touching the service.
+# - rebuild-main: the original from-source path — build `main` HEAD, push,
+#   roll. Kept as the explicit fallback (e.g. staging is broken and a fix
+#   must ship directly), not the routine path.
 #
 # Design choices:
 # - workflow_dispatch ONLY, with a REQUIRED `reason` input. There is no
@@ -15,6 +28,8 @@
 # - The existing `vitana-gateway-awsdr` task definition is PRESERVED: only
 #   the container image and the commit-stamp env vars (GIT_COMMIT_SHA /
 #   COMMIT_SHA / BUILD_INFO_MARKER) are replaced, same pattern as staging.
+#   In promote mode NOTHING else is taken from the staging task def — env
+#   vars/secrets stay the awsdr ones (the image is env-agnostic).
 # - Smoke gate mirrors AWS-STAGE-DEPLOY-GATEWAY.yml: /api/v1/admin/health
 #   must report env=production AND /api/v1/admin/build-info must report
 #   the deployed commit — otherwise the job fails loudly (CLAUDE.md §15).
@@ -54,12 +69,28 @@ on:
         required: false
         default: ''
       reason:
-        description: 'Reason for this AWS production (DR) gateway deploy — required'
+        description: 'Reason for this AWS production gateway deploy — required'
         required: true
-      gateway_url:
-        description: 'Public gateway URL for post-deploy verification'
+      deploy_mode:
+        description: 'promote-staging = ship the exact image AWS staging runs (default); rebuild-main = build main HEAD from source'
         required: false
-        default: 'https://dr-gateway.vitanaland.com'
+        type: choice
+        options:
+          - promote-staging
+          - rebuild-main
+        default: 'promote-staging'
+      expected_commit:
+        description: 'promote-staging only: full commit SHA the operator expects staging to be serving — run fails if staging moved (set automatically by the Command Hub PUBLISH button)'
+        required: false
+        default: ''
+      staging_url:
+        description: 'AWS staging gateway URL used to verify what staging actually serves before promoting'
+        required: false
+        default: 'https://preview-aws-gateway.vitanaland.com'
+      gateway_url:
+        description: 'Public gateway URL for post-deploy verification (canonical hostname since VTID-03419)'
+        required: false
+        default: 'https://gateway.vitanaland.com'
       aws_region:
         description: 'AWS region'
         required: false
@@ -142,13 +173,76 @@ jobs:
             exit 1
           fi
 
-      - name: Build and push image
+      # VTID-03420: decide WHAT ships. promote-staging resolves the exact
+      # image + commit AWS staging (`vitana-gateway`) is running and verifies
+      # staging actually serves it over HTTP; rebuild-main falls through to
+      # the build step below with this checkout's HEAD.
+      - name: Resolve deploy source (promote-staging vs rebuild-main)
+        id: source
+        env:
+          DEPLOY_MODE: ${{ inputs.deploy_mode || 'promote-staging' }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          STAGING_URL: ${{ inputs.staging_url || 'https://preview-aws-gateway.vitanaland.com' }}
+        run: |
+          set -e
+          if [ "$DEPLOY_MODE" != "promote-staging" ]; then
+            echo "mode=rebuild-main" >> "$GITHUB_OUTPUT"
+            echo "sha=${{ steps.commit.outputs.sha }}" >> "$GITHUB_OUTPUT"
+            echo "short=${{ steps.commit.outputs.short }}" >> "$GITHUB_OUTPUT"
+            echo "image=" >> "$GITHUB_OUTPUT"
+            echo "Mode: rebuild-main — building ${{ steps.commit.outputs.short }} from source."
+            exit 0
+          fi
+
+          # 1) What does ECS say staging runs?
+          STAGING_TD=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services vitana-gateway \
+            --query 'services[0].taskDefinition' --output text)
+          IMAGE=$(aws ecs describe-task-definition --task-definition "$STAGING_TD" \
+            --query 'taskDefinition.containerDefinitions[0].image' --output text)
+          SHA=$(aws ecs describe-task-definition --task-definition "$STAGING_TD" \
+            --query 'taskDefinition.containerDefinitions[0].environment[?name==`GIT_COMMIT_SHA`].value | [0]' --output text)
+          echo "Staging task def: $STAGING_TD"
+          echo "Staging image:    $IMAGE"
+          echo "Staging commit:   $SHA"
+          case "$IMAGE" in
+            *"/${{ env.ECR_REPOSITORY }}:"*) ;;
+            *) echo "::error::Staging image '$IMAGE' is not from ECR repo '${{ env.ECR_REPOSITORY }}' — refusing to promote an ungoverned image."; exit 1 ;;
+          esac
+          if [ -z "$SHA" ] || [ "$SHA" = "None" ]; then
+            echo "::error::Staging task def has no GIT_COMMIT_SHA env var — cannot pin the promotion. Deploy staging via AWS-STAGE-DEPLOY-GATEWAY first."
+            exit 1
+          fi
+
+          # 2) Does staging actually SERVE that commit? (functional check —
+          # ECS state alone produced false greens during VTID-03419.)
+          LIVE=$(curl -fsS "$STAGING_URL/api/v1/admin/build-info" | jq -r '.git_commit // empty')
+          if [ "$LIVE" != "$SHA" ]; then
+            echo "::error::AWS staging serves commit '$LIVE' but its task def says '$SHA' — staging is mid-deploy or drifted. Retry when stable."
+            exit 1
+          fi
+
+          # 3) Operator pin: fail if staging moved since the PUBLISH click.
+          if [ -n "$EXPECTED_COMMIT" ] && [ "$EXPECTED_COMMIT" != "$SHA" ]; then
+            echo "::error::expected_commit=$EXPECTED_COMMIT but staging is serving $SHA — staging changed between the operator's confirmation and this run. Re-publish from the Command Hub."
+            exit 1
+          fi
+
+          {
+            echo "mode=promote-staging"
+            echo "sha=$SHA"
+            echo "short=$(echo "$SHA" | cut -c1-12)"
+            echo "image=$IMAGE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Mode: promote-staging — shipping $IMAGE ($SHA) with NO rebuild."
+
+      - name: Build and push image (rebuild-main only)
         id: build
+        if: ${{ (inputs.deploy_mode || 'promote-staging') == 'rebuild-main' }}
         env:
           REGISTRY: ${{ steps.ecr.outputs.registry }}
         run: |
           set -e
-          IMAGE="$REGISTRY/${{ env.ECR_REPOSITORY }}:${{ steps.commit.outputs.short }}"
+          IMAGE="$REGISTRY/${{ env.ECR_REPOSITORY }}:${{ steps.source.outputs.short }}"
           docker build -t "$IMAGE" -t "$REGISTRY/${{ env.ECR_REPOSITORY }}:awsdr-latest" services/gateway
           docker push "$IMAGE"
           docker push "$REGISTRY/${{ env.ECR_REPOSITORY }}:awsdr-latest"
@@ -162,9 +256,13 @@ jobs:
           NOVA_TENANTS_INPUT: ${{ inputs.nova_canary_tenant_ids }}
         run: |
           set -e
-          IMAGE="${{ steps.build.outputs.image }}"
-          SHA="${{ steps.commit.outputs.sha }}"
-          SHORT="${{ steps.commit.outputs.short }}"
+          # VTID-03420: promote mode ships staging's image; rebuild mode ships
+          # the image built above.
+          IMAGE="${{ steps.source.outputs.image }}"
+          if [ -z "$IMAGE" ]; then IMAGE="${{ steps.build.outputs.image }}"; fi
+          if [ -z "$IMAGE" ]; then echo "::error::No image resolved from either mode."; exit 1; fi
+          SHA="${{ steps.source.outputs.sha }}"
+          SHORT="${{ steps.source.outputs.short }}"
           TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
             --query 'services[0].taskDefinition' --output text)
           echo "Current task definition: $TD_ARN"
@@ -206,7 +304,7 @@ jobs:
         run: |
           set -e
           URL="${{ env.GATEWAY_URL }}"
-          SHA="${{ steps.commit.outputs.sha }}"
+          SHA="${{ steps.source.outputs.sha }}"
           for i in 1 2 3 4 5 6; do
             HEALTH=$(curl -fsS "$URL/api/v1/admin/health" 2>/dev/null || echo '')
             BUILD=$(curl -fsS "$URL/api/v1/admin/build-info" 2>/dev/null || echo '')
@@ -228,8 +326,8 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SVC: ${{ secrets.SUPABASE_SERVICE_ROLE }}
-          SHA: ${{ steps.commit.outputs.sha }}
-          SHORT: ${{ steps.commit.outputs.short }}
+          SHA: ${{ steps.source.outputs.sha }}
+          SHORT: ${{ steps.source.outputs.short }}
           OUTCOME: ${{ job.status }}
           REASON: ${{ inputs.reason }}
         run: |
@@ -265,8 +363,9 @@ jobs:
         run: |
           {
             echo "## AWS Production (DR) gateway deploy"
-            echo "- Image: \`${{ steps.build.outputs.image }}\`"
-            echo "- Commit: \`${{ steps.commit.outputs.sha }}\`"
+            echo "- Mode: ${{ steps.source.outputs.mode }}"
+            echo "- Image: \`${{ steps.source.outputs.image || steps.build.outputs.image }}\`"
+            echo "- Commit: \`${{ steps.source.outputs.sha }}\`"
             echo "- Verified live at: ${{ env.GATEWAY_URL }}"
             echo "- Reason: ${{ env.DEPLOY_REASON }}"
             echo "- VTID: VTID-03398"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,7 +338,7 @@ Shared infra across all of the above:
 | ALB | `vitana-alb-prod` — all host-header rules sit **below** priority 10 (see hard rule below) |
 | Deploy auth | GitHub OIDC federation, `AWS_PROD_ROLE_ARN` (all except community-app's frontend workflow — see its row above) |
 | Deploy trigger | Every `AWS-PROD-DEPLOY-*.yml` is `workflow_dispatch`-only, required `reason`, never on push |
-| Command Hub PUBLISH dual-publish | `AWS_DUAL_PUBLISH_ENABLED=true` (gateway env var, default off) makes the PUBLISH button best-effort dispatch `AWS-PROD-DEPLOY-GATEWAY.yml` alongside the GCP `EXEC-DEPLOY.yml` dispatch — see `services/gateway/src/routes/operator.ts` `POST /publish` step 7b. Not yet extended to the other 7 deploy paths. |
+| Command Hub PUBLISH target | `PUBLISH_TARGET_CLOUD=aws` (gateway env var, VTID-03420, default `gcp`) switches the PUBLISH button to promote **AWS staging → AWS prod**: `POST /publish` resolves the commit `vitana-gateway` staging actually serves (HTTP build-info, never ECS status) and dispatches `AWS-PROD-DEPLOY-GATEWAY.yml` in `promote-staging` mode with `expected_commit` pinned — the exact tested ECR image ships, no rebuild. `/operator/revisions` for the two gateway rows is likewise build-info-backed (Cloud Run APIs have no credentials on ECS). `GCP_DUAL_PUBLISH_ENABLED=true` (default off) additionally refreshes the GCP rollback target via EXEC-DEPLOY with the same commit. With the var unset/`gcp`, the original GCP flow is untouched (where `AWS_DUAL_PUBLISH_ENABLED=true` still best-effort dispatches the AWS workflow — legacy leg, rebuilds `main`). |
 
 **Secrets intentionally deferred (2026-07-24):** `ANTHROPIC_API_KEY` and
 `OPENAI_API_KEY` are not populated in AWS Secrets Manager pending an AWS
@@ -650,6 +650,17 @@ FRONTEND_DEPLOY_REPO=exafyltd/vitana-v1
 # regardless of this flag — see §1b. Failure on the AWS leg never fails the
 # publish (response reports aws_promote.ok=false with detail).
 AWS_DUAL_PUBLISH_ENABLED=true|false
+# VTID-03420: which cloud the Command Hub PUBLISH button promotes. 'aws' =
+# promote AWS staging (vitana-gateway) → AWS prod (vitana-gateway-awsdr) by
+# exact-image promotion (AWS-PROD-DEPLOY-GATEWAY.yml promote-staging mode,
+# expected_commit pinned); default 'gcp' = original gateway-staging →
+# gateway Cloud Run flow. Set 'aws' on the AWS task defs post-VTID-03419.
+PUBLISH_TARGET_CLOUD=aws|gcp
+# VTID-03420 (only used when PUBLISH_TARGET_CLOUD=aws): when 'true', PUBLISH
+# also best-effort ships the same commit to GCP Cloud Run via EXEC-DEPLOY so
+# the standing rollback target stays fresh. Default off — mirror image of
+# AWS_DUAL_PUBLISH_ENABLED's deliberate-action tradeoff.
+GCP_DUAL_PUBLISH_ENABLED=true|false
 GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1
 GCP_PROJECT=lovable-vitana-vers1
 VERTEX_LOCATION=us-central1
@@ -1187,6 +1198,7 @@ Use these PATs with the GitHub REST API (`api.github.com`) for all PR and deploy
 
 | Date | Change | VTID |
 |------|--------|------|
+| 2026-07-28 | AWS staging→prod publish path (PUBLISH parity): `AWS-PROD-DEPLOY-GATEWAY.yml` gained `deploy_mode=promote-staging` (new default — ships the EXACT ECR image `vitana-gateway` staging runs, verified over HTTP build-info, pinned via new `expected_commit` input; `rebuild-main` keeps the old from-source path) and its smoke URL default is now canonical `gateway.vitanaland.com`. Gateway: new `PUBLISH_TARGET_CLOUD=aws\|gcp` switch (default `gcp`, zero change until set) makes `POST /operator/publish` promote AWS staging→AWS prod (frontend leg → `AWS-PROD-DEPLOY-FRONTEND.yml`; optional `GCP_DUAL_PUBLISH_ENABLED` refreshes the GCP rollback target; canary → 400 on AWS) and backs `/operator/revisions` for the gateway rows with build-info from the AWS stacks — fixes the Command Hub PUBLISH popover's "Could not load: staging 500" on the ECS-served gateway (no GCP ADC there). New `services/gateway/src/services/aws-gateway-admin.ts` (HTTP-only introspection; `vitana-ecs-task-role` has no `ecs:Describe*`). | VTID-03420 |
 | 2026-07-24 | Added automatic once-a-day "Did You Know" News Feed card: `did_you_know_state` table (per-tenant rotation index) + `POST /api/v1/scheduled-notifications/daily-feature-tip` (advances through a curated `services/gateway/src/data/feature-tips.ts` list, publishes a tenant-wide `did-you-know-feature` announcement, fans out in-app + push in each user's locale) + Cloud Scheduler entry (`scripts/setup-cloud-scheduler.sh`, daily 17:00 UTC). Companion vitana-v1 fix: feature-announcement cards no longer pinned permanently at the News Feed top — now merge chronologically into the post stream so they get pushed down by new posts, per live user report. No VTID existed for this yet; tracked under this BOOTSTRAP tag pending one. Requires someone with `gcloud` access to run the updated `setup-cloud-scheduler.sh` once to actually create the Cloud Scheduler job — code shipping does not create it automatically. | BOOTSTRAP-DAILY-FEATURE-TIP |
 | 2026-07-24 | Built the AWS-DR RunTask dispatch path for the autopilot executor — new `dispatchExecutorJobAws()` in `services/gateway/src/services/aws-ecs-admin.ts` (mirrors `dispatchExecutorJob()`'s return shape via `ecs:RunTask` against task def family `vitana-autopilot-executor`), branched in `dev-autopilot-execute.ts` on a new `DEV_AUTOPILOT_JOB_CLOUD=aws\|gcp` env var (default `gcp`). New `AWS-PROD-DEPLOY-AUTOPILOT-EXECUTOR.yml` (build+push+register only — no ECS service to roll, next RunTask dispatch picks up `:LATEST`). `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` deliberately omitted from the live task definition (deferred pending AWS/Anthropic sponsorship decision). Updated §1b table + Never-rule exception. | VTID-03415 |
 | 2026-07-24 | Added the missing AWS deploy pipeline for `orb-agent` (`AWS-PROD-DEPLOY-ORB-AGENT.yml`) — the ECS service and task def family (`vitana-orb-agent`) already existed from the unexplained 2026-07-09 bulk-provisioning event, but had no CI/CD, so it could silently drift from `main`. No public ALB/DNS (outbound-only to LiveKit Cloud) — verified via ECS-level container `healthCheck` + `aws ecs wait services-stable`. Updated §1b table. | VTID-03414 |

--- a/docs/AWS-CUTOVER-RUNBOOK.md
+++ b/docs/AWS-CUTOVER-RUNBOOK.md
@@ -275,4 +275,5 @@ until AWS has run as sole production for an agreed burn-in period
 | VTID-03410 | oasis-operator AWS-DR | Prerequisite infra — done, but see §2 burn-in checklist item |
 | VTID-03411 | Backend services hardening | Prerequisite infra — done |
 | VTID-03412 | **This runbook** | Governance artifact — does not execute anything |
-| *(not yet allocated)* | Actual cutover execution | Must reference this runbook, gated on §2 checklist |
+| VTID-03419 | Actual cutover execution (gateway + apex DNS) | Executed 2026-07-27 — see §3's EXECUTION RECORD blocks |
+| VTID-03420 | AWS staging→prod publish path | Post-cutover follow-up: the Command Hub PUBLISH button promotes AWS staging (`vitana-gateway`) → AWS prod (`vitana-gateway-awsdr`) by exact-image promotion when `PUBLISH_TARGET_CLOUD=aws`; `AWS-PROD-DEPLOY-GATEWAY.yml` gained `promote-staging` (default) vs `rebuild-main` modes with an `expected_commit` pin. Closes the gap where the only AWS-prod path was a manual dispatch that rebuilt `main` HEAD — reported live 2026-07-28 (PUBLISH popover showed "Could not load: staging 500" on the ECS-served gateway, and AWS staging/prod had already drifted 0c72cfc vs 53cfb71). |

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -72,6 +72,28 @@ FRONTEND_DEPLOY_REPO=exafyltd/vitana-v1
 #   aws_promote.ok=false with detail). GCP remains canonical regardless.
 AWS_DUAL_PUBLISH_ENABLED=false
 
+# VTID-03420: which cloud the Command Hub PUBLISH button promotes.
+# PUBLISH_TARGET_CLOUD: 'aws' = promote AWS staging (vitana-gateway) → AWS
+#   prod (vitana-gateway-awsdr) by exact-image promotion
+#   (AWS-PROD-DEPLOY-GATEWAY.yml promote-staging mode, expected_commit
+#   pinned) and back /operator/revisions with AWS build-info. OPTIONAL —
+#   defaults to 'gcp' (the original gateway-staging → gateway Cloud Run
+#   flow, byte-identical to pre-VTID-03420 behavior). Set 'aws' on the AWS
+#   task defs post-VTID-03419 cutover.
+PUBLISH_TARGET_CLOUD=gcp
+# GCP_DUAL_PUBLISH_ENABLED: only read when PUBLISH_TARGET_CLOUD=aws. When
+#   'true', PUBLISH ALSO best-effort ships the same commit to GCP Cloud Run
+#   via EXEC-DEPLOY so the standing rollback target stays fresh. OPTIONAL —
+#   defaults to off (mirror image of AWS_DUAL_PUBLISH_ENABLED's
+#   deliberate-action tradeoff; response reports gcp_promote.ok=false).
+GCP_DUAL_PUBLISH_ENABLED=false
+# AWS_STAGING_GATEWAY_URL / AWS_PROD_GATEWAY_URL: base URLs
+#   aws-gateway-admin.ts resolves AWS gateway state from (HTTP build-info —
+#   the ECS task role has no ecs:Describe*). OPTIONAL — call-site defaults
+#   are the canonical hostnames below; override only if those ever change.
+AWS_STAGING_GATEWAY_URL=https://preview-aws-gateway.vitanaland.com
+AWS_PROD_GATEWAY_URL=https://gateway.vitanaland.com
+
 # BOOTSTRAP-PRODUCT-ANALYTICS: daily rollup + retention purge for
 # product_analytics_events (default on; set to "false" to disable)
 PRODUCT_ANALYTICS_ROLLUP_ENABLED=true

--- a/services/gateway/src/routes/operator.ts
+++ b/services/gateway/src/routes/operator.ts
@@ -64,6 +64,11 @@ import { getDeploymentHistory, getNextSWV, insertSoftwareVersion, SoftwareVersio
 // Phase 0 staging build (P0.4): VTID allocator + Cloud Run Admin + admin auth.
 import { allocateVtid } from '../services/operator-service';
 import { describeService, listRevisions, updateTrafficToRevision, shortRevisionName } from '../services/cloud-run-admin';
+import {
+  describeAwsStagingGateway,
+  describeAwsProdGateway,
+  toRevisionRow,
+} from '../services/aws-gateway-admin';
 // Note: deployOrchestrator + emitOasisEvent are imported mid-file (lines ~590).
 import { requireAdminAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 // VTID-0525-B: naturalLanguageService disabled for MVP - using simple command matching
@@ -587,7 +592,7 @@ router.post('/upload', async (req: Request, res: Response) => {
 // Simple command matching for deploy commands using existing CICD infrastructure
 
 import deployOrchestrator from '../services/deploy-orchestrator';
-import { triggerWorkflow } from '../services/github-service';
+import { triggerWorkflow, getWorkflowRuns } from '../services/github-service';
 import { emitOasisEvent } from '../services/oasis-event-service';
 // VTID-0525-B: DeployCommandSchema and TaskCommandSchema unused in MVP
 // import { DeployCommandSchema, TaskCommandSchema } from '../types/operator-command';
@@ -1249,6 +1254,17 @@ router.get('/revisions', requireAdminAuth, async (req: Request, res: Response) =
       return res.status(400).json({ ok: false, error: 'unsupported_service', service });
     }
 
+    // VTID-03420: post-cutover (VTID-03419) the canonical gateway is AWS ECS,
+    // which has no Cloud Run revisions and no GCP credentials. When targeting
+    // AWS, back the two gateway rows with live build-info from the AWS stacks
+    // instead — same row shape, so the publish popover works unchanged.
+    if (PUBLISH_TARGET_CLOUD === 'aws' && (service === 'gateway' || service === 'gateway-staging')) {
+      const summary = service === 'gateway-staging'
+        ? await describeAwsStagingGateway()
+        : await describeAwsProdGateway();
+      return res.status(200).json({ ok: true, service, revisions: [toRevisionRow(summary)] });
+    }
+
     const revisions = await listRevisions(service, limit);
     return res.status(200).json({ ok: true, service, revisions });
   } catch (error) {
@@ -1266,6 +1282,13 @@ const STAGING_PUBLISH_BAKE_MS = (() => {
   const raw = parseInt(process.env.STAGING_PUBLISH_BAKE_SECONDS || '0', 10);
   return Number.isFinite(raw) && raw >= 0 ? raw * 1000 : 0;
 })();
+
+// VTID-03420: which cloud the PUBLISH button promotes. Post-VTID-03419 the
+// canonical gateway hostname is served by AWS ECS, so the AWS stacks set this
+// to 'aws' (task-def env var). Default 'gcp' keeps the pre-cutover behavior
+// byte-identical everywhere the var is not set.
+const PUBLISH_TARGET_CLOUD: 'aws' | 'gcp' =
+  process.env.PUBLISH_TARGET_CLOUD === 'aws' ? 'aws' : 'gcp';
 
 /**
  * POST /publish → /api/v1/operator/publish
@@ -1299,12 +1322,272 @@ const STAGING_PUBLISH_BAKE_MS = (() => {
  *   9. Emit production.publish.requested + production.publish.completed events
  *      (payload includes frontend_promote + aws_promote outcomes).
  */
+/**
+ * VTID-03420: AWS variant of POST /publish — promotes AWS staging
+ * (`vitana-gateway`) to AWS production (`vitana-gateway-awsdr`) by
+ * dispatching AWS-PROD-DEPLOY-GATEWAY.yml in promote-staging mode, pinned
+ * to the exact commit staging serves at click time (expected_commit).
+ *
+ * Mirrors the GCP flow step-for-step (resolve staging → bake guard → VTID
+ * → requested event → dispatch → best-effort secondary legs → SWV row →
+ * completed event) and returns the same response shape, so the Command Hub
+ * popover works unchanged. Runs only when PUBLISH_TARGET_CLOUD=aws.
+ */
+async function publishAwsFlow(
+  req: Request,
+  res: Response,
+  identity: { user_id: string },
+  requestId: string,
+): Promise<Response> {
+  // ECS rolling deploys have no Cloud-Run-style traffic splitting — refuse
+  // canary explicitly rather than silently doing a full rollout.
+  if (req.body?.mode === 'canary') {
+    return res.status(400).json({
+      ok: false,
+      error: 'canary_unsupported_on_aws',
+      detail: 'Canary publish uses Cloud Run traffic splitting; the AWS ECS target only supports full rolling promotion. Re-publish with mode=full.',
+    });
+  }
+
+  // Step 2 (AWS): resolve what AWS staging is actually SERVING (build-info
+  // over HTTP — never ECS status fields; see aws-gateway-admin.ts header).
+  let staging;
+  try {
+    staging = await describeAwsStagingGateway();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    await emitOasisEvent({
+      vtid: 'BOOTSTRAP-PUBLISH',
+      type: 'production.publish.failed',
+      source: 'gateway-operator',
+      status: 'error',
+      message: `publish(aws): cannot resolve AWS staging gateway (${msg})`,
+      actor_id: identity.user_id,
+      actor_role: 'admin',
+      surface: 'command-hub',
+      payload: { request_id: requestId, stage: 'describe_staging', platform: 'aws-ecs' },
+    });
+    return res.status(502).json({ ok: false, error: 'staging_unreachable', detail: msg });
+  }
+
+  const stagingCommit = staging.commitSha;
+  if (!stagingCommit) {
+    return res.status(409).json({
+      ok: false,
+      error: 'staging_commit_unknown',
+      detail: `AWS staging build-info reports no git_commit. AWS-STAGE-DEPLOY-GATEWAY stamps GIT_COMMIT_SHA on every deploy — a missing commit means an ungoverned build is serving staging.`,
+    });
+  }
+  const stagingRevShort = staging.marker || stagingCommit.slice(0, 12);
+
+  // Step 4 (AWS): bake-time guard against the serving container's boot time.
+  const ageMs = staging.bootedAt
+    ? Date.now() - Date.parse(staging.bootedAt)
+    : STAGING_PUBLISH_BAKE_MS; // unknown age — same treat-as-old-enough fallback as GCP
+  if (STAGING_PUBLISH_BAKE_MS > 0 && ageMs < STAGING_PUBLISH_BAKE_MS) {
+    const remainingSec = Math.ceil((STAGING_PUBLISH_BAKE_MS - ageMs) / 1000);
+    return res.status(409).json({
+      ok: false,
+      error: 'bake_time_not_met',
+      detail: `AWS staging build ${stagingRevShort} is only ${Math.floor(ageMs / 1000)}s old; needs ${STAGING_PUBLISH_BAKE_MS / 1000}s. Wait ${remainingSec}s, or set STAGING_PUBLISH_BAKE_SECONDS=0 to override.`,
+    });
+  }
+
+  // Step 5: allocate the per-publish VTID (same allocator as the GCP path).
+  const allocation = await allocateVtid('publish.api', 'INFRA', 'GATEWAY');
+  if (!allocation.ok || !allocation.vtid) {
+    return res.status(503).json({
+      ok: false,
+      error: 'vtid_allocation_failed',
+      detail: allocation.message || allocation.error || 'unknown',
+    });
+  }
+  const vtid = allocation.vtid;
+
+  // Step 6: publish-requested event before dispatching.
+  await emitOasisEvent({
+    vtid,
+    type: 'production.publish.requested',
+    source: 'gateway-operator',
+    status: 'info',
+    message: `publish(aws): vitana-gateway ${stagingRevShort} (${stagingCommit.slice(0, 7)}) → vitana-gateway-awsdr`,
+    actor_id: identity.user_id,
+    actor_role: 'admin',
+    surface: 'command-hub',
+    payload: {
+      request_id: requestId,
+      source_revision: stagingRevShort,
+      source_commit: stagingCommit,
+      promote_mode: 'aws-image-promote',
+      platform: 'aws-ecs',
+      staging_age_seconds: Math.floor(ageMs / 1000),
+      confirm_short_sha: typeof req.body?.confirm_short_sha === 'string' ? req.body.confirm_short_sha : null,
+    },
+  });
+
+  // Step 7: dispatch the promotion. promote-staging + expected_commit means
+  // the workflow ships the EXACT ECR image staging runs and fails (before
+  // touching the service) if staging moved between click and run.
+  let workflowUrl: string | null = null;
+  let workflowRunId: number | null = null;
+  try {
+    await triggerWorkflow('exafyltd/vitana-platform', 'AWS-PROD-DEPLOY-GATEWAY.yml', 'main', {
+      reason: `Command Hub PUBLISH (${vtid}): promote AWS staging ${stagingCommit.slice(0, 7)} by ${identity.user_id}`,
+      deploy_mode: 'promote-staging',
+      expected_commit: stagingCommit,
+    });
+    try {
+      const runs = await getWorkflowRuns('exafyltd/vitana-platform', 'AWS-PROD-DEPLOY-GATEWAY.yml');
+      workflowUrl = runs.workflow_runs[0]?.html_url ?? null;
+      workflowRunId = runs.workflow_runs[0]?.id ?? null;
+    } catch {
+      // URL lookup is cosmetic — the dispatch above already succeeded.
+    }
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : 'aws_dispatch_failed';
+    await emitOasisEvent({
+      vtid,
+      type: 'production.publish.failed',
+      source: 'gateway-operator',
+      status: 'error',
+      message: `publish(aws): AWS-PROD-DEPLOY-GATEWAY dispatch failed — ${detail}`,
+      actor_id: identity.user_id,
+      actor_role: 'admin',
+      surface: 'command-hub',
+      payload: { request_id: requestId, source_revision: stagingRevShort, source_commit: stagingCommit, deploy_error: detail },
+    });
+    return res.status(500).json({ ok: false, vtid, error: 'deploy_dispatch_failed', detail });
+  }
+
+  // Step 7b: best-effort FRONTEND promote — AWS twin. Rebuilds vitana-v1
+  // main with the prod gateway URL baked (there is no AWS frontend staging
+  // artifact to promote; mirrors the GCP flow's rebuild-from-commit leg).
+  let frontendPromote: { ok: boolean; detail?: string; source_commit?: string | null } = {
+    ok: false,
+    detail: 'not_attempted',
+  };
+  try {
+    const FRONTEND_REPO = process.env.FRONTEND_DEPLOY_REPO || 'exafyltd/vitana-v1';
+    const FRONTEND_TOKEN = process.env.FRONTEND_DEPLOY_TOKEN;
+    if (!FRONTEND_TOKEN) {
+      frontendPromote = {
+        ok: false,
+        detail: 'FRONTEND_DEPLOY_TOKEN not set — frontend NOT promoted. Dispatch AWS-PROD-DEPLOY-FRONTEND.yml manually, or set the secret to enable one-button-both.',
+      };
+    } else {
+      await triggerWorkflow(
+        FRONTEND_REPO,
+        'AWS-PROD-DEPLOY-FRONTEND.yml',
+        'main',
+        { reason: `publish-both via Command Hub (${vtid}, gateway ${stagingCommit.slice(0, 7)})` },
+        FRONTEND_TOKEN,
+      );
+      frontendPromote = { ok: true, source_commit: null };
+    }
+  } catch (e) {
+    frontendPromote = { ok: false, detail: e instanceof Error ? e.message : 'frontend_dispatch_failed' };
+  }
+
+  // Step 7c: best-effort GCP mirror — exact inverse of the old AWS leg.
+  // GCP Cloud Run is now the standing rollback target (VTID-03419 §8); a
+  // publish can keep it fresh by shipping the same commit through the
+  // governed EXEC-DEPLOY path. Gated (default off) for the same reason
+  // AWS_DUAL_PUBLISH_ENABLED was: cross-cloud prod deploys stay deliberate.
+  let gcpPromote: { ok: boolean; detail?: string; source_commit?: string | null } = {
+    ok: false,
+    detail: 'not_attempted',
+  };
+  if (process.env.GCP_DUAL_PUBLISH_ENABLED === 'true') {
+    try {
+      const gcpResult = await deployOrchestrator.executeDeploy({
+        vtid,
+        service: 'gateway',
+        environment: 'production',
+        source: 'api',
+        canary: false,
+        // No prebuilt GCP image to reuse from here — EXEC-DEPLOY builds this
+        // exact commit from source (its documented fallback path).
+        commitSha: stagingCommit,
+      });
+      gcpPromote = gcpResult.ok
+        ? { ok: true, source_commit: stagingCommit }
+        : { ok: false, detail: gcpResult.error || 'gcp_deploy_failed' };
+    } catch (e) {
+      gcpPromote = { ok: false, detail: e instanceof Error ? e.message : 'gcp_dispatch_failed' };
+    }
+  } else {
+    gcpPromote = { ok: false, detail: 'GCP_DUAL_PUBLISH_ENABLED not set to true — GCP rollback target NOT refreshed.' };
+  }
+
+  // Step 8: record the publish in software_versions (same optimistic model
+  // as the GCP path; the workflow's own best-effort emission records the
+  // deploy outcome under service vitana-gateway-aws-dr).
+  const swvId = await getNextSWV();
+  await insertSoftwareVersion({
+    swv_id: swvId,
+    service: 'gateway',
+    git_commit: stagingCommit,
+    deploy_type: 'normal',
+    initiator: 'user',
+    status: 'success',
+    environment: 'production',
+    cloud_run_revision: null,
+    source_revision: stagingRevShort,
+    initiator_id: identity.user_id,
+  });
+
+  await emitOasisEvent({
+    vtid,
+    type: 'production.publish.completed',
+    source: 'gateway-operator',
+    status: 'success',
+    message: `publish(aws): ${stagingRevShort} promotion dispatched; AWS-PROD-DEPLOY-GATEWAY ${workflowUrl ?? 'dispatched'}`,
+    actor_id: identity.user_id,
+    actor_role: 'admin',
+    surface: 'command-hub',
+    payload: {
+      request_id: requestId,
+      vtid,
+      swv_id: swvId,
+      mode: 'full',
+      source_revision: stagingRevShort,
+      source_commit: stagingCommit,
+      workflow_run_id: workflowRunId,
+      workflow_url: workflowUrl,
+      frontend_promote: frontendPromote,
+      gcp_promote: gcpPromote,
+    },
+  });
+
+  return res.status(200).json({
+    ok: true,
+    vtid,
+    swv_id: swvId,
+    source_revision: stagingRevShort,
+    source_commit: stagingCommit,
+    workflow_run_id: workflowRunId,
+    workflow_url: workflowUrl,
+    frontend_promote: frontendPromote,
+    // Field name kept for popover/event consumers: on the AWS target the
+    // "aws" leg IS the primary promotion.
+    aws_promote: { ok: true, source_commit: stagingCommit },
+    gcp_promote: gcpPromote,
+  });
+}
+
 router.post('/publish', requireAdminAuth, async (req: Request, res: Response) => {
   const requestId = randomUUID();
   const { identity } = req as AuthenticatedRequest;
   if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
 
   try {
+    // VTID-03420: post-cutover the canonical gateway is AWS ECS — promote
+    // AWS staging → AWS prod instead of the GCP pair. Selected per-stack via
+    // task-def env, so GCP-hosted gateways keep the original flow untouched.
+    if (PUBLISH_TARGET_CLOUD === 'aws') {
+      return await publishAwsFlow(req, res, identity, requestId);
+    }
+
     // Step 2: resolve staging service state.
     let stagingSummary;
     try {

--- a/services/gateway/src/services/aws-gateway-admin.ts
+++ b/services/gateway/src/services/aws-gateway-admin.ts
@@ -1,0 +1,121 @@
+/**
+ * AWS gateway introspection for the Command Hub publish flow — VTID-03420.
+ *
+ * AWS analogue of cloud-run-admin.ts's describeService()/listRevisions(),
+ * used by /api/v1/operator/publish and /revisions when
+ * PUBLISH_TARGET_CLOUD=aws (post-VTID-03419, gateway.vitanaland.com is
+ * served by ECS `vitana-gateway-awsdr`, promoted from ECS staging
+ * `vitana-gateway`).
+ *
+ * Deliberately resolves state over HTTP (/api/v1/admin/build-info on the
+ * public hostnames) rather than the ECS API, for two reasons:
+ *  1. `vitana-ecs-task-role` has no ecs:Describe* permissions, and adding
+ *     them needs IAM admin rights this deployment path doesn't assume.
+ *  2. Build-info reports what a stack is actually SERVING, not what ECS
+ *     says it should run — the functional-verification discipline from
+ *     the VTID-03419 cutover (ECS healthStatus and DMS task status both
+ *     produced false greens during that migration).
+ *
+ * The ECS-side resolution (task-def image lookup, register, roll) lives in
+ * AWS-PROD-DEPLOY-GATEWAY.yml's promote-staging mode, which runs under the
+ * GitHub OIDC deploy role that already has those permissions.
+ */
+
+export const AWS_STAGING_GATEWAY_URL =
+  process.env.AWS_STAGING_GATEWAY_URL || 'https://preview-aws-gateway.vitanaland.com';
+export const AWS_PROD_GATEWAY_URL =
+  process.env.AWS_PROD_GATEWAY_URL || 'https://gateway.vitanaland.com';
+
+export interface AwsGatewaySummary {
+  /** 'staging' | 'production' — as self-reported by the stack's health env. */
+  env: string | null;
+  /** Full git commit SHA the stack is serving (GIT_COMMIT_SHA). */
+  commitSha: string | null;
+  /** Short (12-char) commit marker (BUILD_INFO_MARKER). */
+  marker: string | null;
+  /** ISO timestamp the serving container booted — proxy for deploy time. */
+  bootedAt: string | null;
+  /** The URL the summary was resolved from. */
+  url: string;
+}
+
+async function fetchBuildInfo(baseUrl: string): Promise<AwsGatewaySummary> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const resp = await fetch(`${baseUrl}/api/v1/admin/build-info`, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`aws-gateway-admin: ${baseUrl} build-info HTTP ${resp.status}`);
+    }
+    const data = await resp.json() as {
+      env?: string;
+      git_commit?: string;
+      marker?: string;
+      booted_at?: string;
+    };
+    return {
+      env: data.env ?? null,
+      commitSha: data.git_commit ?? null,
+      marker: data.marker ?? (data.git_commit ? data.git_commit.slice(0, 12) : null),
+      bootedAt: data.booted_at ?? null,
+      url: baseUrl,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve what the AWS staging gateway (`vitana-gateway`) is serving.
+ * Throws if unreachable or if it does not self-report env=staging —
+ * promoting from a stack that isn't staging is never OK.
+ */
+export async function describeAwsStagingGateway(): Promise<AwsGatewaySummary> {
+  const summary = await fetchBuildInfo(AWS_STAGING_GATEWAY_URL);
+  if (summary.env !== 'staging') {
+    throw new Error(
+      `aws-gateway-admin: ${AWS_STAGING_GATEWAY_URL} self-reports env='${summary.env}', expected 'staging' — refusing to treat it as the promotion source`,
+    );
+  }
+  return summary;
+}
+
+/**
+ * Resolve what the AWS production gateway (`vitana-gateway-awsdr`, behind
+ * the canonical hostname) is serving. Resolved over HTTP rather than from
+ * this process's own env so the answer is correct no matter which stack
+ * happens to run the code asking.
+ */
+export async function describeAwsProdGateway(): Promise<AwsGatewaySummary> {
+  return fetchBuildInfo(AWS_PROD_GATEWAY_URL);
+}
+
+/**
+ * Shape an AwsGatewaySummary into the RevisionSummary row format the
+ * Command Hub publish popover already consumes from the GCP-backed
+ * /api/v1/operator/revisions — one synthetic "revision" per stack (ECS
+ * has no Cloud-Run-style revision list to enumerate over HTTP; the
+ * currently-serving build is the only row that matters to the popover).
+ */
+export function toRevisionRow(summary: AwsGatewaySummary): {
+  name: string;
+  shortName: string;
+  image: string | null;
+  createdAt: string;
+  isActive: boolean;
+  trafficPercent: number;
+  commitSha: string | null;
+} {
+  return {
+    name: summary.url,
+    shortName: summary.marker ?? 'unknown',
+    image: null,
+    createdAt: summary.bootedAt ?? new Date(0).toISOString(),
+    isActive: true,
+    trafficPercent: 100,
+    commitSha: summary.commitSha,
+  };
+}


### PR DESCRIPTION
## Problem (reported live, 2026-07-28)

Since the VTID-03419 cutover, `gateway.vitanaland.com` is served by AWS ECS (`vitana-gateway-awsdr`), but:

- The Command Hub **PUBLISH** button still promotes **GCP** `gateway-staging` → `gateway` (`operator.ts` step 7) — no longer what serves the canonical hostname.
- The only AWS-prod path (`AWS-PROD-DEPLOY-GATEWAY.yml`, manual dispatch — or the `AWS_DUAL_PUBLISH_ENABLED` leg) **rebuilds `main` HEAD from source** instead of shipping the artifact AWS staging actually runs. No version pinning, no staging-verified guarantee.
- The PUBLISH popover is visibly broken on the AWS gateway: `GET /api/v1/operator/revisions` is Cloud-Run-Admin-backed and ECS has no GCP credentials → **"Could not load: staging 500"**.
- Drift is already real: AWS staging serves `0c72cfc`, AWS prod serves `53cfb71`.

## Change (VTID-03420, spec approved)

**`AWS-PROD-DEPLOY-GATEWAY.yml`** — new `deploy_mode` input:
- `promote-staging` (**default**): resolve the exact ECR image + `GIT_COMMIT_SHA` from `vitana-gateway`'s task def (staging and prod share the `vitana/gateway` ECR repo), verify staging **serves** that commit over HTTP build-info (never ECS status fields), honor the new optional `expected_commit` pin (fails before touching the service if staging moved since the operator confirmed), register that image on `vitana-gateway-awsdr`. **No rebuild.**
- `rebuild-main`: the original from-source path, kept as the explicit fallback.
- Smoke default URL is now the canonical `https://gateway.vitanaland.com`; still `workflow_dispatch`-only with a required `reason`.

**New `services/gateway/src/services/aws-gateway-admin.ts`** — HTTP-only introspection of the AWS stacks via `/api/v1/admin/build-info`. Deliberate: `vitana-ecs-task-role` has no `ecs:Describe*` (IAM write to add it was denied for this session's credentials), and build-info reports what a stack *actually serves* — the functional-verification discipline from the cutover.

**`operator.ts`** — new `PUBLISH_TARGET_CLOUD=aws|gcp` switch (default `gcp` → **zero behavior change until the env var is set on the AWS task defs**). Under `aws`:
- `POST /operator/publish` promotes AWS staging→AWS prod by dispatching the workflow above with `deploy_mode=promote-staging` + `expected_commit=<staging commit>`. Same response shape, same per-publish VTID allocation, same OASIS events. `mode=canary` → 400 (`canary_unsupported_on_aws`; ECS rolling has no traffic splitting).
- Frontend leg dispatches `AWS-PROD-DEPLOY-FRONTEND.yml` (exafyltd/vitana-v1) instead of `DEPLOY.yml`.
- `GCP_DUAL_PUBLISH_ENABLED=true` (default off) optionally refreshes the GCP rollback target with the same commit via governed EXEC-DEPLOY — mirror image of the old `AWS_DUAL_PUBLISH_ENABLED` gate.
- `GET /operator/revisions` for the two gateway rows returns build-info-backed rows in the existing `RevisionSummary` shape — fixes the popover 500, and the popover's post-publish verification poll (`/revisions?service=gateway` until the source commit appears) now works end-to-end against ECS with **no UI changes**.

Docs: CLAUDE.md §1b/§8 + change log; runbook VTID table.

## Activation sequence (after merge)

1. Merge → `AWS-STAGE-DEPLOY-GATEWAY.yml` auto-deploys this code to AWS staging.
2. One manual dispatch of `AWS-PROD-DEPLOY-GATEWAY.yml` (defaults = promote-staging) — this both closes the current staging/prod drift **and** ships the new publish code to prod.
3. Register a `vitana-gateway-awsdr` task-def revision adding `PUBLISH_TARGET_CLOUD=aws` + roll (one-time env change; same pattern as revisions 5/6).
4. PUBLISH button in the Command Hub now promotes AWS staging→AWS prod, pinned to the displayed commit.

## Verification

- Workflow YAML parse-validated; promote path guarded (ECR-repo check, staging-serves-commit check, expected_commit pin, existing anti-staging-service guardrail untouched).
- Local `tsc` was not possible (npm registry blocked by egress policy; pre-existing TS5107 aborts tsc before file checks) — **GATEWAY-CI is the typecheck of record** for this PR.
- Runtime behavior with `PUBLISH_TARGET_CLOUD` unset is unchanged by construction (single early-return branch + one guarded block in `/revisions`).

VTID-03420 — spec validated (9/9 sections), quality 95, approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF)_