### PR TITLE
feat: add AWS-PROVISION-APPILIX-SECRETS workflow (BOOTSTRAP-CHAT-PUSH-NOTIF)

### DIFF
--- a/.github/workflows/AWS-PROVISION-APPILIX-SECRETS.yml
+++ b/.github/workflows/AWS-PROVISION-APPILIX-SECRETS.yml
@@ -1,0 +1,263 @@
+# AWS-PROVISION-APPILIX-SECRETS — one-off provisioning: create/update the
+# Appilix push credentials in AWS Secrets Manager and bind them onto the
+# gateway ECS task definitions (staging and/or prod).
+#
+# Context: Appilix native push (services/gateway/src/services/notification-
+# service.ts sendAppilixPush()) requires APPILIX_APP_KEY / APPILIX_API_KEY
+# env vars. These were deliberately stripped from the GCP Cloud Run gateway
+# (see EXEC-DEPLOY.yml: "Appilix API is down (522), secrets not in GCP
+# Secret Manager") and were NEVER wired into the AWS ECS task definitions at
+# all when gateway moved to AWS as sole production (VTID-03419) — so chat
+# push notifications have had no working delivery channel on AWS for native
+# (Appilix-wrapped iOS/Android) app users. The two GitHub repository secrets
+# (APPILIX_APP_KEY / APPILIX_API_KEY) already exist and hold real values;
+# this workflow is what actually gets them in front of the running service.
+#
+# Design:
+# - workflow_dispatch only, with a required `reason` and a `target` choice
+#   (staging / prod / both) so this stays a deliberate, auditable action —
+#   same spirit as every other AWS-*.yml in this repo.
+# - Idempotent: uses describe-secret to decide create-secret vs
+#   put-secret-value, so re-running (e.g. after rotating the Appilix keys)
+#   is safe.
+# - Preserves the existing task definition; only ADDS/REPLACES the two
+#   `secrets` entries (task-def `secrets`, not `environment` — the values
+#   never appear in the task definition JSON itself, only the secret ARNs
+#   do). Everything else on the task def carries forward untouched.
+# - Does NOT touch the running image/commit — this is a config-only change,
+#   deliberately decoupled from a code deploy.
+# - If the ECS task execution role lacks secretsmanager:GetSecretValue on
+#   the new secret ARNs, `aws ecs wait services-stable` will fail loudly
+#   (new tasks won't start; old tasks keep serving, so no outage) — that is
+#   the expected, safe failure mode if IAM needs a follow-up grant.
+#
+# Required repository secrets:
+#   APPILIX_APP_KEY / APPILIX_API_KEY  — the actual Appilix credentials
+#   AWS_STAGING_ACCESS_KEY_ID / AWS_STAGING_SECRET_ACCESS_KEY  — staging leg
+#   AWS_PROD_ROLE_ARN  — prod leg (GitHub OIDC)
+
+name: AWS Provision Appilix Secrets
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for this provisioning run — required'
+        required: true
+      target:
+        description: 'Which stack(s) to provision'
+        required: false
+        type: choice
+        options:
+          - staging
+          - prod
+          - both
+        default: 'staging'
+      aws_region:
+        description: 'AWS region'
+        required: false
+        default: 'eu-central-1'
+      ecs_cluster:
+        description: 'ECS cluster name'
+        required: false
+        default: 'Vitana-ECS-Cluster'
+
+permissions:
+  contents: read
+  id-token: write # required for the prod leg's OIDC role assumption
+
+concurrency:
+  group: aws-provision-appilix-secrets
+  cancel-in-progress: false
+
+jobs:
+  provision-staging:
+    if: ${{ inputs.target == 'staging' || inputs.target == 'both' }}
+    runs-on: ubuntu-latest
+    env:
+      TARGET_AWS_REGION: ${{ inputs.aws_region }}
+      ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+      ECS_SERVICE: vitana-gateway
+      APP_SECRET_NAME: vitana/gateway/appilix-app-key
+      API_SECRET_NAME: vitana/gateway/appilix-api-key
+    steps:
+      - name: Configure AWS credentials (staging static keys)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.TARGET_AWS_REGION }}
+
+      - name: Create/update secrets in AWS Secrets Manager
+        id: secrets
+        env:
+          APPILIX_APP_KEY: ${{ secrets.APPILIX_APP_KEY }}
+          APPILIX_API_KEY: ${{ secrets.APPILIX_API_KEY }}
+        run: |
+          set -e
+          if [ -z "$APPILIX_APP_KEY" ] || [ -z "$APPILIX_API_KEY" ]; then
+            echo "::error::APPILIX_APP_KEY / APPILIX_API_KEY repository secrets are not set."
+            exit 1
+          fi
+
+          upsert_secret() {
+            local name="$1" value="$2"
+            if aws secretsmanager describe-secret --secret-id "$name" >/dev/null 2>&1; then
+              aws secretsmanager put-secret-value --secret-id "$name" --secret-string "$value" \
+                --query 'ARN' --output text
+            else
+              aws secretsmanager create-secret --name "$name" \
+                --description "Appilix push credential (gateway staging)" \
+                --secret-string "$value" --query 'ARN' --output text
+            fi
+          }
+
+          APP_ARN=$(upsert_secret "$APP_SECRET_NAME" "$APPILIX_APP_KEY")
+          API_ARN=$(upsert_secret "$API_SECRET_NAME" "$APPILIX_API_KEY")
+          echo "app_arn=$APP_ARN" >> "$GITHUB_OUTPUT"
+          echo "api_arn=$API_ARN" >> "$GITHUB_OUTPUT"
+          echo "Provisioned $APP_SECRET_NAME -> $APP_ARN"
+          echo "Provisioned $API_SECRET_NAME -> $API_ARN"
+
+      - name: Bind secrets onto the ECS task definition + roll the service
+        env:
+          APP_ARN: ${{ steps.secrets.outputs.app_arn }}
+          API_ARN: ${{ steps.secrets.outputs.api_arn }}
+        run: |
+          set -e
+          TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' --output text)
+          echo "Current task definition: $TD_ARN"
+          NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
+            | jq --arg APP_ARN "$APP_ARN" --arg API_ARN "$API_ARN" '
+                .containerDefinitions[0].secrets = (
+                  ( (.containerDefinitions[0].secrets // [])
+                    | map(select(.name | IN("APPILIX_APP_KEY","APPILIX_API_KEY") | not)) )
+                  + [ {name:"APPILIX_APP_KEY", valueFrom:$APP_ARN},
+                      {name:"APPILIX_API_KEY", valueFrom:$API_ARN} ] )
+                | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                      .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "Registered $NEW_ARN"
+          aws ecs update-service --cluster "${{ env.ECS_CLUSTER }}" --service "${{ env.ECS_SERVICE }}" \
+            --task-definition "$NEW_ARN" >/dev/null
+          echo "Waiting for service to stabilize (up to ~10 min)…"
+          aws ecs wait services-stable --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}"
+          echo "Service stable on $NEW_ARN"
+
+      - name: Verify env vars landed (no values printed)
+        run: |
+          set -e
+          TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' --output text)
+          aws ecs describe-task-definition --task-definition "$TD_ARN" \
+            --query 'taskDefinition.containerDefinitions[0].secrets[].name' --output table
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## Appilix secrets provisioned — AWS staging (vitana-gateway)"
+            echo "- Secrets bound: APPILIX_APP_KEY, APPILIX_API_KEY"
+            echo "- Reason: ${{ inputs.reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  provision-prod:
+    needs: [provision-staging]
+    # Prod leg proceeds even if staging was skipped (target=prod) — `needs`
+    # only blocks it from running BEFORE a requested staging leg finishes.
+    # A single `if:` (not two) — duplicate keys in the same YAML mapping
+    # are invalid and silently drop the first one, which bit a prior PR.
+    if: |
+      always() &&
+      (inputs.target == 'prod' || inputs.target == 'both') &&
+      (needs.provision-staging.result == 'success' || needs.provision-staging.result == 'skipped')
+    runs-on: ubuntu-latest
+    env:
+      TARGET_AWS_REGION: ${{ inputs.aws_region }}
+      ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+      ECS_SERVICE: vitana-gateway-awsdr
+      APP_SECRET_NAME: vitana/gateway-awsdr/appilix-app-key
+      API_SECRET_NAME: vitana/gateway-awsdr/appilix-api-key
+    steps:
+      - name: Configure AWS credentials (prod OIDC role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_ARN }}
+          aws-region: ${{ env.TARGET_AWS_REGION }}
+
+      - name: Create/update secrets in AWS Secrets Manager
+        id: secrets
+        env:
+          APPILIX_APP_KEY: ${{ secrets.APPILIX_APP_KEY }}
+          APPILIX_API_KEY: ${{ secrets.APPILIX_API_KEY }}
+        run: |
+          set -e
+          if [ -z "$APPILIX_APP_KEY" ] || [ -z "$APPILIX_API_KEY" ]; then
+            echo "::error::APPILIX_APP_KEY / APPILIX_API_KEY repository secrets are not set."
+            exit 1
+          fi
+
+          upsert_secret() {
+            local name="$1" value="$2"
+            if aws secretsmanager describe-secret --secret-id "$name" >/dev/null 2>&1; then
+              aws secretsmanager put-secret-value --secret-id "$name" --secret-string "$value" \
+                --query 'ARN' --output text
+            else
+              aws secretsmanager create-secret --name "$name" \
+                --description "Appilix push credential (gateway prod, VTID-03398 AWS-DR)" \
+                --secret-string "$value" --query 'ARN' --output text
+            fi
+          }
+
+          APP_ARN=$(upsert_secret "$APP_SECRET_NAME" "$APPILIX_APP_KEY")
+          API_ARN=$(upsert_secret "$API_SECRET_NAME" "$APPILIX_API_KEY")
+          echo "app_arn=$APP_ARN" >> "$GITHUB_OUTPUT"
+          echo "api_arn=$API_ARN" >> "$GITHUB_OUTPUT"
+          echo "Provisioned $APP_SECRET_NAME -> $APP_ARN"
+          echo "Provisioned $API_SECRET_NAME -> $API_ARN"
+
+      - name: Bind secrets onto the ECS task definition + roll the service
+        env:
+          APP_ARN: ${{ steps.secrets.outputs.app_arn }}
+          API_ARN: ${{ steps.secrets.outputs.api_arn }}
+        run: |
+          set -e
+          TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' --output text)
+          echo "Current task definition: $TD_ARN"
+          NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
+            | jq --arg APP_ARN "$APP_ARN" --arg API_ARN "$API_ARN" '
+                .containerDefinitions[0].secrets = (
+                  ( (.containerDefinitions[0].secrets // [])
+                    | map(select(.name | IN("APPILIX_APP_KEY","APPILIX_API_KEY") | not)) )
+                  + [ {name:"APPILIX_APP_KEY", valueFrom:$APP_ARN},
+                      {name:"APPILIX_API_KEY", valueFrom:$API_ARN} ] )
+                | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                      .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "Registered $NEW_ARN"
+          aws ecs update-service --cluster "${{ env.ECS_CLUSTER }}" --service "${{ env.ECS_SERVICE }}" \
+            --task-definition "$NEW_ARN" >/dev/null
+          echo "Waiting for service to stabilize (up to ~10 min)…"
+          aws ecs wait services-stable --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}"
+          echo "Service stable on $NEW_ARN"
+
+      - name: Verify env vars landed (no values printed)
+        run: |
+          set -e
+          TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
+            --query 'services[0].taskDefinition' --output text)
+          aws ecs describe-task-definition --task-definition "$TD_ARN" \
+            --query 'taskDefinition.containerDefinitions[0].secrets[].name' --output table
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## Appilix secrets provisioned — AWS prod (vitana-gateway-awsdr)"
+            echo "- Secrets bound: APPILIX_APP_KEY, APPILIX_API_KEY"
+            echo "- Reason: ${{ inputs.reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-CHAT-PUSH-NOTIF` _(follow-up to #2999, no VTID exists for this yet; tracked under this BOOTSTRAP tag pending one)_

