### PR TITLE
fix(orb): dedupe confirmation-reuse guidance in navigate_to_screen

### DIFF
--- a/services/gateway/src/orb/live/tools/live-tool-catalog.ts
+++ b/services/gateway/src/orb/live/tools/live-tool-catalog.ts
@@ -2159,9 +2159,6 @@ export function buildLiveApiTools(
             '',
             '── "MY MATCHES" — do not confuse the list with a single detail ──',
             'INTENTS.MATCH_DETAIL is a SINGLE match\'s detail page — it requires a real `match_id` you already have from context (e.g. the user just discussed that specific match). For "show me my matches" / "My Matches" / any general request to see their matches, use COMM.FIND_PARTNER_MATCHES (mobile) or COMM.MATCHES (desktop) instead — those need no parameter. Calling INTENTS.MATCH_DETAIL without a real match_id always fails.',
-            '',
-            '── CONFIRMING A DESTINATION YOU JUST OFFERED ──',
-            'If you just offered to take the user somewhere by name (e.g. you asked "Should I take you to Connected Apps?" or "Soll ich dich zu den verbundenen Apps bringen?") and the user simply confirms without repeating the destination ("yes", "ja", "mach das", "do it", "gerne", "klar", "sure"), call this tool with the SAME screen_id you already resolved for that offer. A bare confirmation carries no screen information on its own — do not treat it as a new, unresolvable request and do not ask again; reuse the screen_id from your own last offer.',
           ].join('\n'),
           parameters: {
             type: 'object',

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -1609,9 +1609,6 @@ If the catalog entry has \`:param\` placeholders, also send the param: \`match_i
 ── "MY MATCHES" — do not confuse the list with a single detail ──
 INTENTS.MATCH_DETAIL is a SINGLE match's detail page — it requires a real \`match_id\` you already have from context (e.g. the user just discussed that specific match). For "show me my matches" / "My Matches" / any general request to see their matches, use COMM.FIND_PARTNER_MATCHES (mobile) or COMM.MATCHES (desktop) instead — those need no parameter. Calling INTENTS.MATCH_DETAIL without a real match_id always fails.
 
-── CONFIRMING A DESTINATION YOU JUST OFFERED ──
-If you just offered to take the user somewhere by name (e.g. you asked "Should I take you to Connected Apps?" or "Soll ich dich zu den verbundenen Apps bringen?") and the user simply confirms without repeating the destination ("yes", "ja", "mach das", "do it", "gerne", "klar", "sure"), call this tool with the SAME screen_id you already resolved for that offer. A bare confirmation carries no screen information on its own — do not treat it as a new, unresolvable request and do not ask again; reuse the screen_id from your own last offer.
-
 ### scan_existing_matches
 BEFORE posting an intent, call this to see who is already in the catalog with a similar ask.
 Use the same intent_kind you would pass to post_intent + the category_prefix (e.g. dance.) and
@@ -4479,9 +4476,6 @@ If the catalog entry has \`:param\` placeholders, also send the param: \`match_i
 
 ── "MY MATCHES" — do not confuse the list with a single detail ──
 INTENTS.MATCH_DETAIL is a SINGLE match's detail page — it requires a real \`match_id\` you already have from context (e.g. the user just discussed that specific match). For "show me my matches" / "My Matches" / any general request to see their matches, use COMM.FIND_PARTNER_MATCHES (mobile) or COMM.MATCHES (desktop) instead — those need no parameter. Calling INTENTS.MATCH_DETAIL without a real match_id always fails.
-
-── CONFIRMING A DESTINATION YOU JUST OFFERED ──
-If you just offered to take the user somewhere by name (e.g. you asked "Should I take you to Connected Apps?" or "Soll ich dich zu den verbundenen Apps bringen?") and the user simply confirms without repeating the destination ("yes", "ja", "mach das", "do it", "gerne", "klar", "sure"), call this tool with the SAME screen_id you already resolved for that offer. A bare confirmation carries no screen information on its own — do not treat it as a new, unresolvable request and do not ask again; reuse the screen_id from your own last offer.
 
 ### scan_existing_matches
 BEFORE posting an intent, call this to see who is already in the catalog with a similar ask.

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -2226,10 +2226,7 @@ Overlays (entry_kind=overlay): they open as a popup/drawer on the current screen
 If the catalog entry has \`:param\` placeholders, also send the param: \`match_id\` for INTENTS.MATCH_DETAIL; \`vitana_id\` (+ optional \`intent_id\`) for PROFILE.PUBLIC / PROFILE.WITH_MATCH; \`meetup_id\` / \`event_id\` for OVERLAY.MEETUP_DRAWER / OVERLAY.EVENT_DRAWER; \`user_id\` for OVERLAY.PROFILE_PREVIEW; \`id\` for DISCOVER.PRODUCT_DETAIL / DISCOVER.PROVIDER_PROFILE / NEWS.DETAIL; \`groupId\` for COMM.GROUP_DETAIL; \`roomId\` for COMM.LIVE_ROOM_VIEWER. NEVER invent/guess a value for any of these params — if you do not already know the real id from context, use the corresponding LIST/overview screen instead (see below) or ask the user which one they mean.
 
 ── "MY MATCHES" — do not confuse the list with a single detail ──
-INTENTS.MATCH_DETAIL is a SINGLE match's detail page — it requires a real \`match_id\` you already have from context (e.g. the user just discussed that specific match). For "show me my matches" / "My Matches" / any general request to see their matches, use COMM.FIND_PARTNER_MATCHES (mobile) or COMM.MATCHES (desktop) instead — those need no parameter. Calling INTENTS.MATCH_DETAIL without a real match_id always fails.
-
-── CONFIRMING A DESTINATION YOU JUST OFFERED ──
-If you just offered to take the user somewhere by name (e.g. you asked "Should I take you to Connected Apps?" or "Soll ich dich zu den verbundenen Apps bringen?") and the user simply confirms without repeating the destination ("yes", "ja", "mach das", "do it", "gerne", "klar", "sure"), call this tool with the SAME screen_id you already resolved for that offer. A bare confirmation carries no screen information on its own — do not treat it as a new, unresolvable request and do not ask again; reuse the screen_id from your own last offer.",
+INTENTS.MATCH_DETAIL is a SINGLE match's detail page — it requires a real \`match_id\` you already have from context (e.g. the user just discussed that specific match). For "show me my matches" / "My Matches" / any general request to see their matches, use COMM.FIND_PARTNER_MATCHES (mobile) or COMM.MATCHES (desktop) instead — those need no parameter. Calling INTENTS.MATCH_DETAIL without a real match_id always fails.",
         "name": "navigate_to_screen",
         "parameters": {
           "properties": {
@@ -14971,10 +14968,7 @@ Overlays (entry_kind=overlay): they open as a popup/drawer on the current screen
 If the catalog entry has \`:param\` placeholders, also send the param: \`match_id\` for INTENTS.MATCH_DETAIL; \`vitana_id\` (+ optional \`intent_id\`) for PROFILE.PUBLIC / PROFILE.WITH_MATCH; \`meetup_id\` / \`event_id\` for OVERLAY.MEETUP_DRAWER / OVERLAY.EVENT_DRAWER; \`user_id\` for OVERLAY.PROFILE_PREVIEW; \`id\` for DISCOVER.PRODUCT_DETAIL / DISCOVER.PROVIDER_PROFILE / NEWS.DETAIL; \`groupId\` for COMM.GROUP_DETAIL; \`roomId\` for COMM.LIVE_ROOM_VIEWER. NEVER invent/guess a value for any of these params — if you do not already know the real id from context, use the corresponding LIST/overview screen instead (see below) or ask the user which one they mean.
 
 ── "MY MATCHES" — do not confuse the list with a single detail ──
-INTENTS.MATCH_DETAIL is a SINGLE match's detail page — it requires a real \`match_id\` you already have from context (e.g. the user just discussed that specific match). For "show me my matches" / "My Matches" / any general request to see their matches, use COMM.FIND_PARTNER_MATCHES (mobile) or COMM.MATCHES (desktop) instead — those need no parameter. Calling INTENTS.MATCH_DETAIL without a real match_id always fails.
-
-── CONFIRMING A DESTINATION YOU JUST OFFERED ──
-If you just offered to take the user somewhere by name (e.g. you asked "Should I take you to Connected Apps?" or "Soll ich dich zu den verbundenen Apps bringen?") and the user simply confirms without repeating the destination ("yes", "ja", "mach das", "do it", "gerne", "klar", "sure"), call this tool with the SAME screen_id you already resolved for that offer. A bare confirmation carries no screen information on its own — do not treat it as a new, unresolvable request and do not ask again; reuse the screen_id from your own last offer.",
+INTENTS.MATCH_DETAIL is a SINGLE match's detail page — it requires a real \`match_id\` you already have from context (e.g. the user just discussed that specific match). For "show me my matches" / "My Matches" / any general request to see their matches, use COMM.FIND_PARTNER_MATCHES (mobile) or COMM.MATCHES (desktop) instead — those need no parameter. Calling INTENTS.MATCH_DETAIL without a real match_id always fails.",
         "name": "navigate_to_screen",
         "parameters": {
           "properties": {


### PR DESCRIPTION
## Summary

PR #2996 and PR #2998 independently fixed the same gap — `navigate_to_screen` missing the "reuse your last offer on a bare confirmation" guidance that `navigate` already had (from #2855) — and merged ~12 minutes apart. Git had no textual conflict since both insertions landed at different points in the same array literal, so `main` ended up with the same instruction duplicated in `navigate_to_screen`'s description, in two slightly different wordings.

Not a functional break (both blocks say the same thing), but it's redundant instruction text sent to the model on every call.

## Changes

- `services/gateway/src/orb/live/tools/live-tool-catalog.ts` — removed the later (#2996) duplicate block, kept #2998's earlier-positioned version.
- Regenerated the two characterization snapshots that embed this description verbatim (`tool-catalog.characterization.test.ts.snap`, `system-instruction.characterization.test.ts.snap`) — hand-edited to match (no `node_modules`/npm registry access in this sandbox; CI's Jest suite will confirm the snapshots match exactly).

## Testing

- `npx tsc --noEmit` passes clean (string-only change).
- Manually verified via grep that both source and both snapshot files now contain exactly one `navigate_to_screen`-scoped "CONFIRMING A DESTINATION" block (down from two), leaving the pre-existing unrelated `navigate`-tool block untouched.

## Breaking Changes

None — prompt/tool-description text only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3z6fKEY5maHGpRfqkQh18)_