### PR TITLE
Fix VALIDATOR-CHECK: invalid awk made the path-ownership gate un-passable (VTID-03549)

### DIFF
--- a/.github/workflows/VALIDATOR-CHECK.yml
+++ b/.github/workflows/VALIDATOR-CHECK.yml
@@ -93,24 +93,23 @@ jobs:
             exit 20
           fi
 
+          # VTID-03549: these guards previously used a multi-line awk program
+          # with a newline directly after `!(` — invalid awk syntax, so awk
+          # exited 1 and (under bash -e) the gate failed on EVERY PR it
+          # triggered on, regardless of content. grep -Ev expresses the same
+          # allowlist without the parse trap; it exits 1 when no violations
+          # remain, which is success here — hence `|| true`.
           if [ "$PROFILE" = "command_hub_frontend" ]; then
             # allow only the two command-hub frontend trees + docs/validation for evidence
-            awk '
-              !(
-                $0 ~ "^services/gateway/src/frontend/command-hub/" ||
-                $0 ~ "^services/gateway/dist/frontend/command-hub/" ||
-                $0 ~ "^docs/validation/"
-              )
-            ' /tmp/changed_files.txt > /tmp/violations.txt
+            grep -Ev '^(services/gateway/src/frontend/command-hub/|services/gateway/dist/frontend/command-hub/|docs/validation/)' \
+              /tmp/changed_files.txt > /tmp/violations.txt || true
           elif [ "$PROFILE" = "gateway_backend" ]; then
-            awk '
-              !(
-                $0 ~ "^services/gateway/src/" ||
-                $0 ~ "^services/gateway/dist/" ||
-                $0 ~ "^services/gateway/openapi/" ||
-                $0 ~ "^docs/validation/"
-              )
-            ' /tmp/changed_files.txt > /tmp/violations.txt
+            # services/gateway/test/ is allowlisted too (VTID-03549): the
+            # Acceptance Mapping Gate below REQUIRES TEST: tokens, and those
+            # jest suites live in services/gateway/test/ — a profile that
+            # forbids shipping the tests it demands can never be satisfied.
+            grep -Ev '^(services/gateway/src/|services/gateway/dist/|services/gateway/test/|services/gateway/openapi/|docs/validation/)' \
+              /tmp/changed_files.txt > /tmp/violations.txt || true
           else
             echo "REJECTED: unknown VALIDATION_PROFILE=$PROFILE"
             exit 21


### PR DESCRIPTION
Found live on #3067 (the first PR to actually reach the profile branch since the VTID-03525 revival): both path-ownership guards in `VALIDATOR-CHECK.yml` use a multi-line awk program with a newline directly after `!(` — an awk syntax error. awk exits 1 (`awk: cmd. line:3: !( ^ unexpected newline or end of string`), and under `bash -e` the step dies before producing a verdict. **The gate could not pass for any PR it triggered on, regardless of content** — the same failure-mode family VTID-03525 itself documented: a governance gate that is red for structural reasons gets muted.

Changes:
1. Replaced both awk programs with `grep -Ev` over the identical allowlists (no parse trap; exits 1 when no violations remain, which is success — hence `|| true`). Logic exercised against fixture file lists: violations detected, clean case empty, YAML parses.
2. Allowlisted `services/gateway/test/` under `gateway_backend`: the workflow's own Acceptance Mapping Gate requires `TEST:` tokens naming jest suites, and those suites live in `services/gateway/test/` — a profile that forbids shipping the tests it demands can never be satisfied.

This PR touches only the workflow file, which is outside the gate's `paths:` trigger, so it is not judged by the broken gate itself. Once merged, #3067 (gateway Partner Portal, VTID-03544) re-runs against the fixed gate with its evidence pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012D5CuaUMRoDdgCDiaJMxeU

---
_Generated by [Claude Code](https://claude.ai/code/session_012D5CuaUMRoDdgCDiaJMxeU)_