### PR TITLE
fix: fan out Appilix push across separate iOS/Android app credentials (BOOTSTRAP-CHAT-PUSH-NOTIF)

### DIFF
--- a/.github/workflows/AWS-PROVISION-APPILIX-SECRETS.yml
+++ b/.github/workflows/AWS-PROVISION-APPILIX-SECRETS.yml
@@ -3,15 +3,24 @@
 # gateway ECS task definitions (staging and/or prod).
 #
 # Context: Appilix native push (services/gateway/src/services/notification-
-# service.ts sendAppilixPush()) requires APPILIX_APP_KEY / APPILIX_API_KEY
-# env vars. These were deliberately stripped from the GCP Cloud Run gateway
-# (see EXEC-DEPLOY.yml: "Appilix API is down (522), secrets not in GCP
-# Secret Manager") and were NEVER wired into the AWS ECS task definitions at
-# all when gateway moved to AWS as sole production (VTID-03419) — so chat
-# push notifications have had no working delivery channel on AWS for native
-# (Appilix-wrapped iOS/Android) app users. The two GitHub repository secrets
-# (APPILIX_APP_KEY / APPILIX_API_KEY) already exist and hold real values;
-# this workflow is what actually gets them in front of the running service.
+# service.ts sendAppilixPush()) requires Appilix app_key/api_key env vars.
+# These were deliberately stripped from the GCP Cloud Run gateway (see
+# EXEC-DEPLOY.yml: "Appilix API is down (522), secrets not in GCP Secret
+# Manager") and were NEVER wired into the AWS ECS task definitions at all
+# when gateway moved to AWS as sole production (VTID-03419) — so chat push
+# notifications had no working delivery channel on AWS for native
+# (Appilix-wrapped) app users at all.
+#
+# MAXINA is registered as TWO SEPARATE Appilix apps — one tagged "iOS", one
+# tagged "Android" on the Appilix dashboard (same https://vitanaland.com
+# source, but each has its own app_key/api_key and its own pool of
+# registered devices). Android's pair (APPILIX_APP_KEY/APPILIX_API_KEY)
+# shipped first and confirmed working; iOS stayed silent until its own pair
+# (APPILIX_IOS_APP_KEY/APPILIX_IOS_API_KEY) was added here too — the server
+# code (sendAppilixPush) fans out across whichever platforms have
+# credentials configured. All four GitHub repository secrets already exist
+# with real values; this workflow is what actually gets them in front of
+# the running service.
 #
 # Design:
 # - workflow_dispatch only, with a required `reason` and a `target` choice
@@ -20,7 +29,11 @@
 # - Idempotent: uses describe-secret to decide create-secret vs
 #   put-secret-value, so re-running (e.g. after rotating the Appilix keys)
 #   is safe.
-# - Preserves the existing task definition; only ADDS/REPLACES the two
+# - iOS credentials are OPTIONAL at the workflow level (Android is
+#   required) — if APPILIX_IOS_APP_KEY/APPILIX_IOS_API_KEY repo secrets
+#   aren't set, the run proceeds Android-only rather than failing, so this
+#   workflow keeps working even if iOS keys are rotated/removed later.
+# - Preserves the existing task definition; only ADDS/REPLACES the Appilix
 #   `secrets` entries (task-def `secrets`, not `environment` — the values
 #   never appear in the task definition JSON itself, only the secret ARNs
 #   do). Everything else on the task def carries forward untouched.
@@ -29,10 +42,14 @@
 # - If the ECS task execution role lacks secretsmanager:GetSecretValue on
 #   the new secret ARNs, `aws ecs wait services-stable` will fail loudly
 #   (new tasks won't start; old tasks keep serving, so no outage) — that is
-#   the expected, safe failure mode if IAM needs a follow-up grant.
+#   the expected, safe failure mode if IAM needs a follow-up grant. (The
+#   IAM policies already granted for the Android pair use a
+#   `vitana/gateway[-awsdr]/appilix-*` wildcard resource, so they also
+#   cover the iOS secret names below with no additional grant needed.)
 #
 # Required repository secrets:
