### PR TITLE
docs: "use a preview instead" was wrong — every frontend writes to prod Supabase (VTID-03506)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,17 +246,25 @@ Claude must apply the following **conditional logic**:
 **Test user UUID:** `a27552a3-0257-4305-8ed0-351a80fd3701`
 Use this user when an authenticated user is needed for testing (e.g., Playwright screenshots, API calls, profile checks).
 
-31. **NEVER create community content as this account — on ANY host.** No posts,
-    comments, likes, videos or chat messages, whether you are pointed at
-    `vitanaland.com`, `preview.vitanaland.com`, or a per-PR preview. **There is
+31. **NEVER write as this account — on ANY host. Reading is fine everywhere.**
+    Not a post, not a comment, not a like, not a profile edit, not an onboarding
+    step, not a settings toggle, not an automation, not a wallet call. **There is
     exactly one Supabase project and every frontend writes to it:**
     `PREVIEW-DEPLOY-FRONTEND.yml` and `STAGE-DEPLOY-FRONTEND.yml` override only
     the gateway URL and leave Supabase unset, inheriting prod from the committed
     `.env`, because `gateway-staging` runs against prod Supabase too
     (BOOTSTRAP-ORB-STAGING-SUPABASE-ALIGN) and a mismatched project makes staging
     logins anonymous to the gateway. **The host selects which code runs, not
-    which database gets written.** Reading as the test user is fine everywhere.
+    which database gets written**, so "do it on the preview instead" mitigates
+    nothing for *any* write. The sign-in's own auth session is the sole
+    unavoidable exception. Anything beyond that needs an explicit recorded
+    reason, must touch only rows this account owns, and must be reverted after.
     (VTID-03506)
+31b. **Community content is the absolute case — no exception clause applies.**
+    Posts, comments, likes, videos and chat messages reach real members' feeds
+    and lock screens the instant they land, and no amount of cleanup afterwards
+    recalls them. A "harmless" test post is indistinguishable from a real
+    member's, because this account is a full member of the production tenant.
 32. **IF** verifying a change needs content that does not exist yet (a post to
     like, a message to reply to, a video to comment on) → **THEN** verify against
     content that already exists, a unit/integration test, or a local Supabase —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,20 +246,30 @@ Claude must apply the following **conditional logic**:
 **Test user UUID:** `a27552a3-0257-4305-8ed0-351a80fd3701`
 Use this user when an authenticated user is needed for testing (e.g., Playwright screenshots, API calls, profile checks).
 
