### PR TITLE
fix(orb): retry chat_messages bridge writes so voice conversations don't vanish from Inbox history

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -87,6 +87,55 @@ export function isNovaProvider(session: GeminiLiveSession): boolean {
 }
 
 /**
+ * BOOTSTRAP-CHAT-BRIDGE-RELIABILITY: write one voice-transcript turn into
+ * chat_messages so it shows up in the user's "Vitana" Inbox thread. This is
+ * the ONLY path that makes a voice conversation visible in chat history —
+ * previously a failed insert here was fire-and-forget with just a
+ * console.warn, so a transient DB/network blip silently and permanently
+ * dropped that turn from the user's history with no trace anywhere
+ * (reported as "I had several conversations with Vitana and none show up").
+ * Retries once, and emits a durable OASIS event on final failure so lost
+ * history is visible in telemetry instead of only a Cloud Run log line.
+ */
+export async function bridgeVoiceTranscript(
+  bridgeSupabase: NonNullable<ReturnType<typeof getSupabase>>,
+  row: {
+    tenant_id: string;
+    sender_id: string;
+    receiver_id: string;
+    content: string;
+    message_type: string;
+    metadata: Record<string, unknown>;
+    created_at: string;
+    read_at?: string;
+  },
+  direction: 'user_to_vitana' | 'vitana_to_user',
+  sessionId: string,
+): Promise<void> {
+  const MAX_ATTEMPTS = 2;
+  let lastError: string | undefined;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const { error } = await bridgeSupabase.from('chat_messages').insert(row);
+    if (!error) return;
+    lastError = error.message;
+    console.warn(`[VTID-CHAT-BRIDGE] ${direction} transcript write attempt ${attempt}/${MAX_ATTEMPTS} failed for session ${sessionId}: ${error.message}`);
+  }
+  emitOasisEvent({
+    vtid: 'BOOTSTRAP-CHAT-BRIDGE-RELIABILITY',
+    type: 'orb.chat_bridge.write_failed' as any,
+    source: 'orb-live-upstream-message-handler',
+    status: 'error',
+    message: `Voice transcript (${direction}) failed to bridge into chat_messages after ${MAX_ATTEMPTS} attempts — this turn will not appear in the user's Inbox`,
+    payload: {
+      orb_session_id: sessionId,
+      tenant_id: row.tenant_id,
+      direction,
+      error: lastError,
+    },
+  }).catch(() => { /* best-effort telemetry only, never let this throw into the voice pipeline */ });
+}
+
+/**
  * orb-live.ts-local helpers the handler body invokes. Future slices may
  * lift these out individually; until then, the deps-bag is the seam.
  */
