### PR TITLE
fix(orb): idle-deadline fail-safe rotation — the clock nothing was watching

### DIFF
--- a/services/gateway/src/orb/live/config.ts
+++ b/services/gateway/src/orb/live/config.ts
@@ -82,6 +82,28 @@ export const MAX_CONNECTIONS_PER_IP = 5;
 export const MAX_RECONNECTS = 10;
 
 /**
+ * BOOTSTRAP-NOVA-IDLE-ROTATION: attempts allowed for a PLANNED Nova stream
+ * rotation (wall-clock cap or idle fail-safe) before giving up on Nova and
+ * falling back to Vertex for the rest of the session.
+ *
+ * Deliberately small and deliberately separate from MAX_RECONNECTS: a planned
+ * rotation refunds the reconnect budget on every attempt (success or failure)
+ * so a fail-safe can never eat the budget a genuine mid-call disconnect needs.
+ * This counter is what bounds the retry loop instead.
+ */
+export const NOVA_ROTATION_MAX_ATTEMPTS = 3;
+
+/**
+ * Linear backoff base between planned-rotation attempts (attempt N waits
+ * N × this). Total worst case ≈ 3s, comfortably inside the ~55s of headroom
+ * the 240s idle fail-safe leaves before Bedrock's ~295s kill.
+ */
+export const NOVA_ROTATION_RETRY_BACKOFF_MS = 1_000;
+
+/** Why a Nova stream rotation ran — carried into diag + OASIS payloads. */
+export type NovaRotationReason = 'provider_stream_rotation' | 'idle_deadline_failsafe';
+
+/**
  * Languages the Live API officially supports. New languages must land
  * here AND in the voice + greeting lookup tables.
  *

--- a/services/gateway/src/orb/live/upstream/nova-sonic-config.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-config.ts
@@ -26,6 +26,35 @@ export type NovaSonicLanguage = (typeof NOVA_SONIC_SUPPORTED_LANGUAGES)[number];
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
 /** 7m15s — rotate 45s before Bedrock's 8-minute bidirectional stream cap. */
 const DEFAULT_ROTATION_AFTER_MS = 435_000;
+// BOOTSTRAP-NOVA-IDLE-ROTATION: Bedrock enforces TWO independent deadlines,
+// and `rotationAfterMs` above only covers the first:
+//
+//   1. Stream cap  — ~8 min of WALL CLOCK since connect, regardless of
+//                    traffic. `rotationAfterMs` (435s) covers this.
+//   2. Idle timeout — ~295s since the last ACCEPTED INPUT. Bedrock's own
+//                    words: "Timed out waiting for audio bytes or
+//                    interactive content … less than 295 seconds".
+//
+// These run on different clocks, so a 435s wall-clock timer CANNOT protect
+// the 295s idle deadline — a session that stops feeding frames dies at ~295s
+// with the rotation timer still 140s away. That is exactly the production
+// P0: a healthy 10-turn session terminated ~292s after its last input.
+//
+// The silence keepalive normally makes idle unreachable (it feeds a frame
+// every 250ms), so in a healthy session this watchdog never fires. It exists
+// because the keepalive stopping is precisely the failure that killed
+// production once already — VTID-LOOPGUARD used to clear it deliberately.
+// This is the backstop for "the frames stopped for a reason nobody predicted".
+//
+// 240s leaves ~55s of headroom to open, validate, and swap to a replacement
+// stream before Bedrock would kill the old one.
+const DEFAULT_IDLE_ROTATION_AFTER_MS = 240_000;
+/**
+ * How often the idle watchdog samples the elapsed-since-last-input clock.
+ * Sampling, not a one-shot timer, because the deadline is relative to a
+ * moving timestamp. 5s bounds the overshoot well inside the 55s headroom.
+ */
+export const NOVA_IDLE_WATCHDOG_TICK_MS = 5_000;
 // Under NodeHttp2Handler's 480s idle sessionTimeout so the pooled HTTP/2
 // session never expires between pings.
 const DEFAULT_KEEPWARM_MS = 240_000;
@@ -89,6 +118,7 @@ export type NovaSonicConfigIssue =
   | 'nova_canary_tenant_ids_invalid'
   | 'nova_connect_timeout_invalid'
   | 'nova_rotation_after_invalid'
+  | 'nova_idle_rotation_after_invalid'
   | 'nova_keepwarm_invalid'
   | 'nova_model_warm_invalid'
   | 'nova_max_tokens_invalid'