**Layer:** CICDL (AWS ECS secrets provisioning)

**Priority:** P1

---

## 📋 Summary

Follow-up to #2999. That PR fixed the fire-and-forget race that dropped chat push notifications intermittently — but after deploying it, chat push was still **completely, consistently** missing (not random-drop, total no-op).

Root cause: **Appilix native push has had no working credentials anywhere in AWS.** Chat pushes always carry a deep-link URL, so Appilix is the *only* channel that reaches native-app (iOS/Android, Appilix-wrapped WebView) users — FCM can't substitute today because the frontend deliberately never registers an FCM token inside the Appilix WebView (a past fix found that registration crashes it).

`APPILIX_API_KEY`/`APPILIX_APP_KEY` were deliberately stripped from the GCP Cloud Run gateway (`EXEC-DEPLOY.yml`: *"Appilix API is down (522), secrets not in GCP Secret Manager"*), and were **never wired into the AWS ECS task definitions at all** when gateway cut over to sole AWS production (VTID-03419). `sendAppilixPush()` (`services/gateway/src/services/notification-service.ts`) checks for these env vars and returns `false` silently (no log line) when missing — so every chat push has been a clean, invisible no-op.

The good news: the `APPILIX_APP_KEY`/`APPILIX_API_KEY` **repository secrets already exist** (added ~4 months ago) with real values — nothing has ever read them into AWS.

