### PR TITLE
docs: close the VTID-03419 documentation gap — cutover runbook + CLAUDE.md never reflected the completed cutover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,15 @@ Claude must **never** do the following:
 1. **Never invent new projects, environments, or services.** (Exception:
    the AWS parallel/DR environment, sanctioned under **VTID-03398,
    VTID-03409, VTID-03410, VTID-03411, VTID-03414, VTID-03415** — see
-   §1b. GCP remains canonical production; AWS is additive DR capacity,
-   not a new canonical target, and not yet a sole-production cutover —
-   see `docs/AWS-CUTOVER-RUNBOOK.md` (VTID-03412) for what still gates
-   that. Extending AWS-DR to a service not already listed in §1b still
-   needs its own new VTID.)
+   §1b. GCP remains canonical production for every service **except
+   gateway and community-app** — those two were cut over to AWS as
+   sole production under **VTID-03419** (2026-07-27; DNS execution
+   record in `docs/AWS-CUTOVER-RUNBOOK.md` §3). Everything else (Aurora
+   as a failover target, oasis-projector, orb-agent, autopilot-cdc, and
+   full GCP decommission) remains additive DR only — not yet a
+   sole-production cutover, and still gated on that runbook's §2
+   checklist plus its own separate execution VTID. Extending AWS-DR to
+   a service not already listed in §1b still needs its own new VTID.)
 2. **Never bypass governance gates.**
 3. **Never execute without a VTID.**
 4. **Never deploy without OASIS approval.**
@@ -311,15 +315,20 @@ gcloud run deploy <service> \
 ## 1b. AWS PRODUCTION (DR) (VTID-03398, VTID-03409, VTID-03410, VTID-03411, VTID-03414, VTID-03415)
 
 GCP (`lovable-vitana-vers1`) remains the **canonical** production for every
-service. AWS hosts **parallel/DR production infrastructure for 7 services**
-plus a RunTask job-dispatch path — additive capacity, not a migration, and
-not yet a sole-production cutover. Extending this pattern to a service not
-listed in the table below still needs its own new VTID.
+service **except gateway and community-app**. Those two were cut over to
+AWS as **sole production** under **VTID-03419** (2026-07-27) — see
+`docs/AWS-CUTOVER-RUNBOOK.md` §3 for the DNS execution record. For every
+other service in the table below, AWS remains **parallel/DR production
+infrastructure** — additive capacity, not a migration, not yet a
+sole-production cutover, gated on `docs/AWS-CUTOVER-RUNBOOK.md`
+(VTID-03412) §2's checklist and its own separate execution VTID.
+Extending this pattern to a service not listed in the table below still
+needs its own new VTID.
 
 | Service | VTID | ECS resource / dispatch | Public URL / access | Deploy workflow |
 |---|---|---|---|---|
 | gateway | VTID-03398 | ECS service `vitana-gateway-awsdr`, task def family `vitana-gateway-awsdr`, target group `vitana-tg-gateway-awsdr` | `https://dr-gateway.vitanaland.com` (ALB host rule, priority 5) | `AWS-PROD-DEPLOY-GATEWAY.yml` |
