### PR TITLE
fix(ci): chain android emulator script commands on one shell line

### DIFF
--- a/.github/workflows/ANDROID-DEVICE-E2E.yml
+++ b/.github/workflows/ANDROID-DEVICE-E2E.yml
@@ -79,13 +79,12 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: |
-            cd e2e
-            npm run sim:doctor:android
-            node mobile-sim/android/run.mjs \
-              --url "${{ inputs.url }}" \
-              --flow "${{ inputs.flow }}" \
-              --out mobile-sim/artifacts/run
+          # reactivecircus/android-emulator-runner runs each line of `script`
+          # as its OWN separate shell invocation — a `cd` on one line does
+          # NOT persist to the next (confirmed: the first live run failed
+          # with "Missing script" because `npm run` executed from the repo
+          # root, not e2e/). Chain everything with && on one logical line.
+          script: cd e2e && npm run sim:doctor:android && node mobile-sim/android/run.mjs --url "${{ inputs.url }}" --flow "${{ inputs.flow }}" --out mobile-sim/artifacts/run
 
       - name: Upload artifacts (screenshots + element dumps + summary + video)
         if: always()


### PR DESCRIPTION
## Summary
First live `ANDROID-DEVICE-E2E` run (see #2886) confirmed the KVM-backed emulator boots correctly via `reactivecircus/android-emulator-runner` (~2s snapshot restore) but failed immediately after: `npm run sim:doctor:android` errored with `Missing script` because it ran from the repo root, not `e2e/`. Root cause: that action's `script:` input runs **each line as its own separate shell invocation** — the preceding `cd e2e` did not persist to the next line. Fix: chain the whole sequence with `&&` on one line.

## Changes
- `.github/workflows/ANDROID-DEVICE-E2E.yml` — single-line `script:` for the emulator-runner step.

## Testing
Diagnosed directly from the failed run's logs (job 89153283120, run 29990905264). No functional/deploy risk — CI workflow only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L41p2JvfT7yWhzCmDi8VPq)_