-#   APPILIX_APP_KEY / APPILIX_API_KEY  — the actual Appilix credentials
+#   APPILIX_APP_KEY / APPILIX_API_KEY  — Android Appilix credentials
+#   APPILIX_IOS_APP_KEY / APPILIX_IOS_API_KEY  — iOS Appilix credentials (optional)
 #   AWS_STAGING_ACCESS_KEY_ID / AWS_STAGING_SECRET_ACCESS_KEY  — staging leg
 #   AWS_PROD_ROLE_ARN  — prod leg (GitHub OIDC)
 
@@ -78,8 +95,10 @@ jobs:
       TARGET_AWS_REGION: ${{ inputs.aws_region }}
       ECS_CLUSTER: ${{ inputs.ecs_cluster }}
       ECS_SERVICE: vitana-gateway
-      APP_SECRET_NAME: vitana/gateway/appilix-app-key
-      API_SECRET_NAME: vitana/gateway/appilix-api-key
+      ANDROID_APP_SECRET_NAME: vitana/gateway/appilix-app-key
+      ANDROID_API_SECRET_NAME: vitana/gateway/appilix-api-key
+      IOS_APP_SECRET_NAME: vitana/gateway/appilix-ios-app-key
+      IOS_API_SECRET_NAME: vitana/gateway/appilix-ios-api-key
     steps:
       - name: Configure AWS credentials (staging static keys)
         uses: aws-actions/configure-aws-credentials@v4
@@ -93,48 +112,69 @@ jobs:
         env:
           APPILIX_APP_KEY: ${{ secrets.APPILIX_APP_KEY }}
           APPILIX_API_KEY: ${{ secrets.APPILIX_API_KEY }}
+          APPILIX_IOS_APP_KEY: ${{ secrets.APPILIX_IOS_APP_KEY }}
+          APPILIX_IOS_API_KEY: ${{ secrets.APPILIX_IOS_API_KEY }}
         run: |
           set -e
           if [ -z "$APPILIX_APP_KEY" ] || [ -z "$APPILIX_API_KEY" ]; then
             echo "::error::APPILIX_APP_KEY / APPILIX_API_KEY repository secrets are not set."
             exit 1
           fi
+          if [ -z "$APPILIX_IOS_APP_KEY" ] || [ -z "$APPILIX_IOS_API_KEY" ]; then
+            echo "::warning::APPILIX_IOS_APP_KEY / APPILIX_IOS_API_KEY not set — provisioning Android only this run."
+          fi
 
           upsert_secret() {
-            local name="$1" value="$2"
+            local name="$1" value="$2" desc="$3"
             if aws secretsmanager describe-secret --secret-id "$name" >/dev/null 2>&1; then
               aws secretsmanager put-secret-value --secret-id "$name" --secret-string "$value" \
                 --query 'ARN' --output text
             else
               aws secretsmanager create-secret --name "$name" \
-                --description "Appilix push credential (gateway staging)" \
+                --description "$desc" \
                 --secret-string "$value" --query 'ARN' --output text
             fi
           }
 
-          APP_ARN=$(upsert_secret "$APP_SECRET_NAME" "$APPILIX_APP_KEY")
-          API_ARN=$(upsert_secret "$API_SECRET_NAME" "$APPILIX_API_KEY")
-          echo "app_arn=$APP_ARN" >> "$GITHUB_OUTPUT"
-          echo "api_arn=$API_ARN" >> "$GITHUB_OUTPUT"
-          echo "Provisioned $APP_SECRET_NAME -> $APP_ARN"
-          echo "Provisioned $API_SECRET_NAME -> $API_ARN"
+          ANDROID_APP_ARN=$(upsert_secret "$ANDROID_APP_SECRET_NAME" "$APPILIX_APP_KEY" "Appilix push credential, Android (gateway staging)")
+          ANDROID_API_ARN=$(upsert_secret "$ANDROID_API_SECRET_NAME" "$APPILIX_API_KEY" "Appilix push credential, Android (gateway staging)")
+          echo "android_app_arn=$ANDROID_APP_ARN" >> "$GITHUB_OUTPUT"
+          echo "android_api_arn=$ANDROID_API_ARN" >> "$GITHUB_OUTPUT"
+          echo "Provisioned $ANDROID_APP_SECRET_NAME -> $ANDROID_APP_ARN"
+          echo "Provisioned $ANDROID_API_SECRET_NAME -> $ANDROID_API_ARN"
+
+          if [ -n "$APPILIX_IOS_APP_KEY" ] && [ -n "$APPILIX_IOS_API_KEY" ]; then
+            IOS_APP_ARN=$(upsert_secret "$IOS_APP_SECRET_NAME" "$APPILIX_IOS_APP_KEY" "Appilix push credential, iOS (gateway staging)")
+            IOS_API_ARN=$(upsert_secret "$IOS_API_SECRET_NAME" "$APPILIX_IOS_API_KEY" "Appilix push credential, iOS (gateway staging)")
+            echo "ios_app_arn=$IOS_APP_ARN" >> "$GITHUB_OUTPUT"
+            echo "ios_api_arn=$IOS_API_ARN" >> "$GITHUB_OUTPUT"
+            echo "Provisioned $IOS_APP_SECRET_NAME -> $IOS_APP_ARN"
+            echo "Provisioned $IOS_API_SECRET_NAME -> $IOS_API_ARN"
+          fi
 
       - name: Bind secrets onto the ECS task definition + roll the service
         env:
