### PR TITLE
fix(notifications): make scheduled fan-outs idempotent (VTID-03487)

### DIFF
--- a/scripts/setup-cloud-scheduler.sh
+++ b/scripts/setup-cloud-scheduler.sh
@@ -146,7 +146,7 @@ for JOB in "${MEMORY_INTELLIGENCE_JOBS[@]}"; do
         --http-method=POST \
         --headers="Content-Type=application/json" \
         --message-body="{\"tenant_id\":\"$TENANT_ID\"}" \
-        --attempt-deadline=300s \
+        --attempt-deadline=1800s \
         --max-retry-attempts=1 \
         --description="Autopilot $AP_ID: $NAME"
     fi
@@ -187,7 +187,7 @@ for JOB in "${JOBS[@]}"; do
         --http-method=POST \
         --headers="Content-Type=application/json" \
         --message-body="{\"tenant_id\":\"$TENANT_ID\"}" \
-        --attempt-deadline=300s \
+        --attempt-deadline=1800s \
         --max-retry-attempts=1 \
         --description="Autopilot $AP_ID: $NAME"
     fi

--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -94,6 +94,34 @@ router.post('/token', requireAuth, requireTenant, async (req: Request, res: Resp
     return res.status(500).json({ ok: false, error: error.message });
   }
 
+  // ── Prune this user's own stale tokens (VTID-03487) ───────────────────────
+  // Separate duplicate source from the cross-account one above: FCM rotates a
+  // token periodically and the client registers the NEW one, but the old row
+  // was never retired — so one account accumulated a token per rotation and
+  // sendPushToUser, which loops over every token it finds, delivered one push
+  // per stale row. Same language, so it reads as a plain double notification
+  // rather than the two-language pair. Found in production at up to EIGHT
+  // active tokens on a single account.
+  //
+  // The client re-registers on every app start (see pushNotifications.ts's
+  // refresh monitor), so a row untouched for 30 days belongs to an app that
+  // has not opened in a month — that is a dead token, not a second device.
+  // Scoped to the registering user and never touching the row just written,
+  // so the blast radius is one account and it self-heals as people open the
+  // app. Best-effort: a failure here must not fail the registration.
+  const staleCutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const { error: pruneError } = await supabase
+    .from('user_device_tokens')
+    .update({ revoked_at: new Date().toISOString(), revoked_reason: 'stale' })
+    .eq('user_id', identity.user_id)
+    .neq('fcm_token', fcm_token)
+    .lt('updated_at', staleCutoff)
+    .is('revoked_at', null);
+
+  if (pruneError) {
+    console.warn('[Notifications] Stale token prune failed:', pruneError.message);
+  }
+
   res.json({ ok: true });
 });
 

--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -56,6 +56,68 @@ function getTenantId(req: Request): string | null {
   return req.body?.tenant_id || process.env.DEFAULT_TENANT_ID || null;
 }
 
