### PR TITLE
fix(watcher): stop scoping learned lessons on the emitting service (VTID-03534)

### DIFF
--- a/services/gateway/src/services/watcher/distiller.ts
+++ b/services/gateway/src/services/watcher/distiller.ts
@@ -168,7 +168,32 @@ export function distilStep(step: WatcherStep & { id?: string }): DistilledLesson
   const scope: LessonScope = {};
   const ev = step.evidence || {};
   if (ev.scanner) scope.scanner = String(ev.scanner);
-  if (ev.service) scope.service = String(ev.service);
+
+  // `evidence.service` is deliberately NOT copied into the scope — VTID-03534.
+  //
+  // scope is a RETRIEVAL filter, and scopeMatches() refuses a scoped lesson
+  // whenever the caller does not supply that key (correctly — otherwise a
+  // scanner-specific lesson leaks into every unrelated prompt). But
+  // evidence.service is the name of the service that EMITTED the event, which
+  // is provenance, not a caller context. The two are different things, and
+  // conflating them made every learned lesson unreachable by all three of its
+  // consumers:
+  //
+  //   planner        passes stage + scanner, never service  -> no match
+  //   executor       passes stage + scanner, never service  -> no match
+  //   worker-runner  passes service = its DOMAIN ('backend') while the lesson
+  //                  carried the emitter name ('worker-backend')  -> no match
+  //
+  // Measured on production data after the VTID-03531 backfill: 34 lessons
+  // stored, 25 injectable by frequency, and 0 reachable by any real caller.
+  // The memory existed and nothing could read it — the same shape as the bug
+  // VTID-03531 fixed one layer down.
+  //
+  // The emitting service is not lost: it stays in the step's evidence and in
+  // the lesson's pattern_key/example_message, where it belongs as provenance.
+  // Leaving scope empty makes the lesson universal within its stage, which is
+  // the correct default — "a previous attempt failed to typecheck" is worth
+  // knowing regardless of which service emitted it.
 
   const raw = String((ev.message as string) || (ev.error as string) || '');
 

