### PR TITLE
fix(orb): force web_search via tool_choice:any, not just a system prompt (VTID-03472)

### DIFF
--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -596,26 +596,39 @@ async function fetchWebHits(
     try {
       const Anthropic = (await import('@anthropic-ai/sdk')).default;
       const client = new Anthropic({ apiKey });
-      const msg = await client.messages.create(
-        {
-          model: process.env.WEB_SEARCH_GROUNDING_MODEL || 'claude-haiku-4-5-20251001',
-          max_tokens: 1024,
-          // Claude decides for itself whether a query needs the web_search
-          // tool — without an explicit instruction it can (and, verified
-          // live on staging, does) just answer directly and skip searching
-          // entirely, especially on Haiku. This call exists ONLY to search,
-          // so remove that judgment call rather than leave it to chance.
-          system: 'You are a web search assistant. For every query, you MUST invoke the web_search tool at least once before responding — never answer from your own knowledge alone, even if you are confident. After searching, give a concise, factual summary of what you found.',
-          messages: [{ role: 'user', content: query }],
-          tools: [{ type: 'web_search_20260209', name: 'web_search', max_uses: 3 }],
-        },
-        // Bound below orb-live.ts's 3000ms TOOL_TIMEOUT_MS for search_web —
-        // without this, a slow/stalled call outlives the voice-tool deadline:
-        // the model gets a timeout error instead of a result (or the
-        // Perplexity fallback), while the un-aborted request keeps running.
-        // Same budget as fetchWithTimeout()'s FETCH_TIMEOUT_MS.
-        { timeout: CONTEXT_PACK_CONFIG.FETCH_TIMEOUT_MS },
-      );
+      const baseRequest = {
+        model: process.env.WEB_SEARCH_GROUNDING_MODEL || 'claude-haiku-4-5-20251001',
+        max_tokens: 1024,
+        // Belt-and-braces with tool_choice below: keep the instruction too,
+        // since it still shapes how Claude phrases the post-search summary.
+        system: 'You are a web search assistant. For every query, you MUST invoke the web_search tool at least once before responding — never answer from your own knowledge alone, even if you are confident. After searching, give a concise, factual summary of what you found.',
+        messages: [{ role: 'user' as const, content: query }],
+        tools: [{ type: 'web_search_20260209' as const, name: 'web_search' as const, max_uses: 3 }],
+      };
+      // Bound below orb-live.ts's 3000ms TOOL_TIMEOUT_MS for search_web —
+      // without this, a slow/stalled call outlives the voice-tool deadline:
+      // the model gets a timeout error instead of a result (or the
+      // Perplexity fallback), while the un-aborted request keeps running.
+      // Same budget as fetchWithTimeout()'s FETCH_TIMEOUT_MS.
+      const requestOptions = { timeout: CONTEXT_PACK_CONFIG.FETCH_TIMEOUT_MS };
+
+      let msg;
+      try {
+        // VTID-03472 follow-up #2: the system-prompt instruction alone was
+        // verified live on staging to still be insufficient — Haiku
+        // sometimes answers directly and skips web_search anyway. Force it
+        // structurally: tool_choice:'any' prefills the assistant turn so it
+        // MUST open with a tool call (the only tool offered is web_search).
+        // Anthropic's docs don't explicitly confirm or rule out tool_choice
+        // for server-side tools, so this is guarded by a fallback retry.
+        msg = await client.messages.create(
+          { ...baseRequest, tool_choice: { type: 'any' } },
+          requestOptions,
+        );
+      } catch (forcedError: any) {
+        console.warn(`[VTID-03472] tool_choice:any rejected by API (${forcedError.message}) — retrying without it`);
+        msg = await client.messages.create(baseRequest, requestOptions);
+      }
       const hits = hitsFromClaudeCitations(msg.content, limit);
       if (hits.length > 0) {
         console.log(`[VTID-03472] Claude web_search returned ${hits.length} web hits for: ${query.substring(0, 50)}`);

--- a/services/gateway/test/services/context-pack-builder-web-search.test.ts
+++ b/services/gateway/test/services/context-pack-builder-web-search.test.ts
@@ -27,7 +27,7 @@ process.env.SUPABASE_SERVICE_ROLE = 'test-service-role';
 delete process.env.PERPLEXITY_API_KEY;
 process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
 
-let claudeBehavior: 'cited' | 'no_citations' | 'throw' = 'cited';
+let claudeBehavior: 'cited' | 'no_citations' | 'throw' | 'reject_tool_choice' = 'cited';
 const messagesCreateCalls: any[] = [];
 
 jest.mock('@anthropic-ai/sdk', () => {
@@ -39,6 +39,9 @@ jest.mock('@anthropic-ai/sdk', () => {
           messagesCreateCalls.push({ ...body, requestOptions });
           if (claudeBehavior === 'throw') {
             throw new Error('Claude web_search mock failure');
+          }
+          if (claudeBehavior === 'reject_tool_choice' && body.tool_choice) {
+            throw new Error('tool_choice: any is not supported with server tools');
           }
           if (claudeBehavior === 'no_citations') {
             return { content: [{ type: 'text', text: 'No results found.', citations: null }] };
@@ -152,7 +155,7 @@ beforeEach(() => {
 });
 
 describe('fetchWebHits — Claude web_search (VTID-03472)', () => {
-  it('calls the Anthropic SDK with the web_search tool and a bounded timeout — never Vertex/GCP', async () => {
+  it('calls the Anthropic SDK with the web_search tool, tool_choice:any, and a bounded timeout — never Vertex/GCP', async () => {
     await buildContextPack(webOnlyInput('news about Mariia Maksina'));
     expect(messagesCreateCalls.length).toBeGreaterThan(0);
     const call = messagesCreateCalls[messagesCreateCalls.length - 1];
@@ -167,6 +170,9 @@ describe('fetchWebHits — Claude web_search (VTID-03472)', () => {
     // clearly time-sensitive query. This call exists ONLY to search, so it
     // must not leave that judgment call to the model.
     expect(call.system).toEqual(expect.stringContaining('MUST invoke the web_search tool'));
+    // VTID-03472 follow-up #2: the system prompt alone was ALSO verified
+    // live to be insufficient — force it structurally instead.
+    expect(call.tool_choice).toEqual({ type: 'any' });
   });
 
   it('returns real web_hits from Claude web_search citations', async () => {
@@ -188,6 +194,18 @@ describe('fetchWebHits — Claude web_search (VTID-03472)', () => {
     claudeBehavior = 'throw';
     const pack = await buildContextPack(webOnlyInput('news about Mariia Maksina'));
     expect(pack.web_hits).toEqual([]);
+  });
+
+  it('retries without tool_choice if the API rejects tool_choice:any on a server tool, and still returns hits', async () => {
+    claudeBehavior = 'reject_tool_choice';
+    const pack = await buildContextPack(webOnlyInput('news about Mariia Maksina'));
+    // First call (with tool_choice) throws per the mock; second call (retry,
+    // no tool_choice) succeeds — proves the retry path recovers instead of
+    // silently degrading to the broken Perplexity fallback.
+    expect(messagesCreateCalls.length).toBe(2);
+    expect(messagesCreateCalls[0].tool_choice).toEqual({ type: 'any' });
+    expect(messagesCreateCalls[1].tool_choice).toBeUndefined();
+    expect(pack.web_hits.length).toBe(2);
   });
 
   it('never imports @google-cloud/vertexai — Vertex/GCP is fully removed', async () => {


### PR DESCRIPTION
## Summary

- Follow-up to #3033. Live-verified on staging that the system-prompt-only instruction ("MUST invoke the web_search tool") was still insufficient — Claude (esp. Haiku) sometimes answered directly and skipped `web_search` anyway, so `web_hits` stayed empty for clearly time-sensitive queries (e.g. "news about Mariia Maksina").
- `fetchWebHits()` in `context-pack-builder.ts` now passes `tool_choice: { type: 'any' }` on the Anthropic `messages.create()` call, structurally forcing the first assistant turn to open with a tool call (the only tool offered is `web_search`) instead of leaving it as a model judgment call.
- Guarded with a fallback retry: if the API ever rejects `tool_choice` on this server-side tool (undocumented compatibility either way), the code retries once without it — falling back to the existing system-prompt-only behavior — rather than silently dropping through to the broken Perplexity fallback (`PERPLEXITY_API_KEY` is still not configured anywhere).

## Test plan

- [x] `npx tsc --noEmit` clean (pre-existing unrelated `@aws-sdk`/`aws-ecs-admin.ts` errors only, confirmed present on `main` too)
- [x] `npx jest test/services/context-pack-builder-web-search.test.ts` — 8/8 passing, including new coverage: asserts `tool_choice: { type: 'any' }` is sent, and a new test for the reject-and-retry-without-tool_choice path
- [x] `npx jest test/services/context-pack-builder.test.ts` — 18/18 passing (unaffected)
- [ ] Live-verify on staging post-deploy via `POST /api/v1/conversation/turn` (same methodology as prior VTID-03472 fixes) — confirm `context_pack.web_hits` is non-empty for a live news query


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrBb3Yk49EqD6mdUgyxyX)_