+/**
+ * Which of these users already received `type` recently — i.e. this run is a
+ * REPEAT for them and must send nothing (VTID-03487).
+ *
+ * Every scheduled fan-out in this file is driven by Cloud Scheduler with
+ * `--attempt-deadline=300s --max-retry-attempts=1`, and each one loops over the
+ * whole tenant synchronously before responding. Once the tenant grew past what
+ * fits in five minutes, Scheduler stopped seeing a 200, declared the run failed,
+ * and retried it — re-running the ENTIRE fan-out. Nothing was idempotent, so
+ * every user got the notification a second time.
+ *
+ * That is exactly what happened to the morning briefing on 2026-08-04: wave one
+ * ran 05:00–05:04, the deadline expired at 05:05:00, and wave two immediately
+ * re-sent all ~200 users. On 2026-08-03 the same job finished in three minutes,
+ * never timed out, and produced no duplicates — which is why this looked
+ * intermittent. Because the briefing picks a random greeting per send, the two
+ * copies read as "the same notification with two different wordings" rather
+ * than as an obvious duplicate.
+ *
+ * Uses a lookback WINDOW rather than a calendar-day boundary on purpose: these
+ * jobs are scheduled in Europe/Berlin while the DB stores UTC, so a midnight
+ * boundary would both mis-bucket around DST and fail to suppress a retry that
+ * straddles it. A window shorter than the job's own cadence suppresses the
+ * retry (minutes later) while never blocking the next legitimate run.
+ *
+ * Fails OPEN: if the lookup errors we return an empty set and send anyway. A
+ * missed briefing is worse than a duplicated one, and this guard is a safety
+ * net over the schedule, not the thing that decides who is eligible.
+ */
+async function findRecentlyNotified(
+  supa: any,
+  tenantId: string,
+  userIds: string[],
+  type: string,
+  withinHours: number,
+): Promise<Set<string>> {
+  const already = new Set<string>();
+  if (!userIds.length) return already;
+
+  const since = new Date(Date.now() - withinHours * 60 * 60 * 1000).toISOString();
+
+  // Chunked so a large tenant doesn't build an unbounded PostgREST `in.()` list.
+  const CHUNK = 500;
+  for (let i = 0; i < userIds.length; i += CHUNK) {
+    const chunk = userIds.slice(i, i + CHUNK);
+    const { data, error } = await supa
+      .from('user_notifications')
+      .select('user_id')
+      .eq('tenant_id', tenantId)
+      .eq('type', type)
+      .gte('created_at', since)
+      .in('user_id', chunk);
+
+    if (error) {
+      console.warn(`[Scheduled] ${type} idempotency lookup failed, sending anyway: ${error.message}`);
+      return new Set<string>();
+    }
+    for (const row of data || []) already.add(row.user_id);
+  }
+  return already;
+}
+
 // ── Helper: fan-out a localized notification across a user list ───────
 // Looks up each user's preferred locale (bulk), then dispatches the
 // notification with the title/body resolved per-user against the gateway