@@ -873,7 +922,7 @@ export function createUpstreamLiveMessageHandler(
 
                 // User speech → chat_messages (sender=user, receiver=Vitana)
                 if (chatBridgeUserText.length > 0) {
-                  bridgeSupabase.from('chat_messages').insert({
+                  void bridgeVoiceTranscript(bridgeSupabase, {
                     tenant_id: bridgeTenantId,
                     sender_id: bridgeUserId,
                     receiver_id: VITANA_BOT_USER_ID,
@@ -881,15 +930,13 @@ export function createUpstreamLiveMessageHandler(
                     message_type: 'voice_transcript',
                     metadata: { ...bridgeMeta, direction: 'user_to_vitana' },
                     created_at: userMsgTime.toISOString(),
-                  }).then(({ error }) => {
-                    if (error) console.warn(`[VTID-CHAT-BRIDGE] User transcript write failed: ${error.message}`);
-                  });
+                  }, 'user_to_vitana', session.sessionId);
                 }
 
                 // Vitana speech → chat_messages (sender=Vitana, receiver=user)
                 // Pre-set read_at since user already heard this during the voice session
                 if (chatBridgeAssistantText.length > 0) {
-                  bridgeSupabase.from('chat_messages').insert({
+                  void bridgeVoiceTranscript(bridgeSupabase, {
                     tenant_id: bridgeTenantId,
                     sender_id: VITANA_BOT_USER_ID,
                     receiver_id: bridgeUserId,
@@ -898,9 +945,7 @@ export function createUpstreamLiveMessageHandler(
                     metadata: { ...bridgeMeta, direction: 'vitana_to_user', is_greeting: isGreetingTurn },
                     read_at: assistantMsgTime.toISOString(),
                     created_at: assistantMsgTime.toISOString(),
-                  }).then(({ error }) => {
-                    if (error) console.warn(`[VTID-CHAT-BRIDGE] Vitana transcript write failed: ${error.message}`);
-                  });
+                  }, 'vitana_to_user', session.sessionId);
                 }
               }
             }
@@ -2408,7 +2453,7 @@ export function handleTurnComplete(
       const assistantMsgTime = new Date(userMsgTime.getTime() + 1);
 
       if (chatBridgeUserText.length > 0) {
-        bridgeSupabase.from('chat_messages').insert({
+        void bridgeVoiceTranscript(bridgeSupabase, {
           tenant_id: bridgeTenantId,
           sender_id: bridgeUserId,
           receiver_id: VITANA_BOT_USER_ID,
@@ -2416,13 +2461,11 @@ export function handleTurnComplete(
           message_type: 'voice_transcript',
           metadata: { ...bridgeMeta, direction: 'user_to_vitana' },
           created_at: userMsgTime.toISOString(),
-        }).then(({ error }) => {
-          if (error) console.warn(`[VTID-CHAT-BRIDGE] User transcript write failed: ${error.message}`);
-        });
+        }, 'user_to_vitana', session.sessionId);
       }
 
       if (chatBridgeAssistantText.length > 0) {
-        bridgeSupabase.from('chat_messages').insert({
+        void bridgeVoiceTranscript(bridgeSupabase, {
           tenant_id: bridgeTenantId,
           sender_id: VITANA_BOT_USER_ID,
           receiver_id: bridgeUserId,
@@ -2431,9 +2474,7 @@ export function handleTurnComplete(
           metadata: { ...bridgeMeta, direction: 'vitana_to_user', is_greeting: isGreetingTurn },
           read_at: assistantMsgTime.toISOString(),
           created_at: assistantMsgTime.toISOString(),
-        }).then(({ error }) => {
-          if (error) console.warn(`[VTID-CHAT-BRIDGE] Vitana transcript write failed: ${error.message}`);
-        });
+        }, 'vitana_to_user', session.sessionId);
       }
     }
   }

--- a/services/gateway/test/orb/live/session/chat-bridge-reliability.test.ts
+++ b/services/gateway/test/orb/live/session/chat-bridge-reliability.test.ts
@@ -1,0 +1,89 @@
+/**
+ * BOOTSTRAP-CHAT-BRIDGE-RELIABILITY
+ *
+ * `bridgeVoiceTranscript` is the ONLY path that copies a voice-session turn
+ * into `chat_messages` so it shows up in the user's "Vitana" Inbox thread.
+ * Before this fix a failed insert was fire-and-forget with just a
+ * console.warn — a transient DB/network blip silently and permanently
+ * dropped that turn from the user's chat history with no trace anywhere
+ * (user-reported: "I had several conversations with Vitana and none show
+ * up in my chat history"). This suite pins the retry + failure-telemetry
+ * behavior directly, independent of the wider WS message-handler tests
+ * (which mock `getSupabase()` to `null` and deliberately keep this branch
+ * out of scope).
+ */
+
+import { bridgeVoiceTranscript } from '../../../../src/orb/live/session/upstream-message-handler';
+import { emitOasisEvent } from '../../../../src/services/oasis-event-service';
+
+jest.mock('../../../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+const mockEmitOasisEvent = emitOasisEvent as jest.MockedFunction<typeof emitOasisEvent>;
+
+function makeRow() {
+  return {
+    tenant_id: 'tenant-1',
+    sender_id: 'user-1',
+    receiver_id: 'vitana-bot',
+    content: 'hello vitana',
+    message_type: 'voice_transcript',
+    metadata: {},
+    created_at: new Date().toISOString(),
+  };
+}
+
+function makeSupabase(insertMock: jest.Mock) {
+  return {
+    from: jest.fn().mockReturnValue({ insert: insertMock }),
+  } as any;
+}
+
+describe('bridgeVoiceTranscript', () => {
+  beforeEach(() => {
+    mockEmitOasisEvent.mockClear();
+  });
+
+  it('writes once and returns on first-attempt success', async () => {
+    const insert = jest.fn().mockResolvedValue({ error: null });
+    const supabase = makeSupabase(insert);
+
+    await bridgeVoiceTranscript(supabase, makeRow(), 'user_to_vitana', 'sess-1');
+
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(mockEmitOasisEvent).not.toHaveBeenCalled();
+  });
+
+  it('retries once on a transient failure and does not emit a failure event if the retry succeeds', async () => {
+    const insert = jest
+      .fn()
+      .mockResolvedValueOnce({ error: { message: 'connection reset' } })
+      .mockResolvedValueOnce({ error: null });
+    const supabase = makeSupabase(insert);
+
+    await bridgeVoiceTranscript(supabase, makeRow(), 'vitana_to_user', 'sess-2');
+
+    expect(insert).toHaveBeenCalledTimes(2);
+    expect(mockEmitOasisEvent).not.toHaveBeenCalled();
+  });
+
+  it('emits a durable OASIS event after exhausting retries, instead of silently dropping the turn', async () => {
+    const insert = jest.fn().mockResolvedValue({ error: { message: 'db unavailable' } });
+    const supabase = makeSupabase(insert);
+
+    await bridgeVoiceTranscript(supabase, makeRow(), 'user_to_vitana', 'sess-3');
+
+    expect(insert).toHaveBeenCalledTimes(2);
+    expect(mockEmitOasisEvent).toHaveBeenCalledTimes(1);
+    const [event] = mockEmitOasisEvent.mock.calls[0];
+    expect(event).toMatchObject({
+      status: 'error',
+      payload: expect.objectContaining({
+        orb_session_id: 'sess-3',
+        direction: 'user_to_vitana',
+        error: 'db unavailable',
+      }),
+    });
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-CHAT-BRIDGE-RELIABILITY` _(no formal VTID existed for this bug yet, tracked under this BOOTSTRAP tag per repo convention — see other `BOOTSTRAP-*` rows in CLAUDE.md's change log)_

**Layer:** APIL (gateway / orb-live session handling)

**Priority:** P1 — user-reported chat history data loss

---

## 📋 Summary

User report: "I had several conversations with Vitana [the orb widget] in the meantime, but none of them are displayed in the chat history." Traced this to `services/gateway/src/orb/live/session/upstream-message-handler.ts`'s `VTID-CHAT-BRIDGE`, the only code path that copies a voice session's transcript into `chat_messages` (so it shows up as the "Vitana" DM thread in the Inbox). The insert was fire-and-forget with only a `console.warn` on failure — a transient DB/network blip during that insert silently and **permanently** dropped the turn from the user's chat history, with the voice conversation itself completing normally and no error ever surfacing to the user or to durable telemetry.

## ✅ Changes

- [x] Extracted the duplicated insert logic (two call sites in `upstream-message-handler.ts` — the raw WS message handler and `handleTurnComplete`) into a shared `bridgeVoiceTranscript()` helper
- [x] Helper retries the insert once before giving up
- [x] On final failure, emits a durable OASIS event (`orb.chat_bridge.write_failed`) instead of only a Cloud Run log line that scrolls away
- [x] No change to the gate that gm skips the bridge entirely for sessions with no resolved identity (anonymous sessions correctly never write into another user's inbox — that's by design, not the bug)

## 🧪 Testing

- [x] Automated tests added: `test/orb/live/session/chat-bridge-reliability.test.ts` (success-first-try, retry-then-succeed, and final-failure-emits-OASIS-event cases)
- [x] Full gateway `npm run typecheck` — clean
- [x] Full existing suite for the edited file (`upstream-message-handler.test.ts`, its characterization suite, `upstream-session-binding.test.ts`, `nova-idle-keepalive.test.ts`, `upstream-provider-parity.test.ts`) — 131 passed, 0 regressions
- [ ] Verified in staging/dev environment _(no live GCP/AWS access in this session — code + test verification only; please verify on staging before promoting)_

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] N/A — no workflow files touched

### File Names
- [x] New test file follows kebab-case (`chat-bridge-reliability.test.ts`)
- [x] No files violate naming canon

### Code Standards
- [x] Event type uses snake_case (`orb.chat_bridge.write_failed` matches existing `orb.*` event taxonomy in this file)
- [x] Status values use lowercase (`error`)

### Cloud Run Deployments
- [x] N/A — no deploy scripts or Cloud Run service config touched

### Documentation
- [x] BOOTSTRAP tag referenced in commit message and this PR (no formal VTID existed for this bug)

---

## 🚨 Breaking Changes

None. Behavior for the success path is unchanged; the only externally observable change is that a previously-silent, permanent failure now retries once and, if still failing, emits an OASIS event.

---

## 📌 Additional Notes

Investigated three candidate causes before landing on this one (confirmed with the user which surface they used): (1) typing directly into the Inbox's Vitana thread — already worked correctly; (2) the separate "AI Companion" health-coach chat, which writes to unrelated `ai_conversations`/`ai_messages` tables with zero bridge to `chat_messages` — a real but different gap, out of scope here since the user confirmed they used the orb widget, not this screen; (3) **the orb voice widget's chat-history bridge — confirmed by the user, fixed in this PR.**


---
_Generated by [Claude Code](https://claude.ai/code/session_01GvyLrmRXB6usjYcaeCFtRN)_