-          APP_ARN: ${{ steps.secrets.outputs.app_arn }}
-          API_ARN: ${{ steps.secrets.outputs.api_arn }}
+          ANDROID_APP_ARN: ${{ steps.secrets.outputs.android_app_arn }}
+          ANDROID_API_ARN: ${{ steps.secrets.outputs.android_api_arn }}
+          IOS_APP_ARN: ${{ steps.secrets.outputs.ios_app_arn }}
+          IOS_API_ARN: ${{ steps.secrets.outputs.ios_api_arn }}
         run: |
           set -e
           TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
             --query 'services[0].taskDefinition' --output text)
           echo "Current task definition: $TD_ARN"
           NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
-            | jq --arg APP_ARN "$APP_ARN" --arg API_ARN "$API_ARN" '
+            | jq --arg ANDROID_APP_ARN "$ANDROID_APP_ARN" --arg ANDROID_API_ARN "$ANDROID_API_ARN" \
+                 --arg IOS_APP_ARN "$IOS_APP_ARN" --arg IOS_API_ARN "$IOS_API_ARN" '
                 .containerDefinitions[0].secrets = (
                   ( (.containerDefinitions[0].secrets // [])
-                    | map(select(.name | IN("APPILIX_APP_KEY","APPILIX_API_KEY") | not)) )
-                  + [ {name:"APPILIX_APP_KEY", valueFrom:$APP_ARN},
-                      {name:"APPILIX_API_KEY", valueFrom:$API_ARN} ] )
+                    | map(select(.name | IN("APPILIX_APP_KEY","APPILIX_API_KEY","APPILIX_IOS_APP_KEY","APPILIX_IOS_API_KEY") | not)) )
+                  + [ {name:"APPILIX_APP_KEY", valueFrom:$ANDROID_APP_ARN},
+                      {name:"APPILIX_API_KEY", valueFrom:$ANDROID_API_ARN} ]
+                  + ( if $IOS_APP_ARN != "" and $IOS_API_ARN != "" then
+                        [ {name:"APPILIX_IOS_APP_KEY", valueFrom:$IOS_APP_ARN},
+                          {name:"APPILIX_IOS_API_KEY", valueFrom:$IOS_API_ARN} ]
+                      else [] end ) )
                 | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
                       .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
           NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" \
@@ -156,10 +196,16 @@ jobs:
 
       - name: Summary
         if: success()
+        env:
+          IOS_APP_ARN: ${{ steps.secrets.outputs.ios_app_arn }}
         run: |