@@ -103,6 +133,14 @@ export interface NovaSonicConfig {
   canaryTenantIds: ReadonlySet<string>;
   connectTimeoutMs: number;
   rotationAfterMs: number;
+  /**
+   * Fail-safe: rotate the stream once this long has passed since the last
+   * ACCEPTED input, to stay ahead of Bedrock's ~295s idle deadline. Distinct
+   * clock from `rotationAfterMs` (wall-clock since connect) — see the
+   * DEFAULT_IDLE_ROTATION_AFTER_MS comment for why one cannot cover the
+   * other. 0 disables the watchdog.
+   */
+  idleRotationAfterMs: number;
   /**
    * Interval for the Bedrock connection keep-warm ping (latency: keeps the
    * pooled HTTP/2 session + resolved credentials hot between real sessions;
@@ -217,6 +255,14 @@ export function getNovaSonicConfig(env: NodeJS.ProcessEnv): NovaSonicConfig {
   );
   if (rotationAfterMs === null) issues.push('nova_rotation_after_invalid');
 
+  // Non-negative (not positive) so 0 is a legitimate "disable the watchdog"
+  // value, matching keepWarmMs/modelWarmMs.
+  const idleRotationAfterMs = parseNonNegativeInt(
+    env.NOVA_SONIC_IDLE_ROTATION_AFTER_MS,
+    DEFAULT_IDLE_ROTATION_AFTER_MS,
+  );
+  if (idleRotationAfterMs === null) issues.push('nova_idle_rotation_after_invalid');
+
   const keepWarmMs = parseNonNegativeInt(
     env.NOVA_SONIC_KEEPWARM_MS,
     DEFAULT_KEEPWARM_MS,
@@ -257,6 +303,7 @@ export function getNovaSonicConfig(env: NodeJS.ProcessEnv): NovaSonicConfig {
     canaryTenantIds: canaryTenantIds ?? new Set(),
     connectTimeoutMs: connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
     rotationAfterMs: rotationAfterMs ?? DEFAULT_ROTATION_AFTER_MS,
+    idleRotationAfterMs: idleRotationAfterMs ?? DEFAULT_IDLE_ROTATION_AFTER_MS,
     keepWarmMs: keepWarmMs ?? DEFAULT_KEEPWARM_MS,
     modelWarmMs: modelWarmMs ?? DEFAULT_MODEL_WARM_MS,
     maxTokens: maxTokens ?? DEFAULT_MAX_TOKENS,

--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -38,6 +38,7 @@ import type {
   UpstreamUsageEvent,
 } from './types';
 import type { NovaSonicConfig } from './nova-sonic-config';
+import { NOVA_IDLE_WATCHDOG_TICK_MS } from './nova-sonic-config';
 import {
   buildAudioContentStart,
   buildAudioInput,
@@ -190,6 +191,15 @@ export interface NovaSonicLiveClientDeps {
   createCommand?: (input: { modelId: string; body: AsyncIterable<unknown> }) => unknown;
   /** Rotation callback — fired ONCE at config.rotationAfterMs. */
   onRotationDue?: () => void;
+  /**
+   * BOOTSTRAP-NOVA-IDLE-ROTATION: fail-safe rotation callback, fired when
+   * no input has been ACCEPTED for config.idleRotationAfterMs — i.e. the
+   * session is drifting toward Bedrock's ~295s idle kill. Unlike
+   * onRotationDue this can fire more than once per stream (a session may go
+   * idle, rotate, converse, and go idle again), but never twice without
+   * fresh input in between.
+   */
+  onIdleDeadlineApproaching?: (info: { msSinceLastInput: number }) => void;
   /** Audio queue high-water mark override. */
   audioHighWaterMark?: number;
 }
@@ -393,6 +403,17 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
   private normalizer = new NovaOutputNormalizer();
   private rotationTimer: NodeJS.Timeout | null = null;
   private rotationFired = false;
+  /** Idle-deadline fail-safe (BOOTSTRAP-NOVA-IDLE-ROTATION). */
+  private idleWatchdog: NodeJS.Timeout | null = null;
+  /**
+   * Wall-clock of the last input Bedrock actually ACCEPTED. A refused frame
+   * (backpressure) is deliberately NOT stamped — it never reached Bedrock,
+   * so it never reset Bedrock's idle clock, and pretending otherwise would
+   * make this watchdog blind in exactly the situation it exists for.
+   */
+  private lastInputAcceptedAt = 0;
+  /** Set when the idle callback fires; cleared by the next accepted input. */
+  private idleRotationSignalled = false;
   private closeEmitted = false;
   /** Frames actually queued — gates the audio contentEnd on teardown. */
   private audioFramesSent = 0;
@@ -518,7 +539,13 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       }
 
       this.state = 'open';
+      // The init sequence above (sessionStart → promptStart → system block →
+      // audioContentStart) is real accepted input, so the idle clock starts
+      // here rather than at zero — otherwise a stream would look 240s idle
+      // the instant it opened.
+      this.markInputAccepted();
       this.armRotationTimer();
+      this.armIdleWatchdog();
       this.responseLoopDone = this.runResponseLoop(response.body);
     } catch (err) {
       const code = classifyNovaError(err);
@@ -544,6 +571,61 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     }, this.deps.config.rotationAfterMs);
     // Never keep the process alive for a rotation timer.
     this.rotationTimer.unref?.();
