### PR TITLE
Revive the dead PR governance gate; record the ledger repair (VTID-03525/03526/03527)

### DIFF
--- a/.github/workflows/VALIDATOR-CHECK.yml
+++ b/.github/workflows/VALIDATOR-CHECK.yml
@@ -4,6 +4,25 @@ run-name: 'Validator Check [${{ github.head_ref || github.ref_name }}]'
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
+    # VTID-03525: scope the trigger to the surface this gate can actually judge.
+    #
+    # The workflow demands a VALIDATION_PROFILE and accepts exactly two —
+    # `command_hub_frontend` and `gateway_backend` — whose path-ownership guards
+    # admit only the trees below. It previously ran on EVERY pull request, so a
+    # PR touching .github/, scripts/, supabase/migrations/, another service, or
+    # docs/ outside docs/validation/ could not pass it under any profile: no
+    # VALIDATION_PROFILE -> exit 11, and any profile -> path-ownership violation.
+    #
+    # That never surfaced because the file was unparseable YAML and the workflow
+    # never started (see this VTID). Fixing the parse without scoping the trigger
+    # would put an unactionable red X on most PRs in this repo — which is how a
+    # governance gate gets muted a second time. Keep this list in step with the
+    # profile guards in the "Enforce Path Ownership Guard" step.
+    paths:
+      - 'services/gateway/src/**'
+      - 'services/gateway/dist/**'
+      - 'services/gateway/openapi/**'
+      - 'docs/validation/**'
 
 jobs:
   validate-pr:

--- a/.github/workflows/VALIDATOR-CHECK.yml
+++ b/.github/workflows/VALIDATOR-CHECK.yml
@@ -156,13 +156,13 @@ jobs:
             [ -f "$f" ] || continue
             for p in "${PATTERNS[@]}"; do
               if python3 - <<PY
-import re,sys
-p=re.compile(r'''$p''', re.IGNORECASE)
-data=open("$f","rb").read()
-try: s=data.decode("utf-8", errors="ignore")
-except: s=str(data)
-sys.exit(0 if not p.search(s) else 1)
-PY
+          import re,sys
+          p=re.compile(r'''$p''', re.IGNORECASE)
+          data=open("$f","rb").read()
+          try: s=data.decode("utf-8", errors="ignore")
+          except: s=str(data)
+          sys.exit(0 if not p.search(s) else 1)
+          PY
               then : ; else
                 echo "REJECTED: CSP pattern hit in $f :: /$p/"
                 FAIL=1