+          PLATFORMS="APPILIX_APP_KEY, APPILIX_API_KEY (Android)"
+          if [ -n "$IOS_APP_ARN" ]; then
+            PLATFORMS="$PLATFORMS, APPILIX_IOS_APP_KEY, APPILIX_IOS_API_KEY (iOS)"
+          fi
           {
             echo "## Appilix secrets provisioned — AWS staging (vitana-gateway)"
-            echo "- Secrets bound: APPILIX_APP_KEY, APPILIX_API_KEY"
+            echo "- Secrets bound: $PLATFORMS"
             echo "- Reason: ${{ inputs.reason }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -178,8 +224,10 @@ jobs:
       TARGET_AWS_REGION: ${{ inputs.aws_region }}
       ECS_CLUSTER: ${{ inputs.ecs_cluster }}
       ECS_SERVICE: vitana-gateway-awsdr
-      APP_SECRET_NAME: vitana/gateway-awsdr/appilix-app-key
-      API_SECRET_NAME: vitana/gateway-awsdr/appilix-api-key
+      ANDROID_APP_SECRET_NAME: vitana/gateway-awsdr/appilix-app-key
+      ANDROID_API_SECRET_NAME: vitana/gateway-awsdr/appilix-api-key
+      IOS_APP_SECRET_NAME: vitana/gateway-awsdr/appilix-ios-app-key
+      IOS_API_SECRET_NAME: vitana/gateway-awsdr/appilix-ios-api-key
     steps:
       - name: Configure AWS credentials (prod OIDC role)
         uses: aws-actions/configure-aws-credentials@v4
@@ -192,48 +240,69 @@ jobs:
         env:
           APPILIX_APP_KEY: ${{ secrets.APPILIX_APP_KEY }}
           APPILIX_API_KEY: ${{ secrets.APPILIX_API_KEY }}
+          APPILIX_IOS_APP_KEY: ${{ secrets.APPILIX_IOS_APP_KEY }}
+          APPILIX_IOS_API_KEY: ${{ secrets.APPILIX_IOS_API_KEY }}
         run: |
           set -e
           if [ -z "$APPILIX_APP_KEY" ] || [ -z "$APPILIX_API_KEY" ]; then
             echo "::error::APPILIX_APP_KEY / APPILIX_API_KEY repository secrets are not set."
             exit 1
           fi
+          if [ -z "$APPILIX_IOS_APP_KEY" ] || [ -z "$APPILIX_IOS_API_KEY" ]; then
+            echo "::warning::APPILIX_IOS_APP_KEY / APPILIX_IOS_API_KEY not set — provisioning Android only this run."
+          fi
 
           upsert_secret() {
-            local name="$1" value="$2"
+            local name="$1" value="$2" desc="$3"
             if aws secretsmanager describe-secret --secret-id "$name" >/dev/null 2>&1; then
               aws secretsmanager put-secret-value --secret-id "$name" --secret-string "$value" \
                 --query 'ARN' --output text
             else
               aws secretsmanager create-secret --name "$name" \
-                --description "Appilix push credential (gateway prod, VTID-03398 AWS-DR)" \
+                --description "$desc" \
                 --secret-string "$value" --query 'ARN' --output text
             fi
           }
 
-          APP_ARN=$(upsert_secret "$APP_SECRET_NAME" "$APPILIX_APP_KEY")
-          API_ARN=$(upsert_secret "$API_SECRET_NAME" "$APPILIX_API_KEY")
-          echo "app_arn=$APP_ARN" >> "$GITHUB_OUTPUT"
-          echo "api_arn=$API_ARN" >> "$GITHUB_OUTPUT"
-          echo "Provisioned $APP_SECRET_NAME -> $APP_ARN"
-          echo "Provisioned $API_SECRET_NAME -> $API_ARN"
+          ANDROID_APP_ARN=$(upsert_secret "$ANDROID_APP_SECRET_NAME" "$APPILIX_APP_KEY" "Appilix push credential, Android (gateway prod, VTID-03398 AWS-DR)")
+          ANDROID_API_ARN=$(upsert_secret "$ANDROID_API_SECRET_NAME" "$APPILIX_API_KEY" "Appilix push credential, Android (gateway prod, VTID-03398 AWS-DR)")
+          echo "android_app_arn=$ANDROID_APP_ARN" >> "$GITHUB_OUTPUT"
+          echo "android_api_arn=$ANDROID_API_ARN" >> "$GITHUB_OUTPUT"
+          echo "Provisioned $ANDROID_APP_SECRET_NAME -> $ANDROID_APP_ARN"
+          echo "Provisioned $ANDROID_API_SECRET_NAME -> $ANDROID_API_ARN"
+
+          if [ -n "$APPILIX_IOS_APP_KEY" ] && [ -n "$APPILIX_IOS_API_KEY" ]; then
+            IOS_APP_ARN=$(upsert_secret "$IOS_APP_SECRET_NAME" "$APPILIX_IOS_APP_KEY" "Appilix push credential, iOS (gateway prod, VTID-03398 AWS-DR)")
+            IOS_API_ARN=$(upsert_secret "$IOS_API_SECRET_NAME" "$APPILIX_IOS_API_KEY" "Appilix push credential, iOS (gateway prod, VTID-03398 AWS-DR)")
+            echo "ios_app_arn=$IOS_APP_ARN" >> "$GITHUB_OUTPUT"
+            echo "ios_api_arn=$IOS_API_ARN" >> "$GITHUB_OUTPUT"
+            echo "Provisioned $IOS_APP_SECRET_NAME -> $IOS_APP_ARN"
+            echo "Provisioned $IOS_API_SECRET_NAME -> $IOS_API_ARN"
+          fi
 
       - name: Bind secrets onto the ECS task definition + roll the service
         env:
-          APP_ARN: ${{ steps.secrets.outputs.app_arn }}
-          API_ARN: ${{ steps.secrets.outputs.api_arn }}
+          ANDROID_APP_ARN: ${{ steps.secrets.outputs.android_app_arn }}
+          ANDROID_API_ARN: ${{ steps.secrets.outputs.android_api_arn }}
+          IOS_APP_ARN: ${{ steps.secrets.outputs.ios_app_arn }}
+          IOS_API_ARN: ${{ steps.secrets.outputs.ios_api_arn }}
         run: |
           set -e
           TD_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" \
             --query 'services[0].taskDefinition' --output text)
           echo "Current task definition: $TD_ARN"
           NEW_DEF=$(aws ecs describe-task-definition --task-definition "$TD_ARN" --query taskDefinition \
-            | jq --arg APP_ARN "$APP_ARN" --arg API_ARN "$API_ARN" '
+            | jq --arg ANDROID_APP_ARN "$ANDROID_APP_ARN" --arg ANDROID_API_ARN "$ANDROID_API_ARN" \
+                 --arg IOS_APP_ARN "$IOS_APP_ARN" --arg IOS_API_ARN "$IOS_API_ARN" '
                 .containerDefinitions[0].secrets = (
                   ( (.containerDefinitions[0].secrets // [])
-                    | map(select(.name | IN("APPILIX_APP_KEY","APPILIX_API_KEY") | not)) )
-                  + [ {name:"APPILIX_APP_KEY", valueFrom:$APP_ARN},
-                      {name:"APPILIX_API_KEY", valueFrom:$API_ARN} ] )
+                    | map(select(.name | IN("APPILIX_APP_KEY","APPILIX_API_KEY","APPILIX_IOS_APP_KEY","APPILIX_IOS_API_KEY") | not)) )
+                  + [ {name:"APPILIX_APP_KEY", valueFrom:$ANDROID_APP_ARN},
+                      {name:"APPILIX_API_KEY", valueFrom:$ANDROID_API_ARN} ]
+                  + ( if $IOS_APP_ARN != "" and $IOS_API_ARN != "" then
+                        [ {name:"APPILIX_IOS_APP_KEY", valueFrom:$IOS_APP_ARN},
+                          {name:"APPILIX_IOS_API_KEY", valueFrom:$IOS_API_ARN} ]
+                      else [] end ) )
                 | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
                       .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)')
           NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" \
@@ -255,9 +324,15 @@ jobs:
 
       - name: Summary
         if: success()
