### PR TITLE
perf: real model-execution keep-warm for Nova Sonic — cut cold-tail latency (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/upstream/nova-sonic-config.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-config.ts
@@ -29,6 +29,15 @@ const DEFAULT_ROTATION_AFTER_MS = 435_000;
 // Under NodeHttp2Handler's 480s idle sessionTimeout so the pooled HTTP/2
 // session never expires between pings.
 const DEFAULT_KEEPWARM_MS = 240_000;
+// BOOTSTRAP-NOVA-SONIC-VOICE (latency): the transport-only keep-warm ping
+// above rides a marker model ID Bedrock rejects before any inference — it
+// keeps DNS/TCP/TLS/HTTP2 hot but never touches the model-execution path.
+// Real production data (2026-07-29) showed audio_out_first_chunk ranging
+// 2.5s-9.9s for Nova vs. Vertex's tighter 3.3-5.6s band — the same
+// "cold vs. warm" split observed earlier in isolated latency testing, this
+// time on live customer traffic. A real (tiny) inference round-trip on a
+// shorter cadence keeps the model executor itself warm, not just the pipe.
+const DEFAULT_MODEL_WARM_MS = 90_000;
 // Per-turn output budget. The Nova sample's 1024 starves real ORB turns —
 // the greeting turn alone (16KB wake prompt + tool rounds) exhausted it and
 // ended with no speech (staging session live-dedf85d5).
@@ -42,6 +51,7 @@ export type NovaSonicConfigIssue =
   | 'nova_connect_timeout_invalid'
   | 'nova_rotation_after_invalid'
   | 'nova_keepwarm_invalid'
+  | 'nova_model_warm_invalid'
   | 'nova_max_tokens_invalid';
 
 export interface NovaSonicConfig {
@@ -58,6 +68,12 @@ export interface NovaSonicConfig {
    * NodeHttp2Handler drops idle sessions after 8 min). 0 disables.
    */
   keepWarmMs: number;
+  /**
+   * Interval for the real (tiny) model-execution warm-up: a genuine minimal
+   * inference round-trip (not the zero-cost 4xx marker ping) that keeps
+   * Bedrock's model executor itself hot, not just the transport. 0 disables.
+   */
+  modelWarmMs: number;
   /** sessionStart inferenceConfiguration.maxTokens (per-turn output budget). */
   maxTokens: number;
   /**
@@ -149,6 +165,12 @@ export function getNovaSonicConfig(env: NodeJS.ProcessEnv): NovaSonicConfig {
   );
   if (keepWarmMs === null) issues.push('nova_keepwarm_invalid');
 
+  const modelWarmMs = parseNonNegativeInt(
+    env.NOVA_SONIC_MODEL_WARM_MS,
+    DEFAULT_MODEL_WARM_MS,
+  );
+  if (modelWarmMs === null) issues.push('nova_model_warm_invalid');
+
   const maxTokens = parsePositiveInt(env.NOVA_SONIC_MAX_TOKENS, DEFAULT_MAX_TOKENS);
   if (maxTokens === null) issues.push('nova_max_tokens_invalid');
 
@@ -161,6 +183,7 @@ export function getNovaSonicConfig(env: NodeJS.ProcessEnv): NovaSonicConfig {
     connectTimeoutMs: connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
     rotationAfterMs: rotationAfterMs ?? DEFAULT_ROTATION_AFTER_MS,
     keepWarmMs: keepWarmMs ?? DEFAULT_KEEPWARM_MS,
+    modelWarmMs: modelWarmMs ?? DEFAULT_MODEL_WARM_MS,
     maxTokens: maxTokens ?? DEFAULT_MAX_TOKENS,
     issues,
     ready: enabled && issues.length === 0,

--- a/services/gateway/src/orb/live/upstream/nova-sonic-keepwarm.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-keepwarm.ts
@@ -16,7 +16,7 @@
  */
 
 import type { NovaSonicConfig } from './nova-sonic-config';
-import { warmNovaSonicConnection } from './nova-sonic-live-client';
+import { warmNovaSonicConnection, warmNovaSonicModelExecution } from './nova-sonic-live-client';
 
 export interface NovaKeepWarmDeps {
   /** Injectable warm fn for tests; defaults to warmNovaSonicConnection. */
@@ -29,6 +29,17 @@ let keepWarmTimer: NodeJS.Timeout | null = null;
 
 export function isNovaKeepWarmRunning(): boolean {
   return keepWarmTimer !== null;
+}
+
+// BOOTSTRAP-NOVA-SONIC-VOICE (latency): a SEPARATE timer for the real
+// model-execution warm probe (warmNovaSonicModelExecution) — deliberately
+// not folded into the transport-only loop above so the two stay independent
+// (different interval, different failure mode, either can be disabled via
+// its own env var without touching the other).
+let modelWarmTimer: NodeJS.Timeout | null = null;
+
+export function isNovaModelWarmRunning(): boolean {
+  return modelWarmTimer !== null;
 }
 
 /**
@@ -73,5 +84,48 @@ export function stopNovaSonicKeepWarm(): void {
   if (keepWarmTimer) {
     clearTimeout(keepWarmTimer);
     keepWarmTimer = null;
+  }
+}
+
+/**
+ * Start the model-execution warm-up loop (real tiny inference round-trips,
+ * not the transport-only 4xx marker). Idempotent; disabled when
+ * `config.modelWarmMs <= 0`. Mirrors `startNovaSonicKeepWarm`'s shape
+ * exactly — same re-arm-after-await discipline, same unref'd timer.
+ */
+export function startNovaSonicModelWarm(config: NovaSonicConfig, deps: NovaKeepWarmDeps = {}): boolean {
+  if (modelWarmTimer) return true;
+  if (config.modelWarmMs <= 0) return false;
+  const warm = deps.warm ?? warmNovaSonicModelExecution;
+  const log = deps.log ?? ((line: string) => console.log(line));
+
+  const arm = () => {
+    modelWarmTimer = setTimeout(async () => {
+      try {
+        const ms = await warm(config);
+        if (ms === null) {
+          log('[BOOTSTRAP-NOVA-SONIC-VOICE] model-execution warm-up failed (will retry next interval)');
+        } else {
+          log(`[BOOTSTRAP-NOVA-SONIC-VOICE] model-execution warm-up ok ms=${ms}`);
+        }
+      } catch {
+        /* warm() never throws by contract; belt-and-braces only */
+      }
+      if (modelWarmTimer) {
+        modelWarmTimer = null;
+        arm();
+      }
+    }, config.modelWarmMs);
+    modelWarmTimer.unref?.();
+  };
+
+  arm();
+  return true;
+}
+
+export function stopNovaSonicModelWarm(): void {
+  if (modelWarmTimer) {
+    clearTimeout(modelWarmTimer);
+    modelWarmTimer = null;
   }
 }

--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -270,6 +270,81 @@ export async function warmNovaSonicConnection(config: NovaSonicConfig): Promise<
   }
 }
 
+/** Minimal system instruction for the model-execution warm probe — no tools,
+ *  no persona, no user context. Small enough to add negligible processing
+ *  time of its own, while still exercising the real inference path. */
+const MODEL_WARM_SYSTEM_INSTRUCTION =
+  'You are a connection health probe. When you receive any input, respond ' +
+  'with exactly one short word and then stop. Do not ask questions.';
+const MODEL_WARM_PROMPT = 'Say one short word to confirm you are working.';
+const MODEL_WARM_TIMEOUT_MS = 8_000;
+
+/**
+ * BOOTSTRAP-NOVA-SONIC-VOICE (latency): real (tiny) model-execution warm-up.
+ *
+ * `warmNovaSonicConnection` above keeps the TRANSPORT hot (DNS/TCP/TLS/HTTP2
+ * + credentials) via a request Bedrock rejects before inference — it never
+ * touches the model executor. Live production data showed Nova's
+ * audio_out_first_chunk swinging 2.5s-9.9s (vs. Vertex's tighter 3.3-5.6s
+ * band) — the same cold/warm split found in earlier isolated testing, now
+ * on real customer traffic: a session that lands right after another is
+ * consistently fast, one after any idle gap pays a much larger tax.
+ *
+ * This opens a real, minimal `NovaSonicLiveClient` session (no tools, a
+ * one-line system instruction, a one-line forced turn), waits for the FIRST
+ * genuine model output (audio, transcript, or turn-complete — whichever
+ * arrives first proves the executor actually ran), then closes immediately.
+ * The tiny real inference cost is the point: it is what keeps the model
+ * executor itself hot between real user sessions, the way
+ * `warmNovaSonicConnection` keeps the pipe hot. Runs fully isolated from
+ * `liveSessions` / OASIS session bookkeeping / quota meters — it is
+ * infrastructure health, never a user-visible session — and, per the
+ * keep-warm telemetry discipline (CLAUDE.md: "Never mark polling or
+ * heartbeats as OASIS events"), emits nothing but a console line.
+ *
+ * Returns latency ms (connect start → first genuine output) on success,
+ * null on any failure (transport, timeout, or model error) — same contract
+ * shape as `warmNovaSonicConnection` so the keep-warm loop can treat both
+ * uniformly.
+ */
+export async function warmNovaSonicModelExecution(config: NovaSonicConfig): Promise<number | null> {
+  const t0 = Date.now();
+  const client = new NovaSonicLiveClient({ config, voiceId: 'tina' });
+  let settled = false;
+  return new Promise<number | null>((resolve) => {
+    const finish = (result: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      void client.close('model_warm_probe_done').catch(() => { /* best-effort */ });
+      resolve(result);
+    };
+    const timer = setTimeout(() => finish(null), MODEL_WARM_TIMEOUT_MS);
+    (timer as NodeJS.Timeout).unref?.();
+
+    client.onAudioOutput(() => finish(Date.now() - t0));
+    client.onTranscript((e) => { if (e.direction === 'output') finish(Date.now() - t0); });
+    client.onTurnComplete(() => finish(Date.now() - t0));
+    client.onError(() => finish(null));
+    client.onClose(() => finish(null));
+
+    client
+      .connect({
+        model: config.modelId,
+        voiceName: 'tina',
+        responseModalities: ['audio'],
+        vadSilenceMs: 750,
+        systemInstruction: MODEL_WARM_SYSTEM_INSTRUCTION,
+        tools: [],
+        connectTimeoutMs: config.connectTimeoutMs,
+      })
+      .then(() => {
+        client.sendTextTurn(MODEL_WARM_PROMPT, true);
+      })
+      .catch(() => finish(null));
+  });
+}
+
 /**
  * Boot-time prewarm: build the shared client, resolve the credential chain
  * (ECS task-role fetch), and establish the TLS/HTTP/2 path — all off the

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1397,7 +1397,7 @@ import { synthesizeGreetingBridgeAudioPcm, GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ } 
 import { resolveNovaSonicVoice } from '../orb/live/voice/nova-sonic-voice';
 import { prewarmNovaSonicBedrock } from '../orb/live/upstream/nova-sonic-live-client';
 import { sanitizeInstructionForNova } from '../orb/live/upstream/nova-instruction-sanitizer';
-import { startNovaSonicKeepWarm } from '../orb/live/upstream/nova-sonic-keepwarm';
+import { startNovaSonicKeepWarm, startNovaSonicModelWarm } from '../orb/live/upstream/nova-sonic-keepwarm';
 import { createUpstreamClient } from '../orb/live/upstream/upstream-client-factory';
 import { bindUpstreamSessionHandlers } from '../orb/live/session/upstream-message-handler';
 import { createNovaWsFacade } from '../orb/live/upstream/nova-ws-facade';
@@ -1604,6 +1604,12 @@ if (googleAuth && VERTEX_PROJECT_ID) {
     // would put TLS/H2 setup back on the next user's critical path).
     const keepWarm = startNovaSonicKeepWarm(novaBootCfg);
     console.log(`[BOOTSTRAP-NOVA-SONIC-VOICE] Bedrock keep-warm ${keepWarm ? `enabled (every ${novaBootCfg.keepWarmMs}ms)` : 'disabled'}`);
+    // Latency fix: the transport ping above never touches the model
+    // executor. This second loop performs a real, tiny inference round-trip
+    // on a shorter cadence to keep Bedrock's Nova model executor itself
+    // warm — see warmNovaSonicModelExecution's doc comment for why.
+    const modelWarm = startNovaSonicModelWarm(novaBootCfg);
+    console.log(`[BOOTSTRAP-NOVA-SONIC-VOICE] Bedrock model-execution warm-up ${modelWarm ? `enabled (every ${novaBootCfg.modelWarmMs}ms)` : 'disabled'}`);
   }
 }
 

--- a/services/gateway/test/orb/live/upstream/nova-sonic-config.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-config.test.ts
@@ -25,6 +25,7 @@ describe('getNovaSonicConfig', () => {
         connectTimeoutMs: 15000,
         rotationAfterMs: 435000,
         keepWarmMs: 240000,
+        modelWarmMs: 90000,
         maxTokens: 4096,
         issues: [],
       }),
@@ -86,6 +87,7 @@ describe('getNovaSonicConfig', () => {
       NOVA_SONIC_CONNECT_TIMEOUT_MS: 'soon',
       NOVA_SONIC_ROTATION_AFTER_MS: '-5',
       NOVA_SONIC_KEEPWARM_MS: 'often',
+      NOVA_SONIC_MODEL_WARM_MS: 'soon',
     } as NodeJS.ProcessEnv);
     expect(cfg.ready).toBe(false);
     expect(cfg.issues).toEqual(
@@ -93,6 +95,7 @@ describe('getNovaSonicConfig', () => {
         'nova_connect_timeout_invalid',
         'nova_rotation_after_invalid',
         'nova_keepwarm_invalid',
+        'nova_model_warm_invalid',
       ]),
     );
   });
@@ -105,6 +108,19 @@ describe('getNovaSonicConfig', () => {
     expect(cfg.keepWarmMs).toBe(0);
     expect(cfg.ready).toBe(true);
     expect(cfg.issues).toEqual([]);
+  });
+
+  it('model-execution warm-up is env-tunable and accepts 0 as an explicit disable', () => {
+    expect(
+      getNovaSonicConfig({ NOVA_SONIC_MODEL_WARM_MS: '30000' } as NodeJS.ProcessEnv).modelWarmMs,
+    ).toBe(30000);
+    const disabled = getNovaSonicConfig({
+      NOVA_SONIC_ENABLED: 'true',
+      NOVA_SONIC_MODEL_WARM_MS: '0',
+    } as NodeJS.ProcessEnv);
+    expect(disabled.modelWarmMs).toBe(0);
+    expect(disabled.ready).toBe(true);
+    expect(disabled.issues).toEqual([]);
   });
 });
 

--- a/services/gateway/test/orb/live/upstream/nova-sonic-keepwarm.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-keepwarm.test.ts
@@ -6,8 +6,11 @@
 
 import {
   isNovaKeepWarmRunning,
+  isNovaModelWarmRunning,
   startNovaSonicKeepWarm,
+  startNovaSonicModelWarm,
   stopNovaSonicKeepWarm,
+  stopNovaSonicModelWarm,
 } from '../../../../src/orb/live/upstream/nova-sonic-keepwarm';
 import { getNovaSonicConfig } from '../../../../src/orb/live/upstream/nova-sonic-config';
 
@@ -15,6 +18,12 @@ const cfg = (keepWarmMs: string) =>
   getNovaSonicConfig({
     NOVA_SONIC_ENABLED: 'true',
     NOVA_SONIC_KEEPWARM_MS: keepWarmMs,
+  } as NodeJS.ProcessEnv);
+
+const modelCfg = (modelWarmMs: string) =>
+  getNovaSonicConfig({
+    NOVA_SONIC_ENABLED: 'true',
+    NOVA_SONIC_MODEL_WARM_MS: modelWarmMs,
   } as NodeJS.ProcessEnv);
 
 describe('startNovaSonicKeepWarm', () => {
@@ -68,5 +77,75 @@ describe('startNovaSonicKeepWarm', () => {
     expect(isNovaKeepWarmRunning()).toBe(false);
     await jest.advanceTimersByTimeAsync(5000);
     expect(warm).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('startNovaSonicModelWarm (BOOTSTRAP-NOVA-SONIC-VOICE latency: real model-execution warm-up)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    stopNovaSonicModelWarm();
+    jest.useRealTimers();
+  });
+
+  it('modelWarmMs=0 disables the loop', () => {
+    expect(startNovaSonicModelWarm(modelCfg('0'), { warm: jest.fn(), log: jest.fn() })).toBe(false);
+    expect(isNovaModelWarmRunning()).toBe(false);
+  });
+
+  it('runs independently of the transport keep-warm loop on its own interval', async () => {
+    const warm = jest.fn().mockResolvedValue(123);
+    const log = jest.fn();
+    expect(startNovaSonicModelWarm(modelCfg('1000'), { warm, log })).toBe(true);
+    expect(isNovaModelWarmRunning()).toBe(true);
+    expect(warm).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(warm).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('model-execution warm-up ok ms=123'));
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(warm).toHaveBeenCalledTimes(2);
+  });
+
+  it('a failed probe logs a retry line and keeps the loop alive', async () => {
+    const warm = jest.fn().mockResolvedValue(null);
+    const log = jest.fn();
+    startNovaSonicModelWarm(modelCfg('1000'), { warm, log });
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('model-execution warm-up failed'));
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(warm).toHaveBeenCalledTimes(2);
+  });
+
+  it('is idempotent while running and stops cleanly, independent of the transport loop', async () => {
+    const warm = jest.fn().mockResolvedValue(10);
+    startNovaSonicModelWarm(modelCfg('1000'), { warm, log: jest.fn() });
+    expect(startNovaSonicModelWarm(modelCfg('1000'), { warm: jest.fn(), log: jest.fn() })).toBe(true);
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(warm).toHaveBeenCalledTimes(1);
+
+    stopNovaSonicModelWarm();
+    expect(isNovaModelWarmRunning()).toBe(false);
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(warm).toHaveBeenCalledTimes(1);
+  });
+
+  it('starting both loops together keeps independent timers and counters', async () => {
+    const transportWarm = jest.fn().mockResolvedValue(1);
+    const modelWarm = jest.fn().mockResolvedValue(2);
+    startNovaSonicKeepWarm(cfg('1000'), { warm: transportWarm, log: jest.fn() });
+    startNovaSonicModelWarm(modelCfg('500'), { warm: modelWarm, log: jest.fn() });
+
+    await jest.advanceTimersByTimeAsync(500);
+    expect(modelWarm).toHaveBeenCalledTimes(1);
+    expect(transportWarm).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(500);
+    expect(modelWarm).toHaveBeenCalledTimes(2);
+    expect(transportWarm).toHaveBeenCalledTimes(1);
+
+    stopNovaSonicKeepWarm();
   });
 });

--- a/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-sonic-live-client.test.ts
@@ -8,6 +8,7 @@ import {
   NovaInputQueue,
   classifyNovaError,
   warmNovaSonicConnection,
+  warmNovaSonicModelExecution,
   __setSharedBedrockClientForTests,
   type NovaBedrockLike,
 } from '../../../../src/orb/live/upstream/nova-sonic-live-client';
@@ -460,5 +461,80 @@ describe('warmNovaSonicConnection (zero-cost connection warm)', () => {
     };
     __setSharedBedrockClientForTests(shared);
     expect(await warmNovaSonicConnection(config)).toBeNull();
+  });
+});
+
+describe('warmNovaSonicModelExecution (BOOTSTRAP-NOVA-SONIC-VOICE latency: real model-execution warm-up)', () => {
+  afterEach(() => {
+    __setSharedBedrockClientForTests(null);
+  });
+
+  it('a real audio output means the model executor ran — returns latency, closes the probe session', async () => {
+    const body = new FakeResponseBody();
+    const closeSpy = jest.fn();
+    const shared: NovaBedrockLike = {
+      send: jest.fn(async () => ({ body })),
+      // NovaSonicLiveClient.close() only needs `send` per NovaBedrockLike;
+      // nothing else to inject — the probe's own client.close() drains its
+      // queue locally without another `send` call.
+    };
+    __setSharedBedrockClientForTests(shared);
+
+    const resultPromise = warmNovaSonicModelExecution(config);
+    // Let connect()'s internal send() resolve and the probe's sendTextTurn
+    // land, then simulate the model actually responding.
+    await flush();
+    body.feed({ event: { audioOutput: { content: 'QUJD' } } });
+
+    const ms = await resultPromise;
+    expect(typeof ms).toBe('number');
+    expect(shared.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('a turn-complete with no audio still proves the executor ran — returns latency', async () => {
+    const body = new FakeResponseBody();
+    const shared: NovaBedrockLike = { send: jest.fn(async () => ({ body })) };
+    __setSharedBedrockClientForTests(shared);
+
+    const resultPromise = warmNovaSonicModelExecution(config);
+    await flush();
+    body.feed({ event: { completionEnd: { stopReason: 'END_TURN' } } });
+
+    expect(typeof (await resultPromise)).toBe('number');
+  });
+
+  it('a transport-level failure returns null, never throws', async () => {
+    const shared: NovaBedrockLike = {
+      send: jest.fn(async () => {
+        throw Object.assign(new Error('socket hang up'), { name: 'ModelStreamErrorException' });
+      }),
+    };
+    __setSharedBedrockClientForTests(shared);
+    expect(await warmNovaSonicModelExecution(config)).toBeNull();
+  });
+
+  it('a model error (e.g. validation) after connect returns null, never throws', async () => {
+    const body = new FakeResponseBody();
+    const shared: NovaBedrockLike = { send: jest.fn(async () => ({ body })) };
+    __setSharedBedrockClientForTests(shared);
+
+    const resultPromise = warmNovaSonicModelExecution(config);
+    await flush();
+    body.feedRaw({ validationException: { message: 'ValidationException: probe rejected' } } as any);
+
+    expect(await resultPromise).toBeNull();
+  });
+
+  it('never resolves before a real signal arrives, and times out to null if the model never responds', async () => {
+    jest.useFakeTimers();
+    const body = new FakeResponseBody();
+    const shared: NovaBedrockLike = { send: jest.fn(async () => ({ body })) };
+    __setSharedBedrockClientForTests(shared);
+
+    const resultPromise = warmNovaSonicModelExecution(config);
+    await jest.advanceTimersByTimeAsync(7_999);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(await resultPromise).toBeNull();
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- Real production latency data (2026-07-29, post-Maxina-restore) showed Nova's `audio_out_first_chunk` swinging **2.5s-9.9s** vs. Vertex's tighter 3.3-5.6s band — the same cold/warm split found earlier in isolated testing, now confirmed on live customer traffic.
- Root cause: the existing Bedrock keep-warm ping (`warmNovaSonicConnection`) rides a marker model ID Bedrock rejects with a fast 4xx **before any inference** — it keeps DNS/TCP/TLS/HTTP2 + credentials hot but never touches the model executor. Only a real preceding inference call warms that path, and nothing was doing that on a schedule.
- Fix: `warmNovaSonicModelExecution()` opens a real, minimal `NovaSonicLiveClient` session (no tools, one-line system instruction, one-line forced turn), waits for the first genuine model output (audio/transcript/turn-complete), then closes — a real (tiny) inference round-trip that keeps the model executor hot between real sessions.
- Runs on its own interval (`NOVA_SONIC_MODEL_WARM_MS`, default 90s) via a new, independent keep-warm loop (`startNovaSonicModelWarm`/`stopNovaSonicModelWarm`) — deliberately separate from the transport-only loop so either can be tuned/disabled independently.
- Fully isolated from `liveSessions` / OASIS session bookkeeping / quota meters — this is infrastructure health, never a user-visible session, and (per the existing keep-warm telemetry discipline — CLAUDE.md: "Never mark polling or heartbeats as OASIS events") emits nothing but a console line.

This is step one of a staged latency push (target: <5s now, <3s next, <2s eventually). It does not touch the greeting-cadence fix from #2993, and does not change anything about which sessions route to Nova — Maxina stays on Nova throughout.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest test/orb/live/upstream/nova-sonic-{live-client,keepwarm,config}.test.ts` — 53/53 pass, including 5 new tests for `warmNovaSonicModelExecution` (success via audio output, success via turn-complete, transport failure → null, model error → null, timeout → null) and 5 new tests for the independent `startNovaSonicModelWarm` loop
- [x] `npx jest test/orb` — 140 suites / 2895 tests pass
- [x] `npm run build` — clean
- [ ] Deploy to AWS staging, let the new loop run for a few cycles, compare real `voice.latency.measured` `audio_out_first_chunk` distribution before/after
- [ ] Report measured improvement before considering further latency work

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_