+  }
+
+  /**
+   * BOOTSTRAP-NOVA-IDLE-ROTATION: sample the elapsed-since-last-accepted-input
+   * clock and signal when it approaches Bedrock's ~295s idle deadline.
+   *
+   * Sampling rather than a one-shot `setTimeout` because the deadline is
+   * measured from a MOVING timestamp — every accepted frame pushes it out.
+   * Re-arming a one-shot on every audio frame would mean tearing down and
+   * rebuilding a timer 4x/second for the entire session.
+   */
+  private armIdleWatchdog(): void {
+    const limit = this.deps.config.idleRotationAfterMs;
+    if (!limit || limit <= 0) return; // explicitly disabled
+    this.idleWatchdog = setInterval(() => {
+      if (this.state !== 'open') return;
+      // One signal per idle episode. Without this the callback would re-fire
+      // every tick for as long as the session stayed quiet, stacking
+      // rotation attempts on top of each other.
+      if (this.idleRotationSignalled) return;
+      const msSinceLastInput = Date.now() - this.lastInputAcceptedAt;
+      if (msSinceLastInput < limit) return;
+      this.idleRotationSignalled = true;
+      try {
+        this.deps.onIdleDeadlineApproaching?.({ msSinceLastInput });
+      } catch {
+        /* fail-safe callback must never destabilize the stream */
+      }
+    }, NOVA_IDLE_WATCHDOG_TICK_MS);
+    this.idleWatchdog.unref?.();
+  }
+
+  private clearIdleWatchdog(): void {
+    if (this.idleWatchdog) {
+      clearInterval(this.idleWatchdog);
+      this.idleWatchdog = null;
+    }
+  }
+
+  /**
+   * Stamp the idle clock. Call ONLY where Bedrock genuinely accepted input —
+   * a dropped/refused event must not reset it.
+   */
+  private markInputAccepted(): void {
+    this.lastInputAcceptedAt = Date.now();
+    this.idleRotationSignalled = false;
+  }
+
+  /**
+   * Milliseconds since the last accepted input, for telemetry and tests.
+   * Returns 0 before the stream opens.
+   */
+  getMsSinceLastAcceptedInput(): number {
+    if (!this.lastInputAcceptedAt) return 0;
+    return Date.now() - this.lastInputAcceptedAt;
   }
 
   private async runResponseLoop(
@@ -636,9 +718,14 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       buildAudioInput({ promptName: this.promptName, contentName: this.audioContentName, dataB64: audioB64 }),
     );
     if (!accepted) {
+      // Deliberately no markInputAccepted() here — a refused frame never
+      // reached Bedrock, so Bedrock's idle clock did not move. Stamping it
+      // would hide sustained backpressure from the idle watchdog, which is
+      // one of the ways frames can silently stop flowing.
       this.emitError({ code: 'nova_backpressure', message: 'Nova input queue high-water mark reached; audio chunk dropped' });
     } else {
       this.audioFramesSent++;
+      this.markInputAccepted();
     }
     return accepted;
   }
@@ -649,6 +736,7 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     this.queue.push(buildTextContentStart({ promptName: this.promptName, contentName, role: 'USER' }));
     this.queue.push(buildTextInput({ promptName: this.promptName, contentName, content: text }));
     this.queue.push(buildContentEnd({ promptName: this.promptName, contentName }));
+    this.markInputAccepted();
     return true;
   }
 
@@ -688,6 +776,11 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     })) {
       this.queue.push(event);
     }
+    // Bedrock's idle message names "audio bytes or interactive content" —
+    // a tool result is interactive content, so it resets the idle clock. This
+    // matters for long tool round-trips, where a slow tool is the only thing
+    // keeping the session from looking idle.
+    this.markInputAccepted();
     return true;
   }
 
@@ -699,6 +792,7 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       clearTimeout(this.rotationTimer);
       this.rotationTimer = null;
     }
+    this.clearIdleWatchdog();
     // Orderly teardown: close the audio block, end the prompt + session,
     // then close the input queue so the request stream completes. Nova
     // rejects a contentEnd for a content block that never received data
@@ -740,6 +834,7 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
       clearTimeout(this.rotationTimer);
       this.rotationTimer = null;
     }
