### PR TITLE
fix(notifications): stop duplicate push — one device, one account (VTID-03481)

### DIFF
--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -43,6 +43,36 @@ router.post('/token', requireAuth, requireTenant, async (req: Request, res: Resp
   }
 
   const supabase = getSupabase();
+
+  // ── Device takeover (VTID-03481) ──────────────────────────────────────────
+  // An FCM token identifies a DEVICE INSTALLATION, not a (user, device) pair —
+  // FCM hands the token to whoever registered last, so exactly one account can
+  // own it at a time. This upsert's conflict target is (user_id, fcm_token),
+  // which means a token re-registered by a DIFFERENT account used to INSERT a
+  // second row instead of displacing the first. Combined with a sign-out that
+  // never removed the row, every account that had ever signed in on a device
+  // accumulated — and each one got its own copy of every fan-out notification,
+  // rendered in ITS OWN locale. That is the "same notification twice, once in
+  // German and once in English" bug: one phone, two accounts, two languages.
+  //
+  // So: revoke every OTHER account's claim on this device first, then take it.
+  // Order matters — user_device_tokens_one_active_owner allows only one active
+  // row per token, and doing this the other way round transiently violates it.
+  const { error: revokeError } = await supabase
+    .from('user_device_tokens')
+    .update({ revoked_at: new Date().toISOString(), revoked_reason: 'taken_over' })
+    .eq('fcm_token', fcm_token)
+    .neq('user_id', identity.user_id)
+    .is('revoked_at', null);
+
+  if (revokeError) {
+    // Don't take the device over on a half-applied state — the unique index
+    // would reject the upsert anyway, and silently leaving the previous owner
+    // active is exactly the duplicate-push bug.
+    console.error('[Notifications] Device takeover failed:', revokeError);
+    return res.status(500).json({ ok: false, error: revokeError.message });
+  }
+
   const { error } = await supabase
     .from('user_device_tokens')
     .upsert(
@@ -52,6 +82,9 @@ router.post('/token', requireAuth, requireTenant, async (req: Request, res: Resp
         fcm_token,
         device_label: device_label || null,
         updated_at: new Date().toISOString(),
+        // Re-claim after a previous sign-out/takeover on this same device.
+        revoked_at: null,
+        revoked_reason: null,
       },
       { onConflict: 'user_id,fcm_token' }
     );
@@ -75,12 +108,19 @@ router.delete('/token', requireAuth, async (req: Request, res: Response) => {
     return res.status(400).json({ ok: false, error: 'fcm_token is required' });
   }
 
+  // Soft-revoke rather than DELETE (VTID-03481). The row is the only record
+  // that this user was once signed in on this device; the Appilix suppression
+  // in notification-service.ts needs it to tell "signed out on a device we
+  // know about" (→ don't push, the device now belongs to someone else) apart
+  // from "never registered a device token at all" (→ still needs the legacy
+  // Appilix user_identity fallback, e.g. an iOS shell that never captured one).
   const supabase = getSupabase();
   await supabase
     .from('user_device_tokens')
-    .delete()
+    .update({ revoked_at: new Date().toISOString(), revoked_reason: 'signed_out' })
     .eq('user_id', identity.user_id)
-    .eq('fcm_token', fcm_token);
+    .eq('fcm_token', fcm_token)
+    .is('revoked_at', null);
 
   res.json({ ok: true });
 });

--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -18,7 +18,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { notifyUser, notifyUserAsync, sendPushToUser, sendAppilixPush, TYPE_META } from '../services/notification-service';
+import { notifyUser, notifyUserAsync, sendPushToUser, sendAppilixPush, isSignedOutOnAllKnownDevices, TYPE_META } from '../services/notification-service';
 import { generatePersonalRecommendations } from '../services/recommendation-engine';
 import { LangCode, resolveLanguage } from '../services/recommendation-engine/analyzers/community-user-analyzer';
 import { tt, type GatewayI18nKey } from '../i18n/catalog';
@@ -1150,16 +1150,25 @@ router.post('/push-dispatch', async (req: Request, res: Response) => {
           ? Object.fromEntries(Object.entries(notif.data).map(([k, v]) => [k, String(v)]))
           : undefined,
       };
+      //
+      // VTID-03481: mirror notifyUser()'s Appilix suppression too. This cron is
+      // the path that delivers the trigger-written community fan-out — the one
+      // that produced "Neuer Beitrag" and "New post" on the SAME phone a minute
+      // apart, because two accounts had been signed in on it and Appilix still
+      // had both identities mapped to the device.
       let sent = 0;
       let appilixSent = false;
+      const appilixSuppressed = await isSignedOutOnAllKnownDevices(notif.user_id, supa);
       if (hasDeepLink) {
-        appilixSent = await sendAppilixPush(notif.user_id, pushPayload);
+        appilixSent = appilixSuppressed
+          ? false
+          : await sendAppilixPush(notif.user_id, pushPayload);
         if (!appilixSent) {
           sent = await sendPushToUser(notif.user_id, notif.tenant_id, pushPayload, supa);
         }
       } else {
         sent = await sendPushToUser(notif.user_id, notif.tenant_id, pushPayload, supa);
-        if (sent === 0) {
+        if (sent === 0 && !appilixSuppressed) {
           appilixSent = await sendAppilixPush(notif.user_id, pushPayload);
         }
       }
@@ -1467,17 +1476,23 @@ async function scheduleReminderFcmPush(
     // notification. Only fire Appilix when there's no native token, or as a
     // last resort when FCM reached zero devices (e.g. web-only token that
     // opens the browser, not the app).
+    //
+    // VTID-03481: only count devices this user still OWNS, and skip Appilix
+    // altogether once they are signed out on every known device — otherwise a
+    // reminder for the account that left a shared phone still buzzes it.
     let appilixSent = false;
+    const appilixSuppressed = await isSignedOutOnAllKnownDevices(row.user_id, supa);
     const { count: nativeMobileCount } = await supa
       .from('user_device_tokens')
       .select('*', { count: 'exact', head: true })
       .eq('user_id', row.user_id)
       .eq('tenant_id', row.tenant_id)
+      .is('revoked_at', null)
       .like('device_label', 'Appilix %');
-    if (!nativeMobileCount) {
+    if (!nativeMobileCount && !appilixSuppressed) {
       appilixSent = await sendAppilixPush(row.user_id, payload);
     }
-    if (fcmSent === 0 && !appilixSent) {
+    if (fcmSent === 0 && !appilixSent && !appilixSuppressed) {
       appilixSent = await sendAppilixPush(row.user_id, payload);
     }
     console.log(`[reminders-tick] FCM push for ${row.id}: fcm=${fcmSent} appilix=${appilixSent} nativeTokens=${nativeMobileCount || 0}`);

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -255,7 +255,13 @@ export async function sendPushToUser(
     .from('user_device_tokens')
     .select('fcm_token')
     .eq('user_id', userId)
-    .eq('tenant_id', tenantId);
+    .eq('tenant_id', tenantId)
+    // Only devices this user still OWNS (VTID-03481). A revoked row means the
+    // device was taken over by another account, or the user signed out on it —
+    // pushing there would buzz a phone that now belongs to someone else, which
+    // is how one device ended up receiving the same post notification once per
+    // account that had ever signed in on it.
+    .is('revoked_at', null);
 
   if (!tokens?.length) return 0;
 
@@ -265,13 +271,47 @@ export async function sendPushToUser(
     if (ok) {
       sent++;
     } else {
+      // FCM rejected the token as unregistered/invalid — it is dead for every
+      // owner, so revoke it outright rather than scoping to this user.
       await supabase
         .from('user_device_tokens')
-        .delete()
-        .eq('fcm_token', fcm_token);
+        .update({ revoked_at: new Date().toISOString(), revoked_reason: 'fcm_invalid' })
+        .eq('fcm_token', fcm_token)
+        .is('revoked_at', null);
     }
   }
   return sent;
+}
+
+/**
+ * True when this user has device tokens on record but every one of them has
+ * been revoked — i.e. they are signed out on every device we know about.
+ *
+ * VTID-03481. Appilix push targets by user_identity, NOT by device token, and
+ * Appilix's own identity→device registry keeps stale mappings that we have no
+ * API to purge. So after two accounts have been used on one phone, an Appilix
+ * push addressed to the account that is no longer signed in STILL lands on that
+ * phone — in that account's language. Fixing the token table alone therefore
+ * would not have stopped the duplicate lock-screen notifications; this gate is
+ * what actually suppresses the second copy.
+ *
+ * Deliberately returns false when the user has NO rows at all: that is the
+ * legitimate legacy case (an iOS Appilix shell whose bridge never captured an
+ * FCM token) which depends on the user_identity fallback and must keep working.
+ */
+export async function isSignedOutOnAllKnownDevices(
+  userId: string,
+  supabase: SupabaseClient<any, any, any>
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('user_device_tokens')
+    .select('revoked_at')
+    .eq('user_id', userId);
+
+  // On a query error, fail OPEN (deliver). A missed notification is worse than
+  // a duplicate one, and the token takeover already removes most duplicates.
+  if (error || !data?.length) return false;
+  return data.every((row: { revoked_at: string | null }) => row.revoked_at !== null);
 }
 
 // ── Appilix Native Push (Maxina iOS + Android apps) ──────────
@@ -637,18 +677,25 @@ export async function notifyUser(
   let pushed = 0;
   let appilixSent = false;
   if (shouldSendPush) {
+    // VTID-03481: skip Appilix entirely for a user who is signed out on every
+    // device we know about. Appilix targets by user_identity and retains stale
+    // identity→device mappings we can't purge, so without this the account that
+    // LEFT a shared phone keeps pushing to it — the second, wrong-language copy
+    // of every notification.
+    const appilixSuppressed = await isSignedOutOnAllKnownDevices(userId, supabase);
+
     if (payload.data?.url) {
       // Notifications with deep-link URLs must go through Appilix first.
       // Appilix honors open_link_url on tap; FCM-delivered notifications
       // crash the Appilix WebView ("Something went wrong") because FCM
       // doesn't pass the URL to Appilix's native tap handler.
-      appilixSent = await sendAppilixPush(userId, payload);
+      appilixSent = appilixSuppressed ? false : await sendAppilixPush(userId, payload);
       if (!appilixSent) {
         pushed = await sendPushToUser(userId, tenantId, payload, supabase);
       }
     } else {
       pushed = await sendPushToUser(userId, tenantId, payload, supabase);
-      if (pushed === 0) {
+      if (pushed === 0 && !appilixSuppressed) {
         appilixSent = await sendAppilixPush(userId, payload);
       }
     }

--- a/supabase/migrations/20260803200000_vtid_03481_device_token_ownership.sql
+++ b/supabase/migrations/20260803200000_vtid_03481_device_token_ownership.sql
@@ -1,0 +1,88 @@
+-- VTID-03481 — One device, one account.
+--
+-- SYMPTOM (reported with a lock-screen screenshot, 2026-08-03): every
+-- notification arrived on the same phone TWICE, once in German and once in
+-- English, ~1 minute apart — "Neuer Beitrag / Mariia Maksina hat einen neuen
+-- Beitrag geteilt" next to "New post / Mariia Maksina shared a new post", and
+-- "Tagebuch-Erinnerung" next to "Diary Reminder".
+--
+-- IT WAS NEVER A WORDING BUG. user_notifications held exactly ONE correctly
+-- localized row per recipient. The duplication happened at DELIVERY: the same
+-- physical device was registered under SEVERAL accounts, so a tenant-wide
+-- fan-out sent one push per stale account, each rendered in THAT account's
+-- language. Verified on production data:
+--
+--   fcm_token eVlsdh6zTBiP…  (one Android phone)
+--     → 0adc6ff6 "Alex BLUE" (stt_language en-US) → "New post"     19:12:33Z
+--     → c5a4daf9 "Alex RED"  (stt_language de-DE) → "Neuer Beitrag" 19:13:08Z
+--   fcm_token eZzu7fszMacS…  (one Windows browser) → FIVE accounts
+--
+-- ROOT CAUSE: POST /api/v1/notifications/token upserts with
+-- onConflict='user_id,fcm_token'. An FCM token identifies a DEVICE
+-- INSTALLATION, not a (user, device) pair — FCM itself hands the token to
+-- whoever registered last. But because the conflict target includes user_id,
+-- a token re-registered by a DIFFERENT account INSERTS a second row instead of
+-- taking the device over, and sign-out never removed the old one. Every
+-- account that has ever signed in on a device accumulates forever.
+--
+-- This migration makes the invariant structural: at most one ACTIVE owner per
+-- fcm_token. Losing rows are SOFT-revoked rather than deleted, because
+-- revoked_at is also the signal the gateway needs to suppress Appilix pushes
+-- (Appilix targets by user_identity, not by token, and its own device registry
+-- can't be purged from our side — see notification-service.ts).
+
+-- ── 1. Ownership columns ─────────────────────────────────────────────────────
+ALTER TABLE user_device_tokens
+  ADD COLUMN IF NOT EXISTS revoked_at     TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS revoked_reason TEXT;
+
+COMMENT ON COLUMN user_device_tokens.revoked_at IS
+  'NULL = this user is the current owner of the device and may receive push. '
+  'Non-NULL = the device was taken over by another account or the user signed '
+  'out; keep the row (not a DELETE) so the gateway can tell "signed out on a '
+  'known device" apart from "never had a device token", which still needs the '
+  'legacy Appilix user_identity fallback. VTID-03481.';
+
+COMMENT ON COLUMN user_device_tokens.revoked_reason IS
+  'taken_over | signed_out | backfill — why the row stopped being active.';
+
+-- ── 2. Backfill: resolve devices that already have several owners ────────────
+-- Keep the most recently updated row per token (that is the account actually
+-- signed in on the device now) and revoke the rest. This is what stops the
+-- duplicate lock-screen notifications for devices that are ALREADY polluted —
+-- without it users would keep double-buzzing until every device happened to
+-- re-register.
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY fcm_token
+           ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST, id
+         ) AS rn
+  FROM user_device_tokens
+  WHERE revoked_at IS NULL
+)
+UPDATE user_device_tokens t
+   SET revoked_at = now(),
+       revoked_reason = 'backfill'
+  FROM ranked r
+ WHERE r.id = t.id
+   AND r.rn > 1;
+
+-- ── 3. Enforce it ────────────────────────────────────────────────────────────
+-- At most one ACTIVE row per device token. Revoked rows are exempt, so a
+-- device's full sign-in history is retained.
+--
+-- Safe against the multi-tenant case: the pre-existing UNIQUE(user_id,
+-- fcm_token) already allowed a user only ONE row per token across all tenants,
+-- so this adds no restriction beyond the cross-account one it is meant to fix.
+--
+-- Callers MUST revoke other owners BEFORE upserting their own row (see
+-- routes/notifications.ts) — the reverse order transiently violates this index.
+CREATE UNIQUE INDEX IF NOT EXISTS user_device_tokens_one_active_owner
+  ON user_device_tokens (fcm_token)
+  WHERE revoked_at IS NULL;
+
+-- Dispatch reads "active tokens for this user in this tenant" on every push.
+CREATE INDEX IF NOT EXISTS user_device_tokens_active_by_user
+  ON user_device_tokens (user_id, tenant_id)
+  WHERE revoked_at IS NULL;


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03481`

**Layer:** APIL (gateway notifications + Supabase schema)

**Priority:** P1 — live user-facing notification spam

---

## 📋 Summary

Every notification was arriving on the same phone **twice — once in German, once in English**, about a minute apart. It was never a wording or translation bug: `user_notifications` held exactly **one** correctly localized row per recipient. The duplication happened at **delivery** — the same physical device was registered under several accounts, so a tenant-wide fan-out sent one push per stale account, each rendered in *that* account's language.

Confirmed against production data:

| device token | account | locale | push sent |
|---|---|---|---|
| `eVlsdh6zTBiP…` (one Android phone) | Alex BLUE | `en-US` | `New post` — 19:12:33Z |
| `eVlsdh6zTBiP…` (same phone) | Alex RED | `de-DE` | `Neuer Beitrag` — 19:13:08Z |

Those are exactly the two notifications in the reported screenshot. A second token (one Windows browser) was claimed by **five** accounts.

**Root cause:** `POST /api/v1/notifications/token` upserts with `onConflict='user_id,fcm_token'`. An FCM token identifies a *device installation*, not a `(user, device)` pair — FCM hands it to whoever registered last. Because the conflict target included `user_id`, a token re-registered by a **different** account INSERTED a second row instead of displacing the first, and sign-out never removed the old one. Every account that had ever signed in on a device accumulated forever.

---

## ✅ Changes

- [x] `routes/notifications.ts` — registration revokes every **other** account's claim on the device before taking it (order matters: the new unique index permits one active owner per token). `DELETE /token` soft-revokes instead of deleting, so *"signed out on a known device"* stays distinguishable from *"never had a device token"*.
- [x] `services/notification-service.ts` — `sendPushToUser` only targets devices the user still owns; a token FCM rejects is revoked rather than hard-deleted. New `isSignedOutOnAllKnownDevices()` suppresses Appilix push for accounts revoked on every known device.
- [x] `routes/scheduled-notifications.ts` — same gate on `/push-dispatch` (the path that actually delivers the trigger-written community fan-out) and on reminder push, which now also counts only devices the user still owns.
- [x] `supabase/migrations/20260803200000_vtid_03481_device_token_ownership.sql` — `revoked_at` / `revoked_reason`, a backfill resolving devices that already have several owners (keeping the most recently signed-in account), and a partial unique index making the invariant structural.

### Why the Appilix gate is necessary

Appilix targets by `user_identity`, **not** by device token, and its identity→device registry cannot be purged from our side. Fixing the token table alone would therefore not have stopped the second copy — the account that *left* a shared phone would keep pushing to it. Users with **no** device rows at all are deliberately **not** gated: that is the legacy iOS case which still depends on the `user_identity` fallback.

---

## 🧪 Testing

- [x] Automated tests: gateway suite **617/617 suites, 12,062 tests passing** (7 skipped, 6 todo — pre-existing)
- [x] `tsc --noEmit` clean (only the pre-existing `TS5107` tsconfig deprecation, identical on baseline)
- [x] Migration applied to production and verified — **10 stale claims revoked, 0 devices still shared**; the reported phone now has exactly one active owner (the account that most recently signed in)
- [ ] Verify in staging after deploy

**Note on rollout:** the data cleanup only takes effect once this gateway ships — the running build does not yet read `revoked_at`, so revoked rows are still honored until deploy.

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] No workflow files touched

### File Names
- [x] New migration follows the existing `<timestamp>_vtid_<id>_<desc>.sql` convention
- [x] No new source files added; no naming canon violations

### Code Standards
- [x] VTID referenced in commit message and inline comments
- [x] Column/enum values use `snake_case` / lowercase (`taken_over`, `signed_out`, `fcm_invalid`, `backfill`)

### Cloud Run Deployments
- [x] N/A — no deploy scripts or service labels changed

### Documentation
- [x] VTID in commit messages
- [x] `revoked_at` / `revoked_reason` documented via `COMMENT ON COLUMN`

---

## 🚨 Breaking Changes

None. Both columns are nullable and additive; existing reads are unaffected until the gateway ships.

One deliberate behavior change: a user signed out on every device we know about no longer receives Appilix push. That is the intended fix — their in-app notification row is still written, so nothing is lost from the bell.

---

## 🔗 Links

- Companion frontend PR: `exafyltd/vitana-v1` — sign-out now releases the device claim
- Ledger: `VTID-03481` (`spec_status=approved`, `status=in_progress`)

---

## 📌 Additional Notes

The two accounts in the evidence table are the reporter's own test accounts on one phone, but nothing about the bug is test-specific: it fires for any device where a second account has ever signed in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BApisG7aSKG4p4SEHuuPmT)_