-| community-app (frontend) | VTID-03409 | ECS service `vitana-community-app-awsdr`, target group `vitana-tg-community-awsdr` | `https://dr-app.vitanaland.com` (ALB host rule, priority 6); static SPA build bakes the **canonical GCP prod** gateway URL (`gateway.vitanaland.com`) into `.env.production` — no runtime env var to flip | `AWS-PROD-DEPLOY-FRONTEND.yml` (in `exafyltd/vitana-v1`) — still on static `AWS_STAGING_ACCESS_KEY_ID`/`SECRET` repo secrets, not yet OIDC (follow-up) |
+| community-app (frontend) | VTID-03409, cut over to sole production VTID-03419 | ECS service `vitana-community-app-awsdr` (now serving `vitanaland.com` apex + `www`, not just the `dr-app` DR hostname), target group `vitana-tg-community-awsdr` | `https://dr-app.vitanaland.com` (ALB host rule, priority 6) **and** `https://vitanaland.com` (apex/`www`, since VTID-03419 — routed via a Cloudflare Worker whose origin was repointed at cutover time, not by DNS alone, see runbook §3.2); static SPA build bakes the canonical gateway URL (`gateway.vitanaland.com`, itself AWS since VTID-03419) into `.env.production` — no runtime env var to flip | `AWS-PROD-DEPLOY-FRONTEND.yml` (in `exafyltd/vitana-v1`) — still on static `AWS_STAGING_ACCESS_KEY_ID`/`SECRET` repo secrets, not yet OIDC (follow-up) |
 | oasis-operator | VTID-03410 | ECS service `vitana-oasis-operator-awsdr` (256 CPU/512MB, stateless, no DB dependency), target group `vitana-tg-oasis-op-awsdr` | `https://dr-oasis-operator.vitanaland.com` (ALB host rule, priority 7) | `AWS-PROD-DEPLOY-OASIS-OPERATOR.yml` — first CI/CD path this service has ever had; its source didn't exist in git and was restored from a stale `.backup` snapshot |
 | oasis-projector | VTID-03411 | ECS service `vitana-oasis-projector`, fixed `desiredCount` — **no autoscaling**, the Ledger Writer has no cross-instance locking | No public ALB/DNS — internal DB reconciliation loop; verify via ECS `healthStatus` (`/ready`) | `AWS-PROD-DEPLOY-OASIS-PROJECTOR.yml` |
 | worker-runner | VTID-03411 | ECS service `vitana-worker-runner`, fixed `desiredCount` | No public ALB/DNS — polls outward to gateway; verify via ECS `healthStatus` (`/alive`) | `AWS-PROD-DEPLOY-WORKER-RUNNER.yml` |
@@ -1198,6 +1207,8 @@ Use these PATs with the GitHub REST API (`api.github.com`) for all PR and deploy
 
 | Date | Change | VTID |
 |------|--------|------|
