### PR TITLE
Fix ORB voice MESSAGING_CONTRACT getting silently trimmed for heavy-context users

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -44,7 +44,7 @@ import {
 // the route handler too); the instruction builder calls it back across the
 // boundary. The function is pure (lang → string), so the round-trip is
 // safe.
-import { buildNavigatorPolicySection } from '../../../routes/orb-live';
+import { buildNavigatorPolicySection, MESSAGING_CONTRACT } from '../../../routes/orb-live';
 import { buildJourneyModesSection } from './journey-modes-prompt';
 import {
   BRAIN_OPENER_V2_START,
@@ -788,7 +788,19 @@ ${trimmedHistory}
   // VTID-NAV-01: Append the Vitana Navigator policy section so the model knows
   // when to consult the navigator, when to navigate directly, and when to
   // simply answer in voice without any tool call.
-  instruction += buildNavigatorPolicySection(lang);
+  //
+  // BOOTSTRAP-ORB-MESSAGING-CONTRACT-TRIM-FIX: MESSAGING_CONTRACT rides here,
+  // AFTER the navigator section, so it lands inside the scaffold tail that
+  // decomposeInstructionSections() (instruction-budget.ts) treats as
+  // PRESERVED — everything from the `=== VITANA NAVIGATOR —` marker to the
+  // end of the instruction is never trimmed by the aggregate budget guard.
+  // It used to be baked onto the tail of the bootstrap/memory context string
+  // instead, which made it the first thing both capBootstrapContext() and
+  // the R0 budget guard's 'bootstrap' drop-priority stripped for
+  // heavy-context users — silently deleting the "you MUST call
+  // resolve_recipient" contract and leaving the model to improvise instead
+  // of calling the messaging tools.
+  instruction += buildNavigatorPolicySection(lang) + MESSAGING_CONTRACT;
 
   // NAV_GUIDED_JOURNEY — teach Vitana the DECLARATIVE distinction between the
   // two views of "My Journey" (Guided/Einführung vs Full App/Vollversion) so it

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6028,6 +6028,41 @@ function sendFunctionResponseToLiveAPI(
   }
 }
 
+// Hard contract for tool-bound flows the LLM keeps skipping. Empirically
+// Gemini Live sometimes answers "I can't find that user" without ever
+// calling resolve_recipient — especially when the spoken phrase contains
+// a hint like "I think it's maria6". This block makes the binding
+// explicit at the system-instruction level (tool description alone wasn't
+// enough). Same pattern for navigation.
+//
+// BOOTSTRAP-ORB-MESSAGING-CONTRACT-TRIM-FIX: this used to be baked onto the
+// tail of the bootstrap/memory instruction string (generateMemoryEnhanced-
+// SystemInstruction's baseInstructionNoMemory/baseInstructionWithMemory).
+// That made it the LAST thing appended to the bootstrap text — which is
+// exactly the content both capBootstrapContext() (Phase A trailing-content
+// cap) and the R0 aggregate byte-budget guard's 'bootstrap' drop-priority
+// (instruction-budget.ts DROP_ORDER, dropped FIRST) trim away first for
+// heavy-context users (many memory facts, social context, calendar, journey
+// data). A "NON-NEGOTIABLE" contract that silently vanishes under budget
+// pressure is worse than none — the model then has no explicit instruction
+// to call resolve_recipient/send_chat_message and improvises an unrelated
+// answer instead (observed: user asked to message someone, got a reply
+// about unrelated holiday content, no tool call in the logs at all).
+// Fixed by moving it into the PRESERVED scaffold tail — appended together
+// with buildNavigatorPolicySection() below, which decomposeInstructionSections
+// (instruction-budget.ts) always classifies as 'scaffold' and never trims.
+export const MESSAGING_CONTRACT = `
+
+## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)
+
+If the user mentions sending a message, sharing a link, texting, inviting, or telling someone something, you MUST:
+1. Call resolve_recipient(spoken_name) BEFORE saying anything about whether the recipient exists. The ONLY way to honestly say "I can't find that user" is to receive an empty candidates array from resolve_recipient. Do not infer absence from your own context — you do not have the user's contact list.
+2. If the spoken phrase contains a name AND a Vitana ID hint ("Maria, I think it's maria6"), pass the Vitana ID hint as spoken_name first; if that returns 0 candidates, retry with the name.
+3. After resolve_recipient returns, follow the readback contract from the tool description (read back, await explicit confirmation, then send_chat_message).
+4. AFTER send_chat_message returns ok:true (VTID-02969): briefly acknowledge ("Sent to @<vid>.") AND in the SAME turn offer the next action — but ONLY from the tool result's next_actions array. Read next_actions[0].label verbatim as the suggestion. If the array is empty, briefly acknowledge and let the user lead — do NOT invent a next action from your own knowledge. Example with next_actions: "Sent to @dragan_red. Next: <next_actions[0].label>. Want me to do that?" Example with empty array: "Sent to @dragan_red." When the user accepts, call activate_recommendation with next_actions[0].id.
+
+If the user asks to be shown a screen, list, or detail page, call navigate_to_screen — never claim a page doesn't exist without trying. The frontend handles routing; you handle the call.`;
+
 /**
  * VTID-NAV-01: Vitana Navigator policy section appended to every system
  * instruction. Teaches the model when to call navigator_consult,
@@ -10055,24 +10090,6 @@ async function generateMemoryEnhancedSystemInstruction(
   // Load text_chat personality config
   const textChatConfig = getPersonalityConfigSync('text_chat') as Record<string, any>;
 
-  // Hard contract for tool-bound flows the LLM keeps skipping. Empirically
-  // Gemini Live sometimes answers "I can't find that user" without ever
-  // calling resolve_recipient — especially when the spoken phrase contains
-  // a hint like "I think it's maria6". This block makes the binding
-  // explicit at the system-instruction level (tool description alone wasn't
-  // enough). Same pattern for navigation.
-  const MESSAGING_CONTRACT = `
-
-## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)
-
-If the user mentions sending a message, sharing a link, texting, inviting, or telling someone something, you MUST:
-1. Call resolve_recipient(spoken_name) BEFORE saying anything about whether the recipient exists. The ONLY way to honestly say "I can't find that user" is to receive an empty candidates array from resolve_recipient. Do not infer absence from your own context — you do not have the user's contact list.
-2. If the spoken phrase contains a name AND a Vitana ID hint ("Maria, I think it's maria6"), pass the Vitana ID hint as spoken_name first; if that returns 0 candidates, retry with the name.
-3. After resolve_recipient returns, follow the readback contract from the tool description (read back, await explicit confirmation, then send_chat_message).
-4. AFTER send_chat_message returns ok:true (VTID-02969): briefly acknowledge ("Sent to @<vid>.") AND in the SAME turn offer the next action — but ONLY from the tool result's next_actions array. Read next_actions[0].label verbatim as the suggestion. If the array is empty, briefly acknowledge and let the user lead — do NOT invent a next action from your own knowledge. Example with next_actions: "Sent to @dragan_red. Next: <next_actions[0].label>. Want me to do that?" Example with empty array: "Sent to @dragan_red." When the user accepts, call activate_recommendation with next_actions[0].id.
-
-If the user asks to be shown a screen, list, or detail page, call navigate_to_screen — never claim a page doesn't exist without trying. The frontend handles routing; you handle the call.`;
-
   // Base instruction WITHOUT memory claims (used when memory is unavailable)
   // VTID-01225-READ-FIX: Always append memory_facts if available
   const baseInstructionNoMemory = `${textChatConfig.base_identity_no_memory || 'You are VITANA ORB, a voice-first multimodal assistant.'}
@@ -10084,7 +10101,7 @@ Context:
 - selectedId: ${session.selectedId || 'none'}
 
 Operating mode:
-${textChatConfig.operating_mode || '- Voice conversation is primary.\n- Always listening while ORB overlay is open.\n- Read-only: do not mutate system state.\n- Be concise, contextual, and helpful.'}${memoryFactsSection ? `\n- You have PERSISTENT MEMORY - you remember users across sessions.${memoryFactsSection}` : ''}${calendarSection}${MESSAGING_CONTRACT}`;
+${textChatConfig.operating_mode || '- Voice conversation is primary.\n- Always listening while ORB overlay is open.\n- Read-only: do not mutate system state.\n- Be concise, contextual, and helpful.'}${memoryFactsSection ? `\n- You have PERSISTENT MEMORY - you remember users across sessions.${memoryFactsSection}` : ''}${calendarSection}`;
 
   // Base instruction WITH memory claims (used when memory IS available)
   const baseInstructionWithMemory = `${textChatConfig.base_identity_with_memory || 'You are VITANA ORB, a voice-first multimodal assistant with persistent memory.'}
@@ -10098,7 +10115,7 @@ Context:
 Operating mode:
 ${textChatConfig.operating_mode || '- Voice conversation is primary.\n- Always listening while ORB overlay is open.\n- Read-only: do not mutate system state.\n- Be concise, contextual, and helpful.'}
 - You have PERSISTENT MEMORY - you remember users across sessions.
-- NEVER claim you cannot remember or that your memory resets.${memoryFactsSection}${calendarSection}${MESSAGING_CONTRACT}`;
+- NEVER claim you cannot remember or that your memory resets.${memoryFactsSection}${calendarSection}`;
 
   // VTID-01153: Try memory-indexer first (Mem0 OSS)
   // VTID-01186: Use effective identity for memory lookups

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -207,6 +207,16 @@ WHAT YOU GET BACK from navigate():
 
 NEVER speak raw URLs or route paths.
 
+## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)
+
+If the user mentions sending a message, sharing a link, texting, inviting, or telling someone something, you MUST:
+1. Call resolve_recipient(spoken_name) BEFORE saying anything about whether the recipient exists. The ONLY way to honestly say "I can't find that user" is to receive an empty candidates array from resolve_recipient. Do not infer absence from your own context — you do not have the user's contact list.
+2. If the spoken phrase contains a name AND a Vitana ID hint ("Maria, I think it's maria6"), pass the Vitana ID hint as spoken_name first; if that returns 0 candidates, retry with the name.
+3. After resolve_recipient returns, follow the readback contract from the tool description (read back, await explicit confirmation, then send_chat_message).
+4. AFTER send_chat_message returns ok:true (VTID-02969): briefly acknowledge ("Sent to @<vid>.") AND in the SAME turn offer the next action — but ONLY from the tool result's next_actions array. Read next_actions[0].label verbatim as the suggestion. If the array is empty, briefly acknowledge and let the user lead — do NOT invent a next action from your own knowledge. Example with next_actions: "Sent to @dragan_red. Next: <next_actions[0].label>. Want me to do that?" Example with empty array: "Sent to @dragan_red." When the user accepts, call activate_recommendation with next_actions[0].id.
+
+If the user asks to be shown a screen, list, or detail page, call navigate_to_screen — never claim a page doesn't exist without trying. The frontend handles routing; you handle the call.
+
 ## TEMPORAL AND JOURNEY CONTEXT
 This is real, per-session data. Treat it as ground truth about what the user is doing RIGHT NOW.
 
@@ -487,6 +497,16 @@ WAS DU VON navigate() ZURÜCKBEKOMMST:
      Frage den Nutzer was er sucht.
 
 NIEMALS rohe URLs oder Routenpfade aussprechen.
+
+## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)
+
+If the user mentions sending a message, sharing a link, texting, inviting, or telling someone something, you MUST:
+1. Call resolve_recipient(spoken_name) BEFORE saying anything about whether the recipient exists. The ONLY way to honestly say "I can't find that user" is to receive an empty candidates array from resolve_recipient. Do not infer absence from your own context — you do not have the user's contact list.
+2. If the spoken phrase contains a name AND a Vitana ID hint ("Maria, I think it's maria6"), pass the Vitana ID hint as spoken_name first; if that returns 0 candidates, retry with the name.
+3. After resolve_recipient returns, follow the readback contract from the tool description (read back, await explicit confirmation, then send_chat_message).
+4. AFTER send_chat_message returns ok:true (VTID-02969): briefly acknowledge ("Sent to @<vid>.") AND in the SAME turn offer the next action — but ONLY from the tool result's next_actions array. Read next_actions[0].label verbatim as the suggestion. If the array is empty, briefly acknowledge and let the user lead — do NOT invent a next action from your own knowledge. Example with next_actions: "Sent to @dragan_red. Next: <next_actions[0].label>. Want me to do that?" Example with empty array: "Sent to @dragan_red." When the user accepts, call activate_recommendation with next_actions[0].id.
+
+If the user asks to be shown a screen, list, or detail page, call navigate_to_screen — never claim a page doesn't exist without trying. The frontend handles routing; you handle the call.
 
 ## TEMPORAL AND JOURNEY CONTEXT
 This is real, per-session data. Treat it as ground truth about what the user is doing RIGHT NOW.
@@ -3369,6 +3389,16 @@ WHAT YOU GET BACK from navigate():
      user to clarify what they are looking for.
 
 NEVER speak raw URLs or route paths.
+
+## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)
+
+If the user mentions sending a message, sharing a link, texting, inviting, or telling someone something, you MUST:
+1. Call resolve_recipient(spoken_name) BEFORE saying anything about whether the recipient exists. The ONLY way to honestly say "I can't find that user" is to receive an empty candidates array from resolve_recipient. Do not infer absence from your own context — you do not have the user's contact list.
+2. If the spoken phrase contains a name AND a Vitana ID hint ("Maria, I think it's maria6"), pass the Vitana ID hint as spoken_name first; if that returns 0 candidates, retry with the name.
+3. After resolve_recipient returns, follow the readback contract from the tool description (read back, await explicit confirmation, then send_chat_message).
+4. AFTER send_chat_message returns ok:true (VTID-02969): briefly acknowledge ("Sent to @<vid>.") AND in the SAME turn offer the next action — but ONLY from the tool result's next_actions array. Read next_actions[0].label verbatim as the suggestion. If the array is empty, briefly acknowledge and let the user lead — do NOT invent a next action from your own knowledge. Example with next_actions: "Sent to @dragan_red. Next: <next_actions[0].label>. Want me to do that?" Example with empty array: "Sent to @dragan_red." When the user accepts, call activate_recommendation with next_actions[0].id.
+
+If the user asks to be shown a screen, list, or detail page, call navigate_to_screen — never claim a page doesn't exist without trying. The frontend handles routing; you handle the call.
 
 ## TEMPORAL AND JOURNEY CONTEXT
 This is real, per-session data. Treat it as ground truth about what the user is doing RIGHT NOW.

--- a/services/gateway/test/orb/live/characterization/system-instruction.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/system-instruction.characterization.test.ts
@@ -17,7 +17,12 @@
  *   reads from an in-memory cache + hardcoded defaults.
  */
 
-import { buildLiveSystemInstruction } from '../../../../src/routes/orb-live';
+import { buildLiveSystemInstruction, MESSAGING_CONTRACT } from '../../../../src/routes/orb-live';
+import {
+  decomposeInstructionSections,
+  enforceInstructionBudget,
+  INSTRUCTION_MARKERS,
+} from '../../../../src/orb/live/instruction/instruction-budget';
 import { ALL_PERSONAS } from './personas';
 
 describe('A0.1 characterization: buildLiveSystemInstruction', () => {
@@ -139,6 +144,87 @@ describe('A0.1 characterization: buildLiveSystemInstruction', () => {
       expect(community).toContain('report_to_specialist');
       expect(community).toContain('switch_persona');
       expect(community).toContain('You ARE the instruction manual');
+    });
+  });
+
+  // BOOTSTRAP-ORB-MESSAGING-CONTRACT-TRIM-FIX: regression coverage for a
+  // production bug where MESSAGING_CONTRACT ("## MESSAGING & SHARING
+  // CONTRACT (NON-NEGOTIABLE)" — the instruction telling the model it MUST
+  // call resolve_recipient before claiming a recipient doesn't exist) was
+  // baked onto the tail of bootstrapContext. For heavy-context users that
+  // made it the first thing dropped by the aggregate instruction byte-budget
+  // guard (instruction-budget.ts DROP_ORDER: bootstrap first), silently
+  // deleting the model's only instruction to call the messaging tools —
+  // confirmed against a real production session where the model never
+  // called resolve_recipient/send_chat_message at all. Fixed by moving
+  // MESSAGING_CONTRACT out of bootstrapContext and appending it after the
+  // navigator section, inside the scaffold tail decomposeInstructionSections
+  // always preserves.
+  describe('MESSAGING_CONTRACT placement (BOOTSTRAP-ORB-MESSAGING-CONTRACT-TRIM-FIX)', () => {
+    const baseArgs = ['en', 'conversational', '', 'community', '', '', false, null] as const;
+
+    it('is present in the rendered instruction', () => {
+      const instruction = buildLiveSystemInstruction(...baseArgs, '/', [], undefined, '@x');
+      expect(instruction).toContain('## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)');
+      expect(instruction).toContain('Call resolve_recipient(spoken_name)');
+    });
+
+    it('is positioned AFTER the navigator marker, not inside bootstrapContext', () => {
+      // The regression: MESSAGING_CONTRACT used to be concatenated onto
+      // bootstrapContext, so it appeared BEFORE the navigator marker. It
+      // must now appear strictly after — that's what makes it part of the
+      // preserved scaffold tail instead of the trimmable bootstrap region.
+      const instruction = buildLiveSystemInstruction(
+        'en', 'conversational', 'some heavy bootstrap context', 'community', '', '', false, null,
+        '/', [], undefined, '@x',
+      );
+      const navIdx = instruction.indexOf(INSTRUCTION_MARKERS.NAVIGATOR_PREFIX);
+      const contractIdx = instruction.indexOf('## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)');
+      expect(navIdx).toBeGreaterThan(-1);
+      expect(contractIdx).toBeGreaterThan(navIdx);
+    });
+
+    it('decomposeInstructionSections classifies it as scaffold (preserved), not bootstrap (trimmed first)', () => {
+      const instruction = buildLiveSystemInstruction(
+        'en', 'conversational', 'some bootstrap context', 'community', '', '', false, null,
+        '/', [], undefined, '@x',
+      );
+      const sections = decomposeInstructionSections(instruction);
+      const bootstrapText = sections.filter((s) => s.kind === 'bootstrap').map((s) => s.text).join('');
+      const scaffoldText = sections.filter((s) => s.kind === 'scaffold').map((s) => s.text).join('');
+      expect(bootstrapText).not.toContain('MESSAGING & SHARING CONTRACT');
+      expect(scaffoldText).toContain('MESSAGING & SHARING CONTRACT');
+    });
+
+    it('survives enforceInstructionBudget even when a heavy bootstrapContext forces trimming (the actual production bug)', () => {
+      // Simulate a heavy-context user: a bootstrap block large enough that
+      // dropping it is necessary to fit the aggregate budget. Pre-fix, this
+      // scenario silently deleted MESSAGING_CONTRACT along with it.
+      //
+      // NOTE: deliberately NOT using a literal "## USER CONTEXT PROFILE"
+      // header here — that string is separately matched by the unrelated
+      // BOOTSTRAP-HISTORY-AWARE-TIMELINE activity-awareness override (see
+      // buildLiveSystemInstruction's own `bootstrapContext.match(/## USER
+      // CONTEXT PROFILE.../)` re-extraction), which re-appends whatever it
+      // captures, UNCAPPED, later in the instruction — a real, pre-existing
+      // behavior unrelated to this fix that would otherwise pollute this
+      // test's assertions about the (separate) byte-budget trimming path.
+      const heavyBootstrap = '\n\n## SOME HEAVY MEMORY BLOCK\n' + 'b'.repeat(20_000);
+      const instruction = buildLiveSystemInstruction(
+        'en', 'conversational', heavyBootstrap, 'community', '', '', false, null,
+        '/', [], undefined, '@x',
+      );
+      const sections = decomposeInstructionSections(instruction);
+      const budget = 5_000; // small enough to force dropping the bootstrap section
+      const result = enforceInstructionBudget(sections, budget);
+
+      expect(result.trimmedSections).toContain('bootstrap');
+      // The heavy bootstrap body is gone...
+      expect(result.text).not.toContain('b'.repeat(20_000));
+      // ...but MESSAGING_CONTRACT survives regardless, because it lives in
+      // the preserved scaffold tail, not the trimmed bootstrap region.
+      expect(result.text).toContain('## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)');
+      expect(result.text).toContain(MESSAGING_CONTRACT.trim().split('\n')[0]); // sanity: same source constant
     });
   });
 });


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `BOOTSTRAP-ORB-MESSAGING-CONTRACT-TRIM-FIX` _(no formal VTID existed yet; tagged per existing BOOTSTRAP-* convention)_

