### PR TITLE
fix(ci): remove apostrophe from jq comment breaking AWS staging deploy (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/.github/workflows/AWS-STAGE-DEPLOY-GATEWAY.yml
+++ b/.github/workflows/AWS-STAGE-DEPLOY-GATEWAY.yml
@@ -178,6 +178,20 @@ jobs:
           # EVERY deploy so a canary flip (or rollback to disabled/empty) is
           # exactly one variable change + one dispatch. Never AWS access keys
           # here — Nova auth is the task role via the SDK default chain.
+          #
+          # BOOTSTRAP-NOVA-SONIC-VOICE: FEATURE_ORB_GREETING_TTS_BRIDGE_ENV
+          # is upserted to "off" below (2026-07-28, disabled) -- rejected on
+          # product grounds (voice mismatch: the Cloud TTS bridge phrase is
+          # never the same voice as the live upstream). See STAGE-DEPLOY.yml
+          # for the full rationale. Explicitly set to "off" (not removed) so
+          # it cannot silently drift back to a stale "staging-only" value
+          # left on the task definition from before.
+          #
+          # NOTE: comments inside the jq program string below (the single
+          # quoted block starting on the next line) must never contain an
+          # apostrophe -- it is bash single-quoted, so a stray "'" closes
+          # the string early and breaks the whole command (bit us once,
+          # see PR #2978's failed AWS deploy run).
           NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
             | jq --arg IMG "$IMAGE" --arg SHA "$SHA" --arg SHORT "$SHORT" \
                  --arg NOVA_ENABLED "$NOVA_SONIC_ENABLED" \
@@ -197,14 +211,6 @@ jobs:
                           {name:"NOVA_SONIC_MODEL_ID", value:"amazon.nova-2-sonic-v1:0"},
                           {name:"NOVA_SONIC_CANARY_USER_IDS", value:$NOVA_USERS},
                           {name:"NOVA_SONIC_CANARY_TENANT_IDS", value:$NOVA_TENANTS},
-                          # BOOTSTRAP-NOVA-SONIC-VOICE: DISABLED (2026-07-28)
-                          # — rejected on product grounds (voice mismatch: the
-                          # Cloud TTS bridge phrase is never the same voice as
-                          # Nova Sonic's live voice). See STAGE-DEPLOY.yml's
-                          # matching entry for the full rationale. Explicitly
-                          # upserted to "off" (not just removed) so it can't
-                          # silently drift back to a stale "staging-only"
-                          # value left on the task definition from before.
                           {name:"FEATURE_ORB_GREETING_TTS_BRIDGE_ENV", value:"off"} ] )
                 | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
                       .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')


### PR DESCRIPTION
## What

Fixes a CI bug I introduced in #2978: `AWS-STAGE-DEPLOY-GATEWAY.yml`'s "Register task-definition revision" step started failing on every push to `main` because a jq-embedded comment contained apostrophes (`"can't"`, `"Sonic's"`) inside a bash single-quoted program string. The apostrophe closed the string early, producing `jq: error: syntax error, unexpected end of file (Unix shell quoting issues?)` and failing the step — meaning the push-triggered AWS staging deploy off commit `a91205d` never actually rolled the ECS service (build succeeded, task-definition registration failed).

## Fix

- Moved the explanation for disabling `FEATURE_ORB_GREETING_TTS_BRIDGE_ENV` to the step's outer comment block (a normal `#` YAML comment, not inside the jq single-quoted string).
- Removed the apostrophe-bearing comment from inside the jq program entirely.
- Added a guard comment directly above the jq invocation warning against ever putting an apostrophe inside that single-quoted block again.

## Verification

Extracted the exact step script from the YAML via `yaml.safe_load()` and ran it end-to-end against a mocked `aws` CLI (mocked `describe-task-definition` / `register-task-definition` / `describe-services` / `update-service` / `wait`):
- No jq syntax error — full script runs clean.
- Captured the exact JSON jq would register: `FEATURE_ORB_GREETING_TTS_BRIDGE_ENV` is `"off"`, and every other env var (Nova vars, commit stamps, pre-existing vars) survives untouched.

## After merge

Next push-triggered `AWS-STAGE-DEPLOY-GATEWAY.yml` run will actually apply the disable (GCP staging already got it fine — its deploy path uses a flat `--set-env-vars` array, not jq, so it was never affected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_