+    this.clearIdleWatchdog();
     try {
       this.closeHandler?.(event);
     } catch {

--- a/services/gateway/src/orb/live/upstream/upstream-provider-selector.ts
+++ b/services/gateway/src/orb/live/upstream/upstream-provider-selector.ts
@@ -89,6 +89,14 @@ export type SelectionReason =
   | 'nova_not_allowlisted'        // nova gate on but identity not in allowlist → vertex
   | 'nova_language_unsupported'   // session language outside en/de/fr/es → vertex
   | 'nova_runtime_unsupported'    // runtime cannot carry the HTTP/2 stream (GCP) → vertex
+  // BOOTSTRAP-NOVA-IDLE-ROTATION: a mid-session pin applied by the CALLER,
+  // never returned by selectUpstreamProvider() itself (which is stateless and
+  // has no notion of a session's rotation history). Set when a planned Nova
+  // rotation — wall-clock cap or idle fail-safe — exhausted its attempts, so
+  // the session finishes on Vertex instead of dying on a stream Nova cannot
+  // replace. Lives in this union so the override is a typed, greppable
+  // decision rather than a cast.
+  | 'nova_rotation_exhausted_fallback'
   | 'provider_invalid';           // unknown provider string anywhere → vertex
 
 export interface CanarySelectorConfig {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6527,6 +6527,23 @@ async function connectToLiveAPI(
       canary: false,
     };
   }
+  // BOOTSTRAP-NOVA-IDLE-ROTATION: a session that already exhausted its Nova
+  // rotation attempts is pinned to Vertex for the remainder of its life. This
+  // has to be applied AFTER the selector (which is stateless and would happily
+  // hand back Nova again) and BEFORE `session.upstreamProvider` is recorded,
+  // so latency attribution and the connect branch below both see the pin.
+  // Loud, never silent — CLAUDE.md "Never allow silent model fallback".
+  if ((session as any)._novaFallbackToVertex && __upstreamDecision.provider === 'nova_sonic') {
+    console.warn(
+      `[BOOTSTRAP-NOVA-IDLE-ROTATION] Session ${session.sessionId} is pinned to Vertex after exhausting ` +
+        `Nova rotation attempts — overriding selector decision '${__upstreamDecision.provider}'.`,
+    );
+    __upstreamDecision = {
+      ...__upstreamDecision,
+      provider: 'vertex',
+      reason: 'nova_rotation_exhausted_fallback',
+    };
+  }
   console.log(
     `[VTID-02976] upstream provider selected: provider=${__upstreamDecision.provider}` +
       ` requested=${__upstreamDecision.requested ?? 'none'}` +
@@ -7205,28 +7222,66 @@ async function connectToLiveAPI(
         // history rebuild + persona voice re-resolution), switch the session
         // to it, then close the old stream. The browser WS/SSE stays
         // connected and no greeting replays (greetingSent remains true).
-        let rotateNovaStream: (() => Promise<void>) | null = null;
+        let rotateNovaStream: ((reason: NovaRotationReason) => Promise<void>) | null = null;
 
         const novaClient = createUpstreamClient('nova_sonic', {
           nova: {
             config: novaCfg,
             voiceId: novaVoice,
             onRotationDue: () => {
-              void rotateNovaStream?.();
+              void rotateNovaStream?.('provider_stream_rotation');
+            },
+            // BOOTSTRAP-NOVA-IDLE-ROTATION: the fail-safe. Fires only when
+            // input has genuinely stopped reaching Bedrock for ~240s, which
+            // in a healthy session never happens (the 250ms silence keepalive
+            // keeps the clock pinned). Same open-before-close swap as the
+            // wall-clock rotation — the only difference is why it ran.
+            onIdleDeadlineApproaching: ({ msSinceLastInput }) => {
+              console.warn(
+                `[BOOTSTRAP-NOVA-IDLE-ROTATION] Session ${session.sessionId} has accepted no input for ` +
+                  `${Math.round(msSinceLastInput / 1000)}s — approaching Bedrock's ~295s idle deadline. ` +
+                  `Rotating pre-emptively. If this fires in production the silence keepalive has stopped ` +
+                  `feeding frames; that is the real bug to chase, this is only the backstop.`,
+              );
+              emitDiag(session, 'nova_idle_deadline_approaching', {
+                provider: 'nova_sonic',
+                ms_since_last_input: msSinceLastInput,
+              });
+              void emitOasisEvent({
+                type: 'orb.upstream.nova.idle_deadline_approaching',
+                vtid: 'BOOTSTRAP-NOVA-IDLE-ROTATION',
+                payload: {
+                  session_id: session.sessionId,
+                  provider: 'nova_sonic',
+                  ms_since_last_input: msSinceLastInput,
+                } as any,
+              } as any).catch(() => { /* best-effort */ });
+              void rotateNovaStream?.('idle_deadline_failsafe');
             },
           },
         });
 
-        rotateNovaStream = async () => {
+        rotateNovaStream = async (reason: NovaRotationReason) => {
           if (!session.active) return;
+          // A wall-clock rotation and an idle fail-safe can in principle come
+          // due together; running two swaps concurrently would race two
+          // replacement streams onto one session.
+          if ((session as any)._novaRotationInFlight) {
+            emitDiag(session, 'nova_rotation_skipped', { provider: 'nova_sonic', reason, code: 'already_in_flight' });
+            return;
+          }
           (session as any)._novaRotationInFlight = true;
-          emitDiag(session, 'nova_rotation_started', { provider: 'nova_sonic' });
+          emitDiag(session, 'nova_rotation_started', { provider: 'nova_sonic', reason });
           void emitOasisEvent({
             type: 'orb.upstream.nova.rotation_started',
             vtid: 'BOOTSTRAP-NOVA-SONIC-VOICE',
-            payload: { session_id: session.sessionId, provider: 'nova_sonic', reason: 'provider_stream_rotation' } as any,
+            payload: { session_id: session.sessionId, provider: 'nova_sonic', reason } as any,
           } as any).catch(() => { /* best-effort */ });
-          try {
+
+          // One planned-rotation attempt. Returns true when the replacement
+          // stream is open and the session has been switched onto it.
+          const attemptSwap = async (attempt: number): Promise<boolean> => {
+            const before = ((session as any)._reconnectCount as number) || 0;
             const ok = await attemptTransparentReconnect(
               session,
               onAudioResponse,
@@ -7235,34 +7290,138 @@ async function connectToLiveAPI(
               onTurnComplete,
               onInterrupted,
             );
-            if (ok) {
-              // Planned rotation must not consume the failure-reconnect
-              // budget — refund the slot the reconnect helper just took.
-              (session as any)._reconnectCount = Math.max(0, ((session as any)._reconnectCount || 1) - 1);
-              await novaClient.close('provider_stream_rotation');
-              emitDiag(session, 'nova_rotation_succeeded', { provider: 'nova_sonic' });
+            // A PLANNED rotation must never consume the unplanned-failure
+            // reconnect budget — refund the slot whether or not the attempt
+            // succeeded. Rotation retries are bounded separately below, so
+            // refunding on failure cannot spin.
+            //
+            // Refund only what was actually SPENT: attemptTransparentReconnect
+            // returns false WITHOUT incrementing when it is already at
+            // MAX_RECONNECTS, so an unconditional decrement would erode the
+            // counter on every failed attempt and quietly hand the session
+            // more reconnect budget than the cap allows.
+            const after = ((session as any)._reconnectCount as number) || 0;
+            if (after > before) {
+              (session as any)._reconnectCount = Math.max(0, after - 1);
+            }
+            if (!ok) {
+              emitDiag(session, 'nova_rotation_attempt_failed', {
+                provider: 'nova_sonic',
+                reason,
+                attempt,
+                code: 'nova_rotation_failed',
+              });
+            }
+            return ok;
+          };
+
+          try {
+            let swapped = false;
+            for (let attempt = 1; attempt <= NOVA_ROTATION_MAX_ATTEMPTS && !swapped; attempt++) {
+              if (!session.active) break;
+              try {
+                swapped = await attemptSwap(attempt);
+              } catch (e) {
+                emitDiag(session, 'nova_rotation_attempt_failed', {
+                  provider: 'nova_sonic',
+                  reason,
+                  attempt,
+                  code: 'nova_rotation_failed',
+                  error: (e as Error).message,
+                });
+              }
+              if (!swapped && attempt < NOVA_ROTATION_MAX_ATTEMPTS) {
+                await new Promise((r) => setTimeout(r, NOVA_ROTATION_RETRY_BACKOFF_MS * attempt));
+              }
+            }
+
+            if (swapped) {
+              await novaClient.close(reason);
+              emitDiag(session, 'nova_rotation_succeeded', { provider: 'nova_sonic', reason });
               void emitOasisEvent({
                 type: 'orb.upstream.nova.rotation_succeeded',
                 vtid: 'BOOTSTRAP-NOVA-SONIC-VOICE',
-                payload: { session_id: session.sessionId, provider: 'nova_sonic' } as any,
+                payload: { session_id: session.sessionId, provider: 'nova_sonic', reason } as any,
               } as any).catch(() => { /* best-effort */ });
-            } else {
-              // Replacement failed — keep the old stream until its Bedrock
-              // deadline; its eventual close surfaces ONE typed issue via
-              // the close handler (rotation flag cleared below).
-              emitDiag(session, 'nova_rotation_failed', { provider: 'nova_sonic', code: 'nova_rotation_failed' });
-              void emitOasisEvent({
-                type: 'orb.upstream.nova.rotation_failed',
-                vtid: 'BOOTSTRAP-NOVA-SONIC-VOICE',
-                payload: { session_id: session.sessionId, provider: 'nova_sonic', code: 'nova_rotation_failed' } as any,
-              } as any).catch(() => { /* best-effort */ });
+              return;
             }
-          } catch (e) {
+
+            // Every Nova replacement attempt failed. For a wall-clock rotation
+            // the old stream still has ~45s; for the idle fail-safe it has
+            // ~55s — either way, riding it to the deadline drops the user.
+            // Fall back to Vertex, which has no equivalent idle-kill, rather
+            // than let the conversation die on a provider that cannot hold it.
+            // NEVER silent (CLAUDE.md "Never allow silent model fallback").
             emitDiag(session, 'nova_rotation_failed', {
               provider: 'nova_sonic',
+              reason,
               code: 'nova_rotation_failed',
-              error: (e as Error).message,
+              attempts: NOVA_ROTATION_MAX_ATTEMPTS,
             });
+            void emitOasisEvent({
+              type: 'orb.upstream.nova.rotation_failed',
+              vtid: 'BOOTSTRAP-NOVA-SONIC-VOICE',
+              payload: {
+                session_id: session.sessionId,
+                provider: 'nova_sonic',
+                reason,
+                code: 'nova_rotation_failed',
+                attempts: NOVA_ROTATION_MAX_ATTEMPTS,
+              } as any,
+            } as any).catch(() => { /* best-effort */ });
+
+            if (!session.active) return;
+            console.warn(
+              `[BOOTSTRAP-NOVA-IDLE-ROTATION] Nova rotation failed ${NOVA_ROTATION_MAX_ATTEMPTS}x for session ` +
+                `${session.sessionId} (reason=${reason}) — falling back to Vertex for the rest of this session.`,
+            );
+            // Pinned for the REST of the session, not just this attempt: if
+            // Nova could not give us a stream three times in a row, bouncing
+            // the next rotation back onto it would just repeat this.
+            (session as any)._novaFallbackToVertex = true;
+            emitDiag(session, 'nova_fallback_to_vertex', { provider: 'nova_sonic', reason });
+            void emitOasisEvent({
+              type: 'orb.upstream.nova.fallback_to_vertex',
+              vtid: 'BOOTSTRAP-NOVA-IDLE-ROTATION',
+              payload: { session_id: session.sessionId, from: 'nova_sonic', to: 'vertex', reason } as any,
+            } as any).catch(() => { /* best-effort */ });
+
+            let fellBack = false;
+            try {
+              fellBack = await attemptTransparentReconnect(
+                session,
+                onAudioResponse,
+                onTextResponse,
+                onError,
+                onTurnComplete,
+                onInterrupted,
+              );
+            } catch (e) {
+              emitDiag(session, 'nova_fallback_failed', {
+                provider: 'vertex',
+                reason,
+                error: (e as Error).message,
+              });
+            }
+            if (fellBack) {
+              await novaClient.close(`${reason}_vertex_fallback`);
+              emitDiag(session, 'nova_fallback_succeeded', { provider: 'vertex', reason });
+              void emitOasisEvent({
+                type: 'orb.upstream.nova.fallback_succeeded',
+                vtid: 'BOOTSTRAP-NOVA-IDLE-ROTATION',
+                payload: { session_id: session.sessionId, from: 'nova_sonic', to: 'vertex', reason } as any,
+              } as any).catch(() => { /* best-effort */ });
+            } else {
+              // Nothing left to try — keep the old Nova stream so the user
+              // gets whatever time remains before its deadline rather than
+              // being cut off now. Its close handler surfaces the typed issue.
+              emitDiag(session, 'nova_fallback_failed', { provider: 'vertex', reason, code: 'nova_fallback_failed' });
+              void emitOasisEvent({
+                type: 'orb.upstream.nova.fallback_failed',
+                vtid: 'BOOTSTRAP-NOVA-IDLE-ROTATION',
+                payload: { session_id: session.sessionId, from: 'nova_sonic', to: 'vertex', reason } as any,
+              } as any).catch(() => { /* best-effort */ });
+            }
           } finally {
             (session as any)._novaRotationInFlight = false;
           }
@@ -7824,6 +7983,12 @@ async function connectToLiveAPI(
  */
 // A2 (orb-live-refactor): MAX_RECONNECTS lifted to orb/live/config.ts.
 import { MAX_RECONNECTS } from '../orb/live/config';
+// BOOTSTRAP-NOVA-IDLE-ROTATION: planned-rotation retry budget + reason type.
+import {
+  NOVA_ROTATION_MAX_ATTEMPTS,
+  NOVA_ROTATION_RETRY_BACKOFF_MS,
+  type NovaRotationReason,
+} from '../orb/live/config';
 
 // VTID-03273 Pillar B — how long before the server's GoAway deadline we
 // proactively rotate the connection. Small enough to overlap the warning

--- a/services/gateway/test/orb/live/upstream/nova-idle-rotation.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-idle-rotation.test.ts
@@ -1,0 +1,261 @@
+/**
+ * BOOTSTRAP-NOVA-IDLE-ROTATION: the idle-deadline fail-safe.
+ *
+ * Bedrock enforces TWO deadlines on a bidirectional stream:
+ *   - ~8 min wall-clock since connect  → covered by `rotationAfterMs` (435s)
+ *   - ~295s since the last ACCEPTED input → covered by NOTHING, until now
+ *
+ * The production P0 was the second one: a healthy 10-turn session was killed
+ * ~292s after its last input while the wall-clock rotation timer was still
+ * 140s away. These tests pin the behavior of the watchdog that closes that
+ * gap, and — most importantly — the input-accounting rules that decide when
+ * it is allowed to fire.
+ */
+
+import {
+  NovaSonicLiveClient,
+  type NovaBedrockLike,
+} from '../../../../src/orb/live/upstream/nova-sonic-live-client';
+import { getNovaSonicConfig } from '../../../../src/orb/live/upstream/nova-sonic-config';
+import type { UpstreamConnectOptions } from '../../../../src/orb/live/upstream/types';
+
+/**
+ * Bedrock's documented idle limit, from the live termination message:
+ * "Timed out waiting for audio bytes or interactive content … less than 295
+ * seconds". The fail-safe is only a fail-safe if it fires BEFORE this.
+ */
+const BEDROCK_IDLE_DEADLINE_MS = 295_000;
+
+function baseOptions(overrides: Partial<UpstreamConnectOptions> = {}): UpstreamConnectOptions {
+  return {
+    model: 'amazon.nova-2-sonic-v1:0',
+    voiceName: 'tina',
+    responseModalities: ['audio'],
+    vadSilenceMs: 2000,
+    systemInstruction: 'You are Vitana.',
+    connectTimeoutMs: 1000,
+    ...overrides,
+  };
+}
+
+class SilentBody implements AsyncIterable<{ chunk?: { bytes?: Uint8Array } }> {
+  [Symbol.asyncIterator](): AsyncIterator<{ chunk?: { bytes?: Uint8Array } }> {
+    // Never resolves — the stream stays open and produces nothing, which is
+    // exactly the shape of the sessions that died in production.
+    return { next: () => new Promise(() => {}) };
+  }
+}
+
+function makeClient(env: Record<string, string> = {}, audioHighWaterMark?: number) {
+  const config = getNovaSonicConfig({
+    NOVA_SONIC_ENABLED: 'true',
+    ...env,
+  } as NodeJS.ProcessEnv);
+  const bedrock: NovaBedrockLike = { send: async () => ({ body: new SilentBody() }) };
+  const onIdleDeadlineApproaching = jest.fn();
+  const onRotationDue = jest.fn();
+  const client = new NovaSonicLiveClient({
+    config,
+    voiceId: 'tina',
+    createBedrockClient: () => bedrock,
+    createCommand: (input) => input,
+    onRotationDue,
+    onIdleDeadlineApproaching,
+    audioHighWaterMark,
+  });
+  return { client, config, onIdleDeadlineApproaching, onRotationDue };
+}
+
+const SILENCE_FRAME = Buffer.alloc(640).toString('base64');
+
+describe('nova idle-deadline config', () => {
+  it('defaults to 240s — comfortably ahead of Bedrock’s ~295s idle kill', () => {
+    const cfg = getNovaSonicConfig({ NOVA_SONIC_ENABLED: 'true' } as NodeJS.ProcessEnv);
+    expect(cfg.idleRotationAfterMs).toBe(240_000);
+    // The whole point of the value. If someone raises it past the deadline
+    // the fail-safe silently stops being a fail-safe, so assert the relation
+    // rather than just the number.
+    expect(cfg.idleRotationAfterMs).toBeLessThan(BEDROCK_IDLE_DEADLINE_MS);
+    // Enough headroom to open + validate + swap a replacement stream.
+    expect(BEDROCK_IDLE_DEADLINE_MS - cfg.idleRotationAfterMs).toBeGreaterThanOrEqual(30_000);
+  });
+
+  it('is a DIFFERENT clock from the wall-clock rotation timer', () => {
+    const cfg = getNovaSonicConfig({ NOVA_SONIC_ENABLED: 'true' } as NodeJS.ProcessEnv);
+    // The bug: rotationAfterMs (435s) is past the idle deadline, so it can
+    // never protect it. This asserts the two are not conflated again.
+    expect(cfg.rotationAfterMs).toBeGreaterThan(BEDROCK_IDLE_DEADLINE_MS);
+    expect(cfg.idleRotationAfterMs).toBeLessThan(cfg.rotationAfterMs);
+  });
+
+  it('honours NOVA_SONIC_IDLE_ROTATION_AFTER_MS and treats 0 as disabled', () => {
+    const tuned = getNovaSonicConfig({
+      NOVA_SONIC_ENABLED: 'true',
+      NOVA_SONIC_IDLE_ROTATION_AFTER_MS: '120000',
+    } as NodeJS.ProcessEnv);
+    expect(tuned.idleRotationAfterMs).toBe(120_000);
+    expect(tuned.ready).toBe(true);
+
+    const off = getNovaSonicConfig({
+      NOVA_SONIC_ENABLED: 'true',
+      NOVA_SONIC_IDLE_ROTATION_AFTER_MS: '0',
+    } as NodeJS.ProcessEnv);
+    expect(off.idleRotationAfterMs).toBe(0);
+    expect(off.ready).toBe(true);
+  });
+
+  it('fails readiness loudly on a malformed value instead of silently defaulting', () => {
+    const bad = getNovaSonicConfig({
+      NOVA_SONIC_ENABLED: 'true',
+      NOVA_SONIC_IDLE_ROTATION_AFTER_MS: 'soon',
+    } as NodeJS.ProcessEnv);
+    expect(bad.issues).toContain('nova_idle_rotation_after_invalid');
+    expect(bad.ready).toBe(false);
+  });
+});
+
+describe('nova idle-deadline watchdog', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fires when no input has been accepted for the configured window', async () => {
+    const { client, onIdleDeadlineApproaching } = makeClient();
+    await client.connect(baseOptions());
+    expect(client.getState()).toBe('open');
+
+    jest.advanceTimersByTime(239_000);
+    expect(onIdleDeadlineApproaching).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(6_000);
+    expect(onIdleDeadlineApproaching).toHaveBeenCalledTimes(1);
+    expect(onIdleDeadlineApproaching.mock.calls[0][0].msSinceLastInput).toBeGreaterThanOrEqual(240_000);
+  });
+
+  it('fires with time to spare before Bedrock would kill the stream', async () => {
+    const { client, onIdleDeadlineApproaching } = makeClient();
+    await client.connect(baseOptions());
+
+    jest.advanceTimersByTime(BEDROCK_IDLE_DEADLINE_MS);
+    expect(onIdleDeadlineApproaching).toHaveBeenCalledTimes(1);
+    // Fired strictly before the deadline, not merely by the deadline.
+    const { msSinceLastInput } = onIdleDeadlineApproaching.mock.calls[0][0];
+    expect(msSinceLastInput).toBeLessThan(BEDROCK_IDLE_DEADLINE_MS);
+  });
+
+  it('never fires while the silence keepalive is feeding frames', async () => {
+    const { client, onIdleDeadlineApproaching } = makeClient();
+    await client.connect(baseOptions());
+
+    // The real keepalive cadence is 250ms; step well past the idle window.
+    for (let elapsed = 0; elapsed < 400_000; elapsed += 10_000) {
+      client.sendAudioChunk(SILENCE_FRAME, 'audio/pcm;rate=16000');
+      jest.advanceTimersByTime(10_000);
+    }
+    // This is the healthy-session case: the fix must be invisible.
+    expect(onIdleDeadlineApproaching).not.toHaveBeenCalled();
+  });
+
+  it('does NOT count a REFUSED audio frame as input', async () => {
+    // The critical accounting rule. A backpressured frame never reached
+    // Bedrock, so Bedrock's idle clock did not move. If the client stamped it
+    // anyway, sustained backpressure would look like a healthy session right
+    // up until Bedrock killed it — blinding the watchdog in one of the exact
+    // situations it exists to catch.
+    const { client, onIdleDeadlineApproaching } = makeClient({}, 1);
+    await client.connect(baseOptions());
+
+    // Overflow the high-water mark so every subsequent frame is refused.
+    let refusedAtLeastOnce = false;
+    for (let i = 0; i < 10; i++) {
+      if (!client.sendAudioChunk(SILENCE_FRAME, 'audio/pcm;rate=16000')) refusedAtLeastOnce = true;
+    }
+    expect(refusedAtLeastOnce).toBe(true);
+
+    // Keep offering frames that keep being refused, across the idle window.
+    for (let elapsed = 0; elapsed < 250_000; elapsed += 10_000) {
+      client.sendAudioChunk(SILENCE_FRAME, 'audio/pcm;rate=16000');
+      jest.advanceTimersByTime(10_000);
+    }
+    expect(onIdleDeadlineApproaching).toHaveBeenCalled();
+  });
+
+  it('counts a tool result as interactive content and resets the clock', async () => {
+    // Bedrock's own wording is "audio bytes OR interactive content" — a long
+    // tool round-trip is what keeps some turns from looking idle.
+    const { client, onIdleDeadlineApproaching } = makeClient();
+    await client.connect(baseOptions());
+
+    jest.advanceTimersByTime(200_000);
+    client.sendToolResult({ callId: 'abc', success: true, output: '{"ok":true}' });
+    jest.advanceTimersByTime(200_000 - 5_000);
+    expect(onIdleDeadlineApproaching).not.toHaveBeenCalled();
+  });
+
+  it('signals ONCE per idle episode, not on every tick', async () => {
+    const { client, onIdleDeadlineApproaching } = makeClient();
+    await client.connect(baseOptions());
+
+    jest.advanceTimersByTime(300_000);
+    expect(onIdleDeadlineApproaching).toHaveBeenCalledTimes(1);
+    // Without the one-shot latch this would stack a rotation attempt every
+    // 5s tick for as long as the session stayed quiet.
+    jest.advanceTimersByTime(300_000);
+    expect(onIdleDeadlineApproaching).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms after fresh input so a second idle episode is caught', async () => {
+    // A session can go idle, rotate, converse, and go idle again — unlike the
+    // wall-clock rotation, this one must not be fire-once-per-stream.
+    const { client, onIdleDeadlineApproaching } = makeClient();
+    await client.connect(baseOptions());
+
+    jest.advanceTimersByTime(250_000);
+    expect(onIdleDeadlineApproaching).toHaveBeenCalledTimes(1);
+
+    client.sendAudioChunk(SILENCE_FRAME, 'audio/pcm;rate=16000');
+    jest.advanceTimersByTime(250_000);
+    expect(onIdleDeadlineApproaching).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops after close — no callback on a dead stream', async () => {
+    const { client, onIdleDeadlineApproaching } = makeClient();
+    await client.connect(baseOptions());
+
+    // close() clears the watchdog synchronously, then awaits a drain race
+    // against a 1s timeout — which under fake timers only fires when we
+    // advance them. Start the close, advance past the drain, then settle.
+    const closing = client.close('user_stop');
+    jest.advanceTimersByTime(2_000);
+    await closing;
+    expect(client.getState()).toBe('closed');
+
+    jest.advanceTimersByTime(600_000);
+    expect(onIdleDeadlineApproaching).not.toHaveBeenCalled();
+  });
+
+  it('is fully disabled when idleRotationAfterMs is 0', async () => {
+    const { client, onIdleDeadlineApproaching } = makeClient({
+      NOVA_SONIC_IDLE_ROTATION_AFTER_MS: '0',
+    });
+    await client.connect(baseOptions());
+
+    jest.advanceTimersByTime(600_000);
+    expect(onIdleDeadlineApproaching).not.toHaveBeenCalled();
+  });
+
+  it('starts the idle clock at connect, not at zero', async () => {
+    // The init sequence (sessionStart → promptStart → system block →
+    // audioContentStart) is real accepted input. Without stamping it, a
+    // freshly-opened stream would read as 240s idle on the first tick.
+    const { client, onIdleDeadlineApproaching } = makeClient();
+    await client.connect(baseOptions());
+
+    expect(client.getMsSinceLastAcceptedInput()).toBeLessThan(1_000);
+    jest.advanceTimersByTime(6_000);
+    expect(onIdleDeadlineApproaching).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-NOVA-IDLE-ROTATION`
Item **3** of the production disconnect report.

## 📋 Two clocks, one timer

Bedrock enforces **two independent deadlines** on a bidirectional stream:

| # | Deadline | Measured from | Covered by |
|---|---|---|---|
| 1 | ~8 min stream cap | wall clock since connect | `rotationAfterMs` = **435s** ✅ |
| 2 | **~295s idle** | last **accepted input** | **nothing** ❌ |

Because these run on *different clocks*, a 435s wall-clock timer can never protect a 295s idle deadline. That is precisely the P0: a healthy 10-turn session died ~292s after its last input while the rotation timer was still **140s away**.

The keepalive fix (#3007) removed the *cause* of the idle drift. This adds the backstop for when frames stop flowing for a reason nobody predicted.

## ✅ What this adds

**Idle watchdog** in `NovaSonicLiveClient` — samples time-since-last-accepted-input, signals at **240s** (`NOVA_SONIC_IDLE_ROTATION_AFTER_MS`, `0` disables), leaving ~55s to open, validate and swap a replacement.

Sampling, not a one-shot `setTimeout`, because the deadline is measured from a **moving** timestamp — re-arming a timer on every audio frame would mean rebuilding it 4×/second for the whole session.

**The accounting rule that makes it work:** a **refused** audio frame (backpressure) is deliberately *not* stamped. It never reached Bedrock, so Bedrock's idle clock didn't move — stamping it would blind the watchdog during exactly the sustained-backpressure case it exists to catch. Tool results **do** stamp; Bedrock's own wording is *"audio bytes or interactive content"*.

**Rotation gains what it was missing** — it previously had *no retry at all* (`abandon the rotation (no retry), and ride the old stream`):
- bounded retry (3 attempts, linear backoff, ~3s worst case)
- after 3 failures → **explicit fall back to Vertex**, pinned for the rest of the session, emitted as diag + OASIS. Never silent (CLAUDE.md *"Never allow silent model fallback"*)
- concurrent rotations rejected instead of racing two replacement streams onto one session
- every rotation event now carries **why** it ran (`provider_stream_rotation` vs `idle_deadline_failsafe`)

Open-and-validate-before-close already existed and is unchanged.

## 🧪 Testing

- [x] **14 new tests**; full suite **11,500 passed** (13 pre-existing suites fail on a missing local `@aws-sdk/client-ecs` install — all autopilot/operator/governance, none touch ORB)
- [x] **Mutation-verified**: stamping the idle clock on a refused frame fails exactly one test — the one written to catch it
- [x] A guard asserting the 240s default stays **below** the 295s deadline, so raising it can't silently un-fail-safe the fail-safe
- [x] A guard that the two clocks stay distinct (`rotationAfterMs > 295s > idleRotationAfterMs`)
- [x] `tsc` clean

## 🚨 Honest limits

- **In a healthy session this never fires** — the 250ms keepalive pins the clock. If it *does* fire in production, the keepalive has stopped and **that** is the real bug; the log line says so explicitly.
- Rotation replaces the stream, which is also what finally ends a runaway Nova generation (`sendEndOfTurn()` is a no-op). But the loop guard shipped in #3007 signals via `suppressCurrentTurnAudio`, not rotation — **wiring the loop guard into this rotation path is not in this PR.**
- Item **5** (per-turn liveness / stale `vertexHasShownLife`) and item **6** (`local_close` telemetry split) are still open. Item 6 in particular means the *effect* of this change is hard to read in prod telemetry until it lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_