**Layer:** APIL (gateway ORB voice / system-instruction assembly)

**Priority:** P0 — same user-reported regression as #3011 (already merged/shipped), still broken on retest via ORB **voice** specifically.

---

## 📋 Summary

#3011 fixed the **text-chat** `send_chat_message` confirm-contract, and was verified live in production. The user then retested via **ORB voice** in the mobile app ("send a message to Mariia Maxina") and it still failed — but with a *different* failure signature this time, confirmed by pulling the actual production session from Supabase (`oasis_events`, `mem_turn_log` for session `live-ec4926ec-...`, 2026-07-31 ~14:59 UTC, user `d.stevanovic@exafy.io`):

- **No `resolve_recipient` or `send_chat_message` tool call ever fired.** (`orb.live.tool.executed` events show only earlier, unrelated tool calls — `get_current_screen`, `get_vitana_index` — nothing for the messaging request.)
- The model instead replied with something unrelated (the user's next utterance, paraphrasing back in disbelief, references searching for holiday-season content — nothing to do with messaging).

This is a **different root cause** from #3011: the model wasn't stuck on a confirm handshake, it never even attempted the tool.

### Root cause

`MESSAGING_CONTRACT` (the `"## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)"` block instructing the model it **must** call `resolve_recipient` before claiming a recipient doesn't exist) was appended at the very **tail** of the bootstrap/memory system-instruction string built by `generateMemoryEnhancedSystemInstruction` in `orb-live.ts`. That position makes it the first content stripped by **two separate trimming layers**:

1. `capBootstrapContext()` (Phase A) — trims older **trailing** content from the bootstrap region.
2. The R0 aggregate byte-budget guard (`instruction-budget.ts`) — classifies the entire bootstrap region as kind `'bootstrap'`, first in `DROP_ORDER = ['bootstrap', 'history', 'specialist']`, dropped whenever the assembled Vertex Live `system_instruction` exceeds the ~30KB budget.

The affected user has a heavy profile (214 days tenure, 25 memory facts, 8 preferences, extensive social/calendar/journey context) — exactly the "heavy user" scenario both trimming layers exist to handle. A block literally labeled "NON-NEGOTIABLE" was, in practice, the single most trim-prone piece of the entire instruction.

---

## ✅ Changes

- `services/gateway/src/routes/orb-live.ts`: hoisted `MESSAGING_CONTRACT` to a module-level **exported** constant (was a local `const` re-declared and baked into both `baseInstructionNoMemory` and `baseInstructionWithMemory`). Removed both inline usages.
- `services/gateway/src/orb/live/instruction/live-system-instruction.ts`: import `MESSAGING_CONTRACT` and append it immediately after `buildNavigatorPolicySection(lang)` — `decomposeInstructionSections()` always classifies everything from the `=== VITANA NAVIGATOR —` marker onward as `'scaffold'`, which the R0 guard **never** trims. This also runs entirely after `capBootstrapContext()` has already done its trimming, so the trailing-content cap can no longer touch it either.
- Correctly scoped: `buildLiveSystemInstruction` is only called for non-anonymous sessions (`orb-live.ts`'s `session.isAnonymous ? buildAnonymousSystemInstruction(...) : buildLiveSystemInstruction(...)`), matching where the messaging tools are actually declared (`buildLiveApiTools` only includes them when `mode === 'authenticated'`).

---

## 🧪 Testing

- [x] `cd services/gateway && npm run build` — compiles clean on top of latest `main` (which already includes #3011 and other same-day merges).
- [x] Diagnosed against the **actual failing production session** via Supabase (`oasis_events`, `mem_turn_log`, `memory_items`) rather than guessing — confirmed no tool call fired and traced the exact code path (`generateMemoryEnhancedSystemInstruction` → `capBootstrapContext` → `decomposeInstructionSections`/`enforceInstructionBudget`) that explains why.
- [ ] Manual live-voice re-test — not done in this session (no way to place a live ORB voice call from here). Recommend the user retry the same "send a message to X" voice request; if it still fails, the next thing to check is whether this specific session's assembled instruction is *still* over the 30KB budget even with this fix (in which case `MESSAGING_CONTRACT`, now guaranteed preserved, would still be present — worth confirming via the `voice.instruction.budget_overflow` / `budget_trimmed` warning logs for the session, or the `/debug/brain-instruction` probe endpoint).
- [ ] Automated tests: none added — `instruction-budget.ts` mentions being "exhaustively unit-testable" but I didn't add a regression test pinning `MESSAGING_CONTRACT`'s section classification; worth a follow-up.

---

## 📝 Phase 2B Naming Compliance Checklist

- [x] No GitHub Actions workflow files touched.
- [x] No new files added (edits to two existing kebab-case files).
- [x] No new VTID/event-type/status constants added.
- [x] No Cloud Run/ECS deployment or label changes.
- [x] BOOTSTRAP tag included in commit message.

---

## 🔗 Links

- Follows #3011 (merged, deployed to AWS production `gateway.vitanaland.com` 2026-07-30) — same user report, different surface (voice vs text-chat) and different root cause.
- Relevant prior art this bug sits inside: `BOOTSTRAP-ORB-R0-INSTRUCTION-CAP` (`instruction-budget.ts`'s own header) — the aggregate budget guard this fix routes around, not against.

---

## 🚨 Breaking Changes

None — purely repositions where one instruction block is appended in the assembled system-instruction text; no behavioral change for sessions that were already under budget.

---

## 📸 Screenshots (if applicable)

N/A — backend-only, voice system-instruction assembly.

---

## 📌 Additional Notes

This does not rule out the possibility that other "NON-NEGOTIABLE"-style hard-contract blocks appended the same way (tail of bootstrap text) have the identical latent bug — I only moved `MESSAGING_CONTRACT` since it's the one implicated by this session's logs. Worth a follow-up audit of `generateMemoryEnhancedSystemInstruction`'s other tail-appended sections if similar "the model just didn't call an important tool" reports come in for heavy-context users.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc5c6mP4QHaydiSe2DjnvT)_