+        env:
+          IOS_APP_ARN: ${{ steps.secrets.outputs.ios_app_arn }}
         run: |
+          PLATFORMS="APPILIX_APP_KEY, APPILIX_API_KEY (Android)"
+          if [ -n "$IOS_APP_ARN" ]; then
+            PLATFORMS="$PLATFORMS, APPILIX_IOS_APP_KEY, APPILIX_IOS_API_KEY (iOS)"
+          fi
           {
             echo "## Appilix secrets provisioned — AWS prod (vitana-gateway-awsdr)"
-            echo "- Secrets bound: APPILIX_APP_KEY, APPILIX_API_KEY"
+            echo "- Secrets bound: $PLATFORMS"
             echo "- Reason: ${{ inputs.reason }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -274,25 +274,49 @@ export async function sendPushToUser(
   return sent;
 }
 
-// ── Appilix Native Push (Maxina Android app) ────────────────
+// ── Appilix Native Push (Maxina iOS + Android apps) ──────────
 
 /**
- * Send push notification via the Appilix Push Notification API.
- * This delivers a native Android notification branded as "Maxina"
- * (not a Chrome browser notification).
+ * MAXINA is registered as TWO SEPARATE Appilix apps (confirmed on the
+ * Appilix dashboard: one card tagged "iOS", one tagged "Android" — same
+ * https://vitanaland.com source, but each has its OWN app_key/api_key and
+ * its own pool of registered devices/user_identity mappings). A push call
+ * with one platform's credentials only reaches devices registered under
+ * THAT app — sending only Android credentials silently no-ops for every
+ * iOS user (this is exactly what happened: Android delivery worked after
+ * APPILIX_APP_KEY/APPILIX_API_KEY were wired up, iOS stayed silent).
+ * sendAppilixPush() therefore fans out across every configured platform's
+ * credentials and succeeds if ANY of them delivers. Appilix returns HTTP
+ * 200 with status:false ("No devices...") for the platform a given user
+ * isn't on — that's an expected, harmless outcome of trying the other
+ * platform, not a real failure.
+ */
+function getAppilixCredentialSets(): Array<{ platform: string; appKey: string; apiKey: string }> {
+  const sets: Array<{ platform: string; appKey: string; apiKey: string }> = [];
+  if (process.env.APPILIX_APP_KEY && process.env.APPILIX_API_KEY) {
+    sets.push({ platform: 'android', appKey: process.env.APPILIX_APP_KEY, apiKey: process.env.APPILIX_API_KEY });
+  }
+  if (process.env.APPILIX_IOS_APP_KEY && process.env.APPILIX_IOS_API_KEY) {
+    sets.push({ platform: 'ios', appKey: process.env.APPILIX_IOS_APP_KEY, apiKey: process.env.APPILIX_IOS_API_KEY });
+  }
+  return sets;
+}
+
+/**
+ * Send push notification via the Appilix Push Notification API for ONE
+ * platform's credentials. This delivers a native notification branded as
+ * "Maxina" (not a Chrome browser notification).
  *
- * Requires APPILIX_APP_KEY and APPILIX_API_KEY env vars.
  * User identity is mapped via window.appilix_push_notification_user_identity
  * in the Appilix Custom JS (set to the Supabase user ID).
  */
