### PR TITLE
fix(orb): replace Vertex/GCP web-search grounding with Claude web_search (VTID-03472)

### DIFF
--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -394,11 +394,13 @@ NOVA_SONIC_ALLOW_GLOBAL_FLIP=false
 
 # --- Web/news search grounding (VTID-03472) ---
 # fetchWebHits() (context-pack-builder.ts, backs the search_web voice tool)
-# uses Vertex AI's own Google Search grounding via a plain generateContent
-# call — reuses GOOGLE_CLOUD_PROJECT/ADC, no separate key needed. OPTIONAL:
-# unset uses the default below. Falls back to Perplexity (PERPLEXITY_API_KEY)
-# only if that grounding call fails or returns no text.
-WEB_SEARCH_GROUNDING_MODEL=gemini-2.5-flash
+# uses Claude's native web_search tool via the direct Anthropic API — reuses
+# ANTHROPIC_API_KEY, no separate key needed. Never Vertex/GCP (decommissioned
+# 2026-08-03) — Bedrock's tool-use framework does NOT relay to Anthropic's
+# hosted search endpoint, so this must be the direct API. OPTIONAL: unset
+# uses the default below. Falls back to Perplexity (PERPLEXITY_API_KEY) only
+# if ANTHROPIC_API_KEY is unset or the search call fails/returns no citations.
+WEB_SEARCH_GROUNDING_MODEL=claude-haiku-4-5-20251001
 
 # --- Watcher: development-lifecycle observer (VTID-03460) ---
 # Plan: docs/WATCHER-AGENT-PLAN.md (VTID-03454). Phase 1 is read-only —

