### PR TITLE
diag: extend Nova live latency probe to measure a real second turn

### DIFF
--- a/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
@@ -110,6 +110,18 @@ interface LiveProbeMetrics extends Record<string, number> {
   connect_ms: number;
   first_event_ms: number;
   first_audio_ms: number;
+  /**
+   * BOOTSTRAP-NOVA-SONIC-VOICE (per-turn latency follow-up): time from
+   * sending the SECOND text turn to its turn_complete. -1 when no second
+   * turn was requested. This is the number actually missing from
+   * production observability — voice.latency.measured has never captured
+   * a turn>0 sample in 25 days of history (100% of captured events are the
+   * single-turn CI smoke probe below), even though real users report 7-10s
+   * on turn 2+. This field exists to close that gap without waiting on
+   * real user traffic to happen to emit it.
+   */
+  second_turn_ms: number;
+  second_turn_first_audio_ms: number;
 }
 
 interface LiveProbeResult {
@@ -122,6 +134,12 @@ interface LiveProbeResult {
  * Provider-neutral live probe: register handlers, connect, send one short
  * text turn, and measure connect / first-event / first-audio latency. Used
  * identically for Nova and the Vertex baseline so the comparison is fair.
+ *
+ * When `secondTurnText` is supplied, a SECOND turn is sent immediately after
+ * the first turn_complete and timed separately (second_turn_ms /
+ * second_turn_first_audio_ms) — this is turn 2 exactly as a real
+ * conversation would produce it (same stream, same session, no reconnect),
+ * which is the metric actually missing from production telemetry.
  */
 /** 32ms of 16 kHz / 16-bit / mono PCM silence, base64 — one mic frame. */
 const SILENCE_FRAME_B64 = Buffer.alloc(1024).toString('base64');
@@ -131,6 +149,7 @@ async function probeLiveClient(
   connect: () => Promise<void>,
   closeReason: string,
   classifyFailure: (err: unknown) => string,
+  secondTurnText?: string,
 ): Promise<LiveProbeResult> {
   const t0 = Date.now();
   let connectMs = -1;
@@ -141,23 +160,57 @@ async function probeLiveClient(
   const errorCodes: string[] = [];
   let upstreamCloseReason: string | undefined;
 
-  let settled = false;
+  // Second-turn state. turnPhase gates which counters onAudioOutput/
+  // onTurnComplete update, so the first turn's handlers don't also
+  // (mis)attribute the second turn's events.
+  let turnPhase: 'first' | 'second' = 'first';
+  let secondTurnStart = -1;
+  let secondTurnMs = -1;
+  let secondTurnFirstAudioMs = -1;
+  let firstTurnSettled = false;
+  let allSettled = false;
+
   const done = new Promise<void>((resolve) => {
-    const finish = () => { if (!settled) { settled = true; resolve(); } };
-    const timer = setTimeout(finish, PROBE_TIMEOUT_MS);
+    const finishAll = () => { if (!allSettled) { allSettled = true; resolve(); } };
+    const timer = setTimeout(finishAll, secondTurnText ? PROBE_TIMEOUT_MS * 2 : PROBE_TIMEOUT_MS);
     (timer as NodeJS.Timeout).unref?.();
+
     client.onTranscript(() => {
       transcriptCount++;
-      if (firstEventMs < 0) firstEventMs = Date.now() - t0;
+      if (turnPhase === 'first' && firstEventMs < 0) firstEventMs = Date.now() - t0;
     });
     client.onAudioOutput(() => {
       audioCount++;
-      if (firstAudioMs < 0) firstAudioMs = Date.now() - t0;
-      if (firstEventMs < 0) firstEventMs = Date.now() - t0;
+      if (turnPhase === 'first') {
+        if (firstAudioMs < 0) firstAudioMs = Date.now() - t0;
+        if (firstEventMs < 0) firstEventMs = Date.now() - t0;
+      } else if (secondTurnFirstAudioMs < 0) {
+        secondTurnFirstAudioMs = Date.now() - secondTurnStart;
+      }
     });
-    client.onTurnComplete(() => { clearTimeout(timer); finish(); });
-    client.onError((e) => { errorCodes.push(e.code); clearTimeout(timer); finish(); });
-    client.onClose((e) => { upstreamCloseReason = e.reason; clearTimeout(timer); finish(); });
+    client.onTurnComplete(() => {
+      if (turnPhase === 'first') {
+        firstTurnSettled = true;
+        if (!secondTurnText) { clearTimeout(timer); finishAll(); return; }
+        // Fire the second turn from inside the completion handler so it
+        // rides the SAME open stream/session — no reconnect, matching a
+        // real multi-turn conversation exactly.
+        turnPhase = 'second';
+        secondTurnStart = Date.now();
+        try {
+          client.sendTextTurn(secondTurnText);
+        } catch {
+          clearTimeout(timer);
+          finishAll();
+        }
+        return;
+      }
+      secondTurnMs = Date.now() - secondTurnStart;
+      clearTimeout(timer);
+      finishAll();
+    });
+    client.onError((e) => { errorCodes.push(e.code); clearTimeout(timer); finishAll(); });
+    client.onClose((e) => { upstreamCloseReason = e.reason; clearTimeout(timer); finishAll(); });
   });
 
   try {
@@ -168,7 +221,7 @@ async function probeLiveClient(
     // sessions always have the audio pipe flowing, and Nova's server-side
     // turn detection expects it. 32ms frames, real-time pace.
     const silenceTimer = setInterval(() => {
-      if (settled || client.getState() !== 'open') { clearInterval(silenceTimer); return; }
+      if (allSettled || client.getState() !== 'open') { clearInterval(silenceTimer); return; }
       client.sendAudioChunk(SILENCE_FRAME_B64);
     }, 32);
     (silenceTimer as NodeJS.Timeout).unref?.();
@@ -186,9 +239,18 @@ async function probeLiveClient(
       ].join(' ');
       return { ok: false, failDetail: `stream opened but no model response — ${diag}` };
     }
+    if (secondTurnText && !firstTurnSettled) {
+      return { ok: false, failDetail: 'first turn never completed — second turn was never sent' };
+    }
     return {
       ok: true,
-      metrics: { connect_ms: connectMs, first_event_ms: firstEventMs, first_audio_ms: firstAudioMs },
+      metrics: {
+        connect_ms: connectMs,
+        first_event_ms: firstEventMs,
+        first_audio_ms: firstAudioMs,
+        second_turn_ms: secondTurnMs,
+        second_turn_first_audio_ms: secondTurnFirstAudioMs,
+      },
     };
   } catch (err) {
     await client.close(`${closeReason}_failed`).catch(() => { /* idempotent */ });
@@ -197,7 +259,9 @@ async function probeLiveClient(
 }
 
 function formatProbeMetrics(m: LiveProbeMetrics): string {
-  return `connect_ms=${m.connect_ms} first_event_ms=${m.first_event_ms} first_audio_ms=${m.first_audio_ms < 0 ? 'n/a' : m.first_audio_ms}`;
+  const base = `connect_ms=${m.connect_ms} first_event_ms=${m.first_event_ms} first_audio_ms=${m.first_audio_ms < 0 ? 'n/a' : m.first_audio_ms}`;
+  if (m.second_turn_ms < 0) return base;
+  return `${base} second_turn_ms=${m.second_turn_ms} second_turn_first_audio_ms=${m.second_turn_first_audio_ms < 0 ? 'n/a' : m.second_turn_first_audio_ms}`;
 }
 
 /**
@@ -474,6 +538,7 @@ export async function runNovaSonicTestSuite(options: {
       }),
       'nova_test_probe',
       (err) => classifyNovaError(err),
+      'What is the capital of France?',
     );
     if (!result.ok) return { status: 'fail', detail: result.failDetail ?? 'nova_stream_error' };
     novaMetrics = result.metrics!;
@@ -579,6 +644,7 @@ export async function runNovaSonicTestSuite(options: {
       }),
       'nova_bench_vertex_baseline',
       (err) => `vertex_probe_failed: ${((err as Error)?.message ?? 'unknown').slice(0, 120)}`,
+      'What is the capital of France?',
     );
     if (!result.ok) return { status: 'fail', detail: result.failDetail ?? 'vertex_probe_failed' };
     vertexMetrics = result.metrics!;

--- a/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/nova-sonic-test-runner.ts
@@ -144,7 +144,11 @@ interface LiveProbeResult {
 /** 32ms of 16 kHz / 16-bit / mono PCM silence, base64 — one mic frame. */
 const SILENCE_FRAME_B64 = Buffer.alloc(1024).toString('base64');
 
-async function probeLiveClient(
+// Exported for tests only — the second-turn failure paths (stream closes /
+// errors / times out after turn 1, or sendTextTurn refuses because the
+// stream is not open) cannot be reached through runNovaSonicTestSuite
+// without opening a real paid Bedrock stream.
+export async function probeLiveClient(
   client: UpstreamLiveClient,
   connect: () => Promise<void>,
   closeReason: string,
@@ -168,6 +172,7 @@ async function probeLiveClient(
   let secondTurnMs = -1;
   let secondTurnFirstAudioMs = -1;
   let firstTurnSettled = false;
+  let secondTurnSendFailed = false;
   let allSettled = false;
 
   const done = new Promise<void>((resolve) => {
@@ -197,9 +202,11 @@ async function probeLiveClient(
         // real multi-turn conversation exactly.
         turnPhase = 'second';
         secondTurnStart = Date.now();
-        try {
-          client.sendTextTurn(secondTurnText);
-        } catch {
+        // sendTextTurn returns false (never throws) when the stream is not
+        // open — ignoring the return value would hang until the timeout and
+        // then report a false pass, defeating the point of this probe.
+        if (!client.sendTextTurn(secondTurnText)) {
+          secondTurnSendFailed = true;
           clearTimeout(timer);
           finishAll();
         }
@@ -241,6 +248,26 @@ async function probeLiveClient(
     }
     if (secondTurnText && !firstTurnSettled) {
       return { ok: false, failDetail: 'first turn never completed — second turn was never sent' };
+    }
+    // A requested second turn that never completed MUST fail. Otherwise the
+    // probe built specifically to catch broken/slow follow-up turns reports
+    // a pass with second_turn_ms=-1 and the comparison checks downstream
+    // silently proceed on a turn that never happened.
+    if (secondTurnText && secondTurnMs < 0) {
+      const reason = secondTurnSendFailed
+        ? 'stream was not open when the second turn was submitted'
+        : errorCodes.length
+          ? `errors=${errorCodes.join('|')}`
+          : upstreamCloseReason
+            ? `stream closed (${upstreamCloseReason})`
+            : `no turn_complete within ${PROBE_TIMEOUT_MS * 2}ms`;
+      return {
+        ok: false,
+        failDetail:
+          `second turn did not complete — ${reason}` +
+          ` (first turn ok: first_event_ms=${firstEventMs}` +
+          `, second_turn_first_audio_ms=${secondTurnFirstAudioMs < 0 ? 'n/a' : secondTurnFirstAudioMs})`,
+      };
     }
     return {
       ok: true,

--- a/services/gateway/test/services/voice-lab/nova-sonic-test-runner.test.ts
+++ b/services/gateway/test/services/voice-lab/nova-sonic-test-runner.test.ts
@@ -8,7 +8,42 @@
 import {
   runNovaSonicTestSuite,
   listNovaTestRuns,
+  probeLiveClient,
 } from '../../../src/services/voice-lab/nova-sonic-test-runner';
+
+/**
+ * Minimal fake UpstreamLiveClient — lets the second-turn probe paths be
+ * driven deterministically without opening a real (paid) Bedrock stream.
+ * Handlers are captured so the test can fire turn_complete / error / close
+ * in whatever order the scenario needs.
+ */
+function makeFakeClient(opts: { secondSendReturns?: boolean } = {}) {
+  const handlers: Record<string, (e: any) => void> = {};
+  let sendTextCalls = 0;
+  const client = {
+    connect: jest.fn(async () => { /* opened by the test's connect fn */ }),
+    sendAudioChunk: () => true,
+    sendTextTurn: (_text: string) => {
+      sendTextCalls++;
+      // First call is the probe's own "Say OK."; the second is the
+      // follow-up turn whose submission the scenario controls.
+      if (sendTextCalls >= 2 && opts.secondSendReturns === false) return false;
+      return true;
+    },
+    sendEndOfTurn: () => true,
+    sendToolResult: () => true,
+    onAudioOutput: (h: any) => { handlers.audio = h; },
+    onTranscript: (h: any) => { handlers.transcript = h; },
+    onToolCall: (h: any) => { handlers.tool = h; },
+    onTurnComplete: (h: any) => { handlers.turnComplete = h; },
+    onInterrupted: (h: any) => { handlers.interrupted = h; },
+    onError: (h: any) => { handlers.error = h; },
+    onClose: (h: any) => { handlers.close = h; },
+    close: jest.fn(async () => { /* idempotent */ }),
+    getState: () => 'open' as const,
+  };
+  return { client: client as any, handlers, sendTextCalls: () => sendTextCalls };
+}
 
 describe('runNovaSonicTestSuite', () => {
   const savedEnv = { ...process.env };
@@ -75,5 +110,107 @@ describe('runNovaSonicTestSuite', () => {
     const runs = listNovaTestRuns();
     expect(runs.length).toBeGreaterThan(0);
     expect(runs[0].checks.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The probe exists to catch broken/slow SECOND turns. If a requested second
+ * turn never completes, it must FAIL — reporting a pass with
+ * second_turn_ms=-1 would mask exactly the failure it was built to detect.
+ */
+describe('probeLiveClient — second-turn completion is required, never a silent pass', () => {
+  const noopClassify = (e: unknown) => `failed: ${String(e)}`;
+  /** Let the probe get past `await connect()` so its first turn is in flight. */
+  const flush = async () => { for (let i = 0; i < 5; i++) await Promise.resolve(); };
+
+  it('both turns complete → pass, with the second turn timed separately', async () => {
+    const { client, handlers } = makeFakeClient();
+    const probe = probeLiveClient(
+      client,
+      async () => { /* connected */ },
+      'test_probe',
+      noopClassify,
+      'follow-up question',
+    );
+    await flush();
+    handlers.audio?.({});         // turn 1 output
+    handlers.turnComplete?.({});  // turn 1 done → probe submits turn 2
+    handlers.audio?.({});         // turn 2 output
+    handlers.turnComplete?.({});  // turn 2 done
+    const result = await probe;
+    expect(result.ok).toBe(true);
+    expect(result.metrics!.second_turn_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('stream closes after turn 1 → FAIL, not a pass with second_turn_ms=-1', async () => {
+    const { client, handlers } = makeFakeClient();
+    const probe = probeLiveClient(
+      client,
+      async () => { /* connected */ },
+      'test_probe',
+      noopClassify,
+      'follow-up question',
+    );
+    await flush();
+    handlers.audio?.({});             // first turn produced output
+    handlers.turnComplete?.({});      // turn 1 done → probe submits turn 2
+    handlers.close?.({ reason: 'upstream_gone' }); // dies before turn 2 completes
+    const result = await probe;
+    expect(result.ok).toBe(false);
+    expect(result.failDetail).toMatch(/second turn did not complete/);
+    expect(result.failDetail).toMatch(/upstream_gone/);
+  });
+
+  it('stream errors after turn 1 → FAIL with the error code surfaced', async () => {
+    const { client, handlers } = makeFakeClient();
+    const probe = probeLiveClient(
+      client,
+      async () => { /* connected */ },
+      'test_probe',
+      noopClassify,
+      'follow-up question',
+    );
+    await flush();
+    handlers.audio?.({});
+    handlers.turnComplete?.({});
+    handlers.error?.({ code: 'nova_validation' });
+    const result = await probe;
+    expect(result.ok).toBe(false);
+    expect(result.failDetail).toMatch(/second turn did not complete/);
+    expect(result.failDetail).toMatch(/nova_validation/);
+  });
+
+  it('sendTextTurn refuses the second turn (stream not open) → FAIL, return value not ignored', async () => {
+    const { client, handlers } = makeFakeClient({ secondSendReturns: false });
+    const probe = probeLiveClient(
+      client,
+      async () => { /* connected */ },
+      'test_probe',
+      noopClassify,
+      'follow-up question',
+    );
+    await flush();
+    handlers.audio?.({});
+    handlers.turnComplete?.({}); // probe tries to submit turn 2; send returns false
+    const result = await probe;
+    expect(result.ok).toBe(false);
+    expect(result.failDetail).toMatch(/second turn did not complete/);
+    expect(result.failDetail).toMatch(/not open when the second turn was submitted/);
+  });
+
+  it('no second turn requested → single-turn behavior unchanged (still passes)', async () => {
+    const { client, handlers } = makeFakeClient();
+    const probe = probeLiveClient(
+      client,
+      async () => { /* connected */ },
+      'test_probe',
+      noopClassify,
+    );
+    await flush();
+    handlers.audio?.({});
+    handlers.turnComplete?.({});
+    const result = await probe;
+    expect(result.ok).toBe(true);
+    expect(result.metrics?.second_turn_ms).toBe(-1);
   });
 });


### PR DESCRIPTION
## Context

Follow-up to #2997's per-turn latency investigation (7-10s reported on Nova turn 2+). Found that production's `voice.latency.measured` OASIS telemetry — which already has a full per-phase breakdown tagged by provider + turn index — has **zero turn>0 samples across 500 events / 25 days of history**. 100% of captured events are the existing single-turn CI smoke probe, which only exercises turn 0 (connect + greeting). Real per-turn latency has never actually been measured in production; it's only been inferred from one documented log line (`drain_wait_ms=9968`).

## Change

Extends `probeLiveClient` (used by both the Nova and Vertex-baseline live checks in `nova-sonic-test-runner.ts`) to optionally send a second turn on the **same open stream** immediately after the first turn completes — exactly how a real turn 2 happens, no reconnect — and time it separately (`second_turn_ms` / `second_turn_first_audio_ms`).

Diagnostic-only, opt-in (`live: true`), no production hot-path impact.

## How to get a real number

Once deployed to staging, either:
- Click the existing **Nova Sonic Test Bench** live-probe button in the Command Hub, or
- `POST /api/v1/voice-lab/nova/tests/run` with `{"live": true}` (service token / GCP SA / exafy_admin auth)

The `live_connect_probe` and `vertex_baseline_probe` check results will now include `second_turn_ms` — the first real measured Nova turn-2 latency number.

## Testing
- [x] `tsc` typecheck clean (pre-existing unrelated `aws-ecs-admin.ts` error only)
- [x] `nova-sonic-test-runner.test.ts` passes unchanged (4/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_