### PR TITLE
feat(tts): add Amazon Polly provider behind TTS_PROVIDER gate (VTID-03495)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,67 @@ one of these adapters**, alongside `anthropic`, `openai`, `vertex`,
 
 ---
 
+## 2c. TTS — AMAZON POLLY PROVIDER (VTID-03495)
+
+Build 1 of the 4 provider replacements that must exist before any GCP
+shutdown is possible (Polly → Titan image gen → Bedrock vision/tool-calling →
+Nova Sonic promotion).
+
+All Google Cloud TTS synthesis now routes through one seam,
+`services/gateway/src/services/tts/tts-provider.ts`, selected by
+**`TTS_PROVIDER=google|polly`, default `google`** — same deliberate-opt-in
+shape as `BEDROCK_ROLE_ARN` (§2b) and `DEV_AUTOPILOT_JOB_CLOUD` (§1b).
+**Deploying this code changes nothing.** An unrecognised value logs and falls
+back to `google` rather than failing closed and taking voice down.
+
+| Call site | File | Format | Behaviour |
+|---|---|---|---|
+| ORB greeting bridge | `services/tts/greeting-bridge-tts.ts` | PCM | Polly-first when configured |
+| Reminder pre-render | `services/reminder-tts.ts` | MP3 | Polly-first when configured |
+| ORB `/tts` route | `routes/orb-live.ts` (~L13920) | MP3 | Polly-first when configured |
+| Admin voice preview | `routes/voice-config.ts` | MP3 | **Explicit `provider:'polly'` body param only** — deliberately ignores `TTS_PROVIDER` so a preview never lies about what it played |
+| Cloud TTS debug route | `routes/orb-live.ts` (~L12676) | MP3 | **Google only, on purpose** — it is a Cloud-TTS diagnostic |
+
+### Three hard facts about Polly that bit this build
+
+1. **Polly has no Serbian voice, in any engine.** `sr` is a live locale here
+   (§13b lists DE/EN/ES/SR). `resolvePollyVoice('sr')` returns **null** and the
+   caller falls back to Google — it does **not** substitute English. Fluent
+   audio in the wrong language is worse than no audio, because nothing
+   downstream can detect it. **This is an unresolved coverage gap for a full
+   GCP shutdown**: with GCP gone, Serbian users get no TTS at all.
+2. **Polly PCM is 8kHz/16kHz only — it cannot do the 24kHz** the greeting
+   bridge used. `synthesizeGreetingBridgeAudioPcm()` therefore returns
+   `{ audioB64, sampleRateHz }` instead of a bare string, and `orb-live.ts`
+   builds `audio/pcm;rate=` from that value. Hardcoding 24kHz under Polly
+   plays 16kHz samples 1.5× fast — obvious to a listener, invisible to any
+   test that only asserts bytes came back.
+3. **Polly has no `speakingRate` field.** Rate becomes SSML
+   `<prosody rate="N%">`, which forces `TextType:'ssml'` and XML-escaping. At
+   rate 1.0 plain text is sent, avoiding the escaping surface entirely.
+
+Also note Polly's Russian is **standard-engine only** (no neural voice) — a
+quality step down from `ru-RU-Wavenet-A`.
+
+### Fallback is never silent
+
+`TTS_PROVIDER=polly` + an unservable request → falls back to Google **with a
+`[TTS] FALLBACK polly→google` log line**, per "Never allow silent model
+fallback". Set **`TTS_POLLY_STRICT=true`** to disable the fallback — use it in
+a GCP-shutdown rehearsal to prove no hidden Google dependency remains; with it
+on, an unservable request returns null instead of quietly reaching back to GCP.
+
+### Before flipping `TTS_PROVIDER=polly`
+
+The voice/engine table and the Serbian gap were derived from Polly's
+documented voice list and **not verified against the live API** — the session
+that built this had no working AWS credentials. Confirm against
+`aws polly describe-voices` first, and note Polly needs IAM `polly:SynthesizeSpeech`
+on the gateway task role (`AWS_POLLY_REGION`, else `AWS_REGION`, else
+`eu-central-1`).
+
+---
+
 ## 3. DATABASE (SUPABASE)
 
 ### Critical Rules
@@ -1267,6 +1328,7 @@ Use these PATs with the GitHub REST API (`api.github.com`) for all PR and deploy
 
 | Date | Change | VTID |
 |------|--------|------|
