### PR TITLE
Fix daily-feature-tip: await notification dispatch before responding

### DIFF
--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -18,7 +18,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { notifyUserAsync, sendPushToUser, sendAppilixPush, TYPE_META } from '../services/notification-service';
+import { notifyUser, notifyUserAsync, sendPushToUser, sendAppilixPush, TYPE_META } from '../services/notification-service';
 import { generatePersonalRecommendations } from '../services/recommendation-engine';
 import { LangCode, resolveLanguage } from '../services/recommendation-engine/analyzers/community-user-analyzer';
 import { tt, type GatewayI18nKey } from '../i18n/catalog';
@@ -672,7 +672,6 @@ router.post('/daily-feature-tip', async (req: Request, res: Response) => {
         deep_link: tip.deepLink,
         created_by: 'scheduled:daily-feature-tip',
         target_user_ids: null,
-        notified_at: new Date().toISOString(),
       })
       .select('id')
       .single();
@@ -689,30 +688,48 @@ router.post('/daily-feature-tip', async (req: Request, res: Response) => {
     //    /home is a vitana-v1 MAXINA_LANDING_ROUTES entry that auto-opens the
     //    Orb front-door on a fresh mount, which a push-notification tap
     //    counts as; /home/notif is the identical feed minus that collision.
+    // Awaited (via notifyUser, not the fire-and-forget notifyUserAsync) so
+    // the HTTP response isn't sent until every dispatch has actually
+    // finished. Confirmed live: with fire-and-forget, Cloud Run returned the
+    // response and froze/recycled the container before all ~181 background
+    // promises finished writing their row — only 33 of 181 members actually
+    // got notified for one day's run (card still showed for everyone via
+    // the direct RLS read, just the notification silently never arrived for
+    // most people). Promise.allSettled so one bad user can't block the rest.
     const users = await getActiveUsers(supa, tenantId);
     const userIds = users.map((u) => u.user_id);
     const locales = await bulkGetUserLocales(supa, userIds);
-    let dispatched = 0;
-    for (const uid of userIds) {
-      const lc = locales.get(uid) || 'de';
-      notifyUserAsync(
-        uid,
-        tenantId,
-        'feature_announcement',
-        {
-          title: tt('notif.feature_tip.title', lc, { feature: pickTipLocale(tip.title, lc) }),
-          body: pickTipLocale(tip.description, lc),
-          data: { url: '/home/notif', entity_id: announcementId },
-        },
-        supa,
-      );
-      dispatched++;
+    const results = await Promise.allSettled(
+      userIds.map((uid) => {
+        const lc = locales.get(uid) || 'de';
+        return notifyUser(
+          uid,
+          tenantId,
+          'feature_announcement',
+          {
+            title: tt('notif.feature_tip.title', lc, { feature: pickTipLocale(tip.title, lc) }),
+            body: pickTipLocale(tip.description, lc),
+            data: { url: '/home/notif', entity_id: announcementId },
+          },
+          supa,
+        );
+      }),
+    );
+    const dispatched = results.filter((r) => r.status === 'fulfilled').length;
+    const failed = results.length - dispatched;
+    if (failed > 0) {
+      console.warn(`[Scheduled] daily_feature_tip: ${failed}/${results.length} notifyUser calls rejected`);
     }
 
-    // 4. Advance rotation state for next time.
+    // 4. Advance rotation state for next time, and record when dispatch
+    //    actually finished (not when the row was first inserted).
     await supa
       .from('did_you_know_state')
       .upsert({ tenant_id: tenantId, last_index: nextIndex, updated_at: new Date().toISOString() });
+    await supa
+      .from('feature_announcements')
+      .update({ notified_at: new Date().toISOString() })
+      .eq('id', announcementId);
 
     console.log(`[Scheduled] daily_feature_tip → tip=${tip.key} dispatched=${dispatched} users`);
 

--- a/services/gateway/test/scheduled-notifications-daily-feature-tip.test.ts
+++ b/services/gateway/test/scheduled-notifications-daily-feature-tip.test.ts
@@ -13,12 +13,14 @@ import express from 'express';
 import request from 'supertest';
 
 let mockSupabase: any;
-const notifyUserAsyncMock = jest.fn();
+const notifyUserMock = jest.fn();
 const bulkGetUserLocalesMock = jest.fn();
 let upsertedState: any = null;
+let updatedAnnouncement: any = null;
 
 jest.mock('../src/services/notification-service', () => ({
-  notifyUserAsync: (...args: any[]) => notifyUserAsyncMock(...args),
+  notifyUser: (...args: any[]) => notifyUserMock(...args),
+  notifyUserAsync: jest.fn(),
   sendPushToUser: jest.fn(),
   sendAppilixPush: jest.fn(),
   TYPE_META: {},
@@ -59,6 +61,7 @@ function makeFakeSupabase(opts: {
   members: Array<{ user_id: string }>;
 }) {
   upsertedState = null;
+  updatedAnnouncement = null;
   return {
     from: (table: string) => {
       if (table === 'did_you_know_state') {
@@ -78,6 +81,11 @@ function makeFakeSupabase(opts: {
         chain.insert = () => chain;
         chain.select = () => chain;
         chain.single = () => Promise.resolve(opts.insertResult);
+        chain.update = (row: any) => {
+          updatedAnnouncement = row;
+          return chain;
+        };
+        chain.eq = () => Promise.resolve({ data: null, error: null });
         return chain;
       }
       if (table === 'user_tenants') {
@@ -94,7 +102,8 @@ function makeFakeSupabase(opts: {
 }
 
 beforeEach(() => {
-  notifyUserAsyncMock.mockClear();
+  notifyUserMock.mockReset();
+  notifyUserMock.mockResolvedValue({ pushed: 1, inapp: true });
   bulkGetUserLocalesMock.mockReset();
   bulkGetUserLocalesMock.mockResolvedValue(new Map([['u1', 'de'], ['u2', 'en']]));
 });
@@ -125,7 +134,27 @@ describe('POST /daily-feature-tip', () => {
     expect(r.status).toBe(200);
     expect(r.body).toMatchObject({ ok: true, tip: 'tip-b', announcement_id: 'ann-1', dispatched: 2 });
     expect(upsertedState).toMatchObject({ tenant_id: 'tenant-1', last_index: 1 });
-    expect(notifyUserAsyncMock).toHaveBeenCalledTimes(2);
+    expect(notifyUserMock).toHaveBeenCalledTimes(2);
+    expect(updatedAnnouncement).toHaveProperty('notified_at');
+  });
+
+  it('still counts successful dispatches when some users reject (Promise.allSettled)', async () => {
+    mockSupabase = makeFakeSupabase({
+      lastIndex: 0,
+      insertResult: { data: { id: 'ann-1' }, error: null },
+      members: [{ user_id: 'u1' }, { user_id: 'u2' }],
+    });
+    notifyUserMock.mockReset();
+    notifyUserMock
+      .mockResolvedValueOnce({ pushed: 1, inapp: true })
+      .mockRejectedValueOnce(new Error('boom'));
+
+    const r = await request(makeApp())
+      .post('/api/v1/scheduled-notifications/daily-feature-tip')
+      .send({ tenant_id: 'tenant-1' });
+
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ ok: true, dispatched: 1 });
   });
 
   it('wraps around to index 0 once the tip list is exhausted', async () => {


### PR DESCRIPTION
## Summary

- Confirmed live: only 33 of ~181 tenant members got notified for today's "Did You Know" card (Autopilot tip), while the card itself showed correctly for everyone via the direct RLS-scoped feed read. Yesterday's card (Vitana Index) got all 181 — so the failure is non-deterministic, not a hard bug in the fan-out logic itself.
- Root cause: the route dispatched notifications with `notifyUserAsync` (deliberately fire-and-forget) inside a `for` loop, then returned its HTTP response immediately without waiting for any of those background promises to resolve. Cloud Run is free to freeze/recycle the container right after the response is sent — whichever promises hadn't finished their DB write yet were silently abandoned. That's exactly the kind of failure that varies run to run depending on container/scheduling timing.
- Fix: switched to the awaited `notifyUser()` via `Promise.allSettled` (so one bad user's rejection can't block the rest), keeping the request alive until every dispatch has genuinely finished before responding.
- Also fixed `notified_at` to be set *after* dispatch completes rather than optimistically at insert time — it was previously baked into the initial `INSERT` payload, so it never actually reflected whether notifications went out. Now matches `admin-feature-announcements.ts`'s pattern (separate `UPDATE` after the fan-out).

## Test plan

- [x] Updated `test/scheduled-notifications-daily-feature-tip.test.ts` — mocks the awaited `notifyUser` instead of fire-and-forget `notifyUserAsync`; added a case confirming a rejected dispatch doesn't block/miscount the others (`Promise.allSettled` semantics)
- [ ] Live re-verification: confirm tomorrow's 17:00 UTC firing notifies all active tenant members, not a partial subset

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhBPkg9U1DJyo8ojognubd)_