### PR TITLE
fix(session): install gateway deps via SessionStart hook, not the environment setup script path (VTID-03518)

### DIFF
--- a/.claude/hooks/session-start-gateway-setup.sh
+++ b/.claude/hooks/session-start-gateway-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Installs gateway dependencies on session start using an absolute,
+# repo-root-anchored path. The environment-level "Setup script" configured
+# outside this repo assumes cwd is the gateway repo root and runs
+# `cd services/gateway`, which breaks whenever this repo is checked out
+# as a sibling directory alongside another repo (e.g. vitana-v1) instead
+# of being the session's own working directory. Anchoring on
+# $CLAUDE_PROJECT_DIR makes this hook correct regardless of that layout.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+GATEWAY_DIR="${CLAUDE_PROJECT_DIR:-/home/user/vitana-platform}/services/gateway"
+
+if [ ! -d "$GATEWAY_DIR" ]; then
+  echo "session-start-gateway-setup: $GATEWAY_DIR does not exist, skipping" >&2
+  exit 0
+fi
+
+cd "$GATEWAY_DIR"
+npm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,16 @@
             "statusMessage": "Watcher: recording session start..."
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-/home/user/vitana-platform}/.claude/hooks/session-start-gateway-setup.sh\"",
+            "timeout": 120,
+            "statusMessage": "Installing gateway dependencies..."
+          }
+        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03518`

**Layer:** CICDL

**Priority:** P2

---

## 📋 Summary

Every new Claude Code session on this environment opened with:

```
/tmp/init-script-1373638966.sh: line 2: cd: services/gateway: No such file or directory
```

The environment's **Setup script** (configured outside this repo, in
environment settings) runs `cd services/gateway` assuming the session's
working directory is this repo's root. This environment actually checks out
`vitana-platform` and `vitana-v1` as sibling directories under `/home/user`,
so `services/gateway` doesn't exist relative to the session's cwd — it's one
level down, at `vitana-platform/services/gateway`.

I don't have a tool that can edit that environment-level setting directly, so
this PR makes gateway setup stop depending on it: a repo-committed
`SessionStart` hook now installs gateway deps using a path anchored on
`$CLAUDE_PROJECT_DIR`, which is correct regardless of the environment's
top-level layout. The environment's Setup script text still needs a manual
one-line fix in environment settings (`cd services/gateway` →
`cd vitana-platform/services/gateway`) to stop the error message itself from
appearing, but sessions no longer depend on it for gateway deps to actually
install.

---

## ✅ Changes

- [x] Added `.claude/hooks/session-start-gateway-setup.sh` — installs gateway
      npm deps on session start, resolving the gateway path from
      `$CLAUDE_PROJECT_DIR` instead of assuming cwd
- [x] Registered it as an additional `SessionStart` hook in
      `.claude/settings.json` (alongside the existing watcher hook, untouched)

---

## 🧪 Testing

- [x] Manual testing completed — ran the hook directly
      (`CLAUDE_CODE_REMOTE=true CLAUDE_PROJECT_DIR=/home/user/vitana-platform
      bash .claude/hooks/session-start-gateway-setup.sh`); it resolved the
      correct gateway directory and `npm install` completed cleanly (719
      packages)
- [ ] Automated tests added/updated — N/A, shell hook only
- [x] Verified in staging/dev environment — verified in this session's own
      remote environment

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] N/A — no workflow files touched

### File Names
- [x] All new files follow kebab-case (`session-start-gateway-setup.sh`)
- [x] No files violate naming canon

### Code Standards
- [x] N/A — no VTID constants, event types, or status values introduced

### Cloud Run Deployments
- [x] N/A — no Cloud Run services touched

### Documentation
- [x] VTID mentioned in commit message
- [x] Phase 2B compliance verified
- [x] No non-compliant files introduced

---

## 🚨 Breaking Changes

None.

---

## 📌 Additional Notes

The environment's Setup script field itself (outside this repo) still needs
a manual correction by someone with access to this environment's settings —
happy to walk through the exact edit, but I have no tool that reaches that
config from inside a session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbk9qSC9AvDRmgEoGf8V6T)_