### PR TITLE
fix(orb): loop guard must not starve Nova's transport — deterministic 295s session death

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -65,6 +65,24 @@ import { getSupabase } from '../../../lib/supabase';
 import { VITANA_BOT_USER_ID } from '../../../lib/vitana-bot';
 
 /**
+ * BOOTSTRAP-NOVA-IDLE-KEEPALIVE: is this session on Amazon Nova Sonic?
+ *
+ * Exported for tests. Nova's Bedrock bidirectional stream terminates itself if
+ * it receives no audio/interactive content for ~295s ("Timed out waiting for
+ * audio bytes or interactive content"), so the synthetic PCM keepalive is a
+ * TRANSPORT REQUIREMENT there — unlike Vertex, where letting the stream idle is
+ * merely a way to end a runaway response loop. Anything that stops the
+ * keepalive must therefore check the provider first.
+ *
+ * Defaults to NOT-Nova when the field is absent, matching the `?? 'vertex'`
+ * fallback used elsewhere in this file, so the conservative existing behaviour
+ * is preserved for any session whose provider was never stamped.
+ */
+export function isNovaProvider(session: GeminiLiveSession): boolean {
+  return (session as any).upstreamProvider === 'nova_sonic';
+}
+
+/**
  * orb-live.ts-local helpers the handler body invokes. Future slices may
  * lift these out individually; until then, the deps-bag is the seam.
  */