+| 2026-07-29 | **Governance correction, not new work:** `docs/AWS-CUTOVER-RUNBOOK.md` §1's DNS row still said "Unmoved" and §3's "EXECUTION RECORD" citation pointed at content that was never actually written, and this file's §1b/Never-rule-1 prose still said "not yet a sole-production cutover" with no VTID-03419 changelog row at all — despite VTID-03419 (below) having genuinely executed 2 days earlier. The infrastructure change was real and independently verifiable (DNS resolution, live production traffic, working PUBLISH deploys against it); the paper trail describing it was not committed. Root cause: the doc-update step in VTID-03419's own spec (§5) was apparently never pushed before that session's context was summarized. Found via a second Claude session's independent skepticism of a status claim — see its investigation for the discovery. Fixed: runbook §1/§3 now match reality (with real EXECUTION RECORD blocks — ALB rule priorities, exact DNS record changes, the Cloudflare Worker origin override that actually gated the apex leg, verification method, rollback path), this file's §1b/Never-rule-1 updated, VTID-03419 changelog row added below. | (governance fix, no VTID) |
+| 2026-07-27 | **GCP → AWS production cutover for gateway + frontend (VTID-03419).** Repointed `gateway.vitanaland.com` (A→CNAME, `34.111.235.0` → `vitana-alb-prod`) and the `vitanaland.com` apex/`www` (CNAME → the same ALB) to AWS — these two hostnames are now **sole production on AWS**, not DR. Deliberately narrow: excluded Aurora-dependent services (DMS showed ~154k silently-dropped row applies — Aurora is not a valid failover target), `oasis-projector` (dual-writer risk against a DMS-managed table), `orb-agent`/ORB voice (hard Google-Cloud-service dependency, unrelated to hosting), and any GCP decommission — GCP stays fully running as the standing rollback target. Pre-flight added ALB host-header rules at priority 3/4 (below the pre-existing path rules at priority 10, which would otherwise route to AWS staging regardless of `Host`). Caught and fixed a live blocker mid-cutover: a Cloudflare Worker (`vitanaland-proxy`, dashboard-managed) had route rules on `vitanaland.com/*` that override DNS entirely with a hard-coded GCP origin — DNS alone did not move apex traffic; the Worker's origin had to be patched too. Verified via authenticated read+write, a forced-HTTP/1.1 WebSocket handshake, and external-vantage fingerprinting (both clouds report `env:"production"`, so status fields alone don't distinguish them) — 60-minute post-cutover alarm watch clean. Full execution record: `docs/AWS-CUTOVER-RUNBOOK.md` §3. | VTID-03419 |
 | 2026-07-28 | AWS staging→prod publish path (PUBLISH parity): `AWS-PROD-DEPLOY-GATEWAY.yml` gained `deploy_mode=promote-staging` (new default — ships the EXACT ECR image `vitana-gateway` staging runs, verified over HTTP build-info, pinned via new `expected_commit` input; `rebuild-main` keeps the old from-source path) and its smoke URL default is now canonical `gateway.vitanaland.com`. Gateway: new `PUBLISH_TARGET_CLOUD=aws\|gcp` switch (default `gcp`, zero change until set) makes `POST /operator/publish` promote AWS staging→AWS prod (frontend leg → `AWS-PROD-DEPLOY-FRONTEND.yml`; optional `GCP_DUAL_PUBLISH_ENABLED` refreshes the GCP rollback target; canary → 400 on AWS) and backs `/operator/revisions` for the gateway rows with build-info from the AWS stacks — fixes the Command Hub PUBLISH popover's "Could not load: staging 500" on the ECS-served gateway (no GCP ADC there). New `services/gateway/src/services/aws-gateway-admin.ts` (HTTP-only introspection; `vitana-ecs-task-role` has no `ecs:Describe*`). | VTID-03420 |
 | 2026-07-24 | Added automatic once-a-day "Did You Know" News Feed card: `did_you_know_state` table (per-tenant rotation index) + `POST /api/v1/scheduled-notifications/daily-feature-tip` (advances through a curated `services/gateway/src/data/feature-tips.ts` list, publishes a tenant-wide `did-you-know-feature` announcement, fans out in-app + push in each user's locale) + Cloud Scheduler entry (`scripts/setup-cloud-scheduler.sh`, daily 17:00 UTC). Companion vitana-v1 fix: feature-announcement cards no longer pinned permanently at the News Feed top — now merge chronologically into the post stream so they get pushed down by new posts, per live user report. No VTID existed for this yet; tracked under this BOOTSTRAP tag pending one. Requires someone with `gcloud` access to run the updated `setup-cloud-scheduler.sh` once to actually create the Cloud Scheduler job — code shipping does not create it automatically. | BOOTSTRAP-DAILY-FEATURE-TIP |
 | 2026-07-24 | Built the AWS-DR RunTask dispatch path for the autopilot executor — new `dispatchExecutorJobAws()` in `services/gateway/src/services/aws-ecs-admin.ts` (mirrors `dispatchExecutorJob()`'s return shape via `ecs:RunTask` against task def family `vitana-autopilot-executor`), branched in `dev-autopilot-execute.ts` on a new `DEV_AUTOPILOT_JOB_CLOUD=aws\|gcp` env var (default `gcp`). New `AWS-PROD-DEPLOY-AUTOPILOT-EXECUTOR.yml` (build+push+register only — no ECS service to roll, next RunTask dispatch picks up `:LATEST`). `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` deliberately omitted from the live task definition (deferred pending AWS/Anthropic sponsorship decision). Updated §1b table + Never-rule exception. | VTID-03415 |

--- a/docs/AWS-CUTOVER-RUNBOOK.md
+++ b/docs/AWS-CUTOVER-RUNBOOK.md
@@ -2,7 +2,9 @@
 
 **VTID:** VTID-03412
 **Status:** Living document — governance artifact, not an execution authorization.
-**Last updated:** 2026-07-24
+**Last updated:** 2026-07-29 (§1 DNS row + §3 EXECUTION RECORD corrected to
+reflect VTID-03419's completed gateway+frontend cutover — the file had
+drifted out of sync with reality after that execution)
 
 ---
 
@@ -39,7 +41,7 @@ CLI + Cloudflare DNS audit performed under this VTID.
 
 | Area | State |
 |---|---|
-| DNS | **Unmoved.** `gateway.vitanaland.com` and the `vitanaland.com` apex both resolve live to GCP today. Only `dr-*` hostnames (`dr-gateway`, `dr-app`, `dr-oasis-operator`) point at AWS. |
+| DNS | **Moved for 2 hostnames.** As of **VTID-03419** (executed 2026-07-27), `gateway.vitanaland.com` and the `vitanaland.com` apex (+`www`) both resolve live to AWS (`vitana-alb-prod`) — see §3's EXECUTION RECORD blocks for the exact sequence. This was a deliberately narrow cutover of these two hostnames only; it did **not** touch Aurora-dependent services, `oasis-projector`, `orb-agent`, `autopilot-cdc`, or decommission GCP (GCP remains fully running as the standing rollback target — see VTID-03419's own out-of-scope list, mirrored in §3). Everything else in this table (oasis-operator burn-in, mystery services, DB sync divergence, full GCP decommission) is still open and still gated on this runbook's §2 checklist + a separate, larger execution VTID. |
 | gateway | AWS-DR built (VTID-03398), autoscaled, alarmed, dual-publish wired. Healthy. |
 | community-app | AWS-DR built (VTID-03409). **Bakes the GCP `gateway.vitanaland.com` URL into its static Vite bundle at build time, by design** — it was built as a same-backend hot-standby, not a fully independent stack. Will break if GCP disappears without either repointing `gateway.vitanaland.com` to AWS or rebuilding against `dr-gateway.vitanaland.com`. See open decision §4.1. |
 | oasis-operator | AWS-DR built (VTID-03410) from a 9-month-old dead backup (`main.py.backup-20251101-111126`) with zero prior AWS production traffic history. No burn-in yet. |
@@ -52,11 +54,14 @@ CLI + Cloudflare DNS audit performed under this VTID.
 | ALB naming | `vitana-tg-gateway-prod` / `vitana-tg-community-prod` **actually serve AWS staging traffic**, not prod — confirmed live via `/api/v1/admin/health` returning `env:"staging"` through those target groups. Both are `ManagedBy=terraform`-tagged (Terraform state not found in this repo) — not a stray hand-created leftover, part of some external IaC. Tagged 2026-07-24 with `ActualEnvironment=staging` to reduce confusion; not renamed (immutable name, rename requires recreation + ALB rule reattachment, risks a traffic blip). A real cutover must not confuse these with the `-awsdr` target groups. |
 | Legacy/mystery services | ~22 of the 29 (now 31) ECS services in `Vitana-ECS-Cluster` from the 2026-07-09 bulk-provisioning event remain unexplained — flagged, not investigated. Out of scope for cutover unless one turns out to be load-bearing. |
 | Cutover/rollback docs | **Did not exist before this VTID.** No DNS-repoint runbook, no rollback/TTL plan, no GCP decommission checklist. |
-| Governance | **No execution VTID exists yet for a full cutover.** Every AWS VTID this week is scoped to one service's DR build. |
+| Governance | **No execution VTID exists yet for the *full* cutover** (all services, GCP decommission). VTID-03419 executed a narrower, explicitly-scoped DNS repoint for gateway + frontend only, gated by its own approved spec — see §3 EXECUTION RECORD. Every other AWS VTID remains scoped to one service's DR build, not traffic movement. |
 
-**Bottom line:** AWS is a real, growing, increasingly-verified hot standby.
-It is not yet a safe sole-production target. The gaps below are concrete
-and closeable, not hypothetical.
+**Bottom line:** Gateway + frontend are live on AWS today (VTID-03419) —
+that part is no longer hypothetical, it's the current production
+architecture for those two hostnames. Everything else — Aurora as a
+valid failover target, oasis-projector/orb-agent/autopilot parity, the
+mystery services, and GCP decommission — is still open, still concrete,
+and still closeable, not hypothetical either.
 
 ---
 
@@ -164,6 +169,32 @@ simultaneously on a first cutover.
    parallel for at least one full traffic cycle (recommend 1h minimum)
    before considering the gateway leg done.
 
+> **EXECUTION RECORD (VTID-03419, 2026-07-27):**
+> - Pre-flight: added ALB host-header rules on `vitana-alb-prod` at
+>   priority 3 (`gateway.vitanaland.com` → `vitana-tg-gateway-awsdr`) —
+>   below the existing path-based `/api/*`/`/ws/*` rules at priority 10,
+>   which otherwise match first regardless of `Host` and would have
+>   silently routed to AWS **staging**.
+> - Pre-change value captured: `gateway.vitanaland.com` was an **A**
+>   record → `34.111.235.0` (GCP anycast), DNS-only, Cloudflare zone
+>   `859c786db63e634e0ee36065e8a06e20`.
+> - Changed to a **CNAME** (record-type change — an ALB has no static
+>   IP) → `vitana-alb-prod-1579322953.eu-central-1.elb.amazonaws.com`,
+>   DNS-only (not proxied). Automatic TTL, so this was live within
+>   minutes.
+> - Verified functionally, not by status field: `/api/v1/admin/health`
+>   returning `env:"production"` was not sufficient on its own (both
+>   clouds report `production`) — confirmed via external vantage
+>   (`cloud_run_service:null` + boot timestamp matching the ECS task,
+>   i.e. absence of Cloud-Run-specific fields rather than presence of
+>   AWS-specific ones), an authenticated read **and** write, and a
+>   forced-HTTP/1.1 WebSocket handshake (HTTP/2 strips the `Upgrade`
+>   header, which degrades to a false-failing plain GET).
+> - Gateway leg confirmed live ~13:38Z. 60-minute post-cutover alarm
+>   watch: clean, zero new `vitana-*` alarms.
+> - Rollback (never invoked): revert to the A record above — must be
+>   recreated as an **A** record, not a CNAME edit of the same name.
+
 ### 3.2 `vitanaland.com` apex (frontend)
 
 1. **Must happen after §3.1**, and only once the frontend's
@@ -178,6 +209,34 @@ simultaneously on a first cutover.
    pattern from `AWS-PROD-DEPLOY-FRONTEND.yml`).
 5. Manually load the app, sign in, and exercise one read + one write
    path before declaring this leg done.
