### PR TITLE
feat(orb): greeting audio bridge — fill the 5-8s greeting silence with an instant TTS phrase (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/i18n/catalog.ts
+++ b/services/gateway/src/i18n/catalog.ts
@@ -129,7 +129,21 @@ export type GatewayI18nKey =
   // Autopilot recommendation identity (recommendation-identity work) — the
   // "Vitana empfiehlt" header shown on every AI-generated recommendation card
   // so the source is never rendered as a bare "AI" label.
-  | 'recommendation.vitana_label';
+  | 'recommendation.vitana_label'
+  // BOOTSTRAP-NOVA-SONIC-VOICE: greeting AUDIO bridge — a short, near-instant
+  // TTS phrase spoken while the real (context-heavy) upstream greeting is
+  // still being generated, so the user hears Vitana immediately instead of
+  // silence. {date} is locale-formatted by the caller; {line} is one of a
+  // small rotating motivational-line pool below.
+  | 'orb.greeting_bridge.morning'
+  | 'orb.greeting_bridge.afternoon'
+  | 'orb.greeting_bridge.evening'
+  | 'orb.greeting_bridge.transition'
+  | 'orb.greeting_bridge.line_1'
+  | 'orb.greeting_bridge.line_2'
+  | 'orb.greeting_bridge.line_3'
+  | 'orb.greeting_bridge.line_4'
+  | 'orb.greeting_bridge.line_5';
 
 type LocaleCatalog = Record<GatewayI18nKey, string>;
 
@@ -232,6 +246,15 @@ const DE: LocaleCatalog = {
   'priority.greeting.evening.named': 'Guten Abend, {name}. Bereit, wenn du es bist.',
   'priority.greeting.evening': 'Guten Abend. Bereit, wenn du es bist.',
   'recommendation.vitana_label': 'Vitana empfiehlt',
+  'orb.greeting_bridge.morning': 'Guten Morgen! Heute ist der {date}. {line}',
+  'orb.greeting_bridge.afternoon': 'Guten Tag! Heute ist der {date}. {line}',
+  'orb.greeting_bridge.evening': 'Guten Abend! Heute ist der {date}. {line}',
+  'orb.greeting_bridge.transition': 'Lass mich kurz deine aktuellen Daten anschauen …',
+  'orb.greeting_bridge.line_1': 'Ein neuer Tag, eine neue Chance, an dir zu arbeiten.',
+  'orb.greeting_bridge.line_2': 'Kleine Schritte summieren sich zu großen Veränderungen.',
+  'orb.greeting_bridge.line_3': 'Dein zukünftiges Ich dankt dir für das, was du heute tust.',
+  'orb.greeting_bridge.line_4': 'Konstanz schlägt Perfektion — mach einfach weiter.',
+  'orb.greeting_bridge.line_5': 'Jeder Tag ist eine neue Gelegenheit, dich besser zu fühlen.',
 };
 
 const EN: LocaleCatalog = {
@@ -333,6 +356,15 @@ const EN: LocaleCatalog = {
   'priority.greeting.evening.named': 'Good evening, {name}. Ready when you are.',
   'priority.greeting.evening': 'Good evening. Ready when you are.',
   'recommendation.vitana_label': 'Vitana recommends',
+  'orb.greeting_bridge.morning': 'Good morning! Today is {date}. {line}',
+  'orb.greeting_bridge.afternoon': 'Good afternoon! Today is {date}. {line}',
+  'orb.greeting_bridge.evening': 'Good evening! Today is {date}. {line}',
+  'orb.greeting_bridge.transition': "Let me pull up your latest data…",
+  'orb.greeting_bridge.line_1': "A new day, a new chance to invest in yourself.",
+  'orb.greeting_bridge.line_2': "Small steps add up to big changes.",
+  'orb.greeting_bridge.line_3': "Your future self will thank you for what you do today.",
+  'orb.greeting_bridge.line_4': "Consistency beats perfection — just keep going.",
+  'orb.greeting_bridge.line_5': "Every day is a new chance to feel a little better.",
 };
 
 // Draft locales — start as a copy of EN; replace with native strings as they

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1389,6 +1389,11 @@ import {
   isNovaSonicLanguageSupported,
   NOVA_SONIC_MODEL_ID,
 } from '../orb/live/upstream/nova-sonic-config';
+// BOOTSTRAP-NOVA-SONIC-VOICE: greeting AUDIO bridge — see the module doc in
+// greeting-audio-bridge.ts for why this exists (both Vertex and Nova now
+// take 5-8+s to first greeting audio; this fills the silence).
+import { buildGreetingBridgeText } from '../services/conversation/greeting-audio-bridge';
+import { synthesizeGreetingBridgeAudioPcm, GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ } from '../services/tts/greeting-bridge-tts';
 import { resolveNovaSonicVoice } from '../orb/live/voice/nova-sonic-voice';
 import { prewarmNovaSonicBedrock } from '../orb/live/upstream/nova-sonic-live-client';
 import { sanitizeInstructionForNova } from '../orb/live/upstream/nova-instruction-sanitizer';
@@ -8519,6 +8524,54 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
 }
 
 /**
+ * BOOTSTRAP-NOVA-SONIC-VOICE: greeting AUDIO bridge (SSE transport only —
+ * the SSE session/start path is what both the Nova bench and the majority
+ * of real Connect & Talk traffic use today).
+ *
+ * Synthesizes a short "Good morning! Today is <date>. <motivational line>.
+ * Let me pull up your latest data…" phrase via Cloud TTS (LINEAR16 @ 24kHz —
+ * same wire format as the real greeting audio) and writes it to the SSE
+ * stream BEFORE the real upstream connect is even initiated, so ordering is
+ * trivially correct: this function is awaited to completion, and the caller
+ * only opens the real (slow) upstream connection afterward. Feature-flagged
+ * (default off) and fully best-effort — any failure here (TTS unavailable,
+ * synthesis error, closed connection) is swallowed; it never blocks or
+ * breaks the real greeting path that follows.
+ *
+ * Skipped for anonymous sessions (their intro flow is untouched/different)
+ * and for reconnects (a mid-conversation reconnect doesn't need a fresh
+ * "today is..." — the real reconnect-recovery prompt handles that case).
+ */
+async function sendGreetingAudioBridge(session: GeminiLiveSession): Promise<void> {
+  if (!isFeatureLive('ORB_GREETING_TTS_BRIDGE')) return;
+  if (session.isAnonymous) return;
+  if (session.transcriptTurns.length > 0) return; // reconnect, not a fresh session
+  if (!session.sseResponse) return;
+
+  try {
+    const lang = session.lang || 'en';
+    const timezone = session.clientContext?.timezone || 'UTC';
+    const text = buildGreetingBridgeText({ lang, now: new Date(), timezone });
+    const audioB64 = await synthesizeGreetingBridgeAudioPcm(text, lang);
+    if (!audioB64) {
+      emitDiag(session, 'greeting_bridge_skipped', { reason: 'synthesis_unavailable' });
+      return;
+    }
+    if (!session.sseResponse) return; // client disconnected while we were synthesizing
+    session.sseResponse.write(`data: ${JSON.stringify({
+      type: 'audio',
+      data_b64: audioB64,
+      mime: `audio/pcm;rate=${GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ}`,
+      chunk_number: session.audioOutChunks++,
+      source: 'greeting_bridge',
+    })}\n\n`);
+    emitDiag(session, 'greeting_bridge_sent', { lang, chars: text.length });
+  } catch (err) {
+    console.warn('[GREETING-BRIDGE] Failed (non-fatal, real greeting proceeds normally):', (err as Error).message);
+  }
+}
+
+/**
  * VTID-02020: Contextual recovery prompt for reconnects.
  *
  * After a network disconnect, the orb-widget client tears down the dead SSE
@@ -12985,6 +13038,16 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
       audio_in_rate: 16000,
     },
   });
+
+  // BOOTSTRAP-NOVA-SONIC-VOICE: greeting AUDIO bridge — synthesize + write a
+  // short filler phrase BEFORE opening the real (slow) upstream connection.
+  // Awaited deliberately: this guarantees the bridge audio is written to the
+  // SSE stream strictly before any real-greeting audio chunk could possibly
+  // arrive, with no extra buffering/sequencing machinery needed. Adds at
+  // most ~0.3-0.8s (TTS synthesis latency) ahead of a connect that otherwise
+  // takes 5-8+s to first audio — a clear net win, and feature-flagged so it
+  // can be disabled instantly if that tradeoff is ever wrong.
+  await sendGreetingAudioBridge(session);
 
   // VTID-01219: Connect to Vertex AI Live API WebSocket IN PARALLEL (non-blocking).
   // The ready event is already sent so the client gets instant visual + audio feedback

--- a/services/gateway/src/services/conversation/greeting-audio-bridge.ts
+++ b/services/gateway/src/services/conversation/greeting-audio-bridge.ts
@@ -1,0 +1,114 @@
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE: greeting AUDIO bridge.
+ *
+ * The real (context-heavy) greeting takes 5-8+ seconds to reach first audio
+ * on both Vertex and Nova today (see voice.latency.measured — the model must
+ * prefill the full system instruction + tool catalog before it can speak).
+ * That's a wall of silence the user has no reason to expect after tapping
+ * Connect & Talk.
+ *
+ * This module builds a SHORT, near-instant, TTS-synthesized phrase — date +
+ * a rotating motivational line + a transition into the real greeting — that
+ * plays while the real upstream is still connecting/prefilling. It is pure
+ * text generation only; synthesis and SSE wiring live in the caller
+ * (orb-live.ts), which also owns the feature-flag gate.
+ */
+
+import { tt, type GatewayLocale } from '../../i18n/catalog';
+
+const LINE_KEYS = [
+  'orb.greeting_bridge.line_1',
+  'orb.greeting_bridge.line_2',
+  'orb.greeting_bridge.line_3',
+  'orb.greeting_bridge.line_4',
+  'orb.greeting_bridge.line_5',
+] as const;
+
+export type GreetingBridgeTimeOfDay = 'morning' | 'afternoon' | 'evening';
+
+/** Local-hour → greeting bucket. Mirrors the existing priority.greeting.* split. */
+export function resolveGreetingBridgeTimeOfDay(localHour: number): GreetingBridgeTimeOfDay {
+  if (localHour < 12) return 'morning';
+  if (localHour < 18) return 'afternoon';
+  return 'evening';
+}
+
+/**
+ * Deterministic day-of-year rotation — no DB state needed, and every session
+ * on the same calendar day gets the same line (avoids an obviously-random
+ * feel across quick reconnects within one sitting).
+ */
+export function pickGreetingBridgeLineKey(dayOfYear: number): (typeof LINE_KEYS)[number] {
+  const idx = ((dayOfYear % LINE_KEYS.length) + LINE_KEYS.length) % LINE_KEYS.length;
+  return LINE_KEYS[idx];
+}
+
+export interface GreetingBridgeTextOptions {
+  lang: string | GatewayLocale | null | undefined;
+  /** Current instant — pass explicitly so callers stay testable (no Date.now() inside). */
+  now: Date;
+  /** IANA timezone for local-hour + local-date resolution. Falls back to UTC. */
+  timezone?: string | null;
+}
+
+/**
+ * Build the full spoken bridge phrase: "{Good morning/afternoon/evening}!
+ * Today is {date}. {motivational line} {transition into the real greeting}".
+ * Pure — safe to unit test without a TTS client or a live session.
+ */
+export function buildGreetingBridgeText(options: GreetingBridgeTextOptions): string {
+  const tz = options.timezone && options.timezone.trim().length > 0 ? options.timezone : 'UTC';
+  // Normalize ONCE and use this everywhere below (both Intl formatting and
+  // every tt() call) — tt()'s own unknown-locale fallback is 'de' (the
+  // catalog default), which differs from ours ('en'), so passing the raw
+  // unnormalized lang through would mix a German-fallback template with an
+  // English-fallback date, e.g. "Guten Morgen! ... July 26. ...".
+  const locale = normalizeToBcp47(options.lang);
+
+  let localHour: number;
+  let dateText: string;
+  try {
+    localHour = Number(
+      new Intl.DateTimeFormat('en-US', { timeZone: tz, hour: 'numeric', hour12: false }).format(options.now),
+    );
+  } catch {
+    localHour = options.now.getUTCHours();
+  }
+  try {
+    dateText = new Intl.DateTimeFormat(locale, { timeZone: tz, month: 'long', day: 'numeric' }).format(options.now);
+  } catch {
+    dateText = new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', month: 'long', day: 'numeric' }).format(options.now);
+  }
+
+  const startOfYearUtc = Date.UTC(options.now.getUTCFullYear(), 0, 0);
+  const dayOfYear = Math.floor((options.now.getTime() - startOfYearUtc) / 86_400_000);
+  const lineKey = pickGreetingBridgeLineKey(dayOfYear);
+  const line = tt(lineKey, locale);
+  const transition = tt('orb.greeting_bridge.transition', locale);
+
+  const timeOfDay = resolveGreetingBridgeTimeOfDay(localHour);
+  const openerKey =
+    timeOfDay === 'morning'
+      ? 'orb.greeting_bridge.morning'
+      : timeOfDay === 'afternoon'
+        ? 'orb.greeting_bridge.afternoon'
+        : 'orb.greeting_bridge.evening';
+
+  const opener = tt(openerKey, locale, { date: dateText, line });
+  return `${opener} ${transition}`;
+}
+
+/**
+ * Mirrors `normalizeLocale()` in i18n/catalog.ts EXACTLY (same supported set,
+ * same 'de' fallback for anything else) so the Intl-formatted date and the
+ * tt()-rendered template text are always in the SAME language. Nova's canary
+ * additionally supports 'fr' as a spoken language, but the gateway i18n
+ * catalog has no French entries — tt() would silently fall back to German
+ * for 'fr', so this must too, or a French session would hear a French date
+ * glued to a German sentence.
+ */
+function normalizeToBcp47(lang: string | GatewayLocale | null | undefined): string {
+  const base = (lang ?? '').trim().toLowerCase().split(/[-_]/)[0];
+  const supported = new Set(['de', 'en', 'es', 'sr']);
+  return supported.has(base) ? base : 'de';
+}

--- a/services/gateway/src/services/tts/greeting-bridge-tts.ts
+++ b/services/gateway/src/services/tts/greeting-bridge-tts.ts
@@ -1,0 +1,98 @@
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE: greeting AUDIO bridge — TTS synthesis.
+ *
+ * Separate `TextToSpeechClient` instance from the one `routes/orb-live.ts`
+ * uses for `/tts` (that one is module-private there) — Google's TTS client
+ * is stateless/ADC-backed, so a second instance is safe and keeps this
+ * module import-cycle-free from the route file.
+ *
+ * Requests LINEAR16 @ 24kHz (not MP3) so the output drops straight into the
+ * EXISTING PCM playback pipeline the live greeting audio already uses
+ * (orb-widget.js's `_processQueue`) — no client-side changes, no risk of
+ * two audio elements racing/overlapping.
+ */
+
+import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
+import { getNeural2TtsVoice, getGeminiTtsVoice, isNeural2EnabledFor } from '../../orb/live/voice/voice-mapping';
+import { getVoiceConfig } from '../voice-config';
+
+let bridgeTtsClient: TextToSpeechClient | null = null;
+try {
+  bridgeTtsClient = new TextToSpeechClient();
+} catch (err) {
+  console.warn('[GREETING-BRIDGE-TTS] Failed to initialize TTS client:', (err as Error).message);
+}
+
+export const GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ = 24_000;
+
+/**
+ * Synthesize `text` to base64 LINEAR16 PCM @ 24kHz mono. Returns null on any
+ * failure (missing client, API error, empty response) — this is a UX
+ * enhancement, never allowed to block or fail the real greeting path.
+ */
+export async function synthesizeGreetingBridgeAudioPcm(
+  text: string,
+  lang: string,
+): Promise<string | null> {
+  if (!bridgeTtsClient) return null;
+  if (!text || text.trim().length === 0) return null;
+
+  try {
+    const useNeural2 = isNeural2EnabledFor(lang);
+    const voiceConfig = useNeural2 ? getNeural2TtsVoice(lang) : getGeminiTtsVoice(lang);
+    const voiceParams: Record<string, unknown> = {
+      languageCode: voiceConfig.languageCode,
+      name: voiceConfig.name,
+    };
+    if (!useNeural2) {
+      voiceParams.modelName = 'gemini-2.5-flash-tts';
+    }
+
+    const vc = await getVoiceConfig();
+    const request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest = {
+      input: { text },
+      voice: voiceParams,
+      audioConfig: {
+        audioEncoding: 'LINEAR16' as any,
+        sampleRateHertz: GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ,
+        speakingRate: vc.tts.speaking_rate,
+        pitch: 0,
+      },
+    };
+
+    const [response] = await bridgeTtsClient.synthesizeSpeech(request);
+    if (!response.audioContent) return null;
+
+    // LINEAR16 output from Cloud TTS includes a 44-byte WAV header (RIFF/fmt/data
+    // chunks) even though we asked for raw PCM — the playback pipeline expects
+    // headerless PCM samples (it wraps the bytes in its own AudioBuffer), so the
+    // header must be stripped or every bridge phrase would open with ~2.5ms of
+    // header-as-noise and a WAV-chunk-sized DC click.
+    const raw = Buffer.isBuffer(response.audioContent)
+      ? response.audioContent
+      : Buffer.from(response.audioContent as Uint8Array);
+    const pcm = stripWavHeaderIfPresent(raw);
+    return pcm.toString('base64');
+  } catch (err) {
+    console.warn('[GREETING-BRIDGE-TTS] Synthesis failed:', (err as Error).message);
+    return null;
+  }
+}
+
+/** Cloud TTS LINEAR16 responses are WAV-wrapped; strip the RIFF header if present. */
+export function stripWavHeaderIfPresent(buf: Buffer): Buffer {
+  if (buf.length > 44 && buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WAVE') {
+    // Find the 'data' subchunk rather than assuming a fixed 44-byte header —
+    // WAV allows extra chunks (e.g. 'fact') before 'data' for some encoders.
+    let offset = 12;
+    while (offset + 8 <= buf.length) {
+      const chunkId = buf.toString('ascii', offset, offset + 4);
+      const chunkSize = buf.readUInt32LE(offset + 4);
+      if (chunkId === 'data') {
+        return buf.subarray(offset + 8, offset + 8 + chunkSize);
+      }
+      offset += 8 + chunkSize + (chunkSize % 2);
+    }
+  }
+  return buf;
+}

--- a/services/gateway/test/services/conversation/greeting-audio-bridge.test.ts
+++ b/services/gateway/test/services/conversation/greeting-audio-bridge.test.ts
@@ -1,0 +1,101 @@
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE: greeting audio bridge — pure text builder.
+ */
+
+import {
+  buildGreetingBridgeText,
+  resolveGreetingBridgeTimeOfDay,
+  pickGreetingBridgeLineKey,
+} from '../../../src/services/conversation/greeting-audio-bridge';
+
+describe('resolveGreetingBridgeTimeOfDay', () => {
+  it('buckets local hours into morning/afternoon/evening', () => {
+    expect(resolveGreetingBridgeTimeOfDay(0)).toBe('morning');
+    expect(resolveGreetingBridgeTimeOfDay(11)).toBe('morning');
+    expect(resolveGreetingBridgeTimeOfDay(12)).toBe('afternoon');
+    expect(resolveGreetingBridgeTimeOfDay(17)).toBe('afternoon');
+    expect(resolveGreetingBridgeTimeOfDay(18)).toBe('evening');
+    expect(resolveGreetingBridgeTimeOfDay(23)).toBe('evening');
+  });
+});
+
+describe('pickGreetingBridgeLineKey', () => {
+  it('rotates deterministically through the 5-line pool', () => {
+    expect(pickGreetingBridgeLineKey(0)).toBe('orb.greeting_bridge.line_1');
+    expect(pickGreetingBridgeLineKey(1)).toBe('orb.greeting_bridge.line_2');
+    expect(pickGreetingBridgeLineKey(4)).toBe('orb.greeting_bridge.line_5');
+    expect(pickGreetingBridgeLineKey(5)).toBe('orb.greeting_bridge.line_1'); // wraps
+  });
+
+  it('same day-of-year always yields the same line (deterministic, not random)', () => {
+    expect(pickGreetingBridgeLineKey(200)).toBe(pickGreetingBridgeLineKey(200));
+  });
+});
+
+describe('buildGreetingBridgeText', () => {
+  it('builds an English morning greeting with date + motivational line + transition', () => {
+    const text = buildGreetingBridgeText({
+      lang: 'en',
+      now: new Date('2026-07-26T08:00:00Z'),
+      timezone: 'UTC',
+    });
+    expect(text).toContain('Good morning!');
+    expect(text).toContain('July 26');
+    expect(text).toContain('Let me pull up your latest data');
+  });
+
+  it('builds a German evening greeting in German', () => {
+    const text = buildGreetingBridgeText({
+      lang: 'de',
+      now: new Date('2026-07-26T20:00:00Z'),
+      timezone: 'UTC',
+    });
+    expect(text).toContain('Guten Abend!');
+    expect(text).toContain('26. Juli');
+    expect(text).toContain('Lass mich kurz deine aktuellen Daten anschauen');
+  });
+
+  it('picks afternoon for a midday local hour', () => {
+    const text = buildGreetingBridgeText({
+      lang: 'en',
+      now: new Date('2026-07-26T14:00:00Z'),
+      timezone: 'UTC',
+    });
+    expect(text).toContain('Good afternoon!');
+  });
+
+  it('respects timezone offset for the local-hour bucket (not raw UTC hour)', () => {
+    // 22:00 UTC is 07:00 in a UTC+9 zone (Asia/Tokyo) — should read as morning there.
+    const text = buildGreetingBridgeText({
+      lang: 'en',
+      now: new Date('2026-07-25T22:00:00Z'),
+      timezone: 'Asia/Tokyo',
+    });
+    expect(text).toContain('Good morning!');
+  });
+
+  it('falls back to German (the i18n catalog default) for an unsupported/garbage language code — never mixes languages within one phrase', () => {
+    const text = buildGreetingBridgeText({
+      lang: 'xx-not-a-real-lang',
+      now: new Date('2026-07-26T08:00:00Z'),
+      timezone: 'UTC',
+    });
+    expect(text).toContain('Guten Morgen!');
+    expect(text).toContain('26. Juli'); // date must match the same fallback language
+  });
+
+  it("falls back to German for 'fr' — Nova speaks French but the i18n catalog has no French entries, matching tt()'s own fallback", () => {
+    const text = buildGreetingBridgeText({
+      lang: 'fr',
+      now: new Date('2026-07-26T08:00:00Z'),
+      timezone: 'UTC',
+    });
+    expect(text).toContain('Guten Morgen!');
+    expect(text).toContain('26. Juli');
+  });
+
+  it('defaults to UTC when no timezone is provided', () => {
+    const text = buildGreetingBridgeText({ lang: 'en', now: new Date('2026-07-26T08:00:00Z') });
+    expect(text).toContain('Good morning!');
+  });
+});

--- a/services/gateway/test/services/tts/greeting-bridge-tts.test.ts
+++ b/services/gateway/test/services/tts/greeting-bridge-tts.test.ts
@@ -1,0 +1,51 @@
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE: greeting bridge TTS synthesis — WAV-header
+ * stripping (the one nontrivial pure logic here; synthesis itself needs a
+ * live GCP client and is exercised on staging, not in unit tests) and the
+ * empty-text fast-path guard.
+ */
+
+import { stripWavHeaderIfPresent, synthesizeGreetingBridgeAudioPcm } from '../../../src/services/tts/greeting-bridge-tts';
+
+function buildWavBuffer(pcmBytes: Buffer): Buffer {
+  const header = Buffer.alloc(44);
+  header.write('RIFF', 0, 'ascii');
+  header.writeUInt32LE(36 + pcmBytes.length, 4);
+  header.write('WAVE', 8, 'ascii');
+  header.write('fmt ', 12, 'ascii');
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20); // PCM
+  header.writeUInt16LE(1, 22); // mono
+  header.writeUInt32LE(24000, 24); // sample rate
+  header.writeUInt32LE(48000, 28); // byte rate
+  header.writeUInt16LE(2, 32); // block align
+  header.writeUInt16LE(16, 34); // bits per sample
+  header.write('data', 36, 'ascii');
+  header.writeUInt32LE(pcmBytes.length, 40);
+  return Buffer.concat([header, pcmBytes]);
+}
+
+describe('stripWavHeaderIfPresent', () => {
+  it('strips a standard 44-byte RIFF/WAVE header, returning only the PCM payload', () => {
+    const pcm = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+    const wav = buildWavBuffer(pcm);
+    expect(stripWavHeaderIfPresent(wav)).toEqual(pcm);
+  });
+
+  it('passes through a buffer with no RIFF/WAVE signature unchanged', () => {
+    const raw = Buffer.from([9, 9, 9, 9, 9, 9, 9, 9, 9, 9]);
+    expect(stripWavHeaderIfPresent(raw)).toEqual(raw);
+  });
+
+  it('passes through a too-short buffer unchanged rather than throwing', () => {
+    const tiny = Buffer.from([1, 2, 3]);
+    expect(stripWavHeaderIfPresent(tiny)).toEqual(tiny);
+  });
+});
+
+describe('synthesizeGreetingBridgeAudioPcm', () => {
+  it('returns null for empty text without attempting synthesis', async () => {
+    expect(await synthesizeGreetingBridgeAudioPcm('', 'en')).toBeNull();
+    expect(await synthesizeGreetingBridgeAudioPcm('   ', 'en')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

User's request, verbatim: *"you have to build a greeting that bridges the time between greeting and processed tool catalog data... saying something like: Let me take a look at your latest data... Bridge the 8 seconds with a greeting saying like: today is the 26 of July and a motivational greeting."*

A short, near-instant bridge phrase ("Good morning! Today is July 26th. \<motivational line\>. Let me pull up your latest data…") is synthesized via Cloud TTS and written to the SSE stream **before** the real (slow) upstream connection is even opened.

## Why

Confirmed by the controlled paired-comparison in PR #2973's follow-up: both Vertex and Nova take 5-8+ seconds to first greeting audio right now, because the model has to prefill the full system instruction + tool catalog (~9K input tokens) before it can speak. That's silence the user has no reason to expect after tapping Connect & Talk.

## How

- **Ordering is trivially correct, no new buffering machinery**: the bridge send is `await`ed to completion (~0.3-0.8s TTS latency) strictly before the real upstream connect is initiated. The write to SSE always happens-before any real-greeting audio could possibly be produced.
- **Same wire format as the real greeting**: LINEAR16 PCM @ 24kHz (not MP3), so it drops straight into the existing client-side PCM scheduler (`orb-widget.js`) with **zero frontend changes** and no risk of two audio elements racing/overlapping.
- **Locale-consistent by construction**: the bridge's locale fallback mirrors `i18n/catalog.ts`'s `normalizeLocale()` exactly (falls to German, not English) — including for Nova's `fr` canary language, which the gateway i18n catalog doesn't cover, so a French Nova session never gets a French date glued to a German sentence (or vice versa).
- **Deterministic motivational-line rotation**: day-of-year modulo over a 5-line pool — no DB state, and every session on the same calendar day gets the same line.
- **Fully safe to ship**: feature-flagged (`ORB_GREETING_TTS_BRIDGE`, default off), skipped for anonymous sessions and reconnects, and any failure (TTS unavailable, synthesis error, closed connection) is swallowed — never blocks or breaks the real greeting path.

## Tests

- 9 new tests for the pure text builder (time-of-day bucketing, line rotation, locale/timezone handling, the German-fallback consistency fix a test caught mid-build).
- 4 new tests for the TTS module (WAV-header stripping — Cloud TTS's LINEAR16 response is WAV-wrapped and must be unwrapped to raw PCM for the client scheduler — plus the empty-text guard).
- Full `test/orb/live` + `test/services/conversation` + `test/services/tts`: 1005/1005 pass.
- `tsc --noEmit` clean.

## After deploy

Enable `ORB_GREETING_TTS_BRIDGE` on staging only, then a zero-mic session should show: `ready` → (short pause) → bridge audio (source: `greeting_bridge`) → several more seconds → real greeting audio, with no gap the user would call "silence."

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_