@@ -397,12 +415,32 @@ export function createUpstreamLiveMessageHandler(
 
             // VTID-LOOPGUARD: If the model has responded too many times without user input,
             // pause the silence keepalive so Vertex's idle timeout stops the loop naturally.
-            if (session.consecutiveModelTurns > getMaxConsecutiveModelTurns() && !isGreetingTurn) {
+            //
+            // BOOTSTRAP-NOVA-IDLE-KEEPALIVE: this must NEVER run for Nova. The
+            // mechanism deliberately weaponises the provider's idle timeout to
+            // break a runaway loop — defensible on Vertex, fatal on Bedrock.
+            // Nova's idle deadline does not "idle the loop out", it TERMINATES
+            // THE STREAM ("Timed out waiting for audio bytes or interactive
+            // content ... less than 295 seconds"), killing the user's whole
+            // conversation. And the only re-arm site is inside the
+            // input_transcription handler below, so a user who then stays quiet
+            // never gets the keepalive back and the session dies deterministically
+            // ~295s after the last input. Stream rotation cannot save it either:
+            // rotationAfterMs defaults to 435_000, which is well past 295s.
+            //
+            // For Nova the PCM keepalive is TRANSPORT LIVENESS, not a
+            // conversation lever (audit C-30: keepalive and conversation
+            // semantics must not be conflated). Loop-breaking for Nova is
+            // handled by the tool/loop guards that act on the model rather than
+            // by starving the transport.
+            if (!isNovaProvider(session) && session.consecutiveModelTurns > getMaxConsecutiveModelTurns() && !isGreetingTurn) {
               console.warn(`[VTID-LOOPGUARD] Response loop detected for session ${session.sessionId}: ${session.consecutiveModelTurns} consecutive model turns without user speech — pausing silence keepalive`);
               if (session.silenceKeepaliveInterval) {
                 clearInterval(session.silenceKeepaliveInterval);
                 session.silenceKeepaliveInterval = undefined;
               }
+            } else if (isNovaProvider(session) && session.consecutiveModelTurns > getMaxConsecutiveModelTurns() && !isGreetingTurn) {
+              console.warn(`[VTID-LOOPGUARD] Response loop detected for session ${session.sessionId}: ${session.consecutiveModelTurns} consecutive model turns without user speech — keepalive PRESERVED (nova_sonic: starving the transport would terminate the Bedrock stream at its ~295s idle deadline)`);
             }
 
             // VTID-CHAT-BRIDGE: Capture transcript text at turn scope for chat_messages bridge (below)
@@ -2020,12 +2058,18 @@ export function handleTurnComplete(
   }
 
   // Loop guard: pause the silence keepalive so the provider idles the loop out.
-  if (session.consecutiveModelTurns > getMaxConsecutiveModelTurns() && !isGreetingTurn) {
+  // BOOTSTRAP-NOVA-IDLE-KEEPALIVE: never for Nova — see the identical guard in
+  // the raw-Gemini handler above for the full reasoning. Starving Bedrock of
+  // audio frames terminates the stream at its ~295s idle deadline instead of
+  // merely ending the loop.
+  if (!isNovaProvider(session) && session.consecutiveModelTurns > getMaxConsecutiveModelTurns() && !isGreetingTurn) {
     console.warn(`[VTID-LOOPGUARD] Response loop detected for session ${session.sessionId}: ${session.consecutiveModelTurns} consecutive model turns without user speech — pausing silence keepalive`);
     if (session.silenceKeepaliveInterval) {
       clearInterval(session.silenceKeepaliveInterval);
       session.silenceKeepaliveInterval = undefined;
     }
+  } else if (isNovaProvider(session) && session.consecutiveModelTurns > getMaxConsecutiveModelTurns() && !isGreetingTurn) {
+    console.warn(`[VTID-LOOPGUARD] Response loop detected for session ${session.sessionId}: ${session.consecutiveModelTurns} consecutive model turns without user speech — keepalive PRESERVED (nova_sonic: starving the transport would terminate the Bedrock stream at its ~295s idle deadline)`);
   }
 
   let chatBridgeUserText = '';

--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -440,7 +440,24 @@ export function createUpstreamLiveMessageHandler(
                 session.silenceKeepaliveInterval = undefined;
               }
             } else if (isNovaProvider(session) && session.consecutiveModelTurns > getMaxConsecutiveModelTurns() && !isGreetingTurn) {
-              console.warn(`[VTID-LOOPGUARD] Response loop detected for session ${session.sessionId}: ${session.consecutiveModelTurns} consecutive model turns without user speech — keepalive PRESERVED (nova_sonic: starving the transport would terminate the Bedrock stream at its ~295s idle deadline)`);
+              // Codex review on #3007: preserving the keepalive removed the ONLY
+              // brake on a response-only runaway loop (the hard ceiling in
+              // handleToolCall covers tool loops, not this). Log-only would have
+              // traded a disconnect for an unbounded loop. So take a Nova-safe
+              // action instead of starving the transport: stop forwarding the
+              // runaway turn's audio. Reuses the proven VTID-03143 flag, which
+              // auto-clears at turn_complete — and since this guard re-evaluates
+              // on every turn past the limit, it re-arms per turn for as long as
+              // the loop continues.
+              //
+              // HONEST LIMIT: this stops the user hearing the loop and stops the
+              // audio bandwidth. It does NOT stop Bedrock inference cost, because
+              // Nova has no working mid-turn stop (sendEndOfTurn() is a no-op).
+              // Cost containment needs the transparent-rotation fail-safe from the
+              // disconnect report (item 3) — replacing the stream is what actually
+              // ends a runaway generation. Tracked separately.
+              (session as any).suppressCurrentTurnAudio = true;
+              console.warn(`[VTID-LOOPGUARD] Response loop detected for session ${session.sessionId}: ${session.consecutiveModelTurns} consecutive model turns without user speech — keepalive PRESERVED and turn audio SUPPRESSED (nova_sonic: starving the transport would terminate the Bedrock stream at its ~295s idle deadline; suppression stops the runaway reaching the user but not Bedrock inference cost)`);
             }
 
             // VTID-CHAT-BRIDGE: Capture transcript text at turn scope for chat_messages bridge (below)
@@ -2069,7 +2086,12 @@ export function handleTurnComplete(
       session.silenceKeepaliveInterval = undefined;
     }
   } else if (isNovaProvider(session) && session.consecutiveModelTurns > getMaxConsecutiveModelTurns() && !isGreetingTurn) {
-    console.warn(`[VTID-LOOPGUARD] Response loop detected for session ${session.sessionId}: ${session.consecutiveModelTurns} consecutive model turns without user speech — keepalive PRESERVED (nova_sonic: starving the transport would terminate the Bedrock stream at its ~295s idle deadline)`);
+    // Codex review on #3007 — see the identical branch in the raw-Gemini handler
+    // above for the full reasoning. Nova-safe loop brake: suppress the runaway
+    // turn's audio rather than starving the Bedrock transport. Stops the user
+    // hearing it; does NOT stop inference cost (needs rotation, report item 3).
+    (session as any).suppressCurrentTurnAudio = true;
+    console.warn(`[VTID-LOOPGUARD] Response loop detected for session ${session.sessionId}: ${session.consecutiveModelTurns} consecutive model turns without user speech — keepalive PRESERVED and turn audio SUPPRESSED (nova_sonic: starving the transport would terminate the Bedrock stream at its ~295s idle deadline; suppression stops the runaway reaching the user but not Bedrock inference cost)`);
   }
 
   let chatBridgeUserText = '';

--- a/services/gateway/test/orb/live/session/nova-idle-keepalive.test.ts
+++ b/services/gateway/test/orb/live/session/nova-idle-keepalive.test.ts
@@ -76,7 +76,32 @@ describe('loop guard never starves the Nova transport', () => {
   it('keeps a Nova-specific log so a suppressed loop-break is still visible', () => {
     // Silently doing nothing would make a real runaway loop invisible. The
     // guard still fires, it just no longer kills the transport.
-    expect(source).toMatch(/keepalive PRESERVED \(nova_sonic/);
+    expect(source).toMatch(/keepalive PRESERVED/);
+  });
+
+  it('still BRAKES a Nova runaway loop instead of only logging', () => {
+    // Codex review on #3007: preserving the keepalive removed the only brake on
+    // a response-only runaway loop (handleToolCall's ceiling covers tool loops
+    // only). Log-only would trade a disconnect for an unbounded loop. Each Nova
+    // branch must take a real action — suppressing the runaway turn's audio.
+    const novaBranches = source
+      .split('\n')
+      .map((l, i) => ({ l, i }))
+      .filter(({ l }) => l.includes('isNovaProvider(session) && session.consecutiveModelTurns'));
+    expect(novaBranches.length).toBeGreaterThanOrEqual(2);
+
+    const lines = source.split('\n');
+    for (const { i } of novaBranches) {
+      // Within the branch body, an actual brake must be applied.
+      const body = lines.slice(i, i + 25).join('\n');
+      expect(body).toMatch(/suppressCurrentTurnAudio\s*=\s*true/);
+    }
+  });
+
+  it('is honest in-code that suppression does not stop inference cost', () => {
+    // Nova has no working mid-turn stop (sendEndOfTurn is a no-op), so the next
+    // reader must not assume cost is contained by this.
+    expect(source).toMatch(/not\s+Bedrock inference cost|does NOT stop Bedrock inference cost/);
   });
 
   it('documents why this is fatal for Nova specifically', () => {

--- a/services/gateway/test/orb/live/session/nova-idle-keepalive.test.ts
+++ b/services/gateway/test/orb/live/session/nova-idle-keepalive.test.ts
@@ -1,0 +1,87 @@
+/**
+ * BOOTSTRAP-NOVA-IDLE-KEEPALIVE — Nova's transport keepalive must never be
+ * stopped by the conversation loop guard.
+ *
+ * PRODUCTION INCIDENT (2026-07-30): a Nova session healthy for 10 turns was
+ * terminated by Bedrock with "Timed out waiting for audio bytes or interactive
+ * content ... less than 295 seconds", ~292s after the last user input. Of 46
+ * Nova sessions in 72h, 32 ended inside 60s (median 37.5s).
+ *
+ * ROOT CAUSE: VTID-LOOPGUARD clears session.silenceKeepaliveInterval after N
+ * consecutive model turns, with the explicit intent (per its own comment) of
+ * letting "Vertex's idle timeout stop the loop naturally". On Vertex that ends
+ * a runaway loop. On Nova the idle deadline TERMINATES THE STREAM. The only
+ * re-arm site is inside the input_transcription handler, so a user who goes
+ * quiet after the guard fires never gets the keepalive back, and the session
+ * dies deterministically. Rotation cannot rescue it either — rotationAfterMs
+ * defaults to 435_000ms, well past the 295s deadline.
+ *
+ * These tests pin the provider gate so the fatal-for-Nova path cannot come
+ * back. Asserted at source level because the two guard sites sit deep inside
+ * two very large handler bodies with heavy transport/session dependencies;
+ * isNovaProvider itself is exercised directly.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { isNovaProvider } from '../../../../src/orb/live/session/upstream-message-handler';
+import type { GeminiLiveSession } from '../../../../src/routes/orb-live';
+
+const HANDLER_PATH = path.resolve(
+  __dirname,
+  '../../../../src/orb/live/session/upstream-message-handler.ts',
+);
+
+describe('isNovaProvider', () => {
+  it('identifies a Nova session', () => {
+    expect(isNovaProvider({ upstreamProvider: 'nova_sonic' } as unknown as GeminiLiveSession)).toBe(true);
+  });
+
+  it('does not treat Vertex as Nova', () => {
+    expect(isNovaProvider({ upstreamProvider: 'vertex' } as unknown as GeminiLiveSession)).toBe(false);
+  });
+
+  it('defaults to NOT-Nova when the provider was never stamped', () => {
+    // Matches the `?? 'vertex'` fallback used elsewhere in the handler, so an
+    // unstamped session keeps the long-standing Vertex behaviour rather than
+    // silently acquiring Nova's.
+    expect(isNovaProvider({} as unknown as GeminiLiveSession)).toBe(false);
+  });
+});
+
+describe('loop guard never starves the Nova transport', () => {
+  const source = fs.readFileSync(HANDLER_PATH, 'utf8');
+
+  it('every loop-guard branch that can clear the keepalive is provider-gated', () => {
+    // Line-based: each guard condition sits on one line in this file.
+    const guardLines = source
+      .split('\n')
+      .filter((l) => l.includes('consecutiveModelTurns > getMaxConsecutiveModelTurns()'));
+
+    // Two known sites: the raw-Gemini turn handler and the shared
+    // handleTurnComplete path. Each has a negated clearing branch plus an
+    // affirmative Nova log branch → 4 lines. A new ungated site fails below.
+    expect(guardLines.length).toBeGreaterThanOrEqual(2);
+
+    // EVERY such condition must mention the provider gate. A line without it
+    // is either a reinstated unconditional clear or a new unguarded site.
+    const ungated = guardLines.filter((l) => !l.includes('isNovaProvider(session)'));
+    expect(ungated).toEqual([]);
+
+    // And the clearing variant specifically must use the NEGATED form.
+    const clearingBranches = guardLines.filter((l) => l.includes('!isNovaProvider(session)'));
+    expect(clearingBranches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('keeps a Nova-specific log so a suppressed loop-break is still visible', () => {
+    // Silently doing nothing would make a real runaway loop invisible. The
+    // guard still fires, it just no longer kills the transport.
+    expect(source).toMatch(/keepalive PRESERVED \(nova_sonic/);
+  });
+
+  it('documents why this is fatal for Nova specifically', () => {
+    // The next person to touch this must see the 295s deadline, otherwise the
+    // "just pause the keepalive" instinct returns.
+    expect(source).toMatch(/295s idle deadline|less than 295 seconds/);
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-NOVA-IDLE-KEEPALIVE`
**Priority:** **P0 live incident** — "Nova 2 Sonic is constantly disconnecting"

## 📋 The incident

A Nova session healthy for **10 turns** was terminated by Bedrock with:

> `Timed out waiting for audio bytes or interactive content … less than 295 seconds`

~292s after the last user input. Over 72h: **46 Nova sessions, 32 ended inside 60s, median length 37.5s.**

## 🔍 Root cause — confirmed in code, not inferred

`VTID-LOOPGUARD` clears `session.silenceKeepaliveInterval` once `consecutiveModelTurns` exceeds the max. Its own comment states the intent:

```js
// pause the silence keepalive so Vertex's idle timeout stops the loop naturally.
```

That's a defensible **Vertex-era** design — it weaponises the provider's idle timeout to break a runaway response loop.

**On Nova it is fatal.** Bedrock's idle deadline doesn't end a loop, it **terminates the bidirectional stream** and with it the user's entire conversation. Worse: the only re-arm site is inside the `input_transcription` handler, so a user who goes quiet *after* the guard fires never gets the keepalive back — the session dies **deterministically** ~295s later.

Rotation can't rescue it either: `rotationAfterMs` defaults to `435_000`, well past the deadline.

## ✅ The fix

Both unconditional-clear sites (raw-Gemini turn handler + shared `handleTurnComplete`) are now gated on `!isNovaProvider(session)`.

For Nova the synthetic PCM keepalive is **transport liveness**, not a conversation lever — exactly the conflation the audit flags as **C-30**. Loop-breaking for Nova belongs with the guards that act on the *model*, not with starving the transport.

The guard still fires and still logs for Nova (`keepalive PRESERVED`), so a genuine runaway loop stays **visible** rather than becoming silent.

`isNovaProvider()` defaults to NOT-Nova for an unstamped session, matching the `?? 'vertex'` fallback used elsewhere in this file — **no behaviour change for any non-Nova session.**

## 🧪 Testing

- [x] 6 tests: three on `isNovaProvider` (incl. the unstamped default), three pinning the guard
- [x] A **line-based** check that *every* loop-guard condition carries the gate, so a third site can't appear ungated
- [x] **Verified the guard test fails when the gate is removed**
- [x] Full suite **11,477 passed** (13 pre-existing unrelated `@aws-sdk/client-ecs` failures)
- [x] `tsc` clean

## 🚨 Scope — what this does NOT fix

This removes the deterministic idle death. It does **not** implement the rest of the disconnect report:

- No idle-deadline fail-safe rotation at ~240s
- No per-turn liveness watchdog — the current one still consults the session-wide `vertexHasShownLife` flag and was observed skipping recovery with `reason=vertex_alive` **on a Nova session**
- `local_close` still isn't split into `user_stop` / `mobile_transport_lost` / `rotation_swap` / `superseded` / `provider_failure`

Tracked separately. **Also note the report's recommendation #1 is to move production traffic back to Vertex and keep Nova on explicit canary identities until the acceptance suite passes — that decision is not made by this PR.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_