+
+> **EXECUTION RECORD (VTID-03419, 2026-07-27):**
+> - Version-skew guard caught a real problem before the flip: the AWS
+>   frontend build was 4 days stale (`index-C0lN9CoO` vs GCP's live
+>   `index-C7igpqcB`). Rebuilt from `main@fc9bc0f9` first
+>   (`index-CqFaw389`) rather than flip apex traffic to a stale build.
+> - Pre-change value captured: apex + `www` were CNAME →
+>   `community-app-q74ibpv6ia-uc.a.run.app`, **proxied** (orange-cloud)
+>   through Cloudflare.
+> - Changed to CNAME → the same `vitana-alb-prod` ALB, kept **proxied**.
+> - **Found mid-cutover, not anticipated by this runbook:** a
+>   Cloudflare Worker (`vitanaland-proxy`, dashboard-managed, not in any
+>   repo) has route rules on `vitanaland.com/*` + `www.vitanaland.com/*`
+>   that override DNS entirely — Worker routes match before the DNS
+>   record is ever consulted. Its origin was hard-coded to the GCP
+>   Cloud Run URL, so the DNS change alone had **no effect**; apex
+>   traffic stayed on GCP until the Worker's own `ORIGIN` constant was
+>   patched to `https://dr-app.vitanaland.com`. This is the actual
+>   reason the apex leg does not complete atomically with the DNS
+>   change — record that anywhere else in the org that assumes a
+>   Cloudflare DNS edit alone controls `vitanaland.com/*` traffic.
+> - Verified: authenticated read + write, both viewports, plus the same
+>   external-vantage fingerprint check used for the gateway leg.
+> - Rollback (never invoked): apex leg — CNAME back to
+>   `community-app-q74ibpv6ia-uc.a.run.app`; **or**, since the Worker is
+>   what actually controls routing, reverting the Worker's `ORIGIN`
+>   constant back to the Cloud Run URL is the effective/faster rollback
+>   regardless of what DNS says.
 
 ---
 


