### PR TITLE
chore(orb): enable ORB_GREETING_TTS_BRIDGE on staging (GCP + AWS) (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/.github/workflows/AWS-STAGE-DEPLOY-GATEWAY.yml
+++ b/.github/workflows/AWS-STAGE-DEPLOY-GATEWAY.yml
@@ -187,7 +187,8 @@ jobs:
                 | .containerDefinitions[0].environment |=
                     ( [ .[] | select(.name | IN("GIT_COMMIT_SHA","COMMIT_SHA","BUILD_INFO_MARKER",
                                                 "NOVA_SONIC_ENABLED","NOVA_SONIC_REGION","NOVA_SONIC_MODEL_ID",
-                                                "NOVA_SONIC_CANARY_USER_IDS","NOVA_SONIC_CANARY_TENANT_IDS") | not) ]
+                                                "NOVA_SONIC_CANARY_USER_IDS","NOVA_SONIC_CANARY_TENANT_IDS",
+                                                "FEATURE_ORB_GREETING_TTS_BRIDGE_ENV") | not) ]
                       + [ {name:"GIT_COMMIT_SHA", value:$SHA},
                           {name:"COMMIT_SHA", value:$SHA},
                           {name:"BUILD_INFO_MARKER", value:$SHORT},
@@ -195,7 +196,14 @@ jobs:
                           {name:"NOVA_SONIC_REGION", value:"eu-north-1"},
                           {name:"NOVA_SONIC_MODEL_ID", value:"amazon.nova-2-sonic-v1:0"},
                           {name:"NOVA_SONIC_CANARY_USER_IDS", value:$NOVA_USERS},
-                          {name:"NOVA_SONIC_CANARY_TENANT_IDS", value:$NOVA_TENANTS} ] )
+                          {name:"NOVA_SONIC_CANARY_TENANT_IDS", value:$NOVA_TENANTS},
+                          # BOOTSTRAP-NOVA-SONIC-VOICE: upserted (not a repo
+                          # var) — same fixed staging-only value as the GCP
+                          # twin (STAGE-DEPLOY.yml). Bridges the 5-8s
+                          # model-prefill wall of silence with an instant TTS
+                          # phrase; this is the surface where Nova sessions
+                          # actually run, so it must persist here too.
+                          {name:"FEATURE_ORB_GREETING_TTS_BRIDGE_ENV", value:"staging-only"} ] )
                 | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
                       .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
           NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" \

--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -158,6 +158,14 @@ jobs:
             "FEATURE_ORB_FAST_START_ENV=staging-only"
             "FEATURE_ORB_SAFE_FAST_GREETING_ENV=staging-only"
             "ORB_CONTEXT_READY_GATE_TIMEOUT_MS=300"
+            # BOOTSTRAP-NOVA-SONIC-VOICE: the model-prefill bottleneck (full
+            # system instruction + tool catalog, ~9K input tokens) still takes
+            # 5-8s+ to first greeting audio on both Vertex and Nova even with
+            # fast-start above — that's the wall of silence this flag bridges
+            # with an instant TTS phrase (date + motivational line + transition)
+            # written to SSE before the real upstream connects. staging-only;
+            # prod stays off until the experiment window graduates it.
+            "FEATURE_ORB_GREETING_TTS_BRIDGE_ENV=staging-only"
             # NAV continuation / journey-mode experiments — bake into the staging
             # env so they PERSIST across every STAGE-DEPLOY (--set-env-vars
             # REPLACES, so a hand-set gcloud flag is wiped on the next push — the


### PR DESCRIPTION
## What

Turns on the greeting-audio-bridge feature built in #2975, on **staging only**, on both staging surfaces:

- `STAGE-DEPLOY.yml` (GCP `gateway-staging` / `preview-gateway.vitanaland.com`) — added `FEATURE_ORB_GREETING_TTS_BRIDGE_ENV=staging-only` to the authoritative `ENV_VARS` array (same pattern as `FEATURE_ORB_FAST_START_ENV` / `FEATURE_ORB_SAFE_FAST_GREETING_ENV` right above it — `--set-env-vars` replaces, not merges, so a flag has to live in the workflow to persist across deploys).
- `AWS-STAGE-DEPLOY-GATEWAY.yml` (AWS `vitana-gateway` / `preview-aws-gateway.vitanaland.com` — **the surface where Nova canary sessions actually run**) — added `FEATURE_ORB_GREETING_TTS_BRIDGE_ENV` to the jq upsert list alongside the five `NOVA_SONIC_*` vars, since this workflow otherwise only carries forward whatever's already on the task definition. Fixed `staging-only` value, not a repo variable — no per-dispatch override is needed for this one.

## Why

I don't have live `gcloud`/`aws` CLI access in this environment to flip the env var directly on either running service (confirmed — no `gcloud`, no `aws` CLI, and the `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` present resolve to `InvalidClientTokenId` against STS, so they're not usable for ECS mutations either). Baking the flag into both deploy workflows is the only way I can turn this on without needing an operator to run a manual command — and it matches the repo's own established pattern for every other staging-only ORB flag.

## No app code changes

The feature itself (bridge phrase synthesis + SSE wiring) shipped in #2975. This PR is deploy-config only.

## Verification

- `yaml.safe_load()` clean on both edited workflow files.
- Dry-ran the AWS jq upsert transform against a mock task-definition JSON — confirmed a stale `FEATURE_ORB_GREETING_TTS_BRIDGE_ENV` value gets replaced with `staging-only` and every other key (image, commit stamps, Nova vars, unrelated env) survives untouched.

## After merge

- GCP: next push-triggered `STAGE-DEPLOY.yml` run picks it up automatically.
- AWS: next push-triggered `AWS-STAGE-DEPLOY-GATEWAY.yml` run picks it up automatically (mirrors how the Nova canary vars propagate).
- Then run a zero-mic verification session against `preview-aws-gateway.vitanaland.com` and confirm the SSE sequence: `ready` → bridge audio (`source: greeting_bridge`) → real greeting audio, with `greeting_bridge_sent` in OASIS.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_