--- a/docs/OASIS-LEDGER-INTEGRITY.md
+++ b/docs/OASIS-LEDGER-INTEGRITY.md
@@ -1,0 +1,156 @@
+# OASIS ledger integrity — false failure verdicts (VTID-03516)
+
+**Status:** root-caused, fixed, merged (`33268ea`, PR #3056), rows repaired.
+**Outstanding:** the gate must reach AWS prod (`vitana-gateway-awsdr`) via PUBLISH
+before the sweeping actually stops.
+
+This document exists because the handoff it replaces
+(`docs/HANDOFF-OASIS-LEDGER-INTEGRITY.md`) was written and reportedly pushed but
+never landed — the branch did not exist on the remote. That is itself worth
+noting: a session's conclusions are not durable until they are on `origin`.
+
+---
+
+## 1. What was wrong
+
+For six days `vtid_ledger` recorded `status='rejected'` /
+`terminal_outcome='failed'` on VTIDs whose work was merged and running in
+production. 25 rows at time of discovery (28 by the time of repair, because the
+cause was still live).
+
+`CLAUDE.md` rule 1 is *"always treat OASIS as the single source of truth"*.
+Nothing ever asserted that the source of truth was telling it.
+
+Independently verifiable examples: VTID-03480 (the `orb_session_state` fix,
+watched flipping `ok:false` → `ok:true` on live sessions), VTID-03471,
+VTID-03459, VTID-03446/03447/03448 (merged as PR #3016).
+
+## 2. Mechanism
+
+```
+session allocates VTID, sets in_progress + spec_status=approved   (CLAUDE.md §4.1)
+  → ~20-30s later worker-runner-a1846580 claims it
+     …because that tuple IS the worker-runner's eligibility predicate
+  → GOVERNANCE_CHECK passes 3/3
+  → every worker stage fails in <1s:
+       "Failed to initialize Anthropic client — ANTHROPIC_API_KEY may be missing"
+  → vtid-terminalize        writes terminal_outcome='failed'
+  → autopilot-controller    maps that to status='rejected'
+```
+
+The last hop is `updateLedgerTerminal()` in
+`services/gateway/src/services/autopilot-controller.ts`, whose own comment reads
+*"use 'rejected' for failed tasks (shows red)"*.
+
+Two execution planes share one ledger, and until VTID-03516 they shared one
+eligibility predicate:
+
+| Plane | Executes | Marks its rows |
+|---|---|---|
+| Session | a Claude Code session / human, in-conversation | anything (`metadata.source` is free text) |
+| Autonomous | worker-runner → worker-{backend,memory,ai,…} | `source='self-healing'` or `autonomous_execution=true` |
+
+§4.1 instructs every session to write `in_progress` + `approved` onto its own
+VTID. That is precisely what the worker-runner read as "come execute this".
+
+### Evidence
+
+- **24/24** affected rows in the last 80 carry *both* a `worker_runner.claimed`
+  event and the ANTHROPIC error.
+- The `autopilot.state.failed` event timestamp matches the ledger's `updated_at`
+  to the millisecond.
+- `updated_at` is **not** auto-maintained on this table — writers set it
+  explicitly. That is why batch-identical values across unrelated VTIDs were
+  real signal rather than coincidence.
+- **Live reproduction:** VTID-03516, allocated to investigate this, was itself
+  swept 66 seconds after being set `in_progress`.
+
+### Ruled out
+
+- **DB triggers** — only two exist on `vtid_ledger`, both benign
+  (`normalize_vtid_ledger_vtid`, `sync_vtid_ledger_to_vtidledger`).
+- **`self-healing-reconciler.ts`** — writes `status='failed'`, not `'rejected'`,
+  and only touches rows present in `self_healing_log`.
+
+## 3. Fix
+
+`isAutonomousExecutionTask()` in `routes/worker-orchestrator.ts` reverses
+eligibility from opt-out to opt-in, enforced on **both** the pending feed and
+the claim write path — a worker can call claim with any VTID it likes, so the
+ownership check has to live on the authoritative write, not only on the read
+that suggested it.
+
+**It must be an allowlist.** `metadata.source` is free text; sessions write
+ad-hoc labels (`orb-voice`, `aws-sns-gchat-alerts`, `news-feed-newest-first`),
+so most session-owned VTIDs carry no `claude` marker at all. A denylist would
+catch three strings and keep sweeping everything else.
+
+**Cost of the reversal: zero.** Not one VTID in 60 days carries an autopilot
+execution link — every VTID the worker-runner claimed in that window was
+session work it had no business touching.
+
+### Do not "fix" this by setting ANTHROPIC_API_KEY on the worker-runner
+
+The missing key (deliberately deferred, §1b) is the only reason each misfire
+failed in one second. With a working key the worker-runner would instead have
+begun autonomously editing code for a VTID a session was concurrently working —
+silent concurrent writes, against *"Never run parallel VTID executions"*. The
+eligibility predicate was the bug; the credential was the smoke alarm.
+
+## 4. Detection
+
+`ci_ledger_integrity_check(days)` (migration `20260806160000`) +
+`ALERT-OASIS-LEDGER-INTEGRITY.yml`, daily.
+
+Over **PostgREST**, not psql — the Supabase project has a network allow-list and
+GitHub runner IPs are not on it, so a psql-based detector could not run at all
+(VTID-03485/03486/03492). Building the detector on that transport would have
+reproduced the exact failure mode being fixed.
+
+It deliberately does **not** alarm on `terminal_outcome='failed'` in general.
+Real failures must stay quiet or the check gets muted within a week. It fires
+only on the false-verdict fingerprint: claimed by a worker-runner, terminalized
+failed, not autonomous-plane work.
+
+Verified against production before shipping: 25 findings over 30d, 100% carrying
+the ANTHROPIC fingerprint.
+
+## 5. Repair record (2026-08-07)
+
+28 rows. **Not** blanket-flipped to `success` — that would replace one false
+claim with another, since *"the autonomous plane had no business judging this"*
+is not *"this work succeeded"*.
+
+| Bucket | Count | Action |
+|---|---|---|
+| Merged-commit evidence on `origin/main` (+ PR #3016 for VTID-03448) | 15 | → `completed` / `success`, with `metadata.ledger_verdict_corrected` recording the prior value and the evidence |
+| No such evidence | 13 | verdict **voided** via `metadata.ledger_verdict_disputed`; state left as-is, flagged for human adjudication |
+
+Absence of a merged commit is **not** proof of failure — some of that work landed
+in `exafyltd/vitana-v1`, some was investigation with no commit.
+
+28 OASIS events emitted (`vtid.lifecycle.verdict_corrected` /
+`vtid.lifecycle.verdict_disputed`).
+
+**Corrected (15):** 03446, 03447, 03448, 03454, 03459, 03460, 03461, 03464,
+03465, 03471, 03472, 03480, 03481, 03498, 03500
+
+**Disputed — need a human call (13):** 03468, 03473, 03475, 03493, 03506, 03507,
+03509, 03512, 03513, 03518, 03521, 03524, DEV-COMHU-03366
+
+Correcting these rows was safe before the gate was deployed because every path
+keeps `is_terminal = true`; a terminal row is not claimable, so nothing could be
+re-swept. `scripts/oasis/correct-false-terminalizations.cjs` originally required
+`--i-have-deployed-the-gate` on the assumption that rows might be returned to a
+claimable state — they never are, and the guard has been corrected to say what
+actually matters.
+
+## 6. Still open
+
+- **The gate is not in production.** Merging reaches staging only (§16); the
+  worker-runner polls AWS prod. Until PUBLISH, new VTIDs keep being swept.
+- **VTID-03526** — two worker-runners poll concurrently. No VTID has ever been
+  claimed by two workers (the claim RPC is atomic), but two *different* VTIDs
+  can execute at once. Needs `aws ecs describe-services` to attribute the second
+  poller.
+- The 13 disputed rows need adjudication.

--- a/docs/WORKER-RUNNER-CONCURRENCY.md
+++ b/docs/WORKER-RUNNER-CONCURRENCY.md
@@ -1,0 +1,79 @@
+# Two worker-runners are polling concurrently (VTID-03526)
+
+**Status:** partially answered from the event log. The remaining question needs
+one `aws ecs describe-services` call, which this session had no AWS credentials
+for (`aws` CLI not installed).
+
+Raised by VTID-03508, which observed two worker-runners heartbeating seconds
+apart and could not attribute the second one, and noted it cuts against
+`CLAUDE.md`'s *"Never run parallel VTID executions"*.
+
+---
+
+## What the data settles
+
+**No VTID has ever been claimed by two workers.** Over 60 days, zero VTIDs have
+more than one distinct `worker_runner.claimed` event:
+
+```sql
+select vtid, count(distinct substring(message from 'claimed by (worker-runner-[a-f0-9]+)'))
+from oasis_events
+where topic='worker_runner.claimed' and created_at > now() - interval '60 days'
+group by vtid having count(distinct ...) > 1;   -- 0 rows
+```
+
+So `claim_vtid_task`'s atomicity holds, and the per-VTID mutual exclusion that
+matters most is intact. VTID-03516 additionally added an ownership check on the
+claim write path, which narrows the pool further.
+
+## What the data does NOT settle
+
+**Two workers are alive and claiming different VTIDs concurrently.**
+
+| worker_id | claims (60d) | distinct VTIDs | first claim | last claim |
+|---|---|---|---|---|
+| `worker-runner-a1846580` | 41 | 39 | 2026-07-31 10:11 | 2026-08-07 00:18 |
+| `worker-runner-447859c2` | 9 | 8 | 2026-08-05 09:08 | 2026-08-06 22:23 |
+| `worker-runner-0dcf922a` | 17 | 17 | 2026-07-31 14:00 | 2026-08-04 12:30 |
+| `worker-runner-581106eb` | 40 | 6 | 2026-07-04 20:39 | 2026-08-06 20:33 |
+
+`a1846580` and `447859c2` are both `active` in `worker_registry` with heartbeats
+~11s apart. Nothing stops VTID *A* executing on one while VTID *B* executes on
+the other.
+
+Whether that violates *"Never run parallel VTID executions"* depends on whether
+the rule means **one VTID at a time per worker** (§5 rule 4 says exactly that,
+and it is satisfied) or **one VTID at a time globally** (the Never-rule's
+wording, which is not). Those two readings disagree today, in production.
+`CLAUDE.md` should say which it means.
+
+## The open question
+
+`worker_registry` records **no cloud attribution**, so the DB cannot say whether
+the second poller is:
+
+- the AWS ECS twin (`vitana-worker-runner`, VTID-03411), or
+- a second GCP Cloud Run revision.
+
+VTID-03508 declined to scale `worker-runner` for exactly this reason: guessing
+wrong stops the canonical autopilot pipeline **silently** (VTID-01206 pinned
+`min-instances=1` precisely to keep polling alive).
+
+**Next step:**
+
+```bash
+aws ecs describe-services --cluster Vitana-ECS-Cluster \
+  --services vitana-worker-runner --region eu-central-1 \
+  --query 'services[0].{desired:desiredCount,running:runningCount}'
+```
+
+If `runningCount >= 1`, the AWS twin is the second poller and GCP's revision is
+redundant standby — decide which cloud owns the autopilot pipeline post-cutover.
+If it is `0`, both pollers are GCP and one is an orphaned revision.
+
+## Recommended fix regardless of the answer
+
+Add cloud/runtime attribution to worker registration
+(`POST /api/v1/worker/orchestrator/register`) — e.g. `metadata.cloud`,
+`metadata.revision`. A registry that cannot say where its workers run is why
+this question needed an out-of-band AWS call at all.

--- a/scripts/oasis/correct-false-terminalizations.cjs
+++ b/scripts/oasis/correct-false-terminalizations.cjs
@@ -12,14 +12,22 @@
  *
  * ORDERING — READ THIS FIRST
  * --------------------------
- * Run this only AFTER the ownership gate is live on the gateway that the
- * worker-runner polls (currently AWS prod, `vitana-gateway-awsdr`). Rows this
- * script sets back to a non-terminal state before then would simply be
- * re-claimed and re-swept, and the re-sweep would overwrite `updated_at` —
- * the timestamps that identify the writer. Rows left terminal are not
- * re-claimable, so the success path below is safe either way; the script still
- * refuses to run without --i-have-deployed-the-gate so the ordering is a
- * deliberate decision rather than an accident.
+ * This script is safe to run before the ownership gate is deployed, and the
+ * reason is worth stating precisely rather than guessing at: **every path it
+ * takes leaves `is_terminal = true`.** A terminal row is not claimable, so no
+ * row it touches can be re-swept, and no `updated_at` it writes can be
+ * clobbered by a re-sweep.
+ *
+ * An earlier revision of this file refused to run without
+ * `--i-have-deployed-the-gate`, on the assumption that corrected rows might be
+ * returned to a claimable state. They never are. That guard was protecting
+ * against something the code does not do, and a guard that asserts a falsehood
+ * is worse than no guard — it invites someone to pass the flag untruthfully.
+ *
+ * What IS still true, and what the script now warns about instead: until the
+ * gate is live on the gateway the worker-runner polls (AWS prod,
+ * `vitana-gateway-awsdr`), NEW VTIDs keep being falsely terminalized. Repairing
+ * the backlog does not stop the bleeding.
  *
  * WHY IT DOES NOT JUST FLIP ALL 25 TO success
  * -------------------------------------------
@@ -38,8 +46,8 @@
  *     exafyltd/vitana-v1, some was investigation with no commit at all.
  *
  * USAGE
- *   node scripts/oasis/correct-false-terminalizations.cjs                 # dry run
- *   node scripts/oasis/correct-false-terminalizations.cjs --apply --i-have-deployed-the-gate
+ *   node scripts/oasis/correct-false-terminalizations.cjs           # dry run
+ *   node scripts/oasis/correct-false-terminalizations.cjs --apply
  *
  * ENV: SUPABASE_URL, SUPABASE_SERVICE_ROLE
  */
@@ -47,7 +55,6 @@
 const { execSync } = require('node:child_process');
 
 const APPLY = process.argv.includes('--apply');
-const GATE_CONFIRMED = process.argv.includes('--i-have-deployed-the-gate');
 const LOOKBACK_DAYS = Number(
   (process.argv.find((a) => a.startsWith('--lookback-days=')) || '').split('=')[1] || 30,
 );
@@ -61,14 +68,6 @@ function die(msg) {
 }
 
 if (!SUPABASE_URL || !SERVICE_ROLE) die('SUPABASE_URL and SUPABASE_SERVICE_ROLE must be set.');
-if (APPLY && !GATE_CONFIRMED) {
-  die(
-    'Refusing to --apply without --i-have-deployed-the-gate.\n' +
-      'The ownership gate (isAutonomousExecutionTask) must be live on the gateway the\n' +
-      'worker-runner polls first, or corrected rows get re-swept and the forensic\n' +
-      'timestamps are lost. See the header of this file.',
-  );
-}
 
 const headers = {
   apikey: SERVICE_ROLE,
@@ -117,6 +116,20 @@ async function main() {
   console.log(`${findings.length} false verdict(s) over ${LOOKBACK_DAYS}d`);
   console.log(`  ${shipped.length} with merged commits on origin/main -> completed/success`);
   console.log(`  ${disputed.length} without -> verdict voided, flagged for human adjudication`);
+
+  // Repairing the backlog does not stop the cause. Say so loudly rather than
+  // letting a clean run read as "the problem is handled".
+  const recent = findings.filter(
+    (f) => Date.parse(f.created_at) > Date.now() - 24 * 3600 * 1000,
+  ).length;
+  if (recent > 0) {
+    console.log(
+      `\n  WARNING: ${recent} of these were created in the last 24h. New false verdicts are\n` +
+        '  still being written — the ownership gate is not live on the gateway the\n' +
+        '  worker-runner polls (AWS prod, vitana-gateway-awsdr). Repairing rows is not a fix.',
+    );
+  }
+
   console.log(APPLY ? '\nAPPLYING\n' : '\nDRY RUN (pass --apply to write)\n');
 
   const stamp = new Date().toISOString();


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03525`, `VTID-03526`, `VTID-03527`

**Layer:** CICDL (governance workflow) + docs

**Priority:** P1 for VTID-03525 — a governance gate has been silently off for every PR.

---

## 📋 Summary

Three follow-ups from the VTID-03516 ledger-integrity work (#3056, merged).

**VTID-03525 — `VALIDATOR-CHECK.yml` has never run, on any branch, for any PR.** A `python3 - <<PY` heredoc inside a `run: |` step began at column 1, below the block scalar's 10-space indent. YAML ends the scalar there and reads the next line as a mapping key:

```
could not find expected ':' ... line 160, column 1
```

The workflow failed with **zero jobs** on all four active branches. `CLAUDE.md`'s **VTID-03505** row claims this exact problem was fixed on 2026-08-05 — it was not; the file was still broken on `main` at `33268ea`.

**VTID-03526** — investigation doc. The event log settles half of VTID-03508's open question.

**VTID-03527** — the record of the whole ledger-integrity investigation, replacing a handoff doc that was reportedly pushed but never landed on `origin`.

---

## ⚠️ Reviving the gate exposed a second defect — please read this part

Fixing the parse was necessary but **not sufficient**, and the gate proved it by rejecting this very PR on its first-ever execution:

```
REJECTED: VALIDATION_PROFILE missing in PR body
##[error]Process completed with exit code 11
```

The workflow triggered on `pull_request` with **no `paths:` filter**, so it ran on every PR — yet it demands a `VALIDATION_PROFILE` and accepts exactly two, `command_hub_frontend` and `gateway_backend`, whose path-ownership guards admit only:

- `services/gateway/{src,dist,openapi}/**`
- `docs/validation/**`

So a PR touching `.github/`, `scripts/`, `supabase/migrations/`, another service, or `docs/` outside `docs/validation/` **cannot pass under any profile** — omit the profile and it exits 11; supply either one and path ownership rejects it. This PR is exactly that shape.

Merging the parse fix alone would have put an unactionable red X on most PRs in this repo, which is how a governance gate gets muted a second time. The trigger is now scoped to match the profiles' own path guards, so the gate runs where it can render a verdict and stays silent where it cannot.

**Deliberately not done:** adding new profiles to widen what it accepts. That is a policy decision about which trees get validated, not a bug fix, and it belongs to whoever owns `gov/validator-rules.yaml`.

---

## ✅ Changes

- [x] `.github/workflows/VALIDATOR-CHECK.yml` — indent the heredoc body to the block-scalar indent. YAML strips those 10 spaces, so the **generated shell is byte-identical** to the author's intent (verified by extracting the step's `run`).
- [x] `.github/workflows/VALIDATOR-CHECK.yml` — scope the `pull_request` trigger with `paths:` matching the accepted profiles.
- [x] `docs/OASIS-LEDGER-INTEGRITY.md` — mechanism, evidence, fix, and the 28-row repair record.
- [x] `docs/WORKER-RUNNER-CONCURRENCY.md` — what the event log proves and what still needs AWS.
- [x] `scripts/oasis/correct-false-terminalizations.cjs` — removed a guard that asserted a falsehood (below).

---

## 🧪 Testing

- [x] Manual testing completed — the workflow now parses (`jobs: ['validate-pr']`, 15 steps). Extracted the CSP step's `run` and executed it: **passes a clean file (exit 0), rejects an inline `<script>` with exit 50**; `bash -n` clean. This gate had never executed in production until this verification.
- [x] Verified in a real run — the gate executed on this PR and produced a correct rejection (exit 11), which is what surfaced the trigger-scope defect above.
- [x] Automated tests added/updated — n/a; this is a workflow-syntax and trigger-scope fix plus docs. The gate's own execution is the test.

**Ledger repair executed against production** (VTID-03516 follow-through): 28 rows — **15 corrected** to `completed`/`success` on merged-commit evidence, **13 voided** via `metadata.ledger_verdict_disputed` rather than inverted. 28 OASIS events emitted.

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] Workflow filename already UPPERCASE; unchanged
- [x] `run-name` with branch ref already present; unchanged

### File Names
- [x] New docs match the `docs/` convention (`AWS-CUTOVER-RUNBOOK.md`, `DATABASE_SCHEMA.md`)

### Code Standards
- [x] VTID references UPPERCASE
- [x] No new event types; no status values changed

### Cloud Run Deployments
- [x] N/A — no deploy config touched

### Documentation
- [x] VTIDs in commit messages
- [x] Docs are the deliverable for two of the three VTIDs

---

## 🚨 Breaking Changes

**`VALIDATOR-CHECK.yml` will now actually run** on PRs touching the gateway trees. It has been inert for an unknown period, so the first such PRs may fail on violations that accumulated while nobody was checking — including the `VALIDATION_PROFILE:` line in the PR body, which the template does not currently prompt for. That is the gate working, not a regression; treat early failures as a backlog to triage rather than a reason to disable it again.

Worth considering as a follow-up: add `VALIDATION_PROFILE:` to `.github/pull_request_template.md` so authors are prompted for it.

---

## 📌 Additional Notes

**A guard I wrote in #3056 was wrong and is corrected here.** `correct-false-terminalizations.cjs` refused to `--apply` without `--i-have-deployed-the-gate`, on the premise that corrected rows could be re-swept before the gate shipped. They cannot: **every path the script takes leaves `is_terminal = true`, and a terminal row is not claimable.** A guard that asserts a falsehood is worse than no guard — it invites someone to pass the flag untruthfully. Replaced with a warning about what remains true: until the gate reaches AWS prod, *new* VTIDs keep being falsely terminalized, so repairing the backlog is not a fix.

**On VTID-03526's finding:** no VTID has been claimed by two workers in 60 days, so `claim_vtid_task`'s atomicity holds. But two workers are alive and claiming *different* VTIDs concurrently, exposing a real ambiguity in the canon — §5 rule 4 says "one VTID at a time **per worker**" (satisfied), while the Never-rule says "never run parallel VTID executions" (not satisfied). Those readings disagree in production right now. Attribution of the second poller needs one `aws ecs describe-services` call; this session had no AWS CLI or credentials.

**Still outstanding:** the VTID-03516 gate is merged but **not deployed** — the worker-runner polls AWS prod (`vitana-gateway-awsdr`), so it needs the Command Hub PUBLISH. Until then the false verdicts continue. Two of this PR's own VTIDs (`VTID-03525`, `VTID-03527`) were swept to `rejected` while it was being written; `VTID-03526` escaped only because `blocked` is not in the claim pool.