### PR TITLE
fix(orb): force Claude to actually invoke web_search (VTID-03472)

### DIFF
--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -600,6 +600,12 @@ async function fetchWebHits(
         {
           model: process.env.WEB_SEARCH_GROUNDING_MODEL || 'claude-haiku-4-5-20251001',
           max_tokens: 1024,
+          // Claude decides for itself whether a query needs the web_search
+          // tool — without an explicit instruction it can (and, verified
+          // live on staging, does) just answer directly and skip searching
+          // entirely, especially on Haiku. This call exists ONLY to search,
+          // so remove that judgment call rather than leave it to chance.
+          system: 'You are a web search assistant. For every query, you MUST invoke the web_search tool at least once before responding — never answer from your own knowledge alone, even if you are confident. After searching, give a concise, factual summary of what you found.',
           messages: [{ role: 'user', content: query }],
           tools: [{ type: 'web_search_20260209', name: 'web_search', max_uses: 3 }],
         },

--- a/services/gateway/test/services/context-pack-builder-web-search.test.ts
+++ b/services/gateway/test/services/context-pack-builder-web-search.test.ts
@@ -161,6 +161,12 @@ describe('fetchWebHits — Claude web_search (VTID-03472)', () => {
     // slow call fails gracefully instead of outliving the tool call.
     expect(call.requestOptions.timeout).toBeLessThan(3000);
     expect(call.requestOptions.timeout).toBeGreaterThan(0);
+    // VTID-03472 follow-up: verified live on staging that without an
+    // explicit instruction, Claude (esp. Haiku) sometimes answers directly
+    // and skips invoking web_search entirely, returning zero hits for a
+    // clearly time-sensitive query. This call exists ONLY to search, so it
+    // must not leave that judgment call to the model.
+    expect(call.system).toEqual(expect.stringContaining('MUST invoke the web_search tool'));
   });
 
   it('returns real web_hits from Claude web_search citations', async () => {


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03472` (second follow-up — live-verification fix on top of #3032)

---

## 📋 Summary

Live-verified on staging right after #3032 deployed. Confirmed `ANTHROPIC_API_KEY` is genuinely configured (`GET /api/v1/conversation/health` → `web_search:true`), then drove a real conversation turn through the deployed gateway with a query engineered to hit the `external_current` retrieval-router rule ("latest news about the James Webb Space Telescope"). Router correctly selected `web_search` (real ~447ms call latency confirming an actual API round trip happened) — but `web_hits` came back `[]`, and the model's answer was "I am unable to provide the latest news... My capabilities are focused on..."

**Root cause:** `fetchWebHits()` sends only the raw query as a user message, no system instruction. Claude decides for itself whether a given turn warrants invoking `web_search` — on `claude-haiku-4-5-20251001` it sometimes just answers directly and skips the tool entirely. This call exists *only* to search, so leaving that as a model judgment call is wrong.

## ✅ Changes

- Added a `system` prompt instructing the model it **must** invoke `web_search` at least once before responding, never answer from its own knowledge alone.
- Test updated to assert the system prompt is present on the outgoing call.

## 🧪 Testing

- [x] `tsc --noEmit` clean
- [x] `test/services/context-pack-builder.test.ts` + `context-pack-builder-web-search.test.ts`: 25/25 passing
- [ ] Re-verify live on staging after this deploys (same `/conversation/turn` call that surfaced the bug) — will report back with the result before considering this closed

## 🚨 Breaking Changes

None.

## 📌 Additional Notes

This is exactly the kind of gap a mocked unit test can't catch (the mock always returns results regardless of prompt) — only driving a real end-to-end call against the deployed staging environment surfaced it. Continuing to verify live rather than declaring done on green CI alone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX)_