### PR TITLE
feat(images): add Amazon Titan Image Generator provider (VTID-03497)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -592,6 +592,71 @@ on the gateway task role (`AWS_POLLY_REGION`, else `AWS_REGION`, else
 
 ---
 
+## 2d. IMAGE GENERATION — AMAZON TITAN (VTID-03497)
+
+Build 3 of the 4 provider replacements gating a GCP shutdown, and the only
+one Claude cannot cover at all: Vertex **Imagen** generates images and no
+Anthropic model does, so this is a separate Bedrock adapter
+(`services/gateway/src/providers/titan-image.ts`), not an llm-router provider.
+
+Selected by **`IMAGE_PROVIDER=vertex|bedrock`, default `vertex`** — same
+deliberate-opt-in shape as `TTS_PROVIDER` (§2c). **Deploying this changes
+nothing.** Gated additionally on `BEDROCK_ROLE_ARN` (shared with §2b).
+
+**There are TWO Imagen consumers, not one.** The cutover changelog previously
+listed only the outpaint path; a Titan build covering just that would have
+left AI cover generation silently broken on a GCP shutdown:
+
+| Consumer | Imagen call | Titan taskType |
+|---|---|---|
+| `services/cover-image-outpaint.ts` | `EDIT_MODE_OUTPAINT` (capability model) | `OUTPAINTING` |
+| `services/intent-cover-service.ts` | text-to-image (`imagen-3.0-fast-generate-001`) | `TEXT_IMAGE` |
+
+### Three Titan constraints that are not cosmetic
+
+1. **Titan accepts only a fixed set of width/height pairs — 1600x900 is not
+   one of them.** `nearestTitanSize()` maps the cover canvas to **1280x720**
+   (largest supported 16:9) and the outpaint path upscales the result back to
+   1600x900. The mapping weights **aspect ratio above area** deliberately:
+   satisfying a 16:9 request with 1024x1024 would letterbox or crop the
+   subject — visually wrong, and invisible to a test that only asserts the
+   call succeeded.
+2. **Outpaint mask polarity is INVERTED vs Imagen, and is UNVERIFIED.**
+   Imagen: white = generate, black = keep. Titan is documented the other way
+   round, so `cover-image-outpaint.ts` negates its Imagen-convention mask
+   before sending. Get this backwards and the **subject** is regenerated while
+   the margins are preserved — a plausible-looking image that is completely
+   wrong. Because no AWS credentials were available to confirm it, the polarity
+   is env-overridable via **`TITAN_OUTPAINT_MASK_POLARITY=black-generates|white-generates`**
+   (default `black-generates`). **If outpaint output looks wrong, flip this first.**
+   The mask is resized with `kernel:'nearest'` so it stays strictly two-tone —
+   a bilinear resize yields grey edge pixels and a non-deterministic seam.
+3. **Titan is not offered in every region**, and the rest of Vitana's AWS
+   estate is `eu-central-1`. `AWS_TITAN_IMAGE_REGION` is its own var
+   (→ `AWS_BEDROCK_REGION` → `AWS_REGION` → `us-east-1`) rather than
+   inheriting blindly; a wrong region fails with an opaque model-not-found.
+
+### Also worth knowing
+
+- Titan reports content-policy blocks in an `error` field **on a 200 response**
+  — it does not throw. Treating that as success returns empty bytes; the
+  adapter maps it to `error:'blocked'` → `unsafe_prompt`.
+- **There is no server-side letterbox-blur fallback.** The cutover draft spec
+  cited one as Titan's safety net; that behaviour is the *frontend's*, and
+  `routes/cover-images.ts` simply returns an error when outpaint fails. Plan
+  accordingly — a Titan quality regression surfaces as a failed request, not a
+  degraded image.
+
+### Before flipping `IMAGE_PROVIDER=bedrock`
+
+Run `scripts/images/verify-titan-image.ts`. It checks model availability in
+the configured region, the 16:9 size mapping, and — most importantly — renders
+a deterministic red-subject probe that detects inverted mask polarity
+automatically rather than leaving it to eyeballing. Needs `bedrock:InvokeModel`
+on the Titan model for the gateway task role.
+
+---
+
 ## 3. DATABASE (SUPABASE)
 
 ### Critical Rules
@@ -1342,6 +1407,7 @@ Use these PATs with the GitHub REST API (`api.github.com`) for all PR and deploy
 
 | Date | Change | VTID |
 |------|--------|------|
+| 2026-08-05 | **Amazon Titan Image Generator — build 3 of the 4 that gate a GCP shutdown**, and the only one Claude cannot cover at all (Imagen generates images; no Anthropic model does). New `providers/titan-image.ts` behind `IMAGE_PROVIDER=vertex\|bedrock` (**default `vertex` — deploying this flips nothing**), see §2d. **Found a second Imagen consumer the cutover changelog had missed:** `intent-cover-service.ts` does plain text-to-image alongside `cover-image-outpaint.ts`'s outpainting — a Titan build covering only outpainting would have left AI cover generation silently broken on shutdown. Both are now wired (`TEXT_IMAGE` / `OUTPAINTING`). Three Titan constraints handled explicitly: (1) **Titan accepts only fixed width/height pairs and 1600x900 is not one** — `nearestTitanSize()` maps to 1280x720 and weights **aspect above area**, because satisfying 16:9 with a square would letterbox the subject invisibly; the outpaint path upscales back. (2) **Mask polarity is inverted vs Imagen and is UNVERIFIED** — white=generate for Imagen, black=generate for Titan; backwards means the *subject* is regenerated and the margins kept, a plausible-looking but totally wrong image. Env-overridable via `TITAN_OUTPAINT_MASK_POLARITY` so it can be corrected without a redeploy; mask resized with `kernel:'nearest'` to stay two-tone. (3) **Titan isn't offered in every region** — `AWS_TITAN_IMAGE_REGION` is its own var rather than inheriting eu-central-1. Also: Titan reports content-policy blocks in an `error` field **on a 200**, not by throwing. **Correction to the draft spec:** it cited an "existing letterbox-blur fallback" as Titan's safety net — that is the *frontend's* old behaviour; `routes/cover-images.ts` just returns an error, so there is no server-side safety net. `scripts/images/verify-titan-image.ts` checks region/model, the size mapping, and detects inverted mask polarity via a deterministic red-subject probe. 16 new tests; full suite 620/620 suites, 12105 passed. | VTID-03497 |
 | 2026-08-05 | **Bedrock adapter: vision + forced tool-calling — build 2 of the 4 that gate a GCP shutdown.** Removes the blanket `images/tools not supported` rejection in `bedrockAdapter` (§2b). Bedrock speaks the same Anthropic Messages API wire shape, so images become content blocks and `tools`/`forceTool` become `tools` + `tool_choice`, mirrored line-for-line from `anthropicAdapter` so the two stay diffable; `tool_use` responses surface as `AdapterResult.toolCall`. This is the piece `anthropic-vision-client.ts` (Shorts auto-metadata) needed — images **and** a forced `emit_short_metadata` call, the exact combination previously rejected. **Two latent bugs found and fixed while building, both silent:** (1) `tools` was on `BedrockInvokeRequest` but never serialized into the body — passing tools produced a plain completion with no tool call and no error; (2) text was read from `content[0].text`, which is **empty when a forced `tool_use` block is first**, so it would have returned empty text on every vision call. Also moved `BEDROCK_ROLE_ARN`/region reads from module-load to call-time, so setting the var on a task def no longer needs a process restart (and can be tested). Text-only calls still send a plain string `content`, byte-identical to VTID-03403. Still dormant until `BEDROCK_ROLE_ARN` is set and an operator points a stage at `'bedrock'` — deploying this changes no routing. 9 new tests; full suite 619/619 suites, 12089 passed. | VTID-03496 |
 | 2026-08-05 | **Amazon Polly TTS provider — build 1 of the 4 that gate a GCP shutdown.** New `services/tts/polly.ts` + `services/tts/tts-provider.ts` seam; all 4 Google Cloud TTS synthesis call sites route through it, selected by `TTS_PROVIDER=google\|polly` (**default `google` — deploying this flips nothing**). See §2c. Three Polly divergences that are NOT cosmetic: (1) **Polly has no Serbian voice in any engine** — `sr` is a live locale (§13b), so `resolvePollyVoice('sr')` returns null and falls back to Google rather than substituting English; with GCP gone, Serbian TTS has no provider at all, an unresolved shutdown blocker. (2) **Polly PCM is 8k/16k only, not 24k** — `synthesizeGreetingBridgeAudioPcm()` now returns `{audioB64, sampleRateHz}` and the `audio/pcm;rate=` mime is built from it; assuming 24kHz would play Polly audio 1.5× fast, audible to a user but invisible to a bytes-came-back test. (3) **No `speakingRate` field** — rate becomes SSML `<prosody>`, forcing XML-escaping (plain text kept at rate 1.0). Polly Russian is standard-engine only. Fallback polly→google is always logged; `TTS_POLLY_STRICT=true` disables it for shutdown rehearsals. The admin voice-preview route takes an explicit `provider:'polly'` param and deliberately ignores `TTS_PROVIDER` so previews can't lie; the Cloud-TTS debug route stays Google-only by design. **Voice table and the Serbian gap were derived from Polly's documented voice list, not verified against the live API** — the building session had no AWS credentials; confirm via `describe-voices` before flipping. 18 new tests. | VTID-03495 |
 | 2026-08-03 | **`orb_session_state` never existed in production — four ORB features were silently dead for ~2 months.** Investigating a live report of ORB voice failing on mobile, every session was found to emit `orb.session.audio_ready.acked` with `ok:false`. That `ok` is not the client's readiness — it is the return of `writeOrbSessionState()`, and the write was failing because `relation "orb_session_state" does not exist`. Migration `20260606000000_DEV_COMHU_0503_orb_session_state.sql` was authored but never applied (its own header: "Not executed from the sandbox"); the applied-migrations list jumps `20260605…` → `20260609…`. Because every helper in `orb-session-state.ts` fails soft by design (reads → `null`, writes → `{ok:false}`, never throws), nothing surfaced: the **audio-ready handshake** (greeting fell back to a blind 3s timer and could be spoken before the client could play it — the silent-ORB symptom), **close/reopen continuity**, the **pending autopilot CTA**, and **wake-brief opener rotation** were all inert. Applied the migration to prod; `audio_ready.acked` flipped `ok:false` → `ok:true` on the next live session with **no redeploy**, confirming the code had always been calling it correctly. Session telemetry that made this findable: 29 sessions ended `expired_ttl` at ~32 min with `turn_count:0` and `audio_in_chunks:0` while `audio_out` climbed normally — the model spoke, the user never heard it, so nobody ever replied. **Lesson worth keeping:** a fail-soft table with no health check is undetectable — `ok:false` in a payload nobody alerts on is not detection. Documented in `DATABASE_SCHEMA.md`. | VTID-03480 |

--- a/scripts/images/verify-titan-image.ts
+++ b/scripts/images/verify-titan-image.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env npx ts-node
+/**
+ * VTID-03497 — verify the Titan Image Generator assumptions against LIVE AWS.
+ *
+ * Three things in `providers/titan-image.ts` were derived from documentation
+ * and NOT confirmed against the API, because the session that wrote them had
+ * no AWS credentials. Run this before flipping `IMAGE_PROVIDER=bedrock`.
+ *
+ *   1. **Model availability in the chosen region.** Titan Image Generator is
+ *      not offered everywhere, and Vitana's estate is eu-central-1.
+ *   2. **The supported width/height table.** A wrong entry is a hard
+ *      ValidationException, so this is self-announcing — but better here than
+ *      on a user's cover upload.
+ *   3. **Outpaint mask polarity** — the one that fails SILENTLY in the sense
+ *      that bytes come back and look like a plausible image, just with the
+ *      subject regenerated and the margins preserved. This script renders a
+ *      deterministic probe: a red square on the left, mask covering the right
+ *      margin. If polarity is correct the red square SURVIVES; if inverted,
+ *      the red square is replaced and the margin is untouched.
+ *
+ * Usage:
+ *   BEDROCK_ROLE_ARN=... AWS_TITAN_IMAGE_REGION=us-east-1 \
+ *     npx ts-node scripts/images/verify-titan-image.ts
+ *
+ * Writes probe PNGs to /tmp/titan-verify-*.png for eyeballing. Exits non-zero
+ * on any failure that can be detected without a human looking.
+ */
+
+import sharp from 'sharp';
+import {
+  getTitanRegion,
+  getTitanModelId,
+  titanWhiteGenerates,
+  nearestTitanSize,
+  generateTitanImage,
+  outpaintTitanImage,
+  TITAN_SUPPORTED_SIZES,
+} from '../../services/gateway/src/providers/titan-image';
+
+async function main(): Promise<void> {
+  if (!process.env.BEDROCK_ROLE_ARN) {
+    console.error('[verify-titan] BEDROCK_ROLE_ARN is unset — nothing to verify against.');
+    process.exit(1);
+  }
+  console.log(`[verify-titan] region=${getTitanRegion()} model=${getTitanModelId()}`);
+  console.log(`[verify-titan] mask polarity: white_generates=${titanWhiteGenerates()}`);
+
+  let failures = 0;
+
+  // ---- 1. Model reachable + text-to-image at the cover aspect -------------
+  const size = nearestTitanSize(1600, 900);
+  console.log(`\n[1] TEXT_IMAGE at ${size.width}x${size.height} (mapped from 1600x900)`);
+  const gen = await generateTitanImage({
+    prompt: 'A calm sunrise over still water, photorealistic, no text',
+    width: 1600,
+    height: 900,
+  });
+  if (!gen.ok) {
+    console.error(`✗ TEXT_IMAGE failed: ${gen.error} — ${gen.message}`);
+    if (gen.error === 'invoke_failed' && /model|not found|access/i.test(gen.message)) {
+      console.error(
+        '  → Likely the model is not available in this region, or model access is not enabled\n' +
+          '    for the account. Check Bedrock → Model access, and try AWS_TITAN_IMAGE_REGION=us-east-1.',
+      );
+    }
+    failures++;
+  } else {
+    const meta = await sharp(gen.pngBytes).metadata();
+    console.log(`✓ TEXT_IMAGE ok — ${meta.width}x${meta.height}, ${gen.upstream_ms}ms`);
+    if (meta.width !== size.width || meta.height !== size.height) {
+      console.error(`✗ returned ${meta.width}x${meta.height}, expected ${size.width}x${size.height}`);
+      failures++;
+    }
+    await sharp(gen.pngBytes).toFile('/tmp/titan-verify-text-image.png');
+  }
+
+  // ---- 2. Every entry in the size table is actually accepted --------------
+  // Only spot-checked: a full sweep is 15 generations and real money. The
+  // cover path only ever uses the 16:9 entry, so that one is the load-bearing
+  // case and is covered by [1] above.
+  console.log(`\n[2] size table has ${TITAN_SUPPORTED_SIZES.length} entries (spot-checked via [1])`);
+
+  // ---- 3. Mask polarity probe -------------------------------------------
+  console.log('\n[3] OUTPAINTING mask-polarity probe');
+  const W = size.width;
+  const H = size.height;
+  const subjectW = Math.round(W * 0.5);
+
+  // Canvas: solid red on the LEFT half (the "subject"), black on the right.
+  const canvas = await sharp({
+    create: { width: W, height: H, channels: 3, background: { r: 0, g: 0, b: 0 } },
+  })
+    .composite([
+      {
+        input: await sharp({
+          create: { width: subjectW, height: H, channels: 3, background: { r: 255, g: 0, b: 0 } },
+        })
+          .png()
+          .toBuffer(),
+        left: 0,
+        top: 0,
+      },
+    ])
+    .png()
+    .toBuffer();
+
+  // Imagen-convention mask: WHITE where we want generation (right margin),
+  // BLACK over the subject. Then apply the same inversion the production
+  // path applies, so this probe tests the REAL code path's polarity.
+  let mask = await sharp({
+    create: { width: W, height: H, channels: 3, background: { r: 255, g: 255, b: 255 } },
+  })
+    .composite([
+      {
+        input: await sharp({
+          create: { width: subjectW, height: H, channels: 3, background: { r: 0, g: 0, b: 0 } },
+        })
+          .png()
+          .toBuffer(),
+        left: 0,
+        top: 0,
+      },
+    ])
+    .png()
+    .toBuffer();
+  if (!titanWhiteGenerates()) {
+    mask = await sharp(mask).negate({ alpha: false }).png().toBuffer();
+  }
+
+  const out = await outpaintTitanImage({
+    imagePng: canvas,
+    maskPng: mask,
+    prompt: 'Extend the scene naturally to the right. Photorealistic.',
+    width: W,
+    height: H,
+  });
+
+  if (!out.ok) {
+    console.error(`✗ OUTPAINTING failed: ${out.error} — ${out.message}`);
+    failures++;
+  } else {
+    await sharp(out.pngBytes).toFile('/tmp/titan-verify-outpaint.png');
+    // Sample the centre of the left half: it should STILL be red if the
+    // subject was preserved.
+    const { data } = await sharp(out.pngBytes)
+      .extract({ left: Math.round(subjectW / 2) - 4, top: Math.round(H / 2) - 4, width: 8, height: 8 })
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+    let r = 0, g = 0, b = 0;
+    const px = data.length / 3;
+    for (let i = 0; i < data.length; i += 3) {
+      r += data[i]; g += data[i + 1]; b += data[i + 2];
+    }
+    r /= px; g /= px; b /= px;
+    const subjectPreserved = r > 150 && g < 100 && b < 100;
+    console.log(`  sampled subject region: rgb(${r.toFixed(0)}, ${g.toFixed(0)}, ${b.toFixed(0)})`);
+    if (subjectPreserved) {
+      console.log('✓ subject PRESERVED — mask polarity is correct as configured.');
+    } else {
+      console.error(
+        '✗ subject was REGENERATED — mask polarity is INVERTED.\n' +
+          `  → Set TITAN_OUTPAINT_MASK_POLARITY=${titanWhiteGenerates() ? 'black-generates' : 'white-generates'}\n` +
+          '    and re-run. Inspect /tmp/titan-verify-outpaint.png to confirm.',
+      );
+      failures++;
+    }
+  }
+
+  if (failures > 0) {
+    console.error(`\n[verify-titan] ${failures} failure(s) — do NOT flip IMAGE_PROVIDER=bedrock yet.`);
+    process.exit(1);
+  }
+  console.log('\n[verify-titan] all checks passed. Probe images in /tmp/titan-verify-*.png.');
+}
+
+main().catch((err) => {
+  console.error('[verify-titan] failed:', err?.message ?? err);
+  process.exit(1);
+});

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -452,3 +452,26 @@ WATCHER_REMINDERS_ENABLED=false
 # then the canonical prod host. The hook is a strict no-op unless
 # WATCHER_SESSION_TOKEN is also set.
 WATCHER_GATEWAY_URL=
+
+# VTID-03497: Amazon Titan Image Generator (CLAUDE.md §2d). Build 3 of the 4
+# provider replacements gating a GCP shutdown. Replaces Vertex Imagen for BOTH
+# consumers: cover-image-outpaint.ts (OUTPAINTING) and intent-cover-service.ts
+# (TEXT_IMAGE).
+# IMAGE_PROVIDER: OPTIONAL — defaults to 'vertex' in code, so leaving this
+#   unset changes nothing. An unrecognised value logs and falls back to
+#   'vertex'. Also requires BEDROCK_ROLE_ARN (above) to be set.
+IMAGE_PROVIDER=vertex
+# AWS_TITAN_IMAGE_REGION: its OWN var on purpose — Titan Image Generator is
+#   not offered in every region and the rest of this estate is eu-central-1.
+#   Falls back to AWS_BEDROCK_REGION, then AWS_REGION, then us-east-1.
+AWS_TITAN_IMAGE_REGION=us-east-1
+# TITAN_IMAGE_MODEL_ID: OPTIONAL — defaults to amazon.titan-image-generator-v2:0.
+TITAN_IMAGE_MODEL_ID=amazon.titan-image-generator-v2:0
+# TITAN_OUTPAINT_MASK_POLARITY: black-generates (default) | white-generates.
+#   Imagen's convention is white=generate; Titan is documented inverted, so the
+#   outpaint path negates its mask by default. This is UNVERIFIED against the
+#   live API (no AWS credentials when it was written) and is env-overridable
+#   precisely so it can be corrected without a redeploy. If outpaint output
+#   looks wrong — subject regenerated, margins preserved — FLIP THIS FIRST.
+#   Verify with scripts/images/verify-titan-image.ts.
+TITAN_OUTPAINT_MASK_POLARITY=black-generates

--- a/services/gateway/src/providers/titan-image.ts
+++ b/services/gateway/src/providers/titan-image.ts
@@ -1,0 +1,287 @@
+/**
+ * VTID-03497 — Amazon Titan Image Generator provider (Bedrock).
+ *
+ * Build 3 of the 4 provider replacements that must exist before a GCP
+ * shutdown (Polly ✅ → Bedrock vision/tools ✅ → **Titan image gen** → Nova
+ * Sonic promotion). This is the one capability Claude cannot cover at all:
+ * Vertex **Imagen** generates images, and no Anthropic model does.
+ *
+ * Two GCP consumers, not one (CLAUDE.md's changelog listed only the first):
+ *   1. `cover-image-outpaint.ts` — 16:9 OUTPAINTING with a user-supplied mask
+ *   2. `intent-cover-service.ts` — plain TEXT_IMAGE generation
+ * Titan supports both task types, so both are mappable.
+ *
+ * Selected by `IMAGE_PROVIDER=vertex|bedrock`, **default `vertex`** — same
+ * deliberate-opt-in shape as `TTS_PROVIDER` (§2c) and `BEDROCK_ROLE_ARN`
+ * (§2b). Importing or deploying this changes nothing.
+ *
+ * ## Three Titan constraints that are NOT cosmetic
+ *
+ * 1. **Titan only accepts a fixed set of width/height pairs.** The outpaint
+ *    canvas is 1600x900, which is NOT one of them. `nearestTitanSize()` maps
+ *    to 1280x720 (the largest supported 16:9) and the caller upscales the
+ *    result back. Sending 1600x900 straight through is a hard ValidationException,
+ *    not a silent downgrade — but picking a non-16:9 size instead would letterbox
+ *    the subject invisibly, so the mapping is aspect-aware and tested.
+ *
+ * 2. **Mask polarity is INVERTED relative to Imagen — and is UNVERIFIED.**
+ *    Imagen's documented convention (see `cover-image-outpaint.ts`) is
+ *    white = generate, black = keep. Titan's OUTPAINTING `maskImage` is
+ *    documented the other way round: the masked (black) region is what gets
+ *    regenerated. Getting this backwards regenerates the SUBJECT and keeps
+ *    the margins — visually catastrophic, but a test that only asserts "bytes
+ *    came back" passes happily. Because this session had **no AWS credentials
+ *    to confirm it against the live API**, the polarity is a named constant
+ *    with an env override (`TITAN_OUTPAINT_MASK_POLARITY`) so it can be
+ *    corrected without a code change and redeploy. **Check this first if
+ *    outpaint output looks wrong.**
+ *
+ * 3. **Region availability differs from the rest of Vitana's AWS estate.**
+ *    Everything else here is `eu-central-1`; Titan Image Generator is not
+ *    offered in every region. `AWS_TITAN_IMAGE_REGION` is therefore its own
+ *    var (falling back to the Bedrock region, then `us-east-1`) rather than
+ *    inheriting blindly — a wrong region fails at call time with an opaque
+ *    model-not-found rather than anything that reads as "unsupported here".
+ *
+ * Verify all three with `scripts/images/verify-titan-image.ts` before
+ * flipping `IMAGE_PROVIDER=bedrock`.
+ */
+
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+
+export type ImageProviderName = 'vertex' | 'bedrock';
+
+/** Provider gate. Default `vertex` — deploying this flips nothing. */
+export function getImageProvider(): ImageProviderName {
+  const raw = (process.env.IMAGE_PROVIDER || 'vertex').trim().toLowerCase();
+  if (raw === 'bedrock') return 'bedrock';
+  if (raw !== 'vertex' && raw !== '') {
+    console.warn(`[TITAN-IMAGE] Unrecognised IMAGE_PROVIDER='${raw}' — defaulting to 'vertex'.`);
+  }
+  return 'vertex';
+}
+
+export function getTitanRegion(): string {
+  return (
+    process.env.AWS_TITAN_IMAGE_REGION ||
+    process.env.AWS_BEDROCK_REGION ||
+    process.env.AWS_REGION ||
+    'us-east-1'
+  );
+}
+
+export function getTitanModelId(): string {
+  return process.env.TITAN_IMAGE_MODEL_ID || 'amazon.titan-image-generator-v2:0';
+}
+
+/**
+ * Whether a WHITE mask pixel means "generate here".
+ *
+ * Imagen: white generates. Titan is documented inverted (black generates),
+ * hence the default. UNVERIFIED against the live API — see the header note.
+ * Set `TITAN_OUTPAINT_MASK_POLARITY=white-generates` to flip without a deploy.
+ */
+export function titanWhiteGenerates(): boolean {
+  const raw = (process.env.TITAN_OUTPAINT_MASK_POLARITY || 'black-generates').trim().toLowerCase();
+  return raw === 'white-generates';
+}
+
+/**
+ * Width/height pairs Titan Image Generator accepts. Anything else is a
+ * ValidationException. Kept as an explicit table so the constraint is
+ * greppable rather than buried in a resize call.
+ */
+export const TITAN_SUPPORTED_SIZES: ReadonlyArray<{ width: number; height: number }> = [
+  { width: 1024, height: 1024 },
+  { width: 768, height: 768 },
+  { width: 512, height: 512 },
+  { width: 768, height: 1152 },
+  { width: 1152, height: 768 },
+  { width: 768, height: 1280 },
+  { width: 1280, height: 768 },
+  { width: 640, height: 1408 },
+  { width: 1408, height: 640 },
+  { width: 640, height: 1536 },
+  { width: 1536, height: 640 },
+  { width: 720, height: 1280 },
+  { width: 1280, height: 720 },
+  { width: 640, height: 1152 },
+  { width: 1152, height: 640 },
+];
+
+/**
+ * Pick the supported Titan size closest to `width`x`height`, preferring the
+ * nearest ASPECT RATIO first and only then the largest area.
+ *
+ * Aspect is weighted first on purpose: a 16:9 request satisfied by a square
+ * canvas would silently letterbox or crop the subject, which is far worse
+ * than a modest resolution drop. 1600x900 (the cover canvas) maps to
+ * 1280x720, not 1024x1024.
+ */
+export function nearestTitanSize(
+  width: number,
+  height: number,
+): { width: number; height: number } {
+  const targetAspect = width / height;
+  let best = TITAN_SUPPORTED_SIZES[0];
+  let bestScore = Number.POSITIVE_INFINITY;
+  for (const size of TITAN_SUPPORTED_SIZES) {
+    const aspectErr = Math.abs(size.width / size.height - targetAspect) / targetAspect;
+    // Area term only breaks ties between comparable aspects (hence the
+    // small weight) — it must never outvote a better aspect match.
+    const areaErr = 1 - Math.min(size.width * size.height, width * height) /
+      Math.max(size.width * size.height, width * height);
+    const score = aspectErr * 100 + areaErr;
+    if (score < bestScore) {
+      bestScore = score;
+      best = size;
+    }
+  }
+  return best;
+}
+
+export interface TitanImageSuccess {
+  ok: true;
+  /** Raw PNG bytes of the first returned image. */
+  pngBytes: Buffer;
+  model: string;
+  upstream_ms: number;
+}
+
+export interface TitanImageError {
+  ok: false;
+  error: 'not_configured' | 'invoke_failed' | 'blocked' | 'empty_output';
+  message: string;
+}
+
+export type TitanImageResult = TitanImageSuccess | TitanImageError;
+
+let titanClient: BedrockRuntimeClient | null = null;
+function getTitanClient(): BedrockRuntimeClient {
+  if (!titanClient) {
+    // Same HTTP/1.1 forcing as providers/bedrock.ts — the SDK's default
+    // handler can negotiate HTTP/2, which breaks in Cloud Run's sandboxed
+    // network stack (NGHTTP2_PROTOCOL_ERROR, confirmed under VTID-03403).
+    titanClient = new BedrockRuntimeClient({
+      region: getTitanRegion(),
+      requestHandler: new NodeHttpHandler(),
+    });
+  }
+  return titanClient;
+}
+
+/** Test seam — drop the memoized client so a new region applies. */
+export function resetTitanClientForTests(): void {
+  titanClient = null;
+}
+
+/** Shared invoke + response parsing for both task types. */
+async function invokeTitan(body: Record<string, unknown>): Promise<TitanImageResult> {
+  if (!process.env.BEDROCK_ROLE_ARN) {
+    return {
+      ok: false,
+      error: 'not_configured',
+      message: 'BEDROCK_ROLE_ARN not set; Titan image generation is dormant (VTID-03497)',
+    };
+  }
+
+  const model = getTitanModelId();
+  const start = Date.now();
+  try {
+    const resp = await getTitanClient().send(
+      new InvokeModelCommand({
+        modelId: model,
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: JSON.stringify(body),
+      }),
+    );
+    const payload = JSON.parse(new TextDecoder().decode(resp.body)) as {
+      images?: string[];
+      error?: string | null;
+    };
+    // Titan reports content-policy blocks in an `error` field on a 200 —
+    // it does NOT throw. Treating that as success would return empty bytes.
+    if (payload.error) {
+      return { ok: false, error: 'blocked', message: String(payload.error).slice(0, 300) };
+    }
+    const b64 = payload.images?.[0];
+    if (!b64) {
+      return { ok: false, error: 'empty_output', message: 'Titan returned no image' };
+    }
+    return {
+      ok: true,
+      pngBytes: Buffer.from(b64, 'base64'),
+      model,
+      upstream_ms: Date.now() - start,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: 'invoke_failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/** Text-to-image. Replaces `intent-cover-service.ts`'s Imagen generate call. */
+export async function generateTitanImage(opts: {
+  prompt: string;
+  width: number;
+  height: number;
+  negativePrompt?: string;
+  cfgScale?: number;
+  seed?: number;
+}): Promise<TitanImageResult> {
+  const size = nearestTitanSize(opts.width, opts.height);
+  return invokeTitan({
+    taskType: 'TEXT_IMAGE',
+    textToImageParams: {
+      text: opts.prompt,
+      // Titan rejects an empty-string negativeText, so omit rather than blank.
+      ...(opts.negativePrompt ? { negativeText: opts.negativePrompt } : {}),
+    },
+    imageGenerationConfig: {
+      numberOfImages: 1,
+      width: size.width,
+      height: size.height,
+      cfgScale: opts.cfgScale ?? 8.0,
+      ...(typeof opts.seed === 'number' ? { seed: opts.seed } : {}),
+    },
+  });
+}
+
+/**
+ * Outpainting. Replaces `cover-image-outpaint.ts`'s Imagen EDIT_MODE_OUTPAINT.
+ *
+ * `imagePng`/`maskPng` MUST already be at a Titan-supported size — the caller
+ * owns resizing, because it also owns upscaling the result back and knows the
+ * final canvas. `maskPng` polarity must match `titanWhiteGenerates()`; see the
+ * header note, this is the most likely thing to be wrong on first live run.
+ */
+export async function outpaintTitanImage(opts: {
+  imagePng: Buffer;
+  maskPng: Buffer;
+  prompt: string;
+  width: number;
+  height: number;
+  /** 'DEFAULT' blends softly; 'PRECISE' honours the mask edge more strictly. */
+  mode?: 'DEFAULT' | 'PRECISE';
+}): Promise<TitanImageResult> {
+  return invokeTitan({
+    taskType: 'OUTPAINTING',
+    outPaintingParams: {
+      image: opts.imagePng.toString('base64'),
+      maskImage: opts.maskPng.toString('base64'),
+      text: opts.prompt,
+      outPaintingMode: opts.mode ?? 'DEFAULT',
+    },
+    imageGenerationConfig: {
+      numberOfImages: 1,
+      width: opts.width,
+      height: opts.height,
+      cfgScale: 8.0,
+    },
+  });
+}

--- a/services/gateway/src/services/cover-image-outpaint.ts
+++ b/services/gateway/src/services/cover-image-outpaint.ts
@@ -27,6 +27,13 @@
 import { createClient } from '@supabase/supabase-js';
 import { GoogleAuth } from 'google-auth-library';
 import sharp from 'sharp';
+// VTID-03497: Titan seam. No-ops unless IMAGE_PROVIDER=bedrock.
+import {
+  getImageProvider,
+  nearestTitanSize,
+  outpaintTitanImage,
+  titanWhiteGenerates,
+} from '../providers/titan-image';
 
 const BUCKET = process.env.INTENT_COVERS_BUCKET ?? 'intent-covers';
 
@@ -189,14 +196,82 @@ async function composeCanvasAndMask(
 }
 
 /**
+ * VTID-03497 — Amazon Titan outpainting, used when IMAGE_PROVIDER=bedrock.
+ *
+ * Two adaptations Imagen does not need:
+ *
+ * 1. **Resize.** Titan accepts only a fixed set of dimensions and 1600x900 is
+ *    not one of them. We downscale canvas+mask to the nearest supported 16:9
+ *    (1280x720) and upscale the result back to 1600x900. The mask is resized
+ *    with `kernel: 'nearest'` so it stays strictly two-tone — a bilinear
+ *    resize would produce grey edge pixels, and a partially-grey mask makes
+ *    the seam between kept and generated regions non-deterministic.
+ *
+ * 2. **Mask polarity.** This module builds an Imagen-convention mask (WHITE =
+ *    generate, BLACK = keep). Titan is documented inverted, so we invert
+ *    unless `TITAN_OUTPAINT_MASK_POLARITY=white-generates` says otherwise.
+ *    UNVERIFIED against the live API — if outpaint output looks wrong (the
+ *    subject regenerated, margins preserved), this is the first thing to flip.
+ */
+async function callTitanOutpaint(canvasPng: Buffer, maskPng: Buffer): Promise<Buffer> {
+  const target = nearestTitanSize(OUT_W, OUT_H);
+
+  const canvasResized = await sharp(canvasPng)
+    .resize(target.width, target.height, { fit: 'fill' })
+    .png()
+    .toBuffer();
+
+  let maskResized = await sharp(maskPng)
+    .resize(target.width, target.height, { fit: 'fill', kernel: 'nearest' })
+    .png()
+    .toBuffer();
+
+  if (!titanWhiteGenerates()) {
+    // Imagen mask (white=generate) → Titan mask (black=generate).
+    maskResized = await sharp(maskResized).negate({ alpha: false }).png().toBuffer();
+  }
+
+  const result = await outpaintTitanImage({
+    imagePng: canvasResized,
+    maskPng: maskResized,
+    prompt: OUTPAINT_PROMPT,
+    width: target.width,
+    height: target.height,
+  });
+
+  if (!result.ok) {
+    if (result.error === 'blocked') {
+      throw new CoverOutpaintError('unsafe_prompt', result.message);
+    }
+    throw new CoverOutpaintError('provider_failed', `titan ${result.error}: ${result.message}`);
+  }
+
+  console.log(
+    `[cover-outpaint] provider=bedrock model=${result.model} ` +
+      `titan_size=${target.width}x${target.height} upscaled_to=${OUT_W}x${OUT_H} ` +
+      `latency_ms=${result.upstream_ms}`,
+  );
+
+  // Back up to the canonical canvas so an outpaint result is
+  // indistinguishable in size from a passthrough/crop result.
+  return sharp(result.pngBytes).resize(OUT_W, OUT_H, { fit: 'fill' }).png().toBuffer();
+}
+
+/**
  * Hit the Vertex Imagen capability model in outpaint mode.
  * Throws CoverOutpaintError on any provider/network failure so the
  * caller can fall back gracefully.
+ *
+ * VTID-03497: dispatches to Titan when IMAGE_PROVIDER=bedrock. Default
+ * remains `vertex` — deploying this changes nothing.
  */
 async function callImagenOutpaint(
   canvasPng: Buffer,
   maskPng: Buffer,
 ): Promise<Buffer> {
+  if (getImageProvider() === 'bedrock') {
+    return callTitanOutpaint(canvasPng, maskPng);
+  }
   if (!VERTEX_PROJECT) throw new CoverOutpaintError('provider_failed', 'gcp_project_unset');
 
   let token: string;

--- a/services/gateway/src/services/intent-cover-service.ts
+++ b/services/gateway/src/services/intent-cover-service.ts
@@ -30,6 +30,8 @@ import { GoogleAuth } from 'google-auth-library';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { createHash } from 'node:crypto';
+// VTID-03497: Titan seam. No-ops unless IMAGE_PROVIDER=bedrock.
+import { getImageProvider, generateTitanImage } from '../providers/titan-image';
 
 export type CoverTheme =
   | 'dance'
@@ -280,6 +282,31 @@ async function uploadFallbackCover(args: {
 }
 
 async function generateAiCover(theme: CoverTheme, gender: Gender): Promise<Buffer> {
+  // VTID-03497: Titan text-to-image when IMAGE_PROVIDER=bedrock. This is the
+  // SECOND Imagen consumer — CLAUDE.md's cutover changelog listed only
+  // cover-image-outpaint.ts, so a Titan build that covered outpainting alone
+  // would have left AI cover generation silently broken on a GCP shutdown.
+  // Default remains `vertex`; deploying this changes nothing.
+  if (getImageProvider() === 'bedrock') {
+    const result = await generateTitanImage({
+      prompt: buildCoverPrompt(theme, gender),
+      // 16:9, mapped by nearestTitanSize() to Titan's supported 1280x720.
+      width: 1600,
+      height: 900,
+    });
+    if (!result.ok) {
+      if (result.error === 'blocked') {
+        throw new CoverGenError('unsafe_prompt', result.message);
+      }
+      throw new CoverGenError('provider_failed', `titan ${result.error}: ${result.message}`);
+    }
+    console.log(
+      `[intent-cover] provider=bedrock model=${result.model} theme=${theme} ` +
+        `latency_ms=${result.upstream_ms}`,
+    );
+    return result.pngBytes;
+  }
+
   if (!VERTEX_PROJECT) throw new CoverGenError('provider_failed', 'gcp_project_unset');
 
   let token: string;

--- a/services/gateway/test/providers/titan-image.test.ts
+++ b/services/gateway/test/providers/titan-image.test.ts
@@ -1,0 +1,180 @@
+/**
+ * VTID-03497 — Amazon Titan Image Generator provider tests.
+ *
+ * Build 3 of the 4 provider replacements gating a GCP shutdown, and the one
+ * capability Claude cannot cover at all (Vertex Imagen generates images; no
+ * Anthropic model does).
+ *
+ * The interesting tests here are the size mapping and the mask polarity —
+ * both are places where a wrong answer produces a VISUALLY broken image that
+ * a "did bytes come back" assertion happily passes.
+ */
+
+import {
+  getImageProvider,
+  getTitanRegion,
+  getTitanModelId,
+  titanWhiteGenerates,
+  nearestTitanSize,
+  generateTitanImage,
+  outpaintTitanImage,
+  TITAN_SUPPORTED_SIZES,
+} from '../../src/providers/titan-image';
+
+describe('VTID-03497 provider gating', () => {
+  const original = process.env.IMAGE_PROVIDER;
+  afterEach(() => {
+    if (original === undefined) delete process.env.IMAGE_PROVIDER;
+    else process.env.IMAGE_PROVIDER = original;
+  });
+
+  it('defaults to vertex — deploying this code flips nothing', () => {
+    delete process.env.IMAGE_PROVIDER;
+    expect(getImageProvider()).toBe('vertex');
+  });
+
+  it('selects bedrock only on the exact opt-in value, case-insensitively', () => {
+    process.env.IMAGE_PROVIDER = 'BEDROCK';
+    expect(getImageProvider()).toBe('bedrock');
+  });
+
+  it('falls back to vertex on an unrecognised value rather than failing closed', () => {
+    process.env.IMAGE_PROVIDER = 'dalle';
+    expect(getImageProvider()).toBe('vertex');
+  });
+});
+
+describe('VTID-03497 nearestTitanSize', () => {
+  it('maps the 1600x900 cover canvas to 1280x720, not a square', () => {
+    // The whole point: Titan does not accept 1600x900. Satisfying it with
+    // 1024x1024 would letterbox or crop the subject — visually wrong, and
+    // invisible to a test that only checks the call succeeded.
+    expect(nearestTitanSize(1600, 900)).toEqual({ width: 1280, height: 720 });
+  });
+
+  it('always returns a size Titan actually accepts', () => {
+    for (const [w, h] of [[1600, 900], [1080, 1920], [500, 500], [3000, 1000], [1, 4]]) {
+      const out = nearestTitanSize(w, h);
+      expect(TITAN_SUPPORTED_SIZES).toContainEqual(out);
+    }
+  });
+
+  it('preserves orientation — a portrait request never maps to landscape', () => {
+    const out = nearestTitanSize(1080, 1920);
+    expect(out.height).toBeGreaterThan(out.width);
+  });
+
+  it('preserves orientation — a landscape request never maps to portrait', () => {
+    const out = nearestTitanSize(1920, 1080);
+    expect(out.width).toBeGreaterThan(out.height);
+  });
+
+  it('maps a square request to a square size', () => {
+    const out = nearestTitanSize(900, 900);
+    expect(out.width).toBe(out.height);
+  });
+
+  it('weights aspect above area — an extreme panorama keeps its shape', () => {
+    const out = nearestTitanSize(3000, 700); // ~4.3:1
+    expect(out.width / out.height).toBeGreaterThan(2);
+  });
+});
+
+describe('VTID-03497 mask polarity', () => {
+  const original = process.env.TITAN_OUTPAINT_MASK_POLARITY;
+  afterEach(() => {
+    if (original === undefined) delete process.env.TITAN_OUTPAINT_MASK_POLARITY;
+    else process.env.TITAN_OUTPAINT_MASK_POLARITY = original;
+  });
+
+  it('defaults to black-generates (inverted vs Imagen)', () => {
+    // Imagen: white = generate. Titan is documented the other way round, so
+    // cover-image-outpaint.ts inverts its Imagen-convention mask by default.
+    // Getting this backwards regenerates the SUBJECT and keeps the margins.
+    delete process.env.TITAN_OUTPAINT_MASK_POLARITY;
+    expect(titanWhiteGenerates()).toBe(false);
+  });
+
+  it('can be flipped by env without a code change or redeploy', () => {
+    // This override exists because the polarity is UNVERIFIED against the
+    // live API — no AWS credentials were available when it was written.
+    process.env.TITAN_OUTPAINT_MASK_POLARITY = 'white-generates';
+    expect(titanWhiteGenerates()).toBe(true);
+  });
+});
+
+describe('VTID-03497 region and model resolution', () => {
+  const originals = {
+    titan: process.env.AWS_TITAN_IMAGE_REGION,
+    bedrock: process.env.AWS_BEDROCK_REGION,
+    aws: process.env.AWS_REGION,
+    model: process.env.TITAN_IMAGE_MODEL_ID,
+  };
+  afterEach(() => {
+    for (const [key, val] of [
+      ['AWS_TITAN_IMAGE_REGION', originals.titan],
+      ['AWS_BEDROCK_REGION', originals.bedrock],
+      ['AWS_REGION', originals.aws],
+      ['TITAN_IMAGE_MODEL_ID', originals.model],
+    ] as const) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  it('has its OWN region var, because Titan is not offered in every region', () => {
+    // Everything else in Vitana's AWS estate is eu-central-1; inheriting it
+    // blindly would fail at call time with an opaque model-not-found.
+    process.env.AWS_BEDROCK_REGION = 'eu-central-1';
+    process.env.AWS_TITAN_IMAGE_REGION = 'us-east-1';
+    expect(getTitanRegion()).toBe('us-east-1');
+  });
+
+  it('falls back bedrock region → AWS_REGION → us-east-1', () => {
+    delete process.env.AWS_TITAN_IMAGE_REGION;
+    process.env.AWS_BEDROCK_REGION = 'eu-west-1';
+    expect(getTitanRegion()).toBe('eu-west-1');
+
+    delete process.env.AWS_BEDROCK_REGION;
+    process.env.AWS_REGION = 'ap-northeast-1';
+    expect(getTitanRegion()).toBe('ap-northeast-1');
+
+    delete process.env.AWS_REGION;
+    expect(getTitanRegion()).toBe('us-east-1');
+  });
+
+  it('defaults to the Titan v2 model id and honours an override', () => {
+    delete process.env.TITAN_IMAGE_MODEL_ID;
+    expect(getTitanModelId()).toBe('amazon.titan-image-generator-v2:0');
+    process.env.TITAN_IMAGE_MODEL_ID = 'amazon.titan-image-generator-v1';
+    expect(getTitanModelId()).toBe('amazon.titan-image-generator-v1');
+  });
+});
+
+describe('VTID-03497 configuration gate', () => {
+  const original = process.env.BEDROCK_ROLE_ARN;
+  afterEach(() => {
+    if (original === undefined) delete process.env.BEDROCK_ROLE_ARN;
+    else process.env.BEDROCK_ROLE_ARN = original;
+  });
+
+  it('generate reports not_configured without BEDROCK_ROLE_ARN', async () => {
+    delete process.env.BEDROCK_ROLE_ARN;
+    const res = await generateTitanImage({ prompt: 'a calm sunrise', width: 1600, height: 900 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('not_configured');
+  });
+
+  it('outpaint reports not_configured without BEDROCK_ROLE_ARN', async () => {
+    delete process.env.BEDROCK_ROLE_ARN;
+    const res = await outpaintTitanImage({
+      imagePng: Buffer.from('x'),
+      maskPng: Buffer.from('y'),
+      prompt: 'extend naturally',
+      width: 1280,
+      height: 720,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('not_configured');
+  });
+});


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03497` — Amazon Titan Image Generator (GCP cutover build 3 of 4)

**Layer:** AICOR (module `titan-image-gen`)

**Priority:** P2 — additive provider, gated off by default

---

## 📋 Summary

Build **3 of 4** (Polly ✅ → Bedrock vision/tools ✅ → **Titan** → Nova Sonic promotion), and the only one Claude cannot cover at all: Vertex **Imagen** generates images and no Anthropic model does, so this is a separate Bedrock adapter rather than an llm-router provider.

Selected by **`IMAGE_PROVIDER=vertex|bedrock`, default `vertex`** — same shape as `TTS_PROVIDER`. Additionally gated on `BEDROCK_ROLE_ARN`. **Merging changes nothing.**

---

## 🔍 Found a second Imagen consumer the cutover plan had missed

CLAUDE.md's changelog listed only `cover-image-outpaint.ts`. There are **two**:

| Consumer | Imagen call | Titan taskType |
|---|---|---|
| `cover-image-outpaint.ts` | `EDIT_MODE_OUTPAINT` | `OUTPAINTING` |
| `intent-cover-service.ts` | text-to-image | `TEXT_IMAGE` |

A Titan build covering only outpainting would have left **AI cover generation silently broken** the day GCP went away. Both are now wired.

---

## ⚠️ Three Titan constraints, all handled explicitly

**1. Titan accepts only a fixed set of width/height pairs — 1600x900 isn't one.** `nearestTitanSize()` maps the cover canvas to **1280x720** and weights **aspect ratio above area** deliberately: satisfying a 16:9 request with 1024x1024 would letterbox or crop the subject. That's visually wrong and completely invisible to a test that only asserts the call succeeded. The outpaint path upscales the result back to 1600x900.

**2. Outpaint mask polarity is inverted vs Imagen — and is UNVERIFIED.** Imagen: white = generate. Titan is documented black = generate, so the outpaint path negates its Imagen-convention mask. **Get this backwards and the subject is regenerated while the margins are preserved** — a plausible-looking, completely wrong image.

Because no AWS credentials were available to confirm it, the polarity is env-overridable via `TITAN_OUTPAINT_MASK_POLARITY` so it can be corrected **without a redeploy**. If outpaint output looks wrong, flip this first. The mask is resized with `kernel:'nearest'` so it stays strictly two-tone — a bilinear resize yields grey edge pixels and a non-deterministic seam.

**3. Titan isn't offered in every region**, and the rest of this estate is `eu-central-1`. `AWS_TITAN_IMAGE_REGION` is its own var (→ `AWS_BEDROCK_REGION` → `AWS_REGION` → `us-east-1`) rather than inheriting blindly, since a wrong region fails with an opaque model-not-found.

Also: **Titan reports content-policy blocks in an `error` field on a 200 response** rather than throwing. Treating that as success returns empty bytes; it's mapped to `error:'blocked'` → `unsafe_prompt`.

---

## 📌 Correction to the draft cutover spec

The spec cited *"the code's existing letterbox-blur fallback as the safety net if output quality doesn't hold up."* **That fallback does not exist server-side.** It's the frontend's old behaviour; `routes/cover-images.ts` simply returns an error when outpaint fails.

So a Titan quality regression surfaces as a **failed request, not a degraded image**. Worth knowing before anyone flips the switch expecting a soft landing.

---

## ✅ Changes

- [x] `providers/titan-image.ts` — `TEXT_IMAGE` + `OUTPAINTING`, size mapping, polarity control, own region resolution
- [x] `cover-image-outpaint.ts` — Titan branch with resize/invert/upscale
- [x] `intent-cover-service.ts` — Titan branch for text-to-image
- [x] `scripts/images/verify-titan-image.ts` — live-API verification
- [x] `.env.example` — 4 new vars with documented defaults
- [x] CLAUDE.md §2d + changelog row
- [x] 16 new tests

---

## 🧪 Testing

- [x] Automated tests — 16 new, concentrated on the size mapping and mask polarity (the two silent-visual-failure paths)
- [x] `npm run build` clean
- [ ] Verified against live Titan — **not possible here**: no AWS credentials, `BEDROCK_ROLE_ARN` unset everywhere

Full gateway suite: **620/620 suites, 12105 passed**, 7 skipped, 6 todo, 42 snapshots.

**Before flipping `IMAGE_PROVIDER=bedrock`**, run:
```
BEDROCK_ROLE_ARN=... AWS_TITAN_IMAGE_REGION=us-east-1 \
  npx ts-node scripts/images/verify-titan-image.ts
```
It checks model/region availability and the size mapping, and **detects inverted mask polarity automatically** — it renders a red-subject probe and samples the result, so the answer isn't left to eyeballing. Needs `bedrock:InvokeModel` on the Titan model for the gateway task role.

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] No workflow files touched

### File Names
- [x] New files kebab-case (`titan-image.ts`, `verify-titan-image.ts`, `titan-image.test.ts`); new dir `scripts/images/` kebab-case
- [x] No files violate naming canon

### Code Standards
- [x] VTID in file headers, inline comments and commit message
- [x] Wire fields match the Titan API (`taskType`, `outPaintingParams`, `maskImage`); status values lowercase (`'blocked'`, `'not_configured'`, `'empty_output'`, `'invoke_failed'`)

### Cloud Run Deployments
- [x] No deploy config or labels changed

### Documentation
- [x] VTID in commit message
- [x] CLAUDE.md §2d added + changelog row; `.env.example` documents all 4 vars
- [x] No non-compliant files introduced

---

## 🚨 Breaking Changes

**None.** `IMAGE_PROVIDER` defaults to `vertex`; both consumers take the existing Imagen path unchanged unless it's explicitly set to `bedrock` **and** `BEDROCK_ROLE_ARN` is present.

---

## 🔗 Links

- **Related VTIDs:** VTID-03495 (Polly, build 1), VTID-03496 (Bedrock vision/tools, build 2), VTID-02806h (the outpaint feature), VTID-03403 (Bedrock adapter)
- **Documentation:** CLAUDE.md §2d

---

## 📌 Additional Notes

Remaining: **Nova Sonic promotion** (build 4). Before starting it I'd want to look at the `nova_stream_error` uptick — 2 of the last 4 canary sessions — since that build widens Nova's blast radius rather than adding a dormant path.

Still open from build 1 and blocking the shutdown rather than any PR: **Polly has no Serbian voice in any engine**, and `sr` is a live locale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4afBxteyo8TMwS1zuZgTp)_