### PR TITLE
fix(chat): bound the Vitana reply in-flight guard with a staleness TTL (VTID-03459)

### DIFF
--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -26,7 +26,17 @@ const router = Router();
 // VTID-03459: per-user in-flight guard for the fire-and-forget Vitana text
 // reply (see the /send handler below). Module-level because this route file
 // is a singleton Express router — safe within one instance, not distributed.
-const vitanaReplyInFlight = new Set<string>();
+//
+// Maps user_id -> the timestamp the in-flight call started. A plain Set
+// with no expiry was tried first and found live-testing to be unsafe: a
+// stuck handleVitanaTextReply() call (observed live on gateway-staging —
+// memory-orchestrator retrieval can take 30s+ under load, and the turn can
+// stall well past that with no error/telemetry) would hold the guard open
+// forever, permanently blocking that user from ever getting a reply again
+// on this instance. VITANA_REPLY_STALE_MS bounds how long a guard entry is
+// honored before a fresh request is allowed through again.
+const vitanaReplyInFlight = new Map<string, number>();
+const VITANA_REPLY_STALE_MS = 90_000;
 
 function getSupabase() {
   return createClient(
@@ -121,10 +131,12 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
   // failure mode, which is always same-client rapid double-fire hitting the
   // same instance.
   if (isVitanaBot(receiver_id) && trimmedContent.length > 0) {
-    if (vitanaReplyInFlight.has(identity.user_id)) {
+    const now = Date.now();
+    const inFlightSince = vitanaReplyInFlight.get(identity.user_id);
+    if (inFlightSince !== undefined && now - inFlightSince < VITANA_REPLY_STALE_MS) {
       console.warn(`[Chat] Dropping duplicate Vitana text reply request for user ${identity.user_id} (one already in flight)`);
     } else {
-      vitanaReplyInFlight.add(identity.user_id);
+      vitanaReplyInFlight.set(identity.user_id, now);
       handleVitanaTextReply(
         identity.user_id,
         identity.tenant_id!,
@@ -132,7 +144,14 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
         supabase,
       )
         .catch(err => console.warn('[Chat] Vitana text reply failed:', err.message))
-        .finally(() => vitanaReplyInFlight.delete(identity.user_id));
+        .finally(() => {
+          // Only clear the entry this call itself set — a very-late-finishing
+          // stale call must not clobber a fresher in-flight entry that the
+          // staleness window let through in the meantime.
+          if (vitanaReplyInFlight.get(identity.user_id) === now) {
+            vitanaReplyInFlight.delete(identity.user_id);
+          }
+        });
     }
   } else if (!isVitanaBot(receiver_id)) {
     // BOOTSTRAP-NOTIF-CATEGORIES: Resolve the sender's display name so that the


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03459` (follow-up hardening of the in-flight guard just merged in #3025)

**Layer:** Gateway — `services/gateway/src/routes/chat.ts`

**Priority:** P0 — the previous fix's own guard could permanently lock a user out of ever getting a Vitana reply

---

## 📋 Summary

Live-verifying #3025 on `gateway-staging` immediately after merge surfaced a real bug in the in-flight guard it introduced: `handleVitanaTextReply()` can stall for several minutes under load with **zero error/telemetry** (confirmed directly — a test turn sent no further OASIS events after `memory.social.context_built` and never completed, even after 7+ minutes, while unrelated background jobs on the same instance kept logging normally — so this is a stuck async chain, not a frozen container).

The original guard was a plain `Set<string>` with no expiry. A stuck call held it open **forever**, so a single stall permanently blocked that user from ever getting a Vitana reply again on that instance — turning a transient duplicate-reply annoyance into a lasting outage for the affected user. Confirmed live: a second test message from the same user produced **zero** telemetry at all (not even the turn-received event), consistent with the guard silently-but-permanently suppressing it.

---

## ✅ Changes

- [x] `services/gateway/src/routes/chat.ts` — `vitanaReplyInFlight` is now `Map<string, number>` (`user_id` → `started_at`) with a 90s staleness window (well above the 30s+ per-step latencies observed live for embedding generation and social-context building). A fresh attempt is allowed through once the window expires. The `finally` handler only clears an entry it itself set, so a very-late stale call can't clobber a fresher legitimate in-flight entry.

---

## 🧪 Testing

- [x] `npx tsc --noEmit` — clean.
- [x] Full local suite: 605/605 suites, 11830/11843 tests passing (7 skipped, 6 todo — pre-existing).
- [x] Live-tested the failure mode directly on `gateway-staging` before writing this fix (see summary above).

---

## 🚨 Breaking Changes

None — purely a hardening of the guard added in #3025; no other behavior change.

---

## 📌 Additional Notes

**Open question not fixed here:** why `handleVitanaTextReply()` itself can stall for minutes with zero telemetry is a separate, deeper issue — this PR only stops that stall from being a *permanent* lock. Root-causing the stall needs application log access this session doesn't have; flagging to the user rather than guessing blind.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pf7tYQgNxUVeL2iu25zPBS)_