### PR TITLE
Fix: voice-feedback approve/reject auth bypass — require exafy_admin (BOOTSTRAP-TEST-COVERAGE)

### DIFF
--- a/services/gateway/src/routes/voice-feedback.ts
+++ b/services/gateway/src/routes/voice-feedback.ts
@@ -5,8 +5,8 @@
  * - POST /api/v1/voice-feedback/submit          - Submit a feedback report
  * - GET  /api/v1/voice-feedback/reports          - List user's own reports
  * - GET  /api/v1/voice-feedback/reports/:id      - Single report detail
- * - POST /api/v1/voice-feedback/reports/:id/approve  - Admin: approve → create Command Hub task
- * - POST /api/v1/voice-feedback/reports/:id/reject   - Admin: reject with reason
+ * - POST /api/v1/voice-feedback/reports/:id/approve  - Admin (requireAdminAuth): approve → create Command Hub task
+ * - POST /api/v1/voice-feedback/reports/:id/reject   - Admin (requireAdminAuth): reject with reason
  * - GET  /api/v1/voice-feedback/health           - Health check
  */
 
@@ -14,6 +14,7 @@ import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { createClient } from '@supabase/supabase-js';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import { requireAdminAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
 const router = Router();
 
@@ -226,13 +227,8 @@ router.get('/reports/:id', async (req: Request, res: Response) => {
 /**
  * POST /reports/:id/approve — Admin: approve report and create Command Hub task
  */
-router.post('/reports/:id/approve', async (req: Request, res: Response) => {
+router.post('/reports/:id/approve', requireAdminAuth, async (req: AuthenticatedRequest, res: Response) => {
   console.log('[voice-feedback] POST /reports/:id/approve');
-
-  const token = getBearerToken(req);
-  if (!token) {
-    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-  }
 
   const serviceClient = getServiceClient();
   if (!serviceClient) {
@@ -319,13 +315,8 @@ router.post('/reports/:id/approve', async (req: Request, res: Response) => {
 /**
  * POST /reports/:id/reject — Admin: reject report with reason
  */
-router.post('/reports/:id/reject', async (req: Request, res: Response) => {
+router.post('/reports/:id/reject', requireAdminAuth, async (req: AuthenticatedRequest, res: Response) => {
   console.log('[voice-feedback] POST /reports/:id/reject');
-
-  const token = getBearerToken(req);
-  if (!token) {
-    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-  }
 
   const parsed = RejectReportSchema.safeParse(req.body);
   if (!parsed.success) {

--- a/services/gateway/test/routes/voice-feedback.test.ts
+++ b/services/gateway/test/routes/voice-feedback.test.ts
@@ -4,22 +4,52 @@
  *   POST /submit                       — any bearer token + valid Supabase user
  *   GET  /reports                      — any bearer token + valid Supabase user
  *   GET  /reports/:id                  — any bearer token + valid Supabase user
- *   POST /reports/:id/approve          — "Admin" per comment, but the code only
- *   POST /reports/:id/reject             checks for *presence* of a bearer token
- *                                         (getBearerToken) — it never verifies the
- *                                         token or checks exafy_admin. Documented
- *                                         as a finding in the coverage report;
- *                                         tests assert the ACTUAL behavior.
+ *   POST /reports/:id/approve          — gated by requireAdminAuth (real JWT
+ *   POST /reports/:id/reject             verification + exafy_admin claim
+ *                                         check). Previously these two routes
+ *                                         only checked for *presence* of a
+ *                                         bearer token — a real authz bypass,
+ *                                         fixed to use the codebase's
+ *                                         canonical admin middleware.
  *   GET  /health                       — no auth
  *
- * No requireAuth/requireAuthWithTenant middleware is used anywhere in this
- * file — auth is entirely bespoke (getBearerToken + per-request Supabase
- * clients). There is no tenant scoping in the route code itself (relies on
- * Supabase RLS via the user's own JWT for /submit, /reports, /reports/:id;
- * approve/reject use the service-role client with no tenant filter at all).
+ * /submit, /reports, /reports/:id remain on the bespoke getBearerToken +
+ * per-request Supabase client pattern (RLS-scoped via the user's own JWT) —
+ * a separate, lower-severity observation, not part of this fix.
  */
 import request from 'supertest';
 import express from 'express';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAdminAuth: jest.fn((req: any, res: any, next: any) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({
+        ok: false,
+        error: 'UNAUTHENTICATED',
+        message: 'Missing or invalid Authorization header. Expected: Bearer <token>',
+      });
+    }
+    if (authHeader.slice(7) === 'non-admin-tok') {
+      return res.status(403).json({
+        ok: false,
+        error: 'FORBIDDEN',
+        message: 'This endpoint requires exafy_admin privileges',
+      });
+    }
+    req.identity = {
+      user_id: 'admin-1',
+      email: 'admin@test.com',
+      tenant_id: null,
+      exafy_admin: true,
+      role: 'admin',
+      aud: null,
+      exp: null,
+      iat: null,
+    };
+    next();
+  }),
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -302,6 +332,14 @@ describe('POST /api/v1/voice-feedback/reports/:id/approve', () => {
     expect(res.status).toBe(401);
   });
 
+  it('returns 403 when the caller is not exafy_admin', async () => {
+    const res = await request(app)
+      .post('/api/v1/voice-feedback/reports/r1/approve')
+      .set('Authorization', 'Bearer non-admin-tok');
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('FORBIDDEN');
+  });
+
   it('returns 503 when the service-role client is unavailable', async () => {
     delete process.env.SUPABASE_SERVICE_ROLE;
     const res = await request(app)
@@ -414,6 +452,15 @@ describe('POST /api/v1/voice-feedback/reports/:id/reject', () => {
   it('returns 401 without a bearer token', async () => {
     const res = await request(app).post('/api/v1/voice-feedback/reports/r1/reject').send({ reason: 'dup' });
     expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when the caller is not exafy_admin', async () => {
+    const res = await request(app)
+      .post('/api/v1/voice-feedback/reports/r1/reject')
+      .set('Authorization', 'Bearer non-admin-tok')
+      .send({ reason: 'dup' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('FORBIDDEN');
   });
 
   it('returns 400 when reason is missing', async () => {


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-TEST-COVERAGE` (fix for a critical finding surfaced in Phase 7, PR #2981)

**Priority:** P0 — real, exploitable authorization bypass in a shipped route

---

## 📋 Summary

`POST /reports/:id/approve` and `POST /reports/:id/reject` in `voice-feedback.ts` are documented as `"Admin:"` endpoints but only checked that *some* bearer-token string was present (`getBearerToken`) — no JWT verification, no admin-claim check at all. Any caller could approve/reject any user's report and mint a VTID via the unscoped service-role client.

This was flagged during the Phase 7 test-coverage sweep (#2981) and left unfixed pending a decision on the intended auth model. Fix: apply the codebase's existing convention — every other admin `voice-*` route already uses `requireAdminAuth`/`requireExafyAdmin` from `middleware/auth-supabase-jwt`; `voice-feedback.ts` was the sole outlier still on the bespoke bearer-presence check.

---

## ✅ Changes

- [x] `routes/voice-feedback.ts` — both admin routes now run `requireAdminAuth` (verifies the JWT via `jose`, then checks `req.identity.exafy_admin`) before the handler executes. Removed the now-redundant bespoke `getBearerToken` presence check from both.
- [x] `test/routes/voice-feedback.test.ts` — mocks the real `requireAdminAuth` middleware (matching the pattern used in `admin-notifications.test.ts`), adds explicit 403-when-not-admin test cases for both routes, keeps the existing 401-when-missing-token cases.

**Deliberately out of scope:** `/submit`, `GET /reports`, `GET /reports/:id` keep their existing bespoke `getBearerToken` + per-request Supabase client pattern. That pattern is weaker than the codebase convention too, but it's still RLS-scoped via the user's own JWT (a forged/garbage token fails at the Supabase RLS layer) — a separate, lower-severity observation, not the P0 bypass this PR fixes.

---

## 🧪 Testing

- [x] `npx jest test/routes/voice-feedback.test.ts` — 33/33 passed (2 new)
- [x] Full gateway suite: 593 suites / 11,703 tests, all green
- [x] `tsc --noEmit` — no new errors (2 pre-existing, unrelated `express-serve-static-core` augmentation errors confirmed present on `main` before this change too)

---

## 📝 Phase 2B Naming Compliance

No new files added — both changed files already exist with correct kebab-case names.

---

## 🚨 Breaking Changes

Callers of `POST /reports/:id/approve` / `/reject` that are not `exafy_admin` will now correctly get `403 FORBIDDEN` instead of succeeding. This is the intended fix — any such caller was exploiting the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzaoWroFJgiACJ6N5b2Ceb


---
_Generated by [Claude Code](https://claude.ai/code/session_01JzaoWroFJgiACJ6N5b2Ceb)_