### PR TITLE
fix: wire wakeCadenceSkip into decideOpening() to stop repeat-greeting on ORB re-open (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -8440,6 +8440,23 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
   }
 
   const _wb = (session as any).wakeBriefDecision || null;
+  // BOOTSTRAP-NOVA-GREETING-CADENCE: `decideOpening`'s `wakeCadenceSkip` input
+  // was never populated at this call site — the rich B1 greeting-policy engine
+  // (greeting-policy.ts, `decideGreetingPolicyWithEvidence`) computes a skip
+  // verdict elsewhere but nothing forwarded it here, so `wakeCadenceSkip` was
+  // always `undefined` and rung 8 (override_v2) fired the wake-brief's
+  // selected line unconditionally on every fresh `session_id` — including a
+  // brand-new session opened seconds after the user's last one (observed live:
+  // every ORB re-open replayed a full proactive opener, "starts from scratch
+  // every time"). `_reconnectCount` only tracks transport-level reconnects
+  // WITHIN one session object, so a genuinely new session (the user closing
+  // and reopening ORB) always read isReconnect=false too. Close the gap with
+  // the same 'reconnect' bucket (<120s since last session, per
+  // temporal-bucket.ts) `decideGreetingPolicyWithEvidence` already treats as a
+  // forced skip — this was pre-existing on Vertex too, but Nova's slower
+  // per-connection setup and less stable mobile transport made re-opens (and
+  // thus the bug) far more frequent, which is why it surfaced now.
+  const _cadenceBucketPre = describeTimeSince(session.lastSessionInfo).bucket;
   const _openDecision = decideOpening({
     isAnonymous: !!session.isAnonymous,
     hasResumptionHandle: !!session.resumptionHandle,
@@ -8447,6 +8464,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
     wakeSelectedLine: _wb?.selectedContinuation?.userFacingLine ?? null,
     wakeSelectedKind: _wb?.selectedContinuation?.kind ?? null,
     lastOpenerLine: (session as any)._lastOpenerLine ?? null,
+    wakeCadenceSkip: _cadenceBucketPre === 'reconnect',
   });
   console.log(formatOpeningDecisionLog(session.sessionId, _openDecision));
   (session as any)._openingDecision = _openDecision;

--- a/services/gateway/test/orb/live/characterization/vertex-autogreet-on-connect.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/vertex-autogreet-on-connect.characterization.test.ts
@@ -84,4 +84,23 @@ describe('ORB-CONVERSATION-LATENCY: server-driven auto-greet on upstream connect
     expect(src).not.toMatch(/on\(['"]request_welcome['"]/);
     expect(src).not.toMatch(/case\s+['"]request_welcome['"]/);
   });
+
+  it('BOOTSTRAP-NOVA-GREETING-CADENCE: the real decideOpening() call wires wakeCadenceSkip from a fresh-open reconnect-bucket check', () => {
+    // Regression lock for a live incident: `decideOpening`'s `wakeCadenceSkip`
+    // input (proven correct in isolation by opening-contract.test.ts) was never
+    // populated at THIS call site, so a brand-new session_id opened seconds
+    // after the user's last one always fell through to the wake-brief's
+    // selected line (override_v2) instead of staying quiet. `_reconnectCount`
+    // only covers transport-level reconnects within one session object, so it
+    // can't catch "the user closed and reopened ORB" — the bucket check can.
+    const idxDecide = src.indexOf('const _openDecision = decideOpening({');
+    expect(idxDecide).toBeGreaterThan(-1);
+    const callBody = src.slice(idxDecide, idxDecide + 500);
+    expect(callBody).toMatch(/wakeCadenceSkip:\s*_cadenceBucketPre\s*===\s*'reconnect'/);
+    // The bucket must be computed BEFORE the decideOpening call, not after —
+    // otherwise the variable wouldn't exist to reference.
+    const idxBucket = src.indexOf('const _cadenceBucketPre = describeTimeSince(');
+    expect(idxBucket).toBeGreaterThan(-1);
+    expect(idxBucket).toBeLessThan(idxDecide);
+  });
 });


### PR DESCRIPTION
## Summary
- Live incident: real Maxina community users on the Nova canary reported every ORB re-open replaying a full proactive greeting ("starts from scratch every time, like morning greeting"), even seconds after the prior session.
- Root cause (confirmed via live OASIS `orb.live.diag` events during the incident window — 3 distinct `session_id`s ~30-50s apart, all firing `wake_opener=override_v2`): `decideOpening()`'s `wakeCadenceSkip` input — already correct and unit-tested in isolation (`opening-contract.test.ts`) — was never actually populated at the real call site in `sendGreetingPromptToLiveAPI` (`orb-live.ts`). A brand-new `session_id` always read `isReconnect=false` there (`_reconnectCount` only tracks transport-level reconnects *within* one session object, not the user closing and reopening ORB), so whenever the wake-brief ranker had any selected line available, `override_v2` fired unconditionally — regardless of how recently the user was actually talking.
- This gap pre-dates Nova and applies to Vertex too, but Nova's slower per-connection setup (no prompt/context caching) and less stable mobile transport make ORB re-opens — and therefore the bug — far more frequent, which is why it surfaced now.
- Fix: compute the temporal bucket eagerly (`describeTimeSince(session.lastSessionInfo)`) and pass `wakeCadenceSkip: bucket === 'reconnect'` (< 120s since the user's last session, per `temporal-bucket.ts`) into the real `decideOpening()` call.

## Test plan
- [x] `npx tsc --noEmit` — clean (no new errors)
- [x] `npx jest test/orb` — 140 suites / 2884 tests pass
- [x] New source-level regression test (`vertex-autogreet-on-connect.characterization.test.ts`) locks the `wakeCadenceSkip` wiring in place so a future refactor can't silently drop it again
- [x] `npm run build` — clean
- [ ] Deploy to AWS staging and verify with a live canary account: open/close/reopen ORB within ~30-60s, confirm `wake_opener` is no longer `override_v2` on the rapid reopen
- [ ] Restore Maxina tenant to the AWS prod Nova canary only after staging verification

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_