-31. **NEVER sign this account in against a production host** (`vitanaland.com`,
-    `www`, `dr-app.vitanaland.com`, `gateway.vitanaland.com`). Point it at a PR
-    preview or staging (`preview.vitanaland.com` / `preview-gateway.vitanaland.com`).
-    Reading prod as the test user is fine; **writing** is not. (VTID-03506)
+31. **NEVER create community content as this account — on ANY host.** No posts,
+    comments, likes, videos or chat messages, whether you are pointed at
+    `vitanaland.com`, `preview.vitanaland.com`, or a per-PR preview. **There is
+    exactly one Supabase project and every frontend writes to it:**
+    `PREVIEW-DEPLOY-FRONTEND.yml` and `STAGE-DEPLOY-FRONTEND.yml` override only
+    the gateway URL and leave Supabase unset, inheriting prod from the committed
+    `.env`, because `gateway-staging` runs against prod Supabase too
+    (BOOTSTRAP-ORB-STAGING-SUPABASE-ALIGN) and a mismatched project makes staging
+    logins anonymous to the gateway. **The host selects which code runs, not
+    which database gets written.** Reading as the test user is fine everywhere.
+    (VTID-03506)
 32. **IF** verifying a change needs content that does not exist yet (a post to
-    like, a message to reply to, a video to comment on) → **THEN** create it on
-    the preview/staging stack, never on prod. On 2026-08-05 five posts created
-    by this account on production became **960 notifications and 600 pushes** to
-    real members in ~6 minutes, because `trg_notify_community_post` fans out to
-    the whole tenant. Deleting the posts did not recall the pushes. DB-level
-    suppression now exists (`_notif_is_test_actor()` +
-    `trg_suppress_test_actor_notifications`, vitana-v1 migration `20260805160000`)
-    — it silences notifications, it does **not** keep test content out of the
-    real feed, so it is not a licence to write to prod.
+    like, a message to reply to, a video to comment on) → **THEN** verify against
+    content that already exists, a unit/integration test, or a local Supabase —
+    and if none of those can cover it, **raise it as a blocker rather than
+    routing around it**. It needs an isolated Supabase project for testing, and
+    there isn't one. On 2026-08-05 five posts created by this account became
+    **960 notifications and 600 pushes** to real members in ~6 minutes, because
+    `trg_notify_community_post` fans out to the whole tenant; deleting the posts
+    did not recall the pushes. A PR preview would have produced the identical
+    rows and the identical pushes. DB-level suppression now exists
+    (`_notif_is_test_actor()` + `trg_suppress_test_actor_notifications`, vitana-v1
+    migration `20260805160000`) — it silences notifications, it does **not** keep
+    test content out of the real feed, so it is not a licence to write.
 
 **Auth for frontend screenshots (Supabase REST):**
 ```typescript

--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -191,8 +191,11 @@ cast failure) returns `NEW` and the notification is delivered — suppressing te
 noise is worth strictly less than one real member's notification going missing.
 
 **It is a seatbelt, not a permission slip.** It stops *notifications*; it does not
-keep test posts, comments, likes or chat messages out of the real feed. Writing to
-production as a test account is forbidden outright — see CLAUDE.md rules 31/32.
+keep test posts, comments, likes or chat messages out of the real feed. Creating
+community content as a test account is forbidden outright — **on every host, not
+just prod**: staging and per-PR preview frontends deliberately inherit the
+production Supabase project (only the gateway URL is overridden), so they write to
+these same tables. See CLAUDE.md rules 31/32.
 
 **Registering a new test account:**
 ```sql


### PR DESCRIPTION
Follow-up to #3051 (merged). A Codex review on `exafyltd/vitana-v1#967` caught that the rule that PR added points at a host which **is not isolated**, and it was right.

## The error

#3051 said: don't write as the test account on production, use a PR preview or staging instead. Verified against the frontend workflows in `exafyltd/vitana-v1`:

- `PREVIEW-DEPLOY-FRONTEND.yml` (L69–81) and `STAGE-DEPLOY-FRONTEND.yml` (L72–93) each generate an `.env.production` containing **only** `VITE_GATEWAY_BASE` / `VITE_GATEWAY_URL`.
- Supabase is **deliberately left unset**, so both inherit the **production** project from the committed `.env`.
- The workflow comment states the reason: `gateway-staging` itself runs against prod Supabase (BOOTSTRAP-ORB-STAGING-SUPABASE-ALIGN), so a staging frontend on a different project would sign ES256 tokens the gateway's prod HS256 secret can't verify — staging logins go anonymous and authed ORB features silently drop.

There is **one** Supabase project and every frontend writes to it. **The host selects which _code_ runs, not which database gets written.** The 2026-08-05 blast would have been byte-identical from a per-PR preview: same `profile_posts` rows, same `trg_notify_community_post` fan-out, same 600 pushes to real members.

## Changes

- **Rule 31** — never create community content as the test account on **any** host, with the reason stated inline so the next reader doesn't re-derive "preview must be safe". Reading stays fine everywhere.
- **Rule 32** — verify against content that already exists, a unit/integration test, or a local Supabase; when none of those fit, **raise it as a blocker rather than routing around it**. The isolated Supabase project this would need does not exist.
- **`DATABASE_SCHEMA.md`** — same correction on the `notification_test_actors` "seatbelt, not a permission slip" note.

Documentation only. The DB-level guard from #3051 / vitana-v1#967 is unaffected and already live — and it holds regardless of host, since it is a trigger on the shared database rather than a property of the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127mVwAAtocK3hnHQNiTSGp

---
_Generated by [Claude Code](https://claude.ai/code/session_0127mVwAAtocK3hnHQNiTSGp)_