### PR TITLE
fix: await chat push notification dispatch before responding (BOOTSTRAP-CHAT-PUSH-NOTIF)

### DIFF
--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -25,7 +25,7 @@ import {
   AuthenticatedRequest,
 } from '../middleware/auth-supabase-jwt';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { notifyUserAsync } from '../services/notification-service';
+import { notifyUser } from '../services/notification-service';
 import { VITANA_BOT_USER_ID, isVitanaBot } from '../lib/vitana-bot';
 import { processConversationTurn } from '../services/conversation-client';
 import { emitOasisEvent } from '../services/oasis-event-service';
@@ -324,14 +324,23 @@ router.post('/:id/send', requireAuth, requireTenant, async (req: Request, res: R
     }
   }
 
-  fanoutGroupNotifications(
-    supabase,
-    groupId,
-    identity.user_id,
-    identity.tenant_id!,
-    fanoutBody,
-    data.id,
-  ).catch(err => console.warn('[ChatGroups] Fanout failed:', err.message));
+  // Awaited (not fire-and-forget) — Cloud Run can freeze/recycle the
+  // container the instant res.status(201) flushes, silently dropping any
+  // still-in-flight background promise (same failure mode confirmed live
+  // and fixed for daily-feature-tip; see scheduled-notifications.ts
+  // BOOTSTRAP-DAILY-FEATURE-TIP and notifyUser's caller in chat.ts /send).
+  try {
+    await fanoutGroupNotifications(
+      supabase,
+      groupId,
+      identity.user_id,
+      identity.tenant_id!,
+      fanoutBody,
+      data.id,
+    );
+  } catch (err: any) {
+    console.warn('[ChatGroups] Fanout failed:', err?.message || err);
+  }
 
   if (trimmed.length > 0 && VITANA_MENTION_RE.test(trimmed) && !isVitanaBot(identity.user_id)) {
     handleVitanaGroupMention(
@@ -535,27 +544,39 @@ async function fanoutGroupNotifications(
 
   const body = content.length > 100 ? content.slice(0, 97) + '...' : content;
 
-  for (const m of (members || []) as Array<{ user_id: string }>) {
-    if (m.user_id === senderId) continue;
-    if (isVitanaBot(m.user_id)) continue;
-    notifyUserAsync(
-      m.user_id,
-      tenantId,
-      'new_chat_message',
-      {
-        title: groupName,
-        body: `${senderName}: ${body}`,
-        data: {
-          type: 'new_group_message',
-          group_id: groupId,
-          sender_id: senderId,
-          sender_name: senderName,
-          message_id: messageId,
-          url: `/inbox/g/${groupId}`,
+  const recipients = (members || []).filter(
+    (m: { user_id: string }) => m.user_id !== senderId && !isVitanaBot(m.user_id),
+  ) as Array<{ user_id: string }>;
+
+  // Promise.allSettled so one bad member can't block the rest, and so the
+  // caller's await actually finishes before Cloud Run can freeze the
+  // container (see call site's comment for why fire-and-forget silently
+  // drops pushes here).
+  const results = await Promise.allSettled(
+    recipients.map((m) =>
+      notifyUser(
+        m.user_id,
+        tenantId,
+        'new_chat_message',
+        {
+          title: groupName,
+          body: `${senderName}: ${body}`,
+          data: {
+            type: 'new_group_message',
+            group_id: groupId,
+            sender_id: senderId,
+            sender_name: senderName,
+            message_id: messageId,
+            url: `/inbox/g/${groupId}`,
+          },
         },
-      },
-      supabase,
-    );
+        supabase,
+      ),
+    ),
+  );
+  const failed = results.filter((r) => r.status === 'rejected').length;
+  if (failed > 0) {
+    console.warn(`[ChatGroups] fanout: ${failed}/${results.length} notifyUser calls rejected`);
   }
 }
 
@@ -711,25 +732,33 @@ router.post('/:id/refanout-welcome', requireAuth, requireExafyAdmin, async (req:
       continue;
     }
 
-    notifyUserAsync(
-      m.user_id,
-      tenantId,
-      'new_chat_message',
-      {
-        title: groupName,
-        body: `Vitana: ${bodyPreview}`,
-        data: {
-          type: 'new_group_message',
-          group_id: groupId,
-          sender_id: welcome.sender_id,
-          sender_name: 'Vitana',
-          message_id: welcome.id,
-          idempotency_key: idemKey,
-          url: `/inbox/g/${groupId}`,
+    // Awaited (not fire-and-forget) — this loop already awaits a DB query
+    // per member above, so awaiting the push here doesn't change the
+    // endpoint's shape, and avoids the same Cloud Run freeze-after-response
+    // risk as the other notifyUserAsync call sites in this file.
+    try {
+      await notifyUser(
+        m.user_id,
+        tenantId,
+        'new_chat_message',
+        {
+          title: groupName,
+          body: `Vitana: ${bodyPreview}`,
+          data: {
+            type: 'new_group_message',
+            group_id: groupId,
+            sender_id: welcome.sender_id,
+            sender_name: 'Vitana',
+            message_id: welcome.id,
+            idempotency_key: idemKey,
+            url: `/inbox/g/${groupId}`,
+          },
         },
-      },
-      supabase,
-    );
+        supabase,
+      );
+    } catch (err: any) {
+      console.warn(`[ChatGroups] refanout-welcome notifyUser failed for ${m.user_id}:`, err?.message || err);
+    }
     fired++;
   }
 

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -17,7 +17,7 @@ import {
   AuthenticatedRequest,
 } from '../middleware/auth-supabase-jwt';
 import { createClient } from '@supabase/supabase-js';
-import { notifyUserAsync } from '../services/notification-service';
+import { notifyUser } from '../services/notification-service';
 import { VITANA_BOT_USER_ID, isVitanaBot } from '../lib/vitana-bot';
 import { processConversationTurn } from '../services/conversation-client';
 
@@ -149,29 +149,40 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
       }
     }
 
-    notifyUserAsync(
-      receiver_id,
-      identity.tenant_id!,
-      'new_chat_message',
-      {
-        title: senderName,
-        body: notifBody.length > 100 ? notifBody.slice(0, 97) + '...' : notifBody,
-        data: {
-          type: 'new_chat_message',
-          sender_id: identity.user_id,
-          sender_name: senderName,
-          message_id: data.id,
-          thread_id: identity.user_id,
-          // Path-based deep-link — query-string form (?recipient=…&context=global)
-          // silently fails in Appilix's Android in-app browser when launched from
-          // a notification tap (confirmed via BOOTSTRAP-NOTIF-MESSENGER-DIAG:
-          // diagnostic beacon never fired, no Cloud Run hit recorded). Path form
-          // launches cleanly because the URL has no special characters.
-          url: `/inbox/u/${identity.user_id}`,
+    // Awaited (not fire-and-forget) so the HTTP response below isn't sent
+    // until the push dispatch has actually finished — Cloud Run only
+    // guarantees CPU while a request is in flight, so a fire-and-forget
+    // promise here can get frozen/killed the instant res.status(201) flushes
+    // (same failure mode confirmed live and fixed for daily-feature-tip, see
+    // scheduled-notifications.ts BOOTSTRAP-DAILY-FEATURE-TIP). try/catch so a
+    // push failure never turns a successfully-sent chat message into a 500.
+    try {
+      await notifyUser(
+        receiver_id,
+        identity.tenant_id!,
+        'new_chat_message',
+        {
+          title: senderName,
+          body: notifBody.length > 100 ? notifBody.slice(0, 97) + '...' : notifBody,
+          data: {
+            type: 'new_chat_message',
+            sender_id: identity.user_id,
+            sender_name: senderName,
+            message_id: data.id,
+            thread_id: identity.user_id,
+            // Path-based deep-link — query-string form (?recipient=…&context=global)
+            // silently fails in Appilix's Android in-app browser when launched from
+            // a notification tap (confirmed via BOOTSTRAP-NOTIF-MESSENGER-DIAG:
+            // diagnostic beacon never fired, no Cloud Run hit recorded). Path form
+            // launches cleanly because the URL has no special characters.
+            url: `/inbox/u/${identity.user_id}`,
+          },
         },
-      },
-      supabase,
-    );
+        supabase,
+      );
+    } catch (err: any) {
+      console.error('[Chat] Push notification dispatch failed:', err?.message || err);
+    }
   }
 
   return res.status(201).json({ ok: true, data });


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-CHAT-PUSH-NOTIF` _(no VTID exists for this yet; tracked under this BOOTSTRAP tag pending one, same convention as BOOTSTRAP-DAILY-FEATURE-TIP)_

**Layer:** APIL (Gateway chat routes)

**Priority:** P1

---

## 📋 Summary

Fixes a bug where **chat message push notifications never arrived externally** (no lock-screen/notification-tray bell), even though in-app delivery worked fine.

Root cause: `chat.ts` (`/send`) and `chat-groups.ts` (`/send`, `fanoutGroupNotifications`, `/refanout-welcome`) all dispatched push notifications via the fire-and-forget `notifyUserAsync()` immediately before sending the HTTP response (`res.status(201).json(...)` / `res.json(...)`). Cloud Run only guarantees CPU while a request is in flight — once the response flushed, the container could freeze/recycle before the still-running `notifyUser()` promise (DB pref lookups, `user_notifications` insert, FCM/Appilix send) finished, silently dropping the push. The `chat_messages` insert and in-app realtime delivery don't go through this code path at all, which is why in-app notifications were unaffected and worked every time.

This is the exact same failure mode already diagnosed and fixed for the daily-feature-tip notification (see `scheduled-notifications.ts`, `BOOTSTRAP-DAILY-FEATURE-TIP`), where the same fire-and-forget pattern caused only 33 of 181 users to receive a push. That fix was never applied to the chat send paths — this PR closes that gap.

---

## ✅ Changes

- [x] `chat.ts` `/send` — switched from `notifyUserAsync()` to `await notifyUser()` before the response, wrapped in try/catch so a push failure can't turn a successfully-sent message into a 500.
- [x] `chat-groups.ts` `/send` — awaits `fanoutGroupNotifications(...)` before the response (was `.catch()`-only fire-and-forget).
- [x] `chat-groups.ts` `fanoutGroupNotifications()` — internal per-member loop switched from fire-and-forget `notifyUserAsync()` to `Promise.allSettled` over awaited `notifyUser()` calls, so the caller's `await` actually waits for every member's push.
- [x] `chat-groups.ts` `/:id/refanout-welcome` (admin endpoint) — same fire-and-forget pattern found and fixed for consistency, since it's already inside a sequential per-member loop.

---

## 🧪 Testing

- [ ] Manual testing completed
- [x] Verified no new TypeScript errors introduced in the edited regions (full `tsc` build blocked in this sandbox by an unrelated pre-existing `tsconfig.json` `moduleResolution` deprecation error, confirmed present on `main` before this change too; `npm install` also blocked by sandbox registry policy — a full build/test pass should be run in CI or by a reviewer with network access)
- [ ] Verified in staging/dev environment

---

## 🚨 Breaking Changes

None — API responses are unchanged; the only behavioral change is that the HTTP response for a chat send now waits for the push notification dispatch (a few hundred ms of DB/FCM calls) to complete before returning, matching the pattern already used for `daily-feature-tip`.

---

## 📌 Additional Notes

Investigated and fixed per user request. No VTID was assigned before starting this fix; recommend allocating one and updating this PR's VTID reference before merge, per governance rules in `CLAUDE.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8WNmvimt7WKc5e58uQhGb)_