@@ -69,11 +131,26 @@ async function dispatchLocalized(
   bodyKey: GatewayI18nKey,
   data: Record<string, string>,
   bodyParams?: (userId: string) => Record<string, string | number>,
+  /**
+   * Suppress users who already got this type within this many hours
+   * (VTID-03487). Pass the job's own cadence minus a margin: ~20h for a daily
+   * job, ~144h (6d) for a weekly one. Guards against a Cloud Scheduler retry
+   * re-running the whole fan-out — see findRecentlyNotified().
+   */
+  minIntervalHours?: number,
 ): Promise<number> {
   const userIds = users.map((u) => u.user_id);
+  const already = minIntervalHours
+    ? await findRecentlyNotified(supa, tenantId, userIds, type, minIntervalHours)
+    : new Set<string>();
+  if (already.size) {
+    console.log(`[Scheduled] ${type} → skipping ${already.size} already notified within ${minIntervalHours}h`);
+  }
+
   const locales = await bulkGetUserLocales(supa, userIds);
   let dispatched = 0;
   for (const { user_id } of users) {
+    if (already.has(user_id)) continue;
     const lc = locales.get(user_id);
     const params = bodyParams ? bodyParams(user_id) : undefined;
     notifyUserAsync(
@@ -362,9 +439,29 @@ router.post('/morning-briefing', async (req: Request, res: Response) => {
   if (!supa) return res.status(503).json({ ok: false, error: 'Supabase not configured' });
 
   const users = await getActiveUsers(supa, tenantId);
+
+  // VTID-03487 — this is the fan-out that actually double-sent in production.
+  // The per-user body below is expensive (a recommendation generation plus a
+  // context gather each), so the whole loop outgrew Cloud Scheduler's 300s
+  // attempt deadline; Scheduler then retried and re-sent every user a second
+  // briefing, with a freshly randomized greeting so it read as a differently
+  // worded copy rather than an obvious duplicate.
+  //
+  // The check runs BEFORE any of that work, so a retry now costs one query and
+  // returns immediately instead of burning another five minutes and timing out
+  // again. 20h is under the 24h cadence: it suppresses today's retry and never
+  // blocks tomorrow's run.
+  const alreadyBriefed = await findRecentlyNotified(
+    supa, tenantId, users.map((u) => u.user_id), 'morning_briefing_ready', 20,
+  );
   let dispatched = 0;
+  let skippedDuplicate = 0;
 
   for (const { user_id } of users) {
+    if (alreadyBriefed.has(user_id)) {
+      skippedDuplicate++;
+      continue;
+    }
     try {
       // Generate fresh personal recommendations for this user
       await generatePersonalRecommendations(user_id, tenantId, { trigger_type: 'scheduled' });
@@ -395,8 +492,11 @@ router.post('/morning-briefing', async (req: Request, res: Response) => {
     }
   }
 
-  console.log(`[Scheduled] morning_briefing_ready → ${dispatched} users (personalized)`);
-  return res.status(200).json({ ok: true, dispatched });
+  console.log(
+    `[Scheduled] morning_briefing_ready → ${dispatched} users (personalized)` +
+    (skippedDuplicate ? `, ${skippedDuplicate} skipped as already briefed today` : ''),
+  );
+  return res.status(200).json({ ok: true, dispatched, skipped_duplicate: skippedDuplicate });
 });
 
 // =============================================================================
@@ -620,6 +720,8 @@ router.post('/diary-reminder', async (req: Request, res: Response) => {
     'notif.diary_reminder.title',
     'notif.diary_reminder.body',
     { url: '/diary' },
+    undefined,
+    20, // daily job — suppress a same-day Scheduler retry (VTID-03487)
   );
 
   console.log(`[Scheduled] daily_diary_reminder → ${dispatched} users`);
@@ -776,6 +878,8 @@ router.post('/weekly-digest', async (req: Request, res: Response) => {
     'notif.weekly_digest.title',
     'notif.weekly_digest.body',
     { url: '/community' },
+    undefined,
+    144, // weekly job — 6d window suppresses a retry, never next week (VTID-03487)
   );
 
   console.log(`[Scheduled] weekly_community_digest → ${dispatched} users`);
@@ -801,6 +905,8 @@ router.post('/weekly-summary', async (req: Request, res: Response) => {
     'notif.weekly_summary.title',
     'notif.weekly_summary.body',
     { url: '/dashboard' },
+    undefined,
+    144, // weekly job — 6d window suppresses a retry, never next week (VTID-03487)
   );
 
   console.log(`[Scheduled] weekly_activity_summary → ${dispatched} users`);
@@ -826,6 +932,8 @@ router.post('/weekly-reflection', async (req: Request, res: Response) => {
     'notif.weekly_reflection.title',
     'notif.weekly_reflection.body',
     { url: '/diary' },
+    undefined,
+    144, // weekly job — 6d window suppresses a retry, never next week (VTID-03487)
   );
 
   console.log(`[Scheduled] weekly_reflection_prompt → ${dispatched} users`);


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03487`

**Layer:** APIL (gateway scheduled notifications + Cloud Scheduler config)

**Priority:** P1 — every user receiving duplicate push

---

## 📋 Summary

Follow-up to #3038 (VTID-03481), which fixed duplicates caused by one **device** being claimed by several accounts. That was real but narrow — it explained the German/English pairs on one phone, but not the users reporting two copies of the same notification **in the same language**. Checking the data for other duplicate patterns turned up a second, independent cause that affects **everyone**.

`morning_briefing_ready` ran at **exactly 2.00 rows per user across 189 users** on 2026-08-04:

| wave | window | users |
|---|---|---|
| 1 | 05:00–05:04 | ~200 |
| 2 (retry) | **05:05**–05:07 | ~123 |

Wave two starts at **05:05:00 — exactly the 300s attempt deadline.** On 2026-08-03 the same job finished in three minutes, never timed out, and produced **no** duplicates, which is why this looked intermittent.

**Root cause:** every scheduled job in `scheduled-notifications.ts` loops over the whole tenant **synchronously** before responding, and Cloud Scheduler is configured `--attempt-deadline=300s --max-retry-attempts=1`. As the community grew, the briefing stopped finishing inside five minutes → Scheduler declared the run failed → retried → re-ran the entire fan-out. Nothing was idempotent.

Because the briefing picks a **random greeting per send**, the two copies read as *"the same notification with two different wordings"* rather than an obvious duplicate:

> `Guten Morgen!` — "Guten Morgen! Dein Vitana-Index: 50/100 → 93 Autopilot-Aktionen" (05:01:57)
> `Schönen guten Morgen!` — "Einen wunderschönen Morgen! Dein Vitana-Index: 50/100 → 93 Autopilot-Aktionen" (05:05:57)

Same data, different salutation, exactly 4:00 apart.

---

## ✅ Changes

- [x] `findRecentlyNotified()` — shared guard returning which users already received a type within a lookback window. A **window**, not a calendar day: these jobs are scheduled Europe/Berlin while the DB stores UTC, so a midnight boundary would mis-bucket around DST and miss a retry straddling it. **Fails open** — a missed briefing is worse than a duplicated one.
- [x] `/morning-briefing` — guard runs **before** the per-user recommendation generation and context gather, so a retry costs one query instead of burning another five minutes and timing out again.
- [x] `dispatchLocalized()` — optional `minIntervalHours`, covering `diary-reminder` (20h) and the three weekly jobs (144h) in one place.
- [x] `setup-cloud-scheduler.sh` — `--attempt-deadline` 300s → **1800s** (Cloud Scheduler's HTTP max). Handlers are idempotent now so a retry is harmless, but the deadline still has to match reality or every *successful* run is logged as a failure and retried for nothing. The file's own header comment already flagged this exact ceiling for AP-0911.
- [x] `routes/notifications.ts` — prune a user's **own** device tokens untouched for 30 days. Separate same-language duplicate source: FCM rotates tokens, the client registers the new one, and the old rows were never retired — so `sendPushToUser`, which loops over every token it finds, delivered one push per stale row. Found at up to **eight** active tokens on a single account.

`daily-pace-notifications` already had its own `already_sent` guard, which is why it measured at 1.00/user and needed no change.

---

## 🧪 Testing

- [x] Automated tests: **617/617 suites, 12,062 tests passing** (7 skipped, 6 todo — pre-existing)
- [x] `tsc --noEmit` clean (only the pre-existing `TS5107` tsconfig deprecation, identical on baseline)
- [x] Shell script syntax validated with `bash -n` (LF-normalized; the file's pre-existing CRLF endings are preserved by the diff)
- [x] Evidence gathered from production `user_notifications` — per-type/per-user ratios, the two-wave minute histogram, and the paired greeting samples above
- [ ] Verify on staging after deploy: `morning_briefing_ready` should return to 1.00 rows/user, and a manual second POST to `/morning-briefing` should report `skipped_duplicate` > 0 and `dispatched: 0`

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] No workflow files touched

### File Names
- [x] No new files; existing kebab-case paths unchanged

### Code Standards
- [x] VTID referenced in commit message and inline comments
- [x] Response fields use `snake_case` (`skipped_duplicate`)

### Cloud Run Deployments
- [x] N/A — no service labels or deploy scripts changed (Cloud **Scheduler** config only)

### Documentation
- [x] VTID in commit messages
- [x] Root cause documented inline at `findRecentlyNotified()` with the concrete production timeline

---

## 🚨 Breaking Changes

None. The guard only ever *suppresses* a send that would have been a duplicate, and fails open on any lookup error.

---

## 🔗 Links

- Prior fix (merged): #3038 — device-ownership duplicates (VTID-03481)
- Ledger: `VTID-03487` (`spec_status=approved`, `status=in_progress`)

---

## 📌 Additional Notes

**Action needed outside this PR:** the `--attempt-deadline` change only takes effect when someone with `gcloud` access re-runs `scripts/setup-cloud-scheduler.sh`. The idempotency guard stands on its own without it — the duplicates stop either way; re-running the script just also stops every healthy run from being logged as a failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BApisG7aSKG4p4SEHuuPmT)_