-export async function sendAppilixPush(
+async function sendAppilixPushWithCredentials(
   userId: string,
-  payload: NotificationPayload
+  payload: NotificationPayload,
+  platform: string,
+  appKey: string,
+  apiKey: string
 ): Promise<boolean> {
-  const appKey = process.env.APPILIX_APP_KEY;
-  const apiKey = process.env.APPILIX_API_KEY;
-  if (!appKey || !apiKey) return false;
-
   try {
     // Appilix API does NOT decode open_link_url (confirmed by their support),
     // so that field must be sent raw. However, notification_title and
@@ -317,7 +341,7 @@ export async function sendAppilixPush(
     }
 
     console.log(
-      `[Appilix] push user=${userId.slice(0, 8)}… ` +
+      `[Appilix] push(${platform}) user=${userId.slice(0, 8)}… ` +
       `title=${JSON.stringify(payload.title)} ` +
       `body_len=${payload.body.length} ` +
       `open_link_url=${JSON.stringify(resolvedOpenLink ?? null)}`
@@ -332,12 +356,13 @@ export async function sendAppilixPush(
     const text = await res.text().catch(() => '');
 
     if (!res.ok) {
-      console.warn(`[Notifications] Appilix push failed (${res.status}):`, text);
+      console.warn(`[Notifications] Appilix(${platform}) push failed (${res.status}):`, text);
       return false;
     }
 
     // Appilix returns HTTP 200 with { status: false, message: "No devices..." }
-    // when delivery fails (e.g. no device registered for that user_identity).
+    // when delivery fails (e.g. no device registered for that user_identity —
+    // expected/harmless when this user isn't on this platform's app).
     // Parse the JSON body and treat status:false as failure so the log
     // accurately reflects what Appilix did.
     let parsed: { status?: boolean | string; message?: string } | null = null;
@@ -345,17 +370,35 @@ export async function sendAppilixPush(
     const ok = parsed?.status === true || parsed?.status === 'true';
     if (!ok) {
       console.warn(
-        `[Notifications] Appilix push DROPPED for user=${userId.slice(0, 8)}…: ` +
+        `[Notifications] Appilix(${platform}) push DROPPED for user=${userId.slice(0, 8)}…: ` +
         `${parsed?.message || text}`
       );
       return false;
     }
-    console.log(`[Notifications] Appilix push sent for user=${userId.slice(0, 8)}…`);
+    console.log(`[Notifications] Appilix(${platform}) push sent for user=${userId.slice(0, 8)}…`);
     return true;
   } catch (err: any) {
-    console.error('[Notifications] Appilix push error:', err.message || err);
+    console.error(`[Notifications] Appilix(${platform}) push error:`, err.message || err);
     return false;
   }
+}
+
+/**
+ * Public entry point — fans out across every configured Appilix platform
+ * (Android, iOS). Returns true if ANY platform's push actually delivered.
+ * A platform with no configured credentials is skipped, not attempted.
+ */
+export async function sendAppilixPush(
+  userId: string,
+  payload: NotificationPayload
+): Promise<boolean> {
+  const credentialSets = getAppilixCredentialSets();
+  if (credentialSets.length === 0) return false;
+
+  const results = await Promise.all(
+    credentialSets.map((c) => sendAppilixPushWithCredentials(userId, payload, c.platform, c.appKey, c.apiKey))
+  );
+  return results.some((sent) => sent === true);
 }
 
 // ── Dynamic Category Preference Check ────────────────────────


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-CHAT-PUSH-NOTIF` _(follow-up to #2999/#3008, no VTID exists for this yet; tracked under this BOOTSTRAP tag pending one)_

**Layer:** APIL (Gateway notification service) + CICDL (AWS ECS secrets provisioning)

**Priority:** P1

---

## 📋 Summary

Second follow-up to #2999/#3008. After #3008 wired up Appilix credentials on AWS, chat push started working on **Android** but stayed completely silent on **iOS**.

Root cause: MAXINA is registered as **two separate apps** in Appilix's dashboard — one tagged "iOS", one tagged "Android" (confirmed via screenshot: `appilix.com/dashboard/apps`) — same `https://vitanaland.com` source, but each with its **own** `app_key`/`api_key` pair and its own pool of registered devices/`user_identity` mappings. `sendAppilixPush()` only ever sent with **one** credential pair (the Android one, from #3008), so a push call only ever reached devices registered under that specific app. iOS devices, registered under the *other* Appilix app, never received anything — not an error, just a call that never targets them.

---

## ✅ Changes

- [x] `services/gateway/src/services/notification-service.ts`: `sendAppilixPush()` now fans out across **every configured platform's credentials** (Android `APPILIX_APP_KEY`/`APPILIX_API_KEY`, iOS `APPILIX_IOS_APP_KEY`/`APPILIX_IOS_API_KEY`) and succeeds if **any** delivers. Appilix returning `status:false` ("No devices...") for the platform a user isn't on is expected/harmless — that's the mechanism that makes trying both safe.
- [x] `.github/workflows/AWS-PROVISION-APPILIX-SECRETS.yml`: extended to also create/bind `APPILIX_IOS_APP_KEY`/`APPILIX_IOS_API_KEY` (both already exist as GitHub repo secrets) onto the staging (`vitana-gateway`) and prod (`vitana-gateway-awsdr`) ECS task definitions, alongside the existing Android pair. iOS is optional at the workflow level — a rerun without those two secrets set still provisions Android-only rather than hard-failing.

---

## 🧪 Testing

- [x] Type-checked `notification-service.ts` in isolation (`tsc --noEmit`, filtering environment-only "cannot find module" noise from the sandbox's missing `node_modules`) — no errors.
- [x] Validated the workflow YAML parses correctly.
- [ ] Not yet dispatched — plan: merge → verify staging deploy picks up the code → dispatch `AWS-PROVISION-APPILIX-SECRETS.yml` (staging leg) to bind the iOS secrets there → once confirmed, PUBLISH/dispatch prod code deploy → dispatch the provisioning workflow's prod leg → live verification on the reporter's iPhone.
- [ ] The already-attached IAM policies for the Android secrets (`vitana-appilix-secrets-staging`/`-prod`) use a `vitana/gateway[-awsdr]/appilix-*` **wildcard** resource, so they should already cover the new iOS secret names with no additional IAM grant needed — will confirm when the workflow runs.

---

## 🚨 Breaking Changes

None. `sendAppilixPush(userId, payload)`'s public signature is unchanged; all existing call sites (`chat.ts`, `chat-groups.ts`, `scheduled-notifications.ts`) are unaffected. If iOS credentials are ever unset, behavior degrades gracefully to Android-only (today's behavior), not an error.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8WNmvimt7WKc5e58uQhGb)_