--- a/services/gateway/src/services/watcher/lessons-store.ts
+++ b/services/gateway/src/services/watcher/lessons-store.ts
@@ -121,6 +121,18 @@ export async function upsertLesson(input: {
           confidence: confidenceForFrequency(frequency),
           evidence_step_ids: merged,
           last_seen_at: now,
+          // Scope is refreshed on recurrence, not just on insert — VTID-03534.
+          //
+          // The distiller is the authority on what a lesson's retrieval scope
+          // should be, and that definition can change (it just did). Without
+          // this, a row written under the old definition is found by
+          // (stage, pattern_type, pattern_key), has its frequency and evidence
+          // updated, and keeps its stale scope forever — so a scope fix would
+          // only ever apply to patterns never seen before, silently leaving
+          // every already-known pattern unreachable for good. The 34 rows the
+          // VTID-03531 backfill produced are exactly those, and they cover the
+          // highest-frequency patterns, i.e. most of the value.
+          scope: input.scope ?? {},
           // The lesson TEXT is refreshed but the example is not: the first
           // example is as representative as the fiftieth, and churning it
           // would make the row look freshly-edited to a human reviewer on

--- a/services/gateway/test/watcher-lessons.test.ts
+++ b/services/gateway/test/watcher-lessons.test.ts
@@ -120,9 +120,27 @@ describe('distilStep', () => {
     expect(d.pattern_type).toBe('deploy_failure');
   });
 
-  it('carries scanner/service into scope for retrieval', () => {
+  it('carries scanner into scope but NOT the emitting service (VTID-03534)', () => {
+    // This test previously asserted `{ scanner, service }` — it had encoded
+    // the bug as expected behaviour. scope is a RETRIEVAL filter and
+    // scopeMatches refuses a scoped lesson when the caller omits the key, but
+    // evidence.service is the EMITTING service (provenance), not a caller
+    // context. Including it made every learned lesson unreachable by all
+    // three consumers: the planner and executor never pass a service at all,
+    // and worker-runner passes its domain ('backend') against an emitter name
+    // ('worker-backend'). Measured in production: 34 lessons stored, 25
+    // injectable, 0 reachable.
     const d = distilStep(step({ evidence: { scanner: 'missing-tests-scanner-v1', service: 'gateway', message: 'x' } }))!;
-    expect(d.scope).toEqual({ scanner: 'missing-tests-scanner-v1', service: 'gateway' });
+    expect(d.scope).toEqual({ scanner: 'missing-tests-scanner-v1' });
+    expect(d.scope.service).toBeUndefined();
+  });
+
+  it('leaves scope empty — universal within the stage — when only a service is known', () => {
+    // The common case for an OASIS-sourced failure: the normalizer always
+    // populates evidence.service, and there is no scanner. Such a lesson must
+    // end up universal, not silently filtered out of every retrieval.
+    const d = distilStep(step({ evidence: { service: 'worker-orchestrator', message: 'boom' } }))!;
+    expect(d.scope).toEqual({});
   });
 
   it('produces imperative lesson text, not just the signature', () => {

--- a/services/gateway/test/watcher-observer.test.ts
+++ b/services/gateway/test/watcher-observer.test.ts
@@ -461,6 +461,27 @@ describe('distillation is wired into the tick (VTID-03531)', () => {
     expect(rec.lessonUpdates[0].evidence_step_ids).toEqual(['old', 's0']);
   });
 
+  it('refreshes scope on recurrence so a scope-definition change self-heals', async () => {
+    // VTID-03534. Without this, a row written under an older scope definition
+    // is found by (stage, pattern_type, pattern_key), has frequency/evidence
+    // updated, and keeps its stale scope forever — so a scope fix applies
+    // only to patterns never seen before and every already-known pattern
+    // stays unreachable permanently. Raised in review of PR #3062.
+    const { client, rec } = fakeSupabase({
+      cursorAt: '2026-08-01T00:00:00.000Z',
+      eventPages: [[failedEvt('e12', '2026-08-01T01:00:00.000Z', 'error TS2307: cannot find module')]],
+      existingLesson: { id: 'L1', frequency: 3, evidence_step_ids: [] },
+    });
+    mockGetSupabase.mockReturnValue(client);
+
+    await observerTick();
+
+    expect(rec.lessonUpdates).toHaveLength(1);
+    // The distiller no longer scopes on the emitting service, so the stale
+    // {service: ...} must be overwritten with the current definition.
+    expect(rec.lessonUpdates[0].scope).toEqual({});
+  });
+
   it('counts every occurrence in a batch, not one per batch', async () => {
     // Three failures with the same signature really are three occurrences.
     // Counting the batch as a single recurrence undercounts the evidence and


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `VTID-03534` · **Layer:** AGTL · **Priority:** P1

Follow-up to #3031 (VTID-03531), found by verifying the **merged** result against production data rather than treating the merge as the finish line.

---

## 📋 Summary

#3031 made the Watcher store lessons. It did not make them reachable.

After running the backfill against live data:

| | |
|---|---|
| Lessons stored | **34** |
| Injectable by frequency (`>1`, past quarantine) | **25** |
| Returned to any real caller | **0** |

The distiller copied `evidence.service` into the lesson's retrieval `scope`. But `scope` is a **retrieval filter** — `scopeMatches()` deliberately refuses a scoped lesson whenever the caller omits that key, which is correct (otherwise a scanner-specific lesson leaks into every unrelated prompt). `evidence.service`, however, is the name of the service that **emitted the event**. That is provenance, not caller context.

Conflating the two made every lesson unreachable by all three consumers simultaneously:

| Caller | Passes | Lesson scope | Match |
|---|---|---|---|
| `dev-autopilot-planning` | `stage` + `scanner` | `{service: "autopilot-controller"}` | ✗ |
| `dev-autopilot-execute` | `stage` + `scanner` | `{service: "worker-orchestrator"}` | ✗ |
| `worker-runner` | `service = <domain>` → `"backend"` | `{service: "worker-backend"}` | ✗ |

The third is the most instructive: worker-runner *does* pass a service, but it passes its **domain**, while the lesson carries the **emitter name**. Even the one caller that supplied the key could never match.

### Proven live, not inferred

```
GET /remind?stage=execute                              → 3 reminders (3 rules, 0 lessons)
GET /remind?stage=execute&service=autopilot-controller → 6 reminders (3 rules, 3 lessons)
```

Nothing was wrong with the lessons, the scoring, the quarantine, or the endpoint. Only the scope key.

---

## ✅ Changes

- `distiller.ts` no longer copies `evidence.service` into `scope`. Scanner scoping is **kept** — the planner does pass a scanner, and scanner-specific lessons genuinely are specific.
- The emitting service is not lost: it remains in the step's `evidence` and in the lesson's `pattern_key` / `example_message`, where provenance belongs.
- An empty scope makes a lesson universal within its stage, which is the correct default — *"a previous attempt failed to typecheck"* is worth knowing regardless of which service emitted it.

---

## 🧪 Testing

- [x] Manual testing completed — verified against live staging + production data
- [x] Automated tests added/updated
- [x] Verified in staging/dev environment

**A pre-existing test asserted the old behaviour** (`scope` containing both `scanner` and `service`) — it had encoded the bug as expected. Updated to assert the corrected contract, plus a new case for the common OASIS-sourced shape (service known, no scanner) which must end up universal rather than filtered out of every retrieval.

The `scopeMatches` unit tests are unchanged and still pass: the matcher was never wrong. What was wrong was what got written into the scope.

Gateway suite **628/628 suites, 12,223 tests passing**; `tsc --noEmit` clean.

---

## 📝 Phase 2B Naming Compliance Checklist

### GitHub Actions
- [x] No workflow files touched · [x] N/A · [x] N/A

### File Names
- [x] No new files; both touched files already kebab-case
- [x] No naming-canon violations

### Code Standards
- [x] VTID in the commit message and the code comment
- [x] No schema change; no new event types
- [x] N/A

### Cloud Run Deployments
- [x] No deployment change · [x] N/A

### Documentation
- [x] VTID in commit message
- [x] Phase 2B compliance verified
- [x] No non-compliant files introduced

---

## 🚨 Breaking Changes

None. Reminder injection remains advisory and flag-gated; this only widens which lessons a given call can see.

Existing rows written before this change still carry `scope.service` and stay unreachable until their scope is cleared — a one-line `jsonb - 'service'` update, run separately so this PR is code-only.

---

## 📸 Screenshots

N/A — no UI change.

---

## 📌 Additional Notes

The general lesson, and the reason this was worth chasing after the merge: **VTID-03531 and this are the same defect at two different layers.** One stored memory nothing wrote to; the other wrote memory nothing could read. Both passed every unit test, because each component was individually correct — the failure was in the seam between them, and seams are what unit tests are worst at.

Verifying "the feature works" has to mean asking a real consumer for a real answer, not confirming that each part is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgXGuAfVfkStTnzoBhnErh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgXGuAfVfkStTnzoBhnErh)_