### PR TITLE
Fix send_chat_message stuck on stale single-call contract in text chat

### DIFF
--- a/services/gateway/src/services/conversation-client.ts
+++ b/services/gateway/src/services/conversation-client.ts
@@ -574,10 +574,12 @@ ${ucConfig.common_instructions || '- Use the memory context to personalize respo
 
 Sending messages to other members:
 - You CAN send a direct chat message to another community member on the user's behalf using the send_chat_message tool. When the user asks to message someone ("send Maria a message saying ...", "schick Mariia eine Nachricht: ..."), do this:
-  1. Confirm the recipient and the exact message text with the user first ("Soll ich die Nachricht an <name> senden?").
-  2. When the user confirms (e.g. "yes, send it" / "ja, versende es"), call send_chat_message with recipient_label set to the name the user used (full name preferred) and body set to the exact message text.
-  3. If the name is ambiguous, call resolve_recipient first to disambiguate, then confirm with the user.
-- NEVER claim a message was sent unless send_chat_message returned ok. If it returns an error, tell the user honestly and offer to try again — do NOT silently switch to a different action like searching for events.
+  1. If the name is ambiguous, call resolve_recipient first to disambiguate.
+  2. Call send_chat_message with recipient_label set to the name the user used (full name preferred) and body set to the exact message text — WITHOUT confirmed set. This only returns a preview; it does NOT send anything yet.
+  3. Read the preview's recipient and exact message text back to the user and ask them to confirm ("Soll ich die Nachricht an <name> senden: '<text>'?").
+  4. Only when the user confirms (e.g. "yes, send it" / "ja, versende es"), call send_chat_message again with the SAME recipient_label and body PLUS confirmed: true. This second call is what actually delivers the message — the tool enforces this two-call handshake server-side, so skipping straight to confirmed:true or never sending it at all both fail silently from the user's perspective.
+  5. Never narrate this contract (tool names, "confirmed", "resolve_recipient") to the user — it is internal. Speak only in natural language.
+- NEVER claim a message was sent unless a send_chat_message call with confirmed:true returned ok. If it returns an error, tell the user honestly and offer to try again — do NOT silently switch to a different action like searching for events.
 
 Sharing Links:
 - Event search results include a "Link:" field with a URL like https://vitanaland.com/e/{slug}. When the user asks about an event or asks for a link, you MUST copy this exact URL into your response on its own line. NEVER say "the link is on its way" or "I'll send the link" — paste the actual URL.

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -492,12 +492,14 @@ Returns checklist items with pass/fail status based on OASIS evidence.`,
       name: 'send_chat_message',
       description: `Send a direct chat message to another community member on the user's behalf. Use this when the user asks to send/write a message to a person (e.g. "send Maria a message saying ...", "schick Mariia eine Nachricht: ...").
 
-FLOW:
-1. Read back the recipient and the exact message text and ask the user to confirm ("Soll ich die Nachricht senden?").
-2. ONLY after the user confirms (e.g. "yes, send it" / "ja, versende es") call this tool.
-3. Pass recipient_label as the name the user used (full name preferred) and body as the EXACT message text the user dictated.
+CONFIRMATION CONTRACT (mandatory — the server enforces this — a call without confirmed=true never delivers the message):
+1. Call send_chat_message(recipient_label, body) WITHOUT confirmed=true. It returns a preview ("Ready to send to X: ...") — nothing is sent yet.
+2. Read the recipient AND message body back to the user verbatim ("Soll ich die Nachricht an <name> senden: '<body>'?").
+3. Wait for explicit confirmation (e.g. "yes, send it" / "ja, versende es").
+4. Call send_chat_message again with the SAME arguments PLUS confirmed: true to actually deliver it.
 
-NEVER claim a message was sent unless this tool returned ok. If it returns an error, tell the user honestly and offer to try again — do NOT silently switch to a different action.`,
+NEVER call this tool with confirmed=true before the user has confirmed the read-back. NEVER describe these steps to the user in prose — just follow them silently and call the tool.
+NEVER claim a message was sent unless a call with confirmed=true returned ok. If it returns an error, tell the user honestly and offer to try again — do NOT silently switch to a different action.`,
       parameters: {
         type: 'object',
         properties: {
@@ -512,9 +514,13 @@ NEVER claim a message was sent unless this tool returned ok. If it returns an er
           body: {
             type: 'string',
             description: 'The message text to send, exactly as the user dictated it.'
+          },
+          confirmed: {
+            type: 'boolean',
+            description: 'Pass true ONLY after the user explicitly confirmed the read-back of both recipient and message. Omit or false for the preview call.'
           }
         },
-        required: ['body']
+        required: ['recipient_label', 'body']
       }
     },
     // ===== VTID-DEV-ASSIST: Developer Assistant Tools =====
@@ -3037,7 +3043,7 @@ async function callVertexWithTools(
     model: VERTEX_MODEL,
     generationConfig: {
       temperature: 0.7,
-      maxOutputTokens: 1024,
+      maxOutputTokens: 4096,
       topP: 0.95,
       topK: 40
     },
@@ -3138,7 +3144,7 @@ async function sendToolResultsToVertex(
     model: VERTEX_MODEL,
     generationConfig: {
       temperature: 0.7,
-      maxOutputTokens: 1024,
+      maxOutputTokens: 4096,
     },
     systemInstruction: {
       role: 'system',
@@ -3507,7 +3513,7 @@ async function callGeminiWithTools(
     },
     generationConfig: {
       temperature: 0.7,
-      maxOutputTokens: 1024
+      maxOutputTokens: 4096
     }
   };
 
@@ -3635,7 +3641,7 @@ CRITICAL — Sharing links:
     },
     generationConfig: {
       temperature: 0.7,
-      maxOutputTokens: 1024
+      maxOutputTokens: 4096
     }
   };
 


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-CHAT-SEND-CONFIRM-FIX` _(no formal VTID existed yet for this regression fix; tagged per existing BOOTSTRAP-* changelog convention)_

**Layer:** APIL (gateway conversation/tool-calling)

**Priority:** P0 — user-reported production regression, feature completely broken

---

## 📋 Summary

Reported bug: asking Vitana (via the community-app chat / Operator Console) to send a message to another user always used to work, but now Vitana refuses and instead dumps raw internal tool-call syntax into the chat (`resolve_recipient`, `send_chat_message`, "confirmed") as if it were conversational prose, then keeps asking for a recipient the user already gave, and gets cut off mid-sentence.

Root cause: commit `797445fc` added a server-enforced `confirmed === true` gate to the shared `tool_send_chat_message` handler (`orb-tools-shared.ts`) as part of a two-call preview/confirm contract, and updated the **voice** tool catalog (`live-tool-catalog.ts`) to match. It never updated the **text-chat** tool schema/prompt (`gemini-operator.ts` / `conversation-client.ts`), which still describe/expose the old single-call contract with no `confirmed` field. With no legal way to ever satisfy the server's gate, the model had no valid next tool call and instead surfaced the internal contract as raw text to the user.

---

## ✅ Changes

- [x] `gemini-operator.ts`: add `confirmed` boolean param to `send_chat_message`'s tool schema, rewrite its description to the two-call preview/confirm contract (mirrors `live-tool-catalog.ts`), require `recipient_label` alongside `body`.
- [x] `conversation-client.ts`: rewrite the "Sending messages to other members" system-prompt block to the same preview → read-back → confirm(`confirmed:true`) flow, with an explicit instruction to never narrate the tool contract to the user.
- [x] `gemini-operator.ts`: bump `maxOutputTokens` 1024 → 4096 on all four Vertex/Gemini-API-key text-chat generation configs — a model narrating this contract instead of executing it produces a long reply that was getting clipped mid-sentence at the old ceiling (same class of fix already applied to the voice path in `nova-sonic-config.ts`).

---

## 🧪 Testing

- [x] `cd services/gateway && npm run build` — compiles clean, `dist/` produced.
- [ ] Manual verification against a live environment (staging) — not done in this session; recommend a maintainer/operator re-run the exact repro ("send a message to <user> saying <text>" via the community-app chat) on staging before promoting to prod.
- [ ] Automated tests: none added — no existing test harness covers this tool-calling flow.

---

## 📝 Phase 2B Naming Compliance Checklist

- [x] No GitHub Actions workflow files touched.
- [x] No new files added (only edits to two existing kebab-case files).
- [x] No VTID/event-type/status constants added.
- [x] No Cloud Run deployment/label changes.
- [x] VTID/BOOTSTRAP tag included in commit message.

---

## 🔗 Links

- **Related:** commit `797445fc` (added the `confirmed=true` server gate + updated voice's `live-tool-catalog.ts`, but not text-chat) is the change this PR brings back into sync with.

---

## 🚨 Breaking Changes

None — this restores the text-chat `send_chat_message` tool to a working two-call contract that already matches what the server enforces and what voice already does.

---

## 📸 Screenshots (if applicable)

N/A (backend-only fix; user-reported bug included chat screenshots showing the broken behavior, not attached here).

---

## 📌 Additional Notes

Separately noted during investigation (not addressed in this PR, flagging for awareness): gateway was cut over to AWS ECS as sole production on 2026-07-27 (VTID-03419), and `gemini-operator.ts`'s Vertex client relies on ADC, which may not resolve on AWS ECS Fargate without `GCP_SERVICE_ACCOUNT_JSON` being bound (see `gcp-adc-bootstrap.ts`'s own header comment). If Vertex is silently failing on AWS and falling through to the Gemini-API-key path, that's a reliability concern independent of this bug — this PR's fix applies to both paths either way, since they share the same tool schema and system prompt. Worth a maintainer confirming which provider is actually serving traffic (`[VTID-01023] Vertex AI error, trying fallback` in logs) if send-message issues persist after this fix ships.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc5c6mP4QHaydiSe2DjnvT)_