---

## ✅ Changes

- [x] New `.github/workflows/AWS-PROVISION-APPILIX-SECRETS.yml` (`workflow_dispatch`, required `reason`, `target: staging|prod|both`):
  - Creates/updates `vitana/gateway/appilix-{app,api}-key` (staging) and/or `vitana/gateway-awsdr/appilix-{app,api}-key` (prod) in AWS Secrets Manager from the existing `APPILIX_APP_KEY`/`APPILIX_API_KEY` repo secrets.
  - Binds them onto the target ECS task definition's `secrets` array (task-def `secrets`, not `environment` — values never appear in the task definition JSON, only ARNs do) and rolls the service.
  - Preserves everything else on the task def untouched (image, other env vars/secrets).
  - Idempotent — safe to re-run after rotating the Appilix keys.
  - Uses staging's existing static AWS keys (`AWS_STAGING_ACCESS_KEY_ID`/`SECRET`) for the staging leg and the OIDC `AWS_PROD_ROLE_ARN` role for the prod leg, matching each service's existing deploy workflow.

---

## 🧪 Testing

- [x] Validated the workflow YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Not yet dispatched — plan is to run with `target=staging` first, verify via CloudWatch logs that `sendAppilixPush()` now logs `[Notifications] Appilix push sent` instead of a silent no-op, then run `target=prod`.
- [ ] Known risk: if the ECS task execution role lacks `secretsmanager:GetSecretValue` on the new secret ARNs, `aws ecs wait services-stable` will fail loudly (new tasks won't start; old tasks keep serving, so no outage) — that's the expected, safe failure mode if an IAM follow-up grant is needed.

---

## 🚨 Breaking Changes

None. This only adds credentials to existing task definitions; no code path changes. If dispatched and Appilix push still doesn't work, the previous behavior (silent no-op) is unchanged.

---

## 📌 Additional Notes

Direct network access to `appilix.com` from the sandbox that authored this PR is blocked (proxy-restricted), so reachability could not be pre-verified locally — the workflow's own steps run on a GitHub-hosted runner with full internet access and will be the real test.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8WNmvimt7WKc5e58uQhGb)_