### PR TITLE
fix(orb): disable ORB_GREETING_TTS_BRIDGE — voice mismatch, not allowed (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/.github/workflows/AWS-STAGE-DEPLOY-GATEWAY.yml
+++ b/.github/workflows/AWS-STAGE-DEPLOY-GATEWAY.yml
@@ -197,13 +197,15 @@ jobs:
                           {name:"NOVA_SONIC_MODEL_ID", value:"amazon.nova-2-sonic-v1:0"},
                           {name:"NOVA_SONIC_CANARY_USER_IDS", value:$NOVA_USERS},
                           {name:"NOVA_SONIC_CANARY_TENANT_IDS", value:$NOVA_TENANTS},
-                          # BOOTSTRAP-NOVA-SONIC-VOICE: upserted (not a repo
-                          # var) — same fixed staging-only value as the GCP
-                          # twin (STAGE-DEPLOY.yml). Bridges the 5-8s
-                          # model-prefill wall of silence with an instant TTS
-                          # phrase; this is the surface where Nova sessions
-                          # actually run, so it must persist here too.
-                          {name:"FEATURE_ORB_GREETING_TTS_BRIDGE_ENV", value:"staging-only"} ] )
+                          # BOOTSTRAP-NOVA-SONIC-VOICE: DISABLED (2026-07-28)
+                          # — rejected on product grounds (voice mismatch: the
+                          # Cloud TTS bridge phrase is never the same voice as
+                          # Nova Sonic's live voice). See STAGE-DEPLOY.yml's
+                          # matching entry for the full rationale. Explicitly
+                          # upserted to "off" (not just removed) so it can't
+                          # silently drift back to a stale "staging-only"
+                          # value left on the task definition from before.
+                          {name:"FEATURE_ORB_GREETING_TTS_BRIDGE_ENV", value:"off"} ] )
                 | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
                       .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
           NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" \

--- a/.github/workflows/STAGE-DEPLOY.yml
+++ b/.github/workflows/STAGE-DEPLOY.yml
@@ -158,14 +158,20 @@ jobs:
             "FEATURE_ORB_FAST_START_ENV=staging-only"
             "FEATURE_ORB_SAFE_FAST_GREETING_ENV=staging-only"
             "ORB_CONTEXT_READY_GATE_TIMEOUT_MS=300"
-            # BOOTSTRAP-NOVA-SONIC-VOICE: the model-prefill bottleneck (full
-            # system instruction + tool catalog, ~9K input tokens) still takes
-            # 5-8s+ to first greeting audio on both Vertex and Nova even with
-            # fast-start above — that's the wall of silence this flag bridges
-            # with an instant TTS phrase (date + motivational line + transition)
-            # written to SSE before the real upstream connects. staging-only;
-            # prod stays off until the experiment window graduates it.
-            "FEATURE_ORB_GREETING_TTS_BRIDGE_ENV=staging-only"
+            # BOOTSTRAP-NOVA-SONIC-VOICE: DISABLED (2026-07-28) — rejected on
+            # product grounds, not a bug. The bridge phrase is synthesized by
+            # Cloud TTS (a Neural2/Gemini-TTS voice, e.g. "Kore") which is
+            # NEVER the same voice as the real upstream (Nova Sonic's
+            # tina/lennart or Vertex Live's Callirrhoe, etc.) — every session
+            # would audibly switch voices mid-greeting. That's a worse UX than
+            # the silence it was meant to fill, and no TTS-based bridge can
+            # fix it (no standalone API can reproduce the live model's own
+            # voice). Left in code (feature-flagged, off) in case a same-voice
+            # approach is designed later — see greeting-audio-bridge.ts /
+            # greeting-bridge-tts.ts. The real latency fix is trimming the
+            # greeting-turn prefill payload (tool catalog / system
+            # instruction size), not masking the wait with a different voice.
+            "FEATURE_ORB_GREETING_TTS_BRIDGE_ENV=off"
             # NAV continuation / journey-mode experiments — bake into the staging
             # env so they PERSIST across every STAGE-DEPLOY (--set-env-vars
             # REPLACES, so a hand-set gcloud flag is wiped on the next push — the


### PR DESCRIPTION
## What

Disables the greeting-audio-bridge feature shipped in #2975/#2977 by flipping `FEATURE_ORB_GREETING_TTS_BRIDGE_ENV` from `staging-only` to `off` in both `STAGE-DEPLOY.yml` (GCP) and `AWS-STAGE-DEPLOY-GATEWAY.yml` (AWS). Code stays in place, feature-flagged off — not reverted — in case a same-voice approach is designed later.

## Why

Explicit product requirement: **the voice must always be the same**. The bridge phrase is synthesized by Google Cloud TTS using a fixed Neural2/Gemini voice (e.g. `Kore`), which is never the same voice as the real upstream model — Nova Sonic's `tina`/`lennart` or Vertex Live's `Callirrhoe`, etc. Every session would audibly switch voices mid-greeting (TTS voice → model's live voice), which is a worse experience than the silence it was meant to fill, and this isn't fixable by swapping TTS providers — no standalone TTS API can reproduce a live conversational model's own voice.

## Verification before disabling

Confirmed via a zero-mic SSE trace + OASIS diag events that the mechanism itself worked correctly where credentials allowed it:
- **GCP staging (Vertex):** bridge audio (`source: greeting_bridge`) fired at +1287ms, well ahead of the real greeting's first audio at +2252ms — the sequencing/synthesis/wiring all functioned as designed.
- **AWS staging:** separately blocked by an unrelated, pre-existing gap — Google Cloud TTS can't load ADC credentials on ECS (`Could not load the default credentials`, confirmed via the existing `/debug/tts` route) — but that gap is not why this is being disabled; the voice-mismatch problem exists regardless of whether AWS credentials are fixed.

## Next step (separate work, not in this PR)

The real fix for the 5-8s greeting-turn latency is reducing the actual model-prefill payload (system instruction + tool catalog, ~9K input tokens) rather than masking the wait with a different voice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_