+| 2026-08-05 | **Amazon Polly TTS provider — build 1 of the 4 that gate a GCP shutdown.** New `services/tts/polly.ts` + `services/tts/tts-provider.ts` seam; all 4 Google Cloud TTS synthesis call sites route through it, selected by `TTS_PROVIDER=google\|polly` (**default `google` — deploying this flips nothing**). See §2c. Three Polly divergences that are NOT cosmetic: (1) **Polly has no Serbian voice in any engine** — `sr` is a live locale (§13b), so `resolvePollyVoice('sr')` returns null and falls back to Google rather than substituting English; with GCP gone, Serbian TTS has no provider at all, an unresolved shutdown blocker. (2) **Polly PCM is 8k/16k only, not 24k** — `synthesizeGreetingBridgeAudioPcm()` now returns `{audioB64, sampleRateHz}` and the `audio/pcm;rate=` mime is built from it; assuming 24kHz would play Polly audio 1.5× fast, audible to a user but invisible to a bytes-came-back test. (3) **No `speakingRate` field** — rate becomes SSML `<prosody>`, forcing XML-escaping (plain text kept at rate 1.0). Polly Russian is standard-engine only. Fallback polly→google is always logged; `TTS_POLLY_STRICT=true` disables it for shutdown rehearsals. The admin voice-preview route takes an explicit `provider:'polly'` param and deliberately ignores `TTS_PROVIDER` so previews can't lie; the Cloud-TTS debug route stays Google-only by design. **Voice table and the Serbian gap were derived from Polly's documented voice list, not verified against the live API** — the building session had no AWS credentials; confirm via `describe-voices` before flipping. 18 new tests. | VTID-03495 |
 | 2026-08-03 | **`orb_session_state` never existed in production — four ORB features were silently dead for ~2 months.** Investigating a live report of ORB voice failing on mobile, every session was found to emit `orb.session.audio_ready.acked` with `ok:false`. That `ok` is not the client's readiness — it is the return of `writeOrbSessionState()`, and the write was failing because `relation "orb_session_state" does not exist`. Migration `20260606000000_DEV_COMHU_0503_orb_session_state.sql` was authored but never applied (its own header: "Not executed from the sandbox"); the applied-migrations list jumps `20260605…` → `20260609…`. Because every helper in `orb-session-state.ts` fails soft by design (reads → `null`, writes → `{ok:false}`, never throws), nothing surfaced: the **audio-ready handshake** (greeting fell back to a blind 3s timer and could be spoken before the client could play it — the silent-ORB symptom), **close/reopen continuity**, the **pending autopilot CTA**, and **wake-brief opener rotation** were all inert. Applied the migration to prod; `audio_ready.acked` flipped `ok:false` → `ok:true` on the next live session with **no redeploy**, confirming the code had always been calling it correctly. Session telemetry that made this findable: 29 sessions ended `expired_ttl` at ~32 min with `turn_count:0` and `audio_in_chunks:0` while `audio_out` climbed normally — the model spoke, the user never heard it, so nobody ever replied. **Lesson worth keeping:** a fail-soft table with no health check is undetectable — `ok:false` in a payload nobody alerts on is not detection. Documented in `DATABASE_SCHEMA.md`. | VTID-03480 |
 | 2026-08-01 | **Decided (not yet built) the concrete AI/voice provider replacements for the GCP full-cutover draft spec**, at explicit user request. `docs/vtids/VTID-PENDING-GCP-FULL-CUTOVER-SPEC.md` preconditions 3–5b updated: ORB voice → Amazon Nova Sonic (promoted out of canary, replacing Vertex Live entirely, no GCP fallback retained); TTS → Amazon Polly (replacing Google Cloud TTS across all 4 call sites); non-voice text AI → Claude via the existing Bedrock adapter. Two gaps surfaced while confirming these are actually buildable: (1) `cover-image-outpaint.ts` calls Vertex **Imagen** for image *generation*, which Claude cannot do at all — decided to build a separate Bedrock Titan Image Generator adapter for this one feature, with the code's existing letterbox-blur fallback as the safety net if output quality doesn't hold up; (2) at least one feature (`anthropic-vision-client.ts`'s Shorts auto-metadata) needs vision + forced tool-calling, which the Bedrock adapter doesn't support yet (CLAUDE.md §2b) — decided to extend the adapter rather than carve out a permanent exception. This removes the "or accept a written exception" branch the draft spec previously had for AI/voice providers — decided 2026-08-01, so the only open question is now build sequencing, not the target. Documentation only; no code changed yet. | (draft spec update, no VTID) |
 | 2026-08-01 | **ORB voice: WebSocket is now the browser's default transport, and the WS session start stopped being a second implementation.** The widget's default flips from SSE-down + one authenticated POST per 64ms audio chunk (~15.6 req/s while the user speaks) to the single bidirectional socket at `/api/v1/orb/live/ws`. The blocker was not the flip — it was that the WS `start` frame ran a fork of session start dating to VTID-01222, which had never received wake-brief selection (VTID-03079/03101), journey guidance (VTID-03300), guided-topic narration (VTID-03290), fast-start wake deferral, the voice quota gate (VTID-03107), the `AUTH_TOKEN_INVALID` re-auth signal, or reconnect continuity (VTID-02020's `transcript_history`/`reconnect_stage`/`conversation_id`). Six features added to the HTTP path over ~7 months, silently absent from the WS one — flipping the default first would have regressed the opener for every logged-in session. New `orb/live/session/ws-start-adapter.ts` runs the WS start through the same `handleLiveSessionStart` the HTTP path uses (it touches only `req.identity`/`req.headers`/`req.get()`/`req.body`/`res.status().json()`), deleting ~290 lines of fork. **Consequence to know:** the live session id and the `ws-<uuid>` socket id are now different strings — `wsClientSessions` is keyed by the socket, `liveSessions` by the live id, and `cleanupWsSession` was leaking the live session by deleting under the wrong key. Safety on the flip: automatic one-shot fallback to SSE when a WS start fails for a *transport* reason (latched per tab in sessionStorage, not localStorage — a network that blocks upgrades is where the user is, not a verdict on their browser), server rejections deliberately NOT retried on SSE, and a new unauthenticated `GET /api/v1/orb/live/transport` backed by `FEATURE_ORB_WS_TRANSPORT_ENV` so the default can be revoked without redeploying a static asset. | VTID-03471 |

--- a/scripts/tts/verify-polly-voices.ts
+++ b/scripts/tts/verify-polly-voices.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env npx ts-node
+/**
+ * VTID-03495 — verify the Polly voice table against the LIVE Polly API.
+ *
+ * The voice/engine pairs in `services/gateway/src/services/tts/polly.ts` and
+ * the "Polly has no Serbian voice" claim were derived from Polly's published
+ * voice list, NOT from a live API call — the session that wrote them had no
+ * working AWS credentials. Run this before flipping `TTS_PROVIDER=polly`.
+ *
+ * Checks, per language in the table:
+ *   - the VoiceId exists in the target region
+ *   - it actually supports the engine we pin (a voice existing does NOT mean
+ *     it supports `neural` — that is the most likely way this table is wrong)
+ *   - the language code matches
+ * Then re-checks that no Serbian voice has appeared since (if one has, the
+ * `POLLY_UNSUPPORTED_LANGS` entry and the shutdown blocker both go away).
+ *
+ * Usage:  AWS_POLLY_REGION=eu-central-1 npx ts-node scripts/tts/verify-polly-voices.ts
+ * Exits non-zero if any pinned voice/engine pair is not live.
+ */
+
+import { PollyClient, DescribeVoicesCommand } from '@aws-sdk/client-polly';
+
+// Mirrors POLLY_VOICES in services/gateway/src/services/tts/polly.ts.
+// Kept as a literal here on purpose: this script must fail if the two drift,
+// which is the whole point of an independent verification pass.
+const EXPECTED: Record<string, { voiceId: string; engine: string; languageCode: string }> = {
+  en: { voiceId: 'Joanna', engine: 'neural', languageCode: 'en-US' },
+  de: { voiceId: 'Vicki', engine: 'neural', languageCode: 'de-DE' },
+  fr: { voiceId: 'Lea', engine: 'neural', languageCode: 'fr-FR' },
+  es: { voiceId: 'Lucia', engine: 'neural', languageCode: 'es-ES' },
+  ar: { voiceId: 'Hala', engine: 'neural', languageCode: 'ar-AE' },
+  zh: { voiceId: 'Zhiyu', engine: 'neural', languageCode: 'cmn-CN' },
+  ru: { voiceId: 'Tatyana', engine: 'standard', languageCode: 'ru-RU' },
+};
+
+const SERBIAN_PREFIXES = ['sr'];
+
+async function main(): Promise<void> {
+  const region = process.env.AWS_POLLY_REGION || process.env.AWS_REGION || 'eu-central-1';
+  const client = new PollyClient({ region });
+  console.log(`[verify-polly] region=${region}`);
+
+  const voices: Array<{ Id?: string; LanguageCode?: string; SupportedEngines?: string[] }> = [];
+  let token: string | undefined;
+  do {
+    const page = await client.send(new DescribeVoicesCommand({ NextToken: token }));
+    voices.push(...(page.Voices ?? []));
+    token = page.NextToken;
+  } while (token);
+
+  console.log(`[verify-polly] ${voices.length} voices visible in ${region}\n`);
+
+  let failures = 0;
+  for (const [lang, want] of Object.entries(EXPECTED)) {
+    const found = voices.find((v) => v.Id === want.voiceId);
+    if (!found) {
+      console.error(`✗ ${lang}: voice '${want.voiceId}' NOT FOUND in ${region}`);
+      failures++;
+      continue;
+    }
+    const engines = found.SupportedEngines ?? [];
+    if (!engines.includes(want.engine)) {
+      console.error(
+        `✗ ${lang}: '${want.voiceId}' exists but does NOT support engine '${want.engine}' ` +
+          `(supports: ${engines.join(', ') || 'none reported'})`,
+      );
+      failures++;
+      continue;
+    }
+    if (found.LanguageCode !== want.languageCode) {
+      console.error(
+        `✗ ${lang}: '${want.voiceId}' languageCode is '${found.LanguageCode}', ` +
+          `table says '${want.languageCode}'`,
+      );
+      failures++;
+      continue;
+    }
+    console.log(`✓ ${lang}: ${want.voiceId} / ${want.engine} / ${want.languageCode}`);
+  }
+
+  const serbian = voices.filter((v) =>
+    SERBIAN_PREFIXES.some((p) => (v.LanguageCode ?? '').toLowerCase().startsWith(p)),
+  );
+  console.log('');
+  if (serbian.length === 0) {
+    console.log(
+      '✓ Serbian still unsupported by Polly — POLLY_UNSUPPORTED_LANGS is correct.\n' +
+        '  NOTE: this remains a real GCP-shutdown blocker. With GCP gone, Serbian\n' +
+        '  users get no TTS from any configured provider.',
+    );
+  } else {
+    console.log(
+      `! Serbian voice(s) NOW AVAILABLE: ${serbian.map((v) => `${v.Id} (${v.LanguageCode})`).join(', ')}\n` +
+        '  Remove "sr" from POLLY_UNSUPPORTED_LANGS, add it to POLLY_VOICES, and\n' +
+        '  drop the Serbian shutdown blocker from CLAUDE.md §2c.',
+    );
+  }
+
+  if (failures > 0) {
+    console.error(`\n[verify-polly] ${failures} mismatch(es) — do NOT flip TTS_PROVIDER=polly yet.`);
+    process.exit(1);
+  }
+  console.log('\n[verify-polly] voice table matches the live API.');
+}
+
+main().catch((err) => {
+  console.error('[verify-polly] failed:', err?.message ?? err);
+  process.exit(1);
+});

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -348,6 +348,28 @@ AI_STUDIO_LIVE_MODEL=gemini-2.5-flash-native-audio-latest
 # unbound in deploy config; only set to pin a different Claude model.
 # VOICE_INVESTIGATOR_MODEL=claude-sonnet-4-6
 
+# VTID-03495: Amazon Polly TTS provider (CLAUDE.md §2c). Build 1 of the 4
+# provider replacements that gate a GCP shutdown.
+# TTS_PROVIDER: which provider serves the 4 Cloud TTS synthesis call sites.
+#   OPTIONAL — defaults to 'google' in code (getTtsProvider()), so leaving
+#   this unset changes nothing. An unrecognised value logs a warning and
+#   falls back to 'google' rather than failing closed and taking voice down.
+#   Setting 'polly' is a deliberate operator action, same shape as
+#   BEDROCK_ROLE_ARN / PUBLISH_TARGET_CLOUD below.
+TTS_PROVIDER=google
+# AWS_POLLY_REGION: falls back to AWS_REGION, then 'eu-central-1' — the only
+#   region with Vitana AWS infrastructure (account 472838866351). Note Polly
+#   is a separate service from Nova Sonic, which is pinned to eu-north-1.
+AWS_POLLY_REGION=eu-central-1
+# TTS_POLLY_STRICT: when 'true', a request Polly cannot serve returns NO
+#   audio instead of falling back to Google. OPTIONAL — defaults to false in
+#   code. Turn this on only for a GCP-shutdown rehearsal, to prove no hidden
+#   Google TTS dependency remains. Leaving it false is correct for normal
+#   operation because Polly's language coverage is genuinely narrower:
+#   Polly has NO Serbian voice in any engine, and 'sr' is a live locale
+#   (§13b) — with strict on and GCP gone, Serbian users get silence.
+#   Requires polly:SynthesizeSpeech on the gateway task role.
+TTS_POLLY_STRICT=false
 # VTID-03403: Anthropic Claude via Amazon Bedrock, wired as an explicit
 # llm-router.ts provider ('bedrock') that no stage selects by default.
 # BEDROCK_ROLE_ARN: IAM role ARN with least-privilege bedrock:InvokeModel /

--- a/services/gateway/package-lock.json
+++ b/services/gateway/package-lock.json
@@ -11,6 +11,7 @@
         "@anthropic-ai/sdk": "^0.90.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1091.0",
         "@aws-sdk/client-ecs": "^3.1094.0",
+        "@aws-sdk/client-polly": "^3.1091.0",
         "@google-cloud/text-to-speech": "^5.5.0",
         "@google-cloud/vertexai": "^1.9.2",
         "@google/generative-ai": "^0.24.1",
@@ -126,17 +127,38 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-polly": {
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-polly/-/client-polly-3.1103.0.tgz",
+      "integrity": "sha512-BE/wnM5J1pCMDKMCd2DfQo+0nNXjgwRlu6wq3rRf7/G5OoLF8nlwTG+qjDVgggEMnhckh41JDQIC+RSwilCFxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/eventstream-handler-node": "^3.972.31",
+        "@aws-sdk/middleware-eventstream": "^3.972.26",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/core": {
-      "version": "3.976.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.976.0.tgz",
-      "integrity": "sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA==",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.4",
-        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -146,14 +168,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.60.tgz",
-      "integrity": "sha512-BAkxdoe7tpDDqCghGpuOeHQRbm/2znVvOQm0AvpQbA2tbfMN46doN4zx65fv85ImP3KADwc2zQPmbrlI9MPfMg==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -162,16 +184,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.62.tgz",
-      "integrity": "sha512-g/0fGqKTb9xpKdd9AtpmV5Eo3DFKbnkpA2+w0peISSlu7NfAoWOuYBFxsu+yWBtxU89ka55ezoZBCbFaS8pjYQ==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -180,22 +202,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.5.tgz",
-      "integrity": "sha512-ylubazcRfq2TVus/qXucSXeC42Qdjp5HQxTu68K/BsdMiZlcSLD1zkpoCgApXZX1Y6YJhtGGs7ZHhO/GuIgBlw==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.976.0",
-        "@aws-sdk/credential-provider-env": "^3.972.60",
-        "@aws-sdk/credential-provider-http": "^3.972.62",
-        "@aws-sdk/credential-provider-login": "^3.972.67",
-        "@aws-sdk/credential-provider-process": "^3.972.60",
-        "@aws-sdk/credential-provider-sso": "^3.973.4",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.66",
-        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -204,15 +226,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.67.tgz",
-      "integrity": "sha512-CCygIKJ9YbI3n84OClSaSppkgKKHVj2TGT33c6FRORZrYNZQ1POmD+ip0FLYokiJAK7sSdc3YVkOsBm90oxWMQ==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.976.0",
-        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -221,20 +243,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.71.tgz",
-      "integrity": "sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.60",
-        "@aws-sdk/credential-provider-http": "^3.972.62",
-        "@aws-sdk/credential-provider-ini": "^3.973.5",
-        "@aws-sdk/credential-provider-process": "^3.972.60",
-        "@aws-sdk/credential-provider-sso": "^3.973.4",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.66",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -243,14 +265,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.60.tgz",
-      "integrity": "sha512-YIo3f99hM43QdYG8hDzwGemnR/pU95b0kramqSJUTleCqaB7+HwKf7YZFHqvOgTqZTPx/mRmNIqoDRr3U0Z3Tw==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -259,16 +281,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.4.tgz",
-      "integrity": "sha512-BPdmL8sSBOCv4ngZ+3LHxyc3CNqDCEK37CHioCk7zGrTMY5sUtkH8q+o6qA80nn6w3/fyBPGNE7OIRlmoOxRQA==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.976.0",
-        "@aws-sdk/nested-clients": "^3.997.34",
-        "@aws-sdk/token-providers": "3.1092.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -277,15 +299,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1092.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1092.0.tgz",
-      "integrity": "sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.976.0",
-        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -294,15 +316,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.66.tgz",
-      "integrity": "sha512-kSAziJboOmZmsR9/MTbiNjowl2BPes1bQuJpne4qAZ62ubi8fjfr/aupJSQje6udBoYxXTQbsL0e0kby2la3ng==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.976.0",
-        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -311,13 +333,13 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.29.tgz",
-      "integrity": "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+      "integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -326,13 +348,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.24.tgz",
-      "integrity": "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+      "integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -359,17 +381,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.34.tgz",
-      "integrity": "sha512-Y9REVrSwmLM+Qy6sZJ7ofMC2S3Hr3tPP/4CzL5U1olPP7OGoF+6+Px0E49cVQBtSxJtyeLJMf0UaBErfeSahAA==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.976.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -378,13 +400,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
-      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -423,9 +445,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
-      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -3064,9 +3086,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.8.tgz",
-      "integrity": "sha512-rpCbCV+TimOBi3VLNBMmtTvgfOWcFIEAru3+TFlG87SL2F+te4jOnnNR+cf3uR4eJ5Qf4LnT80fqnBKgPRS6zA==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -3077,12 +3099,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.13.tgz",
-      "integrity": "sha512-X+2HNZhWi5i3rJsCas0LPf6fTQUaKyJ40zd8aTO/bwpRfpU3biYaqLr7C1WMibL7PVKJalpi1PyybjGPNoHC8Q==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3091,12 +3113,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.8.tgz",
-      "integrity": "sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==",
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3105,12 +3127,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.9",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.9.tgz",
-      "integrity": "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg==",
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.7",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3119,12 +3141,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.7.tgz",
-      "integrity": "sha512-32PmEsuZV9lz7SZk3gJcm+EfIAoIVu83AJyEzgALpwmSqLvuacdAu0fvCVNMbDbegyk1S0lHUDrMWIfR47Micw==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1091.0",
+    "@aws-sdk/client-polly": "^3.1091.0",
     "@aws-sdk/client-ecs": "^3.1094.0",
     "@google-cloud/text-to-speech": "^5.5.0",
     "@google-cloud/vertexai": "^1.9.2",

--- a/services/gateway/pnpm-lock.yaml
+++ b/services/gateway/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@aws-sdk/client-ecs':
         specifier: ^3.1094.0
         version: 3.1094.0
+      '@aws-sdk/client-polly':
+        specifier: ^3.1091.0
+        version: 3.1103.0
       '@google-cloud/text-to-speech':
         specifier: ^5.5.0
         version: 5.8.1
@@ -176,12 +179,20 @@ packages:
     resolution: {integrity: sha512-FQUjpcKfhi9HgiuV7BilHCrLmPXvEAg8+1k/IuCAfq1R+WvzVTesIiStR8QPNm6GzfSpREVKXlVJab3T3IEh8Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-polly@3.1103.0':
+    resolution: {integrity: sha512-BE/wnM5J1pCMDKMCd2DfQo+0nNXjgwRlu6wq3rRf7/G5OoLF8nlwTG+qjDVgggEMnhckh41JDQIC+RSwilCFxA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.975.3':
     resolution: {integrity: sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.976.0':
     resolution: {integrity: sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.6':
+    resolution: {integrity: sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.59':
@@ -192,12 +203,24 @@ packages:
     resolution: {integrity: sha512-BAkxdoe7tpDDqCghGpuOeHQRbm/2znVvOQm0AvpQbA2tbfMN46doN4zx65fv85ImP3KADwc2zQPmbrlI9MPfMg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.67':
+    resolution: {integrity: sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.61':
     resolution: {integrity: sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.62':
     resolution: {integrity: sha512-g/0fGqKTb9xpKdd9AtpmV5Eo3DFKbnkpA2+w0peISSlu7NfAoWOuYBFxsu+yWBtxU89ka55ezoZBCbFaS8pjYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.69':
+    resolution: {integrity: sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.12':
+    resolution: {integrity: sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.973.4':
@@ -216,6 +239,10 @@ packages:
     resolution: {integrity: sha512-CCygIKJ9YbI3n84OClSaSppkgKKHVj2TGT33c6FRORZrYNZQ1POmD+ip0FLYokiJAK7sSdc3YVkOsBm90oxWMQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.74':
+    resolution: {integrity: sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.70':
     resolution: {integrity: sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==}
     engines: {node: '>=20.0.0'}
@@ -224,12 +251,24 @@ packages:
     resolution: {integrity: sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.78':
+    resolution: {integrity: sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.59':
     resolution: {integrity: sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.60':
     resolution: {integrity: sha512-YIo3f99hM43QdYG8hDzwGemnR/pU95b0kramqSJUTleCqaB7+HwKf7YZFHqvOgTqZTPx/mRmNIqoDRr3U0Z3Tw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.67':
+    resolution: {integrity: sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.11':
+    resolution: {integrity: sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.973.3':
@@ -248,12 +287,24 @@ packages:
     resolution: {integrity: sha512-kSAziJboOmZmsR9/MTbiNjowl2BPes1bQuJpne4qAZ62ubi8fjfr/aupJSQje6udBoYxXTQbsL0e0kby2la3ng==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-web-identity@3.972.73':
+    resolution: {integrity: sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/eventstream-handler-node@3.972.29':
     resolution: {integrity: sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/eventstream-handler-node@3.972.31':
+    resolution: {integrity: sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-eventstream@3.972.24':
     resolution: {integrity: sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.26':
+    resolution: {integrity: sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-websocket@3.972.41':
@@ -268,8 +319,16 @@ packages:
     resolution: {integrity: sha512-Y9REVrSwmLM+Qy6sZJ7ofMC2S3Hr3tPP/4CzL5U1olPP7OGoF+6+Px0E49cVQBtSxJtyeLJMf0UaBErfeSahAA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.41':
+    resolution: {integrity: sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.41':
     resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1088.0':
@@ -284,12 +343,20 @@ packages:
     resolution: {integrity: sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1103.0':
+    resolution: {integrity: sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.974.2':
     resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.36':
     resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -1069,16 +1136,36 @@ packages:
     resolution: {integrity: sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.11':
     resolution: {integrity: sha512-6CUvZwS0tCcVCrcvh2TpwTXxmAkuY6JGNPeKODYRLjHtUUhFLGS3dNkNdRvT/ttJyqimqnhFMTS2nqp4pDZ7oQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.8':
     resolution: {integrity: sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.9.9':
     resolution: {integrity: sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.7':
@@ -3338,6 +3425,19 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-polly@3.1103.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/credential-provider-node': 3.972.78
+      '@aws-sdk/eventstream-handler-node': 3.972.31
+      '@aws-sdk/middleware-eventstream': 3.972.26
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.975.3':
     dependencies:
       '@aws-sdk/types': 3.974.2
@@ -3360,9 +3460,20 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.6':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.59':
     dependencies:
-      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/core': 3.976.0
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
       '@smithy/types': 4.16.1
@@ -3376,9 +3487,17 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.61':
     dependencies:
-      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/core': 3.976.0
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
       '@smithy/fetch-http-handler': 5.6.8
@@ -3396,9 +3515,35 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-http@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.12':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/credential-provider-env': 3.972.67
+      '@aws-sdk/credential-provider-http': 3.972.69
+      '@aws-sdk/credential-provider-login': 3.972.74
+      '@aws-sdk/credential-provider-process': 3.972.67
+      '@aws-sdk/credential-provider-sso': 3.973.11
+      '@aws-sdk/credential-provider-web-identity': 3.972.73
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-ini@3.973.4':
     dependencies:
-      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/core': 3.976.0
       '@aws-sdk/credential-provider-env': 3.972.59
       '@aws-sdk/credential-provider-http': 3.972.61
       '@aws-sdk/credential-provider-login': 3.972.66
@@ -3430,8 +3575,8 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.66':
     dependencies:
-      '@aws-sdk/core': 3.975.3
-      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/nested-clients': 3.997.34
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
       '@smithy/types': 4.16.1
@@ -3443,6 +3588,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.34
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.74':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -3474,9 +3628,23 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.78':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.67
+      '@aws-sdk/credential-provider-http': 3.972.69
+      '@aws-sdk/credential-provider-ini': 3.973.12
+      '@aws-sdk/credential-provider-process': 3.972.67
+      '@aws-sdk/credential-provider-sso': 3.973.11
+      '@aws-sdk/credential-provider-web-identity': 3.972.73
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.59':
     dependencies:
-      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/core': 3.976.0
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
       '@smithy/types': 4.16.1
@@ -3490,9 +3658,27 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-process@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.11':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/token-providers': 3.1103.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-sso@3.973.3':
     dependencies:
-      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/core': 3.976.0
       '@aws-sdk/nested-clients': 3.997.33
       '@aws-sdk/token-providers': 3.1088.0
       '@aws-sdk/types': 3.974.2
@@ -3512,7 +3698,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.65':
     dependencies:
-      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/core': 3.976.0
       '@aws-sdk/nested-clients': 3.997.33
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
@@ -3528,6 +3714,15 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-web-identity@3.972.73':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/eventstream-handler-node@3.972.29':
     dependencies:
       '@aws-sdk/types': 3.974.2
@@ -3535,10 +3730,24 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/eventstream-handler-node@3.972.31':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-eventstream@3.972.24':
     dependencies:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.26':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -3554,7 +3763,7 @@ snapshots:
 
   '@aws-sdk/nested-clients@3.997.33':
     dependencies:
-      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/core': 3.976.0
       '@aws-sdk/signature-v4-multi-region': 3.996.41
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
@@ -3574,6 +3783,17 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.41':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.41':
     dependencies:
       '@aws-sdk/types': 3.974.2
@@ -3581,9 +3801,16 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1088.0':
     dependencies:
-      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/core': 3.976.0
       '@aws-sdk/nested-clients': 3.997.33
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
@@ -3608,12 +3835,26 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1103.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.974.2':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.36':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -4426,9 +4667,26 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.11':
     dependencies:
       '@smithy/core': 3.29.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -4438,9 +4696,21 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/node-http-handler@4.9.9':
     dependencies:
       '@smithy/core': 3.29.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1422,6 +1422,8 @@ import {
 // take 5-8+s to first greeting audio; this fills the silence).
 import { buildGreetingBridgeText } from '../services/conversation/greeting-audio-bridge';
 import { synthesizeGreetingBridgeAudioPcm, GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ } from '../services/tts/greeting-bridge-tts';
+// VTID-03495: Polly seam for the /tts route. No-ops unless TTS_PROVIDER=polly.
+import { tryPollySynthesis } from '../services/tts/tts-provider';
 import { resolveNovaSonicVoice } from '../orb/live/voice/nova-sonic-voice';
 import { prewarmNovaSonicBedrock } from '../orb/live/upstream/nova-sonic-live-client';
 import { sanitizeInstructionForNova } from '../orb/live/upstream/nova-instruction-sanitizer';
@@ -8954,16 +8956,19 @@ async function sendGreetingAudioBridge(session: GeminiLiveSession): Promise<void
     const lang = session.lang || 'en';
     const timezone = session.clientContext?.timezone || 'UTC';
     const text = buildGreetingBridgeText({ lang, now: new Date(), timezone });
-    const audioB64 = await synthesizeGreetingBridgeAudioPcm(text, lang);
-    if (!audioB64) {
+    const bridgeAudio = await synthesizeGreetingBridgeAudioPcm(text, lang);
+    if (!bridgeAudio) {
       emitDiag(session, 'greeting_bridge_skipped', { reason: 'synthesis_unavailable' });
       return;
     }
     if (!session.sseResponse) return; // client disconnected while we were synthesizing
     session.sseResponse.write(`data: ${JSON.stringify({
       type: 'audio',
-      data_b64: audioB64,
-      mime: `audio/pcm;rate=${GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ}`,
+      data_b64: bridgeAudio.audioB64,
+      // VTID-03495: rate comes from the synthesis result, not a constant —
+      // Polly PCM is 16kHz, Cloud TTS 24kHz. Hardcoding either plays the
+      // other at the wrong speed.
+      mime: `audio/pcm;rate=${bridgeAudio.sampleRateHz}`,
       chunk_number: session.audioOutChunks++,
       source: 'greeting_bridge',
     })}\n\n`);
@@ -13907,6 +13912,41 @@ router.post('/tts', optionalAuth, async (req: AuthenticatedRequest, res: Respons
     voice_type: voiceType,
     text_length: text.length
   });
+
+  // VTID-03495: Polly first when configured. This MUST sit above the
+  // `!ttsClient` guard below — in a GCP-free environment the Cloud TTS client
+  // constructor fails and ttsClient stays null, so a Polly attempt placed
+  // after the guard would never run and this route would 503 despite Polly
+  // being available and healthy.
+  {
+    const __vcPolly = await getVoiceConfig();
+    const polly = await tryPollySynthesis({
+      text,
+      lang,
+      format: 'mp3',
+      speakingRate: __vcPolly.tts.speaking_rate,
+      callSite: 'orb-live-tts',
+    });
+    if (polly) {
+      await emitTtsEvent('vtid.tts.success', {
+        lang,
+        voice: polly.voice,
+        voice_type: 'Polly',
+        text_length: text.length,
+        audio_bytes: polly.audioB64.length,
+        mime_type: 'audio/mp3',
+        provider: 'polly',
+      });
+      return res.status(200).json({
+        ok: true,
+        audio_b64: polly.audioB64,
+        mime: 'audio/mp3',
+        voice: polly.voice,
+        voice_type: 'Polly',
+        lang,
+      });
+    }
+  }
 
   // Check if TTS client is available
   if (!ttsClient) {

--- a/services/gateway/src/routes/voice-config.ts
+++ b/services/gateway/src/routes/voice-config.ts
@@ -13,6 +13,8 @@
 
 import { Router, Request, Response } from 'express';
 import textToSpeech, { protos } from '@google-cloud/text-to-speech';
+// VTID-03495: Polly preview support (explicit `provider: 'polly'` only).
+import { synthesizePolly, POLLY_UNSUPPORTED_LANGS } from '../services/tts/polly';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import {
   requireAuthWithTenant,
@@ -205,12 +207,40 @@ router.post(
     }
 
     const provider = body.provider || 'google_tts';
-    if (provider !== 'google_tts') {
+    if (provider !== 'google_tts' && provider !== 'polly') {
       return res.status(400).json({
         ok: false,
         error: `preview for provider '${provider}' not implemented yet`,
         vtid: VTID,
       });
+    }
+
+    // VTID-03495: Polly preview. Deliberately driven by the EXPLICIT `provider`
+    // body param and NOT by the TTS_PROVIDER env var — this endpoint exists so
+    // an operator can audition a specific provider/voice on demand, so honoring
+    // an ambient env switch here would make previews lie about what they played.
+    // Auditioning both sides is how the migration gets validated before flipping.
+    if (provider === 'polly') {
+      const pollyRate = clampRate(body.speaking_rate);
+      const result = await synthesizePolly({
+        text,
+        lang: body.language || 'en',
+        format: 'mp3',
+        speakingRate: pollyRate,
+      });
+      if (!result) {
+        return res.status(422).json({
+          ok: false,
+          error:
+            `Polly cannot synthesize language '${body.language || 'en'}'. ` +
+            `Unsupported: ${[...POLLY_UNSUPPORTED_LANGS].join(', ')}.`,
+          vtid: VTID,
+        });
+      }
+      res.setHeader('Content-Type', 'audio/mpeg');
+      res.setHeader('X-Vitana-Tts-Voice', result.voice);
+      res.setHeader('X-Vitana-Tts-Engine', result.engine);
+      return res.send(Buffer.from(result.audioB64, 'base64'));
     }
 
     const language = body.language || 'en';

--- a/services/gateway/src/services/reminder-tts.ts
+++ b/services/gateway/src/services/reminder-tts.ts
@@ -11,6 +11,8 @@ import textToSpeech from '@google-cloud/text-to-speech';
 import { protos } from '@google-cloud/text-to-speech';
 // VTID-02857: speakingRate read from system_config['tts.speaking_rate']
 import { getVoiceConfig } from './voice-config';
+// VTID-03495: Polly seam. No-ops unless TTS_PROVIDER=polly.
+import { tryPollySynthesis } from './tts/tts-provider';
 
 let ttsClient: InstanceType<typeof textToSpeech.TextToSpeechClient> | null = null;
 try {
@@ -44,6 +46,23 @@ export async function synthesizeReminderTts(
   text: string,
   lang: string,
 ): Promise<{ audio_b64: string | null; voice: string | null; lang: string }> {
+  // VTID-03495: Polly first when configured. Reminders are pre-rendered at
+  // insert time (not on the fire-time critical path), so a provider miss here
+  // costs latency on a background job, never a user-visible delay.
+  {
+    const __vcPolly = await getVoiceConfig();
+    const polly = await tryPollySynthesis({
+      text,
+      lang,
+      format: 'mp3',
+      speakingRate: __vcPolly.tts.speaking_rate,
+      callSite: 'reminder-tts',
+    });
+    if (polly) {
+      return { audio_b64: polly.audioB64, voice: polly.voice, lang: normalizeLang(lang) };
+    }
+  }
+
   if (!ttsClient) {
     try {
       ttsClient = new textToSpeech.TextToSpeechClient();

--- a/services/gateway/src/services/tts/greeting-bridge-tts.ts
+++ b/services/gateway/src/services/tts/greeting-bridge-tts.ts
@@ -15,6 +15,8 @@
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { getNeural2TtsVoice, getGeminiTtsVoice, isNeural2EnabledFor } from '../../orb/live/voice/voice-mapping';
 import { getVoiceConfig } from '../voice-config';
+// VTID-03495: Polly seam. No-ops unless TTS_PROVIDER=polly.
+import { tryPollySynthesis, GOOGLE_PCM_SAMPLE_RATE_HZ } from './tts-provider';
 
 let bridgeTtsClient: TextToSpeechClient | null = null;
 try {
@@ -23,19 +25,51 @@ try {
   console.warn('[GREETING-BRIDGE-TTS] Failed to initialize TTS client:', (err as Error).message);
 }
 
-export const GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ = 24_000;
+export const GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ = GOOGLE_PCM_SAMPLE_RATE_HZ;
 
 /**
- * Synthesize `text` to base64 LINEAR16 PCM @ 24kHz mono. Returns null on any
+ * Result of a greeting-bridge synthesis.
+ *
+ * VTID-03495: `sampleRateHz` is now returned rather than implied by the
+ * module constant. Polly's PCM output cannot do 24kHz (8k/16k only), so the
+ * rate depends on which provider served the request and the caller must use
+ * this value when building the `audio/pcm;rate=` mime. Assuming 24kHz under
+ * Polly would play 16kHz samples 1.5x too fast — chipmunk audio, and a
+ * failure mode that is obvious to a listener but invisible to any test that
+ * only checks "did we get bytes back".
+ */
+export interface GreetingBridgeAudio {
+  audioB64: string;
+  sampleRateHz: number;
+}
+
+/**
+ * Synthesize `text` to base64 LINEAR16 PCM mono. Returns null on any
  * failure (missing client, API error, empty response) — this is a UX
  * enhancement, never allowed to block or fail the real greeting path.
  */
 export async function synthesizeGreetingBridgeAudioPcm(
   text: string,
   lang: string,
-): Promise<string | null> {
-  if (!bridgeTtsClient) return null;
+): Promise<GreetingBridgeAudio | null> {
   if (!text || text.trim().length === 0) return null;
+
+  // VTID-03495: Polly first when configured; falls through to Google below
+  // (logged) when Polly can't serve it and strict mode is off.
+  const vcForPolly = await getVoiceConfig();
+  const polly = await tryPollySynthesis({
+    text,
+    lang,
+    format: 'pcm',
+    speakingRate: vcForPolly.tts.speaking_rate,
+    callSite: 'greeting-bridge',
+  });
+  if (polly) {
+    // Polly PCM is headerless already — no WAV stripping needed.
+    return { audioB64: polly.audioB64, sampleRateHz: polly.sampleRateHz };
+  }
+
+  if (!bridgeTtsClient) return null;
 
   try {
     const useNeural2 = isNeural2EnabledFor(lang);
@@ -72,7 +106,7 @@ export async function synthesizeGreetingBridgeAudioPcm(
       ? response.audioContent
       : Buffer.from(response.audioContent as Uint8Array);
     const pcm = stripWavHeaderIfPresent(raw);
-    return pcm.toString('base64');
+    return { audioB64: pcm.toString('base64'), sampleRateHz: GREETING_BRIDGE_PCM_SAMPLE_RATE_HZ };
   } catch (err) {
     console.warn('[GREETING-BRIDGE-TTS] Synthesis failed:', (err as Error).message);
     return null;

--- a/services/gateway/src/services/tts/polly.ts
+++ b/services/gateway/src/services/tts/polly.ts
@@ -1,0 +1,231 @@
+/**
+ * VTID-03495 — Amazon Polly TTS provider.
+ *
+ * First of the four provider replacements that must exist before a GCP
+ * shutdown is possible (Polly → Titan image gen → Bedrock vision/tool-calling
+ * → Nova Sonic promotion). This module is the Polly half; provider SELECTION
+ * lives in `tts-provider.ts` and is gated on `TTS_PROVIDER`, default `google`.
+ * Importing this file changes nothing on its own.
+ *
+ * Three things about Polly differ materially from Google Cloud TTS and are
+ * handled explicitly here rather than papered over:
+ *
+ * 1. **PCM sample rate.** Cloud TTS will emit LINEAR16 at any rate; the
+ *    greeting bridge asks for 24kHz. Polly's `pcm` output format supports
+ *    ONLY 8000 and 16000 Hz. We emit 16000 and report it back to the caller
+ *    so the `audio/pcm;rate=` mime the widget reads stays truthful — the rate
+ *    is negotiated, never assumed (see `orb-live.ts` ~L8966).
+ *
+ * 2. **Speaking rate.** Cloud TTS takes `speakingRate` as a request field.
+ *    Polly has no equivalent — rate is expressed via SSML `<prosody rate>`,
+ *    so any non-1.0 rate forces `TextType: 'ssml'` and the input text must be
+ *    XML-escaped. At rate 1.0 we send plain text and skip SSML entirely.
+ *
+ * 3. **Serbian is not supported by Polly at all.** Cloud TTS has
+ *    `sr-RS-Standard-A`; Polly has no Serbian voice in any engine. `sr` is a
+ *    live locale for this platform (CLAUDE.md §13b lists DE/EN/ES/SR), so
+ *    this is a real coverage regression, not a rounding error. Rather than
+ *    silently substituting another language's voice — which would emit
+ *    confident, fluent, WRONG-language audio to a Serbian user —
+ *    `resolvePollyVoice()` returns null for `sr` and the caller falls back to
+ *    Google (or degrades to no audio if Google is gone). See
+ *    `POLLY_UNSUPPORTED_LANGS`.
+ *
+ * Voice/engine pairs below are pinned per-language. `Engine` is always sent
+ * explicitly, satisfying CLAUDE.md's "IF TTS is used → THEN specify
+ * model_name explicitly" rule — Polly's `Engine` is that knob.
+ *
+ * NOTE: the voice/engine table and the Serbian gap were derived from Polly's
+ * documented voice list, NOT verified against the live API — this session had
+ * no working AWS credentials. `scripts/tts/verify-polly-voices.ts` exists to
+ * confirm both against `DescribeVoices` before anyone flips `TTS_PROVIDER`.
+ */
+
+import {
+  PollyClient,
+  SynthesizeSpeechCommand,
+  type Engine,
+  type OutputFormat,
+  type VoiceId,
+} from '@aws-sdk/client-polly';
+
+export interface PollyVoiceConfig {
+  /** Polly VoiceId, e.g. 'Vicki'. */
+  voiceId: VoiceId;
+  /** Explicit engine — never left to Polly's default. */
+  engine: Engine;
+  /** Polly language code, for logging/telemetry parity with Cloud TTS. */
+  languageCode: string;
+}
+
+/**
+ * Languages this platform speaks that Polly cannot. Kept as an explicit,
+ * named constant so the gap is greppable rather than an absence in a table.
+ */
+export const POLLY_UNSUPPORTED_LANGS: ReadonlySet<string> = new Set(['sr']);
+
+/**
+ * Language → Polly voice. Female voices throughout, matching the existing
+ * Cloud TTS selections (Neural2-F / Kore).
+ *
+ * `ru` is standard-engine only — Polly has no neural Russian voice. That is a
+ * quality step down from `ru-RU-Wavenet-A`, flagged rather than hidden.
+ */
+const POLLY_VOICES: Record<string, PollyVoiceConfig> = {
+  en: { voiceId: 'Joanna' as VoiceId, engine: 'neural' as Engine, languageCode: 'en-US' },
+  de: { voiceId: 'Vicki' as VoiceId, engine: 'neural' as Engine, languageCode: 'de-DE' },
+  fr: { voiceId: 'Lea' as VoiceId, engine: 'neural' as Engine, languageCode: 'fr-FR' },
+  es: { voiceId: 'Lucia' as VoiceId, engine: 'neural' as Engine, languageCode: 'es-ES' },
+  ar: { voiceId: 'Hala' as VoiceId, engine: 'neural' as Engine, languageCode: 'ar-AE' },
+  zh: { voiceId: 'Zhiyu' as VoiceId, engine: 'neural' as Engine, languageCode: 'cmn-CN' },
+  ru: { voiceId: 'Tatyana' as VoiceId, engine: 'standard' as Engine, languageCode: 'ru-RU' },
+};
+
+/**
+ * Polly's `pcm` OutputFormat accepts only 8000 or 16000 Hz. The greeting
+ * bridge's Cloud TTS path uses 24000; callers must read the rate off the
+ * synthesis result rather than assuming either value.
+ */
+export const POLLY_PCM_SAMPLE_RATE_HZ = 16_000;
+
+export function normalizeLang(input: string): string {
+  return (input || 'en').toLowerCase().split(/[-_]/)[0].slice(0, 2) || 'en';
+}
+
+/**
+ * Resolve a Polly voice for `lang`, or null when Polly cannot serve it.
+ *
+ * Returns null (rather than an English fallback) for unsupported languages
+ * on purpose: emitting fluent audio in the wrong language is a worse failure
+ * than emitting none, because it is not self-evidently broken to the caller.
+ */
+export function resolvePollyVoice(lang: string): PollyVoiceConfig | null {
+  const normalized = normalizeLang(lang);
+  if (POLLY_UNSUPPORTED_LANGS.has(normalized)) return null;
+  return POLLY_VOICES[normalized] ?? POLLY_VOICES['en'];
+}
+
+/** XML-escape text destined for an SSML payload. */
+export function escapeSsml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Wrap `text` in SSML with a prosody rate, or return it unchanged when the
+ * rate is effectively 1.0 (Polly is happy with plain text and it avoids a
+ * whole class of escaping bugs on the common path).
+ */
+export function buildPollyInput(
+  text: string,
+  speakingRate: number,
+): { text: string; textType: 'text' | 'ssml' } {
+  const rate = Number.isFinite(speakingRate) && speakingRate > 0 ? speakingRate : 1;
+  if (Math.abs(rate - 1) < 0.01) return { text, textType: 'text' };
+  const pct = Math.round(rate * 100);
+  return {
+    text: `<speak><prosody rate="${pct}%">${escapeSsml(text)}</prosody></speak>`,
+    textType: 'ssml',
+  };
+}
+
+let pollyClient: PollyClient | null = null;
+
+/**
+ * Region resolution mirrors the Bedrock adapter's precedence
+ * (CLAUDE.md §2b): explicit override → generic AWS region → eu-central-1,
+ * the only region with Vitana AWS infrastructure.
+ */
+export function getPollyRegion(): string {
+  return process.env.AWS_POLLY_REGION || process.env.AWS_REGION || 'eu-central-1';
+}
+
+function getPollyClient(): PollyClient {
+  if (!pollyClient) {
+    pollyClient = new PollyClient({ region: getPollyRegion() });
+  }
+  return pollyClient;
+}
+
+/** Test seam — drop the memoized client so a new region/credential set applies. */
+export function resetPollyClientForTests(): void {
+  pollyClient = null;
+}
+
+export interface PollySynthesisResult {
+  /** Base64 audio. For 'pcm' this is headerless LINEAR16 (Polly sends no WAV header). */
+  audioB64: string;
+  /** Actual sample rate of the returned audio — authoritative, never assumed. */
+  sampleRateHz: number;
+  /** Voice actually used, for telemetry parity with the Cloud TTS path. */
+  voice: string;
+  engine: string;
+  languageCode: string;
+}
+
+/**
+ * Synthesize `text` via Polly.
+ *
+ * Returns null when Polly cannot serve the request (unsupported language,
+ * missing credentials, API error) so every caller keeps the same
+ * "null means fall back / degrade" contract the Cloud TTS helpers already use.
+ */
+export async function synthesizePolly(opts: {
+  text: string;
+  lang: string;
+  format: 'mp3' | 'pcm';
+  speakingRate?: number;
+}): Promise<PollySynthesisResult | null> {
+  const { text, lang, format } = opts;
+  if (!text || text.trim().length === 0) return null;
+
+  const voice = resolvePollyVoice(lang);
+  if (!voice) {
+    console.warn(
+      `[POLLY] No Polly voice for lang='${normalizeLang(lang)}' ` +
+        `(unsupported: ${[...POLLY_UNSUPPORTED_LANGS].join(',')}) — caller must fall back.`,
+    );
+    return null;
+  }
+
+  const { text: input, textType } = buildPollyInput(text, opts.speakingRate ?? 1);
+  // Polly rejects SSML on some standard-engine voices' newer features; the
+  // prosody tag used here is supported on both engines, so no branch needed.
+  const sampleRateHz = format === 'pcm' ? POLLY_PCM_SAMPLE_RATE_HZ : 24_000;
+
+  try {
+    const res = await getPollyClient().send(
+      new SynthesizeSpeechCommand({
+        Text: input,
+        TextType: textType,
+        VoiceId: voice.voiceId,
+        Engine: voice.engine,
+        LanguageCode: voice.languageCode as never,
+        OutputFormat: format as OutputFormat,
+        SampleRate: String(sampleRateHz),
+      }),
+    );
+
+    if (!res.AudioStream) return null;
+    // AudioStream is a stream in Node; the SDK exposes transformToByteArray().
+    const bytes = await (
+      res.AudioStream as unknown as { transformToByteArray(): Promise<Uint8Array> }
+    ).transformToByteArray();
+    if (!bytes || bytes.length === 0) return null;
+
+    return {
+      audioB64: Buffer.from(bytes).toString('base64'),
+      sampleRateHz,
+      voice: String(voice.voiceId),
+      engine: String(voice.engine),
+      languageCode: voice.languageCode,
+    };
+  } catch (err) {
+    console.warn(`[POLLY] Synthesis failed (lang=${lang}, format=${format}):`, (err as Error).message);
+    return null;
+  }
+}

--- a/services/gateway/src/services/tts/tts-provider.ts
+++ b/services/gateway/src/services/tts/tts-provider.ts
@@ -1,0 +1,131 @@
+/**
+ * VTID-03495 — TTS provider selection.
+ *
+ * Single place that decides whether a synthesis request goes to Google Cloud
+ * TTS (canonical today) or Amazon Polly. Every one of the four Cloud TTS
+ * call sites routes through here so the provider can be changed in ONE place
+ * instead of four.
+ *
+ * ## Default is `google`. Deploying this code flips nothing.
+ *
+ * `TTS_PROVIDER=polly` is a deliberate, separate operator action — the same
+ * shape as `BEDROCK_ROLE_ARN` (CLAUDE.md §2b), `DEV_AUTOPILOT_JOB_CLOUD`
+ * (§1b) and `PUBLISH_TARGET_CLOUD` (§8). An unrecognised value falls back to
+ * `google` loudly rather than failing closed and taking voice down.
+ *
+ * ## Fallback semantics
+ *
+ * With `TTS_PROVIDER=polly`, a request Polly cannot serve (Serbian — see
+ * `polly.ts`; or a Polly API error) falls back to Google **unless**
+ * `TTS_POLLY_STRICT=true`. The fallback exists because Polly's language
+ * coverage is genuinely narrower than Cloud TTS's, and losing a locale's
+ * audio outright is worse than a provider split during migration. Set
+ * `TTS_POLLY_STRICT=true` in a GCP-shutdown rehearsal to prove there is no
+ * hidden Google dependency left — with it on, an unservable request returns
+ * null instead of quietly reaching back to GCP.
+ *
+ * Every fallback is logged. CLAUDE.md forbids silent provider fallback
+ * ("Never allow silent model fallback" / "IF model fallback occurs → THEN log
+ * explicitly"), and that rule applies here as much as to the LLM router.
+ */
+
+import { synthesizePolly, resolvePollyVoice, POLLY_PCM_SAMPLE_RATE_HZ } from './polly';
+
+export type TtsProviderName = 'google' | 'polly';
+
+/** Cloud TTS LINEAR16 rate the greeting bridge has always used. */
+export const GOOGLE_PCM_SAMPLE_RATE_HZ = 24_000;
+
+export function getTtsProvider(): TtsProviderName {
+  const raw = (process.env.TTS_PROVIDER || 'google').trim().toLowerCase();
+  if (raw === 'polly') return 'polly';
+  if (raw !== 'google' && raw !== '') {
+    console.warn(`[TTS] Unrecognised TTS_PROVIDER='${raw}' — defaulting to 'google'.`);
+  }
+  return 'google';
+}
+
+export function isPollyStrict(): boolean {
+  return (process.env.TTS_POLLY_STRICT || '').trim().toLowerCase() === 'true';
+}
+
+/**
+ * Sample rate the PCM path will actually produce for the active provider.
+ * Callers MUST use this (or the rate on the synthesis result) when building
+ * an `audio/pcm;rate=` mime — Polly cannot do 24kHz PCM.
+ */
+export function getPcmSampleRateHz(): number {
+  return getTtsProvider() === 'polly' ? POLLY_PCM_SAMPLE_RATE_HZ : GOOGLE_PCM_SAMPLE_RATE_HZ;
+}
+
+export interface TtsResult {
+  audioB64: string;
+  sampleRateHz: number;
+  voice: string;
+  languageCode: string;
+  provider: TtsProviderName;
+  /** Set when the request was served by a provider other than the configured one. */
+  fellBackFrom?: TtsProviderName;
+}
+
+/**
+ * Attempt synthesis on Polly. Returns null when Polly is not the configured
+ * provider, or cannot serve this request.
+ *
+ * Callers use this as a "try Polly first, else run your existing Google code"
+ * seam, which keeps the Google paths byte-for-byte unchanged when
+ * `TTS_PROVIDER` is unset — the safest possible shape for a migration that
+ * touches live voice.
+ */
+export async function tryPollySynthesis(opts: {
+  text: string;
+  lang: string;
+  format: 'mp3' | 'pcm';
+  speakingRate?: number;
+  /** Call-site label for logs, e.g. 'greeting-bridge'. */
+  callSite: string;
+}): Promise<TtsResult | null> {
+  if (getTtsProvider() !== 'polly') return null;
+
+  const started = Date.now();
+  const result = await synthesizePolly({
+    text: opts.text,
+    lang: opts.lang,
+    format: opts.format,
+    speakingRate: opts.speakingRate,
+  });
+
+  if (result) {
+    // CLAUDE.md rule 19: always log provider, model and latency for AI calls.
+    console.log(
+      `[TTS] provider=polly call_site=${opts.callSite} voice=${result.voice} ` +
+        `engine=${result.engine} lang=${result.languageCode} format=${opts.format} ` +
+        `rate_hz=${result.sampleRateHz} latency_ms=${Date.now() - started}`,
+    );
+    return {
+      audioB64: result.audioB64,
+      sampleRateHz: result.sampleRateHz,
+      voice: result.voice,
+      languageCode: result.languageCode,
+      provider: 'polly',
+    };
+  }
+
+  const unsupported = resolvePollyVoice(opts.lang) === null;
+  if (isPollyStrict()) {
+    console.warn(
+      `[TTS] provider=polly call_site=${opts.callSite} lang=${opts.lang} FAILED ` +
+        `(${unsupported ? 'unsupported_language' : 'synthesis_error'}) and ` +
+        `TTS_POLLY_STRICT=true — NOT falling back to Google. No audio returned.`,
+    );
+    return null;
+  }
+
+  // Explicit, never silent (CLAUDE.md: "IF model fallback occurs → THEN log explicitly").
+  console.warn(
+    `[TTS] FALLBACK polly→google call_site=${opts.callSite} lang=${opts.lang} ` +
+      `reason=${unsupported ? 'unsupported_language' : 'synthesis_error'} ` +
+      `latency_ms=${Date.now() - started}`,
+  );
+  return null;
+}

--- a/services/gateway/test/tts/polly-provider.test.ts
+++ b/services/gateway/test/tts/polly-provider.test.ts
@@ -1,0 +1,171 @@
+/**
+ * VTID-03495 — Amazon Polly TTS provider tests.
+ *
+ * Focus is on the three places Polly diverges from Cloud TTS in ways a
+ * "did we get bytes back" test would not catch:
+ *   1. Serbian must return null, never English audio.
+ *   2. PCM sample rate must be reported as 16kHz, never assumed 24kHz.
+ *   3. Speaking rate must become SSML prosody, with the text XML-escaped.
+ */
+
+import {
+  resolvePollyVoice,
+  buildPollyInput,
+  escapeSsml,
+  normalizeLang,
+  POLLY_UNSUPPORTED_LANGS,
+  POLLY_PCM_SAMPLE_RATE_HZ,
+  getPollyRegion,
+} from '../../src/services/tts/polly';
+import {
+  getTtsProvider,
+  getPcmSampleRateHz,
+  isPollyStrict,
+  GOOGLE_PCM_SAMPLE_RATE_HZ,
+} from '../../src/services/tts/tts-provider';
+
+describe('VTID-03495 Polly voice resolution', () => {
+  it('returns null for Serbian rather than silently substituting another language', () => {
+    // The whole point: fluent audio in the WRONG language is worse than none,
+    // because nothing downstream can tell it went wrong.
+    expect(resolvePollyVoice('sr')).toBeNull();
+    expect(resolvePollyVoice('sr-RS')).toBeNull();
+    expect(POLLY_UNSUPPORTED_LANGS.has('sr')).toBe(true);
+  });
+
+  it('resolves the supported languages with an explicit engine', () => {
+    for (const lang of ['en', 'de', 'fr', 'es', 'ar', 'zh', 'ru']) {
+      const v = resolvePollyVoice(lang);
+      expect(v).not.toBeNull();
+      // CLAUDE.md: "IF TTS is used → THEN specify model_name explicitly."
+      expect(v!.engine).toBeTruthy();
+      expect(v!.voiceId).toBeTruthy();
+      expect(v!.languageCode).toBeTruthy();
+    }
+  });
+
+  it('pins Russian to the standard engine (Polly has no neural Russian voice)', () => {
+    expect(resolvePollyVoice('ru')!.engine).toBe('standard');
+  });
+
+  it('falls back to English for languages outside the table but not on the unsupported list', () => {
+    expect(resolvePollyVoice('ja')!.languageCode).toBe('en-US');
+  });
+
+  it('normalizes locale tags down to a base language', () => {
+    expect(normalizeLang('de-DE')).toBe('de');
+    expect(normalizeLang('en_US')).toBe('en');
+    expect(normalizeLang('')).toBe('en');
+  });
+});
+
+describe('VTID-03495 speaking-rate → SSML', () => {
+  it('sends plain text at rate 1.0 (no SSML, no escaping surface)', () => {
+    const out = buildPollyInput('Guten Morgen', 1);
+    expect(out.textType).toBe('text');
+    expect(out.text).toBe('Guten Morgen');
+  });
+
+  it('wraps in prosody SSML for a non-default rate', () => {
+    const out = buildPollyInput('Guten Morgen', 1.15);
+    expect(out.textType).toBe('ssml');
+    expect(out.text).toContain('<prosody rate="115%">');
+    expect(out.text).toContain('</speak>');
+  });
+
+  it('XML-escapes text when building SSML so ampersands cannot break the payload', () => {
+    const out = buildPollyInput('Fish & Chips <b>', 1.5);
+    expect(out.textType).toBe('ssml');
+    expect(out.text).toContain('Fish &amp; Chips &lt;b&gt;');
+    // Raw '&' followed by a space would make Polly reject the whole request.
+    expect(out.text).not.toMatch(/&(?!amp;|lt;|gt;|quot;|apos;)/);
+  });
+
+  it('treats a non-finite or non-positive rate as 1.0 rather than emitting garbage SSML', () => {
+    expect(buildPollyInput('x', NaN).textType).toBe('text');
+    expect(buildPollyInput('x', 0).textType).toBe('text');
+    expect(buildPollyInput('x', -2).textType).toBe('text');
+  });
+
+  it('escapeSsml covers all five XML entities', () => {
+    expect(escapeSsml(`&<>"'`)).toBe('&amp;&lt;&gt;&quot;&apos;');
+  });
+});
+
+describe('VTID-03495 PCM sample rate', () => {
+  const original = process.env.TTS_PROVIDER;
+  afterEach(() => {
+    if (original === undefined) delete process.env.TTS_PROVIDER;
+    else process.env.TTS_PROVIDER = original;
+  });
+
+  it('Polly PCM is 16kHz — NOT the 24kHz Cloud TTS uses', () => {
+    // Playing 16kHz samples at 24kHz is a 1.5x speed-up: obvious to a
+    // listener, invisible to any assertion that only checks for bytes.
+    expect(POLLY_PCM_SAMPLE_RATE_HZ).toBe(16_000);
+    expect(GOOGLE_PCM_SAMPLE_RATE_HZ).toBe(24_000);
+    expect(POLLY_PCM_SAMPLE_RATE_HZ).not.toBe(GOOGLE_PCM_SAMPLE_RATE_HZ);
+  });
+
+  it('reports the PCM rate of whichever provider is active', () => {
+    process.env.TTS_PROVIDER = 'polly';
+    expect(getPcmSampleRateHz()).toBe(16_000);
+    process.env.TTS_PROVIDER = 'google';
+    expect(getPcmSampleRateHz()).toBe(24_000);
+  });
+});
+
+describe('VTID-03495 provider gating', () => {
+  const originalProvider = process.env.TTS_PROVIDER;
+  const originalStrict = process.env.TTS_POLLY_STRICT;
+  afterEach(() => {
+    if (originalProvider === undefined) delete process.env.TTS_PROVIDER;
+    else process.env.TTS_PROVIDER = originalProvider;
+    if (originalStrict === undefined) delete process.env.TTS_POLLY_STRICT;
+    else process.env.TTS_POLLY_STRICT = originalStrict;
+  });
+
+  it('defaults to google when TTS_PROVIDER is unset — deploying this code flips nothing', () => {
+    delete process.env.TTS_PROVIDER;
+    expect(getTtsProvider()).toBe('google');
+  });
+
+  it('falls back to google (loudly) on an unrecognised value rather than failing closed', () => {
+    process.env.TTS_PROVIDER = 'azure';
+    expect(getTtsProvider()).toBe('google');
+  });
+
+  it('selects polly only on the exact opt-in value, case-insensitively', () => {
+    process.env.TTS_PROVIDER = 'POLLY';
+    expect(getTtsProvider()).toBe('polly');
+  });
+
+  it('strict mode is off unless explicitly set to true', () => {
+    delete process.env.TTS_POLLY_STRICT;
+    expect(isPollyStrict()).toBe(false);
+    process.env.TTS_POLLY_STRICT = 'true';
+    expect(isPollyStrict()).toBe(true);
+  });
+});
+
+describe('VTID-03495 region resolution', () => {
+  const originals = { p: process.env.AWS_POLLY_REGION, r: process.env.AWS_REGION };
+  afterEach(() => {
+    if (originals.p === undefined) delete process.env.AWS_POLLY_REGION;
+    else process.env.AWS_POLLY_REGION = originals.p;
+    if (originals.r === undefined) delete process.env.AWS_REGION;
+    else process.env.AWS_REGION = originals.r;
+  });
+
+  it('defaults to eu-central-1, the only region with Vitana AWS infrastructure', () => {
+    delete process.env.AWS_POLLY_REGION;
+    delete process.env.AWS_REGION;
+    expect(getPollyRegion()).toBe('eu-central-1');
+  });
+
+  it('prefers the explicit override over the generic AWS region', () => {
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.AWS_POLLY_REGION = 'eu-west-1';
+    expect(getPollyRegion()).toBe('eu-west-1');
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03495` — Amazon Polly TTS provider (GCP cutover build 1 of 4)

**Layer:** AICOR (module `tts-polly`)

**Priority:** P2 — additive provider, gated off by default

---

## 📋 Summary

Build **1 of the 4** provider replacements that must exist before a GCP shutdown is possible (Polly → Titan image gen → Bedrock vision/tool-calling → Nova Sonic promotion).

All Google Cloud TTS synthesis now routes through a single seam, `services/tts/tts-provider.ts`, selected by **`TTS_PROVIDER=google|polly`, default `google`**. Same deliberate-opt-in shape as `BEDROCK_ROLE_ARN` (§2b) and `DEV_AUTOPILOT_JOB_CLOUD` (§1b). **Deploying this changes nothing.** An unrecognised value logs and falls back to `google` rather than failing closed and taking voice down.

---

## ✅ Changes

- [x] `services/tts/polly.ts` — Polly synthesis, voice/engine table, SSML prosody, explicit `Engine`
- [x] `services/tts/tts-provider.ts` — provider gate + logged fallback + `TTS_POLLY_STRICT`
- [x] Wired all 4 synthesis call sites
- [x] `scripts/tts/verify-polly-voices.ts` — validates the voice table against the live API
- [x] `@aws-sdk/client-polly` dependency
- [x] CLAUDE.md §2c + changelog row
- [x] 18 new tests

| Call site | Behaviour |
|---|---|
| ORB greeting bridge | Polly-first when configured |
| Reminder pre-render | Polly-first when configured |
| ORB `/tts` route | Polly-first when configured |
| Admin voice preview | **Explicit `provider:'polly'` param only** — deliberately ignores `TTS_PROVIDER`, so a preview can never lie about what it played |
| Cloud TTS debug route | **Google only, by design** — it is a Cloud-TTS diagnostic |

---

## 🚨 Three Polly divergences that are NOT cosmetic

**1. Polly has no Serbian voice, in any engine.** `sr` is a live locale (CLAUDE.md §13b lists DE/EN/ES/SR). `resolvePollyVoice('sr')` returns **null** and the caller falls back to Google — it does **not** substitute English, because fluent audio in the wrong language is worse than none: nothing downstream can detect it.

> ⚠️ **This is an unresolved GCP-shutdown blocker.** With GCP gone, Serbian users get no TTS from any configured provider. Recorded rather than worked around — it needs a decision (accept the gap, find a third provider, or keep GCP TTS alive for `sr`).

**2. Polly PCM is 8kHz/16kHz only — it cannot do the 24kHz** the greeting bridge used. `synthesizeGreetingBridgeAudioPcm()` now returns `{ audioB64, sampleRateHz }` and `orb-live.ts` builds `audio/pcm;rate=` from that value. Hardcoding 24kHz under Polly plays 16kHz samples **1.5× fast** — obvious to a listener, invisible to any test that only asserts bytes came back.

**3. Polly has no `speakingRate` field.** Rate becomes SSML `<prosody rate="N%">`, forcing `TextType:'ssml'` and XML-escaping. Plain text is kept at rate 1.0 to avoid the escaping surface on the common path.

Also: **Polly Russian is standard-engine only** (no neural voice) — a quality step down from `ru-RU-Wavenet-A`.

### Call-site subtlety worth reviewing

The `/tts` Polly attempt sits **above** the `!ttsClient` guard. In a GCP-free environment the Cloud TTS constructor fails, `ttsClient` stays null, and a Polly attempt placed after the guard would never run — the route would 503 despite Polly being healthy.

---

## 🧪 Testing

- [x] Manual testing completed — n/a, no live AWS credentials in this session (see below)
- [x] Automated tests added — 18 new, covering the Serbian null-return, the 16k≠24k rate split, SSML escaping, and provider gating
- [ ] Verified in staging/dev environment — **not possible here**; requires `TTS_PROVIDER=polly` + IAM on a real stack

Full gateway suite: **618/618 suites, 12080 passed**, 7 skipped, 6 todo, 42 snapshots — no regressions. `npm run build` clean.

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] No workflow files touched

### File Names
- [x] New files kebab-case (`polly.ts`, `tts-provider.ts`, `verify-polly-voices.ts`, `polly-provider.test.ts`)
- [x] Directory names kebab-case (`scripts/tts/`, `test/tts/`)
- [x] No files violate naming canon

### Code Standards
- [x] VTID referenced in file headers and commit message
- [x] Status/enum values lowercase (`'google' | 'polly'`)
- [x] Event fields snake_case (`mime_type`, `text_length`, `provider`)

### Cloud Run Deployments
- [x] No deploy config changed

### Documentation
- [x] VTID in commit message
- [x] CLAUDE.md §2c added + changelog row
- [x] No non-compliant files introduced

---

## ⚠️ Before flipping `TTS_PROVIDER=polly`

**The voice/engine table and the Serbian gap were derived from Polly's documented voice list and NOT verified against the live API** — this session had no working AWS credentials (`AWS_ACCESS_KEY_ID` was the placeholder `proxy-injected`). A voice existing does not mean it supports the `neural` engine I pinned; that is the most likely way this table is wrong.

Run first:
```
AWS_POLLY_REGION=eu-central-1 npx ts-node scripts/tts/verify-polly-voices.ts
```
It exits non-zero on any mismatch and re-checks whether Serbian has appeared since.

Also required: `polly:SynthesizeSpeech` on the gateway task role. Region resolves `AWS_POLLY_REGION` → `AWS_REGION` → `eu-central-1`.

---

## 🚨 Breaking Changes

One internal signature change: `synthesizeGreetingBridgeAudioPcm()` returns `{ audioB64, sampleRateHz }` instead of `string | null`. Single caller, updated in the same commit. No API or wire-format change — the `audio/pcm;rate=` mime the widget already reads now carries the true rate instead of a constant.

---

## 🔗 Links

- **Related:** `docs/vtids/VTID-PENDING-GCP-FULL-CUTOVER-SPEC.md` (preconditions 3–5b), VTID-03403 (Bedrock adapter, same gating pattern), VTID-03491 (previous build in this series)
- **Documentation:** CLAUDE.md §2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4afBxteyo8TMwS1zuZgTp)_