--- a/services/gateway/src/routes/conversation.ts
+++ b/services/gateway/src/routes/conversation.ts
@@ -1174,10 +1174,10 @@ router.get('/tools', (_req: Request, res: Response) => {
 // =============================================================================
 
 router.get('/health', (_req: Request, res: Response) => {
-  // VTID-03472: web_search's primary backend is Vertex AI Google Search
-  // grounding (GOOGLE_CLOUD_PROJECT), with Perplexity as a fallback — report
-  // available when EITHER is configured, not Perplexity alone.
-  const hasVertex = !!process.env.GOOGLE_CLOUD_PROJECT;
+  // VTID-03472: web_search's primary backend is Claude's web_search tool via
+  // direct Anthropic API (ANTHROPIC_API_KEY), with Perplexity as a fallback —
+  // report available when EITHER is configured. Never GCP/Vertex.
+  const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
   const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
 
   res.status(200).json({
@@ -1189,7 +1189,7 @@ router.get('/health', (_req: Request, res: Response) => {
     features: {
       memory_garden: true,
       knowledge_hub: true,
-      web_search: hasVertex || !!PERPLEXITY_API_KEY,
+      web_search: hasAnthropic || !!PERPLEXITY_API_KEY,
       streaming: true,
     },
   });

--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -555,7 +555,8 @@ async function fetchKnowledgeHits(
 // =============================================================================
 
 /**
- * VTID-03472: Fetch web search hits via Vertex AI Google Search grounding.
+ * VTID-03472: Fetch web search hits via Claude's native web_search tool
+ * (direct Anthropic API).
  *
  * Perplexity was the originally-approved provider (see fetchWebHitsPerplexity
  * below) but PERPLEXITY_API_KEY has never been configured in staging or prod
@@ -571,12 +572,18 @@ async function fetchKnowledgeHits(
  * function tool, and it was always returning empty. Reported live: "check
  * the internet for news about Mariia Maksina" on Nova → no results.
  *
- * Fix: use Vertex AI's own Google Search grounding via a plain (non-live)
- * generateContent call instead of Perplexity — GOOGLE_CLOUD_PROJECT/ADC is
- * already configured and working (the same credentials the LLM router's
- * vertex adapter uses), so this needs no new secret. Falls back to
- * Perplexity if that key is ever configured later; the sentence-splitting
- * formatter is shared so output shape is unchanged either way.
+ * IMPORTANT: an earlier version of this fix used Vertex AI (Gemini) grounding
+ * — WRONG. ORB voice moved off Vertex to Nova Sonic 5 days before this fix
+ * (2026-07-27), and GCP itself is being turned off entirely (2026-08-03,
+ * this coming Monday) — a Vertex dependency would have silently regressed
+ * back to this exact bug within days. Every LLM call on this platform now
+ * targets Anthropic. Claude's web_search is a genuine server-side tool (runs
+ * on Anthropic's infrastructure, not Bedrock's — Bedrock's tool-use
+ * framework does NOT relay to Anthropic's hosted search endpoint, confirmed
+ * against AWS docs before writing this), so it needs ANTHROPIC_API_KEY (the
+ * same env var llm-router.ts's `anthropic` adapter already reads), not
+ * Bedrock credentials. Falls back to Perplexity if that's ever configured;
+ * falls back further to empty (never GCP) if neither is available.
  */
 async function fetchWebHits(
   query: string,
@@ -584,92 +591,78 @@ async function fetchWebHits(
 ): Promise<{ hits: WebHit[]; latency_ms: number }> {
   const startTime = Date.now();
 
-  const projectId = process.env.GOOGLE_CLOUD_PROJECT;
-  if (projectId) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (apiKey) {
     try {
-      const { VertexAI } = await import('@google-cloud/vertexai');
-      const location = process.env.VERTEX_LOCATION || 'us-central1';
-      const vertex = new VertexAI({ project: projectId, location });
-      const model = vertex.getGenerativeModel(
+      const Anthropic = (await import('@anthropic-ai/sdk')).default;
+      const client = new Anthropic({ apiKey });
+      const msg = await client.messages.create(
         {
-          model: process.env.WEB_SEARCH_GROUNDING_MODEL || 'gemini-2.5-flash',
-          // Gemini 2.x+ requires the `googleSearch` tool — `googleSearchRetrieval`
-          // is the Gemini 1.5-era legacy tool and is rejected for 2.x models.
-          // `as any`: this SDK's types (@google-cloud/vertexai 1.9.2) predate
-          // the 2.x tool but the request is a plain JSON pass-through
-          // (functions/generate_content.js forwards `tools` verbatim), so the
-          // untyped field still reaches the wire correctly.
-          tools: [{ googleSearch: {} } as any],
+          model: process.env.WEB_SEARCH_GROUNDING_MODEL || 'claude-haiku-4-5-20251001',
+          max_tokens: 1024,
+          messages: [{ role: 'user', content: query }],
+          tools: [{ type: 'web_search_20260209', name: 'web_search', max_uses: 3 }],
         },
         // Bound below orb-live.ts's 3000ms TOOL_TIMEOUT_MS for search_web —
-        // without this, a slow/stalled Vertex call outlives the voice-tool
-        // deadline: the model gets a timeout error instead of a result (or
-        // the Perplexity fallback), while the un-aborted request keeps
-        // running. Same budget as fetchWithTimeout()'s FETCH_TIMEOUT_MS.
+        // without this, a slow/stalled call outlives the voice-tool deadline:
+        // the model gets a timeout error instead of a result (or the
+        // Perplexity fallback), while the un-aborted request keeps running.
+        // Same budget as fetchWithTimeout()'s FETCH_TIMEOUT_MS.
         { timeout: CONTEXT_PACK_CONFIG.FETCH_TIMEOUT_MS },
       );
-      const result = await model.generateContent({
-        contents: [{ role: 'user', parts: [{ text: query }] }],
-      });
-      const candidate = result.response?.candidates?.[0];
-      const parts = (candidate?.content?.parts || []) as Array<{ text?: string; thought?: boolean }>;
-      const text = parts.filter((p) => !p.thought).map((p) => p.text || '').join('');
-      const grounding = candidate?.groundingMetadata;
-      if (text.trim()) {
-        // groundingChunks is a source table, not sentence-aligned — align
-        // via groundingSupports (text span -> chunk indices) so each hit's
-        // citation is the source actually backing that claim, not just the
-        // i-th chunk for the i-th sentence.
-        const supportHits = hitsFromGroundingSupports(grounding, limit);
-        const hits = supportHits.length > 0
-          ? supportHits
-          : splitIntoWebHits(text, (grounding?.groundingChunks || []).map((c) => c.web?.uri).filter((u): u is string => !!u), limit);
-        console.log(`[VTID-03472] Vertex grounding returned ${hits.length} web hits for: ${query.substring(0, 50)}`);
+      const hits = hitsFromClaudeCitations(msg.content, limit);
+      if (hits.length > 0) {
+        console.log(`[VTID-03472] Claude web_search returned ${hits.length} web hits for: ${query.substring(0, 50)}`);
         return { hits, latency_ms: Date.now() - startTime };
       }
-      console.warn('[VTID-03472] Vertex grounding returned no text — falling back to Perplexity');
+      console.warn('[VTID-03472] Claude web_search returned no citations — falling back to Perplexity');
     } catch (error: any) {
-      console.error(`[VTID-03472] Vertex grounding error: ${error.message} — falling back to Perplexity`);
+      console.error(`[VTID-03472] Claude web_search error: ${error.message} — falling back to Perplexity`);
     }
   } else {
-    console.warn('[VTID-03472] GOOGLE_CLOUD_PROJECT not configured — falling back to Perplexity');
+    console.warn('[VTID-03472] ANTHROPIC_API_KEY not configured — falling back to Perplexity');
   }
 
   return fetchWebHitsPerplexity(query, limit, startTime);
 }
 
-interface VertexGroundingChunk { web?: { uri?: string; title?: string } }
-interface VertexGroundingSupport { segment?: { text?: string }; groundingChunkIndices?: number[] }
-interface VertexGroundingMetadata {
-  groundingChunks?: VertexGroundingChunk[];
-  groundingSupports?: VertexGroundingSupport[];
+interface ClaudeWebSearchCitation {
+  type: string;
+  cited_text?: string;
+  title?: string | null;
+  url?: string;
+}
+interface ClaudeContentBlock {
+  type: string;
+  citations?: ClaudeWebSearchCitation[] | null;
 }
 
 /**
- * Builds one WebHit per grounding support — each is a text span Gemini
- * actually attributed to specific source chunk(s), so the citation is
- * correct for that claim (unlike zipping citations[i] to sentence i).
- * Returns [] when the response carries no groundingSupports (e.g. a very
- * short answer), letting the caller fall back to splitIntoWebHits.
+ * Builds one WebHit per web-search citation Claude actually attached to its
+ * answer — cited_text/title/url come straight off the citation, so (unlike
+ * the old positional sentence-zip) each hit's source is the one that
+ * genuinely backs that claim, with zero extra parsing/alignment needed.
+ * Returns [] when the response carries no web_search_result_location
+ * citations (tool not invoked, or search found nothing) — matches the
+ * governance requirement that web search results must carry real citations.
  */
-function hitsFromGroundingSupports(grounding: VertexGroundingMetadata | undefined, limit: number): WebHit[] {
-  const chunks = grounding?.groundingChunks || [];
-  const supports = grounding?.groundingSupports || [];
+function hitsFromClaudeCitations(content: ClaudeContentBlock[], limit: number): WebHit[] {
   const hits: WebHit[] = [];
-  for (let i = 0; i < supports.length && hits.length < limit; i++) {
-    const text = supports[i].segment?.text?.trim();
-    if (!text || text.length <= 20) continue;
-    const chunkIdx = supports[i].groundingChunkIndices?.[0];
-    const chunk = typeof chunkIdx === 'number' ? chunks[chunkIdx] : undefined;
-    const url = chunk?.web?.uri;
-    hits.push({
-      id: `web-${hits.length}`,
-      title: chunk?.web?.title || text.substring(0, 80) + (text.length > 80 ? '...' : ''),
-      snippet: text.substring(0, CONTEXT_PACK_CONFIG.MAX_CONTENT_LENGTH),
-      url: url || 'https://google.com/search',
-      citation: url || '[Google Search]',
-      relevance_score: 1 - hits.length * 0.1,
-    });
+  for (const block of content) {
+    if (block.type !== 'text' || !block.citations) continue;
+    for (const c of block.citations) {
+      if (c.type !== 'web_search_result_location' || !c.cited_text) continue;
+      hits.push({
+        id: `web-${hits.length}`,
+        title: c.title || c.cited_text.substring(0, 80) + (c.cited_text.length > 80 ? '...' : ''),
+        snippet: c.cited_text.substring(0, CONTEXT_PACK_CONFIG.MAX_CONTENT_LENGTH),
+        url: c.url || 'https://www.google.com/search',
+        citation: c.url || '[Claude web search]',
+        relevance_score: 1 - hits.length * 0.1,
+      });
+      if (hits.length >= limit) break;
+    }
+    if (hits.length >= limit) break;
   }
   return hits.slice(0, CONTEXT_PACK_CONFIG.MAX_WEB_HITS);
 }
@@ -812,17 +805,18 @@ async function checkToolHealth(): Promise<ToolHealthStatus[]> {
     last_checked: now,
   });
 
-  // Web Search — Vertex AI Google Search grounding (primary, VTID-03472) or
-  // Perplexity (fallback). Available if EITHER backend is configured.
+  // Web Search — Claude web_search tool via direct Anthropic API (primary,
+  // VTID-03472) or Perplexity (fallback). Available if EITHER is configured.
+  // Never GCP/Vertex — decommissioned 2026-08-03.
   const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
-  const hasVertex = !!process.env.GOOGLE_CLOUD_PROJECT;
+  const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
   tools.push({
     name: 'web_search',
-    available: hasVertex || !!PERPLEXITY_API_KEY,
+    available: hasAnthropic || !!PERPLEXITY_API_KEY,
     last_checked: now,
-    error: hasVertex || PERPLEXITY_API_KEY
+    error: hasAnthropic || PERPLEXITY_API_KEY
       ? undefined
-      : 'Neither GOOGLE_CLOUD_PROJECT nor PERPLEXITY_API_KEY configured',
+      : 'Neither ANTHROPIC_API_KEY nor PERPLEXITY_API_KEY configured',
   });
 
   return tools;

--- a/services/gateway/test/services/context-pack-builder-web-search.test.ts
+++ b/services/gateway/test/services/context-pack-builder-web-search.test.ts
@@ -1,15 +1,19 @@
 /**
- * VTID-03472: regression coverage for fetchWebHits()'s Vertex AI grounding
+ * VTID-03472: regression coverage for fetchWebHits()'s Claude web_search
  * path — the fix for "check the internet for news about X" returning
  * nothing on Nova Sonic (and silently on Vertex too, masked by Vertex's
  * native google_search grounding covering for it).
  *
  * Root cause: PERPLEXITY_API_KEY has never been configured in staging or
  * prod, so the search_web tool's ONLY backend always returned empty hits.
- * Fix: try Vertex AI's own Google Search grounding (via a plain
- * generateContent call, not the Live API's native grounding) first —
- * GOOGLE_CLOUD_PROJECT/ADC is already configured — falling back to
- * Perplexity only if that's ever configured later.
+ *
+ * Fix (v2 — Vertex REMOVED): use Claude's native web_search server-side tool
+ * via the direct Anthropic API (ANTHROPIC_API_KEY), not Vertex/GCP. ORB voice
+ * moved off Vertex to Nova Sonic 5 days before this fix, and GCP itself is
+ * being decommissioned entirely (2026-08-03) — a Vertex dependency here
+ * would have silently regressed within days. Bedrock does NOT relay to
+ * Anthropic's hosted search endpoint, so this must be the direct API, not
+ * Bedrock credentials.
  *
  * This file exercises both context-pack-builder.ts's fetchWebHits() (via
  * buildContextPack, forcing web_search only) AND the actual voice tool
@@ -21,60 +25,67 @@ process.env.NODE_ENV = 'test';
 process.env.SUPABASE_URL = 'http://localhost:54321';
 process.env.SUPABASE_SERVICE_ROLE = 'test-service-role';
 delete process.env.PERPLEXITY_API_KEY;
-process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
 
-let vertexBehavior: 'grounded' | 'grounded_no_supports' | 'no_text' | 'throw' = 'grounded';
-const getGenerativeModelCalls: any[] = [];
+let claudeBehavior: 'cited' | 'no_citations' | 'throw' = 'cited';
+const messagesCreateCalls: any[] = [];
 
-jest.mock('@google-cloud/vertexai', () => ({
-  VertexAI: jest.fn().mockImplementation(() => ({
-    getGenerativeModel: jest.fn().mockImplementation((modelParams: any, requestOptions: any) => {
-      getGenerativeModelCalls.push({ ...modelParams, requestOptions });
-      return {
-        generateContent: jest.fn().mockImplementation(async () => {
-          if (vertexBehavior === 'throw') {
-            throw new Error('Vertex grounding mock failure');
+jest.mock('@anthropic-ai/sdk', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      messages: {
+        create: jest.fn().mockImplementation(async (body: any, requestOptions: any) => {
+          messagesCreateCalls.push({ ...body, requestOptions });
+          if (claudeBehavior === 'throw') {
+            throw new Error('Claude web_search mock failure');
           }
-          if (vertexBehavior === 'no_text') {
-            return { response: { candidates: [{ content: { parts: [] } }] } };
+          if (claudeBehavior === 'no_citations') {
+            return { content: [{ type: 'text', text: 'No results found.', citations: null }] };
           }
-          const text =
-            'Mariia Maksina is featured in a recent Vitana longevity community spotlight. ' +
-            'She discussed her wellness routine in an interview published this week.';
-          const groundingChunks = [
-            { web: { uri: 'https://example.com/mariia-maksina-spotlight', title: 'Spotlight' } },
-            { web: { uri: 'https://example.com/mariia-maksina-interview', title: 'Interview' } },
-          ];
-          const groundingMetadata =
-            vertexBehavior === 'grounded_no_supports'
-              ? { groundingChunks }
-              : {
-                  groundingChunks,
-                  // Real Gemini shape: each support maps a TEXT SPAN to the
-                  // chunk(s) that back it — this is what lets citations be
-                  // attributed to the right source per claim, not just
-                  // zipped by sentence position.
-                  groundingSupports: [
-                    {
-                      segment: { text: 'Mariia Maksina is featured in a recent Vitana longevity community spotlight' },
-                      groundingChunkIndices: [0],
-                    },
-                    {
-                      segment: { text: 'She discussed her wellness routine in an interview published this week' },
-                      groundingChunkIndices: [1],
-                    },
-                  ],
-                };
           return {
-            response: {
-              candidates: [{ content: { parts: [{ text }] }, groundingMetadata }],
-            },
+            content: [
+              {
+                type: 'server_tool_use',
+                id: 'srvtool_1',
+                name: 'web_search',
+                input: { query: 'Mariia Maksina news' },
+              },
+              {
+                type: 'web_search_tool_result',
+                tool_use_id: 'srvtool_1',
+                content: [
+                  { type: 'web_search_result', title: 'Spotlight', url: 'https://example.com/mariia-maksina-spotlight', encrypted_content: 'x', page_age: null },
+                  { type: 'web_search_result', title: 'Interview', url: 'https://example.com/mariia-maksina-interview', encrypted_content: 'x', page_age: null },
+                ],
+              },
+              {
+                type: 'text',
+                text: 'Mariia Maksina is featured in a recent Vitana longevity community spotlight. She discussed her wellness routine in an interview published this week.',
+                citations: [
+                  {
+                    type: 'web_search_result_location',
+                    cited_text: 'Mariia Maksina is featured in a recent Vitana longevity community spotlight',
+                    title: 'Spotlight',
+                    url: 'https://example.com/mariia-maksina-spotlight',
+                    encrypted_index: 'x',
+                  },
+                  {
+                    type: 'web_search_result_location',
+                    cited_text: 'She discussed her wellness routine in an interview published this week',
+                    title: 'Interview',
+                    url: 'https://example.com/mariia-maksina-interview',
+                    encrypted_index: 'x',
+                  },
+                ],
+              },
+            ],
           };
         }),
-      };
-    }),
-  })),
-}));
+      },
+    })),
+  };
+});
 
 function restResponse(body: unknown, status = 200) {
   return {
@@ -135,61 +146,47 @@ function webOnlyInput(query: string): BuildContextPackInput {
 }
 
 beforeEach(() => {
-  vertexBehavior = 'grounded';
+  claudeBehavior = 'cited';
   mockFetch.mockClear();
-  getGenerativeModelCalls.length = 0;
+  messagesCreateCalls.length = 0;
 });
 
-describe('fetchWebHits — Vertex AI grounding (VTID-03472)', () => {
-  it('calls the SDK with the Gemini 2.x googleSearch tool (NOT the legacy googleSearchRetrieval) and a bounded timeout', async () => {
+describe('fetchWebHits — Claude web_search (VTID-03472)', () => {
+  it('calls the Anthropic SDK with the web_search tool and a bounded timeout — never Vertex/GCP', async () => {
     await buildContextPack(webOnlyInput('news about Mariia Maksina'));
-    expect(getGenerativeModelCalls.length).toBeGreaterThan(0);
-    const call = getGenerativeModelCalls[getGenerativeModelCalls.length - 1];
-    expect(call.tools).toEqual([{ googleSearch: {} }]);
-    expect(call.tools[0].googleSearchRetrieval).toBeUndefined();
+    expect(messagesCreateCalls.length).toBeGreaterThan(0);
+    const call = messagesCreateCalls[messagesCreateCalls.length - 1];
+    expect(call.tools).toEqual([{ type: 'web_search_20260209', name: 'web_search', max_uses: 3 }]);
     // Must stay below orb-live.ts's 3000ms search_web TOOL_TIMEOUT_MS so a
-    // slow Vertex call fails gracefully instead of outliving the tool call.
+    // slow call fails gracefully instead of outliving the tool call.
     expect(call.requestOptions.timeout).toBeLessThan(3000);
     expect(call.requestOptions.timeout).toBeGreaterThan(0);
   });
 
-  it('returns real web_hits from grounded text + citations when Vertex succeeds', async () => {
+  it('returns real web_hits from Claude web_search citations', async () => {
     const pack = await buildContextPack(webOnlyInput('news about Mariia Maksina'));
-    expect(pack.web_hits.length).toBeGreaterThan(0);
-    expect(pack.web_hits[0].url).toMatch(/^https:\/\/example\.com/);
-    expect(pack.web_hits[0].snippet.length).toBeGreaterThan(0);
+    expect(pack.web_hits.length).toBe(2);
+    expect(pack.web_hits[0].url).toBe('https://example.com/mariia-maksina-spotlight');
+    expect(pack.web_hits[1].url).toBe('https://example.com/mariia-maksina-interview');
+    expect(pack.web_hits[0].snippet).toContain('Mariia Maksina');
     expect(pack.retrieval_trace.hit_counts.web_search).toBe(pack.web_hits.length);
   });
 
-  it('attributes each hit to the source its groundingSupport actually cites, not just position', async () => {
-    const pack = await buildContextPack(webOnlyInput('news about Mariia Maksina'));
-    // Support 0 cites chunk 0 (spotlight), support 1 cites chunk 1 (interview)
-    // — this must survive even though the naive per-sentence zip would have
-    // produced the same order here (the point is it's now driven by the
-    // actual citation mapping, verified by the mismatched-count case below).
-    expect(pack.web_hits[0].url).toBe('https://example.com/mariia-maksina-spotlight');
-    expect(pack.web_hits[1].url).toBe('https://example.com/mariia-maksina-interview');
-  });
-
-  it('falls back to the naive sentence-splitter when the response has no groundingSupports', async () => {
-    vertexBehavior = 'grounded_no_supports';
-    const pack = await buildContextPack(webOnlyInput('news about Mariia Maksina'));
-    // Still gets real hits with real citations — just positionally zipped
-    // instead of support-aligned, matching the pre-existing Perplexity shape.
-    expect(pack.web_hits.length).toBeGreaterThan(0);
-    expect(pack.web_hits[0].url).toMatch(/^https:\/\/example\.com/);
-  });
-
-  it('falls back to empty (not a throw) when Vertex returns no text', async () => {
-    vertexBehavior = 'no_text';
+  it('falls back to empty (not a throw) when Claude returns no citations', async () => {
+    claudeBehavior = 'no_citations';
     const pack = await buildContextPack(webOnlyInput('obscure query with no results'));
     expect(pack.web_hits).toEqual([]);
   });
 
-  it('falls back to empty (not a throw) when Vertex grounding call errors', async () => {
-    vertexBehavior = 'throw';
+  it('falls back to empty (not a throw) when the Claude call errors', async () => {
+    claudeBehavior = 'throw';
     const pack = await buildContextPack(webOnlyInput('news about Mariia Maksina'));
     expect(pack.web_hits).toEqual([]);
+  });
+
+  it('never imports @google-cloud/vertexai — Vertex/GCP is fully removed', async () => {
+    await buildContextPack(webOnlyInput('news about Mariia Maksina'));
+    expect(require.cache[require.resolve('@google-cloud/vertexai')]).toBeUndefined();
   });
 });
 

--- a/services/gateway/test/services/context-pack-builder.test.ts
+++ b/services/gateway/test/services/context-pack-builder.test.ts
@@ -23,10 +23,10 @@ process.env.NODE_ENV = 'test';
 process.env.SUPABASE_URL = 'http://localhost:54321';
 process.env.SUPABASE_SERVICE_ROLE = 'test-service-role';
 delete process.env.PERPLEXITY_API_KEY;
-// VTID-03472: fetchWebHits() now tries Vertex AI grounding first when
-// GOOGLE_CLOUD_PROJECT is set — delete it so these tests stay deterministic
+// VTID-03472: fetchWebHits() now tries Claude's web_search tool first when
+// ANTHROPIC_API_KEY is set — delete it so these tests stay deterministic
 // (no live network call) regardless of the runner's ambient environment.
-delete process.env.GOOGLE_CLOUD_PROJECT;
+delete process.env.ANTHROPIC_API_KEY;
 
 function restResponse(body: unknown, status = 200) {
   return {


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03472` (follow-up correction to the just-merged #3029)

---

## 📋 Summary

**Corrects a critical mistake in the just-merged VTID-03472 fix (#3029).** That fix implemented `search_web`'s backend using Vertex AI (Gemini) Google Search grounding. That's wrong: ORB voice moved off Vertex to Nova Sonic **5 days before this fix** (2026-07-27), every LLM call on this platform now targets Anthropic, and **GCP itself is being decommissioned entirely this coming Monday (2026-08-03)**. A Vertex dependency here would have silently regressed back to the exact reported bug ("check the internet for news about Mariia Maksina" returning nothing) within days of shipping — the whole point of the original fix would have been undone by the GCP cutoff.

## ✅ Changes

- `fetchWebHits()` now uses **Claude's native `web_search` server-side tool** via the **direct Anthropic API** (`ANTHROPIC_API_KEY` — the same env var `llm-router.ts`'s `anthropic` adapter already reads). Verified before writing code that this must be the direct API, not Bedrock: Bedrock's tool-use framework does **not** relay to Anthropic's hosted search endpoint, so `web_search` as a Bedrock toolSpec goes unrecognized.
- Bounded by the same `FETCH_TIMEOUT_MS` budget as before, below `orb-live.ts`'s 3000ms `search_web` `TOOL_TIMEOUT_MS`.
- Citations come directly off each text block's `citations` array (`web_search_result_location`: `cited_text`/`title`/`url`) — Claude attributes claims to sources natively, no positional-zip alignment hack needed (this was actually a real quality issue in the Vertex version, per Codex's review on #3029).
- `checkToolHealth()` and `GET /api/v1/conversation/health` now report `web_search` available based on `ANTHROPIC_API_KEY` (or `PERPLEXITY_API_KEY` fallback) — never `GOOGLE_CLOUD_PROJECT`.
- `.env.example`'s `WEB_SEARCH_GROUNDING_MODEL` default updated to `claude-haiku-4-5-20251001`.
- `@google-cloud/vertexai` is no longer imported anywhere in this file — a test asserts this directly (`require.cache` check) so it can never silently come back.

## 🧪 Testing

- [x] `tsc --noEmit` clean
- [x] Test suite rewritten for the new mock shape: web_search tool call assertion (tool type + bounded timeout), citation-derived hits, no-citations/error fallback paths, and a direct assertion that `@google-cloud/vertexai` is never imported.
- [x] End-to-end `tool_search_web()` test still reproduces the exact reported query.
- [x] Full local suite: 12,026/12,040 passing — only the pre-existing, unrelated `nav-manifest-sync.test.ts` drift failure (a `vitana-v1` navigation-catalog check, skipped in CI, untouched by this diff).
- [ ] Verified in staging (pending merge + `STAGE-DEPLOY.yml`)

## 🚨 Breaking Changes

None. This only changes `search_web`'s backend implementation, not its tool declaration, dispatch, or role gating.

## 📌 Additional Notes

Root-caused via direct user correction — I had not verified current LLM/voice routing before building the original fix on Vertex, despite this exact conversation having already established Nova Sonic as the live production voice provider. Confirmed via `docs/vtids/VTID-PENDING-GCP-FULL-CUTOVER-SPEC.md` (merged same day) that this is a real, imminent decommission, not a future maybe.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX)_