### PR TITLE
fix: AP-0907 hourly local-hour gating, AP-0911 batch cap + time budget

### DIFF
--- a/docs/autopilot-automations/09-memory-intelligence.md
+++ b/docs/autopilot-automations/09-memory-intelligence.md
@@ -128,11 +128,18 @@ Fans `extractPatternsForUser` (guide/pattern-extractor, VTID-01936 — previousl
 |-------|-------|
 | **Status** | `IMPLEMENTED` |
 | **Priority** | `P2` |
-| **Trigger** | Cron, daily 18:10 |
+| **Trigger** | Cron, hourly at :10 |
 | **Handler** | `runDailyLearningDigest` |
 
 **What it does:**
 The standalone half of the shared felt-learning detector (`conversation/new-facts-detector.ts`): notifies users who gained `memory_facts` in the last 24h but did not get the moment in a session (greeting-ledger `facts_learned` not spoken today, `learning_surfaced_v1` not stamped today). Localized via the gateway i18n catalog; silent when nothing new.
+
+Runs hourly rather than once daily at a fixed UTC time — a single fixed
+18:10 UTC fire delivered this "evening" push at the wrong local time for
+anyone not near UTC (e.g. ~2am for UTC+8). Each user is only notified
+during their own local 18:xx hour, gated per-user via `getUserTimezone` /
+`userLocalHour` (`daily-pace-service.ts`) — the same resolution the
+existing daily-pace-notifications automation uses.
 
 ---
 
@@ -184,11 +191,20 @@ Drains the fact-embedding backlog (96% of live facts were unembedded, blinding t
 |-------|-------|
 | **Status** | `IMPLEMENTED` |
 | **Priority** | `P1` |
-| **Trigger** | Cron, daily 5:05am |
+| **Trigger** | Cron, hourly at :35 |
 | **Handler** | `runUserModelSynthesis` |
 
 **What it does:**
 One LLM pass per active user (≥3 facts) connecting facts + routines + active goal + Vitana Index into a compact grounded narrative ("who is this person"), stored in `user_assistant_state` (`user_profile_narrative_v1`) and injected by the UserContextProfiler into the TTL-cached ORB bootstrap — synthesized understanding at zero added latency. Skips users whose inputs hash is unchanged.
+
+Runs hourly in batches of 25 (highest fact-count users first) with a hard
+4-minute per-run time budget, instead of one daily pass over every eligible
+user — a serial LLM-call loop bounded by a single synchronous HTTP request
+risked silently exceeding Cloud Scheduler's 300s `--attempt-deadline` as the
+eligible pool grew, with no partial-progress recovery. Any users not
+reached within the time budget are simply picked up on the next hourly
+pass; the inputs-hash skip keeps already-synthesized users a cheap no-op,
+so the batch naturally rotates to whoever is actually stale.
 
 ---
 

--- a/scripts/setup-cloud-scheduler.sh
+++ b/scripts/setup-cloud-scheduler.sh
@@ -87,16 +87,33 @@ JOBS=(
 # single-user local-time notification slot — same reasoning as the
 # daily-recompute / daily-pace-notifications jobs further down this
 # file, which are also UTC.
+#
+# UPDATE (PR #2969 code review, chatgpt-codex-connector): AP-0907 and
+# AP-0911 were flagged and fixed before their jobs were ever created —
+#   - AP-0907 (Daily Learning Digest): was daily 18:10 UTC. A fixed UTC
+#     fire sends this user-facing "evening" push at the wrong local hour
+#     for anyone not near UTC (~2am for UTC+8). Now hourly; the handler
+#     itself resolves each user's real timezone and only notifies during
+#     their own local evening hour (mirrors daily-pace-notifications'
+#     per-user local-hour gate) — the UTC cron cadence is unchanged in
+#     spirit (still "backend sweep, not a notification slot"), the
+#     handler is what makes the delivery timezone-correct now.
+#   - AP-0911 (User Model Synthesis): was daily 5:05 UTC processing up to
+#     100 users serially through an LLM call each — a large eligible pool
+#     could exceed the 300s scheduler attempt-deadline and never
+#     complete (nor retry successfully). Now hourly with a smaller batch
+#     + a hard per-run time budget, so it always returns before the
+#     deadline; anything left over is picked up next hour.
 # ──────────────────────────────────────────────────────────────
 MEMORY_INTELLIGENCE_JOBS=(
   "AP-0906|memory-routine-pattern-extraction|30 3 * * *|UTC"
   "AP-0909|memory-relationship-graph-projection|50 3 * * *|UTC"
   "AP-0908|memory-behavior-preference-inference|40 4 * * *|UTC"
   "AP-0912|memory-health-correlation-insights|55 4 * * *|UTC"
-  "AP-0911|memory-user-model-synthesis|5 5 * * *|UTC"
+  "AP-0911|memory-user-model-synthesis|35 * * * *|UTC"
   "AP-0913|memory-own-post-capture|15 * * * *|UTC"
   "AP-0910|memory-embedding-backfill|25 * * * *|UTC"
-  "AP-0907|memory-daily-learning-digest|10 18 * * *|UTC"
+  "AP-0907|memory-daily-learning-digest|10 * * * *|UTC"
 )
 
 for JOB in "${MEMORY_INTELLIGENCE_JOBS[@]}"; do

--- a/services/gateway/src/services/automation-handlers/memory-intelligence.ts
+++ b/services/gateway/src/services/automation-handlers/memory-intelligence.ts
@@ -16,6 +16,7 @@ import {
   readLearningSurfacedAt,
 } from '../conversation/new-facts-detector';
 import { SIGNAL_GREETING_FACTS, parseFacts } from '../conversation/greeting-facts-ledger';
+import { getUserTimezone, userLocalHour } from '../daily-pace-service';
 
 // ── AP-0901: Memory-Informed Matching ───────────────────────
 // On a positive match reaction, look up the user's most recent self-facts
@@ -219,11 +220,19 @@ async function runRoutinePatternExtraction(ctx: AutomationContext) {
 // a deep link into the Memory Garden. Silent when nothing new — no filler.
 const LEARNING_DIGEST_WINDOW_MS = 24 * 3600 * 1000;
 const LEARNING_DIGEST_MAX_USERS_PER_RUN = 500;
+// BOOTSTRAP-MEMORY-DAILY-LEARNING (PR #2969 review): this automation now
+// runs hourly (registry cron '10 * * * *') instead of once daily at a fixed
+// 18:10 UTC — a fixed UTC fire delivered this "evening" push at the wrong
+// local time for anyone not near UTC (e.g. ~2am for UTC+8). Each user is
+// only notified during their OWN local evening hour, resolved the same way
+// daily-pace-service.ts already does for daily-pace-notifications.
+const LEARNING_DIGEST_LOCAL_HOUR = 18;
 
 async function runDailyLearningDigest(ctx: AutomationContext) {
   const { supabase, tenantId } = ctx;
   const nowMs = Date.now();
-  const nowIso = new Date(nowMs).toISOString();
+  const nowUtc = new Date(nowMs);
+  const nowIso = nowUtc.toISOString();
   const today = nowIso.slice(0, 10);
   const sinceIso = new Date(nowMs - LEARNING_DIGEST_WINDOW_MS).toISOString();
 
@@ -250,6 +259,14 @@ async function runDailyLearningDigest(ctx: AutomationContext) {
   let usersAffected = 0;
   for (const userId of userIds) {
     try {
+      // Local-evening gate: only fire during this user's own local 18:xx
+      // hour. The hourly cron sweeps every UTC hour, so every timezone
+      // (including fractional offsets like Asia/Kathmandu) gets exactly
+      // one matching tick per day — same reasoning daily-pace-service.ts
+      // documents for its 19:xx gate.
+      const tz = await getUserTimezone(supabase, userId, tenantId);
+      if (userLocalHour(nowUtc, tz) !== LEARNING_DIGEST_LOCAL_HOUR) continue;
+
       // Guard 1: greeting already surfaced learning in a session today (3e wins).
       const { data: ledgerRow } = await supabase
         .from('user_assistant_state')
@@ -663,14 +680,30 @@ async function runMemoryEmbeddingBackfill(ctx: AutomationContext) {
 }
 
 // ── AP-0911: User Model Synthesis ───────────────────────────
-// Nightly narrative profile per active user (see user-model-synthesis.ts):
-// one LLM pass connects facts + routines + goal + Vitana Index into a
-// compact "who is this person" paragraph the ORB bootstrap injects at zero
-// latency cost. Skips users with <3 facts and unchanged inputs.
-const SYNTHESIS_MAX_USERS_PER_RUN = 100;
+// Narrative profile per active user (see user-model-synthesis.ts): one LLM
+// pass connects facts + routines + goal + Vitana Index into a compact "who
+// is this person" paragraph the ORB bootstrap injects at zero latency cost.
+// Skips users with <3 facts and unchanged inputs.
+//
+// BOOTSTRAP-MEMORY-DAILY-LEARNING (PR #2969 review): previously ran once
+// daily processing up to 100 users serially through an LLM call each, inside
+// a single synchronous HTTP cron request. Cloud Scheduler's
+// --attempt-deadline=300s (and the gateway's own request wall) can cut that
+// connection before executeAutomation ever records completion — and since
+// the job only ran once a day, a large eligible pool meant it could
+// silently never finish (the retry hits the identical wall). Now hourly
+// (registry cron '35 * * * *') with a smaller per-run batch AND a hard time
+// budget that aborts the loop with whatever's done so far — unprocessed
+// users simply get picked up on the next hourly pass. synthesizeUserModel's
+// own inputs-hash skip makes already-synthesized, unchanged users a cheap
+// no-op, so the batch naturally rotates to whoever is actually stale —
+// mirrors AP-0910's proven hourly small-batch backlog-draining pattern.
+const SYNTHESIS_MAX_USERS_PER_RUN = 25;
+const SYNTHESIS_TIME_BUDGET_MS = 4 * 60 * 1000; // 4 min — safely under the 300s Cloud Scheduler deadline
 
 async function runUserModelSynthesis(ctx: AutomationContext) {
   const { supabase, tenantId } = ctx;
+  const runStartMs = Date.now();
 
   const { data: factRows, error } = await supabase
     .from('memory_facts')
@@ -694,7 +727,15 @@ async function runUserModelSynthesis(ctx: AutomationContext) {
 
   const { synthesizeUserModel } = await import('../user-model-synthesis');
   let written = 0;
+  let processed = 0;
   for (const userId of userIds) {
+    if (Date.now() - runStartMs > SYNTHESIS_TIME_BUDGET_MS) {
+      ctx.log(
+        `time budget exceeded after ${processed}/${userIds.length} users — remaining picked up next hourly run`,
+      );
+      break;
+    }
+    processed++;
     try {
       const result = await synthesizeUserModel(supabase, tenantId, userId);
       if (result.written) written++;
@@ -705,6 +746,7 @@ async function runUserModelSynthesis(ctx: AutomationContext) {
 
   await ctx.emitEvent('autopilot.memory.profiles_synthesized', {
     users_scanned: userIds.length,
+    users_processed: processed,
     narratives_written: written,
   });
   return { usersAffected: written, actionsTaken: written };

--- a/services/gateway/src/services/automation-registry.ts
+++ b/services/gateway/src/services/automation-registry.ts
@@ -794,9 +794,18 @@ const MEMORY_INTEL: AutomationDefinition[] = [
     // shared felt-learning detector; the greeting ledger (6th signal) wins
     // for users who opened a session, this catches the rest. Evening slot so
     // the day's conversations have been extracted.
+    //
+    // Hourly (not a single daily 18:10 UTC fire): a fixed UTC time sends the
+    // push at the wrong local hour for anyone not near UTC (e.g. ~2am for
+    // UTC+8) — flagged in PR #2969 review. runDailyLearningDigest now
+    // resolves each user's real timezone and only notifies during their own
+    // local 18:xx hour (mirrors daily-pace-service.ts's getUserTimezone/
+    // userLocalHour pattern), so the hourly sweep is what actually delivers
+    // "evening" correctly across timezones — same reasoning as
+    // daily-pace-notifications.
     id: 'AP-0907', name: 'Daily Learning Digest', domain: 'memory-intelligence',
     status: 'IMPLEMENTED', priority: 'P2', triggerType: 'cron',
-    triggerConfig: { cronExpression: '10 18 * * *' }, // daily 18:10
+    triggerConfig: { cronExpression: '10 * * * *' }, // hourly at :10
     targetRoles: [...MEMBER_ROLES],
     handler: 'runDailyLearningDigest',
   },
@@ -831,13 +840,25 @@ const MEMORY_INTEL: AutomationDefinition[] = [
     handler: 'runMemoryEmbeddingBackfill',
   },
   {
-    // Nightly narrative profile synthesis — one LLM pass per active user
-    // connecting facts/routines/goal/Index into a compact "who is this
-    // person" paragraph for the ORB bootstrap. After all nightly writers
-    // (AP-0906 3:30, AP-0909 3:50, AP-0908 4:40) so it reads fresh inputs.
+    // Narrative profile synthesis — one LLM pass per active user connecting
+    // facts/routines/goal/Index into a compact "who is this person"
+    // paragraph for the ORB bootstrap.
+    //
+    // Hourly with a small per-run batch + time budget (not a single daily
+    // 5:05am fire processing up to 100 users): flagged in PR #2969 review —
+    // a synchronous HTTP cron request serially running up to 100 LLM calls
+    // cannot reliably finish inside Cloud Scheduler's --attempt-deadline=
+    // 300s, so a large eligible pool made this job silently never complete
+    // (and never retry successfully, since the retry hits the same wall).
+    // runUserModelSynthesis now caps itself to a safe batch (25 users) and
+    // aborts early on a 4-minute time budget; unprocessed users are picked
+    // up on the next hourly pass — mirrors AP-0910's proven hourly small-
+    // batch backlog-draining pattern. synthesizeUserModel's own inputs-hash
+    // skip makes already-synthesized users a cheap no-op, so the batch
+    // naturally rotates to whoever's stale.
     id: 'AP-0911', name: 'User Model Synthesis', domain: 'memory-intelligence',
     status: 'IMPLEMENTED', priority: 'P1', triggerType: 'cron',
-    triggerConfig: { cronExpression: '5 5 * * *' }, // daily 5:05am
+    triggerConfig: { cronExpression: '35 * * * *' }, // hourly at :35
     targetRoles: [...MEMBER_ROLES],
     handler: 'runUserModelSynthesis',
   },

--- a/services/gateway/test/services/automation-handlers-phase2.test.ts
+++ b/services/gateway/test/services/automation-handlers-phase2.test.ts
@@ -53,6 +53,21 @@ jest.mock('../../src/services/orb-memory-bridge', () => ({
 import { writeMemoryItemWithIdentity } from '../../src/services/orb-memory-bridge';
 const mockedWriteMemoryItem = writeMemoryItemWithIdentity as jest.MockedFunction<typeof writeMemoryItemWithIdentity>;
 
+// AP-0907 resolves each user's own local hour (BOOTSTRAP-MEMORY-DAILY-LEARNING
+// hourly + per-user gating fix) via daily-pace-service's real getUserTimezone,
+// which itself queries app_users/user_preferences/memory_facts — mocking the
+// whole module keeps the existing queued-response fixtures below hermetic.
+// Only memory-intelligence.ts and scheduled-notifications.ts import from this
+// module (confirmed via grep), so this mock can't affect other handlers
+// registered/tested in this shared file.
+jest.mock('../../src/services/daily-pace-service', () => ({
+  getUserTimezone: jest.fn(async () => 'UTC'),
+  userLocalHour: jest.fn(() => 18), // matches LEARNING_DIGEST_LOCAL_HOUR
+}));
+import { getUserTimezone, userLocalHour } from '../../src/services/daily-pace-service';
+const mockedGetUserTimezone = getUserTimezone as jest.MockedFunction<typeof getUserTimezone>;
+const mockedUserLocalHour = userLocalHour as jest.MockedFunction<typeof userLocalHour>;
+
 registerPersonalizationEnginesHandlers();
 registerMemoryIntelligenceHandlers();
 registerEventMeetupInitiativeHandlers();
@@ -425,6 +440,32 @@ describe('runDailyLearningDigest (AP-0907)', () => {
     expect(notify).not.toHaveBeenCalled();
     expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
   });
+
+  it('skips a user outside their own local evening hour (hourly cron, per-user gate)', async () => {
+    // The cron now sweeps every UTC hour, so most ticks will hit a user
+    // whose local time is NOT 18:xx yet — the gate must silently skip them
+    // rather than notifying at the wrong local hour (the exact bug this
+    // fix addresses: a fixed 18:10 UTC fire landing at ~2am for UTC+8).
+    mockedUserLocalHour.mockReturnValueOnce(2);
+    const supabase = makeFakeSupabase({
+      memory_facts: [
+        { data: [{ user_id: 'u1' }], error: null },
+        { data: [{ fact_key: 'user_favorite_tea', fact_value: 'Earl Grey' }], error: null },
+      ],
+      user_assistant_state: [
+        { data: null, error: null },
+        { data: null, error: null },
+        { data: null, error: null },
+      ],
+      app_users: [{ data: [], error: null }],
+    });
+    const { ctx, notify } = makeCtx(supabase);
+    const handler = getHandler('runDailyLearningDigest')!;
+    const result = await handler(ctx);
+    expect(mockedGetUserTimezone).toHaveBeenCalledWith(supabase, 'u1', 't-1');
+    expect(notify).not.toHaveBeenCalled();
+    expect(result).toEqual({ usersAffected: 0, actionsTaken: 0 });
+  });
 });
 
 describe('runBehaviorPreferenceInference (AP-0908)', () => {
@@ -526,6 +567,60 @@ describe('runUserModelSynthesis (AP-0911)', () => {
     expect(mockedSynthesize).toHaveBeenCalledTimes(1);
     expect(mockedSynthesize).toHaveBeenCalledWith(supabase, 't-1', 'u1');
     expect(result).toEqual({ usersAffected: 1, actionsTaken: 1 });
+  });
+
+  it('caps a single run at 25 users, picking the highest fact-counts first', async () => {
+    // 30 eligible users (3 facts each) — the fix's hourly-small-batch
+    // redesign must slice to the top 25 by fact count, not attempt all 30
+    // in one synchronous HTTP request.
+    const factRows: Array<{ user_id: string }> = [];
+    for (let i = 0; i < 30; i++) {
+      const userId = `u${String(i).padStart(2, '0')}`;
+      const factCount = 3 + (30 - i); // strictly descending so order is deterministic
+      for (let f = 0; f < factCount; f++) factRows.push({ user_id: userId });
+    }
+    const supabase = makeFakeSupabase({ memory_facts: [{ data: factRows, error: null }] });
+    mockedSynthesize.mockReset();
+    mockedSynthesize.mockResolvedValue({ ok: true, written: true });
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runUserModelSynthesis')!;
+    const result = await handler(ctx);
+    expect(mockedSynthesize).toHaveBeenCalledTimes(25);
+    // Highest fact-count users are u00..u24 (descending counts) — the
+    // lowest-count stragglers u25..u29 must NOT be in this run.
+    expect(mockedSynthesize).toHaveBeenCalledWith(supabase, 't-1', 'u00');
+    expect(mockedSynthesize).not.toHaveBeenCalledWith(supabase, 't-1', 'u25');
+    expect(result).toEqual({ usersAffected: 25, actionsTaken: 25 });
+  });
+
+  it('stops early once the time budget is exceeded, leaving the rest for the next hourly run', async () => {
+    const factRows: Array<{ user_id: string }> = [];
+    for (let i = 0; i < 5; i++) {
+      const userId = `u${i}`;
+      for (let f = 0; f < 3; f++) factRows.push({ user_id: userId });
+    }
+    const supabase = makeFakeSupabase({ memory_facts: [{ data: factRows, error: null }] });
+    mockedSynthesize.mockReset();
+    // Simulate the 3rd synthesis call taking long enough to blow the budget:
+    // after it resolves, Date.now() has advanced past SYNTHESIS_TIME_BUDGET_MS
+    // (4 min), so the loop must abort before a 4th call.
+    let calls = 0;
+    const realDateNow = Date.now;
+    const startMs = realDateNow();
+    jest.spyOn(Date, 'now').mockImplementation(() => {
+      return calls >= 2 ? startMs + 5 * 60 * 1000 : startMs;
+    });
+    mockedSynthesize.mockImplementation(async () => {
+      calls++;
+      return { ok: true, written: true };
+    });
+    const { ctx } = makeCtx(supabase);
+    const handler = getHandler('runUserModelSynthesis')!;
+    const result = await handler(ctx);
+    (Date.now as jest.Mock).mockRestore();
+    expect(mockedSynthesize).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ usersAffected: 2, actionsTaken: 2 });
+    expect(ctx.log).toHaveBeenCalledWith(expect.stringContaining('time budget exceeded'));
   });
 });
 


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-MEMORY-DAILY-LEARNING` (follow-up to PR #2969; no dedicated VTID exists yet)

**Layer:** Autopilot Automations (memory-intelligence domain)

**Priority:** P1 / P2

---

## 📋 Summary

PR #2969 wired the AP-09xx memory-intelligence automations into `scripts/setup-cloud-scheduler.sh` for the first time, fixing the actual root cause of "daily learning never reaches users" (they were never scheduled at all). Its Codex review flagged two real correctness/safety bugs in the automations themselves, caught **before** anyone runs the scheduler script against real Cloud Scheduler — this PR fixes both while it's still free to do so:

- **AP-0907 (Daily Learning Digest, P2):** fired unconditionally at a single fixed `18:10 UTC` for every user regardless of timezone — "evening" at UTC lands at ~2am for a user near UTC+8.
- **AP-0911 (User Model Synthesis, P1):** ran a serial per-user LLM-call loop over every eligible user (previously capped at 100) inside one synchronous HTTP request bounded by Cloud Scheduler's 300s `--attempt-deadline`, with no partial-progress recovery if it ran long.

---

## ✅ Changes

- [x] AP-0907: registry cron changed to hourly (`10 * * * *`); handler now resolves each user's own timezone via the existing `getUserTimezone`/`userLocalHour` (`daily-pace-service.ts`) and only notifies during that user's local 18:xx hour.
- [x] AP-0911: registry cron changed to hourly (`35 * * * *`); handler batch size reduced from 100 to 25 users per run (highest fact-count first) and a hard 4-minute time budget aborts the loop early, leaving the rest for the next hourly pass.
- [x] `scripts/setup-cloud-scheduler.sh`'s `MEMORY_INTELLIGENCE_JOBS` entries for AP-0907/AP-0911 updated to match the new hourly schedules.
- [x] `docs/autopilot-automations/09-memory-intelligence.md` updated for both automations' new trigger cadence and behavior.
- [x] New tests: AP-0907 local-hour skip gate; AP-0911 batch-size cap and time-budget early-exit.

---

## 🧪 Testing

- [x] Automated tests added/updated (`services/gateway/test/services/automation-handlers-phase2.test.ts`)
- [x] `npm run build` (TypeScript) passes clean in `services/gateway`
- [x] Full gateway test suite run: 596 suites, 11745/11759 tests pass — only the pre-existing, unrelated `nav-manifest-sync` drift-gate failure remains (baseline, not touched by this change)
- [ ] Verified in staging/dev environment — N/A: these automations don't run at all until someone with `gcloud` access executes `setup-cloud-scheduler.sh`; not part of this PR

---

## 🚨 Breaking Changes

None. Both automations remain unreferenced by any real Cloud Scheduler job until `scripts/setup-cloud-scheduler.sh` is actually run against `lovable-vitana-vers1` — this PR only changes what that (future) run will provision, and the in-code cron/gating logic it ships with.

---

## 📌 Additional Notes

Once merged, the still-outstanding manual step from PR #2969 remains unchanged: someone with `gcloud` access must run `./scripts/setup-cloud-scheduler.sh --tenant <TENANT_ID>` against `lovable-vitana-vers1` to actually create the real Cloud Scheduler jobs — that is outside this session's access.


---
_Generated by [Claude Code](https://claude.ai/code/session_014nXnLyojrW5m8L9SegctxH)_