### PR DESCRIPTION
## What this fixes

Docs-only. No infrastructure, code, or behavior change.

VTID-03419 (the gateway.vitanaland.com + vitanaland.com apex cutover to AWS) executed for real on 2026-07-27 — independently re-verified today (live DNS resolution to the AWS ALB, real production traffic, and this session's own working PUBLISH deploys against it). But the governance paper trail for it never landed on `main`:

- `docs/AWS-CUTOVER-RUNBOOK.md` §1's DNS row still said **"Unmoved"** — both hostnames resolve live to GCP. False as of the cutover.
- §3's "see EXECUTION RECORD blocks" citation pointed at content that was **never actually written** into the committed file.
- `CLAUDE.md`'s Never-rule-1 exception and §1b prose both still said "not yet a sole-production cutover," with **zero VTID-03419 changelog entry** — only a passing mention buried in an unrelated VTID-03420 line.

Root cause: the doc-update step was in VTID-03419's own approved spec (§5, "Files to Modify") but apparently never got pushed before that session's context was summarized/compacted.

This was caught by a **second Claude session's skepticism** of a status claim it was handed rather than trusting it outright — verified directly against the live repo (`git show origin/main:...`) before writing anything here.

## What changed

- `docs/AWS-CUTOVER-RUNBOOK.md`:
  - §1 DNS row, governance row, and bottom-line corrected to reflect the completed (narrow, 2-hostname) cutover.
  - Real EXECUTION RECORD blocks added under §3.1/§3.2: pre-flight ALB rule priorities, exact DNS record changes with pre-change values, the Cloudflare Worker origin override that actually gated the apex leg (DNS alone didn't move that traffic — worth flagging clearly since it's a real trap), verification method, rollback path.
- `CLAUDE.md`:
  - Never-rule-1 exception + §1b prose updated: gateway and community-app are now sole production on AWS; every other service remains DR-only, unchanged.
  - §1b table's community-app row updated (was still describing it as baking in "the canonical GCP prod gateway URL" — that hostname is AWS now too).
  - VTID-03419 changelog row added.
  - A same-day changelog row records this correction itself, so anyone reading the history later understands what was missing and why.

## Verification

- `git show origin/main:CLAUDE.md` / `docs/AWS-CUTOVER-RUNBOOK.md` confirmed the gap before writing the fix (not from memory).
- `gateway.vitanaland.com` DNS resolution to the AWS ALB re-confirmed live.
- All factual claims in the new EXECUTION RECORD blocks come from this session's own first-hand execution history (Cloudflare zone/record IDs, ALB rule priorities, timestamps) — not reconstructed after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQE36mRo6MTcsLTmzUTxtF)_