### PR TITLE
fix(orb): navigate_to_screen dispatches immediately + fix identifier/param drift (BOOTSTRAP-NOVA-SONIC-VOICE)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -866,36 +866,49 @@ export function createUpstreamLiveMessageHandler(
             // committed before the widget tears down the session.
             if (session.pendingNavigation) {
               const nav = session.pendingNavigation;
-              const directive = {
-                type: 'orb_directive',
-                directive: 'navigate',
-                screen_id: nav.screen_id,
-                route: nav.route,
-                title: nav.title,
-                reason: nav.reason,
-                vtid: 'VTID-NAV-01',
-              };
-              if (session.sseResponse) {
-                writeSseEvent(session.sseResponse, directive);
-              }
-              if ((session as any).clientWs && (session as any).clientWs.readyState === WebSocket.OPEN) {
-                try { ctx.deps.sendWsMessage((session as any).clientWs, directive); } catch (_e) { /* WS closed */ }
-              }
-              console.log(`[VTID-NAV-01] orb_directive dispatched: navigate to ${nav.screen_id} (${nav.route}) — session=${session.sessionId}`);
-              emitOasisEvent({
-                vtid: 'VTID-NAV-01',
-                type: 'orb.navigator.dispatched',
-                source: 'orb-live-ws',
-                status: 'info',
-                message: `dispatched navigate to ${nav.screen_id}`,
-                payload: {
-                  session_id: session.sessionId,
+              // BOOTSTRAP-NOVA-SONIC-VOICE-NAV-FIX: navigate_to_screen now
+              // flushes the orb_directive immediately at tool-call time
+              // (VTID-NAV-FAST) instead of waiting for turn_complete — Nova
+              // Sonic can take many seconds (observed 9968ms live,
+              // 2026-07-29) to close out a turn, which made the redirect
+              // feel broken even though the tool call itself succeeded in
+              // single-digit ms. Skip the duplicate send here; the pending
+              // state still exists so the extraction-force/memory-order
+              // logic above this block keeps working unchanged.
+              if (!session.navigationDirectiveSentImmediately) {
+                const directive = {
+                  type: 'orb_directive',
+                  directive: 'navigate',
                   screen_id: nav.screen_id,
                   route: nav.route,
-                  decision_source: nav.decision_source,
-                  drain_wait_ms: Date.now() - nav.requested_at,
-                },
-              }).catch(() => {});
+                  title: nav.title,
+                  reason: nav.reason,
+                  vtid: 'VTID-NAV-01',
+                };
+                if (session.sseResponse) {
+                  writeSseEvent(session.sseResponse, directive);
+                }
+                if ((session as any).clientWs && (session as any).clientWs.readyState === WebSocket.OPEN) {
+                  try { ctx.deps.sendWsMessage((session as any).clientWs, directive); } catch (_e) { /* WS closed */ }
+                }
+                console.log(`[VTID-NAV-01] orb_directive dispatched: navigate to ${nav.screen_id} (${nav.route}) — session=${session.sessionId}`);
+                emitOasisEvent({
+                  vtid: 'VTID-NAV-01',
+                  type: 'orb.navigator.dispatched',
+                  source: 'orb-live-ws',
+                  status: 'info',
+                  message: `dispatched navigate to ${nav.screen_id}`,
+                  payload: {
+                    session_id: session.sessionId,
+                    screen_id: nav.screen_id,
+                    route: nav.route,
+                    decision_source: nav.decision_source,
+                    drain_wait_ms: Date.now() - nav.requested_at,
+                  },
+                }).catch(() => {});
+              } else {
+                console.log(`[VTID-NAV-FAST] turn_complete for session ${session.sessionId}: navigate to ${nav.screen_id} already dispatched immediately at tool-call time — skipping duplicate send.`);
+              }
               // Clear pending so we don't re-dispatch on subsequent turns.
               // navigationDispatched stays TRUE so input audio stays gated until
               // the widget closes the connection.
@@ -2349,36 +2362,46 @@ export function handleTurnComplete(
   // VTID-NAV: dispatch pending navigation AFTER memory/bridge/extraction.
   if (session.pendingNavigation) {
     const nav = session.pendingNavigation;
-    const directive = {
-      type: 'orb_directive',
-      directive: 'navigate',
-      screen_id: nav.screen_id,
-      route: nav.route,
-      title: nav.title,
-      reason: nav.reason,
-      vtid: 'VTID-NAV-01',
-    };
-    if (session.sseResponse) {
-      writeSseEvent(session.sseResponse, directive);
-    }
-    if ((session as any).clientWs && (session as any).clientWs.readyState === WebSocket.OPEN) {
-      try { ctx.deps.sendWsMessage((session as any).clientWs, directive); } catch (_e) { /* WS closed */ }
-    }
-    console.log(`[VTID-NAV-01] orb_directive dispatched: navigate to ${nav.screen_id} (${nav.route}) — session=${session.sessionId}`);
-    emitOasisEvent({
-      vtid: 'VTID-NAV-01',
-      type: 'orb.navigator.dispatched',
-      source: 'orb-live-ws',
-      status: 'info',
-      message: `dispatched navigate to ${nav.screen_id}`,
-      payload: {
-        session_id: session.sessionId,
+    // BOOTSTRAP-NOVA-SONIC-VOICE-NAV-FIX: see the raw handler's mirror of
+    // this block for the full rationale — navigate_to_screen already
+    // flushed the directive immediately at tool-call time when this flag
+    // is set, so skip the duplicate send (this is the path Nova sessions
+    // actually take: bindUpstreamSessionHandlers routes Nova through this
+    // handler, not the raw one above).
+    if (!session.navigationDirectiveSentImmediately) {
+      const directive = {
+        type: 'orb_directive',
+        directive: 'navigate',
         screen_id: nav.screen_id,
         route: nav.route,
-        decision_source: nav.decision_source,
-        drain_wait_ms: Date.now() - nav.requested_at,
-      },
-    }).catch(() => {});
+        title: nav.title,
+        reason: nav.reason,
+        vtid: 'VTID-NAV-01',
+      };
+      if (session.sseResponse) {
+        writeSseEvent(session.sseResponse, directive);
+      }
+      if ((session as any).clientWs && (session as any).clientWs.readyState === WebSocket.OPEN) {
+        try { ctx.deps.sendWsMessage((session as any).clientWs, directive); } catch (_e) { /* WS closed */ }
+      }
+      console.log(`[VTID-NAV-01] orb_directive dispatched: navigate to ${nav.screen_id} (${nav.route}) — session=${session.sessionId}`);
+      emitOasisEvent({
+        vtid: 'VTID-NAV-01',
+        type: 'orb.navigator.dispatched',
+        source: 'orb-live-ws',
+        status: 'info',
+        message: `dispatched navigate to ${nav.screen_id}`,
+        payload: {
+          session_id: session.sessionId,
+          screen_id: nav.screen_id,
+          route: nav.route,
+          decision_source: nav.decision_source,
+          drain_wait_ms: Date.now() - nav.requested_at,
+        },
+      }).catch(() => {});
+    } else {
+      console.log(`[VTID-NAV-FAST] turn_complete for session ${session.sessionId}: navigate to ${nav.screen_id} already dispatched immediately at tool-call time — skipping duplicate send.`);
+    }
     session.pendingNavigation = undefined;
   } else {
     console.log(`[VTID-NAV-DIAG] turn_complete for session ${session.sessionId}: NO pendingNavigation (navigationDispatched=${!!session.navigationDispatched}, consecutiveToolCalls=${session.consecutiveToolCalls}) — widget will transition to listening`);

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1095,6 +1095,14 @@ export interface GeminiLiveSession {
   // forwarding so Gemini doesn't start a new turn while the widget is closing.
   // Once true, the session is effectively in "closing for navigation" mode.
   navigationDispatched?: boolean;
+  // BOOTSTRAP-NOVA-SONIC-VOICE-NAV-FIX: set true when handleNavigateToScreen
+  // already wrote the orb_directive to the transport at tool-call time
+  // (VTID-NAV-FAST), instead of waiting for turn_complete to flush
+  // pendingNavigation. pendingNavigation stays populated either way (other
+  // turn_complete bookkeeping — forced fact extraction, memory bridge order
+  // — still reads it), but the turn_complete dispatch blocks must skip
+  // re-sending the same directive a second time when this is true.
+  navigationDirectiveSentImmediately?: boolean;
   // VTID-NAV: Current page URL the user is on when the orb session opened.
   // Used by navigator_consult to exclude the current screen from recommendations.
   current_route?: string;
@@ -2881,10 +2889,49 @@ export async function handleNavigateToScreen(
     };
   }
 
-  // Vertex-only: set pendingNavigation + eagerly update current_route so
-  // turn_complete + get_current_screen see the fresh destination.
+  // BOOTSTRAP-NOVA-SONIC-VOICE-NAV-FIX: dispatch the orb_directive
+  // IMMEDIATELY, on the same tick the tool result is decided, instead of
+  // queuing pendingNavigation and waiting for the turn_complete handler to
+  // flush it. That deferred design was fine under Gemini (whose forced
+  // function-response continuation reaches turn_complete in tens to a few
+  // thousand ms — see historical drain_wait_ms of 19-2489ms in
+  // orb.navigator.dispatched telemetry), but Nova Sonic can take many
+  // seconds to close out the turn (observed live 2026-07-29, session
+  // live-cadd6787...: drain_wait_ms=9968 — Nova chained a SECOND tool call,
+  // end_teaching_session, before ever emitting END_TURN). A ~10s stall
+  // after asking Vitana to navigate reads as "navigation is broken" even
+  // though the tool call itself succeeded in 6ms. Mirrors the pattern
+  // handleNavigate() (the free-text `navigate` tool) already uses.
   if (result.directive && result.screen_id && result.route && result.title) {
     const reason = String(args.reason || 'navigate_to_screen tool call');
+    const directiveJson = JSON.stringify(result.directive);
+    if (session.sseResponse) {
+      try { session.sseResponse.write(`data: ${directiveJson}\n\n`); } catch (_e) { /* SSE closed */ }
+    }
+    if ((session as any).clientWs && (session as any).clientWs.readyState === 1 /* WebSocket.OPEN */) {
+      try { sendWsMessage((session as any).clientWs, result.directive); } catch (_e) { /* WS closed */ }
+    }
+    console.log(`[VTID-NAV-FAST] Immediate orb_directive dispatched: ${result.screen_id} (${result.route})`);
+    emitOasisEvent({
+      vtid: 'VTID-NAV-01',
+      type: 'orb.navigator.dispatched',
+      source: 'orb-live-ws',
+      status: 'info',
+      message: `dispatched navigate to ${result.screen_id}`,
+      payload: {
+        session_id: session.sessionId,
+        screen_id: result.screen_id,
+        route: result.route,
+        decision_source: 'direct',
+        drain_wait_ms: 0,
+      },
+    }).catch(() => {});
+
+    // pendingNavigation is still populated (unchanged from before this fix)
+    // so the turn_complete handler's forced-fact-extraction and memory
+    // bookkeeping keep working; navigationDirectiveSentImmediately tells
+    // that handler the directive was already flushed here, so it must
+    // skip re-sending it when the turn eventually completes.
     session.pendingNavigation = {
       screen_id: result.screen_id,
       route: result.route,
@@ -2894,6 +2941,7 @@ export async function handleNavigateToScreen(
       requested_at: Date.now(),
     };
     session.navigationDispatched = true;
+    session.navigationDirectiveSentImmediately = true;
 
     const isOverlay = result.entry_kind === 'overlay';
     if (!isOverlay) {

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -2864,6 +2864,20 @@ export async function tool_navigate_to_screen(
   const screenIdArg = String(args.screen_id ?? args.target ?? '').trim();
   if (!screenIdArg) return { ok: false, error: 'screen_id (or legacy target) is required' };
 
+  // VTID-NAV-IDENTIFIER-ALIAS: the navigate_to_screen tool schema
+  // (live-tool-catalog.ts) tells the model to send `vitana_id` for
+  // PROFILE.PUBLIC / PROFILE.WITH_MATCH, but both the NAV_ENTITY_RESOLVE
+  // gate below and the generic ":identifier" param-substitution only ever
+  // read `args.identifier` — a key the schema never defines, so the model
+  // never sends it. Confirmed live in production (oasis_events,
+  // 2026-04-10 through 2026-06-22): every PROFILE.PUBLIC navigate_to_screen
+  // call carrying a vitana_id failed with "missing required parameter(s)
+  // identifier", 100% of the time, for months. Alias it here once so both
+  // downstream readers see it.
+  if (args.identifier === undefined && typeof args.vitana_id === 'string' && args.vitana_id.trim()) {
+    args.identifier = args.vitana_id.trim().replace(/^@/, '');
+  }
+
   // Identity facts (with args fallback for the LiveKit Python wrapper that
   // sends them in the body alongside current_route).
   const isAnon = (typeof args.is_anonymous === 'boolean' ? args.is_anonymous : id.is_anonymous)

--- a/supabase/migrations/20260729120000_nav_catalog_settings_tenant_drift_fix.sql
+++ b/supabase/migrations/20260729120000_nav_catalog_settings_tenant_drift_fix.sql
@@ -1,0 +1,46 @@
+-- BOOTSTRAP-NOVA-SONIC-VOICE-NAV-FIX: while auditing the Navigator catalog
+-- for broken routes (nav_catalog entries whose route no longer exists as a
+-- real SPA path, same check the admin /coverage endpoint runs), found one
+-- pre-existing drift unrelated to the Nova regression: SETTINGS.TENANT
+-- (Mobile-only) points at '/settings/tenant', which App.tsx never
+-- registers — only '/settings/tenant-role' (already covered by the
+-- SETTINGS.TENANT_ROLE catalog entry, mobile + desktop) and the unrelated
+-- dev-only '/dev/settings/tenants' exist. Any voice or catalog-driven
+-- redirect to SETTINGS.TENANT lands on a dead route.
+--
+-- Repoints the route to the real, live page — same pattern as
+-- 20260616130000_nav_catalog_mobile_drift_fixes.sql (several catalog
+-- entries already legitimately share one destination route, e.g.
+-- HOME.MATCHES/HOME.AI_FEED/HOME.CONTEXT/HOME.ACTIONS all → '/home').
+--
+-- impact-allow-solo-migration: pure data correction in the existing
+-- nav_catalog table (the runtime already reads it). No code change required.
+BEGIN;
+
+UPDATE nav_catalog SET route = '/settings/tenant-role', updated_at = now()
+  WHERE platform = 'mobile' AND tenant_id IS NULL AND screen_id = 'SETTINGS.TENANT';
+
+-- Second, unrelated drift found in the same audit: the navigate_to_screen
+-- tool schema (services/gateway/src/orb/live/tools/live-tool-catalog.ts)
+-- tells the model to send a `groupId` argument "for COMM.GROUP_DETAIL" —
+-- one static description, not platform-specific. The Mobile catalog row's
+-- route template ('/comm/groups/:groupId') matches that param name, but
+-- the Desktop row used ':id' instead, so param substitution
+-- (orb-tools-shared.ts, `route.replace(/:(\w+)/, (_, name) => args[name])`)
+-- always found `args['id']` missing on Desktop voice sessions and rejected
+-- the navigation with "missing required parameter(s) id" — the model was
+-- never told to send `id` for this screen. Route param names are internal
+-- to this substitution (React Router matches by URL position once the
+-- placeholder is filled in, not by the name the catalog happened to use),
+-- so renaming the placeholder to match the tool schema is a safe, purely
+-- cosmetic-to-the-router data fix.
+UPDATE nav_catalog SET route = '/comm/groups/:groupId', updated_at = now()
+  WHERE platform = 'desktop' AND tenant_id IS NULL AND screen_id = 'COMM.GROUP_DETAIL';
+
+-- Same class of bug, same tool schema doc ("`match_id` for
+-- INTENTS.MATCH_DETAIL"): the Mobile row already uses ':match_id', but
+-- Desktop used ':id' and could never receive it from the model.
+UPDATE nav_catalog SET route = '/intents/match/:match_id', updated_at = now()
+  WHERE platform = 'desktop' AND tenant_id IS NULL AND screen_id = 'INTENTS.MATCH_DETAIL';
+
+COMMIT;


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-NOVA-SONIC-VOICE-NAV-FIX` _(no formal VTID exists yet for this fix; tracked under this BOOTSTRAP tag pending one, same pattern as other recent entries in CLAUDE.md's change log)_

**Layer:** APIL (gateway ORB voice pipeline)

**Priority:** P1

---

## 📋 Summary

Root-caused and fixed the "Vitana voice navigation stopped working" regression reported after the Nova 2 Sonic integration, plus three unrelated pre-existing navigation bugs found while auditing the full nav_catalog (~290 entries) against the app's real routes and production telemetry.

**Main fix — `navigate_to_screen` redirect latency:**
`handleNavigateToScreen` only queued `session.pendingNavigation` and relied on the `turn_complete` handler to flush the `orb_directive` to the client. That was fine under Gemini/Vertex (turn_complete follows a tool call in tens of ms to a few seconds — historical `drain_wait_ms` of 19–2489ms in production telemetry), but Nova Sonic can take many seconds to close out a turn, especially when it chains a second tool call first.

Confirmed live in production (`oasis_events`, session `live-cadd6787...`, 2026-07-29): `navigate_to_screen` succeeded in 6ms, but the redirect didn't reach the client until `drain_wait_ms=9968` — a **~10 second stall** that reads as "broken" even though the backend call worked. In the same session, Nova chained a second tool call (`end_teaching_session`) before ever emitting `END_TURN`, which is what stretched the wait.

**Fix:** `handleNavigateToScreen` now writes the `orb_directive` to the transport immediately at tool-call time, mirroring the free-text `navigate` tool's existing immediate-dispatch pattern. `pendingNavigation` stays populated (unchanged) so downstream `turn_complete` bookkeeping (forced fact extraction, memory-write ordering) keeps working; a new `navigationDirectiveSentImmediately` flag tells both `turn_complete` dispatch sites (the raw Gemini/Vertex handler and the Nova-routed mirror handler in `upstream-message-handler.ts`) to skip re-sending the same directive.

**Also found + fixed while auditing the catalog for "does every route work":**
- **PROFILE.PUBLIC / PROFILE.WITH_MATCH** — the tool schema tells the model to send `vitana_id`, but the code only ever read `args.identifier`, a key the model never sends. Production telemetry shows *every* `PROFILE.PUBLIC` navigate_to_screen call carrying a `vitana_id` has failed this way for months (April–June 2026) — unrelated to Nova, pre-existing. Now aliased in `orb-tools-shared.ts`.
- **Desktop `COMM.GROUP_DETAIL` / `INTENTS.MATCH_DETAIL`** — the DB catalog rows used `:id` while the tool schema documents `groupId`/`match_id` for those screens, so desktop voice navigation to a specific group or match always failed with a missing-param error. Fixed via migration (route param names are internal to the substitution step, not the live React Router path, so renaming is safe).
- **`SETTINGS.TENANT` (mobile)** pointed at `/settings/tenant`, which no longer exists as an app route (only `/settings/tenant-role` does). Repointed via migration.

---

## ✅ Changes

- [x] `services/gateway/src/routes/orb-live.ts` — `handleNavigateToScreen` dispatches `orb_directive` immediately; new `navigationDirectiveSentImmediately` session field
- [x] `services/gateway/src/orb/live/session/upstream-message-handler.ts` — both `turn_complete` dispatch sites skip re-sending when already dispatched immediately
- [x] `services/gateway/src/services/orb-tools-shared.ts` — alias `args.vitana_id` → `args.identifier` for PROFILE.PUBLIC / PROFILE.WITH_MATCH
- [x] `supabase/migrations/20260729120000_nav_catalog_settings_tenant_drift_fix.sql` — 3 data-only nav_catalog route corrections

---

## 🧪 Testing

- [x] `npx tsc --noEmit` passes clean on all touched files
- [x] Read through every existing test file that exercises this code path (`test/nav-redirect-flow.test.ts`, `test/nav-entity-resolve.test.ts`, `test/nav-regression-contract.test.ts`, `test/routes/orb-live-nova-incident-regressions.test.ts`, `test/orb/live/session/upstream-message-handler.test.ts`, `test/orb/live/session/upstream-session-binding.test.ts`) and confirmed by inspection that every existing assertion still holds — `pendingNavigation` is deliberately left populated (not cleared) at tool-call time specifically so those tests' contract doesn't change, and the new `vitana_id`→`identifier` alias only fires when `identifier` is absent, so it's purely additive.
- [x] Verified nav_catalog structurally: cross-checked all ~290 active catalog rows against `vitana-v1`'s live `App.tsx` router (routes registered directly + nested route children) — no other broken routes found beyond the 3 fixed here.
- [x] Verified against real production `oasis_events` telemetry (Supabase project `inmkhvwdcuyhnxkgfvsb`) for both the Nova latency regression and the pre-existing PROFILE.PUBLIC failures.
- [ ] **Could not run the Jest suite in this sandbox** — `node_modules` isn't installed for this repo and installing from the npm registry is blocked by this session's egress policy (403). Please run `npm test` (or at minimum `test/nav-redirect-flow.test.ts`, `test/nav-entity-resolve.test.ts`, and `test/routes/orb-live-nova-incident-regressions.test.ts`) in CI/locally before merging to confirm the above by-inspection analysis.
- [ ] Verified in staging/dev environment — not done from this session; this PR auto-deploys to `gateway-staging` on merge per the staging-first pipeline. Recommend a real Nova voice session against staging asking to navigate somewhere, then checking `orb.navigator.dispatched.drain_wait_ms` in `oasis_events` drops to near-zero for `navigate_to_screen` calls (vs. the ~10s seen in prod before this fix).

---

## 🚨 Breaking Changes

None. `pendingNavigation`'s external contract (fields, timing relative to `navigationDispatched`) is unchanged. The new `navigationDirectiveSentImmediately` field is additive. The nav_catalog migration only corrects 3 already-broken routes (no valid redirect changes destination).

---

## 📌 Additional Notes

This fixes the *architectural* dependency on Nova's turn-completion latency; it's complementary to #2994 (`perf: add real model-execution keep-warm for Nova Sonic`, merged just ahead of this branch), which reduces that latency at the infrastructure level. This PR makes navigation redirects immune to it regardless of how long Nova takes to close out the turn.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3z6fKEY5maHGpRfqkQh18)_