### PR TITLE
fix(orb): readable Nova disconnect reasons, transport/response liveness split, flaky test, L-02 transport overlap (BOOTSTRAP-NOVA-LIVENESS-TELEMETRY)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -311,7 +311,10 @@ export function cleanupWsSession(sessionId: string): void {
 
     if (clientSession.liveSession.upstreamWs) {
       try {
-        clientSession.liveSession.upstreamWs.close();
+        // Nova item 6: name the reason. A bare close() lands in the
+        // catch-all 'local_close' bucket, which made 42 of 46 prod Nova
+        // sessions indistinguishable in telemetry.
+        clientSession.liveSession.upstreamWs.close(1000, 'ws_session_cleanup');
       } catch (e) {
         // Ignore
       }
@@ -2003,7 +2006,8 @@ export async function handleLiveSessionStop(
   // Close upstream WebSocket if exists
   if (session.upstreamWs) {
     try {
-      session.upstreamWs.close();
+      // Nova item 6: explicit user-initiated stop (POST /session/stop).
+      session.upstreamWs.close(1000, 'user_stop');
     } catch (e) {
       // Ignore close errors
     }
@@ -2310,9 +2314,13 @@ export async function handleLiveStreamSend(
           session.lastAudioForwardedTime = Date.now();
           // VTID-FORWARDING-WATCHDOG + VTID-01984 (R5) sliding logic
           if (!session.isModelSpeaking) {
-            if (session.vertexHasShownLife) {
+            // Nova item 5: skip the watchdog only when the model has actually
+            // responded on THIS turn. The old check used a session-wide flag
+            // that the user's own transcription could set, so a stalled turn
+            // read as alive and recovery never armed.
+            if (session.modelRespondedThisTurn) {
               if (session.audioInChunks % 200 === 0) {
-                deps.emitDiag(session, 'watchdog_skipped', { reason: 'vertex_alive' });
+                deps.emitDiag(session, 'watchdog_skipped', { reason: 'model_responded_this_turn' });
               }
             } else {
               const canSlide = !session.responseWatchdogTimer

--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -810,7 +810,9 @@ export function createUpstreamLiveMessageHandler(
                       if (driftCount >= 2 && session.upstreamWs) {
                         console.warn(`[VTID-02670] Forcing hard reconnect to re-anchor persona ${activePersonaForCheck}`);
                         (session as any)._personaSwapInFlight = true;
-                        try { session.upstreamWs.close(); } catch { /* ignore */ }
+                        // Nova item 6: deliberate reconnect to re-anchor the
+                        // persona, not a failure or a user stop.
+                        try { session.upstreamWs.close(1000, 'persona_drift_reanchor'); } catch { /* ignore */ }
                       }
                     }
                   }
@@ -1035,11 +1037,10 @@ export function createUpstreamLiveMessageHandler(
                   session.isModelSpeaking = true;
                   // VTID-TOOLGUARD: Model produced audio — reset tool call counter
                   session.consecutiveToolCalls = 0;
-                  // VTID-01984 (R5): Vertex has spoken — upstream WS is healthy.
-                  // Once true, the audio-forwarding paths skip arming the
-                  // forwarding_no_ack watchdog so we never kill a healthy
-                  // session in the middle of Vertex computing a follow-up turn.
-                  session.vertexHasShownLife = true;
+                  // Nova item 5: model output — proves BOTH transport liveness
+                  // and that the model has responded on this turn.
+                  session.transportHasShownLife = true;
+                  session.modelRespondedThisTurn = true;
                   console.log(`[VTID-VOICE-INIT] Model started speaking for session ${session.sessionId} — mic audio gated`);
                   // Phase 1 W2: first TTS chunk forwarded to the client.
                   ctx.deps.markVoiceLatency(session, 'audio_out_first_chunk');
@@ -1199,12 +1200,12 @@ export function createUpstreamLiveMessageHandler(
               console.log(`[VTID-VOICE-INIT] Filtering greeting prompt from input transcription: "${inputTranscription.substring(0, 60)}..."`);
             } else {
               console.log(`[VTID-01219] Input transcription: ${inputTranscription}`);
-              // VTID-01984 (R5): Vertex's VAD fired and produced a transcription —
-              // upstream WS is demonstrably healthy. Mark life signal so subsequent
-              // user-audio chunks don't arm the forwarding_no_ack watchdog (which
-              // was destroying healthy sessions when first-turn inference exceeded
-              // 15 s). Real WS failures are still caught by native handlers.
-              session.vertexHasShownLife = true;
+              // Nova item 5: this is the USER's speech coming back as a
+              // transcription. It proves the socket works — it does NOT prove
+              // the model owes/produced anything. Transport liveness only;
+              // setting response liveness here is exactly the bug that let a
+              // stalled turn read as "alive" and skip recovery.
+              session.transportHasShownLife = true;
               // Phase 1 W2: first STT fragment of the turn = transcript_ready.
               // inputTranscriptBuffer is still empty until the append below, so
               // an empty buffer marks the leading fragment exactly once per turn.
@@ -1588,7 +1589,9 @@ export function handleAudioOutput(
   if (!session.isModelSpeaking) {
     session.isModelSpeaking = true;
     session.consecutiveToolCalls = 0;
-    session.vertexHasShownLife = true;
+    // Nova item 5: model output — transport AND response liveness.
+    session.transportHasShownLife = true;
+    session.modelRespondedThisTurn = true;
     console.log(`[VTID-VOICE-INIT] Model started speaking for session ${session.sessionId} — mic audio gated`);
     ctx.deps.markVoiceLatency(session, 'audio_out_first_chunk');
     ctx.deps.emitDiag(session, 'model_start_speaking');
@@ -1664,7 +1667,9 @@ export function handleTranscript(
       console.log(`[VTID-VOICE-INIT] Filtering greeting prompt from input transcription: "${inputTranscription.substring(0, 60)}..."`);
       return;
     }
-    session.vertexHasShownLife = true;
+    // Nova item 5: user speech — transport liveness only (see the paired
+    // site above; this is the same signal on the normalized event path).
+    session.transportHasShownLife = true;
     if (!session.inputTranscriptBuffer) {
       ctx.deps.markVoiceLatency(session, 'transcript_ready', { chars: inputTranscription.length });
     }
@@ -1715,6 +1720,11 @@ export function handleTranscript(
   }
 
   // Output (assistant) transcript.
+  // Nova item 5: model output — a text-only turn (no audio) still means the
+  // model responded, so response liveness must be set here too, not only on
+  // the audio path.
+  session.transportHasShownLife = true;
+  session.modelRespondedThisTurn = true;
   const outputTranscription = event.text;
   if (session.navigationDispatched) {
     console.log(`[VTID-NAV-HOTFIX] Dropping post-nav output transcription: "${outputTranscription.substring(0, 60)}..."`);
@@ -1819,6 +1829,9 @@ export function handleToolCall(
         output: loopGuardGuidance,
       });
     }
+    // Nova item 5: the model has been handed results (here, guidance telling
+    // it to answer) — it owes output again, so response liveness resets.
+    session.modelRespondedThisTurn = false;
 
     // VTID-TOOLGUARD-FIX: hard ceiling as a backstop in case the reworded
     // guidance above still doesn't land — well above the normal threshold
@@ -1909,6 +1922,12 @@ export function handleToolCall(
         });
         if (!sent) {
           console.error(`[VTID-01224] tool result NOT sent for ${toolName} — upstream client no longer open. Session ${session.sessionId} may be stalled.`);
+        } else {
+          // Nova item 5: result delivered — the model owes a response for this
+          // turn again. This is the exact live-3577c2fa shape: tool call at
+          // 15:05:40, result delivered, then silence. Without this reset the
+          // turn still reads "alive" from the pre-tool-call model audio.
+          session.modelRespondedThisTurn = false;
         }
         // BOOTSTRAP-ORB-TOOL-CARRYOVER: same contract as the Vertex send site —
         // record only what actually reached the model, clear at turn_complete.
@@ -1947,6 +1966,9 @@ export function handleToolCall(
           output: '',
           error: err.message,
         });
+        // Nova item 5: a failed tool result is still a result — the model owes
+        // a response to it, so response liveness resets here too.
+        session.modelRespondedThisTurn = false;
       });
   }
 }
@@ -2007,6 +2029,10 @@ export function handleTurnComplete(
 
   ctx.deps.clearResponseWatchdog(session);
   session.isModelSpeaking = false;
+  // Nova item 5: the turn is over — the model no longer owes output. The
+  // next turn must re-earn response liveness, otherwise a stall on turn N+1
+  // inherits turn N's "alive" and skips the watchdog.
+  session.modelRespondedThisTurn = false;
   session.turnCompleteAt = Date.now();
   console.log(`[VTID-VOICE-INIT] Model stopped speaking for session ${session.sessionId} — mic audio ungated (cooldown ${getPostTurnCooldownMs()}ms)`);
   ctx.deps.emitDiag(session, 'turn_complete');

--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -786,7 +786,11 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
 
   async close(reason?: string): Promise<void> {
     if (this.state === 'closed' || this.state === 'closing') return;
-    this.localCloseReason = reason ?? 'local_close';
+    // Nova item 6: every caller should name its reason. The fallback is
+    // deliberately NOT the old catch-all 'local_close' — if this label shows
+    // up in telemetry it means a close path was added without a reason, and
+    // that should be visible rather than blending into the historical bucket.
+    this.localCloseReason = reason ?? 'local_close_unspecified';
     this.state = 'closing';
     if (this.rotationTimer) {
       clearTimeout(this.rotationTimer);
@@ -814,7 +818,11 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     }
     if (!this.closeEmitted) {
       this.state = 'closed';
-      this.finalizeClose({ initiatedLocally: true, reason });
+      // Use the normalized reason, not the raw arg — a bare close() must
+      // report the same label here as it does on the response-loop path
+      // (which reads localCloseReason), otherwise the same event shows up
+      // as two different reasons depending on which path won the race.
+      this.finalizeClose({ initiatedLocally: true, reason: this.localCloseReason });
     }
     try {
       // Never destroy the shared client — its pooled HTTP/2 sessions are
@@ -829,6 +837,16 @@ export class NovaSonicLiveClient implements UpstreamLiveClient {
     if (this.closeEmitted) return;
     this.closeEmitted = true;
     this.state = 'closed';
+    // Nova item 6: one structured line per disconnect. 72h of prod showed 42
+    // of 46 Nova sessions labelled only 'local_close', which made the cause
+    // unreadable. These fields are the ones that were actually missing when
+    // trying to tell a user stop from a transport loss from a rotation swap.
+    console.log(
+      `[BOOTSTRAP-NOVA-SONIC-VOICE] nova_close reason=${event.reason ?? 'unknown'} ` +
+        `initiated_locally=${event.initiatedLocally} rotation_fired=${this.rotationFired} ` +
+        `ms_since_last_input=${this.lastInputAcceptedAt ? Date.now() - this.lastInputAcceptedAt : -1} ` +
+        `commit=${process.env.GIT_COMMIT_SHA?.slice(0, 12) ?? 'unknown'}`,
+    );
     this.queue.close();
     if (this.rotationTimer) {
       clearTimeout(this.rotationTimer);

--- a/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/nova-sonic-live-client.ts
@@ -227,11 +227,34 @@ async function buildBedrockClient(config: NovaSonicConfig): Promise<NovaBedrockL
  */
 let sharedBedrockClient: NovaBedrockLike | null = null;
 
+/**
+ * L-02: promise-memoized, not just value-memoized.
+ *
+ * The old `if (!sharedBedrockClient) sharedBedrockClient = await build(...)`
+ * shape races: two callers arriving before the first build resolves both see
+ * null and both build a client, the second overwriting the first. That was
+ * harmless while the only caller was serial, but the session path now kicks
+ * transport preparation CONCURRENTLY with context assembly, which makes the
+ * race the normal case rather than a rarity. Memoizing the in-flight promise
+ * collapses concurrent callers onto one build; a failed build clears the
+ * memo so the next attempt can retry rather than caching the failure.
+ */
+let sharedBedrockClientPromise: Promise<NovaBedrockLike> | null = null;
+
 async function defaultBedrockFactory(config: NovaSonicConfig): Promise<NovaBedrockLike> {
-  if (!sharedBedrockClient) {
-    sharedBedrockClient = await buildBedrockClient(config);
+  if (sharedBedrockClient) return sharedBedrockClient;
+  if (!sharedBedrockClientPromise) {
+    sharedBedrockClientPromise = buildBedrockClient(config)
+      .then((client) => {
+        sharedBedrockClient = client;
+        return client;
+      })
+      .catch((err) => {
+        sharedBedrockClientPromise = null;
+        throw err;
+      });
   }
-  return sharedBedrockClient;
+  return sharedBedrockClientPromise;
 }
 
 /**
@@ -388,6 +411,9 @@ export async function prewarmNovaSonicBedrock(config: NovaSonicConfig): Promise<
 /** Test seam: inject/clear the shared client without touching real AWS SDKs. */
 export function __setSharedBedrockClientForTests(client: NovaBedrockLike | null): void {
   sharedBedrockClient = client;
+  // Must clear the in-flight memo too — otherwise a test that injects null to
+  // force a rebuild would still be served the previously memoized promise.
+  sharedBedrockClientPromise = null;
 }
 
 export class NovaSonicLiveClient implements UpstreamLiveClient {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -7251,6 +7251,21 @@ async function connectToLiveAPI(
     if (__upstreamDecision.provider === 'nova_sonic') {
       try {
         const novaCfg = getNovaSonicConfig(process.env);
+        // L-02: kick Bedrock transport preparation NOW — credential-chain
+        // resolution, SDK module load, and the pooled DNS/TCP/TLS/HTTP2 path
+        // — concurrently with context assembly below. None of that work
+        // depends on the system instruction, but it used to sit behind the
+        // envelope await purely because connect() is called after it.
+        //
+        // Deliberately NOT awaited: on a warm process this is a memoized
+        // no-op (boot prewarm + the keep-warm loop already populated the
+        // shared client), so awaiting could only ever add latency. The value
+        // is on the cold path — first session after a fresh task, or when
+        // boot prewarm failed — where connect() would otherwise pay the full
+        // credential/TLS cost serially after context assembly. connect()
+        // still resolves the client itself, so correctness does not depend
+        // on this finishing, or finishing first.
+        void prewarmNovaSonicBedrock(novaCfg).catch(() => false);
         const envelope = (await buildOrbVertexSetupEnvelope()) as { setup?: Record<string, any> };
         const setup = envelope.setup ?? {};
         // Nova's RAI content filter rejects the stream over the IDENTITY

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1054,14 +1054,29 @@ export interface GeminiLiveSession {
   // safe when the reason is 'forwarding_no_ack' — a model-response watchdog
   // must not be reset by user audio or we'd suppress legitimate stalls.
   responseWatchdogReason?: string;
-  // VTID-01984 (R5): true once Vertex has shown ANY sign of life on this
-  // session — first input_transcription, first model_start_speaking, or
-  // first audio_out chunk. The audio-forwarding paths skip the
-  // forwarding_no_ack watchdog entirely once this is true, because the
-  // upstream WS is demonstrably healthy and a 15-45 s "no ack" window is
-  // simply Vertex computing a response, not a stall. Native WS error /
-  // close handlers still catch real connection failures.
-  vertexHasShownLife?: boolean;
+  // Nova item 5 — liveness is TWO properties, and the old session-wide
+  // `vertexHasShownLife` conflated them, which is why a stalled turn read as
+  // "alive" and skipped recovery.
+  //
+  //   transportHasShownLife — the upstream socket works. An
+  //   input_transcription proves this (the provider received our audio and
+  //   answered), so it is a legitimate setter. Session-wide and never reset:
+  //   once a socket has carried traffic, it was real.
+  //
+  //   modelRespondedThisTurn — the model has produced output for THIS turn.
+  //   ONLY model output (audio out / output transcription) may set it, and it
+  //   resets at turn_complete and whenever a tool result is delivered (at
+  //   which point the model owes a response again). This is the property the
+  //   forwarding watchdog actually needs.
+  //
+  // In the live-3577c2fa trace the user's speech was transcribed at
+  // 15:05:35-38, a tool call fired at 15:05:40, then silence — a per-turn
+  // flag set by transcription would STILL have read "alive". Hence the split
+  // rather than merely resetting the old flag per turn. Named
+  // provider-neutrally because Nova sessions inherited the Vertex-era flag
+  // and reported `reason=vertex_alive` on a Nova session.
+  transportHasShownLife?: boolean;
+  modelRespondedThisTurn?: boolean;
   // VTID-LOOPGUARD: Consecutive model turns without user speech.
   // Detects response loops where model keeps elaborating without being asked.
   consecutiveModelTurns: number;
@@ -1156,7 +1171,9 @@ setInterval(() => {
   let purged = 0;
   for (const [sid, s] of liveSessions) {
     if (now - s.createdAt.getTime() > MAX_SESSION_AGE_MS) {
-      if (s.upstreamWs) { try { s.upstreamWs.close(); } catch (_) { /* ignore */ } }
+      // Nova item 6: this is the abandoned-session sweep, not a user action —
+      // distinguish it from user_stop / client_disconnect in telemetry.
+      if (s.upstreamWs) { try { s.upstreamWs.close(1000, 'zombie_sweep_max_age'); } catch (_) { /* ignore */ } }
       // BOOTSTRAP-ORB-1007-AUDIT: emit session.stop so abandoned sessions
       // (client closed tab / mobile killed app mid-conversation) show up in
       // OASIS instead of just disappearing. Prior behaviour left a silent
@@ -1214,7 +1231,8 @@ function terminateExistingSessionsForUser(userId: string, excludeSessionId?: str
 
     // Close upstream WebSocket
     if (existingSession.upstreamWs) {
-      try { existingSession.upstreamWs.close(); } catch (_e) { /* ignore */ }
+      // Nova item 6: replaced because the same user started a newer session.
+      try { existingSession.upstreamWs.close(1000, 'superseded_by_new_session'); } catch (_e) { /* ignore */ }
       existingSession.upstreamWs = null;
     }
 
@@ -13665,7 +13683,9 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
     // VTID-01219: Close upstream WebSocket on client disconnect
     if (session.upstreamWs) {
       try {
-        session.upstreamWs.close();
+        // Nova item 6: the client's transport went away (tab closed, app
+        // backgrounded, mobile network lost) — not a deliberate stop.
+        session.upstreamWs.close(1000, 'client_disconnect');
       } catch (e) {
         // Ignore
       }
@@ -15214,12 +15234,13 @@ async function handleWsAudioMessage(clientSession: WsClientSession, message: WsC
       // WS and SSE transports stay in lockstep until Phase 3 collapses
       // them onto one adapter.
       if (!liveSession.isModelSpeaking) {
-        // VTID-01984 (R5): mirror of SSE-path gate — once Vertex has shown
-        // life, skip arming the forwarding_no_ack watchdog. Healthy WS does
-        // not need a 15-45 s heuristic to detect Vertex's compute window.
-        if (liveSession.vertexHasShownLife) {
+        // Nova item 5: mirror of the SSE-path gate — skip arming the
+        // forwarding_no_ack watchdog only while the model has already
+        // responded on THIS turn. Transport liveness (the user's own
+        // transcription) must not suppress recovery.
+        if (liveSession.modelRespondedThisTurn) {
           if (liveSession.audioInChunks % 200 === 0) {
-            emitDiag(liveSession, 'watchdog_skipped', { reason: 'vertex_alive' });
+            emitDiag(liveSession, 'watchdog_skipped', { reason: 'model_responded_this_turn' });
           }
         } else {
           const canSlide = !liveSession.responseWatchdogTimer
@@ -15406,7 +15427,8 @@ function handleWsStopSession(clientSession: WsClientSession): void {
     // Close upstream WebSocket
     if (liveSession.upstreamWs) {
       try {
-        liveSession.upstreamWs.close();
+        // Nova item 6: explicit stop_session control frame from the client.
+        liveSession.upstreamWs.close(1000, 'user_stop');
       } catch (e) {
         // Ignore
       }

--- a/services/gateway/test/news-feed.test.ts
+++ b/services/gateway/test/news-feed.test.ts
@@ -78,9 +78,20 @@ describe('GET /api/v1/news-feed/top-performer', () => {
     expect(res.body.ok).toBe(true);
     expect(res.body.performer.user_id).toBe('a'); // bigger delta wins
     expect(res.body.performer.improvement).toBe(40);
-    // Exact Index scores must never be exposed.
-    expect(JSON.stringify(res.body)).not.toContain('540');
-    expect(JSON.stringify(res.body)).not.toContain('score_total');
+    // Exact Index scores must never be exposed. Strip the volatile timestamp
+    // before serializing: computed_at is generated at request time and its
+    // millisecond component can itself spell a score, which made this a real
+    // ~1-in-1000 CI flake (a run at 2026-07-30T11:51:03.540Z matched '540'
+    // and failed an unrelated PR). The leak we actually care about is a score
+    // in the payload fields, not digits in a clock reading.
+    const { computed_at, ...performerFields } = res.body.performer;
+    expect(computed_at).toEqual(expect.any(String));
+    const serialized = JSON.stringify({ ...res.body, performer: performerFields });
+    for (const score of ['500', '540', '600', '610']) {
+      expect(serialized).not.toContain(score);
+    }
+    expect(serialized).not.toContain('score_total');
+    expect(res.body.performer).not.toHaveProperty('score_total');
   });
 
   it('returns null when nobody opted in', async () => {

--- a/services/gateway/test/orb/live/session/live-session-controller.test.ts
+++ b/services/gateway/test/orb/live/session/live-session-controller.test.ts
@@ -988,7 +988,11 @@ describe('A8.2-complete: handleLiveStreamSend', () => {
       audioInChunks: 0,
       videoInFrames: 0,
       turn_count: 0,
-      vertexHasShownLife: true,
+      // Nova item 5: the fixture's intent is "don't arm the forwarding
+      // watchdog". That is now response liveness, not the old session-wide
+      // flag — transport liveness alone no longer suppresses it.
+      transportHasShownLife: true,
+      modelRespondedThisTurn: true,
       lastActivity: new Date(),
       lastTelemetryEmitTime: 0,
       lastAudioForwardedTime: 0,
@@ -1092,6 +1096,61 @@ describe('A8.2-complete: handleLiveStreamSend', () => {
     expect(sendSpy).toHaveBeenCalledWith(upstreamWs, 'AUDIO', 'audio/pcm;rate=16000');
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  // Nova item 5 — the whole point of splitting the liveness flag.
+  //
+  // Prod trace live-3577c2fa: the user's speech was transcribed, a tool call
+  // fired, then the model went silent. The old session-wide flag was set by
+  // that transcription, so the forwarding watchdog was skipped and recovery
+  // never armed. Transport liveness must NOT suppress the watchdog.
+  it('arms the forwarding watchdog when only the USER has shown life (transport, not response)', async () => {
+    const watchdogSpy = jest.fn();
+    configureLiveSessionController(baseDeps({ startResponseWatchdog: watchdogSpy }));
+    liveSessions.set(
+      's-transport-only',
+      makeSession({
+        upstreamWs: { readyState: WS_OPEN },
+        transportHasShownLife: true, // user's transcription came back
+        modelRespondedThisTurn: false, // model owes output for this turn
+      }),
+    );
+    const req: any = {
+      query: { session_id: 's-transport-only' },
+      body: { type: 'audio', data_b64: 'AUDIO', mime: 'audio/pcm;rate=16000' },
+    };
+    await handleLiveStreamSend(req, makeRes());
+    expect(watchdogSpy).toHaveBeenCalled();
+    expect(watchdogSpy.mock.calls[0][2]).toBe('forwarding_no_ack');
+  });
+
+  it('skips the forwarding watchdog once the model has responded on this turn', async () => {
+    const watchdogSpy = jest.fn();
+    const diagSpy = jest.fn();
+    configureLiveSessionController(
+      baseDeps({ startResponseWatchdog: watchdogSpy, emitDiag: diagSpy }),
+    );
+    liveSessions.set(
+      's-model-responded',
+      makeSession({
+        upstreamWs: { readyState: WS_OPEN },
+        transportHasShownLife: true,
+        modelRespondedThisTurn: true,
+        audioInChunks: 199, // becomes 200 → hits the sampled diag branch
+      }),
+    );
+    const req: any = {
+      query: { session_id: 's-model-responded' },
+      body: { type: 'audio', data_b64: 'AUDIO', mime: 'audio/pcm;rate=16000' },
+    };
+    await handleLiveStreamSend(req, makeRes());
+    expect(watchdogSpy).not.toHaveBeenCalled();
+    // Provider-neutral reason — Nova sessions used to report 'vertex_alive'.
+    expect(diagSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'watchdog_skipped',
+      { reason: 'model_responded_this_turn' },
+    );
   });
 
   it('silently returns ok:true for anonymous sessions past turn limit (VTID-ANON-NUDGE)', async () => {

--- a/services/gateway/test/orb/live/upstream/nova-bedrock-factory-memo.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-bedrock-factory-memo.test.ts
@@ -1,0 +1,70 @@
+/**
+ * L-02 — Bedrock transport preparation overlaps context assembly.
+ *
+ * The session path now kicks `prewarmNovaSonicBedrock` concurrently with
+ * `buildOrbVertexSetupEnvelope()` instead of leaving all credential/TLS work
+ * behind that await. That makes concurrent entry into the shared-client
+ * factory the NORMAL case, so the factory must collapse concurrent callers
+ * onto a single build rather than racing and building twice.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const SRC = join(__dirname, '../../../../src');
+
+describe('L-02: Bedrock client factory memoization', () => {
+  it('memoizes the in-flight promise, not just the resolved value', () => {
+    const src = readFileSync(
+      join(SRC, 'orb/live/upstream/nova-sonic-live-client.ts'),
+      'utf8',
+    );
+    // The racy shape assigned the awaited result straight onto the shared
+    // slot, so two concurrent callers both saw null and both built.
+    expect(src).not.toMatch(/sharedBedrockClient = await buildBedrockClient/);
+    expect(src).toContain('let sharedBedrockClientPromise');
+    expect(src).toContain('if (sharedBedrockClient) return sharedBedrockClient;');
+    expect(src).toContain('if (!sharedBedrockClientPromise)');
+  });
+
+  it('clears the memo on build failure so the next attempt can retry', () => {
+    const src = readFileSync(
+      join(SRC, 'orb/live/upstream/nova-sonic-live-client.ts'),
+      'utf8',
+    );
+    // A cached rejected promise would wedge every later session.
+    expect(src).toMatch(/\.catch\(\(err\) => \{\s*sharedBedrockClientPromise = null;\s*throw err;/);
+  });
+
+  it('test seam clears the in-flight memo alongside the value', () => {
+    const src = readFileSync(
+      join(SRC, 'orb/live/upstream/nova-sonic-live-client.ts'),
+      'utf8',
+    );
+    const seam = src.slice(src.indexOf('__setSharedBedrockClientForTests'));
+    expect(seam).toContain('sharedBedrockClientPromise = null;');
+  });
+
+  it('starts transport prep before awaiting the setup envelope, and does not await it', () => {
+    const src = readFileSync(join(SRC, 'routes/orb-live.ts'), 'utf8');
+    // Anchor on the connect branch specifically. `provider === 'nova_sonic'`
+    // is NOT unique — its first occurrence is the rotation-exhausted override
+    // branch, which has no envelope build at all.
+    const anchor = 'const novaCfg = getNovaSonicConfig(process.env);';
+    expect(src.split(anchor).length - 1).toBe(1); // stays unique
+    const novaBranch = src.indexOf(anchor);
+    expect(novaBranch).toBeGreaterThan(-1);
+    const window = src.slice(novaBranch, novaBranch + 2500);
+
+    const prewarmAt = window.indexOf('prewarmNovaSonicBedrock(novaCfg)');
+    const envelopeAt = window.indexOf('await buildOrbVertexSetupEnvelope()');
+    expect(prewarmAt).toBeGreaterThan(-1);
+    expect(envelopeAt).toBeGreaterThan(-1);
+    // The whole point: prep is kicked BEFORE the context await.
+    expect(prewarmAt).toBeLessThan(envelopeAt);
+    // Fire-and-forget — awaiting it could only add latency on a warm process.
+    expect(window).toContain('void prewarmNovaSonicBedrock(novaCfg)');
+    expect(window).not.toContain('await prewarmNovaSonicBedrock(novaCfg)');
+    // An unawaited promise must not be able to raise an unhandled rejection.
+    expect(window).toMatch(/void prewarmNovaSonicBedrock\(novaCfg\)\.catch\(/);
+  });
+});

--- a/services/gateway/test/orb/live/upstream/nova-close-reasons.test.ts
+++ b/services/gateway/test/orb/live/upstream/nova-close-reasons.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Nova item 6 — disconnect reasons must be readable.
+ *
+ * 72h of production showed 42 of 46 Nova sessions labelled only 'local_close',
+ * which made the disconnect cause unreadable: a user tapping stop, a mobile
+ * transport dropping, a rotation swap, and a session being superseded all
+ * collapsed into one bucket.
+ *
+ * Two guards here:
+ *  1. The client normalizes a reason-less close to an explicitly *unnamed*
+ *     label, so a close path added without a reason is visible in telemetry
+ *     rather than blending into the historical catch-all.
+ *  2. A source invariant: no `upstreamWs.close()` call site may omit its
+ *     reason. This is what actually regresses — the reason is supplied by the
+ *     caller, so the guard has to live at the call sites, not in the client.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
+
+const SRC = join(__dirname, '../../../../src');
+
+describe('Nova item 6: close-reason taxonomy', () => {
+  it('normalizes a reason-less close to an explicitly unnamed label, not the old catch-all', () => {
+    const client = readFileSync(
+      join(SRC, 'orb/live/upstream/nova-sonic-live-client.ts'),
+      'utf8',
+    );
+    // The fallback must not be the historical 'local_close' bucket.
+    expect(client).toContain("this.localCloseReason = reason ?? 'local_close_unspecified'");
+    expect(client).not.toMatch(/localCloseReason = reason \?\? 'local_close'/);
+  });
+
+  it('reports the same label on both close paths (no race-dependent reason)', () => {
+    const client = readFileSync(
+      join(SRC, 'orb/live/upstream/nova-sonic-live-client.ts'),
+      'utf8',
+    );
+    // close() must finalize with the NORMALIZED reason. Passing the raw arg
+    // makes a bare close() surface as `undefined` on one path and
+    // 'local_close_unspecified' on the other, depending on which wins.
+    expect(client).toContain(
+      'this.finalizeClose({ initiatedLocally: true, reason: this.localCloseReason })',
+    );
+  });
+
+  it('emits a structured close line carrying the fields the incident needed', () => {
+    const client = readFileSync(
+      join(SRC, 'orb/live/upstream/nova-sonic-live-client.ts'),
+      'utf8',
+    );
+    for (const field of [
+      'nova_close reason=',
+      'initiated_locally=',
+      'rotation_fired=',
+      'ms_since_last_input=',
+      'commit=',
+    ]) {
+      expect(client).toContain(field);
+    }
+  });
+
+  it('has no upstreamWs.close() call site that omits its reason', () => {
+    // grep -r over the gateway source; an empty result is the passing state.
+    let hits = '';
+    try {
+      hits = execSync(
+        `grep -rn "upstreamWs\\.close()" ${SRC} --include=*.ts || true`,
+        { encoding: 'utf8' },
+      ).trim();
+    } catch {
+      hits = '';
+    }
+    expect(hits).toBe('');
+  });
+
+  it('names each distinct disconnect cause at its call site', () => {
+    const controller = readFileSync(
+      join(SRC, 'orb/live/session/live-session-controller.ts'),
+      'utf8',
+    );
+    const orbLive = readFileSync(join(SRC, 'routes/orb-live.ts'), 'utf8');
+    const handler = readFileSync(
+      join(SRC, 'orb/live/session/upstream-message-handler.ts'),
+      'utf8',
+    );
+
+    expect(controller).toContain("'ws_session_cleanup'");
+    expect(controller).toContain("'user_stop'");
+    expect(orbLive).toContain("'zombie_sweep_max_age'");
+    expect(orbLive).toContain("'superseded_by_new_session'");
+    expect(orbLive).toContain("'client_disconnect'");
+    expect(orbLive).toContain("'user_stop'");
+    expect(handler).toContain("'persona_drift_reanchor'");
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-NOVA-LIVENESS-TELEMETRY` _(no VTID allocated yet — tracked under this tag)_

**Layer:** APIL (gateway ORB session + upstream client) + test infra

**Priority:** P2 — diagnosability and a stall-recovery correctness bug. No user-visible behavior change on the happy path.

---

## 📋 Summary

Four self-contained items from the open Nova backlog. Grouped into one PR only because the branch rules pin this work to a single `claude/` branch — they are independent and each is separately revertable by commit.

| # | Item | Commit |
|---|---|---|
| 30 | Flaky test blocking unrelated PRs | `fb71499` |
| 34 | Nova item 5 — liveness flag conflated two properties | `fb71499` |
| 35 | Nova item 6 — disconnect telemetry unreadable | `fb71499` |
| 28 | L-02 — overlap Bedrock transport prep with context assembly | `ef3078b` |

---

## 1. Nova item 6 — disconnect reasons were unreadable (#35)

72h of production showed **42 of 46 Nova sessions labelled only `local_close`**. Cause: every bare `upstreamWs.close()` fell through to the client's catch-all default, so a user tapping stop, a mobile transport dropping, a rotation swap, and a session being superseded all collapsed into one bucket.

Named the reason at all **seven** call sites:

| Site | Reason |
|---|---|
| `cleanupWsSession` | `ws_session_cleanup` |
| `POST /session/stop` | `user_stop` |
| WS `stop_session` frame | `user_stop` |
| 30-min zombie sweep | `zombie_sweep_max_age` |
| session-limit termination | `superseded_by_new_session` |
| SSE client disconnect | `client_disconnect` |
| persona-drift reconnect | `persona_drift_reanchor` |

Supporting changes:
- Client fallback is now `local_close_unspecified`, **not** the historical `local_close` — a close path added without a reason becomes *visible* in telemetry rather than blending into the old bucket.
- `close()` finalizes with the **normalized** reason. It previously passed the raw arg on one path and read `localCloseReason` on the other, so a bare close reported two different reasons depending on which teardown won the race.
- One structured `nova_close` line carrying `reason`, `initiated_locally`, `rotation_fired`, `ms_since_last_input`, `commit`.

## 2. Nova item 5 — liveness conflated transport with response (#34)

`vertexHasShownLife` was session-wide, never reset, and **two of its four set sites fired on `input_transcription` — the USER's own speech**.

Prod trace `live-3577c2fa`: user transcribed 15:05:35-38 → tool call 15:05:40 → silence. The forwarding watchdog was skipped because the user's speech had marked the session "alive", so recovery never armed.

**Making it merely per-turn would not have fixed this** — the user's own speech would still set it within the same turn. The flag conflates two genuinely different properties, so they are now two fields:

- **`transportHasShownLife`** — the socket works. A transcription legitimately proves this. Session-wide, never reset.
- **`modelRespondedThisTurn`** — the model has produced output for *this* turn. Set **only** by model output (audio out / output transcription), reset at `turn_complete` **and** on every tool-result delivery (at which point the model owes a response again).

The forwarding watchdog reads *response* liveness. Renamed provider-neutral — Nova sessions were reporting `reason=vertex_alive`, which is how this surfaced.

Timeout headroom checked: the forwarding watchdog is 45s, comfortably above normal inference, so arming per-turn does not reintroduce the VTID-01984 (R5) problem of killing healthy sessions mid-compute.

## 3. Flaky test (#30)

`news-feed.test.ts` asserted `JSON.stringify(res.body)` must not contain `'540'` — but matched the **entire** body including `computed_at`. A run at `2026-07-30T11:51:03.540Z` collided on the millisecond component and failed an unrelated PR (~1-in-1000). Now strips the timestamp before serializing and broadens the check to all four fixture scores.

## 4. L-02 — transport prep overlap (#28)

**Smaller than the original note assumed, and worth stating plainly.** The premise was that Bedrock credential/TLS/HTTP2 work sits serially behind context assembly. That is largely **already solved** by infrastructure that landed after the note was written: boot-time `prewarmNovaSonicBedrock`, the keep-warm loop, and a process-wide memoized shared client. On a warm process the factory is a cache hit and the SDK module is already loaded.

Shipped:
- Kick `prewarmNovaSonicBedrock` **concurrently** with `buildOrbVertexSetupEnvelope`, fire-and-forget. Not awaited — on a warm process that could only add latency. The win is the **cold path**: first session after a fresh task, or when boot prewarm failed.
- Made the shared-client factory **promise-memoized**. The old `if (!shared) shared = await build()` shape raced two concurrent callers into two builds; kicking prewarm concurrently makes that race the normal case. Failed builds clear the memo so the next attempt retries instead of caching the failure.

**Not done, deliberately:** no speculative split of `connect()`'s protocol ordering. The initialization queue genuinely needs the system instruction, so the stream open cannot move ahead of context assembly.

---

## 🧪 Testing

- **11 new tests** (5 close-reason, 2 liveness, 4 L-02)
- **Each verified to fail against the pre-fix code**, not just to pass against the new code:
  - flaky-test assertion → probed with a real leaked score value (a first probe added `best.score_total`, which is `undefined` and silently dropped — the probe was wrong, not the test)
  - close-reason invariant → reverted one call site to a bare `close()`, both invariants failed
  - liveness → pointed the watchdog back at `transportHasShownLife`, the user-speech test failed
- `tsc --noEmit` clean (the two `aws-ecs-admin` errors are pre-existing — `@aws-sdk/client-ecs` is not installed in this sandbox — and in a file this PR does not touch)
- **1440 passing** across `test/orb/`, the Nova incident regressions, and `news-feed`

One test in this PR is a **source invariant**: no `upstreamWs.close()` call site may omit its reason. The reason is supplied by the caller, so a guard inside the client cannot catch the regression — it has to live at the call sites.

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] No workflow files added or renamed

### File Names
- [x] New test files kebab-case (`nova-close-reasons.test.ts`, `nova-bedrock-factory-memo.test.ts`)
- [x] Directory names unchanged

### Code Standards
- [x] Close reasons lowercase snake_case
- [x] Diag reason `model_responded_this_turn` snake_case
- [x] No Cloud Run label changes

### Documentation
- [x] Tag in commit messages
- [x] No schema changes, so no `DATABASE_SCHEMA.md` update

---

## 🚨 Breaking Changes

None. The close-reason strings are telemetry labels with no consumer keyed on `local_close`. The liveness split changes *when the forwarding watchdog arms* — it now arms in a case it previously skipped (model owes output but only the user has shown life), which is the bug being fixed. The L-02 change is additive and fire-and-forget.

---

## 📌 Additional Notes

**Still open, not in this PR:**
- **#32 (L-04/L-05)** — make the single WebSocket the browser default instead of SSE + ~15.6 authenticated POSTs/sec. This is the biggest remaining latency win, but it is a real change to how every browser session talks to the gateway and deserves a deliberate decision rather than being folded into a telemetry PR.
- **#25 / #16 / #12** — all blocked on things unreachable from this sandbox: no `GATEWAY_SERVICE_TOKEN` to fire the live probe, so the first real Nova turn-2 number still does not exist. #25's next steps stay gated on that data rather than guessing.

**Process note:** `main` carries a "Mandatory Codebase Intelligence Workflow" section requiring RepoWise/Graphify queries before implementation. Neither MCP server is available in this session, so that step could not be performed — flagging rather than silently skipping.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5oEMYRbMCpXMFqnQF46eC)_