### PR TITLE
Gateway: Commerce Mesh Partner Portal surface over live factory tables (VTID-03544)

### DIFF
--- a/docs/validation/VTID-03544/acceptance.md
+++ b/docs/validation/VTID-03544/acceptance.md
@@ -1,0 +1,41 @@
+# VTID-03544 — Acceptance (Commerce Mesh Partner Portal, gateway slice)
+
+Scope of THIS PR: gateway-only (`services/gateway/src/**` + this evidence
+pack). The mesh factory tables it reads/writes (VTID-03535 migration 0001)
+were applied to Supabase on 2026-08-09 under the same VTID; the vcaop-side
+mesh work ships separately in PR #3066 (this validator's path-ownership
+guard admits only gateway trees, so the two cannot share a PR).
+
+Verification tokens: TEST = jest suite (`services/gateway/test/routes/
+vcaop-portal.test.ts`, captured in ./outputs/portal-tests.txt), CURL = HTTP
+contract to run against `preview-gateway.vitanaland.com` after merge (per
+CLAUDE.md §15, a push deploys STAGING only).
+
+AC-1 — Portal endpoints are admin-gated: community role is denied, no DB touch happens first
+  TEST: "community role is denied everywhere (403)"
+  CURL: GET /api/v1/vcaop/portal/connections with a community Bearer -> 403 {"ok":false,"error":"forbidden"}
+
+AC-2 — Input validation precedes persistence on connection creation
+  TEST: "create validates required fields before touching the database"
+  CURL: POST /api/v1/vcaop/portal/connections {"name":"x"} as admin -> 400 naming connector_id/provider_id
+
+AC-3 — The 11-state connection machine is a byte-faithful mirror of services/vcaop, pinned by a sync test
+  TEST: "the mirrored transition map matches the canonical map row for row" (parses STATE_TRANSITIONS out of services/vcaop/src/factory/manifest.ts source; fails CI on any divergence)
+  TEST: "canTransition follows the map and rejects unknown states"
+
+AC-4 — Sandbox tests are honest about what they are: gateway_dev_sandbox evaluates the mapping gate only and records contract_tests_executed: 0
+  TEST: "pendingReviewMappings flags sensitive + low-confidence non-human mappings only"
+  CURL: POST /api/v1/vcaop/portal/connections/:id/sandbox-tests -> 200 with certification and test_results.mode = "gateway_dev_sandbox"
+
+AC-5 — Activation is a separate admin approval gated on a certified version; illegal transitions are 409
+  TEST: transition-map tests above (certified -> active is the only activation edge)
+  CURL: POST /api/v1/vcaop/portal/connections/:id/approve-activation on an uncertified connection -> 409
+
+AC-6 — Degraded infrastructure fails closed with JSON, not a crash
+  TEST: "admin without a database gets 503, not a crash"
+  CURL: (staging) any portal route while DB unavailable -> 503 {"ok":false,"error":"database unavailable"}
+
+ROUTE_MOUNT: `/api/v1/vcaop/portal` mounted in services/gateway/src/index.ts via mountRouterSync BEFORE the `/api/v1/vcaop` catch-all (same ordering rule as the postback/shopify/awin sub-paths).
+FINAL_URL: https://preview-gateway.vitanaland.com/api/v1/vcaop/portal/connections
+CURL_PROOF: after merge-to-main auto-deploys staging, `curl -s -o /dev/null -w "%{http_code} %{content_type}" https://preview-gateway.vitanaland.com/api/v1/vcaop/portal/connections` must return `401 application/json...` (route exists, auth required) — NOT `404 text/html` (route missing, per §15's HTML-vs-JSON diagnostic).
+OASIS_PROOF: every mutating handler emits a `vcaop.portal.*` OASIS event (connection.started, sandbox_tests.completed, connection.activated, connection.paused/resumed/reauthorize_requested/revoked) through the same oasis_events insert pattern as routes/vcaop.ts; state transitions only, no polling events (§6). Verify post-merge: `SELECT type, message FROM oasis_events WHERE type LIKE 'vcaop.portal.%' ORDER BY created_at DESC LIMIT 5;`

--- a/docs/validation/VTID-03544/acceptance.md
+++ b/docs/validation/VTID-03544/acceptance.md
@@ -35,7 +35,32 @@ AC-6 — Degraded infrastructure fails closed with JSON, not a crash
   TEST: "admin without a database gets 503, not a crash"
   CURL: (staging) any portal route while DB unavailable -> 503 {"ok":false,"error":"database unavailable"}
 
-ROUTE_MOUNT: `/api/v1/vcaop/portal` mounted in services/gateway/src/index.ts via mountRouterSync BEFORE the `/api/v1/vcaop` catch-all (same ordering rule as the postback/shopify/awin sub-paths).
+The merchant self-service `/my` surface (VTID-03553, same PR: owner-scoped
+twin of the admin router at `/api/v1/vcaop/portal/my`, backed by migration
+0005's `partner_tenant.owner_user_id`; jest suite
+`services/gateway/test/routes/vcaop-portal-my.test.ts`, captured in
+./outputs/portal-my-tests.txt):
+
+AC-7 — Every merchant read is scoped to partner_tenant.owner_user_id = caller; foreign rows read as 404
+  TEST: "GET /connections filters on partner_tenant.owner_user_id = the caller"
+  TEST: "a connection owned by someone else reads as 404, not 403"
+  CURL: GET /api/v1/vcaop/portal/my/connections/<other-merchant-id> as merchant A -> 404 {"ok":false,"error":"connection not found"}
+
+AC-8 — Creation stamps ownership from the JWT, never from the request body
+  TEST: "create stamps owner_user_id + owner_email from the JWT, never the body"
+  CURL: POST /api/v1/vcaop/portal/my/connections with body owner_user_id=spoofed -> created row carries the caller's user_id
+
+AC-9 — The platform's one-approval activation does NOT exist on the merchant surface
+  TEST: "no /approve-activation on the merchant surface — activation stays admin-only"
+  TEST: "activation-summary reports awaiting_platform_approval instead of can_activate"
+  CURL: POST /api/v1/vcaop/portal/my/connections/:id/approve-activation -> 404 (route absent)
+
+AC-10 — Lifecycle writes on foreign connections are refused before any DB write
+  TEST: "lifecycle transition on a foreign connection is 404 and writes nothing"
+  CURL: POST /api/v1/vcaop/portal/my/connections/<foreign>/revoke as non-owner -> 404, row unchanged
+
+ROUTE_MOUNT: `/api/v1/vcaop/portal` mounted in services/gateway/src/index.ts via mountRouterSync BEFORE the `/api/v1/vcaop` catch-all (same ordering rule as the postback/shopify/awin sub-paths). `/api/v1/vcaop/portal/my` (VTID-03553) mounts BEFORE `/api/v1/vcaop/portal` so the owner-scoped handlers win over the admin ones.
 FINAL_URL: https://preview-gateway.vitanaland.com/api/v1/vcaop/portal/connections
-CURL_PROOF: after merge-to-main auto-deploys staging, `curl -s -o /dev/null -w "%{http_code} %{content_type}" https://preview-gateway.vitanaland.com/api/v1/vcaop/portal/connections` must return `401 application/json...` (route exists, auth required) — NOT `404 text/html` (route missing, per §15's HTML-vs-JSON diagnostic).
-OASIS_PROOF: every mutating handler emits a `vcaop.portal.*` OASIS event (connection.started, sandbox_tests.completed, connection.activated, connection.paused/resumed/reauthorize_requested/revoked) through the same oasis_events insert pattern as routes/vcaop.ts; state transitions only, no polling events (§6). Verify post-merge: `SELECT type, message FROM oasis_events WHERE type LIKE 'vcaop.portal.%' ORDER BY created_at DESC LIMIT 5;`
+FINAL_URL: https://preview-gateway.vitanaland.com/api/v1/vcaop/portal/my/connections
+CURL_PROOF: after merge-to-main auto-deploys staging, `curl -s -o /dev/null -w "%{http_code} %{content_type}" https://preview-gateway.vitanaland.com/api/v1/vcaop/portal/connections` must return `401 application/json...` (route exists, auth required) — NOT `404 text/html` (route missing, per §15's HTML-vs-JSON diagnostic). Same check against `/api/v1/vcaop/portal/my/connections`.
+OASIS_PROOF: every mutating handler emits a `vcaop.portal.*` OASIS event (connection.started, sandbox_tests.completed, connection.activated, connection.paused/resumed/reauthorize_requested/revoked) through the same oasis_events insert pattern as routes/vcaop.ts; state transitions only, no polling events (§6). The `/my` handlers emit the same event types with `metadata.surface = "merchant_self_service"` and `source = "vcaop-portal-my"`. Verify post-merge: `SELECT type, message FROM oasis_events WHERE type LIKE 'vcaop.portal.%' ORDER BY created_at DESC LIMIT 5;`

--- a/docs/validation/VTID-03544/commands.log
+++ b/docs/validation/VTID-03544/commands.log
@@ -16,3 +16,7 @@ cd services/gateway && npx jest test/routes/vcaop-portal.test.ts
 #    that are IDENTICAL on clean origin/main (stale local node_modules —
 #    missing `compression` types); verified by stashing the diff and
 #    rebuilding. CI's clean `npm ci && npm run build` is the authority.
+
+# VTID-03553 /my surface (2026-08-09)
+cd services/gateway && npx tsc --noEmit   # pre-existing local-env compression/any errors only (also present on stashed tree)
+npx jest test/routes/vcaop-portal-my.test.ts test/routes/vcaop-portal.test.ts   # 16/16 pass -> outputs/portal-my-tests.txt

--- a/docs/validation/VTID-03544/commands.log
+++ b/docs/validation/VTID-03544/commands.log
@@ -1,0 +1,18 @@
+# VTID-03544 — commands executed for verification (2026-08-09)
+
+# 1. Route + helper + auth tests (output captured in ./outputs/portal-tests.txt)
+cd services/gateway && npx jest test/routes/vcaop-portal.test.ts
+# -> Test Suites: 1 passed; Tests: 8 passed
+
+# 2. Transition-map sync verification is part of the suite above — it parses
+#    STATE_TRANSITIONS out of services/vcaop/src/factory/manifest.ts at test
+#    time and compares row-for-row against the mirror in the route module.
+
+# 3. Mesh factory tables applied to Supabase (project inmkhvwdcuyhnxkgfvsb)
+#    via MCP apply_migration as vcaop_mesh_factory_0001_vtid_03535 (RLS
+#    enabled on all 8 tables). Applied 2026-08-09, before this route ships.
+
+# 4. Local `npm run build` on this container reports 3 pre-existing errors
+#    that are IDENTICAL on clean origin/main (stale local node_modules —
+#    missing `compression` types); verified by stashing the diff and
+#    rebuilding. CI's clean `npm ci && npm run build` is the authority.

--- a/docs/validation/VTID-03544/outputs/portal-my-tests.txt
+++ b/docs/validation/VTID-03544/outputs/portal-my-tests.txt
@@ -1,0 +1,27 @@
+ts-jest[config] (WARN) 
+    The "ts-jest" config option "isolatedModules" is deprecated and will be removed in v30.0.0. Please use "isolatedModules: true" in /home/user/vitana-platform/services/gateway/tsconfig.json instead, see https://www.typescriptlang.org/tsconfig/#isolatedModules
+  
+  console.log
+    ✅ Test setup loaded - fetch mocked, env vars set
+
+      at Object.<anonymous> (test/__mocks__/setup-tests.ts:517:9)
+
+PASS test/routes/vcaop-portal-my.test.ts
+  ownership scoping
+    ✓ GET /connections filters on partner_tenant.owner_user_id = the caller (29 ms)
+    ✓ a connection owned by someone else reads as 404, not 403 (8 ms)
+    ✓ create stamps owner_user_id + owner_email from the JWT, never the body (17 ms)
+  authority boundaries
+    ✓ no /approve-activation on the merchant surface — activation stays admin-only (17 ms)
+    ✓ activation-summary reports awaiting_platform_approval instead of can_activate (6 ms)
+  input + infrastructure guards
+    ✓ database unavailable → 503, not a crash (4 ms)
+    ✓ create validates required fields before touching the database (4 ms)
+    ✓ lifecycle transition on a foreign connection is 404 and writes nothing (3 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       8 passed, 8 total
+Snapshots:   0 total
+Time:        1.02 s, estimated 2 s
+Ran all test suites matching /test\/routes\/vcaop-portal-my.test.ts/i.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?

--- a/docs/validation/VTID-03544/outputs/portal-tests.txt
+++ b/docs/validation/VTID-03544/outputs/portal-tests.txt
@@ -1,0 +1,27 @@
+ts-jest[config] (WARN) 
+    The "ts-jest" config option "isolatedModules" is deprecated and will be removed in v30.0.0. Please use "isolatedModules: true" in /home/user/vitana-platform/services/gateway/tsconfig.json instead, see https://www.typescriptlang.org/tsconfig/#isolatedModules
+  
+  console.log
+    ✅ Test setup loaded - fetch mocked, env vars set
+
+      at Object.<anonymous> (test/__mocks__/setup-tests.ts:517:9)
+
+PASS test/routes/vcaop-portal.test.ts
+  state machine mirror stays in sync with services/vcaop
+    ✓ every mirrored state exists in the canonical CONNECTION_STATES (4 ms)
+    ✓ the mirrored transition map matches the canonical map row for row (3 ms)
+  pure helpers
+    ✓ canTransition follows the map and rejects unknown states (1 ms)
+    ✓ pendingReviewMappings flags sensitive + low-confidence non-human mappings only (1 ms)
+    ✓ extractSchemaSources pulls component schemas with required flags
+  route auth rules
+    ✓ community role is denied everywhere (403) (26 ms)
+    ✓ admin without a database gets 503, not a crash (4 ms)
+    ✓ create validates required fields before touching the database (21 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       8 passed, 8 total
+Snapshots:   0 total
+Time:        1.158 s, estimated 2 s
+Ran all test suites matching /test\/routes\/vcaop-portal.test.ts/i.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -315,6 +315,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const vcaopPostbackRouter = require('./routes/vcaop-postback').default;
   // VCAOP: Commerce Mesh Partner Portal (connect-business workflow, VTID-03544)
   const vcaopPortalRouter = require('./routes/vcaop-portal').default;
+  // VCAOP: merchant self-service portal — owner-scoped /my surface (VTID-03553)
+  const vcaopPortalMyRouter = require('./routes/vcaop-portal-my').default;
   // VCAOP: Shopify own-store catalog sync (admin trigger; background worker in services)
   const shopifySyncRouter = require('./routes/shopify-sync').default;
   // VCAOP: Awin joined-programme sync (admin trigger; background worker in services)
@@ -712,6 +714,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // VCAOP: public affiliate postback receiver — MUST mount before the authed vcaop
   // router so /api/v1/vcaop/postback/* resolves to the key-verified public handler.
   mountRouterSync(app, '/api/v1/vcaop/postback', vcaopPostbackRouter, { owner: 'vcaop-postback' });
+  // VCAOP: merchant self-service /my surface — MUST mount before the admin
+  // portal router so /api/v1/vcaop/portal/my/* resolves to the owner-scoped
+  // handlers instead of the admin ones (VTID-03553).
+  mountRouterSync(app, '/api/v1/vcaop/portal/my', vcaopPortalMyRouter, { owner: 'vcaop-portal-my' });
   // VCAOP: Partner Portal — mount before the vcaop router so the sub-path resolves.
   mountRouterSync(app, '/api/v1/vcaop/portal', vcaopPortalRouter, { owner: 'vcaop-portal' });
   // VCAOP: Shopify catalog sync — mount before the vcaop router so the sub-path resolves.

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -313,6 +313,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const vcaopRouter = require('./routes/vcaop').default;
   // VCAOP: public, key-verified affiliate postback receiver (Admitad) — no user auth
   const vcaopPostbackRouter = require('./routes/vcaop-postback').default;
+  // VCAOP: Commerce Mesh Partner Portal (connect-business workflow, VTID-03544)
+  const vcaopPortalRouter = require('./routes/vcaop-portal').default;
   // VCAOP: Shopify own-store catalog sync (admin trigger; background worker in services)
   const shopifySyncRouter = require('./routes/shopify-sync').default;
   // VCAOP: Awin joined-programme sync (admin trigger; background worker in services)
@@ -710,6 +712,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // VCAOP: public affiliate postback receiver — MUST mount before the authed vcaop
   // router so /api/v1/vcaop/postback/* resolves to the key-verified public handler.
   mountRouterSync(app, '/api/v1/vcaop/postback', vcaopPostbackRouter, { owner: 'vcaop-postback' });
+  // VCAOP: Partner Portal — mount before the vcaop router so the sub-path resolves.
+  mountRouterSync(app, '/api/v1/vcaop/portal', vcaopPortalRouter, { owner: 'vcaop-portal' });
   // VCAOP: Shopify catalog sync — mount before the vcaop router so the sub-path resolves.
   mountRouterSync(app, '/api/v1/vcaop/shopify', shopifySyncRouter, { owner: 'vcaop-shopify' });
   // VCAOP: Awin programme sync — mount before the vcaop router so the sub-path resolves.

--- a/services/gateway/src/routes/vcaop-portal-my.ts
+++ b/services/gateway/src/routes/vcaop-portal-my.ts
@@ -1,0 +1,332 @@
+/**
+ * VCAOP Merchant Self-Service Portal — `/my` surface (VTID-03553).
+ *
+ * The user side of the Partner Portal (CLAUDE.md §13c: self-service merchant
+ * onboarding — a business owner connects their own storefront to Discover
+ * without an engineer hand-writing a migration). Same tables, same mirrored
+ * state machine, same factory plane as the admin router (vcaop-portal.ts) —
+ * the ONLY differences are scoping and authority:
+ *
+ *  - Auth: any authenticated user (requireAuth), NOT exafy_admin. Every
+ *    query is scoped to partner_tenant.owner_user_id = the caller, so a
+ *    merchant sees exactly the businesses they created and nothing else;
+ *    foreign rows read as 404, indistinguishable from nonexistent.
+ *  - Creation stamps ownership (owner_user_id from the JWT, owner_email from
+ *    the JWT email claim — never from the request body).
+ *  - THE one-approval activation is deliberately ABSENT here. Certification
+ *    approval stays back-office (admin router's /approve-activation); a
+ *    merchant can take a connection all the way to `certified` and then
+ *    waits for platform approval. Mapping decisions for the merchant's OWN
+ *    schema are theirs to make (decided_by = the authenticated caller).
+ *
+ * Served to the commerce.vitanaland.com frontend (host-routed community-app
+ * build); DNS/exposure for that host is deferred the BLK-006 way.
+ */
+import { Router, Request, Response } from 'express';
+import { createHash, randomUUID } from 'crypto';
+import { getSupabase } from '../lib/supabase';
+import { requireAuth } from '../middleware/auth-supabase-jwt';
+import {
+  ConnectionState,
+  canTransition,
+  extractSchemaSources,
+  pendingReviewMappings,
+} from './vcaop-portal';
+
+const router = Router();
+router.use(requireAuth as any);
+
+function db(res: Response) {
+  const s = getSupabase();
+  if (!s) {
+    res.status(503).json({ ok: false, error: 'database unavailable' });
+    return null;
+  }
+  return s;
+}
+function userId(req: Request): string {
+  return String((req as any).identity?.user_id || '');
+}
+function userEmail(req: Request): string | null {
+  const e = (req as any).identity?.email;
+  return typeof e === 'string' && e.length > 0 ? e : null;
+}
+function tenantId(req: Request): string {
+  return String((req as any).identity?.tenant_id || 'platform');
+}
+async function emitEvent(supabase: any, type: string, status: string, message: string, payload: Record<string, unknown>) {
+  try {
+    await supabase.from('oasis_events').insert({
+      id: randomUUID(), service: 'vcaop', source: 'vcaop-portal-my', type, topic: type, status, message,
+      metadata: payload, created_at: new Date().toISOString(),
+    });
+  } catch { /* never block the request on the audit write */ }
+}
+
+/** Load a manifest row the CALLER OWNS (partner_tenant.owner_user_id).
+ * Anything else — other merchants' rows, admin-seeded rows with no owner —
+ * reads as 404. */
+async function getOwnedManifest(supabase: any, req: Request) {
+  const { data } = await supabase
+    .from('integration_manifest')
+    .select('id,partner_tenant_id,connector_id,provider_id,connection_type,risk_level,status,created_at,updated_at, partner_tenant!inner(id,tenant_id,name,jurisdiction,owner_user_id)')
+    .eq('id', req.params.id)
+    .eq('partner_tenant.owner_user_id', userId(req))
+    .maybeSingle();
+  return data ?? null;
+}
+
+async function latestVersion(supabase: any, manifestId: string) {
+  const { data } = await supabase
+    .from('integration_version')
+    .select('id,version,certification_status,document_hash,created_at')
+    .eq('manifest_id', manifestId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return data ?? null;
+}
+
+async function transition(supabase: any, req: Request, res: Response, to: ConnectionState, eventType: string) {
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  if (!canTransition(rec.status, to)) {
+    return res.status(409).json({ ok: false, error: `illegal transition ${rec.status} -> ${to}` });
+  }
+  const now = new Date().toISOString();
+  await supabase.from('integration_manifest').update({ status: to, updated_at: now }).eq('id', rec.id);
+  await emitEvent(supabase, eventType, 'success', `connection ${rec.id}: ${rec.status} -> ${to}`, {
+    connection_id: rec.id, from: rec.status, to, actor: userId(req), surface: 'merchant_self_service',
+  });
+  return res.json({ ok: true, data: { id: rec.id, state: to } });
+}
+
+// ===== List / create =====
+router.get('/connections', async (req: Request, res: Response) => {
+  const supabase = db(res); if (!supabase) return;
+  const { data, error } = await supabase
+    .from('integration_manifest')
+    .select('id,connector_id,provider_id,connection_type,risk_level,status,created_at,updated_at, partner_tenant!inner(tenant_id,name,jurisdiction,owner_user_id)')
+    .eq('partner_tenant.owner_user_id', userId(req))
+    .order('updated_at', { ascending: false });
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  res.json({
+    ok: true,
+    data: (data || []).map((m: any) => ({
+      id: m.id, name: m.partner_tenant?.name, connector_id: m.connector_id, provider_id: m.provider_id,
+      connection_type: m.connection_type, risk_level: m.risk_level, state: m.status,
+      jurisdiction: m.partner_tenant?.jurisdiction, updated_at: m.updated_at,
+    })),
+  });
+});
+
+router.post('/connections', async (req: Request, res: Response) => {
+  const supabase = db(res); if (!supabase) return;
+  const { name, connector_id, provider_id, connection_type, risk_level, jurisdiction, openapi_document } = req.body ?? {};
+  if (!name || !connector_id || !provider_id) {
+    return res.status(400).json({ ok: false, error: 'name, connector_id and provider_id are required' });
+  }
+  const owner = userId(req);
+  const now = new Date().toISOString();
+
+  // One partner_tenant row per (owner, business name) — a merchant's own
+  // business, distinct from any admin-seeded partner with the same name.
+  const { data: existingPartner } = await supabase
+    .from('partner_tenant').select('id').eq('owner_user_id', owner).eq('name', name).maybeSingle();
+  let partnerId = existingPartner?.id;
+  if (!partnerId) {
+    partnerId = randomUUID();
+    const { error } = await supabase.from('partner_tenant').insert({
+      id: partnerId, tenant_id: tenantId(req), name, status: 'discovered', jurisdiction: jurisdiction ?? null,
+      owner_user_id: owner, owner_email: userEmail(req),
+      created_at: now, updated_at: now,
+    });
+    if (error) return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  const initialState: ConnectionState = openapi_document ? 'mapping' : 'authorization_required';
+  const manifestId = randomUUID();
+  const { error: mErr } = await supabase.from('integration_manifest').insert({
+    id: manifestId, partner_tenant_id: partnerId, connector_id, provider_id,
+    connection_type: connection_type ?? 'api', risk_level: risk_level ?? 'medium',
+    status: initialState, created_at: now, updated_at: now,
+  });
+  if (mErr) {
+    const dup = /duplicate|unique/i.test(mErr.message);
+    return res.status(dup ? 409 : 500).json({ ok: false, error: dup ? 'connection already exists for this business + connector' : mErr.message });
+  }
+
+  if (openapi_document) {
+    const versionId = randomUUID();
+    const docJson = JSON.stringify(openapi_document);
+    await supabase.from('integration_version').insert({
+      id: versionId, manifest_id: manifestId, version: '0.1.0', document: openapi_document,
+      document_hash: createHash('sha256').update(docJson).digest('hex'), certification_status: 'draft', created_at: now,
+    });
+    const sources = extractSchemaSources(openapi_document);
+    for (const s of sources) {
+      await supabase.from('schema_source').insert({
+        id: randomUUID(), version_id: versionId, name: s.name, fields: s.fields,
+        hash: createHash('sha256').update(JSON.stringify(s.fields)).digest('hex'), created_at: now,
+      });
+    }
+  }
+
+  await emitEvent(supabase, 'vcaop.portal.connection.started', 'success', `connection ${manifestId} started (${initialState})`, {
+    connection_id: manifestId, connector_id, provider_id, state: initialState, actor: owner, surface: 'merchant_self_service',
+  });
+  res.status(201).json({ ok: true, data: { id: manifestId, name, state: initialState } });
+});
+
+// ===== Detail / mapping preview / decisions =====
+router.get('/connections/:id', async (req: Request, res: Response) => {
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  const version = await latestVersion(supabase, rec.id);
+  res.json({
+    ok: true,
+    data: {
+      id: rec.id, name: rec.partner_tenant?.name, connector_id: rec.connector_id, provider_id: rec.provider_id,
+      connection_type: rec.connection_type, risk_level: rec.risk_level, state: rec.status,
+      jurisdiction: rec.partner_tenant?.jurisdiction, latest_version: version, updated_at: rec.updated_at,
+    },
+  });
+});
+
+router.get('/connections/:id/mapping-preview', async (req: Request, res: Response) => {
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  const version = await latestVersion(supabase, rec.id);
+  if (!version) {
+    return res.json({ ok: true, data: { state: rec.status, pipeline_status: 'awaiting_specification', sources: [], mappings: [], pending_review: [] } });
+  }
+  const [{ data: sources }, { data: mappings }] = await Promise.all([
+    supabase.from('schema_source').select('id,name,fields').eq('version_id', version.id),
+    supabase.from('schema_mapping')
+      .select('id,source_schema,source_field,canonical_entity,canonical_field,transform,confidence,decided_by,sensitive')
+      .eq('version_id', version.id),
+  ]);
+  const pending = pendingReviewMappings(mappings || []);
+  res.json({
+    ok: true,
+    data: {
+      state: rec.status,
+      pipeline_status: (mappings || []).length === 0 ? 'awaiting_factory_run' : 'mapped',
+      version: version.version,
+      sources: sources || [],
+      mappings: mappings || [],
+      pending_review: pending,
+    },
+  });
+});
+
+// A merchant decides mappings for their OWN business's schema.
+router.post('/connections/:id/mapping-decisions', async (req: Request, res: Response) => {
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  const { mapping_id, decision, reason } = req.body ?? {};
+  if (!mapping_id || !['approve', 'reject'].includes(decision)) {
+    return res.status(400).json({ ok: false, error: 'mapping_id and decision (approve|reject) required' });
+  }
+  const version = await latestVersion(supabase, rec.id);
+  if (!version) return res.status(409).json({ ok: false, error: 'no integration version to decide on' });
+  const { data: mapping } = await supabase
+    .from('schema_mapping').select('id,version_id').eq('id', mapping_id).eq('version_id', version.id).maybeSingle();
+  if (!mapping) return res.status(404).json({ ok: false, error: 'mapping not found on latest version' });
+
+  const now = new Date().toISOString();
+  // decided_by is ALWAYS the authenticated caller — a client-supplied value is ignored.
+  await supabase.from('mapping_decision').insert({
+    id: randomUUID(), mapping_id, decision, decided_by: userId(req), reason: reason ?? null, created_at: now,
+  });
+  if (decision === 'approve') {
+    await supabase.from('schema_mapping').update({ decided_by: 'human' }).eq('id', mapping_id);
+  }
+  await emitEvent(supabase, 'vcaop.portal.mapping.decided', 'success', `mapping ${mapping_id}: ${decision}`, {
+    connection_id: rec.id, mapping_id, decision, actor: userId(req), surface: 'merchant_self_service',
+  });
+  res.json({ ok: true, data: { mapping_id, decision } });
+});
+
+// ===== Sandbox tests (gateway_dev_sandbox mode — same honest record as admin) =====
+router.post('/connections/:id/sandbox-tests', async (req: Request, res: Response) => {
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  if (!canTransition(rec.status, 'testing') && rec.status !== 'testing') {
+    return res.status(409).json({ ok: false, error: `cannot run tests from state ${rec.status}` });
+  }
+  const version = await latestVersion(supabase, rec.id);
+  if (!version) return res.status(409).json({ ok: false, error: 'no integration version to test' });
+
+  const { data: mappings } = await supabase
+    .from('schema_mapping').select('id,sensitive,confidence,decided_by').eq('version_id', version.id);
+  const pending = pendingReviewMappings(mappings || []);
+  const certStatus = pending.length > 0 ? 'approval_required' : 'certified';
+  const now = new Date().toISOString();
+
+  await supabase.from('connector_certification').insert({
+    id: randomUUID(), version_id: version.id, status: certStatus,
+    test_results: { mode: 'gateway_dev_sandbox', contract_tests_executed: 0, mapping_gate: pending.length === 0 ? 'pass' : 'pending_review' },
+    pending_mappings: pending, reasons: pending.length > 0 ? ['sensitive or low-confidence mappings need a human decision'] : [],
+    certified_by: null, created_at: now,
+  });
+  await supabase.from('integration_version').update({ certification_status: certStatus }).eq('id', version.id);
+  const nextState: ConnectionState = certStatus === 'certified' ? 'certified' : 'approval_required';
+  await supabase.from('integration_manifest').update({ status: nextState, updated_at: now }).eq('id', rec.id);
+  await emitEvent(supabase, 'vcaop.portal.sandbox_tests.completed', 'success', `connection ${rec.id}: ${certStatus}`, {
+    connection_id: rec.id, version: version.version, status: certStatus, pending: pending.length, actor: userId(req), surface: 'merchant_self_service',
+  });
+  res.json({ ok: true, data: { state: nextState, certification: certStatus, pending_review: pending } });
+});
+
+router.get('/connections/:id/activation-summary', async (req: Request, res: Response) => {
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  const version = await latestVersion(supabase, rec.id);
+  let cert = null;
+  if (version) {
+    const { data } = await supabase
+      .from('connector_certification').select('id,status,test_results,pending_mappings,reasons,created_at')
+      .eq('version_id', version.id).order('created_at', { ascending: false }).limit(1).maybeSingle();
+    cert = data ?? null;
+  }
+  res.json({
+    ok: true,
+    data: {
+      id: rec.id, state: rec.status, version: version?.version ?? null,
+      certification: cert,
+      // The merchant surface never activates — it reports whether the
+      // connection is WAITING on the platform's one-approval activation.
+      awaiting_platform_approval: rec.status === 'certified' && cert?.status === 'certified',
+    },
+  });
+});
+
+// NOTE: there is deliberately NO /approve-activation here. Activation is the
+// platform's one-approval gate and lives on the admin router only.
+
+// ===== Lifecycle (a merchant manages their own connection) =====
+router.post('/connections/:id/pause', async (req, res) => {
+  const supabase = db(res); if (!supabase) return;
+  await transition(supabase, req, res, 'suspended', 'vcaop.portal.connection.paused');
+});
+router.post('/connections/:id/resume', async (req, res) => {
+  const supabase = db(res); if (!supabase) return;
+  await transition(supabase, req, res, 'active', 'vcaop.portal.connection.resumed');
+});
+router.post('/connections/:id/reauthorize', async (req, res) => {
+  const supabase = db(res); if (!supabase) return;
+  await transition(supabase, req, res, 'suspended', 'vcaop.portal.connection.reauthorize_requested');
+});
+// Irreversible for the connection — the owner may always sever their own integration.
+router.post('/connections/:id/revoke', async (req, res) => {
+  const supabase = db(res); if (!supabase) return;
+  await transition(supabase, req, res, 'revoked', 'vcaop.portal.connection.revoked');
+});
+
+export default router;

--- a/services/gateway/src/routes/vcaop-portal-my.ts
+++ b/services/gateway/src/routes/vcaop-portal-my.ts
@@ -54,7 +54,7 @@ function userEmail(req: Request): string | null {
 function tenantId(req: Request): string {
   return String((req as any).identity?.tenant_id || 'platform');
 }
-async function emitEvent(supabase: any, type: string, status: string, message: string, payload: Record<string, unknown>) {
+async function emitOasisEvent(supabase: any, type: string, status: string, message: string, payload: Record<string, unknown>) {
   try {
     await supabase.from('oasis_events').insert({
       id: randomUUID(), service: 'vcaop', source: 'vcaop-portal-my', type, topic: type, status, message,
@@ -87,7 +87,7 @@ async function latestVersion(supabase: any, manifestId: string) {
   return data ?? null;
 }
 
-async function transition(supabase: any, req: Request, res: Response, to: ConnectionState, eventType: string) {
+async function transitionAndEmitOasisEvent(supabase: any, req: Request, res: Response, to: ConnectionState, eventType: string) {
   const rec = await getOwnedManifest(supabase, req);
   if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
   if (!canTransition(rec.status, to)) {
@@ -95,7 +95,7 @@ async function transition(supabase: any, req: Request, res: Response, to: Connec
   }
   const now = new Date().toISOString();
   await supabase.from('integration_manifest').update({ status: to, updated_at: now }).eq('id', rec.id);
-  await emitEvent(supabase, eventType, 'success', `connection ${rec.id}: ${rec.status} -> ${to}`, {
+  await emitOasisEvent(supabase, eventType, 'success', `connection ${rec.id}: ${rec.status} -> ${to}`, {
     connection_id: rec.id, from: rec.status, to, actor: userId(req), surface: 'merchant_self_service',
   });
   return res.json({ ok: true, data: { id: rec.id, state: to } });
@@ -172,7 +172,7 @@ router.post('/connections', async (req: Request, res: Response) => {
     }
   }
 
-  await emitEvent(supabase, 'vcaop.portal.connection.started', 'success', `connection ${manifestId} started (${initialState})`, {
+  await emitOasisEvent(supabase, 'vcaop.portal.connection.started', 'success', `connection ${manifestId} started (${initialState})`, {
     connection_id: manifestId, connector_id, provider_id, state: initialState, actor: owner, surface: 'merchant_self_service',
   });
   res.status(201).json({ ok: true, data: { id: manifestId, name, state: initialState } });
@@ -245,7 +245,7 @@ router.post('/connections/:id/mapping-decisions', async (req: Request, res: Resp
   if (decision === 'approve') {
     await supabase.from('schema_mapping').update({ decided_by: 'human' }).eq('id', mapping_id);
   }
-  await emitEvent(supabase, 'vcaop.portal.mapping.decided', 'success', `mapping ${mapping_id}: ${decision}`, {
+  await emitOasisEvent(supabase, 'vcaop.portal.mapping.decided', 'success', `mapping ${mapping_id}: ${decision}`, {
     connection_id: rec.id, mapping_id, decision, actor: userId(req), surface: 'merchant_self_service',
   });
   res.json({ ok: true, data: { mapping_id, decision } });
@@ -277,7 +277,7 @@ router.post('/connections/:id/sandbox-tests', async (req: Request, res: Response
   await supabase.from('integration_version').update({ certification_status: certStatus }).eq('id', version.id);
   const nextState: ConnectionState = certStatus === 'certified' ? 'certified' : 'approval_required';
   await supabase.from('integration_manifest').update({ status: nextState, updated_at: now }).eq('id', rec.id);
-  await emitEvent(supabase, 'vcaop.portal.sandbox_tests.completed', 'success', `connection ${rec.id}: ${certStatus}`, {
+  await emitOasisEvent(supabase, 'vcaop.portal.sandbox_tests.completed', 'success', `connection ${rec.id}: ${certStatus}`, {
     connection_id: rec.id, version: version.version, status: certStatus, pending: pending.length, actor: userId(req), surface: 'merchant_self_service',
   });
   res.json({ ok: true, data: { state: nextState, certification: certStatus, pending_review: pending } });
@@ -313,20 +313,20 @@ router.get('/connections/:id/activation-summary', async (req: Request, res: Resp
 // ===== Lifecycle (a merchant manages their own connection) =====
 router.post('/connections/:id/pause', async (req, res) => {
   const supabase = db(res); if (!supabase) return;
-  await transition(supabase, req, res, 'suspended', 'vcaop.portal.connection.paused');
+  await transitionAndEmitOasisEvent(supabase, req, res, 'suspended', 'vcaop.portal.connection.paused');
 });
 router.post('/connections/:id/resume', async (req, res) => {
   const supabase = db(res); if (!supabase) return;
-  await transition(supabase, req, res, 'active', 'vcaop.portal.connection.resumed');
+  await transitionAndEmitOasisEvent(supabase, req, res, 'active', 'vcaop.portal.connection.resumed');
 });
 router.post('/connections/:id/reauthorize', async (req, res) => {
   const supabase = db(res); if (!supabase) return;
-  await transition(supabase, req, res, 'suspended', 'vcaop.portal.connection.reauthorize_requested');
+  await transitionAndEmitOasisEvent(supabase, req, res, 'suspended', 'vcaop.portal.connection.reauthorize_requested');
 });
 // Irreversible for the connection — the owner may always sever their own integration.
 router.post('/connections/:id/revoke', async (req, res) => {
   const supabase = db(res); if (!supabase) return;
-  await transition(supabase, req, res, 'revoked', 'vcaop.portal.connection.revoked');
+  await transitionAndEmitOasisEvent(supabase, req, res, 'revoked', 'vcaop.portal.connection.revoked');
 });
 
 export default router;

--- a/services/gateway/src/routes/vcaop-portal.ts
+++ b/services/gateway/src/routes/vcaop-portal.ts
@@ -127,7 +127,7 @@ function requireAdmin(req: Request, res: Response): boolean {
   }
   return true;
 }
-async function emitEvent(supabase: any, type: string, status: string, message: string, payload: Record<string, unknown>) {
+async function emitOasisEvent(supabase: any, type: string, status: string, message: string, payload: Record<string, unknown>) {
   try {
     await supabase.from('oasis_events').insert({
       id: randomUUID(), service: 'vcaop', source: 'vcaop-portal', type, topic: type, status, message,
@@ -158,7 +158,7 @@ async function latestVersion(supabase: any, manifestId: string) {
   return data ?? null;
 }
 
-async function transition(supabase: any, req: Request, res: Response, to: ConnectionState, eventType: string) {
+async function transitionAndEmitOasisEvent(supabase: any, req: Request, res: Response, to: ConnectionState, eventType: string) {
   const rec = await getOwnedManifest(supabase, req);
   if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
   if (!canTransition(rec.status, to)) {
@@ -166,7 +166,7 @@ async function transition(supabase: any, req: Request, res: Response, to: Connec
   }
   const now = new Date().toISOString();
   await supabase.from('integration_manifest').update({ status: to, updated_at: now }).eq('id', rec.id);
-  await emitEvent(supabase, eventType, 'success', `connection ${rec.id}: ${rec.status} -> ${to}`, {
+  await emitOasisEvent(supabase, eventType, 'success', `connection ${rec.id}: ${rec.status} -> ${to}`, {
     connection_id: rec.id, from: rec.status, to, actor: userId(req),
   });
   return res.json({ ok: true, data: { id: rec.id, state: to } });
@@ -245,7 +245,7 @@ router.post('/connections', async (req: Request, res: Response) => {
     }
   }
 
-  await emitEvent(supabase, 'vcaop.portal.connection.started', 'success', `connection ${manifestId} started (${initialState})`, {
+  await emitOasisEvent(supabase, 'vcaop.portal.connection.started', 'success', `connection ${manifestId} started (${initialState})`, {
     connection_id: manifestId, connector_id, provider_id, state: initialState, actor: userId(req),
   });
   res.status(201).json({ ok: true, data: { id: manifestId, name, state: initialState } });
@@ -320,7 +320,7 @@ router.post('/connections/:id/mapping-decisions', async (req: Request, res: Resp
   if (decision === 'approve') {
     await supabase.from('schema_mapping').update({ decided_by: 'human' }).eq('id', mapping_id);
   }
-  await emitEvent(supabase, 'vcaop.portal.mapping.decided', 'success', `mapping ${mapping_id}: ${decision}`, {
+  await emitOasisEvent(supabase, 'vcaop.portal.mapping.decided', 'success', `mapping ${mapping_id}: ${decision}`, {
     connection_id: rec.id, mapping_id, decision, actor: userId(req),
   });
   res.json({ ok: true, data: { mapping_id, decision } });
@@ -356,7 +356,7 @@ router.post('/connections/:id/sandbox-tests', async (req: Request, res: Response
   await supabase.from('integration_version').update({ certification_status: certStatus }).eq('id', version.id);
   const nextState: ConnectionState = certStatus === 'certified' ? 'certified' : 'approval_required';
   await supabase.from('integration_manifest').update({ status: nextState, updated_at: now }).eq('id', rec.id);
-  await emitEvent(supabase, 'vcaop.portal.sandbox_tests.completed', 'success', `connection ${rec.id}: ${certStatus}`, {
+  await emitOasisEvent(supabase, 'vcaop.portal.sandbox_tests.completed', 'success', `connection ${rec.id}: ${certStatus}`, {
     connection_id: rec.id, version: version.version, status: certStatus, pending: pending.length, actor: userId(req),
   });
   res.json({ ok: true, data: { state: nextState, certification: certStatus, pending_review: pending } });
@@ -402,7 +402,7 @@ router.post('/connections/:id/approve-activation', async (req: Request, res: Res
     .update({ certified_by: userId(req) })
     .eq('version_id', version.id).eq('status', 'certified').is('certified_by', null);
   await supabase.from('integration_manifest').update({ status: 'active', updated_at: now }).eq('id', rec.id);
-  await emitEvent(supabase, 'vcaop.portal.connection.activated', 'success', `connection ${rec.id} activated`, {
+  await emitOasisEvent(supabase, 'vcaop.portal.connection.activated', 'success', `connection ${rec.id} activated`, {
     connection_id: rec.id, version: version.version, approved_by: userId(req),
   });
   res.json({ ok: true, data: { id: rec.id, state: 'active' } });
@@ -412,23 +412,23 @@ router.post('/connections/:id/approve-activation', async (req: Request, res: Res
 router.post('/connections/:id/pause', async (req, res) => {
   if (!requireAdmin(req, res)) return;
   const supabase = db(res); if (!supabase) return;
-  await transition(supabase, req, res, 'suspended', 'vcaop.portal.connection.paused');
+  await transitionAndEmitOasisEvent(supabase, req, res, 'suspended', 'vcaop.portal.connection.paused');
 });
 router.post('/connections/:id/resume', async (req, res) => {
   if (!requireAdmin(req, res)) return;
   const supabase = db(res); if (!supabase) return;
-  await transition(supabase, req, res, 'active', 'vcaop.portal.connection.resumed');
+  await transitionAndEmitOasisEvent(supabase, req, res, 'active', 'vcaop.portal.connection.resumed');
 });
 router.post('/connections/:id/reauthorize', async (req, res) => {
   if (!requireAdmin(req, res)) return;
   const supabase = db(res); if (!supabase) return;
-  await transition(supabase, req, res, 'suspended', 'vcaop.portal.connection.reauthorize_requested');
+  await transitionAndEmitOasisEvent(supabase, req, res, 'suspended', 'vcaop.portal.connection.reauthorize_requested');
 });
 // Irreversible for the connection — still admin-only, emits its own event.
 router.post('/connections/:id/revoke', async (req, res) => {
   if (!requireAdmin(req, res)) return;
   const supabase = db(res); if (!supabase) return;
-  await transition(supabase, req, res, 'revoked', 'vcaop.portal.connection.revoked');
+  await transitionAndEmitOasisEvent(supabase, req, res, 'revoked', 'vcaop.portal.connection.revoked');
 });
 
 export default router;

--- a/services/gateway/src/routes/vcaop-portal.ts
+++ b/services/gateway/src/routes/vcaop-portal.ts
@@ -1,0 +1,434 @@
+/**
+ * VCAOP Partner Portal — gateway surface (Commerce Mesh, VTID-03544 / BLK-001).
+ *
+ * Thin persistence + state-machine surface over the mesh factory tables
+ * (partner_tenant, integration_manifest, integration_version, schema_source,
+ * schema_mapping, mapping_decision, connector_certification — VTID-03535
+ * migration, applied 2026-08-09). The heavy factory logic (OpenAPI ingest,
+ * mapping proposal, compiled connectors, real contract tests) lives in
+ * services/vcaop and runs on the worker/CI plane — this route deliberately
+ * does NOT fork it (ADR-001: one execution engine). What IS mirrored here is
+ * the 11-state connection state machine, byte-for-byte from
+ * services/vcaop/src/factory/manifest.ts, pinned by a sync test
+ * (test/routes/vcaop-portal-transitions-sync.test.ts) the same way the nav
+ * catalog is pinned to the vitana-v1 manifest.
+ *
+ * Roles: portal management is back-office → exafy_admin only. The
+ * one-approval activation and revoke additionally emit OASIS events.
+ * Sandbox tests here run in `gateway_dev_sandbox` mode: they evaluate the
+ * deterministic mapping gate (no sensitive/low-confidence mapping without a
+ * human decision) and execute ZERO live partner calls — test_results says so
+ * explicitly rather than pretending contract tests ran.
+ */
+import { Router, Request, Response } from 'express';
+import { createHash, randomUUID } from 'crypto';
+import { getSupabase } from '../lib/supabase';
+import { requireAuth } from '../middleware/auth-supabase-jwt';
+
+// ---------------------------------------------------------------------------
+// Connection state machine — MIRROR of services/vcaop/src/factory/manifest.ts.
+// Do not edit here without editing the canonical source; the sync test fails
+// on any divergence.
+// ---------------------------------------------------------------------------
+export const CONNECTION_STATES = [
+  'discovered',
+  'authorization_required',
+  'mapping',
+  'testing',
+  'approval_required',
+  'certified',
+  'active',
+  'degraded',
+  'suspended',
+  'revoked',
+  'failed',
+] as const;
+export type ConnectionState = (typeof CONNECTION_STATES)[number];
+
+export const STATE_TRANSITIONS: Record<ConnectionState, ConnectionState[]> = {
+  discovered: ['authorization_required', 'mapping', 'failed', 'revoked'],
+  authorization_required: ['mapping', 'failed', 'revoked'],
+  mapping: ['testing', 'failed', 'revoked'],
+  testing: ['approval_required', 'certified', 'failed', 'revoked'],
+  approval_required: ['certified', 'mapping', 'failed', 'revoked'],
+  certified: ['active', 'revoked'],
+  active: ['degraded', 'suspended', 'revoked'],
+  degraded: ['active', 'suspended', 'failed', 'revoked'],
+  suspended: ['active', 'revoked'],
+  revoked: [],
+  failed: ['mapping', 'revoked'],
+};
+
+export function canTransition(from: string, to: ConnectionState): boolean {
+  const legal = STATE_TRANSITIONS[from as ConnectionState];
+  return Array.isArray(legal) && legal.includes(to);
+}
+
+/** Mapping gate (mirrors certification rule): sensitive or low-confidence
+ * AI-decided mappings need a human decision before certification. */
+export const LOW_CONFIDENCE_THRESHOLD = 0.75;
+export function pendingReviewMappings(
+  mappings: Array<{ id: string; sensitive: boolean; confidence: number; decided_by: string }>,
+): string[] {
+  return mappings
+    .filter((m) => m.decided_by !== 'human' && (m.sensitive || m.confidence < LOW_CONFIDENCE_THRESHOLD))
+    .map((m) => m.id);
+}
+
+/** Minimal, lossless schema-source extraction from an OpenAPI document:
+ * component schemas → {name, fields}. No mapping proposal happens here —
+ * that is the factory plane's job. */
+export function extractSchemaSources(doc: unknown): Array<{ name: string; fields: Array<{ name: string; type: string; required: boolean }> }> {
+  const schemas = (doc as any)?.components?.schemas;
+  if (!schemas || typeof schemas !== 'object') return [];
+  const out: Array<{ name: string; fields: Array<{ name: string; type: string; required: boolean }> }> = [];
+  for (const [name, schema] of Object.entries<any>(schemas)) {
+    const props = schema?.properties;
+    if (!props || typeof props !== 'object') continue;
+    const required: string[] = Array.isArray(schema.required) ? schema.required : [];
+    out.push({
+      name,
+      fields: Object.entries<any>(props).map(([fname, fdef]) => ({
+        name: fname,
+        type: typeof fdef?.type === 'string' ? fdef.type : 'unknown',
+        required: required.includes(fname),
+      })),
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+
+const router = Router();
+router.use(requireAuth as any);
+
+function db(res: Response) {
+  const s = getSupabase();
+  if (!s) {
+    res.status(503).json({ ok: false, error: 'database unavailable' });
+    return null;
+  }
+  return s;
+}
+function isAdmin(req: Request): boolean {
+  return Boolean((req as any).identity?.exafy_admin);
+}
+function userId(req: Request): string {
+  return String((req as any).identity?.user_id || '');
+}
+function tenantId(req: Request): string {
+  return String((req as any).identity?.tenant_id || 'platform');
+}
+function requireAdmin(req: Request, res: Response): boolean {
+  if (!isAdmin(req)) {
+    res.status(403).json({ ok: false, error: 'forbidden' });
+    return false;
+  }
+  return true;
+}
+async function emitEvent(supabase: any, type: string, status: string, message: string, payload: Record<string, unknown>) {
+  try {
+    await supabase.from('oasis_events').insert({
+      id: randomUUID(), service: 'vcaop', source: 'vcaop-portal', type, topic: type, status, message,
+      metadata: payload, created_at: new Date().toISOString(),
+    });
+  } catch { /* never block the request on the audit write */ }
+}
+
+/** Load a manifest row scoped to the caller's tenant; foreign rows read as 404. */
+async function getOwnedManifest(supabase: any, req: Request) {
+  const { data } = await supabase
+    .from('integration_manifest')
+    .select('id,partner_tenant_id,connector_id,provider_id,connection_type,risk_level,status,created_at,updated_at, partner_tenant!inner(id,tenant_id,name,jurisdiction)')
+    .eq('id', req.params.id)
+    .eq('partner_tenant.tenant_id', tenantId(req))
+    .maybeSingle();
+  return data ?? null;
+}
+
+async function latestVersion(supabase: any, manifestId: string) {
+  const { data } = await supabase
+    .from('integration_version')
+    .select('id,version,certification_status,document_hash,created_at')
+    .eq('manifest_id', manifestId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return data ?? null;
+}
+
+async function transition(supabase: any, req: Request, res: Response, to: ConnectionState, eventType: string) {
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  if (!canTransition(rec.status, to)) {
+    return res.status(409).json({ ok: false, error: `illegal transition ${rec.status} -> ${to}` });
+  }
+  const now = new Date().toISOString();
+  await supabase.from('integration_manifest').update({ status: to, updated_at: now }).eq('id', rec.id);
+  await emitEvent(supabase, eventType, 'success', `connection ${rec.id}: ${rec.status} -> ${to}`, {
+    connection_id: rec.id, from: rec.status, to, actor: userId(req),
+  });
+  return res.json({ ok: true, data: { id: rec.id, state: to } });
+}
+
+// ===== List / create =====
+router.get('/connections', async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  const { data, error } = await supabase
+    .from('integration_manifest')
+    .select('id,connector_id,provider_id,connection_type,risk_level,status,created_at,updated_at, partner_tenant!inner(tenant_id,name,jurisdiction)')
+    .eq('partner_tenant.tenant_id', tenantId(req))
+    .order('updated_at', { ascending: false });
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  res.json({
+    ok: true,
+    data: (data || []).map((m: any) => ({
+      id: m.id, name: m.partner_tenant?.name, connector_id: m.connector_id, provider_id: m.provider_id,
+      connection_type: m.connection_type, risk_level: m.risk_level, state: m.status,
+      jurisdiction: m.partner_tenant?.jurisdiction, updated_at: m.updated_at,
+    })),
+  });
+});
+
+router.post('/connections', async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  const { name, connector_id, provider_id, connection_type, risk_level, jurisdiction, openapi_document } = req.body ?? {};
+  if (!name || !connector_id || !provider_id) {
+    return res.status(400).json({ ok: false, error: 'name, connector_id and provider_id are required' });
+  }
+  const tenant = tenantId(req);
+  const now = new Date().toISOString();
+
+  // One partner_tenant row per (tenant, business name).
+  const { data: existingPartner } = await supabase
+    .from('partner_tenant').select('id').eq('tenant_id', tenant).eq('name', name).maybeSingle();
+  let partnerId = existingPartner?.id;
+  if (!partnerId) {
+    partnerId = randomUUID();
+    const { error } = await supabase.from('partner_tenant').insert({
+      id: partnerId, tenant_id: tenant, name, status: 'discovered', jurisdiction: jurisdiction ?? null,
+      created_at: now, updated_at: now,
+    });
+    if (error) return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  // No spec yet → the connection waits on partner authorization (same rule as
+  // the vcaop onboarding service).
+  const initialState: ConnectionState = openapi_document ? 'mapping' : 'authorization_required';
+  const manifestId = randomUUID();
+  const { error: mErr } = await supabase.from('integration_manifest').insert({
+    id: manifestId, partner_tenant_id: partnerId, connector_id, provider_id,
+    connection_type: connection_type ?? 'api', risk_level: risk_level ?? 'medium',
+    status: initialState, created_at: now, updated_at: now,
+  });
+  if (mErr) {
+    const dup = /duplicate|unique/i.test(mErr.message);
+    return res.status(dup ? 409 : 500).json({ ok: false, error: dup ? 'connection already exists for this partner + connector' : mErr.message });
+  }
+
+  if (openapi_document) {
+    const versionId = randomUUID();
+    const docJson = JSON.stringify(openapi_document);
+    await supabase.from('integration_version').insert({
+      id: versionId, manifest_id: manifestId, version: '0.1.0', document: openapi_document,
+      document_hash: createHash('sha256').update(docJson).digest('hex'), certification_status: 'draft', created_at: now,
+    });
+    const sources = extractSchemaSources(openapi_document);
+    for (const s of sources) {
+      await supabase.from('schema_source').insert({
+        id: randomUUID(), version_id: versionId, name: s.name, fields: s.fields,
+        hash: createHash('sha256').update(JSON.stringify(s.fields)).digest('hex'), created_at: now,
+      });
+    }
+  }
+
+  await emitEvent(supabase, 'vcaop.portal.connection.started', 'success', `connection ${manifestId} started (${initialState})`, {
+    connection_id: manifestId, connector_id, provider_id, state: initialState, actor: userId(req),
+  });
+  res.status(201).json({ ok: true, data: { id: manifestId, name, state: initialState } });
+});
+
+// ===== Detail / mapping preview / decisions =====
+router.get('/connections/:id', async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  const version = await latestVersion(supabase, rec.id);
+  res.json({
+    ok: true,
+    data: {
+      id: rec.id, name: rec.partner_tenant?.name, connector_id: rec.connector_id, provider_id: rec.provider_id,
+      connection_type: rec.connection_type, risk_level: rec.risk_level, state: rec.status,
+      jurisdiction: rec.partner_tenant?.jurisdiction, latest_version: version, updated_at: rec.updated_at,
+    },
+  });
+});
+
+router.get('/connections/:id/mapping-preview', async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  const version = await latestVersion(supabase, rec.id);
+  if (!version) {
+    return res.json({ ok: true, data: { state: rec.status, pipeline_status: 'awaiting_specification', sources: [], mappings: [], pending_review: [] } });
+  }
+  const [{ data: sources }, { data: mappings }] = await Promise.all([
+    supabase.from('schema_source').select('id,name,fields').eq('version_id', version.id),
+    supabase.from('schema_mapping')
+      .select('id,source_schema,source_field,canonical_entity,canonical_field,transform,confidence,decided_by,sensitive')
+      .eq('version_id', version.id),
+  ]);
+  const pending = pendingReviewMappings(mappings || []);
+  res.json({
+    ok: true,
+    data: {
+      state: rec.status,
+      pipeline_status: (mappings || []).length === 0 ? 'awaiting_factory_run' : 'mapped',
+      version: version.version,
+      sources: sources || [],
+      mappings: mappings || [],
+      pending_review: pending,
+    },
+  });
+});
+
+router.post('/connections/:id/mapping-decisions', async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  const { mapping_id, decision, reason } = req.body ?? {};
+  if (!mapping_id || !['approve', 'reject'].includes(decision)) {
+    return res.status(400).json({ ok: false, error: 'mapping_id and decision (approve|reject) required' });
+  }
+  const version = await latestVersion(supabase, rec.id);
+  if (!version) return res.status(409).json({ ok: false, error: 'no integration version to decide on' });
+  const { data: mapping } = await supabase
+    .from('schema_mapping').select('id,version_id').eq('id', mapping_id).eq('version_id', version.id).maybeSingle();
+  if (!mapping) return res.status(404).json({ ok: false, error: 'mapping not found on latest version' });
+
+  const now = new Date().toISOString();
+  // decided_by is ALWAYS the authenticated caller — a client-supplied value is ignored.
+  await supabase.from('mapping_decision').insert({
+    id: randomUUID(), mapping_id, decision, decided_by: userId(req), reason: reason ?? null, created_at: now,
+  });
+  if (decision === 'approve') {
+    await supabase.from('schema_mapping').update({ decided_by: 'human' }).eq('id', mapping_id);
+  }
+  await emitEvent(supabase, 'vcaop.portal.mapping.decided', 'success', `mapping ${mapping_id}: ${decision}`, {
+    connection_id: rec.id, mapping_id, decision, actor: userId(req),
+  });
+  res.json({ ok: true, data: { mapping_id, decision } });
+});
+
+// ===== Sandbox tests (gateway_dev_sandbox mode) =====
+router.post('/connections/:id/sandbox-tests', async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  if (!canTransition(rec.status, 'testing') && rec.status !== 'testing') {
+    return res.status(409).json({ ok: false, error: `cannot run tests from state ${rec.status}` });
+  }
+  const version = await latestVersion(supabase, rec.id);
+  if (!version) return res.status(409).json({ ok: false, error: 'no integration version to test' });
+
+  const { data: mappings } = await supabase
+    .from('schema_mapping').select('id,sensitive,confidence,decided_by').eq('version_id', version.id);
+  const pending = pendingReviewMappings(mappings || []);
+  const certStatus = pending.length > 0 ? 'approval_required' : 'certified';
+  const now = new Date().toISOString();
+
+  await supabase.from('connector_certification').insert({
+    id: randomUUID(), version_id: version.id, status: certStatus,
+    // Honest record: the gateway dev sandbox evaluates the deterministic
+    // mapping gate only. Real contract tests execute in the VCAOP factory
+    // plane (workers/CI) — never claimed here.
+    test_results: { mode: 'gateway_dev_sandbox', contract_tests_executed: 0, mapping_gate: pending.length === 0 ? 'pass' : 'pending_review' },
+    pending_mappings: pending, reasons: pending.length > 0 ? ['sensitive or low-confidence mappings need a human decision'] : [],
+    certified_by: null, created_at: now,
+  });
+  await supabase.from('integration_version').update({ certification_status: certStatus }).eq('id', version.id);
+  const nextState: ConnectionState = certStatus === 'certified' ? 'certified' : 'approval_required';
+  await supabase.from('integration_manifest').update({ status: nextState, updated_at: now }).eq('id', rec.id);
+  await emitEvent(supabase, 'vcaop.portal.sandbox_tests.completed', 'success', `connection ${rec.id}: ${certStatus}`, {
+    connection_id: rec.id, version: version.version, status: certStatus, pending: pending.length, actor: userId(req),
+  });
+  res.json({ ok: true, data: { state: nextState, certification: certStatus, pending_review: pending } });
+});
+
+router.get('/connections/:id/activation-summary', async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  const version = await latestVersion(supabase, rec.id);
+  let cert = null;
+  if (version) {
+    const { data } = await supabase
+      .from('connector_certification').select('id,status,test_results,pending_mappings,reasons,created_at')
+      .eq('version_id', version.id).order('created_at', { ascending: false }).limit(1).maybeSingle();
+    cert = data ?? null;
+  }
+  res.json({
+    ok: true,
+    data: {
+      id: rec.id, state: rec.status, version: version?.version ?? null,
+      certification: cert, can_activate: rec.status === 'certified' && cert?.status === 'certified',
+    },
+  });
+});
+
+// THE one-approval activation — admin only, gated on a certified version.
+router.post('/connections/:id/approve-activation', async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  const rec = await getOwnedManifest(supabase, req);
+  if (!rec) return res.status(404).json({ ok: false, error: 'connection not found' });
+  if (!canTransition(rec.status, 'active')) {
+    return res.status(409).json({ ok: false, error: `illegal transition ${rec.status} -> active (certification first)` });
+  }
+  const version = await latestVersion(supabase, rec.id);
+  if (!version || version.certification_status !== 'certified') {
+    return res.status(409).json({ ok: false, error: 'latest version is not certified' });
+  }
+  const now = new Date().toISOString();
+  await supabase.from('connector_certification')
+    .update({ certified_by: userId(req) })
+    .eq('version_id', version.id).eq('status', 'certified').is('certified_by', null);
+  await supabase.from('integration_manifest').update({ status: 'active', updated_at: now }).eq('id', rec.id);
+  await emitEvent(supabase, 'vcaop.portal.connection.activated', 'success', `connection ${rec.id} activated`, {
+    connection_id: rec.id, version: version.version, approved_by: userId(req),
+  });
+  res.json({ ok: true, data: { id: rec.id, state: 'active' } });
+});
+
+// ===== Lifecycle =====
+router.post('/connections/:id/pause', async (req, res) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  await transition(supabase, req, res, 'suspended', 'vcaop.portal.connection.paused');
+});
+router.post('/connections/:id/resume', async (req, res) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  await transition(supabase, req, res, 'active', 'vcaop.portal.connection.resumed');
+});
+router.post('/connections/:id/reauthorize', async (req, res) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  await transition(supabase, req, res, 'suspended', 'vcaop.portal.connection.reauthorize_requested');
+});
+// Irreversible for the connection — still admin-only, emits its own event.
+router.post('/connections/:id/revoke', async (req, res) => {
+  if (!requireAdmin(req, res)) return;
+  const supabase = db(res); if (!supabase) return;
+  await transition(supabase, req, res, 'revoked', 'vcaop.portal.connection.revoked');
+});
+
+export default router;

--- a/services/gateway/test/routes/vcaop-portal-my.test.ts
+++ b/services/gateway/test/routes/vcaop-portal-my.test.ts
@@ -1,0 +1,144 @@
+/**
+ * VCAOP merchant self-service portal — /my surface (VTID-03553).
+ *
+ * The load-bearing assertions are the OWNERSHIP ones: every read filters on
+ * partner_tenant.owner_user_id = the caller, creation stamps ownership from
+ * the JWT (never the body), and the platform's one-approval activation
+ * endpoint does not exist on this surface at all.
+ */
+import express, { NextFunction, Response } from 'express';
+import request from 'supertest';
+import vcaopPortalMyRouter from '../../src/routes/vcaop-portal-my';
+import { requireAuth } from '../../src/middleware/auth-supabase-jwt';
+import { getSupabase } from '../../src/lib/supabase';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({ requireAuth: jest.fn() }));
+jest.mock('../../src/lib/supabase', () => ({ getSupabase: jest.fn() }));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/vcaop/portal/my', vcaopPortalMyRouter);
+
+const asMerchant = (id = 'merchant-1', email: string | null = 'owner@example.test') =>
+  (requireAuth as jest.Mock).mockImplementation((req: any, _res: Response, next: NextFunction) => {
+    req.identity = { user_id: id, tenant_id: 'platform', email, exafy_admin: false };
+    next();
+  });
+
+/** Chainable Supabase query stub that records every eq() filter applied. */
+function tableStub(result: { data?: any; error?: any }) {
+  const filters: Record<string, unknown> = {};
+  const chain: any = {
+    filters,
+    select: jest.fn(() => chain),
+    insert: jest.fn(() => Promise.resolve({ error: null })),
+    update: jest.fn(() => chain),
+    eq: jest.fn((col: string, val: unknown) => { filters[col] = val; return chain; }),
+    is: jest.fn(() => chain),
+    order: jest.fn(() => chain),
+    limit: jest.fn(() => chain),
+    maybeSingle: jest.fn(() => Promise.resolve({ data: result.data ?? null, error: result.error ?? null })),
+    then: (resolve: any) => resolve({ data: result.data ?? null, error: result.error ?? null }),
+  };
+  return chain;
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('ownership scoping', () => {
+  test('GET /connections filters on partner_tenant.owner_user_id = the caller', async () => {
+    asMerchant('merchant-1');
+    const manifests = tableStub({ data: [] });
+    (getSupabase as jest.Mock).mockReturnValue({ from: jest.fn(() => manifests) });
+    const res = await request(app).get('/api/v1/vcaop/portal/my/connections');
+    expect(res.status).toBe(200);
+    expect(manifests.filters['partner_tenant.owner_user_id']).toBe('merchant-1');
+  });
+
+  test('a connection owned by someone else reads as 404, not 403', async () => {
+    asMerchant('merchant-2');
+    const manifests = tableStub({ data: null }); // owner filter excludes the row
+    (getSupabase as jest.Mock).mockReturnValue({ from: jest.fn(() => manifests) });
+    const res = await request(app).get('/api/v1/vcaop/portal/my/connections/some-id');
+    expect(res.status).toBe(404);
+    expect(manifests.filters['partner_tenant.owner_user_id']).toBe('merchant-2');
+  });
+
+  test('create stamps owner_user_id + owner_email from the JWT, never the body', async () => {
+    asMerchant('merchant-3', 'real@owner.test');
+    const inserted: any[] = [];
+    const partnerLookup = tableStub({ data: null });
+    const tables: Record<string, any> = {
+      partner_tenant: {
+        ...partnerLookup,
+        insert: jest.fn((row: any) => { inserted.push(row); return Promise.resolve({ error: null }); }),
+      },
+      integration_manifest: { insert: jest.fn(() => Promise.resolve({ error: null })) },
+      oasis_events: { insert: jest.fn(() => Promise.resolve({ error: null })) },
+    };
+    (getSupabase as jest.Mock).mockReturnValue({ from: jest.fn((t: string) => tables[t] ?? tableStub({})) });
+    const res = await request(app).post('/api/v1/vcaop/portal/my/connections').send({
+      name: 'My Shop', connector_id: 'shopify', provider_id: 'shopify',
+      owner_user_id: 'spoofed-user', owner_email: 'spoofed@evil.test',
+    });
+    expect(res.status).toBe(201);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].owner_user_id).toBe('merchant-3');
+    expect(inserted[0].owner_email).toBe('real@owner.test');
+  });
+});
+
+describe('authority boundaries', () => {
+  test('no /approve-activation on the merchant surface — activation stays admin-only', async () => {
+    asMerchant();
+    (getSupabase as jest.Mock).mockReturnValue({ from: jest.fn(() => tableStub({})) });
+    const res = await request(app).post('/api/v1/vcaop/portal/my/connections/x/approve-activation');
+    expect(res.status).toBe(404); // Express default: route does not exist
+  });
+
+  test('activation-summary reports awaiting_platform_approval instead of can_activate', async () => {
+    asMerchant('merchant-1');
+    const rec = { id: 'm-1', status: 'certified', partner_tenant: { name: 'Shop', owner_user_id: 'merchant-1' } };
+    const version = { id: 'v-1', version: '0.1.0', certification_status: 'certified' };
+    const cert = { id: 'c-1', status: 'certified' };
+    const tables: Record<string, any> = {
+      integration_manifest: tableStub({ data: rec }),
+      integration_version: tableStub({ data: version }),
+      connector_certification: tableStub({ data: cert }),
+    };
+    (getSupabase as jest.Mock).mockReturnValue({ from: jest.fn((t: string) => tables[t] ?? tableStub({})) });
+    const res = await request(app).get('/api/v1/vcaop/portal/my/connections/m-1/activation-summary');
+    expect(res.status).toBe(200);
+    expect(res.body.data.awaiting_platform_approval).toBe(true);
+    expect(res.body.data).not.toHaveProperty('can_activate');
+  });
+});
+
+describe('input + infrastructure guards', () => {
+  test('database unavailable → 503, not a crash', async () => {
+    asMerchant();
+    (getSupabase as jest.Mock).mockReturnValue(null);
+    const res = await request(app).get('/api/v1/vcaop/portal/my/connections');
+    expect(res.status).toBe(503);
+  });
+
+  test('create validates required fields before touching the database', async () => {
+    asMerchant();
+    (getSupabase as jest.Mock).mockReturnValue({ from: jest.fn(() => tableStub({})) });
+    const res = await request(app).post('/api/v1/vcaop/portal/my/connections').send({ name: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/connector_id/);
+  });
+
+  test('lifecycle transition on a foreign connection is 404 and writes nothing', async () => {
+    asMerchant('merchant-9');
+    const update = jest.fn();
+    const manifests = tableStub({ data: null });
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn(() => ({ ...manifests, update })),
+    });
+    const res = await request(app).post('/api/v1/vcaop/portal/my/connections/foreign/revoke');
+    expect(res.status).toBe(404);
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/services/gateway/test/routes/vcaop-portal.test.ts
+++ b/services/gateway/test/routes/vcaop-portal.test.ts
@@ -1,0 +1,141 @@
+/**
+ * VCAOP Partner Portal gateway surface (VTID-03544).
+ *
+ * Includes the transition-map SYNC TEST: the gateway mirrors the connection
+ * state machine from services/vcaop/src/factory/manifest.ts (the gateway
+ * Docker image cannot depend on the vcaop package), so any edit to the
+ * canonical map that is not mirrored here must fail CI — same pattern as
+ * nav-manifest-sync.test.ts pinning the vitana-v1 manifest.
+ */
+import fs from 'fs';
+import path from 'path';
+import express, { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import vcaopPortalRouter, {
+  CONNECTION_STATES,
+  STATE_TRANSITIONS,
+  canTransition,
+  extractSchemaSources,
+  pendingReviewMappings,
+} from '../../src/routes/vcaop-portal';
+import { requireAuth } from '../../src/middleware/auth-supabase-jwt';
+import { getSupabase } from '../../src/lib/supabase';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({ requireAuth: jest.fn() }));
+jest.mock('../../src/lib/supabase', () => ({ getSupabase: jest.fn() }));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/vcaop/portal', vcaopPortalRouter);
+
+const asAdmin = () =>
+  (requireAuth as jest.Mock).mockImplementation((req: any, _res: Response, next: NextFunction) => {
+    req.identity = { user_id: 'admin-1', tenant_id: 'platform', exafy_admin: true };
+    next();
+  });
+const asCommunity = () =>
+  (requireAuth as jest.Mock).mockImplementation((req: any, _res: Response, next: NextFunction) => {
+    req.identity = { user_id: 'user-1', tenant_id: 'platform', exafy_admin: false };
+    next();
+  });
+
+describe('state machine mirror stays in sync with services/vcaop', () => {
+  const canonicalSource = fs.readFileSync(
+    path.join(__dirname, '../../../vcaop/src/factory/manifest.ts'),
+    'utf8',
+  );
+
+  test('every mirrored state exists in the canonical CONNECTION_STATES', () => {
+    for (const state of CONNECTION_STATES) {
+      expect(canonicalSource).toMatch(new RegExp(`'${state}'`));
+    }
+  });
+
+  test('the mirrored transition map matches the canonical map row for row', () => {
+    // Parse the canonical STATE_TRANSITIONS object literal out of the source.
+    const block = canonicalSource.match(/STATE_TRANSITIONS[^=]*=\s*\{([\s\S]*?)\n\};/);
+    expect(block).not.toBeNull();
+    const rows = [...block![1].matchAll(/(\w+):\s*\[([^\]]*)\]/g)];
+    expect(rows.length).toBe(CONNECTION_STATES.length);
+    for (const [, from, targets] of rows) {
+      const canonicalTargets = targets
+        .split(',')
+        .map((t) => t.replace(/['"\s]/g, ''))
+        .filter(Boolean)
+        .sort();
+      const mirrored = [...(STATE_TRANSITIONS as any)[from]].sort();
+      expect({ from, targets: mirrored }).toEqual({ from, targets: canonicalTargets });
+    }
+  });
+});
+
+describe('pure helpers', () => {
+  test('canTransition follows the map and rejects unknown states', () => {
+    expect(canTransition('certified', 'active')).toBe(true);
+    expect(canTransition('discovered', 'active')).toBe(false);
+    expect(canTransition('revoked', 'active')).toBe(false);
+    expect(canTransition('nonsense', 'active')).toBe(false);
+  });
+
+  test('pendingReviewMappings flags sensitive + low-confidence non-human mappings only', () => {
+    const pending = pendingReviewMappings([
+      { id: 'a', sensitive: true, confidence: 0.99, decided_by: 'ai' },
+      { id: 'b', sensitive: false, confidence: 0.5, decided_by: 'ai' },
+      { id: 'c', sensitive: false, confidence: 0.99, decided_by: 'ai' },
+      { id: 'd', sensitive: true, confidence: 0.4, decided_by: 'human' },
+    ]);
+    expect(pending).toEqual(['a', 'b']);
+  });
+
+  test('extractSchemaSources pulls component schemas with required flags', () => {
+    const sources = extractSchemaSources({
+      components: {
+        schemas: {
+          Order: {
+            type: 'object',
+            required: ['id'],
+            properties: { id: { type: 'string' }, total: { type: 'number' } },
+          },
+          Empty: { type: 'object' },
+        },
+      },
+    });
+    expect(sources).toEqual([
+      {
+        name: 'Order',
+        fields: [
+          { name: 'id', type: 'string', required: true },
+          { name: 'total', type: 'number', required: false },
+        ],
+      },
+    ]);
+    expect(extractSchemaSources(undefined)).toEqual([]);
+    expect(extractSchemaSources({})).toEqual([]);
+  });
+});
+
+describe('route auth rules', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('community role is denied everywhere (403)', async () => {
+    asCommunity();
+    (getSupabase as jest.Mock).mockReturnValue({});
+    const res = await request(app).get('/api/v1/vcaop/portal/connections');
+    expect(res.status).toBe(403);
+  });
+
+  test('admin without a database gets 503, not a crash', async () => {
+    asAdmin();
+    (getSupabase as jest.Mock).mockReturnValue(null);
+    const res = await request(app).get('/api/v1/vcaop/portal/connections');
+    expect(res.status).toBe(503);
+  });
+
+  test('create validates required fields before touching the database', async () => {
+    asAdmin();
+    (getSupabase as jest.Mock).mockReturnValue({});
+    const res = await request(app).post('/api/v1/vcaop/portal/connections').send({ name: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/connector_id/);
+  });
+});


### PR DESCRIPTION
Gateway slice of the Commerce Mesh activation wave (BLK-001, user-approved 2026-08-09). Split from #3066 because VALIDATOR-CHECK's path-ownership guard only admits gateway trees — the vcaop/prisma/mcp side stays in #3066. Now also carries the merchant self-service `/my` surface (VTID-03553, user-directed 2026-08-09: "user sided portal on commerce.vitanaland.com" — merchants, self-service).

VALIDATION_PROFILE: gateway_backend

SCOPE_ALLOWLIST: services/gateway/src/routes/vcaop-portal.ts, services/gateway/src/routes/vcaop-portal-my.ts, services/gateway/src/index.ts (mount lines), services/gateway/test/routes/vcaop-portal.test.ts, services/gateway/test/routes/vcaop-portal-my.test.ts, docs/validation/VTID-03544/**

ACCEPTANCE: docs/validation/VTID-03544/acceptance.md — AC-1…AC-6 (admin portal) + AC-7…AC-10 (merchant `/my` surface: ownership scoping, JWT-stamped ownership, no activation endpoint, foreign-row 404s), each mapped to TEST/CURL tokens; ROUTE_MOUNT/FINAL_URL/CURL_PROOF included for the route-mount gate.

MERGE_PAYLOAD_PREVIEW: merge title "Gateway: Commerce Mesh Partner Portal surface over live factory tables (VTID-03544)"; merging auto-deploys `gateway-staging` via STAGE-DEPLOY.yml; verify `401 application/json` (not `404 text/html`) on https://preview-gateway.vitanaland.com/api/v1/vcaop/portal/connections AND https://preview-gateway.vitanaland.com/api/v1/vcaop/portal/my/connections; production only via PUBLISH.

OASIS_IMPACT: yes

## What this adds
New admin-gated surface `/api/v1/vcaop/portal/*` over the mesh factory tables (VTID-03535 migration, applied to Supabase 2026-08-09 with RLS): connection create/list/detail, mapping preview + human mapping decisions, `gateway_dev_sandbox` tests (deterministic mapping gate only — `contract_tests_executed: 0` recorded honestly; real contract tests stay in the vcaop factory plane), one-approval activation gated on a certified version, pause/resume/reauthorize/revoke.

The 11-state connection machine is **mirrored, not forked**: a sync test parses `STATE_TRANSITIONS` out of `services/vcaop/src/factory/manifest.ts` and fails CI on any divergence (the gateway Docker image cannot depend on the vcaop package). Every mutation emits a `vcaop.portal.*` OASIS event — state transitions and decisions only.

## Merchant self-service `/my` surface (VTID-03553)
`/api/v1/vcaop/portal/my/*` — the user side of the same portal, for the commerce.vitanaland.com host-routed frontend (DNS deferred, BLK-006 pattern). Any authenticated user manages the connections of businesses they own via `partner_tenant.owner_user_id` (migration 0005, applied to Supabase 2026-08-09). Ownership is stamped from the JWT (never the request body), foreign rows read as 404, and **the one-approval activation deliberately does not exist on this surface** — a merchant drives their connection to `certified` and the summary reports `awaiting_platform_approval`; activation stays admin-only. `/my` events carry `metadata.surface = "merchant_self_service"`.

## Tests
`test/routes/vcaop-portal.test.ts` — 8/8: transition-map sync (2), pure helpers (3), auth/validation/degraded-DB behavior (3).
`test/routes/vcaop-portal-my.test.ts` — 8/8: ownership scoping (3), authority boundaries (2), input/infra guards (3). Output captured in `docs/validation/VTID-03544/outputs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012D5CuaUMRoDdgCDiaJMxeU